### PR TITLE
feat(ard): resource_discovery (ARD) capability + runtime attach seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       brave_search_integration: ${{ steps.core_filter.outputs.brave_search_integration }}
       duckduckgo_integration: ${{ steps.core_filter.outputs.duckduckgo_integration }}
       parallel_integration: ${{ steps.core_filter.outputs.parallel_integration }}
+      ard_integration: ${{ steps.core_filter.outputs.ard_integration }}
       skip_slow_rust: ${{ steps.ci_opt_outs.outputs.skip_slow_rust }}
       skip_postgres_integration: ${{ steps.ci_opt_outs.outputs.skip_postgres_integration }}
       skip_sdk_compat: ${{ steps.ci_opt_outs.outputs.skip_sdk_compat }}
@@ -205,6 +206,8 @@ jobs:
               - 'integrations/duckduckgo/**'
             parallel_integration:
               - 'integrations/parallel/**'
+            ard_integration:
+              - 'integrations/ard/**'
 
       # Exclusion filters need `predicate-quantifier: every`; with the default
       # `some`, a rule like `!integrations/foo/**/*.md` matches almost every
@@ -374,6 +377,7 @@ jobs:
           cargo test -p everruns-integrations-e2b
           cargo test -p everruns-integrations-github
           cargo test -p everruns-integrations-sprites
+          cargo test -p everruns-integrations-ard
 
   # Durable-worker PR coverage. Catches regressions in the worker crate's
   # durable execution paths (act/reason/input task handling, DLQ emission,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,6 +2514,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-ard"
+version = "0.14.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-integrations-brave-search"
 version = "0.14.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "integrations/browserless",
     "integrations/e2b",
     "integrations/sprites",
+    "integrations/ard",
     "examples/coding-cli",
 ]
 

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -253,6 +253,17 @@ mod tests {
             session.title = Some(title);
             Ok(session.clone())
         }
+
+        async fn upsert_session_mcp_servers(
+            &self,
+            _session_id: SessionId,
+            servers: crate::mcp_server::ScopedMcpServers,
+        ) -> Result<()> {
+            // MERGE (last-wins by name), mirroring the production semantics.
+            let mut session = self.session.lock().expect("poisoned");
+            session.mcp_servers.extend(servers);
+            Ok(())
+        }
     }
 
     struct MockAgentStore {
@@ -408,5 +419,71 @@ mod tests {
             }
             _ => panic!("expected success"),
         }
+    }
+
+    #[tokio::test]
+    async fn upsert_session_mcp_servers_merges_not_replaces() {
+        use crate::mcp_server::{ScopedMcpServer, ScopedMcpServers};
+        use crate::traits::SessionMutator;
+
+        // Seed the session with one pre-existing scoped MCP server.
+        let mut session = build_session(None);
+        let mut existing: ScopedMcpServers = Default::default();
+        existing.insert(
+            "existing".to_string(),
+            ScopedMcpServer {
+                url: "https://existing.example.com/mcp".to_string(),
+                ..Default::default()
+            },
+        );
+        session.mcp_servers = existing;
+
+        let shared = Arc::new(Mutex::new(session));
+        let mutator = MockSessionMutator {
+            session: shared.clone(),
+        };
+
+        // Upsert a new, differently-named server.
+        let mut incoming: ScopedMcpServers = Default::default();
+        incoming.insert(
+            "attached".to_string(),
+            ScopedMcpServer {
+                url: "https://attached.example.com/mcp".to_string(),
+                ..Default::default()
+            },
+        );
+        mutator
+            .upsert_session_mcp_servers(SessionId::new(), incoming)
+            .await
+            .expect("upsert succeeds");
+
+        let after = shared.lock().expect("poisoned").mcp_servers.clone();
+        // MERGE: the pre-existing entry is preserved alongside the new one.
+        assert_eq!(after.len(), 2);
+        assert!(after.contains_key("existing"));
+        assert_eq!(
+            after.get("attached").map(|s| s.url.as_str()),
+            Some("https://attached.example.com/mcp")
+        );
+
+        // Last-wins on the same name.
+        let mut overlay: ScopedMcpServers = Default::default();
+        overlay.insert(
+            "attached".to_string(),
+            ScopedMcpServer {
+                url: "https://attached-v2.example.com/mcp".to_string(),
+                ..Default::default()
+            },
+        );
+        mutator
+            .upsert_session_mcp_servers(SessionId::new(), overlay)
+            .await
+            .expect("upsert succeeds");
+        let after = shared.lock().expect("poisoned").mcp_servers.clone();
+        assert_eq!(after.len(), 2);
+        assert_eq!(
+            after.get("attached").map(|s| s.url.as_str()),
+            Some("https://attached-v2.example.com/mcp")
+        );
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -178,12 +178,36 @@ impl<T: SessionStore + ?Sized> SessionStore for std::sync::Arc<T> {
 pub trait SessionMutator: Send + Sync {
     /// Update a session's human-readable title.
     async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session>;
+
+    /// Merge the provided scoped MCP servers into the session's existing
+    /// `mcp_servers` overlay (last-wins by logical name, matching
+    /// [`crate::mcp_server::merge_scoped_mcp_servers`]). This is a MERGE, not a
+    /// replace: existing entries with other names are preserved.
+    ///
+    /// The next `GetTurnContext` re-resolves the session's scoped MCP set from
+    /// this overlay, so attaching a server here makes it callable on the next
+    /// turn without any worker turn-start changes (EVE-593).
+    async fn upsert_session_mcp_servers(
+        &self,
+        session_id: SessionId,
+        servers: crate::mcp_server::ScopedMcpServers,
+    ) -> Result<()>;
 }
 
 #[async_trait]
 impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
     async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
         (**self).update_session_title(session_id, title).await
+    }
+
+    async fn upsert_session_mcp_servers(
+        &self,
+        session_id: SessionId,
+        servers: crate::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        (**self)
+            .upsert_session_mcp_servers(session_id, servers)
+            .await
     }
 }
 

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -33,6 +33,9 @@ service WorkerService {
     rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
     rpc SetSessionStatus(SetSessionStatusRequest) returns (SetSessionStatusResponse);
     rpc SetSessionTitle(SetSessionTitleRequest) returns (SetSessionTitleResponse);
+    // Merge scoped MCP servers into the session's mcp_servers overlay (EVE-593).
+    // Dedicated RPC because SetSessionTitleResponse's Session drops mcp_servers.
+    rpc UpsertSessionMcpServers(UpsertSessionMcpServersRequest) returns (UpsertSessionMcpServersResponse);
     // Message operations
     rpc GetMessage(GetMessageRequest) returns (GetMessageResponse);
     rpc LoadMessages(LoadMessagesRequest) returns (LoadMessagesResponse);
@@ -464,6 +467,16 @@ message SetSessionTitleRequest {
 message SetSessionTitleResponse {
     Session session = 1;
 }
+
+message UpsertSessionMcpServersRequest {
+    Uuid session_id = 1;
+    int64 org_id = 2;
+    // JSON-encoded ScopedMcpServers (map of logical name -> ScopedMcpServer) to
+    // MERGE into the session's existing mcp_servers overlay (last-wins by name).
+    google.protobuf.Struct mcp_servers = 3;
+}
+
+message UpsertSessionMcpServersResponse {}
 
 // ============================================================================
 // Message types

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -57,6 +57,21 @@ impl SessionMutator for InMemorySessionStore {
         session.updated_at = Utc::now();
         Ok(session.clone())
     }
+
+    async fn upsert_session_mcp_servers(
+        &self,
+        session_id: SessionId,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .get_mut(&session_id)
+            .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
+        // MERGE into the existing overlay (last-wins by logical name).
+        session.mcp_servers.extend(servers);
+        session.updated_at = Utc::now();
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -75,6 +75,17 @@ impl SessionMutator for TestSessionStore {
         session.title = Some(title);
         Ok(session.clone())
     }
+
+    async fn upsert_session_mcp_servers(
+        &self,
+        session_id: SessionId,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> everruns_core::error::Result<()> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions.get_mut(&session_id).expect("session exists");
+        session.mcp_servers.extend(servers);
+        Ok(())
+    }
 }
 
 #[derive(Clone)]

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -640,6 +640,45 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .ok_or_else(|| store_error("Session not found after update"))
     }
 
+    async fn upsert_session_mcp_servers(
+        &self,
+        org_id: i64,
+        session_id: Uuid,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        let session_id_typed = SessionId::from_uuid(session_id);
+
+        // Load the current org-scoped overlay so we MERGE (last-wins by name)
+        // rather than replace.
+        let session = self
+            .get_session(org_id, session_id)
+            .await?
+            .ok_or_else(|| store_error("Session not found"))?;
+        let merged =
+            everruns_core::mcp_server::merge_scoped_mcp_servers(&session.mcp_servers, &servers);
+
+        // Defense-in-depth: reject stdio transport, unsafe URLs, and duplicate
+        // sanitized names before persisting. The next GetTurnContext validates
+        // again, but failing here keeps an invalid set out of the column.
+        validate_scoped_mcp_servers(&merged)
+            .map_err(|e| store_error(format!("invalid scoped MCP servers: {e}")))?;
+
+        let mcp_servers_json = serde_json::to_value(&merged)
+            .map_err(|e| store_error(format!("failed to serialize scoped MCP servers: {e}")))?;
+        let update = UpdateSession {
+            mcp_servers: Some(mcp_servers_json),
+            ..Default::default()
+        };
+        self.db
+            .update_session(org_id, session_id_typed, update)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to upsert session MCP servers: {}", e);
+                store_error("Failed to upsert session MCP servers")
+            })?;
+        Ok(())
+    }
+
     // =========================================================================
     // Message Operations
     // =========================================================================

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -263,6 +263,8 @@ use everruns_internal_protocol::proto::{
     UpdateSessionTaskRequest,
     UpsertLeasedResourceRequest,
     UpsertLeasedResourceResponse,
+    UpsertSessionMcpServersRequest,
+    UpsertSessionMcpServersResponse,
 };
 use everruns_internal_protocol::{
     WorkerService, WorkerServiceServer,

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -1045,3 +1045,141 @@ async fn test_list_orphaned_session_tasks_excludes_null_heartbeat() {
         task_id
     );
 }
+
+// ============================================
+// UpsertSessionMcpServers (EVE-593 runtime attach seam)
+// ============================================
+
+/// End-to-end-ish: upserting a scoped MCP server persists it into the session's
+/// `mcp_servers` overlay, and the same resolution the GetTurnContext handler
+/// uses (`merge_effective_scoped_mcp_servers_with_capabilities`) then includes
+/// it — i.e. the server becomes part of the next turn's effective MCP set.
+#[tokio::test]
+async fn upsert_session_mcp_servers_persists_and_is_resolved_next_turn() {
+    let svc = test_worker_service().await;
+    let session = create_grpc_test_session(&svc).await;
+    let session_id = proto_session_id(&session);
+
+    let overlay = serde_json::json!({
+        "ard_weather": { "type": "http", "url": "https://mcp.example.com/v1/mcp" }
+    });
+    svc.upsert_session_mcp_servers(Request::new(UpsertSessionMcpServersRequest {
+        session_id: session.id.clone(),
+        org_id: everruns_core::DEFAULT_ORG_ID,
+        mcp_servers: Some(everruns_internal_protocol::json_to_proto_struct(&overlay)),
+    }))
+    .await
+    .expect("upsert should succeed");
+
+    // The schema Session now carries the attached server in its overlay.
+    let caller = everruns_core::Caller::internal(everruns_core::DEFAULT_ORG_ID);
+    let loaded = svc
+        .session_service
+        .get(&caller, session_id.uuid(), None)
+        .await
+        .expect("get session")
+        .expect("session present");
+    assert!(loaded.mcp_servers.contains_key("ard_weather"));
+    assert_eq!(
+        loaded
+            .mcp_servers
+            .get("ard_weather")
+            .map(|s| s.url.as_str()),
+        Some("https://mcp.example.com/v1/mcp")
+    );
+
+    // And the GetTurnContext resolution path includes it.
+    let harness = crate::domains::harnesses::queries::resolve_effective(
+        &svc.db,
+        everruns_core::DEFAULT_ORG_ID,
+        loaded.harness_id,
+    )
+    .await
+    .expect("resolve harness")
+    .expect("harness present");
+    let effective =
+        crate::domains::mcp_servers::scoped_mcp::merge_effective_scoped_mcp_servers_with_capabilities(
+            &harness,
+            None,
+            &loaded,
+            svc.capability_service.registry(),
+        );
+    assert!(
+        effective.contains_key("ard_weather"),
+        "attached server must be in the effective next-turn MCP set"
+    );
+    crate::domains::mcp_servers::scoped_mcp::validate_scoped_mcp_servers(&effective)
+        .expect("effective set is valid");
+}
+
+/// A second upsert MERGES rather than replaces.
+#[tokio::test]
+async fn upsert_session_mcp_servers_merges_existing_overlay() {
+    let svc = test_worker_service().await;
+    let session = create_grpc_test_session(&svc).await;
+
+    let first = serde_json::json!({
+        "ard_one": { "type": "http", "url": "https://one.example.com/mcp" }
+    });
+    svc.upsert_session_mcp_servers(Request::new(UpsertSessionMcpServersRequest {
+        session_id: session.id.clone(),
+        org_id: everruns_core::DEFAULT_ORG_ID,
+        mcp_servers: Some(everruns_internal_protocol::json_to_proto_struct(&first)),
+    }))
+    .await
+    .expect("first upsert");
+
+    let second = serde_json::json!({
+        "ard_two": { "type": "http", "url": "https://two.example.com/mcp" }
+    });
+    svc.upsert_session_mcp_servers(Request::new(UpsertSessionMcpServersRequest {
+        session_id: session.id.clone(),
+        org_id: everruns_core::DEFAULT_ORG_ID,
+        mcp_servers: Some(everruns_internal_protocol::json_to_proto_struct(&second)),
+    }))
+    .await
+    .expect("second upsert");
+
+    let caller = everruns_core::Caller::internal(everruns_core::DEFAULT_ORG_ID);
+    let loaded = svc
+        .session_service
+        .get(&caller, proto_session_id(&session).uuid(), None)
+        .await
+        .expect("get session")
+        .expect("session present");
+    assert!(loaded.mcp_servers.contains_key("ard_one"));
+    assert!(loaded.mcp_servers.contains_key("ard_two"));
+}
+
+/// Server-side validation rejects an unsafe / disallowed transport and does NOT
+/// persist the invalid entry.
+#[tokio::test]
+async fn upsert_session_mcp_servers_rejects_stdio_and_does_not_persist() {
+    let svc = test_worker_service().await;
+    let session = create_grpc_test_session(&svc).await;
+
+    // stdio transport is hard-off in the hosted product.
+    let bad = serde_json::json!({
+        "ard_bad": { "type": "stdio", "command": "/bin/sh" }
+    });
+    let result = svc
+        .upsert_session_mcp_servers(Request::new(UpsertSessionMcpServersRequest {
+            session_id: session.id.clone(),
+            org_id: everruns_core::DEFAULT_ORG_ID,
+            mcp_servers: Some(everruns_internal_protocol::json_to_proto_struct(&bad)),
+        }))
+        .await;
+    assert!(result.is_err(), "stdio transport must be rejected");
+
+    let caller = everruns_core::Caller::internal(everruns_core::DEFAULT_ORG_ID);
+    let loaded = svc
+        .session_service
+        .get(&caller, proto_session_id(&session).uuid(), None)
+        .await
+        .expect("get session")
+        .expect("session present");
+    assert!(
+        !loaded.mcp_servers.contains_key("ard_bad"),
+        "rejected entry must not be persisted"
+    );
+}

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -477,6 +477,69 @@ impl WorkerService for WorkerServiceImpl {
         }))
     }
 
+    async fn upsert_session_mcp_servers(
+        &self,
+        request: Request<UpsertSessionMcpServersRequest>,
+    ) -> Result<Response<UpsertSessionMcpServersResponse>, Status> {
+        use everruns_internal_protocol::proto_struct_to_json;
+
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        // Preserves TM-TENANT/TM-AGENT org scoping for the storage WHERE org_id.
+        let internal_caller = everruns_core::Caller::internal(req.org_id);
+
+        // Decode the JSON-encoded ScopedMcpServers to merge.
+        let incoming: everruns_core::mcp_server::ScopedMcpServers = match req.mcp_servers {
+            Some(ref s) => serde_json::from_value(proto_struct_to_json(s))
+                .map_err(|e| Status::invalid_argument(format!("invalid mcp_servers: {e}")))?,
+            None => Default::default(),
+        };
+
+        // Load the session (org-scoped) and MERGE incoming into its existing
+        // overlay (last-wins by logical name).
+        let session = self
+            .session_service
+            .get(&internal_caller, session_id, None)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get session: {}", e);
+                Status::internal("Failed to get session")
+            })?
+            .ok_or_else(|| Status::not_found("Session not found"))?;
+
+        let merged =
+            everruns_core::mcp_server::merge_scoped_mcp_servers(&session.mcp_servers, &incoming);
+
+        // Defense-in-depth: reject stdio transport, unsafe URLs, and duplicate
+        // sanitized names server-side before persisting. The next GetTurnContext
+        // re-resolves and re-validates, but failing here keeps an invalid set
+        // out of the column rather than silently dropping all MCP tools later.
+        crate::domains::mcp_servers::scoped_mcp::validate_scoped_mcp_servers(&merged)
+            .map_err(|e| Status::invalid_argument(format!("invalid scoped MCP servers: {e}")))?;
+
+        let mcp_servers_json = serde_json::to_value(&merged)
+            .map_err(|e| Status::internal(format!("failed to serialize mcp_servers: {e}")))?;
+
+        let update = crate::storage::models::UpdateSession {
+            mcp_servers: Some(mcp_servers_json),
+            ..Default::default()
+        };
+        self.db
+            .update_session(
+                req.org_id,
+                everruns_core::SessionId::from_uuid(session_id),
+                update,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to upsert session MCP servers: {}", e);
+                Status::internal("Failed to upsert session MCP servers")
+            })?
+            .ok_or_else(|| Status::not_found("Session not found"))?;
+
+        Ok(Response::new(UpsertSessionMcpServersResponse {}))
+    }
+
     async fn get_message(
         &self,
         request: Request<GetMessageRequest>,

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -512,6 +512,9 @@ impl InMemoryDatabase {
             if input.finished_at.is_some() {
                 session.finished_at = input.finished_at;
             }
+            if let Some(mcp_servers) = input.mcp_servers {
+                session.mcp_servers = mcp_servers;
+            }
             // Update updated_at on every update (mimics DB trigger)
             session.updated_at = Self::now();
             return Ok(Some(session.clone()));

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -3301,3 +3301,85 @@ async fn test_export_user_data() {
     let missing = db.export_user_data(uuid::Uuid::now_v7()).await.unwrap();
     assert!(missing.is_none());
 }
+
+#[tokio::test]
+async fn test_update_session_mcp_servers_round_trips() {
+    // EVE-593: the runtime attach seam persists scoped MCP servers into the
+    // session's mcp_servers JSONB column via UpdateSession.
+    let db = InMemoryDatabase::new();
+
+    let session = db
+        .create_session(CreateSessionRow {
+            workspace_id: None,
+            org_id: DEFAULT_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            title: Some("MCP Session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        })
+        .await
+        .unwrap();
+
+    let overlay = serde_json::json!({
+        "ard_weather": { "type": "http", "url": "https://mcp.example.com/v1/mcp" }
+    });
+    let updated = db
+        .update_session(
+            DEFAULT_ORG_ID,
+            session.id,
+            UpdateSession {
+                mcp_servers: Some(overlay.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .expect("session updated");
+    assert_eq!(updated.mcp_servers, overlay);
+
+    // Re-read confirms durability.
+    let fetched = db
+        .get_session(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap()
+        .expect("session present");
+    assert_eq!(fetched.mcp_servers, overlay);
+
+    // A subsequent update that leaves mcp_servers None preserves the column.
+    db.update_session(
+        DEFAULT_ORG_ID,
+        session.id,
+        UpdateSession {
+            title: Some("renamed".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let fetched = db
+        .get_session(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        fetched.mcp_servers, overlay,
+        "None must not clear the column"
+    );
+}

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -774,6 +774,9 @@ pub struct UpdateSession {
     pub status: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,
+    /// Session-scoped scoped MCP server overlay (JSONB). When `Some`, replaces
+    /// the column via the update; callers MERGE before passing it in (EVE-593).
+    pub mcp_servers: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -613,7 +613,8 @@ impl Database {
                 started_at = COALESCE($14, started_at),
                 finished_at = COALESCE($15, finished_at),
                 agent_version_id = COALESCE($16, agent_version_id),
-                agent_config_hash = COALESCE($17, agent_config_hash)
+                agent_config_hash = COALESCE($17, agent_config_hash),
+                mcp_servers = COALESCE($18, mcp_servers)
             WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, workspace_id, app_id, harness_id, agent_id, agent_version_id, agent_config_hash, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd, parent_session_id,
@@ -637,6 +638,7 @@ impl Database {
         .bind(input.finished_at)
         .bind(input.agent_version_id.map(|id| id.uuid()))
         .bind(input.agent_config_hash)
+        .bind(&input.mcp_servers)
         .fetch_optional(&self.pool)
         .await?;
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -741,6 +741,42 @@ async fn test_session_crud() {
         .expect("Session not found");
     assert_eq!(rehomed.harness_id, Some(harness.id));
 
+    // EVE-593: mcp_servers JSONB round-trips through update_session, and a
+    // later update that leaves it None preserves the column (COALESCE).
+    let overlay = json!({
+        "ard_weather": { "type": "http", "url": "https://mcp.example.com/v1/mcp" }
+    });
+    let with_mcp = backend
+        .update_session(
+            TEST_ORG_ID,
+            session.id,
+            UpdateSession {
+                mcp_servers: Some(overlay.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Failed to update session mcp_servers")
+        .expect("Session not found");
+    assert_eq!(with_mcp.mcp_servers, overlay);
+
+    let preserved = backend
+        .update_session(
+            TEST_ORG_ID,
+            session.id,
+            UpdateSession {
+                title: Some("Title only".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Failed to update session title")
+        .expect("Session not found");
+    assert_eq!(
+        preserved.mcp_servers, overlay,
+        "None must not clear mcp_servers"
+    );
+
     // List sessions with pagination
     let (sessions, total) = backend
         .list_sessions(

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -241,6 +241,30 @@ impl GrpcClient {
         proto_session_to_session(proto_session)
     }
 
+    /// Merge scoped MCP servers into the session's `mcp_servers` overlay (EVE-593).
+    pub async fn upsert_session_mcp_servers(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        servers: &everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        let servers_json = serde_json::to_value(servers).map_err(|e| {
+            AgentLoopError::store(format!("failed to serialize scoped MCP servers: {e}"))
+        })?;
+        let request = proto::UpsertSessionMcpServersRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            org_id,
+            mcp_servers: Some(json_to_proto_struct(&servers_json)),
+        };
+
+        let mut client = self.inner.lock().await;
+        client
+            .upsert_session_mcp_servers(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+        Ok(())
+    }
+
     pub async fn create_image_artifact(
         &self,
         org_id: i64,
@@ -2216,6 +2240,16 @@ impl everruns_core::traits::SessionMutator for GrpcOrgAdapter {
     ) -> Result<everruns_core::session::Session> {
         self.client
             .set_session_title(self.org_id, session_id, &title)
+            .await
+    }
+
+    async fn upsert_session_mcp_servers(
+        &self,
+        session_id: everruns_core::SessionId,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        self.client
+            .upsert_session_mcp_servers(self.org_id, session_id, &servers)
             .await
     }
 }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -156,6 +156,17 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             .await
     }
 
+    async fn upsert_session_mcp_servers(
+        &self,
+        org_id: i64,
+        session_id: Uuid,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        self.client
+            .upsert_session_mcp_servers(org_id, SessionId::from_uuid(session_id), &servers)
+            .await
+    }
+
     // =========================================================================
     // Message Operations
     // =========================================================================

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -76,6 +76,14 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         title: String,
     ) -> Result<Session>;
 
+    /// Merge scoped MCP servers into the session's `mcp_servers` overlay (EVE-593).
+    async fn upsert_session_mcp_servers(
+        &self,
+        org_id: i64,
+        session_id: Uuid,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()>;
+
     // =========================================================================
     // Message Operations
     // =========================================================================
@@ -512,6 +520,16 @@ impl<A: WorkerAdapters> everruns_core::traits::SessionMutator for OrgAdapter<A> 
     async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
         self.adapters
             .set_session_title(self.org_id, session_id.uuid(), title)
+            .await
+    }
+
+    async fn upsert_session_mcp_servers(
+        &self,
+        session_id: SessionId,
+        servers: everruns_core::mcp_server::ScopedMcpServers,
+    ) -> Result<()> {
+        self.adapters
+            .upsert_session_mcp_servers(self.org_id, session_id.uuid(), servers)
             .await
     }
 }

--- a/docs/integrations/ard.md
+++ b/docs/integrations/ard.md
@@ -44,7 +44,7 @@ registry:
 }
 ```
 
-- `registries[].id` — the handle the model uses; `registries[].url` — operator-controlled base URL; `registries[].federation` — optional allowlist of registry hostnames this registry may delegate to.
+- `registries[].id` — the handle the model uses; `registries[].url` — operator-controlled base URL; `registries[].federation` — **reserved / not yet enforced** (intended allowlist of registry hostnames this registry may delegate to; the client does not follow federated links today).
 - Set `allow_local_urls: true` only for local testing; it bypasses local-address blocking and nothing else.
 
 ### 2. Use in sessions

--- a/docs/integrations/ard.md
+++ b/docs/integrations/ard.md
@@ -81,13 +81,17 @@ and records the attachment. Idempotent per URN.
 
 1. `discover_resources` returns ranked candidates by URN.
 2. `attach_resource` verifies and records the attachment as a session resource
-   (`mcp_server` / `external_a2a_agent`).
+   (`mcp_server` / `external_a2a_agent`). For an **MCP server**, it also persists
+   the validated endpoint into the session's MCP overlay so the server's tools
+   become callable on the **next turn**; the result includes
+   `callable_next_turn: true`. **A2A agent** attaches are visibility-only for now
+   and report `callable_next_turn: false`.
 3. `list_attached_resources` shows current attachments.
 
-Attachments are recorded in the session resource registry. Making a freshly
-attached MCP server's tools or A2A agent immediately callable within the same
-session requires a runtime config-overlay seam that is a planned follow-up; see
-the crate `SPEC.md`.
+MCP-server attachments take effect on the next turn (the server re-resolves the
+session's MCP overlay each turn). Making a freshly attached **A2A agent**
+callable within the same session requires an additional runtime seam that is a
+planned follow-up; see the crate `SPEC.md`.
 
 ## Security
 

--- a/docs/integrations/ard.md
+++ b/docs/integrations/ard.md
@@ -1,0 +1,97 @@
+---
+title: Resource Discovery (ARD)
+description: Let agents discover and attach external MCP servers and A2A agents from operator-configured Agentic Resource Discovery (ARD) registries, with trust and SSRF controls.
+---
+
+Everruns can act as a client of [Agentic Resource Discovery (ARD)](https://agenticresourcediscovery.org/spec/)
+registries. The experimental `resource_discovery` capability lets agents search a
+registry for external capabilities and attach the trusted ones into the current
+session — MCP servers become tool providers and A2A agent cards become
+delegation targets.
+
+> Experimental: available on Dev-grade deployments only. The capability may change.
+
+## What You Get
+
+- **Discovery**: search operator-configured registries by natural-language intent.
+- **Attach**: resolve a candidate by URN, verify its trust manifest, validate its endpoint against SSRF rules, and record it as a session resource.
+- **Visibility**: list what has been attached to the session.
+
+## Security model
+
+- The model selects a registry by configured `registry_id` — it can **never** supply a raw registry or resource URL.
+- Every resolved endpoint URL is SSRF-validated (loopback, RFC1918, link-local, cloud-metadata and related ranges are blocked).
+- `require_trust` (default on) requires a trust manifest whose identity matches the resource URN's domain before any attach.
+- `max_attachments` caps how many resources a session may attach.
+- All registry responses are treated as untrusted data.
+
+## Quick Start
+
+### 1. Configure registries
+
+Add the `resource_discovery` capability to an agent and configure at least one
+registry:
+
+```json
+{
+  "registries": [
+    { "id": "main", "url": "https://ard.example.com" }
+  ],
+  "require_trust": true,
+  "allow_attach_types": ["mcp_server", "a2a_agent"],
+  "max_attachments": 8,
+  "allow_local_urls": false
+}
+```
+
+- `registries[].id` — the handle the model uses; `registries[].url` — operator-controlled base URL; `registries[].federation` — optional allowlist of registry hostnames this registry may delegate to.
+- Set `allow_local_urls: true` only for local testing; it bypasses local-address blocking and nothing else.
+
+### 2. Use in sessions
+
+| Tool | Description |
+|------|-------------|
+| `discover_resources` | Search a registry for external capabilities. |
+| `attach_resource` | Resolve, verify, and attach a discovered resource by URN. |
+| `list_attached_resources` | List resources attached to the session. |
+
+#### `discover_resources`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | What capability you need. |
+| `filter` | object | No | Structured filter forwarded to the registry. |
+| `registry_id` | string | No | Which configured registry to search (required if more than one). |
+
+Returns ranked `{ urn, displayName, type, score, source, description }` hits.
+
+#### `attach_resource`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `urn` | string | Yes | URN of a resource from `discover_resources`. |
+| `registry_id` | string | No | Registry that surfaced the URN (required if more than one). |
+
+Resolves the entry, enforces value-or-reference, maps its media type
+(`application/mcp-server+json` → MCP server, `application/a2a-agent-card+json` →
+external A2A agent), runs the trust and SSRF gates, enforces `max_attachments`,
+and records the attachment. Idempotent per URN.
+
+## Lifecycle
+
+1. `discover_resources` returns ranked candidates by URN.
+2. `attach_resource` verifies and records the attachment as a session resource
+   (`mcp_server` / `external_a2a_agent`).
+3. `list_attached_resources` shows current attachments.
+
+Attachments are recorded in the session resource registry. Making a freshly
+attached MCP server's tools or A2A agent immediately callable within the same
+session requires a runtime config-overlay seam that is a planned follow-up; see
+the crate `SPEC.md`.
+
+## Security
+
+See the crate [`SPEC.md`](https://github.com/everruns/everruns/blob/main/integrations/ard/SPEC.md)
+security-review table and the ARD section of the threat model for the full
+control set (registry allowlist, trust gate, SSRF validation, `max_attachments`,
+untrusted-data handling).

--- a/integrations/ard/Cargo.toml
+++ b/integrations/ard/Cargo.toml
@@ -1,0 +1,43 @@
+# Agentic Resource Discovery (ARD) Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: Experimental-only (gated behind DeploymentGrade::Dev)
+# Decision: ARD is a *source* for existing config/attach machinery; registries are
+#           operator-configured (model never supplies raw URLs); all registry
+#           responses are treated as untrusted external data.
+
+[package]
+name = "everruns-integrations-ard"
+readme = "README.md"
+version.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Agentic Resource Discovery (ARD) client integration for Everruns agents"
+keywords = ["everruns", "ard", "discovery", "agents"]
+categories = ["api-bindings", "development-tools"]
+documentation = "https://docs.rs/everruns-integrations-ard"
+
+[dependencies]
+everruns-core.workspace = true
+inventory.workspace = true
+
+# HTTP client for ARD registry APIs
+reqwest.workspace = true
+url = "2"
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/ard/README.md
+++ b/integrations/ard/README.md
@@ -1,0 +1,17 @@
+# everruns-integrations-ard
+
+Agentic Resource Discovery (ARD) client integration for [Everruns](https://everruns.com).
+
+Provides the experimental `resource_discovery` capability so agents can discover
+external capabilities (MCP servers, A2A agents) via operator-configured ARD
+registries ([spec](https://agenticresourcediscovery.org/spec/)) and attach them
+into the session config layer.
+
+Tools:
+
+- `discover_resources({ text, filter?, registry_id? })` — search a configured registry.
+- `attach_resource({ urn, registry_id? })` — resolve, verify trust, SSRF-validate, and attach.
+- `list_attached_resources()` — list attached resources.
+
+See [`SPEC.md`](./SPEC.md) for architecture and security review, and
+[`docs/integrations/ard.md`](../../docs/integrations/ard.md) for the quick start.

--- a/integrations/ard/SPEC.md
+++ b/integrations/ard/SPEC.md
@@ -1,0 +1,101 @@
+# Agentic Resource Discovery (ARD) client — SPEC
+
+Status: Experimental (Dev grade only). Capability id: `resource_discovery`.
+
+This crate lets agents discover external capabilities (MCP servers, A2A agents)
+through operator-configured [Agentic Resource Discovery](https://agenticresourcediscovery.org/spec/)
+registries and attach them into the session config layer. ARD is only a
+*source* for the existing config/attach machinery; it does not modify the agent
+loop or add database migrations.
+
+## Architecture
+
+```
+discover_resources ──POST /search──▶ configured ARD registry ──▶ ranked hits (untrusted)
+attach_resource    ──POST /resolve─▶ configured ARD registry ──▶ envelope (untrusted)
+                       │
+                       ├─ validate value-or-reference (reject url+data)
+                       ├─ media-type → attachment kind (mcp_server | a2a_agent)
+                       ├─ allow_attach_types gate
+                       ├─ trust gate (require_trust): manifest + attestation + URN↔identity
+                       ├─ SSRF: validate_safe_url on resolved endpoint (allow_local_urls bypass)
+                       ├─ max_attachments cap
+                       └─ record session resource (idempotent per URN)
+list_attached_resources ──▶ session resource registry (kind in {mcp_server, external_a2a_agent})
+```
+
+Registries are referenced by operator-configured `id` only. The model never
+supplies a raw registry or resource URL — this is the primary SSRF/exfiltration
+control.
+
+## Tool surface
+
+| Tool | Args | Returns |
+|---|---|---|
+| `discover_resources` | `{ text, filter?, registry_id? }` | `{ registry_id, count, results: [{ urn, displayName, type, score, source, description }] }` |
+| `attach_resource` | `{ urn, registry_id? }` | `{ urn, status: attached\|already_attached, kind, display_name, registry_id }` |
+| `list_attached_resources` | `{}` | `{ count, resources: [{ urn, kind, display_name, status, metadata }] }` |
+
+`registry_id` is required when more than one registry is configured; with a
+single registry it defaults to that one.
+
+## Config (`resource_discovery`)
+
+See `config_schema()` in `src/lib.rs` for the JSON schema. Fields:
+
+- `registries: [{ id, url, federation? }]` — operator-configured registries. `federation` is an allowlist of registry hostnames the registry may delegate to.
+- `require_trust: bool` (default `true`) — trust-manifest gate before any attach.
+- `allow_attach_types: ["mcp_server" | "a2a_agent"]` — empty means all supported kinds.
+- `max_attachments: usize` (default `8`) — per-session attachment cap.
+- `allow_local_urls: bool` (default `false`) — test/dev escape hatch that bypasses ONLY local-address blocking (never scheme/parse rejection).
+
+## Attachment state
+
+Attachments are recorded in the session resource registry
+([`specs/session-resources.md`](../../specs/session-resources.md)):
+
+- MCP server entries → `kind: "mcp_server"`.
+- A2A agent cards → `kind: "external_a2a_agent"`.
+- `resource_id` is the URN, giving idempotency (a repeat attach is a no-op
+  reported as `already_attached`).
+- Metadata carries `ard_urn`, `ard_registry_id`, `ard_media_type`,
+  `attachment_kind`, `endpoint_url`, and `trusted`.
+
+### Runtime attach seam (current limitation, follow-up)
+
+The MCP-server config overlay and external-A2A-agent config are resolved
+**statically at turn start** (`load_turn_context` reads an immutable
+`session.mcp_servers`; `SpawnAgentTool` captures the external-agent list at
+instantiation). `SessionMutator` exposes only `update_session_title()`, and
+`ToolContext` has no API to mutate session-scoped `mcpServers` or the external
+A2A agent list mid-session.
+
+Consequently this increment records the verified, SSRF-checked attachment in the
+session resource registry (the only runtime-mutable seam a tool has) for
+visibility and idempotency. Runtime *consumption* — so a freshly attached MCP
+server's tools or A2A agent become callable in the same session — requires a new
+core seam (e.g. `SessionMutator::upsert_session_mcp_servers` /
+`upsert_external_agents` plus turn-start re-resolution). That plumbing is a
+deliberate follow-up; it does not exist today, and inventing a fragile hack was
+explicitly out of scope.
+
+## Security review
+
+| Threat | Control |
+|---|---|
+| SSRF via attacker-chosen URL | Model picks a configured `registry_id`; never a raw URL. Resolved endpoint validated with the shared `validate_safe_url` (loopback/RFC1918/link-local/metadata/CGNAT/IPv4-mapped-IPv6 blocked). |
+| DNS rebinding on the resolved URL | `validate_safe_url` is the write-time check; execution-time DNS-pinned validation (`validate_url_dns_pinned`) belongs to the consuming MCP/A2A client at call time (deferred with the runtime seam). |
+| Untrusted/malicious registry content | All `/search` and `/resolve` payloads treated as untrusted; envelopes must be value-or-reference; unsupported media types rejected; no registry text is executed. |
+| Spoofed identity | Trust gate: when `require_trust`, a manifest with an attestation must exist and its identity must match the URN authority domain (subdomain match only). |
+| Resource sprawl / DoS | `max_attachments` cap enforced before remote work; idempotent per URN. |
+| Local/internal exposure in dev | `allow_local_urls` bypasses only local-address blocking and defaults false. |
+
+Cryptographic signature verification of the attestation is structural-only in
+this increment (presence + identity match) and is a documented follow-up.
+
+## Parity status
+
+Implemented: SPEC, unit tests, wiremock integration tests, user docs, CI unit
+job + path filter, threat-model section. Deferred follow-ups: connection
+provider + live API tests + dedicated live workflow, seed agent, UI test case,
+cryptographic attestation verification, runtime consumption seam.

--- a/integrations/ard/SPEC.md
+++ b/integrations/ard/SPEC.md
@@ -43,7 +43,7 @@ single registry it defaults to that one.
 
 See `config_schema()` in `src/lib.rs` for the JSON schema. Fields:
 
-- `registries: [{ id, url, federation? }]` — operator-configured registries. `federation` is an allowlist of registry hostnames the registry may delegate to.
+- `registries: [{ id, url, federation? }]` — operator-configured registries. `federation` is **reserved / not yet enforced**: intended as an allowlist of registry hostnames the registry may delegate to, but the client does not follow federated/delegated links today (it only talks to the configured `url`), so the field currently has no security effect. Wiring federation enforcement is a documented follow-up.
 - `require_trust: bool` (default `true`) — trust-manifest gate before any attach.
 - `allow_attach_types: ["mcp_server" | "a2a_agent"]` — empty means all supported kinds.
 - `max_attachments: usize` (default `8`) — per-session attachment cap.

--- a/integrations/ard/SPEC.md
+++ b/integrations/ard/SPEC.md
@@ -61,30 +61,52 @@ Attachments are recorded in the session resource registry
 - Metadata carries `ard_urn`, `ard_registry_id`, `ard_media_type`,
   `attachment_kind`, `endpoint_url`, and `trusted`.
 
-### Runtime attach seam (current limitation, follow-up)
+### Runtime attach seam
 
-The MCP-server config overlay and external-A2A-agent config are resolved
-**statically at turn start** (`load_turn_context` reads an immutable
-`session.mcp_servers`; `SpawnAgentTool` captures the external-agent list at
-instantiation). `SessionMutator` exposes only `update_session_title()`, and
-`ToolContext` has no API to mutate session-scoped `mcpServers` or the external
-A2A agent list mid-session.
+**MCP servers (implemented, EVE-593).** A successful `attach_resource` for an
+MCP-server resource is now *consuming*: the attached server becomes callable by
+the agent on the **next turn**. The mechanism reuses the session's existing
+`mcp_servers` JSONB overlay, which the server re-resolves on every
+`GetTurnContext`:
 
-Consequently this increment records the verified, SSRF-checked attachment in the
-session resource registry (the only runtime-mutable seam a tool has) for
-visibility and idempotency. Runtime *consumption* — so a freshly attached MCP
-server's tools or A2A agent become callable in the same session — requires a new
-core seam (e.g. `SessionMutator::upsert_session_mcp_servers` /
-`upsert_external_agents` plus turn-start re-resolution). That plumbing is a
-deliberate follow-up; it does not exist today, and inventing a fragile hack was
-explicitly out of scope.
+1. After the full security gauntlet (SSRF `validate_safe_url`, trust gate, kind/
+   `allows_kind`, `max_attachments`) and after recording the session-resource
+   entry (kept for idempotency/visibility), the tool builds a one-entry
+   `ScopedMcpServers` (HTTP transport, the SSRF-validated resolved endpoint URL,
+   tool discovery enabled). The logical name is derived deterministically from
+   the URN as `ard_<sanitized-urn>_<fnv1a-hex>` — collision-safe and guaranteed
+   to survive `sanitize_mcp_server_name` without producing the reserved `__`
+   delimiter or an empty prefix (otherwise `validate_scoped_mcp_servers` would
+   reject the whole merged set and silently drop all MCP tools).
+2. The tool calls `SessionMutator::upsert_session_mcp_servers(session_id, overlay)`
+   (from `ToolContext::session_mutator`, populated via
+   `ActAtom::with_session_mutator`). This MERGES (last-wins by name) into the
+   session's overlay server-side via a dedicated internal worker RPC
+   (`UpsertSessionMcpServers`), which re-runs `validate_scoped_mcp_servers`
+   (defense-in-depth: rejects stdio transport, unsafe URLs, dup sanitized names)
+   before persisting into `session.mcp_servers`. Tenant/org scoping is preserved
+   on the RPC (`Caller::internal(org_id)`) and the storage `WHERE org_id`.
+3. The next `GetTurnContext` re-resolves the overlay via
+   `merge_effective_scoped_mcp_servers_with_capabilities`, re-validates it, and
+   builds the scoped MCP tool definitions — DNS-pinned at call time by the
+   standard scoped-MCP client. No worker turn-start changes and no DB migration
+   were needed (the column already exists).
+
+The success payload carries `callable_next_turn: true` for MCP attaches.
+
+**External A2A agents (follow-up).** A2A attach remains visibility-only: it is
+recorded in the session resource registry but does NOT yet become callable in
+the same session. Runtime consumption for A2A needs a new session column +
+migration, a new resolution hook, and a separate mutator method
+(`upsert_external_agents`) — a deliberate, documented follow-up. The
+`attach_resource` payload reports `callable_next_turn: false` for A2A.
 
 ## Security review
 
 | Threat | Control |
 |---|---|
 | SSRF via attacker-chosen URL | Model picks a configured `registry_id`; never a raw URL. Resolved endpoint validated with the shared `validate_safe_url` (loopback/RFC1918/link-local/metadata/CGNAT/IPv4-mapped-IPv6 blocked). |
-| DNS rebinding on the resolved URL | `validate_safe_url` is the write-time check; execution-time DNS-pinned validation (`validate_url_dns_pinned`) belongs to the consuming MCP/A2A client at call time (deferred with the runtime seam). |
+| DNS rebinding on the resolved URL | `validate_safe_url` is the write-time check; execution-time DNS-pinned validation is inherited from the standard scoped-MCP client at call time once the server is resolved into the next turn's effective set. (For A2A, call-time pinning is deferred with the A2A runtime seam.) |
 | Untrusted/malicious registry content | All `/search` and `/resolve` payloads treated as untrusted; envelopes must be value-or-reference; unsupported media types rejected; no registry text is executed. |
 | Spoofed identity | Trust gate: when `require_trust`, a manifest with an attestation must exist and its identity must match the URN authority domain (subdomain match only). |
 | Resource sprawl / DoS | `max_attachments` cap enforced before remote work; idempotent per URN. |
@@ -96,6 +118,8 @@ this increment (presence + identity match) and is a documented follow-up.
 ## Parity status
 
 Implemented: SPEC, unit tests, wiremock integration tests, user docs, CI unit
-job + path filter, threat-model section. Deferred follow-ups: connection
-provider + live API tests + dedicated live workflow, seed agent, UI test case,
-cryptographic attestation verification, runtime consumption seam.
+job + path filter, threat-model section, MCP-server runtime attach seam
+(next-turn callable via `SessionMutator::upsert_session_mcp_servers`). Deferred
+follow-ups: connection provider + live API tests + dedicated live workflow, seed
+agent, UI test case, cryptographic attestation verification, external-A2A runtime
+consumption seam (new column/migration + resolution hook + `upsert_external_agents`).

--- a/integrations/ard/src/client.rs
+++ b/integrations/ard/src/client.rs
@@ -1,0 +1,142 @@
+//! HTTP client for ARD registries.
+//!
+//! Every outbound request target is SSRF-validated. The registry base URL comes
+//! from operator config (never the model), and any resolved resource URL is
+//! validated again before use in `tools.rs`.
+
+use everruns_core::url_validation::{UrlValidationError, validate_safe_url};
+use serde_json::{Value, json};
+
+use crate::config::{ResolvedEntry, SearchResponse};
+
+/// Errors from talking to an ARD registry.
+#[derive(Debug)]
+pub enum ClientError {
+    /// The registry/resolve URL failed SSRF validation.
+    UnsafeUrl(UrlValidationError),
+    /// Transport-level failure.
+    Transport(String),
+    /// The registry returned a non-success status.
+    Status(u16),
+    /// Response body could not be parsed.
+    Decode(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsafeUrl(e) => write!(f, "Unsafe registry URL: {e}"),
+            Self::Transport(e) => write!(f, "Registry request failed: {e}"),
+            Self::Status(s) => write!(f, "Registry returned HTTP {s}"),
+            Self::Decode(e) => write!(f, "Could not parse registry response: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+/// Thin client bound to a single registry base URL.
+pub struct RegistryClient {
+    base_url: String,
+    http: reqwest::Client,
+    /// When true, skip local-URL blocking on the registry base (test/dev only).
+    allow_local_urls: bool,
+}
+
+impl RegistryClient {
+    /// Construct a client for a registry base URL.
+    pub fn new(base_url: impl Into<String>, allow_local_urls: bool) -> Self {
+        Self {
+            base_url: base_url.into(),
+            http: reqwest::Client::new(),
+            allow_local_urls,
+        }
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!(
+            "{}/{}",
+            self.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+
+    /// Validate a URL against SSRF rules, honoring `allow_local_urls`.
+    fn check_url(&self, url: &str) -> Result<(), ClientError> {
+        match validate_safe_url(url) {
+            Ok(_) => Ok(()),
+            // `allow_local_urls` bypasses ONLY local-address blocking, never
+            // scheme/parse errors.
+            Err(UrlValidationError::BlockedHost(_)) if self.allow_local_urls => Ok(()),
+            Err(e) => Err(ClientError::UnsafeUrl(e)),
+        }
+    }
+
+    /// `POST /search` — discover ranked resources for a query.
+    pub async fn search(&self, body: Value) -> Result<SearchResponse, ClientError> {
+        let url = self.endpoint("search");
+        self.check_url(&url)?;
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ClientError::Transport(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(ClientError::Status(resp.status().as_u16()));
+        }
+        resp.json::<SearchResponse>()
+            .await
+            .map_err(|e| ClientError::Decode(e.to_string()))
+    }
+
+    /// `POST /resolve` — resolve a single URN to its envelope.
+    pub async fn resolve(&self, urn: &str) -> Result<ResolvedEntry, ClientError> {
+        let url = self.endpoint("resolve");
+        self.check_url(&url)?;
+        let resp = self
+            .http
+            .post(&url)
+            .json(&json!({ "urn": urn }))
+            .send()
+            .await
+            .map_err(|e| ClientError::Transport(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(ClientError::Status(resp.status().as_u16()));
+        }
+        resp.json::<ResolvedEntry>()
+            .await
+            .map_err(|e| ClientError::Decode(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_joins_paths() {
+        let c = RegistryClient::new("https://ard.example.com/", false);
+        assert_eq!(c.endpoint("search"), "https://ard.example.com/search");
+        assert_eq!(c.endpoint("/resolve"), "https://ard.example.com/resolve");
+    }
+
+    #[test]
+    fn check_url_blocks_local_by_default() {
+        let c = RegistryClient::new("http://127.0.0.1:9000", false);
+        assert!(c.check_url("http://127.0.0.1:9000/search").is_err());
+    }
+
+    #[test]
+    fn check_url_allows_local_when_opted_in() {
+        let c = RegistryClient::new("http://127.0.0.1:9000", true);
+        assert!(c.check_url("http://127.0.0.1:9000/search").is_ok());
+    }
+
+    #[test]
+    fn check_url_never_bypasses_bad_scheme() {
+        let c = RegistryClient::new("ftp://evil.example", true);
+        assert!(c.check_url("ftp://evil.example/search").is_err());
+    }
+}

--- a/integrations/ard/src/config.rs
+++ b/integrations/ard/src/config.rs
@@ -1,0 +1,591 @@
+//! Configuration, ARD envelope types, URN parsing, and trust verification.
+//!
+//! All types here treat registry-returned data as **untrusted** external input.
+//! The model never supplies a raw URL — it picks a configured `registry_id`, and
+//! resolved URLs are SSRF-validated before any outbound use (see `tools.rs`).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ============================================================================
+// Media types -> attachment kinds
+// ============================================================================
+
+/// ARD media type for an MCP server descriptor.
+pub const MEDIA_TYPE_MCP_SERVER: &str = "application/mcp-server+json";
+/// ARD media type for an A2A agent card.
+pub const MEDIA_TYPE_A2A_AGENT_CARD: &str = "application/a2a-agent-card+json";
+
+/// What an attached resource becomes inside the session config layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentKind {
+    /// Session-scoped MCP server (`mcpServers`).
+    McpServer,
+    /// Session-scoped external A2A agent.
+    A2aAgent,
+}
+
+impl AttachmentKind {
+    /// The session-resource registry `kind` string used to record the attachment.
+    pub fn resource_kind(self) -> &'static str {
+        match self {
+            Self::McpServer => "mcp_server",
+            Self::A2aAgent => "external_a2a_agent",
+        }
+    }
+
+    /// The configured `allow_attach_types` token a config must list to permit this.
+    pub fn config_token(self) -> &'static str {
+        match self {
+            Self::McpServer => "mcp_server",
+            Self::A2aAgent => "a2a_agent",
+        }
+    }
+}
+
+/// Map an ARD entry media type to the attachment kind it materializes into.
+///
+/// Returns `None` for any media type this increment does not support (e.g.
+/// skill-type entries), which the caller must reject.
+pub fn attachment_kind_for_media_type(media_type: &str) -> Option<AttachmentKind> {
+    match media_type {
+        MEDIA_TYPE_MCP_SERVER => Some(AttachmentKind::McpServer),
+        MEDIA_TYPE_A2A_AGENT_CARD => Some(AttachmentKind::A2aAgent),
+        _ => None,
+    }
+}
+
+// ============================================================================
+// Capability config
+// ============================================================================
+
+/// A single operator-configured ARD registry.
+///
+/// The model references registries by `id` only — it can NEVER supply a raw
+/// registry URL. This is the primary SSRF/exfiltration control.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RegistryConfig {
+    /// Stable identifier the model uses in `discover_resources`/`attach_resource`.
+    pub id: String,
+    /// Operator-provided base URL of the ARD registry (e.g. `https://ard.example.com`).
+    pub url: String,
+    /// Optional federation allowlist: registry hostnames this registry may
+    /// delegate resolution to. Empty means "this registry only".
+    #[serde(default)]
+    pub federation: Vec<String>,
+}
+
+/// Per-capability config for `resource_discovery`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceDiscoveryConfig {
+    /// Operator-configured registries. The model selects one by `id`.
+    #[serde(default)]
+    pub registries: Vec<RegistryConfig>,
+    /// Require a verifiable trust manifest before any attach. Defaults true.
+    #[serde(default = "default_true")]
+    pub require_trust: bool,
+    /// Attachment kinds permitted. Tokens: "mcp_server", "a2a_agent".
+    /// Empty means "all supported kinds".
+    #[serde(default)]
+    pub allow_attach_types: Vec<String>,
+    /// Maximum number of resources that may be attached in a session.
+    #[serde(default = "default_max_attachments")]
+    pub max_attachments: usize,
+    /// Allow resolved URLs that point at local/private addresses. Defaults false.
+    /// This is a test/dev escape hatch and bypasses ONLY local-URL blocking.
+    #[serde(default)]
+    pub allow_local_urls: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_max_attachments() -> usize {
+    8
+}
+
+impl Default for ResourceDiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            registries: Vec::new(),
+            require_trust: true,
+            allow_attach_types: Vec::new(),
+            max_attachments: default_max_attachments(),
+            allow_local_urls: false,
+        }
+    }
+}
+
+impl ResourceDiscoveryConfig {
+    /// Parse config from the per-capability JSON value, defaulting on error.
+    pub fn from_value(value: &Value) -> Self {
+        serde_json::from_value(value.clone()).unwrap_or_default()
+    }
+
+    /// Look up a configured registry by id.
+    pub fn registry(&self, id: &str) -> Option<&RegistryConfig> {
+        self.registries.iter().find(|r| r.id == id)
+    }
+
+    /// Returns whether the given attachment kind is permitted by config.
+    pub fn allows_kind(&self, kind: AttachmentKind) -> bool {
+        self.allow_attach_types.is_empty()
+            || self
+                .allow_attach_types
+                .iter()
+                .any(|t| t == kind.config_token())
+    }
+}
+
+// ============================================================================
+// ARD envelope (untrusted registry response shapes)
+// ============================================================================
+
+/// A ranked search hit from `POST /search`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchHit {
+    pub urn: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// ARD media type (e.g. `application/mcp-server+json`).
+    #[serde(rename = "type", default)]
+    pub media_type: Option<String>,
+    #[serde(default)]
+    pub score: Option<f64>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Response body of `POST /search`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SearchResponse {
+    #[serde(default)]
+    pub results: Vec<SearchHit>,
+}
+
+/// A trust manifest binding an entry to a verifiable identity.
+///
+/// Verification in this increment is structural: the `identity` domain must
+/// match the entry URN's authority domain (URN domain <-> identity), and an
+/// attestation must be present. Cryptographic signature verification is a
+/// documented follow-up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustManifest {
+    /// Verified identity, e.g. a domain like `example.com`.
+    pub identity: String,
+    /// Attestation blob (signature/JWT/etc.). Presence is required; full
+    /// cryptographic verification is a follow-up.
+    #[serde(default)]
+    pub attestation: Option<String>,
+}
+
+/// A resolved ARD entry envelope from `GET`/`POST` resolve on a registry.
+///
+/// The envelope is **value-or-reference**: it carries either an inline `data`
+/// payload OR a `url` reference, never both. Entries with both are rejected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedEntry {
+    pub urn: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// ARD media type.
+    #[serde(rename = "type")]
+    pub media_type: String,
+    /// Reference URL to the resource descriptor (value-or-reference).
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Inline resource descriptor (value-or-reference).
+    #[serde(default)]
+    pub data: Option<Value>,
+    /// Trust manifest, if the registry provided one.
+    #[serde(default, rename = "trustManifest")]
+    pub trust_manifest: Option<TrustManifest>,
+}
+
+/// Errors arising from envelope/trust validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvelopeError {
+    /// The envelope carried both `url` and `data`.
+    ValueAndReference,
+    /// The envelope carried neither `url` nor `data`.
+    NeitherValueNorReference,
+    /// URN could not be parsed.
+    InvalidUrn(String),
+    /// Unsupported media type for this increment.
+    UnsupportedMediaType(String),
+    /// Trust required but the manifest was missing.
+    MissingTrustManifest,
+    /// Trust required but no attestation was present.
+    MissingAttestation,
+    /// The trust identity does not match the URN domain.
+    IdentityMismatch {
+        urn_domain: String,
+        identity: String,
+    },
+}
+
+impl std::fmt::Display for EnvelopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ValueAndReference => {
+                write!(
+                    f,
+                    "ARD entry carries both `url` and `data` (must be value-or-reference)"
+                )
+            }
+            Self::NeitherValueNorReference => {
+                write!(f, "ARD entry carries neither `url` nor `data`")
+            }
+            Self::InvalidUrn(u) => write!(f, "Invalid URN: {u}"),
+            Self::UnsupportedMediaType(m) => write!(f, "Unsupported resource type: {m}"),
+            Self::MissingTrustManifest => {
+                write!(f, "Trust required but the resource has no trust manifest")
+            }
+            Self::MissingAttestation => {
+                write!(
+                    f,
+                    "Trust required but the trust manifest has no attestation"
+                )
+            }
+            Self::IdentityMismatch {
+                urn_domain,
+                identity,
+            } => write!(
+                f,
+                "Trust identity `{identity}` does not match URN domain `{urn_domain}`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EnvelopeError {}
+
+impl ResolvedEntry {
+    /// Enforce the value-or-reference invariant.
+    pub fn validate_value_or_reference(&self) -> Result<(), EnvelopeError> {
+        match (self.url.is_some(), self.data.is_some()) {
+            (true, true) => Err(EnvelopeError::ValueAndReference),
+            (false, false) => Err(EnvelopeError::NeitherValueNorReference),
+            _ => Ok(()),
+        }
+    }
+
+    /// Resolve the attachment kind from the media type, rejecting unsupported types.
+    pub fn attachment_kind(&self) -> Result<AttachmentKind, EnvelopeError> {
+        attachment_kind_for_media_type(&self.media_type)
+            .ok_or_else(|| EnvelopeError::UnsupportedMediaType(self.media_type.clone()))
+    }
+
+    /// Verify the trust manifest against `require_trust`.
+    ///
+    /// When `require_trust` is true: a manifest with an attestation must be
+    /// present and its identity domain must match the URN authority domain.
+    /// When false: a present manifest is still checked for identity match, but
+    /// absence is tolerated.
+    pub fn verify_trust(&self, require_trust: bool) -> Result<(), EnvelopeError> {
+        let urn = Urn::parse(&self.urn)?;
+        match &self.trust_manifest {
+            None => {
+                if require_trust {
+                    Err(EnvelopeError::MissingTrustManifest)
+                } else {
+                    Ok(())
+                }
+            }
+            Some(manifest) => {
+                if require_trust && manifest.attestation.as_deref().unwrap_or("").is_empty() {
+                    return Err(EnvelopeError::MissingAttestation);
+                }
+                if !urn.domain_matches(&manifest.identity) {
+                    return Err(EnvelopeError::IdentityMismatch {
+                        urn_domain: urn.domain().to_string(),
+                        identity: manifest.identity.clone(),
+                    });
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+// ============================================================================
+// URN parsing + domain extraction
+// ============================================================================
+
+/// A parsed ARD URN of the form `urn:ard:<domain>:<name>[:...]`.
+///
+/// The domain (the authority namespace) is the trust anchor: a trust manifest's
+/// `identity` must correspond to this domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Urn {
+    domain: String,
+    name: String,
+}
+
+impl Urn {
+    /// Parse a URN, extracting its domain (namespace) and name.
+    ///
+    /// Accepts `urn:ard:<domain>:<name>[:more]`. The domain is the third
+    /// colon-delimited segment.
+    pub fn parse(raw: &str) -> Result<Self, EnvelopeError> {
+        let parts: Vec<&str> = raw.split(':').collect();
+        // urn : ard : domain : name ...
+        if parts.len() < 4
+            || !parts[0].eq_ignore_ascii_case("urn")
+            || !parts[1].eq_ignore_ascii_case("ard")
+        {
+            return Err(EnvelopeError::InvalidUrn(raw.to_string()));
+        }
+        let domain = parts[2].trim();
+        let name = parts[3].trim();
+        if domain.is_empty() || name.is_empty() {
+            return Err(EnvelopeError::InvalidUrn(raw.to_string()));
+        }
+        Ok(Self {
+            domain: domain.to_ascii_lowercase(),
+            name: name.to_string(),
+        })
+    }
+
+    /// The authority domain (lowercased).
+    pub fn domain(&self) -> &str {
+        &self.domain
+    }
+
+    /// The entry name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Whether the given identity matches this URN's domain.
+    ///
+    /// Match is exact (case-insensitive) or a subdomain of the identity, so an
+    /// identity `example.com` covers `mcp.example.com` but not `evil.com`.
+    pub fn domain_matches(&self, identity: &str) -> bool {
+        let id = identity.trim().to_ascii_lowercase();
+        if id.is_empty() {
+            return false;
+        }
+        self.domain == id || self.domain.ends_with(&format!(".{id}"))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- Config ---
+
+    #[test]
+    fn config_defaults() {
+        let c = ResourceDiscoveryConfig::default();
+        assert!(c.require_trust);
+        assert!(!c.allow_local_urls);
+        assert_eq!(c.max_attachments, 8);
+        assert!(c.registries.is_empty());
+    }
+
+    #[test]
+    fn config_from_value_roundtrip() {
+        let c = ResourceDiscoveryConfig::from_value(&json!({
+            "registries": [{ "id": "r1", "url": "https://r.example", "federation": ["a.example"] }],
+            "require_trust": false,
+            "max_attachments": 2,
+            "allow_local_urls": true,
+            "allow_attach_types": ["mcp_server"]
+        }));
+        assert_eq!(c.registries.len(), 1);
+        assert_eq!(c.registry("r1").unwrap().federation, vec!["a.example"]);
+        assert!(!c.require_trust);
+        assert!(c.allow_local_urls);
+        assert_eq!(c.max_attachments, 2);
+    }
+
+    #[test]
+    fn config_allows_kind() {
+        let mut c = ResourceDiscoveryConfig::default();
+        // Empty => all permitted.
+        assert!(c.allows_kind(AttachmentKind::McpServer));
+        assert!(c.allows_kind(AttachmentKind::A2aAgent));
+        c.allow_attach_types = vec!["mcp_server".into()];
+        assert!(c.allows_kind(AttachmentKind::McpServer));
+        assert!(!c.allows_kind(AttachmentKind::A2aAgent));
+    }
+
+    // --- Media type mapping ---
+
+    #[test]
+    fn media_type_mapping() {
+        assert_eq!(
+            attachment_kind_for_media_type(MEDIA_TYPE_MCP_SERVER),
+            Some(AttachmentKind::McpServer)
+        );
+        assert_eq!(
+            attachment_kind_for_media_type(MEDIA_TYPE_A2A_AGENT_CARD),
+            Some(AttachmentKind::A2aAgent)
+        );
+        assert_eq!(
+            attachment_kind_for_media_type("application/skill+json"),
+            None
+        );
+    }
+
+    // --- URN parsing + domain extraction ---
+
+    #[test]
+    fn urn_parses_domain_and_name() {
+        let urn = Urn::parse("urn:ard:Example.com:my-server").unwrap();
+        assert_eq!(urn.domain(), "example.com");
+        assert_eq!(urn.name(), "my-server");
+    }
+
+    #[test]
+    fn urn_parses_extra_segments() {
+        let urn = Urn::parse("urn:ard:example.com:agent:v1").unwrap();
+        assert_eq!(urn.domain(), "example.com");
+        assert_eq!(urn.name(), "agent");
+    }
+
+    #[test]
+    fn urn_rejects_malformed() {
+        assert!(Urn::parse("not-a-urn").is_err());
+        assert!(Urn::parse("urn:ard:example.com").is_err());
+        assert!(Urn::parse("urn:other:example.com:x").is_err());
+        assert!(Urn::parse("urn:ard::name").is_err());
+    }
+
+    #[test]
+    fn urn_domain_match_covers_subdomains_only() {
+        let urn = Urn::parse("urn:ard:mcp.example.com:s").unwrap();
+        assert!(urn.domain_matches("example.com"));
+        assert!(urn.domain_matches("mcp.example.com"));
+        assert!(!urn.domain_matches("evil.com"));
+        assert!(!urn.domain_matches("ample.com"));
+        assert!(!urn.domain_matches(""));
+    }
+
+    // --- Envelope value-or-reference ---
+
+    fn entry(url: Option<&str>, data: Option<Value>) -> ResolvedEntry {
+        ResolvedEntry {
+            urn: "urn:ard:example.com:foo".into(),
+            display_name: None,
+            media_type: MEDIA_TYPE_MCP_SERVER.into(),
+            url: url.map(|s| s.to_string()),
+            data,
+            trust_manifest: None,
+        }
+    }
+
+    #[test]
+    fn envelope_rejects_both_value_and_reference() {
+        let e = entry(Some("https://x.example"), Some(json!({ "a": 1 })));
+        assert_eq!(
+            e.validate_value_or_reference(),
+            Err(EnvelopeError::ValueAndReference)
+        );
+    }
+
+    #[test]
+    fn envelope_rejects_neither() {
+        let e = entry(None, None);
+        assert_eq!(
+            e.validate_value_or_reference(),
+            Err(EnvelopeError::NeitherValueNorReference)
+        );
+    }
+
+    #[test]
+    fn envelope_accepts_reference_only() {
+        assert!(
+            entry(Some("https://x.example"), None)
+                .validate_value_or_reference()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn envelope_accepts_value_only() {
+        assert!(
+            entry(None, Some(json!({ "a": 1 })))
+                .validate_value_or_reference()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn unsupported_media_type_rejected() {
+        let mut e = entry(Some("https://x.example"), None);
+        e.media_type = "application/skill+json".into();
+        assert!(matches!(
+            e.attachment_kind(),
+            Err(EnvelopeError::UnsupportedMediaType(_))
+        ));
+    }
+
+    // --- Trust verification ---
+
+    fn trusted_entry(identity: &str, attestation: Option<&str>) -> ResolvedEntry {
+        ResolvedEntry {
+            urn: "urn:ard:mcp.example.com:server".into(),
+            display_name: None,
+            media_type: MEDIA_TYPE_MCP_SERVER.into(),
+            url: Some("https://mcp.example.com".into()),
+            data: None,
+            trust_manifest: Some(TrustManifest {
+                identity: identity.to_string(),
+                attestation: attestation.map(|s| s.to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn trust_passes_with_matching_identity_and_attestation() {
+        let e = trusted_entry("example.com", Some("sig"));
+        assert!(e.verify_trust(true).is_ok());
+    }
+
+    #[test]
+    fn trust_fails_missing_manifest_when_required() {
+        let e = entry(Some("https://mcp.example.com"), None);
+        assert_eq!(
+            e.verify_trust(true),
+            Err(EnvelopeError::MissingTrustManifest)
+        );
+    }
+
+    #[test]
+    fn trust_tolerates_missing_manifest_when_not_required() {
+        let e = entry(Some("https://mcp.example.com"), None);
+        assert!(e.verify_trust(false).is_ok());
+    }
+
+    #[test]
+    fn trust_fails_missing_attestation_when_required() {
+        let e = trusted_entry("example.com", None);
+        assert_eq!(e.verify_trust(true), Err(EnvelopeError::MissingAttestation));
+    }
+
+    #[test]
+    fn trust_fails_identity_mismatch() {
+        let e = trusted_entry("evil.com", Some("sig"));
+        assert!(matches!(
+            e.verify_trust(true),
+            Err(EnvelopeError::IdentityMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn trust_checks_identity_even_when_not_required() {
+        // A present-but-mismatched manifest is always rejected.
+        let e = trusted_entry("evil.com", Some("sig"));
+        assert!(e.verify_trust(false).is_err());
+    }
+}

--- a/integrations/ard/src/config.rs
+++ b/integrations/ard/src/config.rs
@@ -42,6 +42,18 @@ impl AttachmentKind {
             Self::A2aAgent => "a2a_agent",
         }
     }
+
+    /// Reverse of [`Self::resource_kind`]: map a recorded session-resource
+    /// `kind` string back to the attachment kind. Lets repeat
+    /// (`already_attached`) responses report the same `config_token` shape as a
+    /// first attach.
+    pub fn from_resource_kind(kind: &str) -> Option<Self> {
+        match kind {
+            "mcp_server" => Some(Self::McpServer),
+            "external_a2a_agent" => Some(Self::A2aAgent),
+            _ => None,
+        }
+    }
 }
 
 /// Map an ARD entry media type to the attachment kind it materializes into.
@@ -70,8 +82,12 @@ pub struct RegistryConfig {
     pub id: String,
     /// Operator-provided base URL of the ARD registry (e.g. `https://ard.example.com`).
     pub url: String,
-    /// Optional federation allowlist: registry hostnames this registry may
-    /// delegate resolution to. Empty means "this registry only".
+    /// RESERVED — NOT YET ENFORCED. Intended as a federation allowlist of
+    /// registry hostnames this registry may delegate resolution to. The client
+    /// does not follow delegated/federated registry links today (it only talks
+    /// to the configured `url`), so this field has no security effect yet; it
+    /// is parsed and preserved for forward compatibility. Wiring it up is a
+    /// documented follow-up (see SPEC.md).
     #[serde(default)]
     pub federation: Vec<String>,
 }

--- a/integrations/ard/src/lib.rs
+++ b/integrations/ard/src/lib.rs
@@ -1,0 +1,313 @@
+//! Agentic Resource Discovery (ARD) client integration (Experimental).
+//!
+//! Provides the `resource_discovery` capability: agents discover external
+//! capabilities (MCP servers, A2A agents) via operator-configured ARD registries
+//! ([spec](https://agenticresourcediscovery.org/spec/)) and attach them into the
+//! session config layer.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_core::capabilities::Capability;
+//! use everruns_integrations_ard::ResourceDiscoveryCapability;
+//!
+//! let capability = ResourceDiscoveryCapability;
+//! assert_eq!(capability.id(), "resource_discovery");
+//! ```
+//!
+//! # Design notes
+//!
+//! - Registries are operator-configured. The model selects a `registry_id`; it
+//!   can never supply a raw URL. This is the primary SSRF/exfiltration control.
+//! - All registry responses are treated as untrusted external data.
+//! - `attach_resource` runs a security gauntlet (trust gate, value-or-reference
+//!   envelope check, SSRF validation, `max_attachments` cap) before recording a
+//!   session-scoped attachment.
+
+pub mod client;
+pub mod config;
+mod tools;
+
+/// Test-support constructors for the tool implementations.
+///
+/// The tool structs are an internal detail; this module exposes builders so
+/// integration tests can drive `execute_with_context` directly. Not part of the
+/// stable public surface.
+#[doc(hidden)]
+pub mod test_support {
+    use crate::config::ResourceDiscoveryConfig;
+    use crate::tools::{AttachResourceTool, DiscoverResourcesTool, ListAttachedResourcesTool};
+    use everruns_core::tools::Tool;
+
+    /// Build a `discover_resources` tool with the given config.
+    pub fn discover_tool(config: ResourceDiscoveryConfig) -> impl Tool {
+        DiscoverResourcesTool::new(config)
+    }
+
+    /// Build an `attach_resource` tool with the given config.
+    pub fn attach_tool(config: ResourceDiscoveryConfig) -> impl Tool {
+        AttachResourceTool::new(config)
+    }
+
+    /// Build a `list_attached_resources` tool.
+    pub fn list_tool() -> impl Tool {
+        ListAttachedResourcesTool
+    }
+}
+
+use everruns_core::capabilities::{
+    Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin,
+};
+use everruns_core::tools::Tool;
+use serde_json::{Value, json};
+
+use config::ResourceDiscoveryConfig;
+use tools::{AttachResourceTool, DiscoverResourcesTool, ListAttachedResourcesTool};
+
+// ============================================================================
+// Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: true,
+        feature_flag: None,
+        factory: || Box::new(ResourceDiscoveryCapability),
+    }
+}
+
+// ============================================================================
+// Capability
+// ============================================================================
+
+/// The `resource_discovery` capability.
+pub struct ResourceDiscoveryCapability;
+
+impl Capability for ResourceDiscoveryCapability {
+    fn id(&self) -> &str {
+        "resource_discovery"
+    }
+
+    fn name(&self) -> &str {
+        "[Experimental] Resource Discovery (ARD)"
+    }
+
+    fn description(&self) -> &str {
+        "Discover and attach external capabilities (MCP servers, A2A agents) via \
+         Agentic Resource Discovery (ARD) registries. EXPERIMENTAL: this capability \
+         may change."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("compass")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Network")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            "Use `discover_resources` to find external MCP servers / A2A agents in \
+             configured ARD registries, then `attach_resource` to make one usable \
+             in this session; `list_attached_resources` shows what is attached.",
+        )
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "title": "Resource Discovery (ARD) Settings",
+            "properties": {
+                "registries": {
+                    "type": "array",
+                    "description": "Operator-configured ARD registries. The model selects one by id; it can never supply a raw URL.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string" },
+                            "url": { "type": "string", "format": "uri" },
+                            "federation": {
+                                "type": "array",
+                                "items": { "type": "string" },
+                                "description": "Allowlisted registry hostnames this registry may federate to."
+                            }
+                        },
+                        "required": ["id", "url"],
+                        "additionalProperties": false
+                    }
+                },
+                "require_trust": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Require a verifiable trust manifest before any attach."
+                },
+                "allow_attach_types": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["mcp_server", "a2a_agent"] },
+                    "description": "Attachment kinds permitted. Empty means all supported kinds."
+                },
+                "max_attachments": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 8,
+                    "description": "Maximum resources attachable per session."
+                },
+                "allow_local_urls": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Permit resolved URLs pointing at local/private addresses (test/dev only)."
+                }
+            },
+            "additionalProperties": false
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        let parsed: ResourceDiscoveryConfig = serde_json::from_value(config.clone())
+            .map_err(|e| format!("Invalid resource_discovery config: {e}"))?;
+        // Registry ids must be unique and URLs syntactically valid.
+        let mut seen = std::collections::HashSet::new();
+        for r in &parsed.registries {
+            if r.id.trim().is_empty() {
+                return Err("registry id must not be empty".to_string());
+            }
+            if !seen.insert(r.id.clone()) {
+                return Err(format!("duplicate registry id `{}`", r.id));
+            }
+            if url::Url::parse(&r.url).is_err() {
+                return Err(format!("registry `{}` has an invalid url", r.id));
+            }
+        }
+        for t in &parsed.allow_attach_types {
+            if t != "mcp_server" && t != "a2a_agent" {
+                return Err(format!("unknown allow_attach_types value `{t}`"));
+            }
+        }
+        Ok(())
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        // Default (no config): tools with an empty registry list.
+        self.tools_with_config(&Value::Null)
+    }
+
+    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
+        let cfg = ResourceDiscoveryConfig::from_value(config);
+        vec![
+            Box::new(DiscoverResourcesTool::new(cfg.clone())),
+            Box::new(AttachResourceTool::new(cfg)),
+            Box::new(ListAttachedResourcesTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![CapabilityLocalization::text(
+            "uk",
+            "[Експериментально] Виявлення ресурсів (ARD)",
+            "Знаходьте та підключайте зовнішні можливості (MCP-сервери, A2A-агенти) \
+             через реєстри Agentic Resource Discovery (ARD). ЕКСПЕРИМЕНТАЛЬНО: ця \
+             можливість може змінитися.",
+        )]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_metadata() {
+        let cap = ResourceDiscoveryCapability;
+        assert_eq!(cap.id(), "resource_discovery");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.category(), Some("Network"));
+    }
+
+    #[test]
+    fn capability_has_three_tools() {
+        let cap = ResourceDiscoveryCapability;
+        let names: Vec<String> = cap.tools().iter().map(|t| t.name().to_string()).collect();
+        assert_eq!(names.len(), 3);
+        assert!(names.contains(&"discover_resources".to_string()));
+        assert!(names.contains(&"attach_resource".to_string()));
+        assert!(names.contains(&"list_attached_resources".to_string()));
+    }
+
+    #[test]
+    fn all_tools_require_context() {
+        let cap = ResourceDiscoveryCapability;
+        for tool in cap.tools() {
+            assert!(
+                tool.requires_context(),
+                "tool {} should require context",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn config_schema_present() {
+        let cap = ResourceDiscoveryCapability;
+        let schema = cap.config_schema().unwrap();
+        assert!(schema["properties"]["registries"].is_object());
+        assert!(schema["properties"]["require_trust"].is_object());
+        assert!(schema["properties"]["max_attachments"].is_object());
+        assert!(schema["properties"]["allow_local_urls"].is_object());
+    }
+
+    #[test]
+    fn validate_config_accepts_valid() {
+        let cap = ResourceDiscoveryCapability;
+        let cfg = json!({
+            "registries": [{ "id": "main", "url": "https://ard.example.com" }],
+            "require_trust": true,
+            "max_attachments": 4
+        });
+        assert!(cap.validate_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_config_rejects_duplicate_ids() {
+        let cap = ResourceDiscoveryCapability;
+        let cfg = json!({
+            "registries": [
+                { "id": "x", "url": "https://a.example.com" },
+                { "id": "x", "url": "https://b.example.com" }
+            ]
+        });
+        assert!(cap.validate_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_config_rejects_bad_url() {
+        let cap = ResourceDiscoveryCapability;
+        let cfg = json!({ "registries": [{ "id": "x", "url": "not a url" }] });
+        assert!(cap.validate_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn validate_config_rejects_unknown_attach_type() {
+        let cap = ResourceDiscoveryCapability;
+        let cfg = json!({ "allow_attach_types": ["skill"] });
+        assert!(cap.validate_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn empty_config_is_valid() {
+        let cap = ResourceDiscoveryCapability;
+        assert!(cap.validate_config(&json!({})).is_ok());
+    }
+}

--- a/integrations/ard/src/lib.rs
+++ b/integrations/ard/src/lib.rs
@@ -134,7 +134,7 @@ impl Capability for ResourceDiscoveryCapability {
                             "federation": {
                                 "type": "array",
                                 "items": { "type": "string" },
-                                "description": "Allowlisted registry hostnames this registry may federate to."
+                                "description": "RESERVED / not yet enforced: intended allowlist of registry hostnames this registry may federate to. The client does not follow federated links today, so this has no effect yet."
                             }
                         },
                         "required": ["id", "url"],

--- a/integrations/ard/src/tools.rs
+++ b/integrations/ard/src/tools.rs
@@ -249,21 +249,26 @@ impl AttachResourceTool {
 async fn count_attachments(
     registry: &Arc<dyn SessionResourceRegistry>,
     session_id: SessionId,
-) -> usize {
+) -> Result<usize, String> {
+    // Fail CLOSED: a registry error must not be read as "0 attachments", which
+    // would let an attach bypass `max_attachments` (a stated DoS/sprawl
+    // mitigation). Propagate the error so the caller refuses the attach.
     let mut total = 0usize;
     for kind in RESOURCE_KINDS {
         let filter = SessionResourceFilter {
             kind: Some(kind.to_string()),
             status: None,
         };
-        if let Ok(entries) = registry.list(session_id, Some(&filter)).await {
-            total += entries
-                .iter()
-                .filter(|e| e.status != SessionResourceStatus::Released)
-                .count();
-        }
+        let entries = registry
+            .list(session_id, Some(&filter))
+            .await
+            .map_err(|e| format!("Failed to count current attachments: {e}"))?;
+        total += entries
+            .iter()
+            .filter(|e| e.status != SessionResourceStatus::Released)
+            .count();
     }
-    total
+    Ok(total)
 }
 
 /// SSRF-validate a resolved resource URL, honoring `allow_local_urls`.
@@ -338,18 +343,27 @@ impl Tool for AttachResourceTool {
             );
         };
 
-        // Idempotency: a prior attach of this URN short-circuits.
+        // Idempotency: a prior attach of this URN short-circuits. Normalize the
+        // reported `kind` to the same `config_token` shape a first attach
+        // returns (the registry stores the longer `resource_kind` form).
         if let Ok(Some(existing)) = resource_registry.get(context.session_id, &urn).await {
+            let kind_token = AttachmentKind::from_resource_kind(&existing.kind)
+                .map(|k| k.config_token().to_string())
+                .unwrap_or_else(|| existing.kind.clone());
             return ToolExecutionResult::success(json!({
                 "urn": urn,
                 "status": "already_attached",
-                "kind": existing.kind,
+                "kind": kind_token,
                 "display_name": existing.display_name,
             }));
         }
 
-        // Enforce the per-session cap BEFORE doing remote work.
-        let current = count_attachments(&resource_registry, context.session_id).await;
+        // Enforce the per-session cap BEFORE doing remote work. Fails closed if
+        // the registry can't be read (see count_attachments).
+        let current = match count_attachments(&resource_registry, context.session_id).await {
+            Ok(n) => n,
+            Err(e) => return ToolExecutionResult::internal_error_msg(e),
+        };
         if current >= self.config.max_attachments {
             return ToolExecutionResult::tool_error(format!(
                 "Attachment limit reached ({current}/{}). Detach a resource before attaching another.",
@@ -396,42 +410,17 @@ impl Tool for AttachResourceTool {
 
         let display_name = entry.display_name.clone().unwrap_or_else(|| urn.clone());
 
-        // Materialize: record the session-scoped attachment in the session
-        // resource registry. The runtime consumes session-scoped mcpServers /
-        // external A2A agents from their config layer; recording here gives the
-        // attachment durable, idempotent visibility. (See SPEC.md "Runtime
-        // attach seam" — runtime consumption of tool-attached resources is a
-        // documented follow-up gated on a `SessionMutator` overlay API.)
-        let metadata = json!({
-            "ard_urn": urn,
-            "ard_registry_id": registry.id,
-            "ard_media_type": entry.media_type,
-            "attachment_kind": kind.config_token(),
-            "endpoint_url": resolved_endpoint_url(&entry),
-            "trusted": entry.trust_manifest.is_some(),
-        });
-
-        let register = RegisterSessionResource {
-            session_id: context.session_id,
-            resource_id: urn.clone(),
-            kind: kind.resource_kind().to_string(),
-            display_name: display_name.clone(),
-            status: SessionResourceStatus::Active,
-            metadata,
-        };
-
-        if let Err(e) = resource_registry.register(register).await {
-            return ToolExecutionResult::internal_error_msg(format!(
-                "Failed to record attachment: {e}"
-            ));
-        }
-
         // Runtime attach seam (EVE-593): for an MCP-server resource, persist it
-        // into the session's `mcp_servers` overlay via the SessionMutator. The
-        // server re-resolves that overlay on the next GetTurnContext (and
-        // re-validates + DNS-pins at call time), so the server becomes callable
-        // by the agent on the NEXT turn. The session-resource entry above is
-        // kept for idempotency/visibility.
+        // into the session's `mcp_servers` overlay via the SessionMutator FIRST,
+        // before recording the session-resource entry. The server re-resolves
+        // that overlay on the next GetTurnContext (and re-validates + DNS-pins
+        // at call time), so the server becomes callable by the agent on the
+        // NEXT turn.
+        //
+        // Ordering matters: the upsert is what makes the resource callable, so
+        // it must succeed before we record the attachment. If it fails (or the
+        // mutator is unavailable) we return an error and record NOTHING, rather
+        // than leaving a recorded-but-non-callable entry (partial-attach state).
         //
         // External-A2A attach is an explicit follow-up (needs a new column +
         // resolution hook); see SPEC.md.
@@ -468,6 +457,34 @@ impl Tool for AttachResourceTool {
                 ));
             }
             callable_next_turn = true;
+        }
+
+        // Record the session-scoped attachment in the session resource registry
+        // for durable, idempotent visibility (and to back the `already_attached`
+        // short-circuit above). For MCP servers this runs only after the overlay
+        // upsert above succeeded.
+        let metadata = json!({
+            "ard_urn": urn,
+            "ard_registry_id": registry.id,
+            "ard_media_type": entry.media_type,
+            "attachment_kind": kind.config_token(),
+            "endpoint_url": resolved_endpoint_url(&entry),
+            "trusted": entry.trust_manifest.is_some(),
+        });
+
+        let register = RegisterSessionResource {
+            session_id: context.session_id,
+            resource_id: urn.clone(),
+            kind: kind.resource_kind().to_string(),
+            display_name: display_name.clone(),
+            status: SessionResourceStatus::Active,
+            metadata,
+        };
+
+        if let Err(e) = resource_registry.register(register).await {
+            return ToolExecutionResult::internal_error_msg(format!(
+                "Failed to record attachment: {e}"
+            ));
         }
 
         ToolExecutionResult::success(json!({

--- a/integrations/ard/src/tools.rs
+++ b/integrations/ard/src/tools.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use everruns_core::ToolHints;
+use everruns_core::mcp_server::{ScopedMcpServer, ScopedMcpServers, sanitize_mcp_server_name};
 use everruns_core::session_resource::{
     RegisterSessionResource, SessionResourceFilter, SessionResourceStatus,
 };
@@ -25,7 +26,57 @@ use everruns_core::url_validation::{UrlValidationError, validate_safe_url};
 use serde_json::{Value, json};
 
 use crate::client::RegistryClient;
-use crate::config::{ResolvedEntry, ResourceDiscoveryConfig};
+use crate::config::{AttachmentKind, ResolvedEntry, ResourceDiscoveryConfig};
+
+/// Derive a stable, collision-safe logical name for a scoped MCP server from an
+/// ARD URN.
+///
+/// CRITICAL: the result must survive [`sanitize_mcp_server_name`] without
+/// producing `__` (the reserved MCP tool-prefix delimiter) or an empty string;
+/// otherwise `validate_scoped_mcp_servers` rejects the WHOLE merged set and the
+/// next turn silently drops ALL MCP tools.
+///
+/// Construction (deterministic, no deps):
+/// 1. sanitize the URN (lowercase, non-alphanumeric -> `_`),
+/// 2. collapse runs of `_` to a single `_` and trim — kills any `__`,
+/// 3. bound the human-readable portion,
+/// 4. append `_<fnv1a-hex>` of the raw URN for collision safety (hex is
+///    alphanumeric, so it can never introduce `__`),
+/// 5. prefix a fixed `ard_` namespace.
+fn ard_mcp_server_name(urn: &str) -> String {
+    // FNV-1a (64-bit) — stable across processes/releases, unlike DefaultHasher.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in urn.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    let digest = format!("{hash:016x}");
+
+    let sanitized = sanitize_mcp_server_name(urn);
+    let mut readable = String::with_capacity(sanitized.len());
+    let mut prev_underscore = false;
+    for c in sanitized.chars() {
+        if c == '_' {
+            if !prev_underscore {
+                readable.push('_');
+            }
+            prev_underscore = true;
+        } else {
+            readable.push(c);
+            prev_underscore = false;
+        }
+    }
+    let readable = readable.trim_matches('_');
+    // Bound the readable portion so the full name stays reasonable.
+    let readable: String = readable.chars().take(48).collect();
+    let readable = readable.trim_matches('_');
+
+    if readable.is_empty() {
+        format!("ard_{digest}")
+    } else {
+        format!("ard_{readable}_{digest}")
+    }
+}
 
 /// `kind` values this capability records into the session resource registry.
 const RESOURCE_KINDS: [&str; 2] = ["mcp_server", "external_a2a_agent"];
@@ -369,18 +420,66 @@ impl Tool for AttachResourceTool {
             metadata,
         };
 
-        match resource_registry.register(register).await {
-            Ok(_) => ToolExecutionResult::success(json!({
-                "urn": urn,
-                "status": "attached",
-                "kind": kind.config_token(),
-                "display_name": display_name,
-                "registry_id": registry.id,
-            })),
-            Err(e) => {
-                ToolExecutionResult::internal_error_msg(format!("Failed to record attachment: {e}"))
-            }
+        if let Err(e) = resource_registry.register(register).await {
+            return ToolExecutionResult::internal_error_msg(format!(
+                "Failed to record attachment: {e}"
+            ));
         }
+
+        // Runtime attach seam (EVE-593): for an MCP-server resource, persist it
+        // into the session's `mcp_servers` overlay via the SessionMutator. The
+        // server re-resolves that overlay on the next GetTurnContext (and
+        // re-validates + DNS-pins at call time), so the server becomes callable
+        // by the agent on the NEXT turn. The session-resource entry above is
+        // kept for idempotency/visibility.
+        //
+        // External-A2A attach is an explicit follow-up (needs a new column +
+        // resolution hook); see SPEC.md.
+        let mut callable_next_turn = false;
+        if kind == AttachmentKind::McpServer {
+            let Some(url) = resolved_endpoint_url(&entry) else {
+                return ToolExecutionResult::tool_error(
+                    "MCP server resource has no resolvable endpoint URL.",
+                );
+            };
+            // URL was SSRF-validated above; build a one-entry overlay to MERGE.
+            let server = ScopedMcpServer {
+                url,
+                tool_discovery: true,
+                ..Default::default()
+            };
+            let logical_name = ard_mcp_server_name(&urn);
+            let mut overlay: ScopedMcpServers = Default::default();
+            overlay.insert(logical_name, server);
+
+            // Guard with the same "mutator unavailable" handling the title tool
+            // uses (see crates/core/src/capabilities/session.rs).
+            let Some(mutator) = context.session_mutator.clone() else {
+                return ToolExecutionResult::internal_error_msg(
+                    "session mutator unavailable; cannot make the MCP server callable",
+                );
+            };
+            if let Err(e) = mutator
+                .upsert_session_mcp_servers(context.session_id, overlay)
+                .await
+            {
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to register MCP server for next-turn use: {e}"
+                ));
+            }
+            callable_next_turn = true;
+        }
+
+        ToolExecutionResult::success(json!({
+            "urn": urn,
+            "status": "attached",
+            "kind": kind.config_token(),
+            "display_name": display_name,
+            "registry_id": registry.id,
+            // MCP servers become callable on the next turn; A2A attach is
+            // visibility-only for now (documented follow-up).
+            "callable_next_turn": callable_next_turn,
+        }))
     }
 
     fn requires_context(&self) -> bool {
@@ -617,5 +716,51 @@ mod tests {
     fn attach_is_not_readonly() {
         let tool = AttachResourceTool::new(ResourceDiscoveryConfig::default());
         assert!(!tool.hints().readonly.unwrap_or(false));
+    }
+
+    // ------------------------------------------------------------------
+    // URN -> logical MCP server name derivation (EVE-593)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn ard_mcp_server_name_is_validate_safe() {
+        // The name must survive sanitize_mcp_server_name without producing the
+        // reserved `__` delimiter or an empty prefix; otherwise the server-side
+        // validate_scoped_mcp_servers rejects the whole merged set.
+        for urn in [
+            "urn:ard:example.com:weather-mcp",
+            "urn:ard:EXAMPLE.com::weird///urn", // adjacent separators
+            "urn:ard:單純:漢字",                // non-ascii collapses to underscores
+            "::::",                             // degenerate: sanitizes to all underscores
+            "",                                 // empty
+        ] {
+            let name = ard_mcp_server_name(urn);
+            let sanitized = sanitize_mcp_server_name(&name);
+            assert!(
+                !sanitized.contains("__"),
+                "name {name:?} (sanitized {sanitized:?}) must not contain `__`"
+            );
+            assert!(!sanitized.is_empty(), "name for {urn:?} sanitized empty");
+            assert!(
+                name.starts_with("ard_"),
+                "name {name:?} must carry the ard_ namespace"
+            );
+        }
+    }
+
+    #[test]
+    fn ard_mcp_server_name_is_deterministic() {
+        let a = ard_mcp_server_name("urn:ard:example.com:weather-mcp");
+        let b = ard_mcp_server_name("urn:ard:example.com:weather-mcp");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn ard_mcp_server_name_is_collision_safe() {
+        // Two URNs that sanitize to the same readable prefix must still produce
+        // distinct logical names (the hash suffix disambiguates).
+        let a = ard_mcp_server_name("urn:ard:example.com:weather/mcp");
+        let b = ard_mcp_server_name("urn:ard:example.com:weather:mcp");
+        assert_ne!(a, b, "distinct URNs must not collide: {a} == {b}");
     }
 }

--- a/integrations/ard/src/tools.rs
+++ b/integrations/ard/src/tools.rs
@@ -1,0 +1,621 @@
+//! ARD client tools: `discover_resources`, `attach_resource`, `list_attached_resources`.
+//!
+//! Security model (all enforced here):
+//! - Registry allowlist: the model selects a configured `registry_id`; it can
+//!   never supply a raw registry URL.
+//! - `require_trust`: trust-manifest gate runs before any attach.
+//! - SSRF: every resolved resource URL is validated with the shared
+//!   `validate_safe_url` helper; `allow_local_urls` bypasses ONLY local-address
+//!   blocking and defaults false.
+//! - `max_attachments`: per-session cap, checked against the session resource
+//!   registry.
+//! - All registry-returned text/JSON is treated as untrusted external data.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use everruns_core::ToolHints;
+use everruns_core::session_resource::{
+    RegisterSessionResource, SessionResourceFilter, SessionResourceStatus,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{SessionResourceRegistry, ToolContext};
+use everruns_core::typed_id::SessionId;
+use everruns_core::url_validation::{UrlValidationError, validate_safe_url};
+use serde_json::{Value, json};
+
+use crate::client::RegistryClient;
+use crate::config::{ResolvedEntry, ResourceDiscoveryConfig};
+
+/// `kind` values this capability records into the session resource registry.
+const RESOURCE_KINDS: [&str; 2] = ["mcp_server", "external_a2a_agent"];
+
+// ============================================================================
+// discover_resources
+// ============================================================================
+
+/// Proxies `POST /search` to a configured registry and returns ranked results.
+pub struct DiscoverResourcesTool {
+    config: ResourceDiscoveryConfig,
+}
+
+impl DiscoverResourcesTool {
+    pub fn new(config: ResourceDiscoveryConfig) -> Self {
+        Self { config }
+    }
+}
+
+/// Pick the registry: explicit `registry_id` if given, else the sole configured
+/// one. Returns an error result if ambiguous or unknown.
+fn select_registry<'a>(
+    config: &'a ResourceDiscoveryConfig,
+    registry_id: Option<&str>,
+) -> Result<&'a crate::config::RegistryConfig, ToolExecutionResult> {
+    match registry_id {
+        Some(id) => config.registry(id).ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!(
+                "Unknown registry_id `{id}`. Configured registries: {}",
+                configured_ids(config)
+            ))
+        }),
+        None => match config.registries.as_slice() {
+            [] => Err(ToolExecutionResult::tool_error(
+                "No ARD registries are configured for resource_discovery.",
+            )),
+            [only] => Ok(only),
+            _ => Err(ToolExecutionResult::tool_error(format!(
+                "registry_id is required (multiple registries configured): {}",
+                configured_ids(config)
+            ))),
+        },
+    }
+}
+
+fn configured_ids(config: &ResourceDiscoveryConfig) -> String {
+    config
+        .registries
+        .iter()
+        .map(|r| r.id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[async_trait]
+impl Tool for DiscoverResourcesTool {
+    fn name(&self) -> &str {
+        "discover_resources"
+    }
+
+    fn description(&self) -> &str {
+        "Discover external capabilities (MCP servers, A2A agents) via an Agentic \
+         Resource Discovery (ARD) registry. Returns ranked candidates by URN; use \
+         `attach_resource` to make one usable in this session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Natural-language description of the capability you need."
+                },
+                "filter": {
+                    "type": "object",
+                    "description": "Optional structured filter passed through to the registry.",
+                    "additionalProperties": true
+                },
+                "registry_id": {
+                    "type": "string",
+                    "description": "ID of a configured registry to search. Required when more than one is configured."
+                }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("discover_resources requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        _context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let text = match arguments.get("text").and_then(|v| v.as_str()) {
+            Some(t) if !t.is_empty() => t,
+            _ => return ToolExecutionResult::tool_error("Missing required parameter: text"),
+        };
+        let registry_id = arguments.get("registry_id").and_then(|v| v.as_str());
+        let registry = match select_registry(&self.config, registry_id) {
+            Ok(r) => r,
+            Err(e) => return e,
+        };
+
+        let mut body = json!({ "text": text });
+        if let Some(filter) = arguments.get("filter") {
+            body["filter"] = filter.clone();
+        }
+
+        let client = RegistryClient::new(&registry.url, self.config.allow_local_urls);
+        match client.search(body).await {
+            Ok(resp) => {
+                let results: Vec<Value> = resp
+                    .results
+                    .iter()
+                    .map(|hit| {
+                        json!({
+                            "urn": hit.urn,
+                            "displayName": hit.display_name,
+                            "type": hit.media_type,
+                            "score": hit.score,
+                            "source": registry.id,
+                            "description": hit.description,
+                        })
+                    })
+                    .collect();
+                ToolExecutionResult::success(json!({
+                    "registry_id": registry.id,
+                    "count": results.len(),
+                    "results": results,
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e.to_string()),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// attach_resource
+// ============================================================================
+
+/// Resolves a URN, runs the full security gauntlet, and records a session-scoped
+/// attachment (MCP server or external A2A agent) in the session resource registry.
+pub struct AttachResourceTool {
+    config: ResourceDiscoveryConfig,
+}
+
+impl AttachResourceTool {
+    pub fn new(config: ResourceDiscoveryConfig) -> Self {
+        Self { config }
+    }
+}
+
+/// Count currently-attached ARD resources for a session.
+async fn count_attachments(
+    registry: &Arc<dyn SessionResourceRegistry>,
+    session_id: SessionId,
+) -> usize {
+    let mut total = 0usize;
+    for kind in RESOURCE_KINDS {
+        let filter = SessionResourceFilter {
+            kind: Some(kind.to_string()),
+            status: None,
+        };
+        if let Ok(entries) = registry.list(session_id, Some(&filter)).await {
+            total += entries
+                .iter()
+                .filter(|e| e.status != SessionResourceStatus::Released)
+                .count();
+        }
+    }
+    total
+}
+
+/// SSRF-validate a resolved resource URL, honoring `allow_local_urls`.
+fn validate_resolved_url(url: &str, allow_local_urls: bool) -> Result<(), String> {
+    match validate_safe_url(url) {
+        Ok(_) => Ok(()),
+        Err(UrlValidationError::BlockedHost(_)) if allow_local_urls => Ok(()),
+        Err(e) => Err(format!("Resolved resource URL is not allowed: {e}")),
+    }
+}
+
+#[async_trait]
+impl Tool for AttachResourceTool {
+    fn name(&self) -> &str {
+        "attach_resource"
+    }
+
+    fn description(&self) -> &str {
+        "Attach a discovered ARD resource (by URN) into this session: MCP servers \
+         become session-scoped tool providers and A2A agent cards become external \
+         delegation targets. Verifies trust and validates the resolved endpoint \
+         before attaching. Idempotent per URN."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "urn": {
+                    "type": "string",
+                    "description": "URN of a resource returned by discover_resources."
+                },
+                "registry_id": {
+                    "type": "string",
+                    "description": "ID of the configured registry that surfaced the URN. Required when more than one is configured."
+                }
+            },
+            "required": ["urn"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        // Attaching mutates session state; not read-only. Idempotent per URN.
+        ToolHints::default()
+            .with_idempotent(true)
+            .with_open_world(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("attach_resource requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let urn = match arguments.get("urn").and_then(|v| v.as_str()) {
+            Some(u) if !u.is_empty() => u.to_string(),
+            _ => return ToolExecutionResult::tool_error("Missing required parameter: urn"),
+        };
+        let registry_id = arguments.get("registry_id").and_then(|v| v.as_str());
+        let registry = match select_registry(&self.config, registry_id) {
+            Ok(r) => r,
+            Err(e) => return e,
+        };
+
+        let Some(resource_registry) = context.session_resource_registry.clone() else {
+            return ToolExecutionResult::internal_error_msg(
+                "session resource registry unavailable; cannot attach resources",
+            );
+        };
+
+        // Idempotency: a prior attach of this URN short-circuits.
+        if let Ok(Some(existing)) = resource_registry.get(context.session_id, &urn).await {
+            return ToolExecutionResult::success(json!({
+                "urn": urn,
+                "status": "already_attached",
+                "kind": existing.kind,
+                "display_name": existing.display_name,
+            }));
+        }
+
+        // Enforce the per-session cap BEFORE doing remote work.
+        let current = count_attachments(&resource_registry, context.session_id).await;
+        if current >= self.config.max_attachments {
+            return ToolExecutionResult::tool_error(format!(
+                "Attachment limit reached ({current}/{}). Detach a resource before attaching another.",
+                self.config.max_attachments
+            ));
+        }
+
+        // Resolve from the registry (untrusted response).
+        let client = RegistryClient::new(&registry.url, self.config.allow_local_urls);
+        let entry: ResolvedEntry = match client.resolve(&urn).await {
+            Ok(e) => e,
+            Err(e) => return ToolExecutionResult::tool_error(e.to_string()),
+        };
+
+        // Envelope must be value-or-reference, never both.
+        if let Err(e) = entry.validate_value_or_reference() {
+            return ToolExecutionResult::tool_error(e.to_string());
+        }
+
+        // Media type -> attachment kind, and config must permit it.
+        let kind = match entry.attachment_kind() {
+            Ok(k) => k,
+            Err(e) => return ToolExecutionResult::tool_error(e.to_string()),
+        };
+        if !self.config.allows_kind(kind) {
+            return ToolExecutionResult::tool_error(format!(
+                "Attachment type `{}` is not permitted by resource_discovery config.",
+                kind.config_token()
+            ));
+        }
+
+        // Trust gate before any attach.
+        if let Err(e) = entry.verify_trust(self.config.require_trust) {
+            return ToolExecutionResult::tool_error(e.to_string());
+        }
+
+        // SSRF-validate the resolved endpoint URL (reference form, or a `url`
+        // field inside an inline descriptor).
+        if let Some(url) = resolved_endpoint_url(&entry)
+            && let Err(msg) = validate_resolved_url(&url, self.config.allow_local_urls)
+        {
+            return ToolExecutionResult::tool_error(msg);
+        }
+
+        let display_name = entry.display_name.clone().unwrap_or_else(|| urn.clone());
+
+        // Materialize: record the session-scoped attachment in the session
+        // resource registry. The runtime consumes session-scoped mcpServers /
+        // external A2A agents from their config layer; recording here gives the
+        // attachment durable, idempotent visibility. (See SPEC.md "Runtime
+        // attach seam" — runtime consumption of tool-attached resources is a
+        // documented follow-up gated on a `SessionMutator` overlay API.)
+        let metadata = json!({
+            "ard_urn": urn,
+            "ard_registry_id": registry.id,
+            "ard_media_type": entry.media_type,
+            "attachment_kind": kind.config_token(),
+            "endpoint_url": resolved_endpoint_url(&entry),
+            "trusted": entry.trust_manifest.is_some(),
+        });
+
+        let register = RegisterSessionResource {
+            session_id: context.session_id,
+            resource_id: urn.clone(),
+            kind: kind.resource_kind().to_string(),
+            display_name: display_name.clone(),
+            status: SessionResourceStatus::Active,
+            metadata,
+        };
+
+        match resource_registry.register(register).await {
+            Ok(_) => ToolExecutionResult::success(json!({
+                "urn": urn,
+                "status": "attached",
+                "kind": kind.config_token(),
+                "display_name": display_name,
+                "registry_id": registry.id,
+            })),
+            Err(e) => {
+                ToolExecutionResult::internal_error_msg(format!("Failed to record attachment: {e}"))
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+/// Extract the endpoint URL to SSRF-validate: the reference `url` if present,
+/// else a `url` / `base_url` field inside an inline descriptor.
+fn resolved_endpoint_url(entry: &ResolvedEntry) -> Option<String> {
+    if let Some(url) = &entry.url {
+        return Some(url.clone());
+    }
+    let data = entry.data.as_ref()?;
+    for key in ["url", "base_url", "baseUrl", "endpoint"] {
+        if let Some(s) = data.get(key).and_then(|v| v.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    // For an A2A agent card, the endpoint may live under supported interfaces.
+    if let Some(ifaces) = data.get("supported_interfaces").and_then(|v| v.as_array()) {
+        for iface in ifaces {
+            if let Some(s) = iface.get("url").and_then(|v| v.as_str()) {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
+}
+
+// ============================================================================
+// list_attached_resources
+// ============================================================================
+
+/// Lists ARD attachments recorded for the session.
+pub struct ListAttachedResourcesTool;
+
+#[async_trait]
+impl Tool for ListAttachedResourcesTool {
+    fn name(&self) -> &str {
+        "list_attached_resources"
+    }
+
+    fn description(&self) -> &str {
+        "List external resources (MCP servers, A2A agents) attached to this \
+         session via ARD discovery."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("list_attached_resources requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(registry) = context.session_resource_registry.clone() else {
+            return ToolExecutionResult::success(json!({ "count": 0, "resources": [] }));
+        };
+
+        let mut resources: Vec<Value> = Vec::new();
+        for kind in RESOURCE_KINDS {
+            let filter = SessionResourceFilter {
+                kind: Some(kind.to_string()),
+                status: None,
+            };
+            if let Ok(entries) = registry.list(context.session_id, Some(&filter)).await {
+                for e in entries {
+                    resources.push(json!({
+                        "urn": e.resource_id,
+                        "kind": e.kind,
+                        "display_name": e.display_name,
+                        "status": e.status.to_string(),
+                        "metadata": e.metadata,
+                    }));
+                }
+            }
+        }
+
+        ToolExecutionResult::success(json!({
+            "count": resources.len(),
+            "resources": resources,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RegistryConfig;
+
+    fn cfg(registries: Vec<RegistryConfig>) -> ResourceDiscoveryConfig {
+        ResourceDiscoveryConfig {
+            registries,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn select_registry_requires_id_when_ambiguous() {
+        let c = cfg(vec![
+            RegistryConfig {
+                id: "a".into(),
+                url: "https://a.example".into(),
+                federation: vec![],
+            },
+            RegistryConfig {
+                id: "b".into(),
+                url: "https://b.example".into(),
+                federation: vec![],
+            },
+        ]);
+        assert!(select_registry(&c, None).is_err());
+        assert!(select_registry(&c, Some("a")).is_ok());
+        assert!(select_registry(&c, Some("missing")).is_err());
+    }
+
+    #[test]
+    fn select_registry_defaults_to_sole() {
+        let c = cfg(vec![RegistryConfig {
+            id: "only".into(),
+            url: "https://only.example".into(),
+            federation: vec![],
+        }]);
+        assert_eq!(select_registry(&c, None).unwrap().id, "only");
+    }
+
+    #[test]
+    fn select_registry_errors_when_none_configured() {
+        let c = cfg(vec![]);
+        assert!(select_registry(&c, None).is_err());
+    }
+
+    #[test]
+    fn validate_resolved_url_blocks_local_by_default() {
+        assert!(validate_resolved_url("http://127.0.0.1/mcp", false).is_err());
+        assert!(validate_resolved_url("http://localhost/mcp", false).is_err());
+    }
+
+    #[test]
+    fn validate_resolved_url_allows_local_when_opted_in() {
+        assert!(validate_resolved_url("http://127.0.0.1/mcp", true).is_ok());
+    }
+
+    #[test]
+    fn validate_resolved_url_never_bypasses_scheme() {
+        assert!(validate_resolved_url("file:///etc/passwd", true).is_err());
+    }
+
+    #[test]
+    fn validate_resolved_url_allows_public() {
+        assert!(validate_resolved_url("https://mcp.example.com/v1/mcp", false).is_ok());
+    }
+
+    #[test]
+    fn resolved_endpoint_url_prefers_reference() {
+        let entry = ResolvedEntry {
+            urn: "urn:ard:example.com:foo".into(),
+            display_name: None,
+            media_type: "application/mcp-server+json".into(),
+            url: Some("https://mcp.example.com".into()),
+            data: None,
+            trust_manifest: None,
+        };
+        assert_eq!(
+            resolved_endpoint_url(&entry).as_deref(),
+            Some("https://mcp.example.com")
+        );
+    }
+
+    #[test]
+    fn resolved_endpoint_url_reads_inline_agent_card_interface() {
+        let entry = ResolvedEntry {
+            urn: "urn:ard:example.com:agent".into(),
+            display_name: None,
+            media_type: "application/a2a-agent-card+json".into(),
+            url: None,
+            data: Some(json!({
+                "name": "Agent",
+                "supported_interfaces": [{ "url": "https://agent.example.com/jsonrpc", "type": "JSONRPC" }]
+            })),
+            trust_manifest: None,
+        };
+        assert_eq!(
+            resolved_endpoint_url(&entry).as_deref(),
+            Some("https://agent.example.com/jsonrpc")
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_without_context_errors() {
+        let tool = DiscoverResourcesTool::new(ResourceDiscoveryConfig::default());
+        let r = tool.execute(json!({ "text": "x" })).await;
+        assert!(matches!(r, ToolExecutionResult::ToolError(_)));
+    }
+
+    #[test]
+    fn tools_have_stable_names() {
+        assert_eq!(
+            DiscoverResourcesTool::new(ResourceDiscoveryConfig::default()).name(),
+            "discover_resources"
+        );
+        assert_eq!(
+            AttachResourceTool::new(ResourceDiscoveryConfig::default()).name(),
+            "attach_resource"
+        );
+        assert_eq!(ListAttachedResourcesTool.name(), "list_attached_resources");
+    }
+
+    #[test]
+    fn attach_is_not_readonly() {
+        let tool = AttachResourceTool::new(ResourceDiscoveryConfig::default());
+        assert!(!tool.hints().readonly.unwrap_or(false));
+    }
+}

--- a/integrations/ard/tests/plugin_registration.rs
+++ b/integrations/ard/tests/plugin_registration.rs
@@ -1,0 +1,39 @@
+//! Plugin registration tests: the ARD capability auto-registers via inventory
+//! and is gated to Dev (experimental).
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+use everruns_integrations_ard as _; // force-link the crate so inventory submits run
+
+#[test]
+fn ard_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins
+            .iter()
+            .any(|p| (p.factory)().id() == "resource_discovery"),
+        "resource_discovery IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn ard_plugin_is_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let plugin = plugins
+        .iter()
+        .find(|p| (p.factory)().id() == "resource_discovery")
+        .expect("plugin not found");
+    assert!(plugin.experimental_only);
+}
+
+#[test]
+fn ard_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(registry.has("resource_discovery"));
+}
+
+#[test]
+fn ard_not_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(!registry.has("resource_discovery"));
+}

--- a/integrations/ard/tests/tool_integration.rs
+++ b/integrations/ard/tests/tool_integration.rs
@@ -14,14 +14,46 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use everruns_core::error::Result;
+use everruns_core::mcp_server::ScopedMcpServers;
+use everruns_core::session::Session;
 use everruns_core::session_resource::{
     RegisterSessionResource, SessionResourceEntry, SessionResourceFilter, SessionResourceStatus,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
-use everruns_core::traits::{SessionResourceRegistry, ToolContext};
+use everruns_core::traits::{SessionMutator, SessionResourceRegistry, ToolContext};
 use everruns_core::typed_id::SessionId;
 
 use everruns_integrations_ard::config::{RegistryConfig, ResourceDiscoveryConfig};
+
+// ---------------------------------------------------------------------------
+// Mock SessionMutator — records upsert_session_mcp_servers calls (EVE-593)
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct MockMutator {
+    /// Each recorded upsert overlay, in call order.
+    upserts: Mutex<Vec<ScopedMcpServers>>,
+}
+
+#[async_trait]
+impl SessionMutator for MockMutator {
+    async fn update_session_title(
+        &self,
+        _session_id: SessionId,
+        _title: String,
+    ) -> Result<Session> {
+        unreachable!("attach_resource does not set titles")
+    }
+
+    async fn upsert_session_mcp_servers(
+        &self,
+        _session_id: SessionId,
+        servers: ScopedMcpServers,
+    ) -> Result<()> {
+        self.upserts.lock().await.push(servers);
+        Ok(())
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Mock SessionResourceRegistry
@@ -122,6 +154,12 @@ fn context_with(registry: Arc<MockRegistry>) -> ToolContext {
     ToolContext::new(SessionId::new()).with_session_resource_registry(registry)
 }
 
+fn context_with_mutator(registry: Arc<MockRegistry>, mutator: Arc<MockMutator>) -> ToolContext {
+    ToolContext::new(SessionId::new())
+        .with_session_resource_registry(registry)
+        .with_session_mutator(mutator)
+}
+
 async fn mount_search(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/search"))
@@ -195,9 +233,10 @@ async fn attach_mcp_creates_mcp_server_resource() {
         .await;
 
     let registry = Arc::new(MockRegistry::default());
+    let mutator = Arc::new(MockMutator::default());
     let cfg = config_for(&server.uri(), true, true);
     let tool = attach(cfg);
-    let ctx = context_with(registry.clone());
+    let ctx = context_with_mutator(registry.clone(), mutator.clone());
 
     let result = tool
         .execute_with_context(json!({ "urn": "urn:ard:example.com:weather-mcp" }), &ctx)
@@ -205,6 +244,8 @@ async fn attach_mcp_creates_mcp_server_resource() {
     let value = expect_success(result);
     assert_eq!(value["status"], "attached");
     assert_eq!(value["kind"], "mcp_server");
+    // EVE-593: an MCP attach makes the server callable next turn.
+    assert_eq!(value["callable_next_turn"], true);
 
     let stored = registry
         .get(ctx.session_id, "urn:ard:example.com:weather-mcp")
@@ -212,6 +253,19 @@ async fn attach_mcp_creates_mcp_server_resource() {
         .unwrap()
         .expect("resource recorded");
     assert_eq!(stored.kind, "mcp_server");
+
+    // Exactly one upsert, carrying the SSRF-validated URL and a sane name.
+    let upserts = mutator.upserts.lock().await;
+    assert_eq!(upserts.len(), 1, "exactly one upsert call");
+    let overlay = &upserts[0];
+    assert_eq!(overlay.len(), 1);
+    let (name, scoped) = overlay.iter().next().unwrap();
+    assert!(name.starts_with("ard_"), "logical name: {name}");
+    assert!(
+        !everruns_core::mcp_server::sanitize_mcp_server_name(name).contains("__"),
+        "name {name} would be rejected by validation"
+    );
+    assert_eq!(scoped.url, "https://mcp.example.com/v1/mcp");
 }
 
 #[tokio::test]
@@ -233,15 +287,22 @@ async fn attach_a2a_creates_external_agent_resource() {
         .await;
 
     let registry = Arc::new(MockRegistry::default());
+    let mutator = Arc::new(MockMutator::default());
     let cfg = config_for(&server.uri(), true, true);
     let tool = attach(cfg);
-    let ctx = context_with(registry.clone());
+    let ctx = context_with_mutator(registry.clone(), mutator.clone());
 
     let result = tool
         .execute_with_context(json!({ "urn": "urn:ard:example.com:research-agent" }), &ctx)
         .await;
     let value = expect_success(result);
     assert_eq!(value["kind"], "a2a_agent");
+    // A2A attach is visibility-only for now — no MCP overlay upsert.
+    assert_eq!(value["callable_next_turn"], false);
+    assert!(
+        mutator.upserts.lock().await.is_empty(),
+        "A2A attach must not upsert MCP servers"
+    );
 
     let stored = registry
         .get(ctx.session_id, "urn:ard:example.com:research-agent")
@@ -288,11 +349,77 @@ async fn attach_blocks_local_url_unless_allowed() {
     let ok = attach(cfg2)
         .execute_with_context(
             json!({ "urn": "urn:ard:example.com:local-mcp" }),
-            &context_with(Arc::new(MockRegistry::default())),
+            &context_with_mutator(
+                Arc::new(MockRegistry::default()),
+                Arc::new(MockMutator::default()),
+            ),
         )
         .await;
     let value = expect_success(ok);
     assert_eq!(value["status"], "attached");
+}
+
+#[tokio::test]
+async fn attach_with_unsafe_url_does_not_upsert() {
+    // SSRF write-time validation rejects a non-local-but-disallowed scheme
+    // before any registry record or MCP overlay upsert happens.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:bad-scheme",
+            "type": "application/mcp-server+json",
+            "url": "file:///etc/passwd",
+            "trustManifest": { "identity": "example.com", "attestation": "sig" }
+        })))
+        .mount(&server)
+        .await;
+
+    let registry = Arc::new(MockRegistry::default());
+    let mutator = Arc::new(MockMutator::default());
+    let cfg = config_for(&server.uri(), true, true);
+    let result = attach(cfg)
+        .execute_with_context(
+            json!({ "urn": "urn:ard:example.com:bad-scheme" }),
+            &context_with_mutator(registry.clone(), mutator.clone()),
+        )
+        .await;
+    assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+    assert!(
+        mutator.upserts.lock().await.is_empty(),
+        "unsafe URL must not upsert"
+    );
+}
+
+#[tokio::test]
+async fn attach_mcp_without_mutator_errors_and_does_not_attach() {
+    // When the host did not supply a SessionMutator, an MCP attach must fail
+    // loudly rather than silently recording a non-callable resource.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:weather-mcp",
+            "type": "application/mcp-server+json",
+            "url": "https://mcp.example.com/v1/mcp",
+            "trustManifest": { "identity": "example.com", "attestation": "sig" }
+        })))
+        .mount(&server)
+        .await;
+
+    let registry = Arc::new(MockRegistry::default());
+    let cfg = config_for(&server.uri(), true, true);
+    // context_with does NOT attach a session_mutator.
+    let result = attach(cfg)
+        .execute_with_context(
+            json!({ "urn": "urn:ard:example.com:weather-mcp" }),
+            &context_with(registry.clone()),
+        )
+        .await;
+    assert!(
+        matches!(result, ToolExecutionResult::InternalError(_)),
+        "expected internal error when mutator is unavailable, got {result:?}"
+    );
 }
 
 #[tokio::test]
@@ -338,8 +465,9 @@ async fn attach_is_idempotent_per_urn() {
         .await;
 
     let registry = Arc::new(MockRegistry::default());
+    let mutator = Arc::new(MockMutator::default());
     let cfg = config_for(&server.uri(), true, true);
-    let ctx = context_with(registry.clone());
+    let ctx = context_with_mutator(registry.clone(), mutator.clone());
 
     let first = attach(cfg.clone())
         .execute_with_context(json!({ "urn": "urn:ard:example.com:weather-mcp" }), &ctx)

--- a/integrations/ard/tests/tool_integration.rs
+++ b/integrations/ard/tests/tool_integration.rs
@@ -498,10 +498,15 @@ async fn attach_enforces_max_attachments() {
         .await;
 
     let registry = Arc::new(MockRegistry::default());
-    // Pre-seed one attachment so the cap of 1 is already hit.
+    let mut cfg = config_for(&server.uri(), true, true);
+    cfg.max_attachments = 1;
+    let ctx = context_with(registry.clone());
+    // Pre-seed one attachment UNDER THE CONTEXT'S SESSION so the cap of 1 is
+    // already hit. count_attachments is session-scoped, so seeding a different
+    // SessionId would not be counted and the cap check wouldn't fire.
     registry
         .register(RegisterSessionResource {
-            session_id: SessionId::new(),
+            session_id: ctx.session_id,
             resource_id: "urn:ard:example.com:first-mcp".into(),
             kind: "mcp_server".into(),
             display_name: "First".into(),
@@ -510,10 +515,6 @@ async fn attach_enforces_max_attachments() {
         })
         .await
         .unwrap();
-
-    let mut cfg = config_for(&server.uri(), true, true);
-    cfg.max_attachments = 1;
-    let ctx = context_with(registry.clone());
 
     let result = attach(cfg)
         .execute_with_context(json!({ "urn": "urn:ard:example.com:second-mcp" }), &ctx)

--- a/integrations/ard/tests/tool_integration.rs
+++ b/integrations/ard/tests/tool_integration.rs
@@ -1,0 +1,406 @@
+//! Integration tests for the ARD client tools against a wiremock registry.
+//!
+//! Covers: discover ranking, MCP attach -> `mcp_server` resource, A2A attach ->
+//! `external_a2a_agent` resource, local-URL blocking (and the opt-in bypass),
+//! trust-gate rejection, idempotency, and the `max_attachments` cap.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use everruns_core::error::Result;
+use everruns_core::session_resource::{
+    RegisterSessionResource, SessionResourceEntry, SessionResourceFilter, SessionResourceStatus,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{SessionResourceRegistry, ToolContext};
+use everruns_core::typed_id::SessionId;
+
+use everruns_integrations_ard::config::{RegistryConfig, ResourceDiscoveryConfig};
+
+// ---------------------------------------------------------------------------
+// Mock SessionResourceRegistry
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct MockRegistry {
+    entries: Mutex<HashMap<String, SessionResourceEntry>>,
+}
+
+#[async_trait]
+impl SessionResourceRegistry for MockRegistry {
+    async fn register(&self, entry: RegisterSessionResource) -> Result<SessionResourceEntry> {
+        let now = chrono::Utc::now();
+        let stored = SessionResourceEntry {
+            resource_id: entry.resource_id.clone(),
+            session_id: entry.session_id,
+            kind: entry.kind,
+            display_name: entry.display_name,
+            status: entry.status,
+            metadata: entry.metadata,
+            created_at: now,
+            updated_at: now,
+        };
+        self.entries
+            .lock()
+            .await
+            .insert(entry.resource_id, stored.clone());
+        Ok(stored)
+    }
+
+    async fn update_status(
+        &self,
+        _session_id: SessionId,
+        resource_id: &str,
+        status: SessionResourceStatus,
+    ) -> Result<Option<SessionResourceEntry>> {
+        let mut map = self.entries.lock().await;
+        if let Some(e) = map.get_mut(resource_id) {
+            e.status = status;
+            return Ok(Some(e.clone()));
+        }
+        Ok(None)
+    }
+
+    async fn get(
+        &self,
+        _session_id: SessionId,
+        resource_id: &str,
+    ) -> Result<Option<SessionResourceEntry>> {
+        Ok(self.entries.lock().await.get(resource_id).cloned())
+    }
+
+    async fn list(
+        &self,
+        _session_id: SessionId,
+        filter: Option<&SessionResourceFilter>,
+    ) -> Result<Vec<SessionResourceEntry>> {
+        let map = self.entries.lock().await;
+        Ok(map
+            .values()
+            .filter(|e| match filter {
+                Some(f) => f.kind.as_deref().is_none_or(|k| k == e.kind),
+                None => true,
+            })
+            .cloned()
+            .collect())
+    }
+
+    async fn deregister(&self, _session_id: SessionId, resource_id: &str) -> Result<bool> {
+        Ok(self.entries.lock().await.remove(resource_id).is_some())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn config_for(
+    server_uri: &str,
+    allow_local_urls: bool,
+    require_trust: bool,
+) -> ResourceDiscoveryConfig {
+    ResourceDiscoveryConfig {
+        registries: vec![RegistryConfig {
+            id: "main".into(),
+            url: server_uri.to_string(),
+            federation: vec![],
+        }],
+        require_trust,
+        allow_attach_types: vec![],
+        max_attachments: 8,
+        allow_local_urls,
+    }
+}
+
+fn context_with(registry: Arc<MockRegistry>) -> ToolContext {
+    ToolContext::new(SessionId::new()).with_session_resource_registry(registry)
+}
+
+async fn mount_search(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [
+                {
+                    "urn": "urn:ard:example.com:weather-mcp",
+                    "display_name": "Weather MCP",
+                    "type": "application/mcp-server+json",
+                    "score": 0.92,
+                    "description": "Weather data via MCP"
+                },
+                {
+                    "urn": "urn:ard:example.com:research-agent",
+                    "display_name": "Research Agent",
+                    "type": "application/a2a-agent-card+json",
+                    "score": 0.71,
+                    "description": "External research agent"
+                }
+            ]
+        })))
+        .mount(server)
+        .await;
+}
+
+fn discover(cfg: ResourceDiscoveryConfig) -> impl Tool {
+    everruns_integrations_ard::test_support::discover_tool(cfg)
+}
+
+fn attach(cfg: ResourceDiscoveryConfig) -> impl Tool {
+    everruns_integrations_ard::test_support::attach_tool(cfg)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn discover_returns_ranked_results() {
+    let server = MockServer::start().await;
+    mount_search(&server).await;
+
+    let cfg = config_for(&server.uri(), true, true);
+    let tool = discover(cfg);
+    let ctx = context_with(Arc::new(MockRegistry::default()));
+
+    let result = tool
+        .execute_with_context(json!({ "text": "weather" }), &ctx)
+        .await;
+    let value = expect_success(result);
+    assert_eq!(value["count"], 2);
+    let results = value["results"].as_array().unwrap();
+    assert_eq!(results[0]["urn"], "urn:ard:example.com:weather-mcp");
+    assert_eq!(results[0]["source"], "main");
+    assert!(results[0]["score"].as_f64().unwrap() > results[1]["score"].as_f64().unwrap());
+}
+
+#[tokio::test]
+async fn attach_mcp_creates_mcp_server_resource() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:weather-mcp",
+            "display_name": "Weather MCP",
+            "type": "application/mcp-server+json",
+            "url": "https://mcp.example.com/v1/mcp",
+            "trustManifest": { "identity": "example.com", "attestation": "sig" }
+        })))
+        .mount(&server)
+        .await;
+
+    let registry = Arc::new(MockRegistry::default());
+    let cfg = config_for(&server.uri(), true, true);
+    let tool = attach(cfg);
+    let ctx = context_with(registry.clone());
+
+    let result = tool
+        .execute_with_context(json!({ "urn": "urn:ard:example.com:weather-mcp" }), &ctx)
+        .await;
+    let value = expect_success(result);
+    assert_eq!(value["status"], "attached");
+    assert_eq!(value["kind"], "mcp_server");
+
+    let stored = registry
+        .get(ctx.session_id, "urn:ard:example.com:weather-mcp")
+        .await
+        .unwrap()
+        .expect("resource recorded");
+    assert_eq!(stored.kind, "mcp_server");
+}
+
+#[tokio::test]
+async fn attach_a2a_creates_external_agent_resource() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:research-agent",
+            "display_name": "Research Agent",
+            "type": "application/a2a-agent-card+json",
+            "data": {
+                "name": "Research Agent",
+                "supported_interfaces": [{ "url": "https://agent.example.com/jsonrpc", "type": "JSONRPC" }]
+            },
+            "trustManifest": { "identity": "example.com", "attestation": "sig" }
+        })))
+        .mount(&server)
+        .await;
+
+    let registry = Arc::new(MockRegistry::default());
+    let cfg = config_for(&server.uri(), true, true);
+    let tool = attach(cfg);
+    let ctx = context_with(registry.clone());
+
+    let result = tool
+        .execute_with_context(json!({ "urn": "urn:ard:example.com:research-agent" }), &ctx)
+        .await;
+    let value = expect_success(result);
+    assert_eq!(value["kind"], "a2a_agent");
+
+    let stored = registry
+        .get(ctx.session_id, "urn:ard:example.com:research-agent")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.kind, "external_a2a_agent");
+}
+
+#[tokio::test]
+async fn attach_blocks_local_url_unless_allowed() {
+    let make_server = || async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/resolve"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "urn": "urn:ard:example.com:local-mcp",
+                "type": "application/mcp-server+json",
+                "url": "http://127.0.0.1:9000/mcp",
+                "trustManifest": { "identity": "example.com", "attestation": "sig" }
+            })))
+            .mount(&server)
+            .await;
+        server
+    };
+
+    // Blocked by default. allow_local_urls must still be true for the *registry*
+    // base (wiremock is on localhost); the resolved resource URL is what we test.
+    let server = make_server().await;
+    let cfg = config_for(&server.uri(), false, true);
+    // Registry base on localhost would itself be blocked, so this exercises the
+    // registry-side block. Verify it errors.
+    let blocked = attach(cfg)
+        .execute_with_context(
+            json!({ "urn": "urn:ard:example.com:local-mcp" }),
+            &context_with(Arc::new(MockRegistry::default())),
+        )
+        .await;
+    assert!(matches!(blocked, ToolExecutionResult::ToolError(_)));
+
+    // With allow_local_urls = true, registry + resolved local URL both pass.
+    let server2 = make_server().await;
+    let cfg2 = config_for(&server2.uri(), true, true);
+    let ok = attach(cfg2)
+        .execute_with_context(
+            json!({ "urn": "urn:ard:example.com:local-mcp" }),
+            &context_with(Arc::new(MockRegistry::default())),
+        )
+        .await;
+    let value = expect_success(ok);
+    assert_eq!(value["status"], "attached");
+}
+
+#[tokio::test]
+async fn attach_rejected_when_trust_missing_and_required() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:untrusted",
+            "type": "application/mcp-server+json",
+            "url": "https://mcp.example.com/v1/mcp"
+        })))
+        .mount(&server)
+        .await;
+
+    let cfg = config_for(&server.uri(), true, true); // require_trust = true
+    let result = attach(cfg)
+        .execute_with_context(
+            json!({ "urn": "urn:ard:example.com:untrusted" }),
+            &context_with(Arc::new(MockRegistry::default())),
+        )
+        .await;
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.to_lowercase().contains("trust"), "got: {msg}");
+        }
+        other => panic!("expected trust rejection, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn attach_is_idempotent_per_urn() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:weather-mcp",
+            "type": "application/mcp-server+json",
+            "url": "https://mcp.example.com/v1/mcp",
+            "trustManifest": { "identity": "example.com", "attestation": "sig" }
+        })))
+        .mount(&server)
+        .await;
+
+    let registry = Arc::new(MockRegistry::default());
+    let cfg = config_for(&server.uri(), true, true);
+    let ctx = context_with(registry.clone());
+
+    let first = attach(cfg.clone())
+        .execute_with_context(json!({ "urn": "urn:ard:example.com:weather-mcp" }), &ctx)
+        .await;
+    assert_eq!(expect_success(first)["status"], "attached");
+
+    let second = attach(cfg)
+        .execute_with_context(json!({ "urn": "urn:ard:example.com:weather-mcp" }), &ctx)
+        .await;
+    assert_eq!(expect_success(second)["status"], "already_attached");
+
+    let all = registry.list(ctx.session_id, None).await.unwrap();
+    assert_eq!(all.len(), 1);
+}
+
+#[tokio::test]
+async fn attach_enforces_max_attachments() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "urn": "urn:ard:example.com:second-mcp",
+            "type": "application/mcp-server+json",
+            "url": "https://mcp.example.com/v1/mcp",
+            "trustManifest": { "identity": "example.com", "attestation": "sig" }
+        })))
+        .mount(&server)
+        .await;
+
+    let registry = Arc::new(MockRegistry::default());
+    // Pre-seed one attachment so the cap of 1 is already hit.
+    registry
+        .register(RegisterSessionResource {
+            session_id: SessionId::new(),
+            resource_id: "urn:ard:example.com:first-mcp".into(),
+            kind: "mcp_server".into(),
+            display_name: "First".into(),
+            status: SessionResourceStatus::Active,
+            metadata: json!({}),
+        })
+        .await
+        .unwrap();
+
+    let mut cfg = config_for(&server.uri(), true, true);
+    cfg.max_attachments = 1;
+    let ctx = context_with(registry.clone());
+
+    let result = attach(cfg)
+        .execute_with_context(json!({ "urn": "urn:ard:example.com:second-mcp" }), &ctx)
+        .await;
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("limit"), "got: {msg}");
+        }
+        other => panic!("expected cap rejection, got {other:?}"),
+    }
+}
+
+fn expect_success(result: ToolExecutionResult) -> Value {
+    match result {
+        ToolExecutionResult::Success(v) => v,
+        other => panic!("expected success, got {other:?}"),
+    }
+}

--- a/specs/README.md
+++ b/specs/README.md
@@ -84,6 +84,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/mcp-servers.md` - MCP client remote server registration, CRUD API, tool naming, execution
 - `specs/runtime-mcp.md` - MCP client in the in-process runtime: shared `everruns-mcp` crate, transport abstraction (HTTP + optional stdio), pluggable auth
 - `specs/integrations.md` - Integration specs index
+- `integrations/ard/SPEC.md` - Agentic Resource Discovery (ARD) client: `resource_discovery` capability for discovering/attaching external MCP servers and A2A agents
 - `specs/apps.md` - Apps system
 - `specs/app-invocation-channels.md` - App schedule/webhook invocation channels
 - `specs/app-endpoint-auth.md` - Shared inbound auth framework for App-published endpoints

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -67,6 +67,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Sprites | [`integrations/sprites/SPEC.md`](../integrations/sprites/SPEC.md) | Persistent Firecracker microVMs via Sprites (Fly.io). Persistent filesystem, checkpoints, HTTP services. |
 | Cursor | [`integrations/cursor/SPEC.md`](../integrations/cursor/SPEC.md) | Cursor Cloud Agents API for launching and managing asynchronous coding agents on GitHub repositories. |
 | Docker | `integrations/docker/` | Container-based agent execution. Experimental (Dev only). No spec yet. |
+| Resource Discovery (ARD) | [`integrations/ard/SPEC.md`](../integrations/ard/SPEC.md) | `resource_discovery` capability: discover and attach external MCP servers / A2A agents via operator-configured Agentic Resource Discovery registries, with trust gate, SSRF validation, and attachment caps. Experimental (Dev only). |
 
 ## Messaging Integrations (`crates/server/`)
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1360,6 +1360,36 @@ Installed plugins (`specs/plugins.md`) compile third-party remote content into a
 **TM-PLUGIN-002 — Pinned compile-at-install model:**
 The capability that agents execute is the compiled `definition` JSONB persisted in `plugin_installs` at install/update time. Upstream changes to the source repository have no effect on running agents until an admin explicitly updates, at which point the content is re-fetched at the marketplace's current synced SHA and re-validated end to end. This is the same trust shape as a lockfile: sync moves the candidate version; update moves the installed one.
 
+## 27. Resource Discovery (ARD) (TM-ARD)
+
+The `resource_discovery` capability (`integrations/ard/`) is an ARD *client*: it
+fetches search results and resource envelopes from operator-configured external
+registries and, on attach, records a session-scoped MCP server / external A2A
+agent. Registry responses are untrusted external content (prompt-injection and
+SSRF surface), and the model drives discovery. ARD is a source for existing
+config/attach machinery — it does not modify the agent loop or add migrations.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-API-021 | SSRF via attacker-influenced registry or resolved resource URL | High | The model selects an operator-configured `registry_id` and can never supply a raw URL; registry base and every resolved endpoint URL pass `url_validation::validate_safe_url` (loopback, RFC1918, link-local, cloud-metadata, CGNAT, IPv4-mapped IPv6 blocked). `allow_local_urls` (default false) bypasses only local-address blocking, never scheme/parse rejection. See `integrations/ard/src/{client,tools}.rs`. | MITIGATED |
+| TM-TOOL-022 | Malicious/poisoned registry content (spoofed entry, value-and-reference confusion, unsupported type) | Medium | All `/search` and `/resolve` payloads treated as untrusted; envelopes must be value-or-reference (entries with both `url` and `data` rejected); media type must map to a supported attachment kind (`mcp_server`/`a2a_agent`); registry text is never executed. | MITIGATED |
+| TM-AGENT-025 | Trust spoofing — attaching a resource whose identity is forged | Medium | Trust gate: when `require_trust` (default on), a trust manifest with an attestation must be present and its identity must match the resource URN's authority domain (subdomain match only). Cryptographic attestation verification is structural in this increment (presence + identity) with full signature verification a documented follow-up. | PARTIAL |
+| TM-DOS-019 | Resource sprawl / repeated attaches exhausting session config | Medium | `max_attachments` per-session cap enforced before remote work; attaches are idempotent per URN (recorded by URN in the session resource registry). | MITIGATED |
+
+### Mitigation Details
+
+**TM-API-021 — ARD SSRF controls:** The registry allowlist is the primary
+control: configs hold operator-trusted registry base URLs keyed by id, and the
+tool schema only accepts a `registry_id`, so the model cannot point the server
+at an arbitrary host. The resolved resource endpoint (the reference `url`, or a
+`url`/`base_url`/interface URL inside an inline descriptor) is independently
+SSRF-validated before the attachment is recorded.
+
+**TM-AGENT-025 — Trust gate (PARTIAL):** Identity-to-URN-domain binding and
+attestation presence are enforced now; verifying the attestation's cryptographic
+signature against the claimed identity is the remaining work and is tracked as an
+ARD follow-up.
+
 ## Vulnerability Summary
 
 ### Open Threats (Require Action)

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1365,9 +1365,17 @@ The capability that agents execute is the compiled `definition` JSONB persisted 
 The `resource_discovery` capability (`integrations/ard/`) is an ARD *client*: it
 fetches search results and resource envelopes from operator-configured external
 registries and, on attach, records a session-scoped MCP server / external A2A
-agent. Registry responses are untrusted external content (prompt-injection and
-SSRF surface), and the model drives discovery. ARD is a source for existing
-config/attach machinery — it does not modify the agent loop or add migrations.
+agent. For an MCP-server attach it also persists the SSRF-validated server into
+the session's `mcp_servers` overlay so it becomes callable on the **next turn**
+(EVE-593); the write goes through a dedicated internal worker RPC
+(`UpsertSessionMcpServers`) that re-runs `validate_scoped_mcp_servers`
+server-side and is org-scoped via `Caller::internal(org_id)` + storage
+`WHERE org_id`. The next `GetTurnContext` re-resolves and re-validates the
+overlay and DNS-pins at call time via the standard scoped-MCP client. External
+A2A attach remains visibility-only (consumption is a documented follow-up).
+Registry responses are untrusted external content (prompt-injection and SSRF
+surface), and the model drives discovery. ARD reuses existing config/attach +
+session-mutation machinery — it does not modify the agent loop or add migrations.
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|


### PR DESCRIPTION
## What

Implements EVE-593 — Agentic Resource Discovery (ARD) **as a client**, end to end. An agent can discover external capabilities via operator-configured ARD registries and **attach an MCP server so it becomes callable on the next turn**.

Two commits:
1. **Groundwork** — the `everruns-integrations-ard` crate (`resource_discovery` capability, experimental/Dev-grade): `discover_resources`, `attach_resource`, `list_attached_resources`, backed by operator-configured registries, with the full SSRF/trust/value-or-reference/cap security gauntlet. (This was prepared earlier; rebased onto current main.)
2. **Runtime attach seam** — makes an attached MCP server actually callable (the piece EVE-593 was blocked on).

Closes EVE-593. (External-A2A attach remains visibility-only — a documented follow-up; it needs a new session-scoped store + resolution hook.)

## The attach seam (commit 2)

Key finding: the session's `mcp_servers` JSONB column **already exists** and the server **re-resolves + re-validates it on every `GetTurnContext`** (and DNS-pins at call time). So making a discovered server callable is just: persist it into that overlay. **No DB migration, no worker turn-start change.**

- **core** — `SessionMutator::upsert_session_mcp_servers(session_id, ScopedMcpServers)`: MERGE (last-wins by logical name), not replace. Mirrored across every impl (in-memory, mocks, worker adapters).
- **proto** — new internal `UpsertSessionMcpServers` worker RPC (Struct payload, empty response). A dedicated RPC because `SetSessionTitle`'s response `Session` doesn't carry `mcp_servers`.
- **server handler** — decode → load session (org-scoped `Caller::internal(org_id)`) → merge into `session.mcp_servers` → `validate_scoped_mcp_servers` (rejects stdio/unsafe-URL/dup names) → persist via `UpdateSession.mcp_servers`. The Direct (in-process) adapter does the same.
- **storage** — `UpdateSession.mcp_servers` + `update_session` SET `mcp_servers = COALESCE($N, mcp_servers)` (PG, runtime query — no sqlx offline data) and in-memory parity.
- **ARD wiring** — after the existing security gauntlet, an `mcp_server` attach builds a one-entry HTTP `ScopedMcpServer` from the SSRF-validated URL and calls the mutator. Returns `callable_next_turn`.

### Safe logical-name derivation
`ard_mcp_server_name(urn)` = `ard_<readable>_<fnv1a-hex>`. CRITICAL constraint: the name must survive `sanitize_mcp_server_name` without producing the reserved `__` delimiter or an empty string (else `validate_scoped_mcp_servers` rejects the whole merged set and the turn silently drops all MCP tools). The readable part collapses `_`-runs and is bounded; the FNV-1a hex (stable across processes, alphanumeric) guarantees non-empty + collision-safe. Unit-tested against adversarial URNs (`::::`, empty, non-ascii, adjacent separators).

## Security

- **Tenant scoping (TM-TENANT/TM-AGENT)**: the RPC carries `org_id`; the handler reads + writes the session under `Caller::internal(org_id)` and the storage update is org-scoped.
- **SSRF**: the model never supplies a raw URL (selects a configured `registry_id`); resolved endpoints are `validate_safe_url`-checked write-time, **re-validated** server-side on upsert (`validate_scoped_mcp_servers`), and **DNS-pinned at call time** for free (the attached server flows through the standard scoped-MCP execution path).
- **Untrusted registry data**, trust gate, `max_attachments` cap — all preserved from the groundwork.
- `specs/threat-model.md` ARD section updated to reflect the now-consuming attach.

## Validation

- `cargo fmt --check`, full-workspace `clippy -D warnings`, Cargo.lock, migration ordering (001..074 — **no migration**) + immutability, specs index, attribution — all green.
- Tests: core merge-not-replace; ARD name derivation (deterministic / collision-safe / validate-safe) + wiremock attach→upsert paths + failure-no-upsert; storage round-trip (SQL + memory); **gRPC end-to-end** — upsert → next `GetTurnContext` resolution includes the attached server; stdio/invalid rejected and not persisted.

## Follow-ups

- External-A2A attach (needs a session-scoped external-agent store + resolution hook + migration).
- Cryptographic attestation verification (currently structural presence + identity match).
- ARD connection-provider + live API tests + dedicated live workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAaTy59HiBBiQnqM58nj6Z)_