### PR TITLE
chore: use SeaweedFS instead of MinIO for S3 blob backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,7 +780,8 @@ jobs:
           for i in {1..30}; do
             # Any HTTP response (incl. 403 from the unauthenticated ListBuckets)
             # means the S3 gateway is up; curl exits 0 once the port answers.
-            if curl -s -o /dev/null http://localhost:9000/; then
+            # Bounded per attempt so a stalled connect can't hang the job.
+            if curl -s -o /dev/null --connect-timeout 5 --max-time 10 http://localhost:9000/; then
               echo "SeaweedFS is ready!"
               ready=1
               break

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
             # S3 blob-backend integration coverage. Narrow on purpose so the
-            # MinIO-backed job only runs when the object-storage offload code,
+            # SeaweedFS-backed job only runs when the object-storage offload code,
             # its sidecar migration, or the harness/workflow that drives it
             # changes — it should not burn CI on unrelated PRs.
             object_storage:
@@ -616,9 +616,9 @@ jobs:
       # Blob-offload suite against the in-memory object_store backend (no S3
       # container). Exercises the same offload code paths the S3 job covers,
       # giving every PostgreSQL PR coverage of the offload invariants without an
-      # S3/MinIO container (the PostgreSQL service container is still used). The
-      # dedicated `s3-integration-test` job re-runs the
-      # identical suite with STORAGE_BLOB_BACKEND=s3 against MinIO.
+      # S3/SeaweedFS container (the PostgreSQL service container is still used).
+      # The dedicated `s3-integration-test` job re-runs the
+      # identical suite with STORAGE_BLOB_BACKEND=s3 against SeaweedFS.
       - name: Run blob offload integration tests (in-memory backend)
         run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1
 
@@ -686,7 +686,8 @@ jobs:
   # S3 blob-backend integration tests.
   # The PostgreSQL `integration-test` job above only exercises the inline
   # (STORAGE_BLOB_BACKEND=db) storage path. This job brings up a real
-  # S3-compatible object store (MinIO) alongside PostgreSQL and runs the
+  # S3-compatible object store (SeaweedFS, matching local dev) alongside
+  # PostgreSQL and runs the
   # backend-agnostic offload suite with STORAGE_BLOB_BACKEND=s3 so the
   # object-storage offload code (create/read/update/CAS/move/copy/delete,
   # materialization, org-scoped image delete guard) is covered against the real
@@ -710,9 +711,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      # MinIO is started as a `docker run` step (see "Start MinIO" below) rather
-      # than a service container, because the upstream minio/minio image needs a
-      # `server /data` command and GH service containers cannot express a command.
+      # SeaweedFS is started as a `docker run` step (see "Start SeaweedFS"
+      # below) rather than a service container, because the upstream seaweedfs
+      # image needs a `server -s3` command and GH service containers cannot
+      # express a command.
 
     env:
       DATABASE_URL: postgres://everruns:everruns@localhost:5432/everruns_test
@@ -759,34 +761,52 @@ jobs:
       - name: Run migrations
         run: sqlx migrate run --source crates/server/migrations
 
-      - name: Start MinIO and create the bucket
+      - name: Start SeaweedFS and create the bucket
         run: |
-          # Ephemeral S3-compatible store for this job only. `latest` is used
+          # Ephemeral S3-compatible store for this job only, matching the
+          # SeaweedFS backend used in local dev (scripts/lib/seaweedfs.sh). The
+          # S3 gateway runs on the container's :8333, mapped to host :9000 so
+          # STORAGE_S3_ENDPOINT stays unchanged. The same identities config the
+          # local script uses supplies the static credentials. `latest` is used
           # deliberately: these are throwaway test containers (no production
           # surface), and it avoids pinning to an unverifiable date-stamped tag.
-          docker run -d --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=everruns \
-            -e MINIO_ROOT_PASSWORD=everruns-secret \
-            minio/minio:latest server /data
-          echo "Waiting for MinIO to accept S3 requests..."
+          docker run -d --name seaweedfs \
+            -p 9000:8333 \
+            -v "${{ github.workspace }}/local/seaweedfs-s3-config.json:/etc/seaweedfs/s3.json:ro" \
+            chrislusf/seaweedfs:latest \
+            server -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3.json
+          echo "Waiting for SeaweedFS to accept S3 requests..."
           ready=
           for i in {1..30}; do
-            if curl -fsS http://localhost:9000/minio/health/live > /dev/null 2>&1; then
-              echo "MinIO is ready!"
+            # Any HTTP response (incl. 403 from the unauthenticated ListBuckets)
+            # means the S3 gateway is up; curl exits 0 once the port answers.
+            if curl -s -o /dev/null http://localhost:9000/; then
+              echo "SeaweedFS is ready!"
               ready=1
               break
             fi
-            echo "Attempt $i: MinIO not ready yet..."
+            echo "Attempt $i: SeaweedFS not ready yet..."
             sleep 2
           done
           if [ -z "$ready" ]; then
-            echo "MinIO failed to become ready"; docker logs minio || true; exit 1
+            echo "SeaweedFS failed to become ready"; docker logs seaweedfs || true; exit 1
           fi
-          # Create the test bucket with the MinIO client (idempotent).
-          docker run --rm --network host \
-            -e MC_HOST_local="http://everruns:everruns-secret@localhost:9000" \
-            minio/mc:latest mb --ignore-existing local/everruns-test
+          # Create the test bucket via the SeaweedFS shell (idempotent), retried
+          # while the filer finishes coming up behind the S3 gateway.
+          created=
+          for i in {1..15}; do
+            if echo 's3.bucket.create -name everruns-test' \
+              | docker exec -i seaweedfs weed shell -master localhost:9333 > /dev/null 2>&1; then
+              echo "Bucket ready!"
+              created=1
+              break
+            fi
+            echo "Attempt $i: bucket not created yet..."
+            sleep 2
+          done
+          if [ -z "$created" ]; then
+            echo "SeaweedFS bucket creation failed"; docker logs seaweedfs || true; exit 1
+          fi
 
       - name: Run blob offload integration tests (S3 backend)
         run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1

--- a/crates/server/src/storage/blob_store.rs
+++ b/crates/server/src/storage/blob_store.rs
@@ -92,7 +92,7 @@ const META_RECOVERY_KEY: &str = "everruns-recovery";
 ///
 /// Set via object_store's portable `Attribute::Metadata` — the key is just
 /// `everruns-kind` / `everruns-recovery`. On an S3-protocol backend (AWS S3 and
-/// every S3-compatible store: SeaweedFS, MinIO, R2, ...) this surfaces on the
+/// every S3-compatible store: SeaweedFS, R2, ...) this surfaces on the
 /// wire as `x-amz-meta-<key>`; a native GCS/Azure backend would map the same
 /// attribute to its own convention. Nothing here is AWS-specific.
 ///
@@ -188,7 +188,7 @@ pub fn content_sha256(bytes: &[u8]) -> String {
 
 /// A [`BlobStore`] backed by any [`object_store::ObjectStore`].
 ///
-/// Production uses the AWS S3 (S3-compatible, incl. MinIO/R2/etc.) backend;
+/// Production uses the AWS S3 (S3-compatible, incl. SeaweedFS/R2/etc.) backend;
 /// tests use object_store's in-memory backend so the exact production code path
 /// (prefixing, not-found handling) is exercised without a network dependency.
 pub struct ObjectStoreBlobStore {
@@ -222,7 +222,7 @@ impl ObjectStoreBlobStore {
 
         // Start from the environment so AWS deployments can use IAM-role /
         // instance credentials, then override with explicit STORAGE_S3_* values
-        // for S3-compatible endpoints (MinIO, R2, ...) that pass static creds.
+        // for S3-compatible endpoints (SeaweedFS, R2, ...) that pass static creds.
         let mut builder = AmazonS3Builder::from_env().with_bucket_name(&config.bucket);
         if let Some(region) = &config.region {
             builder = builder.with_region(region);
@@ -239,7 +239,7 @@ impl ObjectStoreBlobStore {
         if config.allow_http {
             builder = builder.with_allow_http(true);
         }
-        // MinIO and most non-AWS S3 implementations require path-style requests.
+        // SeaweedFS and most non-AWS S3 implementations require path-style requests.
         if config.force_path_style {
             builder = builder.with_virtual_hosted_style_request(false);
         }
@@ -384,7 +384,7 @@ impl BlobStoreConfig {
             prefix: env_string("STORAGE_S3_PREFIX", ""),
             allow_http: env_bool("STORAGE_S3_ALLOW_HTTP", false),
             // Default to path-style: it is the safe choice for S3-compatible
-            // endpoints (MinIO) and still works against AWS S3.
+            // endpoints (SeaweedFS) and still works against AWS S3.
             force_path_style: env_bool("STORAGE_S3_FORCE_PATH_STYLE", true),
         })
     }

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -51,7 +51,7 @@ const TEST_ORG_ID: i64 = 1;
 ///
 /// `STORAGE_BLOB_BACKEND=s3` selects the real S3-compatible store via the same
 /// `STORAGE_S3_*` config the server reads in production (used by the dedicated
-/// S3 CI job against a MinIO service container). Anything else falls back to
+/// S3 CI job against a SeaweedFS container). Anything else falls back to
 /// object_store's in-memory backend, which exercises the identical offload code
 /// path with no network dependency. The same test body therefore validates both
 /// backends.

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -223,12 +223,12 @@ clients or workers. See [specs/object-storage.md](../../specs/object-storage.md)
 | `STORAGE_BLOB_BACKEND` | No | `db` | `db` keeps bytes inline in PostgreSQL (current behavior); `s3` offloads to object storage. |
 | `STORAGE_S3_BUCKET` | When `s3` | — | Target bucket name. |
 | `STORAGE_S3_REGION` | No | — | Bucket region / region label. |
-| `STORAGE_S3_ENDPOINT` | No | — | Custom endpoint for S3-compatible stores (MinIO, R2). Unset for AWS S3. |
+| `STORAGE_S3_ENDPOINT` | No | — | Custom endpoint for S3-compatible stores (SeaweedFS, R2). Unset for AWS S3. |
 | `STORAGE_S3_ACCESS_KEY_ID` | No | — | Static access key. Omit to use the AWS credential chain (IAM role/instance). |
 | `STORAGE_S3_SECRET_ACCESS_KEY` | No | — | Static secret key. |
 | `STORAGE_S3_PREFIX` | No | (empty) | Key prefix isolating multiple deployments within one bucket. |
-| `STORAGE_S3_ALLOW_HTTP` | No | `false` | Allow plaintext HTTP (local/dev only — e.g. SeaweedFS/MinIO over HTTP). |
-| `STORAGE_S3_FORCE_PATH_STYLE` | No | `true` | Use path-style requests (required by MinIO; harmless on AWS S3). |
+| `STORAGE_S3_ALLOW_HTTP` | No | `false` | Allow plaintext HTTP (local/dev only — e.g. SeaweedFS over HTTP). |
+| `STORAGE_S3_FORCE_PATH_STYLE` | No | `true` | Use path-style requests (required by SeaweedFS; harmless on AWS S3). |
 | `STORAGE_BLOB_GC_INTERVAL_SECONDS` | No | `21600` (6h) | Interval between blob GC sweeps that reclaim orphaned objects. `0` disables GC. Only effective with the `s3` backend (inline `db` storage has no orphans). |
 | `STORAGE_BLOB_GC_GRACE_SECONDS` | No | `86400` (24h) | Safety grace period; orphaned objects younger than this are never deleted (avoids racing in-flight creates). |
 | `STORAGE_BLOB_GC_MAX_DELETES_PER_RUN` | No | `10000` | Per-sweep deletion cap to bound work; remaining orphans are reclaimed next sweep. |
@@ -246,7 +246,7 @@ STORAGE_S3_SECRET_ACCESS_KEY=everruns-secret
 STORAGE_S3_ALLOW_HTTP=true
 ```
 
-Any S3-compatible store works (AWS S3, SeaweedFS, MinIO, R2); only the endpoint
+Any S3-compatible store works (AWS S3, SeaweedFS, R2); only the endpoint
 and credentials differ.
 
 **Notes:**

--- a/specs/object-storage.md
+++ b/specs/object-storage.md
@@ -64,7 +64,7 @@ PostgreSQL metadata  ──────────────┐  workspace_fi
 A narrow byte-blob contract (`crates/server/src/storage/blob_store.rs`):
 `put(key, bytes)`, `get(key) -> Option<bytes>`, `delete(key)`. It is implemented
 over [`object_store`](https://docs.rs/object_store), so the same code path
-serves AWS S3, MinIO, Cloudflare R2, and any S3-compatible endpoint, plus an
+serves AWS S3, SeaweedFS, Cloudflare R2, and any S3-compatible endpoint, plus an
 in-memory backend used in tests to exercise the production offload path without
 a network dependency.
 
@@ -125,8 +125,8 @@ rebuild the `workspace_files` / `images` rows from the objects alone.
 
 Metadata is set through object_store's portable `Attribute::Metadata`, so the
 keys are backend-neutral (`everruns-kind`, `everruns-recovery`). On any
-S3-protocol backend — AWS S3 and every S3-compatible store (SeaweedFS, MinIO,
-R2, ...) — these surface on the wire as `x-amz-meta-<key>`; a native GCS/Azure
+S3-protocol backend — AWS S3 and every S3-compatible store (SeaweedFS, R2,
+...) — these surface on the wire as `x-amz-meta-<key>`; a native GCS/Azure
 backend would map them to that provider's convention. Nothing is AWS-specific.
 
 Each object sets:
@@ -216,12 +216,12 @@ counters; each pass also logs a summary (listed, deleted, bytes, live pointers).
 | `STORAGE_BLOB_BACKEND` | `db` | `db` keeps bytes inline (current behavior); `s3` offloads to object storage. |
 | `STORAGE_S3_BUCKET` | — | Required for `s3`. Target bucket. |
 | `STORAGE_S3_REGION` | — | Bucket region (or compatible region label). |
-| `STORAGE_S3_ENDPOINT` | — | Custom endpoint for S3-compatible stores (MinIO, R2). Unset for AWS. |
+| `STORAGE_S3_ENDPOINT` | — | Custom endpoint for S3-compatible stores (SeaweedFS, R2). Unset for AWS. |
 | `STORAGE_S3_ACCESS_KEY_ID` | — | Static access key. Omit to use the AWS credential chain (IAM role/instance). |
 | `STORAGE_S3_SECRET_ACCESS_KEY` | — | Static secret key. |
 | `STORAGE_S3_PREFIX` | (empty) | Key prefix isolating deployments within a bucket. |
-| `STORAGE_S3_ALLOW_HTTP` | `false` | Allow plaintext HTTP (local/dev only — e.g. SeaweedFS/MinIO over HTTP). |
-| `STORAGE_S3_FORCE_PATH_STYLE` | `true` | Path-style requests (required by MinIO; harmless on AWS). |
+| `STORAGE_S3_ALLOW_HTTP` | `false` | Allow plaintext HTTP (local/dev only — e.g. SeaweedFS over HTTP). |
+| `STORAGE_S3_FORCE_PATH_STYLE` | `true` | Path-style requests (required by SeaweedFS; harmless on AWS). |
 | `STORAGE_BLOB_GC_INTERVAL_SECONDS` | `21600` (6h) | Interval between GC sweeps. `0` disables GC. Only effective with the `s3` backend. |
 | `STORAGE_BLOB_GC_GRACE_SECONDS` | `86400` (24h) | Safety grace period; orphans younger than this are never deleted. |
 | `STORAGE_BLOB_GC_MAX_DELETES_PER_RUN` | `10000` | Per-sweep deletion cap to bound work (consumed per delete attempt). |
@@ -248,7 +248,7 @@ export STORAGE_S3_SECRET_ACCESS_KEY=everruns-secret
 export STORAGE_S3_ALLOW_HTTP=true
 ```
 
-Any S3-compatible store (AWS S3, SeaweedFS, MinIO, Cloudflare R2, ...) works
+Any S3-compatible store (AWS S3, SeaweedFS, Cloudflare R2, ...) works
 unchanged — only the endpoint and credentials differ.
 
 ## Testing
@@ -280,9 +280,9 @@ assertions** run against both backends:
 
 - **In-memory object_store backend** (default) in the `Integration Tests
   (PostgreSQL)` CI job — exercises the offload code path on every PostgreSQL PR
-  with no S3/MinIO container (it still uses the PostgreSQL service container).
+  with no S3/SeaweedFS container (it still uses the PostgreSQL service container).
 - **Real S3-compatible store** in the dedicated `Integration Tests (S3 Blob
-  Backend)` CI job, which starts MinIO via a `docker run` step alongside the
+  Backend)` CI job, which starts SeaweedFS via a `docker run` step alongside the
   PostgreSQL service container, sets `STORAGE_BLOB_BACKEND=s3` + `STORAGE_S3_*`
   (with `STORAGE_S3_ALLOW_HTTP` and path-style addressing for the local
   endpoint), and re-runs the identical suite against the AWS S3 client path. The

--- a/specs/workspace.md
+++ b/specs/workspace.md
@@ -154,7 +154,7 @@ session IDs do not need to change.
 ### Decision 1: PostgreSQL-backed Storage
 **Chosen:** Store files in PostgreSQL BYTEA column
 **Alternatives considered:**
-- Object storage (S3, MinIO): Added complexity for MVP
+- Object storage (S3, SeaweedFS): Added complexity for MVP
 - Local filesystem: Not suitable for distributed deployments
 **Rationale:** PostgreSQL provides ACID transactions, simple deployment, and good performance for small-to-medium files. Can migrate to object storage later for large files.
 


### PR DESCRIPTION
## What
Switch the `Integration Tests (S3 Blob Backend)` CI job from a MinIO container to SeaweedFS, and remove the remaining MinIO mentions from specs, SRE docs, and code comments so SeaweedFS is the sole named S3-compatible example throughout.

## Why
Local dev already runs SeaweedFS for the optional S3 blob backend (`scripts/lib/seaweedfs.sh`), but the S3 CI job started a MinIO container — the only place MinIO was actually used. Aligning CI with local dev removes the mismatch and means the same S3-compatible store is exercised in both places.

## How
- CI `s3-integration-test` job now runs `chrislusf/seaweedfs:latest server -s3` with the S3 gateway on the container's `:8333` mapped to host `:9000`, so `STORAGE_S3_ENDPOINT` is unchanged.
- Mounts the same `local/seaweedfs-s3-config.json` the local dev script uses, so the static test credentials (`everruns` / `everruns-secret`) come from one source.
- Readiness probe waits for the S3 gateway port to answer (any HTTP response, incl. the unauthenticated 403 from ListBuckets); the `everruns-test` bucket is then created via `weed shell` with retries while the filer comes up — mirroring `scripts/lib/seaweedfs.sh`.
- Updated the remaining MinIO references to SeaweedFS in `specs/object-storage.md`, `docs/sre/environment-variables.md`, `specs/workspace.md`, `crates/server/src/storage/blob_store.rs` (comments), and `crates/server/tests/blob_offload_integration_test.rs` (comment).

## Risk
- Low. No product runtime change: the Rust edits are comment-only and the local SeaweedFS dev path is untouched. The only behavioral change is to the CI job, which is validated by this PR's own `s3-integration-test` run.

## Security
- Threat categories reviewed: No security-relevant code changes — CI config, docs, specs, and code comments only.
- Findings and resolutions: None. The CI step uses the same throwaway static credentials for an ephemeral, job-scoped container as the previous MinIO setup; no new secrets, dependencies, or production surface are introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (the existing `blob_offload_integration_test` S3 suite now runs against SeaweedFS; no new tests needed)
- [x] Backward compatibility considered (no runtime/contract change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FJyBRJ3qW43eCoivoLVD9E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJyBRJ3qW43eCoivoLVD9E)_