### PR TITLE
test(llm-tests): align thinking assertion with GPT-5.x text summaries

### DIFF
--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -102,12 +102,10 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
         // OpenAI GPT-5.x surfaces its readable reasoning summary as public
         // text instead of on the private `thinking` field. The summary is
         // folded into the response, which we already asserted is non-empty and
-        // carries the worked-out answer above.
+        // carries the worked-out answer above, so `thinking` must stay empty
+        // (absent or blank).
         assert!(
-            !assistant_msg
-                .thinking
-                .as_ref()
-                .is_some_and(|t| !t.is_empty()),
+            assistant_msg.thinking.as_ref().is_none_or(|t| t.is_empty()),
             "GPT-5.x reasoning summary should surface as public text, not on \
              the private thinking field, for {config}"
         );

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -80,21 +80,38 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
         result.response
     );
 
-    // Verify thinking tokens were captured on the stored assistant message
+    // Verify reasoning was captured on the stored assistant message.
     let messages = runner.messages().await.unwrap();
     let assistant_msg = messages
         .iter()
         .find(|m| m.role == MessageRole::Agent)
         .expect("Should have an agent message");
 
-    assert!(
-        assistant_msg.thinking.is_some(),
-        "Agent message should have thinking content for {config}"
-    );
-    assert!(
-        !assistant_msg.thinking.as_ref().unwrap().is_empty(),
-        "Thinking content should not be empty for {config}"
-    );
+    if config.reasoning_on_thinking_field {
+        // Anthropic (and OpenAI o-series) keep raw reasoning on the private
+        // `thinking` field.
+        assert!(
+            assistant_msg.thinking.is_some(),
+            "Agent message should have thinking content for {config}"
+        );
+        assert!(
+            !assistant_msg.thinking.as_ref().unwrap().is_empty(),
+            "Thinking content should not be empty for {config}"
+        );
+    } else {
+        // OpenAI GPT-5.x surfaces its readable reasoning summary as public
+        // text instead of on the private `thinking` field. The summary is
+        // folded into the response, which we already asserted is non-empty and
+        // carries the worked-out answer above.
+        assert!(
+            !assistant_msg
+                .thinking
+                .as_ref()
+                .is_some_and(|t| !t.is_empty()),
+            "GPT-5.x reasoning summary should surface as public text, not on \
+             the private thinking field, for {config}"
+        );
+    }
 
     // thinking_signature is provider-specific:
     // - Anthropic: cryptographic signature (always present with thinking)

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -21,6 +21,12 @@ pub struct ProviderModelConfig {
     pub provider_type: DriverId,
     pub model_name: &'static str,
     pub env_var: &'static str,
+    /// Whether the model surfaces extended reasoning on the private `thinking`
+    /// field. Anthropic (and OpenAI o-series encrypted reasoning) do. OpenAI
+    /// GPT-5.x instead surfaces its readable reasoning *summary* as public
+    /// text, leaving `thinking` empty — see the `ReasoningSummaryDelta`
+    /// mapping in `openresponses_protocol`.
+    pub reasoning_on_thinking_field: bool,
 }
 
 impl ProviderModelConfig {
@@ -33,7 +39,15 @@ impl ProviderModelConfig {
             provider_type,
             model_name,
             env_var,
+            reasoning_on_thinking_field: true,
         }
+    }
+
+    /// Mark this model as surfacing its reasoning summary as public text rather
+    /// than on the private `thinking` field (OpenAI GPT-5.x behavior).
+    pub const fn reasoning_as_text(mut self) -> Self {
+        self.reasoning_on_thinking_field = false;
+        self
     }
 
     /// Build a `ResolvedModel` from env, returning `None` if the key is
@@ -100,13 +114,13 @@ pub const OPENAI_GPT4O_MINI: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::OpenAI, "gpt-4o-mini", "OPENAI_API_KEY");
 
 pub const OPENAI_GPT52: ProviderModelConfig =
-    ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.2", "OPENAI_API_KEY");
+    ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.2", "OPENAI_API_KEY").reasoning_as_text();
 
 pub const OPENAI_GPT54: ProviderModelConfig =
-    ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.4", "OPENAI_API_KEY");
+    ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.4", "OPENAI_API_KEY").reasoning_as_text();
 
 pub const OPENAI_GPT55: ProviderModelConfig =
-    ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.5", "OPENAI_API_KEY");
+    ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.5", "OPENAI_API_KEY").reasoning_as_text();
 
 pub const GEMINI_FLASH: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Gemini, "gemini-2.5-flash", "GEMINI_API_KEY");


### PR DESCRIPTION
## What
Fix the red `main` CI by aligning the extended-thinking LLM matrix test with the new GPT-5.x reasoning-surfacing behavior.

## Why
Commit `af4833c` ("fix(openresponses): surface reasoning summaries as text") remapped OpenAI GPT-5.x `ReasoningSummaryDelta` from the private `thinking` path to public **text**. The live `test_extended_thinking` cases still required a populated `thinking` field for GPT-5.x, so the **Integration Tests (PostgreSQL)** job failed on `case_3_openai_gpt52` and `case_4_openai_gpt54` with `Agent message should have thinking content for openai(...)`.

(The same run's "Published Crate MSRV" failure was an unrelated transient crates.io network error — `OpenSSL SSL_read: unexpected eof` while downloading `async-nats` — not a code issue.)

## How
- Encode the capability in the test matrix: new `reasoning_on_thinking_field` flag on `ProviderModelConfig`, defaulting `true`, with a `reasoning_as_text()` const builder applied to the GPT-5.x constants.
- Assert per-provider in `test_extended_thinking`: Anthropic keeps raw reasoning on `thinking`; GPT-5.x surfaces its readable summary as public text (so `thinking` stays empty and the answer lands in the response, already asserted).

## Risk
- Low. Test-only change; no production code touched.
- Validated live against real endpoints: all four `test_extended_thinking` cases (Anthropic opus/sonnet, OpenAI gpt-5.2/gpt-5.4) pass.

## Security
- Threat categories reviewed: No security-relevant code changes (test-only).
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019BgzMRxJ9wyYHJzPqRpbQ1)_