### PR TITLE
fix(deps): patch Dependabot npm vulnerabilities (undici, dompurify)

### DIFF
--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "workspaces": [],
   "packageManager": "pnpm@9.15.4",
+  "engines": {
+    "node": ">=20.18.1"
+  },
   "dependencies": {
     "deepsec": "^2.0.12"
   },

--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -13,6 +13,7 @@
     "overrides": {
       "@anthropic-ai/sdk": "^0.91.1",
       "tar": "7.5.16",
+      "undici": "^7.28.0",
       "zod": "^3.25.76"
     }
   }

--- a/.deepsec/pnpm-lock.yaml
+++ b/.deepsec/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@anthropic-ai/sdk': ^0.91.1
   tar: 7.5.16
+  undici: ^7.28.0
   zod: ^3.25.76
 
 importers:
@@ -580,8 +581,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -743,7 +744,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.25.0
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -1203,7 +1204,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unpipe@1.0.0: {}
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -73,7 +73,7 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
-      "dompurify": "3.4.9",
+      "dompurify": "3.4.11",
       "js-yaml": "4.2.0",
       "postcss": "8.5.14",
       "prismjs": "1.30.0",

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  dompurify: 3.4.9
+  dompurify: 3.4.11
   js-yaml: 4.2.0
   postcss: 8.5.14
   prismjs: 1.30.0
@@ -2606,8 +2606,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -6729,7 +6729,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7814,7 +7814,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -1,9 +1,10 @@
 packages: []
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
-# dompurify is pinned to an exact version via pnpm.overrides for a security
-# patch (3.4.11, GHSA ALLOWED_ATTR pollution). Exempt it from the 7-day
-# release-age gate so the fix can land before the window elapses; the exact
-# pin still prevents pulling any other freshly-published version.
+# Security patches adopted before the maturity window (Dependabot GHSA fixes):
+# dompurify 3.4.11 (GHSA-cmwh-pvxp-8882, Dependabot alert #114 — ALLOWED_ATTR
+# pollution via setConfig bypass). Pinned to the exact version via
+# pnpm.overrides, so this exemption cannot pull any other freshly-published
+# version; it only lets the fix land before the 7-day release-age window.
 minimumReleaseAgeExclude:
   - dompurify

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages: []
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
+# dompurify is pinned to an exact version via pnpm.overrides for a security
+# patch (3.4.11, GHSA ALLOWED_ATTR pollution). Exempt it from the 7-day
+# release-age gate so the fix can land before the window elapses; the exact
+# pin still prevents pulling any other freshly-published version.
+minimumReleaseAgeExclude:
+  - dompurify


### PR DESCRIPTION
## What
Resolve the 3 open Dependabot vulnerability alerts on `main`.

| Alert | Severity | Package | Manifest | Fix |
| --- | --- | --- | --- | --- |
| #113 | High | undici (TLS cert validation bypass via dropped request) | `.deepsec/pnpm-lock.yaml` | 7.25.0 → 7.28.0 |
| #112 | Moderate | undici (cross-user info disclosure via shared cache) | `.deepsec/pnpm-lock.yaml` | 7.25.0 → 7.28.0 |
| #114 | Moderate | dompurify (permanent `ALLOWED_ATTR` pollution via `setConfig()` bypass) | `apps/ui/pnpm-lock.yaml` | 3.4.9 → 3.4.11 |

## Why
GitHub Dependabot flagged these as open vulnerabilities on the default branch (1 high, 2 moderate).

## How
- `.deepsec`: `undici` is transitive via `deepsec`; added a `pnpm.overrides` entry `"undici": "^7.28.0"` and re-locked.
- `apps/ui`: `dompurify` is pinned via `pnpm.overrides`; bumped 3.4.9 → 3.4.11 and re-locked. The patch is <7 days old, so it tripped the repo's `minimumReleaseAge` (10080m) supply-chain gate — added a scoped `minimumReleaseAgeExclude: [dompurify]`. The exact override pin still constrains the resolved version, so the age-gate exemption can't pull any other freshly-published version.

## Risk
- Low. Patch-level dependency bumps that resolve known advisories; no application code changed.

## Security
- Threat categories reviewed: TM-API / supply-chain (this PR *is* a security remediation).
- Findings and resolutions: Closes Dependabot alerts #112, #113, #114. The `minimumReleaseAgeExclude` addition is scoped to a single pinned package and does not broadly weaken the age gate.

## Follow-ups
The `minimumReleaseAgeExclude: [dompurify]` entry can be removed once 3.4.11 ages past the 7-day window, if desired. Non-blocking.

## Checklist
- [x] Tests added or updated (n/a — dependency patch)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019BgzMRxJ9wyYHJzPqRpbQ1)_