### PR TITLE
chore(deps): bump everruns-sdk to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbc0ce7f694b861348c2bc44c8a5e754f59c15c7343909a30b5018be8dd0a20"
+checksum = "ebcaab6dbaa76ecf726e51861a1b8e4901756922b51c665c6ead1b9c6239f7f9"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK
-everruns-sdk = "0.1.9"
+everruns-sdk = "0.1.10"
 everruns-core = { path = "crates/core", version = "0.14.0" }
 everruns-mcp = { path = "crates/mcp", version = "0.14.0" }
 everruns-openai = { path = "crates/openai", version = "0.14.0" }


### PR DESCRIPTION
## What
Bump the `everruns-sdk` workspace dependency from `0.1.9` to `0.1.10` (latest published) and refresh `Cargo.lock`.

## Why
`0.1.10` is the newest published `everruns-sdk` release. Keeping the SDK current pulls in upstream fixes for the `crates/cli` and `crates/server` consumers.

## How
- Edited the `everruns-sdk` version in the workspace `Cargo.toml`.
- `cargo update -p everruns-sdk --precise 0.1.10`. The SDK's own dependency set is identical between 0.1.9 and 0.1.10, so the `Cargo.lock` delta is limited to the `everruns-sdk` version + checksum.
- Validated against both consumers:
  - `cargo build -p everruns-cli` ✓ and `cargo build -p everruns-server` ✓
  - `cargo test -p everruns-cli` ✓ (all tests pass)
  - `cargo clippy -p everruns-cli --all-targets --all-features -- -D warnings` ✓
  - Smoke test: built `everruns` binary runs (`--version` → `everruns 0.14.0`, `--help` lists all commands).

## Risk
- Low. Patch-level bump of an internal SDK with an unchanged transitive dependency set; API-compatible (no source changes needed, clippy clean).

## Security
- Threat categories reviewed: dependency / supply-chain risk only. No application code changed; no auth, API, tool, tenant, SQL, bash, or web surface touched.
- Findings and resolutions: First-party `everruns-sdk` crate, patch bump, identical dependency graph. No new transitive dependencies introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (dependency bump; validated via build/test/clippy + CLI smoke test)
- [x] Backward compatibility considered — patch bump, API-compatible, no source changes
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kddn262BK3jGXd8SaWLx8S)_