### PR TITLE
fix(budgets): cache-aware cost estimation (EVE-599)

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -2399,6 +2399,8 @@ impl ReasonAtom {
                         &runtime_agent.model,
                         input,
                         output,
+                        meta.cache_read_tokens.unwrap_or(0),
+                        meta.cache_creation_tokens.unwrap_or(0),
                     );
                     Some(
                         TokenUsage::with_cache(

--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -421,23 +421,63 @@ pub fn get_model_profile(provider_type: &DriverId, model_id: &str) -> Option<Mod
 }
 
 /// Estimate the USD cost of a generation from the model's static price-table
-/// profile. Returns `None` when there is no profile or no cost data for the
-/// model — callers then have no estimate to record and fall back accordingly.
+/// profile, discounting cached-read tokens at the model's `cache_read` rate.
+/// Returns `None` when there is no profile or no cost data for the model —
+/// callers then have no estimate to record and fall back accordingly.
 ///
 /// This is the price-table fallback used when a provider does not report an
 /// authoritative cost inline (e.g. OpenRouter's `usage.cost`). Cost figures in
-/// profiles are per million tokens. Cache tokens are not discounted here,
-/// matching existing budget metering behavior.
+/// profiles are per million tokens.
+///
+/// Cache accounting is provider-aware (see [`prompt_tokens_include_cache`]):
+/// OpenAI-family and Gemini report a prompt token count that already *includes*
+/// cached reads, so the cached subset is billed at the cheaper `cache_read`
+/// rate and only the remainder at the full input rate. Anthropic/Bedrock report
+/// cached tokens separately, so cache-read and cache-creation tokens are added
+/// on top of `input_tokens`. Cache-creation (write) tokens have no dedicated
+/// price in profiles and are billed at the input rate where the provider
+/// reports them separately.
 pub fn estimate_cost_usd(
     provider_type: &DriverId,
     model_id: &str,
     input_tokens: u32,
     output_tokens: u32,
+    cache_read_tokens: u32,
+    cache_creation_tokens: u32,
 ) -> Option<f64> {
     let cost = get_model_profile(provider_type, model_id)?.cost?;
-    let input_cost = (input_tokens as f64 / 1_000_000.0) * cost.input;
-    let output_cost = (output_tokens as f64 / 1_000_000.0) * cost.output;
-    Some(input_cost + output_cost)
+    let per_million = |tokens: u32, rate: f64| (tokens as f64 / 1_000_000.0) * rate;
+    let cache_read_rate = cost.cache_read.unwrap_or(cost.input);
+
+    let (billable_input, cache_write_cost) = if prompt_tokens_include_cache(provider_type) {
+        // `input_tokens` already includes the cached reads (creation tokens are
+        // not reported separately for these providers): bill only the
+        // non-cached remainder at the input rate.
+        (input_tokens.saturating_sub(cache_read_tokens), 0.0)
+    } else {
+        // Cached tokens are reported on top of `input_tokens`: charge the full
+        // input plus the cache-creation tokens at the input rate.
+        (input_tokens, per_million(cache_creation_tokens, cost.input))
+    };
+
+    Some(
+        per_million(billable_input, cost.input)
+            + per_million(cache_read_tokens, cache_read_rate)
+            + cache_write_cost
+            + per_million(output_tokens, cost.output),
+    )
+}
+
+/// Whether the provider's reported prompt/input token count already includes
+/// cached-read tokens (so they must be subtracted before billing the input
+/// rate) versus reporting them separately (so they are additive).
+///
+/// OpenAI Responses/Chat Completions and Gemini include cached reads in the
+/// prompt count; Anthropic (direct and via Bedrock) reports
+/// `cache_read_input_tokens` / `cache_creation_input_tokens` separately. Unknown
+/// external providers are assumed OpenAI-compatible (cache-inclusive).
+fn prompt_tokens_include_cache(provider_type: &DriverId) -> bool {
+    !matches!(provider_type, DriverId::Anthropic | DriverId::Bedrock)
 }
 
 /// Get the vendor/brand for a model id, or None if it is not in the registry
@@ -4359,7 +4399,7 @@ mod tests {
     #[test]
     fn test_estimate_cost_usd_known_model() {
         // gpt-4o profile: input $2.50/M, output $10.00/M.
-        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-4o", 1_000_000, 500_000)
+        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-4o", 1_000_000, 500_000, 0, 0)
             .expect("known model should yield an estimate");
         // 1M input * 2.50 + 0.5M output * 10.00 = 2.50 + 5.00 = 7.50
         assert!((est - 7.50).abs() < 1e-9, "got {est}");
@@ -4367,6 +4407,50 @@ mod tests {
 
     #[test]
     fn test_estimate_cost_usd_unknown_model_is_none() {
-        assert!(estimate_cost_usd(&DriverId::OpenAI, "no-such-model", 100, 50).is_none());
+        assert!(estimate_cost_usd(&DriverId::OpenAI, "no-such-model", 100, 50, 0, 0).is_none());
+    }
+
+    #[test]
+    fn test_estimate_cost_usd_openai_discounts_cached_subset() {
+        // OpenAI reports `prompt_tokens` inclusive of cached reads. gpt-4o:
+        // input $2.50/M, cache_read $1.25/M. Of 1M prompt tokens, 800K are
+        // cached, so only 200K bill at the input rate.
+        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-4o", 1_000_000, 0, 800_000, 0)
+            .expect("known model should yield an estimate");
+        // 200K * 2.50 + 800K * 1.25 = 0.50 + 1.00 = 1.50 (vs 2.50 without discount).
+        assert!((est - 1.50).abs() < 1e-9, "got {est}");
+    }
+
+    #[test]
+    fn test_estimate_cost_usd_openai_cache_heavy_run_is_not_overstated() {
+        // Regression for EVE-599: gpt-5.5 (input $5/M, output $30/M,
+        // cache_read $0.50/M) on a cache-heavy run. 87% of the prompt is cached.
+        let input = 327_079;
+        let cache_read = 284_672;
+        let output = 2_096;
+        let cached = estimate_cost_usd(&DriverId::OpenAI, "gpt-5.5", input, output, cache_read, 0)
+            .expect("known model");
+        let naive =
+            estimate_cost_usd(&DriverId::OpenAI, "gpt-5.5", input, output, 0, 0).expect("known");
+        // The cache-blind figure was ~$1.70; the discounted figure is ~$0.42.
+        assert!((naive - 1.698).abs() < 0.01, "naive {naive}");
+        assert!(cached < 0.45 && cached > 0.39, "cached {cached}");
+    }
+
+    #[test]
+    fn test_estimate_cost_usd_anthropic_cache_is_additive() {
+        // Anthropic reports cached tokens separately from `input_tokens`, so a
+        // cached read must add cost rather than be subtracted out of the input.
+        let model = "claude-haiku-4-5";
+        let base = estimate_cost_usd(&DriverId::Anthropic, model, 1_000, 0, 0, 0)
+            .expect("known anthropic model");
+        let with_cache = estimate_cost_usd(&DriverId::Anthropic, model, 1_000, 0, 5_000, 0)
+            .expect("known anthropic model");
+        // Adding 5K cache-read tokens on top of 1K input must raise the cost,
+        // never lower it (which a subtraction would do).
+        assert!(
+            with_cache > base,
+            "cache-read should be additive for Anthropic: base={base} with_cache={with_cache}"
+        );
     }
 }

--- a/crates/server/src/domains/budgets/service.rs
+++ b/crates/server/src/domains/budgets/service.rs
@@ -13,7 +13,7 @@ use everruns_core::budget::{
     LedgerEntry,
 };
 use everruns_core::events::{Event, EventData, LLM_GENERATION};
-use everruns_core::model_profiles::get_model_profile;
+use everruns_core::model_profiles::estimate_cost_usd;
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::{AgentId, BudgetId, SessionId};
 use everruns_core::{UserFacingError, user_facing_error_codes};
@@ -240,6 +240,8 @@ impl BudgetService {
         provider: Option<&str>,
         input_tokens: i64,
         output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
         provider_cost_usd: Option<f64>,
         finish_reasons: Option<&[String]>,
     ) {
@@ -313,6 +315,8 @@ impl BudgetService {
                     "input_tokens": input_tokens,
                     "output_tokens": output_tokens,
                     "total_tokens": total_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_creation_tokens": cache_creation_tokens,
                     "provider_cost_usd": provider_cost_usd,
                 }),
                 metadata: serde_json::json!({
@@ -341,6 +345,8 @@ impl BudgetService {
                 total_tokens,
                 input_tokens,
                 output_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
                 model,
                 provider,
                 provider_cost_usd,
@@ -444,6 +450,8 @@ impl BudgetService {
         total_tokens: i64,
         input_tokens: i64,
         output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
         model: Option<&str>,
         provider: Option<&str>,
         provider_cost_usd: Option<f64>,
@@ -458,32 +466,31 @@ impl BudgetService {
                 if let Some(cost) = provider_cost_usd.filter(|c| *c > 0.0) {
                     return cost;
                 }
-                // Look up model cost from profiles
+                // Fall back to the price-table estimate. This shares the
+                // cache-aware accounting used for `estimated_cost_usd` so the
+                // meter does not bill cached reads at the full input rate (which
+                // overstated cache-heavy runs and could trip a budget early —
+                // EVE-599).
                 let provider_type = provider
                     .and_then(|p| p.parse::<DriverId>().ok())
                     .unwrap_or(DriverId::OpenAI);
                 let model_id = model.unwrap_or("unknown");
-                if let Some(profile) = get_model_profile(&provider_type, model_id) {
-                    if let Some(cost) = profile.cost {
-                        // Cost is per million tokens
-                        let input_cost = (input_tokens as f64 / 1_000_000.0) * cost.input;
-                        let output_cost = (output_tokens as f64 / 1_000_000.0) * cost.output;
-                        input_cost + output_cost
-                    } else {
-                        // No cost data — fall back to token count
-                        warn!(
-                            model = model_id,
-                            "No cost data for model, using token count as debit"
-                        );
-                        total_tokens as f64
-                    }
-                } else {
+                estimate_cost_usd(
+                    &provider_type,
+                    model_id,
+                    input_tokens.max(0) as u32,
+                    output_tokens.max(0) as u32,
+                    cache_read_tokens.max(0) as u32,
+                    cache_creation_tokens.max(0) as u32,
+                )
+                .unwrap_or_else(|| {
+                    // No profile or no cost data — fall back to raw token count.
                     warn!(
                         model = model_id,
-                        "No profile for model, using token count as debit"
+                        "No cost data for model, using token count as debit"
                     );
                     total_tokens as f64
-                }
+                })
             }
             "credits" => {
                 // 1 credit = 1000 tokens (default rate, customizable via metadata)
@@ -694,6 +701,8 @@ impl EventListener for BudgetService {
 
         let input_tokens = usage.input_tokens as i64;
         let output_tokens = usage.output_tokens as i64;
+        let cache_read_tokens = usage.cache_read_tokens.unwrap_or(0) as i64;
+        let cache_creation_tokens = usage.cache_creation_tokens.unwrap_or(0) as i64;
 
         self.process_llm_generation(
             event,
@@ -701,6 +710,8 @@ impl EventListener for BudgetService {
             data.metadata.provider.as_deref(),
             input_tokens,
             output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
             usage.actual_cost_usd,
             data.metadata.finish_reasons.as_deref(),
         )

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -187,6 +187,8 @@ fn test_compute_debit_tokens_currency() {
         1500,
         1000,
         500,
+        0,
+        0,
         Some("gpt-4o"),
         Some("openai"),
         None,
@@ -202,6 +204,8 @@ fn test_compute_debit_usd_with_known_model() {
         1_000_000 + 500_000,
         1_000_000,
         500_000,
+        0,
+        0,
         Some("gpt-4o"),
         Some("openai"),
         None,
@@ -220,6 +224,8 @@ fn test_compute_debit_usd_prefers_provider_cost() {
         1_500_000,
         1_000_000,
         500_000,
+        0,
+        0,
         Some("gpt-4o"),
         Some("openai"),
         Some(0.0123),
@@ -237,6 +243,8 @@ fn test_compute_debit_usd_provider_cost_covers_unknown_model() {
         1500,
         1000,
         500,
+        0,
+        0,
         Some("some/exotic-model"),
         Some("openai"),
         Some(0.0042),
@@ -253,6 +261,8 @@ fn test_compute_debit_usd_zero_provider_cost_falls_back() {
         1500,
         1000,
         500,
+        0,
+        0,
         Some("unknown-model"),
         Some("openai"),
         Some(0.0),
@@ -268,6 +278,8 @@ fn test_compute_debit_usd_with_unknown_model_falls_back_to_tokens() {
         1500,
         1000,
         500,
+        0,
+        0,
         Some("unknown-model"),
         Some("openai"),
         None,
@@ -278,22 +290,54 @@ fn test_compute_debit_usd_with_unknown_model_falls_back_to_tokens() {
 #[test]
 fn test_compute_debit_credits_currency() {
     let (svc, _) = make_service();
-    let debit = svc.compute_debit("credits", 5000, 3000, 2000, None, None, None);
+    let debit = svc.compute_debit("credits", 5000, 3000, 2000, 0, 0, None, None, None);
     assert_eq!(debit, 5.0);
 }
 
 #[test]
 fn test_compute_debit_custom_currency_uses_token_count() {
     let (svc, _) = make_service();
-    let debit = svc.compute_debit("my_custom", 2000, 1500, 500, None, None, None);
+    let debit = svc.compute_debit("my_custom", 2000, 1500, 500, 0, 0, None, None, None);
     assert_eq!(debit, 2000.0);
 }
 
 #[test]
 fn test_compute_debit_zero_tokens() {
     let (svc, _) = make_service();
-    let debit = svc.compute_debit("tokens", 0, 0, 0, None, None, None);
+    let debit = svc.compute_debit("tokens", 0, 0, 0, 0, 0, None, None, None);
     assert_eq!(debit, 0.0);
+}
+
+#[test]
+fn test_compute_debit_usd_discounts_cached_tokens() {
+    let (svc, _) = make_service();
+    // OpenAI reports prompt tokens inclusive of cached reads. gpt-4o: input
+    // $2.50/M, cache_read $1.25/M. 800K of the 1M prompt tokens are cached.
+    let cached = svc.compute_debit(
+        "usd",
+        1_000_000,
+        1_000_000,
+        0,
+        800_000,
+        0,
+        Some("gpt-4o"),
+        Some("openai"),
+        None,
+    );
+    let naive = svc.compute_debit(
+        "usd",
+        1_000_000,
+        1_000_000,
+        0,
+        0,
+        0,
+        Some("gpt-4o"),
+        Some("openai"),
+        None,
+    );
+    // 200K * 2.50 + 800K * 1.25 = 0.50 + 1.00 = 1.50, well below the cache-blind 2.50.
+    assert!((cached - 1.50).abs() < 1e-9, "cached debit {cached}");
+    assert!((naive - 2.50).abs() < 1e-9, "naive debit {naive}");
 }
 
 // ========================================================================

--- a/specs/budgeting.md
+++ b/specs/budgeting.md
@@ -109,11 +109,12 @@ Look up session → find active budgets in hierarchy
   (session → agent → user → org)
   │
   ▼ (for each matching budget)
-compute_debit(currency, tokens, model, provider, provider_cost_usd)
+compute_debit(currency, tokens, cache tokens, model, provider, provider_cost_usd)
   │  "tokens" → raw count
   │  "usd"    → provider_cost_usd when the provider reports it
-  │            (e.g. OpenRouter usage.cost), else
-  │            tokens * LlmModelProfile cost-per-token, else raw count
+  │            (e.g. OpenRouter usage.cost), else the cache-aware
+  │            LlmModelProfile estimate (cached reads billed at the
+  │            cache_read rate, not the input rate), else raw count
   │  "credits" → tokens / 1000
   │
   ▼

--- a/specs/usage-tracking.md
+++ b/specs/usage-tracking.md
@@ -120,11 +120,15 @@ CREATE TABLE llm_generations (
 Cost is tracked as two independent figures per generation: `actual_cost_usd`, the
 provider's authoritative inline cost when reported (OpenRouter's `usage.cost`),
 and `estimated_cost_usd`, the price-table estimate computed whenever the model
-profile has cost data. Both are computed when the `llm.generation` event's
-`TokenUsage` is built. Keeping them separate avoids information loss: consumers
-prefer the actual charge while still being able to reconcile estimate-vs-actual
-drift. The budget debit uses the actual cost when present and otherwise falls back
-to its own profile-based estimate.
+profile has cost data. The estimate is cache-aware: cached-read tokens are
+billed at the model's `cache_read` rate rather than the full input rate, with
+provider-specific handling for whether the reported prompt count already
+includes cached reads (OpenAI/Gemini) or reports them separately (Anthropic).
+Both are computed when the `llm.generation` event's `TokenUsage` is built.
+Keeping them separate avoids information loss: consumers prefer the actual charge
+while still being able to reconcile estimate-vs-actual drift. The budget debit
+uses the actual cost when present and otherwise falls back to the same
+cache-aware profile estimate.
 
 ### Denormalized Totals
 


### PR DESCRIPTION
## What
Make `estimate_cost_usd` discount cached-read tokens instead of billing the full prompt at the input rate, and reuse the same estimate in the budget meter. Closes EVE-599.

## Why
`estimate_cost_usd` billed the entire prompt at the input rate and ignored cached tokens. For providers whose prompt count *includes* cached reads (OpenAI/Gemini), this overstated cache-heavy runs 4–15×, inflating the emitted `estimated_cost_usd` (trusted by embedders/benchmarks) and tripping budgets early on runs that were well under budget.

Reproduced from the ticket evidence (gpt-5.5: `input_tokens=327079`, `cache_read_tokens=284672` (~87%), `output_tokens=2096`):
- Cache-blind estimate ≈ **$1.698** (matches the reported value)
- Cache-aware estimate ≈ **$0.42** (in line with the ~$0.36–0.38 reconciliation)

## How
- `estimate_cost_usd` now takes `cache_read_tokens` + `cache_creation_tokens` and bills the cached subset at the model's `cache_read` rate.
- **Provider-aware** accounting via a new `prompt_tokens_include_cache` helper:
  - **Cache-inclusive** (OpenAI family, Gemini, unknown external): `prompt_tokens` already includes cached reads → cached subset is *subtracted* from billable input.
  - **Cache-exclusive** (Anthropic, Bedrock): cached tokens reported separately → cache-read (and cache-creation) are *added on top* of `input_tokens`. This also fixes a latent *under*-count for Anthropic, which previously ignored cache tokens entirely.
  - Cache-creation has no dedicated profile price, so it's billed at the input rate where reported separately (OpenAI reports none).
- Call site `crates/core/src/atoms/reason.rs` passes the cache counts already present on `completion_metadata`.
- The budget meter shared the identical cache-blind formula, so `compute_debit` now reuses `estimate_cost_usd` and threads cache tokens through `on_event → process_llm_generation → compute_debit`. Enforcement stays consistent with the emitted estimate. Cache tokens are also recorded in the journal `measures`.
- Specs updated: `specs/usage-tracking.md`, `specs/budgeting.md`.

## Risk
- **Low.** Pure pricing computation; no migration, API-shape, auth, or infra change. The provider's authoritative `actual_cost_usd` (e.g. OpenRouter `usage.cost`) still wins when present — this only changes the price-table fallback. Net effect is *more accurate* enforcement: OpenAI estimates drop to reality; Anthropic estimates rise to include previously-ignored cache cost (no new under-count that could let cost run away).

## Security
- Threat categories reviewed: **TM-DOS / TM-AGENT / TM-LLM (cost runaway)** — budgets are a cost-runaway mitigation (TM-AGENT-006, TM-LLM-008). This change makes the cost figure feeding enforcement *more accurate*; it never under-counts real provider cost (cache-inclusive providers correctly discount the cached subset; cache-exclusive providers now add cache cost that was previously dropped). No injection, auth, tenant-scoping, input-validation, or dependency surface touched. `u32` casts are guarded with `.max(0)` and `saturating_sub` prevents underflow.
- Findings and resolutions: None. No new threat surface; no `specs/threat-model.md` update warranted (improves accuracy of an existing mitigation rather than introducing/weakening one).

## Follow-ups
- `cost_tiers` (>200K-context tiered pricing on gpt-5.4/5.5) is still ignored by the estimator (base rates only) — a separate overcharge from caching, pre-existing behavior. Worth its own ticket; safe to defer as it's orthogonal to this fix and not part of EVE-599.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01XXySbkGETFgaGWHseUqfZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXySbkGETFgaGWHseUqfZY)_