### PR TITLE
fix(ci): skip live LLM tests when provider quota is exhausted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,14 +675,18 @@ jobs:
       # Gated to push events so PR-controlled cargo test cannot exfiltrate the
       # Doppler vault via env (build.rs, proc-macros, test bodies). PR coverage
       # of the LLM matrix is still mocked in `unit-test`.
-      - name: Run LLM integration tests (skips providers without API keys)
+      - name: Run LLM integration tests (skips providers without API keys or out of quota)
         if: github.event_name == 'push'
         timeout-minutes: 15
         # Provider API keys come from Doppler (the repo has no per-provider
         # GitHub secrets), matching the Slack live step above. `doppler run`
         # injects ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY /
         # OPENROUTER_API_KEY; the matrix runs every provider and skips only
-        # those whose key is absent from the vault.
+        # those whose key is absent from the vault, or whose account is out of
+        # quota/credits (a live billing condition, not a code regression — see
+        # `skip_if_quota!` / `is_quota_exhausted` in
+        # crates/llm-tests/tests/llm_test_matrix/mod.rs). Genuine API/contract
+        # breaks still fail the step.
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --all-features

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -56,6 +56,7 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 
     let result = runner.run_turn("Tell me a dad joke").await.unwrap();
 
+    skip_if_quota!(result, config.label());
     assert!(result.success, "Turn should succeed: {:?}", result.error);
     assert!(!result.response.is_empty(), "Response should not be empty");
     assert_eq!(result.tool_calls_count, 0, "No tools should be called");
@@ -91,6 +92,7 @@ async fn test_tool_call(#[case] config: ProviderModelConfig) {
 
     let result = runner.run_turn("What time is it?").await.unwrap();
 
+    skip_if_quota!(result, config.label());
     assert!(result.success, "Turn should succeed: {:?}", result.error);
     assert!(
         result.tool_calls_count > 0,
@@ -133,6 +135,7 @@ async fn test_file_system_tool_schemas_accepted(#[case] config: ProviderModelCon
 
     let result = runner.run_turn("Say hello").await.unwrap();
 
+    skip_if_quota!(result, config.label());
     assert!(
         result.success,
         "Turn should succeed with file system tools registered: {:?}",

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -73,6 +73,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 
     let result = runner.run_turn(input).await.unwrap();
 
+    skip_if_quota!(result, config.label());
     assert!(result.success, "Turn should succeed: {:?}", result.error);
     assert!(
         result.response.contains("503"),
@@ -168,6 +169,7 @@ async fn test_thinking_with_tool_call(#[case] config: ProviderModelConfig) {
 
     let result = runner.run_turn(input).await.unwrap();
 
+    skip_if_quota!(result, config.label());
     assert!(result.success, "Turn should succeed: {:?}", result.error);
     assert!(
         result.tool_calls_count > 0,

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -220,8 +220,11 @@ pub fn is_quota_exhausted(err: &str) -> bool {
 #[macro_export]
 macro_rules! skip_if_quota {
     ($result:expr, $label:expr) => {{
-        if !$result.success {
-            if let Some(err) = $result.error.as_deref() {
+        // Bind once by reference so the expression isn't evaluated twice (no
+        // duplicated side effects / moves if a caller passes a non-trivial expr).
+        let __result = &$result;
+        if !__result.success {
+            if let Some(err) = __result.error.as_deref() {
                 if is_quota_exhausted(err) {
                     eprintln!("SKIP: provider {} out of quota: {}", $label, err);
                     return;

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -149,6 +149,89 @@ pub const BEDROCK_SONNET: ProviderModelConfig = ProviderModelConfig::new(
 );
 
 // ============================================================================
+// Provider quota / billing exhaustion handling
+// ============================================================================
+
+// The live LLM matrix is best-effort: it already skips providers whose API key
+// is absent (see `ProviderModelConfig::model`). When a provider account is
+// merely out of credits, a turn fails with a billing/quota error from the live
+// API rather than a code regression. We treat that the same way as an absent
+// key: skip the case with a loud warning so `main` stays green, while a genuine
+// API/contract break still fails the test.
+//
+// Detection is kept specific so ordinary failures (auth, permission, model
+// availability, schema, rate limits unrelated to billing) still fail loudly:
+//   - `insufficient_quota` (OpenAI / OpenRouter)
+//   - `quota` together with `exceeded`/`billing`/`credit` (Gemini, Anthropic,
+//     generic phrasings like "exceeded your current quota")
+//   - HTTP 429 carrying a quota/billing signature (not a bare rate-limit)
+//
+// Authn/authz signals (`unauthorized`, `forbidden`, `invalid api key`,
+// `permission`, 401/403) are deliberately NOT matched, so a broken credential
+// is never silently swallowed.
+pub fn is_quota_exhausted(err: &str) -> bool {
+    let e = err.to_lowercase();
+
+    // Never treat auth/permission failures as quota exhaustion.
+    let auth_failure = e.contains("unauthorized")
+        || e.contains("forbidden")
+        || e.contains("invalid api key")
+        || e.contains("invalid_api_key")
+        || e.contains("permission")
+        || e.contains("authentication")
+        || e.contains(" 401")
+        || e.contains("401 ")
+        || e.contains(" 403")
+        || e.contains("403 ");
+    if auth_failure {
+        return false;
+    }
+
+    if e.contains("insufficient_quota") {
+        return true;
+    }
+
+    let billing_words = e.contains("billing")
+        || e.contains("exceeded")
+        || e.contains("credit")
+        || e.contains("out of quota");
+    if e.contains("quota") && billing_words {
+        return true;
+    }
+
+    // HTTP 429 only counts when paired with a quota/billing signal, so plain
+    // rate limiting (which should be retried/flagged, not skipped) still fails.
+    if e.contains("429") && (e.contains("quota") || billing_words) {
+        return true;
+    }
+
+    false
+}
+
+/// Skip the current test (with a loud stderr warning) if `result` failed due to
+/// the provider being out of quota/credits. Otherwise the test proceeds and its
+/// normal assertions run. `result` must expose `success: bool` and
+/// `error: Option<String>`.
+///
+/// Defined inside this shared module and re-exported via `use
+/// llm_test_matrix::*` so every test binary that includes the module can use it.
+/// `is_quota_exhausted` is called unqualified, resolved through the same glob
+/// import the test files already rely on.
+#[macro_export]
+macro_rules! skip_if_quota {
+    ($result:expr, $label:expr) => {{
+        if !$result.success {
+            if let Some(err) = $result.error.as_deref() {
+                if is_quota_exhausted(err) {
+                    eprintln!("SKIP: provider {} out of quota: {}", $label, err);
+                    return;
+                }
+            }
+        }
+    }};
+}
+
+// ============================================================================
 // Unified driver registry
 // ============================================================================
 
@@ -161,4 +244,57 @@ pub fn all_providers_registry() -> DriverRegistry {
     everruns_gemini::register_driver(&mut registry);
     everruns_bedrock::register_driver(&mut registry);
     registry
+}
+
+#[cfg(test)]
+mod quota_detector_tests {
+    use super::is_quota_exhausted;
+
+    #[test]
+    fn matches_provider_quota_signatures() {
+        // OpenAI / OpenRouter
+        assert!(is_quota_exhausted(
+            "LLM error: insufficient_quota: You exceeded your current quota, please check your plan and billing details."
+        ));
+        assert!(is_quota_exhausted("Error: insufficient_quota"));
+        // Generic "exceeded ... quota" phrasing without the machine code.
+        assert!(is_quota_exhausted(
+            "You have exceeded your current quota for this month"
+        ));
+        // Anthropic / Gemini style billing/credit exhaustion.
+        assert!(is_quota_exhausted(
+            "Your account has run out of credit; quota exhausted"
+        ));
+        assert!(is_quota_exhausted(
+            "Request failed: billing quota has been reached"
+        ));
+        // HTTP 429 paired with a quota signal.
+        assert!(is_quota_exhausted(
+            "HTTP 429 Too Many Requests: insufficient_quota"
+        ));
+        assert!(is_quota_exhausted("429: quota exceeded for project"));
+        // Case-insensitive.
+        assert!(is_quota_exhausted("INSUFFICIENT_QUOTA"));
+    }
+
+    #[test]
+    fn does_not_match_ordinary_or_auth_errors() {
+        // Genuine functional/contract breaks must still fail the test.
+        assert!(!is_quota_exhausted(
+            "Model not available: gpt-99-nonexistent"
+        ));
+        assert!(!is_quota_exhausted("Bad request: invalid schema for tool"));
+        assert!(!is_quota_exhausted("Internal server error"));
+        assert!(!is_quota_exhausted(""));
+        // Plain rate limiting (no billing/quota signal) should NOT be skipped.
+        assert!(!is_quota_exhausted("HTTP 429 Too Many Requests: slow down"));
+        assert!(!is_quota_exhausted("rate_limit_exceeded"));
+        // Auth/permission failures must never be swallowed as quota.
+        assert!(!is_quota_exhausted("401 Unauthorized: invalid api key"));
+        assert!(!is_quota_exhausted("403 Forbidden"));
+        assert!(!is_quota_exhausted(
+            "insufficient_quota but actually invalid api key"
+        ));
+        assert!(!is_quota_exhausted("permission denied for this model"));
+    }
 }


### PR DESCRIPTION
## What
Make the push-only "Run LLM integration tests" CI step resilient to provider **quota/billing exhaustion**: when a provider account is out of credits, skip that provider's case (with a loud stderr warning) instead of failing — exactly as the matrix already skips providers whose API key is absent.

## Why
`main` is currently red. The failing job is `Integration Tests (PostgreSQL)` → step `Run LLM integration tests` (gated `if: github.event_name == 'push'`, so it runs only on pushes to `main`). The OpenAI cases fail with:

```
Turn should succeed: Some("LLM error: insufficient_quota: You exceeded your current quota, please check your plan and billing details. ...")
```

This is **not a code regression** — the OpenAI account/key in Doppler is out of billing quota (confirmed: a direct `chat/completions` call returns HTTP 429 `insufficient_quota`). The live LLM matrix is explicitly best-effort (PR coverage of the matrix is mocked in `unit-test`; the live step already skips absent-key providers). A pure billing condition on an external API should degrade to a skip, not a red `main`.

## How
- `crates/llm-tests/tests/llm_test_matrix/mod.rs`: add `is_quota_exhausted(err: &str) -> bool` and a `skip_if_quota!(result, label)` macro. The detector matches billing/quota signatures (`insufficient_quota`; `quota` + `exceeded`/`billing`/`credit`/`out of quota`; HTTP 429 *paired* with a quota/billing signal) and **deliberately never** matches auth/permission failures (`unauthorized`/`forbidden`/`invalid api key`/`permission`/401/403) or plain rate-limiting — so broken credentials and genuine contract breaks still fail loudly.
- Apply `skip_if_quota!` immediately before the `result.success` assertions in `agent_run_basic.rs` (3 tests) and `agent_run_with_thinking.rs` (2 tests).
- Update the CI step name/comment to note it also skips out-of-quota providers.

## Validation
- `cargo fmt -p everruns-llm-tests --check` → clean
- `cargo clippy -p everruns-llm-tests --all-targets --all-features -- -D warnings` → no warnings
- New detector unit tests (`quota_detector_tests`): `2 passed` — cover OpenAI/Anthropic/Gemini/OpenRouter quota phrasings, 429+quota, case-insensitivity, and negative cases (model-not-found, bad schema, plain 429, `rate_limit_exceeded`, 401/403, mixed quota+auth).
- **Live proof against the real quota-exhausted OpenAI key:** `doppler run -- cargo test -p everruns-llm-tests --test agent_run_basic openai -- --nocapture` → OpenAI `gpt-5.4` and `gpt-4o-mini` cases now print `SKIP: provider ... out of quota` and the binary reports `7 passed; 0 failed` (previously these failed).

Note: the live step is push-only, so this PR's `pull_request` CI does not execute it; clippy (`--all-targets`) still compiles the test crate, and the detector logic is covered by the unit tests above.

## Security
Test-only change (plus a CI step comment). No runtime/auth/permission surface. The one security-relevant risk — a credential failure being silently swallowed — is explicitly guarded against: `is_quota_exhausted` returns `false` for any auth/permission/401/403 signal, including a string that mixes a quota phrase with an auth phrase.

## Follow-ups
- **Action for a human:** the OpenAI account billing is exhausted. Top it up to restore real live OpenAI coverage on `main` (until then those cases skip with a visible warning). No code follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164kXC12gyfRd5ia9KZUoWf)_