### PR TITLE
fix(mai): validate OAuth authority URLs

### DIFF
--- a/crates/mai/src/auth.rs
+++ b/crates/mai/src/auth.rs
@@ -242,9 +242,11 @@ impl EntraOAuthConfig {
             || url.path() != "/"
             || url.query().is_some()
             || url.fragment().is_some()
+            || !url.username().is_empty()
+            || url.password().is_some()
         {
             return Err(AgentLoopError::llm(
-                "Invalid Microsoft Entra ID OAuth authority URL: authority must be an https origin without port, path, query, or fragment",
+                "Invalid Microsoft Entra ID OAuth authority URL: authority must be an https origin without port, path, query, fragment, or credentials",
             ));
         }
 
@@ -518,6 +520,8 @@ mod tests {
             "https://login.microsoftonline.com/path",
             "https://login.microsoftonline.com?query=1",
             "https://login.microsoftonline.com#fragment",
+            "https://user:pass@login.microsoftonline.com",
+            "https://user@login.microsoftonline.com",
         ] {
             let extra = serde_json::json!({
                 "tenant_id": "tenant",


### PR DESCRIPTION
Re-opens the security fix from #2305 (the original PR's head pointer desynced after a rebase/force-push and GitHub would not let it reopen). Branch content is unchanged plus the review follow-up.

## What
Validate the Microsoft Entra OAuth `authority` from credential JSON before using it to request tokens (SSRF hardening).

## Why
The MAI provider accepted an unvalidated `authority` and POSTed to it for OAuth tokens — an SSRF / internal-response-disclosure risk.

## How
- `EntraOAuthConfig::validate_authority()` at parse time: require `https`, allowlist Entra public/sovereign hosts, reject port/path/query/fragment, and (review follow-up) reject URL userinfo/credentials.
- Disable redirects on the token client (`Policy::none()`).
- Validation runs on both `from_driver_config` and `from_credential_str` paths.

## Risk
- Low. Adds input validation at the credential boundary; legitimate Entra authorities are unaffected.

## Security
- Threat categories reviewed: TM-SSRF / credential handling.
- Findings and resolutions: closes the unvalidated-authority SSRF; userinfo now rejected too.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013RUnCXvnAgVKwpvTuMemFe)_