### PR TITLE
feat(session-tasks): org-scoped task listing endpoint (EVE-583)

### DIFF
--- a/crates/server/migrations/080_session_tasks_created_at_index.sql
+++ b/crates/server/migrations/080_session_tasks_created_at_index.sql
@@ -1,0 +1,9 @@
+-- Org-scoped task listing (EVE-583).
+--
+-- `list_org_tasks` lists every task across an org's sessions, newest-first,
+-- with optional kind/state/age filters and a bounded LIMIT (ops/observability
+-- dashboards). The org boundary is a semijoin on `sessions(org_id)`; this index
+-- lets the recency ordering and the `created_at >= cutoff` age bound be served
+-- without a full-table sort as `session_tasks` grows. The existing
+-- (session_id, state) index only helps the per-session path.
+CREATE INDEX session_tasks_created_at_idx ON session_tasks (created_at DESC);

--- a/crates/server/migrations/080_session_tasks_created_at_index.sql
+++ b/crates/server/migrations/080_session_tasks_created_at_index.sql
@@ -5,5 +5,7 @@
 -- dashboards). The org boundary is a semijoin on `sessions(org_id)`; this index
 -- lets the recency ordering and the `created_at >= cutoff` age bound be served
 -- without a full-table sort as `session_tasks` grows. The existing
--- (session_id, state) index only helps the per-session path.
-CREATE INDEX session_tasks_created_at_idx ON session_tasks (created_at DESC);
+-- (session_id, state) index only helps the per-session path. The `id`
+-- tiebreaker matches the query's `ORDER BY created_at DESC, id DESC`, so rows
+-- sharing a `created_at` need no extra sort step.
+CREATE INDEX session_tasks_created_at_idx ON session_tasks (created_at DESC, id DESC);

--- a/crates/server/src/api/session_tasks.rs
+++ b/crates/server/src/api/session_tasks.rs
@@ -7,7 +7,8 @@
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::{Command, Ctx};
 use crate::domains::session_tasks::{
-    CancelSessionTask, GetSessionTask, ListSessionTasks, PostSessionTaskMessage, SessionTaskDetail,
+    CancelSessionTask, GetSessionTask, ListOrgTasks, ListSessionTasks, PostSessionTaskMessage,
+    SessionTaskDetail,
 };
 use crate::services::EventService;
 use crate::storage::StorageBackend;
@@ -57,6 +58,7 @@ impl_auth_state!(AppState);
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        .route("/v1/tasks", get(list_org_tasks))
         .route("/v1/sessions/{session_id}/tasks", get(list_tasks))
         .route("/v1/sessions/{session_id}/tasks/{task_id}", get(get_task))
         .route(
@@ -68,6 +70,46 @@ pub fn routes(state: AppState) -> Router {
             post(cancel_task),
         )
         .with_state(state)
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ListOrgTasksQuery {
+    pub state: Option<String>,
+    pub kind: Option<String>,
+    pub created_after: Option<String>,
+    pub limit: Option<u32>,
+}
+
+/// List background tasks across every session in the caller's org.
+#[utoipa::path(
+    get,
+    path = "/v1/tasks",
+    params(
+        ("state" = Option<String>, Query, description = "Filter by state"),
+        ("kind" = Option<String>, Query, description = "Filter by kind"),
+        ("created_after" = Option<String>, Query, description = "Only tasks created at/after this RFC3339 timestamp"),
+        ("limit" = Option<u32>, Query, description = "Max tasks, newest first (default 100, max 500)"),
+    ),
+    responses(
+        (status = 200, description = "Org tasks", body = Vec<SessionTask>),
+    ),
+    tag = "session-tasks"
+)]
+pub async fn list_org_tasks(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<ListOrgTasksQuery>,
+) -> ApiResult<Vec<SessionTask>> {
+    Ok(Json(
+        ListOrgTasks {
+            state: query.state,
+            kind: query.kind,
+            created_after: query.created_after,
+            limit: query.limit,
+        }
+        .run(&state.ctx(&org))
+        .await?,
+    ))
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -142,13 +142,14 @@ impl Command for ListOrgTasks {
             None => None,
         };
         let limit = self.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as i64;
+        let state = state.map(|s| s.to_string());
 
         let rows = ctx
             .db
             .list_org_session_tasks(
                 ctx.org_id(),
                 kind.as_deref(),
-                state.map(|s| s.to_string()).as_deref(),
+                state.as_deref(),
                 created_after,
                 limit,
             )

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -76,6 +76,96 @@ impl Command for ListSessionTasks {
 
 inventory::submit! { CommandDescriptor::of::<ListSessionTasks>() }
 
+/// List background tasks across every session in the caller's org.
+///
+/// Org-scoped observability query (EVE-583): unlike `ListSessionTasks`, this is
+/// not bound to a single session. The org is taken from the authenticated
+/// caller (`ctx.org_id()`), never from input, so the result is always scoped to
+/// the caller's tenant.
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct ListOrgTasks {
+    /// Optional state filter (queued, running, awaiting_input, succeeded, failed, canceled).
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Optional kind filter (subagent, external_agent, background_tool, monitor, ...).
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Optional age filter: only tasks created at or after this RFC3339 timestamp.
+    #[serde(default)]
+    pub created_after: Option<String>,
+    /// Max tasks to return, newest first. Defaults to 100, capped at 500.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+impl Command for ListOrgTasks {
+    type Output = Vec<SessionTask>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_org_tasks",
+            category: "session_tasks",
+            description: "List background tasks across every session in the org.",
+            method: "GET",
+            path: "/v1/tasks",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&SESSION_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<SessionTask>, CommandError> {
+        const DEFAULT_LIMIT: u32 = 100;
+        const MAX_LIMIT: u32 = 500;
+
+        let state = match self.state.as_deref().filter(|s| !s.is_empty()) {
+            Some(raw) => Some(SessionTaskState::parse(raw).ok_or_else(|| {
+                CommandError::bad_request(format!(
+                    "Unknown state filter \"{raw}\". Valid states: queued, running, \
+                     awaiting_input, succeeded, failed, canceled."
+                ))
+            })?),
+            None => None,
+        };
+        let kind = self.kind.filter(|k| !k.is_empty());
+        let created_after = match self.created_after.as_deref().filter(|s| !s.is_empty()) {
+            Some(raw) => Some(
+                chrono::DateTime::parse_from_rfc3339(raw)
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+                    .map_err(|e| {
+                        CommandError::bad_request(format!(
+                            "Invalid created_after timestamp \"{raw}\" (expected RFC3339): {e}"
+                        ))
+                    })?,
+            ),
+            None => None,
+        };
+        let limit = self.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as i64;
+
+        let rows = ctx
+            .db
+            .list_org_session_tasks(
+                ctx.org_id(),
+                kind.as_deref(),
+                state.map(|s| s.to_string()).as_deref(),
+                created_after,
+                limit,
+            )
+            .await
+            .map_err(classify_anyhow)?;
+        rows.iter()
+            .map(|r| {
+                r.to_task().map_err(|e| {
+                    CommandError::internal(anyhow::anyhow!("Invalid session task row: {e}"))
+                })
+            })
+            .collect()
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListOrgTasks>() }
+
 /// Task snapshot plus the recent message thread.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SessionTaskDetail {
@@ -444,6 +534,164 @@ mod tests {
         .await
         .unwrap()
         .id
+    }
+
+    /// Create a session owned by an arbitrary org (for cross-tenant tests).
+    async fn create_session_in_org(
+        db: &Arc<StorageBackend>,
+        org_id: i64,
+    ) -> everruns_core::SessionId {
+        db.create_session(CreateSessionRow {
+            org_id,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            title: Some("other-org session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            workspace_id: None,
+        })
+        .await
+        .unwrap()
+        .id
+    }
+
+    // -------------------------------------------------------------------------
+    // ListOrgTasks — cross-session, org-scoped listing (EVE-583)
+    // -------------------------------------------------------------------------
+
+    /// Org-scoped listing must return every task across the caller's org while
+    /// never leaking tasks owned by another org, and must honor kind/state/limit
+    /// filters.
+    #[tokio::test]
+    async fn list_org_tasks_scopes_to_org_and_filters() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = test_ctx(db.clone()); // DEFAULT_ORG_ID
+        let registry = q::registry_for_ctx(&ctx);
+
+        // Org A (the caller's org): one subagent (running), one background_tool (queued).
+        let sess_a = create_session(&db).await;
+        registry
+            .create(CreateSessionTask {
+                session_id: sess_a,
+                id: None,
+                kind: TASK_KIND_SUBAGENT.to_string(),
+                display_name: "A-sub".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+        registry
+            .create(CreateSessionTask {
+                session_id: sess_a,
+                id: None,
+                kind: TASK_KIND_BACKGROUND_TOOL.to_string(),
+                display_name: "A-bg".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Queued,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        // Org B (a different tenant): a task that must never surface for org A.
+        let other_org = DEFAULT_ORG_ID + 12_345;
+        let sess_b = create_session_in_org(&db, other_org).await;
+        registry
+            .create(CreateSessionTask {
+                session_id: sess_b,
+                id: None,
+                kind: TASK_KIND_SUBAGENT.to_string(),
+                display_name: "B-sub".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        // Unfiltered: only org A's two tasks, never org B's.
+        let all = ListOrgTasks::default().execute(&ctx).await.unwrap();
+        assert_eq!(all.len(), 2, "must list exactly org A's two tasks");
+        assert!(
+            all.iter().all(|t| t.session_id == sess_a),
+            "must never leak another org's tasks"
+        );
+
+        // Kind filter.
+        let subs = ListOrgTasks {
+            kind: Some("subagent".to_string()),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await
+        .unwrap();
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0].kind, TASK_KIND_SUBAGENT);
+
+        // State filter.
+        let queued = ListOrgTasks {
+            state: Some("queued".to_string()),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await
+        .unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].state, SessionTaskState::Queued);
+
+        // Limit caps the result set.
+        let one = ListOrgTasks {
+            limit: Some(1),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await
+        .unwrap();
+        assert_eq!(one.len(), 1, "limit must bound the result set");
+
+        // Age filter: a future cutoff excludes everything; bad input is rejected.
+        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let none = ListOrgTasks {
+            created_after: Some(future),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await
+        .unwrap();
+        assert!(none.is_empty(), "future created_after must exclude all");
+
+        let bad = ListOrgTasks {
+            created_after: Some("not-a-timestamp".to_string()),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await;
+        assert!(
+            matches!(bad.unwrap_err().kind, CommandErrorKind::BadRequest(_)),
+            "invalid created_after must be a bad request"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -115,6 +115,7 @@ use utoipa::OpenApi;
         api::session_git::create_branch,
         api::session_git::delete_branch,
         api::session_resources::list_resources,
+        api::session_tasks::list_org_tasks,
         api::session_tasks::list_tasks,
         api::session_tasks::get_task,
         api::session_tasks::post_task_message,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3112,6 +3112,29 @@ impl StorageBackend {
         dispatch!(self, list_session_tasks, session_id, kind, state)
     }
 
+    /// List tasks across every session owned by `org_id`, newest-first, with
+    /// optional kind/state/age filters and a bounded limit. Org scoping is the
+    /// authoritative multitenancy boundary (a semijoin on `sessions.org_id`):
+    /// a task is only returned when its owning session belongs to the org.
+    pub async fn list_org_session_tasks(
+        &self,
+        org_id: i64,
+        kind: Option<&str>,
+        state: Option<&str>,
+        created_after: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<SessionTaskRow>> {
+        dispatch!(
+            self,
+            list_org_session_tasks,
+            org_id,
+            kind,
+            state,
+            created_after,
+            limit
+        )
+    }
+
     pub async fn update_session_task(
         &self,
         session_id: SessionId,

--- a/crates/server/src/storage/memory/session_tasks.rs
+++ b/crates/server/src/storage/memory/session_tasks.rs
@@ -62,6 +62,46 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
+    /// List tasks across every session owned by `org_id`, newest-first, with
+    /// optional kind/state/age filters and a bounded limit. Mirrors the
+    /// PostgreSQL repository: org scoping is the authoritative multitenancy
+    /// boundary — a task is only returned when its owning session belongs to
+    /// the org.
+    pub async fn list_org_session_tasks(
+        &self,
+        org_id: i64,
+        kind: Option<&str>,
+        state: Option<&str>,
+        created_after: Option<chrono::DateTime<chrono::Utc>>,
+        limit: i64,
+    ) -> Result<Vec<SessionTaskRow>> {
+        // Sessions owned by the org — the multitenancy boundary, mirroring the
+        // SQL semijoin on sessions.org_id.
+        let org_sessions: std::collections::HashSet<SessionId> = {
+            let sessions = self.sessions.read();
+            sessions
+                .values()
+                .filter(|s| s.org_id == org_id)
+                .map(|s| s.id)
+                .collect()
+        };
+        let tasks = self.session_tasks.read();
+        let mut result: Vec<_> = tasks
+            .values()
+            .filter(|row| {
+                org_sessions.contains(&row.session_id)
+                    && kind.is_none_or(|k| row.kind == k)
+                    && state.is_none_or(|s| row.state == s)
+                    && created_after.is_none_or(|c| row.created_at >= c)
+            })
+            .cloned()
+            .collect();
+        // Newest-first, matching the PG `ORDER BY created_at DESC, id DESC`.
+        result.sort_by(|a, b| (b.created_at, &b.id).cmp(&(a.created_at, &a.id)));
+        result.truncate(limit.max(0) as usize);
+        Ok(result)
+    }
+
     /// Load the task, apply the update through core invariants, write back.
     pub async fn update_session_task(
         &self,

--- a/crates/server/src/storage/repositories/session_tasks.rs
+++ b/crates/server/src/storage/repositories/session_tasks.rs
@@ -124,6 +124,40 @@ impl Database {
         Ok(rows)
     }
 
+    /// List tasks across every session owned by `org_id`, newest-first, with
+    /// optional kind/state/age filters and a bounded limit. The org boundary is
+    /// a semijoin on `sessions.org_id` — the authoritative multitenancy scope —
+    /// so a task only appears when its owning session belongs to the org.
+    pub async fn list_org_session_tasks(
+        &self,
+        org_id: i64,
+        kind: Option<&str>,
+        state: Option<&str>,
+        created_after: Option<chrono::DateTime<chrono::Utc>>,
+        limit: i64,
+    ) -> Result<Vec<SessionTaskRow>> {
+        let rows = sqlx::query_as::<_, SessionTaskRow>(sqlx::AssertSqlSafe(format!(
+            r#"
+            SELECT {TASK_COLUMNS}
+            FROM session_tasks
+            WHERE session_id IN (SELECT id FROM sessions WHERE org_id = $1)
+              AND ($2::text IS NULL OR kind = $2)
+              AND ($3::text IS NULL OR state = $3)
+              AND ($4::timestamptz IS NULL OR created_at >= $4)
+            ORDER BY created_at DESC, id DESC
+            LIMIT $5
+            "#
+        )))
+        .bind(org_id)
+        .bind(kind)
+        .bind(state)
+        .bind(created_after)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
     /// Load the task, apply the update through core invariants, write back.
     /// Runs in a transaction with `SELECT ... FOR UPDATE`.
     pub async fn update_session_task(

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -2952,3 +2952,170 @@ async fn test_reap_running_agent_health_check_runs() {
         .expect("completed run exists");
     assert_eq!(done_after.status, "completed");
 }
+
+/// Org-scoped task listing (EVE-583) against real PostgreSQL.
+///
+/// Validates the `sessions.org_id` semijoin, the kind/state/created_after
+/// filters, and the bounded limit — including strict cross-org isolation: a
+/// task owned by another org must never appear in the caller org's listing.
+#[tokio::test]
+async fn list_org_session_tasks_pg() {
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, TASK_KIND_BACKGROUND_TOOL, TASK_KIND_SUBAGENT,
+        TaskLinks, TaskWakePolicy, new_session_task,
+    };
+
+    let backend = create_test_backend().await;
+    let org_b = create_test_org(&backend, "EVE-583 Isolation Org").await;
+
+    // A session in each org.
+    let mk_session = |org_id: i64, owner: everruns_core::PrincipalId| {
+        let backend = &backend;
+        async move {
+            backend
+                .create_session(CreateSessionRow {
+                    workspace_id: None,
+                    org_id,
+                    app_id: None,
+                    harness_id: None,
+                    agent_id: None,
+                    agent_identity_id: None,
+                    owner_principal_id: owner,
+                    resolved_owner_user_id: None,
+                    title: Some(format!("eve-583-{}", Uuid::now_v7())),
+                    locale: None,
+                    tags: vec![],
+                    model_id: None,
+                    capabilities: json!([]),
+                    tools: json!([]),
+                    mcp_servers: json!({}),
+                    system_prompt: None,
+                    initial_files: json!([]),
+                    hints: None,
+                    network_access: None,
+                    max_iterations: None,
+                    parallel_tool_calls: None,
+                    blueprint_id: None,
+                    blueprint_config: None,
+                    parent_session_id: None,
+                })
+                .await
+                .expect("create session")
+                .id
+        }
+    };
+
+    let owner_a = create_test_principal(&backend, TEST_ORG_ID).await;
+    let owner_b = create_test_principal(&backend, org_b).await;
+    let session_a = mk_session(TEST_ORG_ID, owner_a).await;
+    let session_b = mk_session(org_b, owner_b).await;
+
+    // Two tasks in org A (distinct kind/state), one in org B.
+    let mk_task = |session_id, kind: &str, state, name: &str| {
+        let task = new_session_task(
+            CreateSessionTask {
+                session_id,
+                id: None,
+                kind: kind.to_string(),
+                display_name: name.to_string(),
+                spec: json!({}),
+                state,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            },
+            Utc::now(),
+        );
+        let backend = &backend;
+        async move {
+            backend
+                .create_session_task(&task)
+                .await
+                .expect("create task");
+            task.id
+        }
+    };
+
+    let a_sub = mk_task(
+        session_a,
+        TASK_KIND_SUBAGENT,
+        SessionTaskState::Running,
+        "A-sub",
+    )
+    .await;
+    let a_bg = mk_task(
+        session_a,
+        TASK_KIND_BACKGROUND_TOOL,
+        SessionTaskState::Queued,
+        "A-bg",
+    )
+    .await;
+    let b_sub = mk_task(
+        session_b,
+        TASK_KIND_SUBAGENT,
+        SessionTaskState::Running,
+        "B-sub",
+    )
+    .await;
+
+    let ids = |rows: &[everruns_server::storage::SessionTaskRow]| {
+        rows.iter()
+            .map(|r| r.id.clone())
+            .collect::<std::collections::HashSet<_>>()
+    };
+
+    // Org A listing: contains both A tasks, never the B task.
+    let a_all = backend
+        .list_org_session_tasks(TEST_ORG_ID, None, None, None, 500)
+        .await
+        .expect("list org A");
+    let a_all_ids = ids(&a_all);
+    assert!(a_all_ids.contains(&a_sub), "A-sub must be listed");
+    assert!(a_all_ids.contains(&a_bg), "A-bg must be listed");
+    assert!(
+        !a_all_ids.contains(&b_sub),
+        "org B's task must never leak into org A's listing"
+    );
+
+    // Org B listing: contains only the B task, never A's.
+    let b_all = backend
+        .list_org_session_tasks(org_b, None, None, None, 500)
+        .await
+        .expect("list org B");
+    let b_all_ids = ids(&b_all);
+    assert!(b_all_ids.contains(&b_sub));
+    assert!(!b_all_ids.contains(&a_sub) && !b_all_ids.contains(&a_bg));
+
+    // Kind filter (org A): only the subagent task.
+    let a_subs = backend
+        .list_org_session_tasks(TEST_ORG_ID, Some("subagent"), None, None, 500)
+        .await
+        .expect("list org A subagents");
+    let a_subs_ids = ids(&a_subs);
+    assert!(a_subs_ids.contains(&a_sub));
+    assert!(!a_subs_ids.contains(&a_bg));
+
+    // State filter (org A): only the queued task.
+    let a_queued = backend
+        .list_org_session_tasks(TEST_ORG_ID, None, Some("queued"), None, 500)
+        .await
+        .expect("list org A queued");
+    let a_queued_ids = ids(&a_queued);
+    assert!(a_queued_ids.contains(&a_bg));
+    assert!(!a_queued_ids.contains(&a_sub));
+
+    // created_after in the future excludes our just-created tasks.
+    let future = Utc::now() + chrono::Duration::hours(1);
+    let a_future = backend
+        .list_org_session_tasks(TEST_ORG_ID, None, None, Some(future), 500)
+        .await
+        .expect("list org A future");
+    let a_future_ids = ids(&a_future);
+    assert!(!a_future_ids.contains(&a_sub) && !a_future_ids.contains(&a_bg));
+
+    // Limit is honored.
+    let a_limited = backend
+        .list_org_session_tasks(TEST_ORG_ID, None, None, None, 1)
+        .await
+        .expect("list org A limited");
+    assert!(a_limited.len() <= 1, "limit must bound the result set");
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -12251,6 +12251,70 @@
         }
       }
     },
+    "/v1/tasks": {
+      "get": {
+        "tags": [
+          "session-tasks"
+        ],
+        "summary": "List background tasks across every session in the caller's org.",
+        "operationId": "list_org_tasks",
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Filter by state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Filter by kind",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "created_after",
+            "in": "query",
+            "description": "Only tasks created at/after this RFC3339 timestamp",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max tasks, newest first (default 100, max 500)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Org tasks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SessionTask"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users": {
       "get": {
         "tags": [

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -314,11 +314,20 @@ a registry policy rather than per-capability cleanup.
 ## API
 
 ```
+GET  /v1/tasks                                  — org-scoped list (state/kind/created_after, newest-first, bounded limit)
 GET  /v1/sessions/{session_id}/tasks            — list (filter by state/kind)
 GET  /v1/sessions/{session_id}/tasks/{task_id}  — snapshot + recent thread
 POST /v1/sessions/{session_id}/tasks/{task_id}/messages — inbound message
 POST /v1/sessions/{session_id}/tasks/{task_id}/cancel   — cancel intent
 ```
+
+`GET /v1/tasks` (EVE-583) is the cross-session, org-scoped query for
+ops/observability: it lists tasks across every session in the caller's org,
+newest-first, with optional `state`, `kind`, and `created_after` (RFC3339) age
+filters and a bounded `limit` (default 100, max 500). The org is taken from the
+authenticated caller, never from input; scoping is a semijoin on
+`sessions.org_id` (the authoritative tenant boundary), backed by the
+`session_tasks (created_at DESC)` index.
 
 Message posts and cancels both invoke the kind's `TaskExecutor` best-effort
 after the durable registry write: the message is recorded and the cancel intent
@@ -441,4 +450,3 @@ No backward compatibility is required; data migrates forward once:
 - Webhooks / push notifications on task transitions.
 - Per-org retention TTL overrides (global TTL ships first; see Retention).
 - Task definitions / recurrence (monitors ship as long-lived tasks first).
-- Cross-session or org-scoped task queries.


### PR DESCRIPTION
## What
Add a cross-session, **org-scoped** task query for ops/observability: `GET /v1/tasks`. Lists every task across the caller's org, newest-first, with optional `state`, `kind`, and `created_after` (RFC3339) filters and a bounded `limit` (default 100, max 500). Auto-registered as a command, so it is available over both HTTP and the CLI. Closes EVE-583.

## Why
`list_tasks` (`SessionTaskFilter`) is scoped to a single `session_id` — there is no "everything running across my org" view for ops/observability dashboards. `specs/session-tasks.md` listed this under "Out of scope (v1)".

## How
- **Command** — `ListOrgTasks` (`crates/server/src/domains/session_tasks/commands.rs`): parses/validates `state` (closed enum), `kind`, `created_after` (RFC3339 → `DateTime<Utc>`, bad input → 400), and `limit` (clamped 1..=500). The org is taken from the authenticated caller (`ctx.org_id()`), **never from input**.
- **Storage** — `StorageBackend::list_org_session_tasks` (PostgreSQL + in-memory). Org scoping is a semijoin on `sessions.org_id` (`WHERE session_id IN (SELECT id FROM sessions WHERE org_id = $1)`) — the authoritative multitenancy boundary — plus the kind/state/age filters, `ORDER BY created_at DESC, id DESC LIMIT $5`. The in-memory backend mirrors this exactly.
- **Route** — `GET /v1/tasks` added to the session-tasks router; thin wrapper that builds `ListOrgTasks` and calls `.run()` (parity with the existing `list_tasks` handler). Registered in `openapi.rs`.
- **Migration 080** — `session_tasks (created_at DESC)` index so the org-wide recency ordering + `created_after` age bound are served without a full-table sort as `session_tasks` grows (the existing `(session_id, state)` index only helps the per-session path).
- **Spec** — `specs/session-tasks.md`: documents the endpoint, removes it from "Out of scope".

## Risk
- **Low.** Additive read-only endpoint; no changes to existing write/lifecycle paths. The new index is created on an existing table (online for an index of this size).

## Security
- **Threat categories reviewed:** TM-TENANT (cross-tenant isolation), TM-API (new endpoint input parsing), TM-DOS (unbounded results).
- **Findings and resolutions:**
  - *Cross-tenant (TM-TENANT):* the org is sourced from the authenticated caller, never request input; scoping is a semijoin on `sessions.org_id`, the same authoritative boundary used elsewhere. A task is returned only when its owning session belongs to the caller's org. Covered by an explicit cross-org isolation assertion in both the in-memory command test and the PostgreSQL integration test (org B's task must never appear in org A's listing, and vice-versa).
  - *Input validation (TM-API):* `state` is parsed against the closed `SessionTaskState` enum; `created_after` is strict RFC3339 (invalid → 400); `kind` is treated as an opaque equality filter (bound parameter, no SQL injection — `sqlx` bind, not string interpolation).
  - *Resource exhaustion (TM-DOS):* `limit` is clamped to 1..=500 (default 100), so the result set is always bounded.

## Follow-ups
No follow-ups. (Cursor pagination beyond a single bounded page is not required for the ops/observability use case; the bounded newest-first window is sufficient and can be extended later if a consumer needs it.)

## Validation
- `cargo fmt --check`, `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p everruns-server --lib list_org_tasks_scopes_to_org_and_filters` — passes (drives `ListOrgTasks::execute` through a real `Ctx` + `StorageBackend` across two orgs: isolation, kind/state/limit/created_after filters, bad-input rejection).
- PostgreSQL integration test `list_org_session_tasks_pg` compiles; exercises the SQL semijoin + filters + cross-org isolation in CI's PostgreSQL job.
- Migration ordering check: sequential 001..080.
- Note: an in-process HTTP boot to curl the live route was not possible in this sandboxed environment (the listener socket bind is killed by the network policy). The HTTP handler is a thin parity wrapper of the already-shipped `list_tasks`; the full command path it invokes is covered by the tests above.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive endpoint; no existing behavior changed)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbTNhuYp6pEgYtw7e9dJF7)_