### PR TITLE
docs: point README links to docs.everruns.com and fill doc gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Define agents and their tools, compose them into reusable harnesses, then ship t
 
 ### Build agents
 
-- **Harnesses, Agents, Capabilities, Skills** — modular configuration that composes into a runtime agent. Built-in harness types for general chat, data analysis, and coding (sandbox or Daytona-backed).
-- **Agent versioning, blueprints, and identities** — iterate safely on production agents and run unattended workloads under virtual principals.
-- **Capabilities library** — web fetch, bash sandbox, session filesystem, session SQL DB, memory, knowledge bases, MCP, voice, and more.
-- **Skills registry** — agentskills.io-format skills with discovery, search, and usage tracking.
+- **[Harnesses](https://docs.everruns.com/features/harnesses/), Agents, Capabilities, Skills** — modular configuration that composes into a runtime agent. [Built-in harness types](https://docs.everruns.com/built-ins/) for general chat, data analysis, and coding (sandbox or Daytona-backed).
+- **[Agent versioning](https://docs.everruns.com/features/agent-versions/), blueprints, and identities** — iterate safely on production agents and run unattended workloads under virtual principals.
+- **[Capabilities library](https://docs.everruns.com/features/capabilities/)** — web fetch, bash sandbox, session filesystem, session SQL DB, memory, knowledge bases, MCP, voice, and more.
+- **[Skills registry](https://docs.everruns.com/features/skills-registry/)** — agentskills.io-format skills with discovery, search, and usage tracking.
 - **Generative UI** — agents can return rich cards via [OpenUI](https://github.com/openuidev/openui), [A2UI](https://github.com/google/a2ui), and inline `ui://everruns/...` MCP App resources.
 
 ### Connect any model and any tool
@@ -31,7 +31,7 @@ Define agents and their tools, compose them into reusable harnesses, then ship t
 
 ### Ship agents to real channels
 
-Define an **App** that binds a Harness + Agent to one or more **channels**:
+Define an **[App](https://docs.everruns.com/features/apps/)** that binds a Harness + Agent to one or more **channels**:
 
 - `slack` — Slack app with thread/channel/user routing
 - `ag_ui` — embeddable web chat (AG-UI)
@@ -42,12 +42,12 @@ Define an **App** that binds a Harness + Agent to one or more **channels**:
 
 ### Run reliably at scale
 
-- **Durable execution engine** — PostgreSQL-backed workflows; agent sessions survive restarts, worker crashes, and network partitions.
+- **[Durable execution engine](https://docs.everruns.com/explanation/durable-execution/)** — PostgreSQL-backed workflows; agent sessions survive restarts, worker crashes, and network partitions.
 - **Control-plane / worker split** — workers talk to the control-plane over gRPC only; no DB credentials on workers.
-- **Streaming events** — SSE with NATS JetStream (production) or in-memory broadcast (dev) for ephemeral deltas, PostgreSQL for durable events.
+- **[Streaming events](https://docs.everruns.com/features/events/)** — SSE with NATS JetStream (production) or in-memory broadcast (dev) for ephemeral deltas, PostgreSQL for durable events.
 - **Multi-tenant** — organizations, fine-grained permissions, audit logging, envelope encryption (AES-256-GCM) for secrets.
 - **Infinity context** — automatic compaction keeps conversations going past any model's context window.
-- **Observability** — OpenTelemetry GenAI semantic conventions, Prometheus `/metrics`, optional Braintrust.
+- **[Observability](https://docs.everruns.com/observability/)** — OpenTelemetry GenAI semantic conventions, Prometheus `/metrics`, optional Braintrust.
 - **Budgeting, usage tracking, reporting** — token meters, budgets with soft enforcement, and async analytical projections (StarRocks or DuckDB-over-object-storage).
 - **Evals** — user-facing behavioral evals plus a SWE-bench Lite harness.
 
@@ -119,21 +119,23 @@ Run `/everruns-dev:whoami` and complete the OAuth flow on first use. See [`plugi
 
 ## Embed in your own app
 
-Need to run Everruns harnesses in-process? Use the embedded runtime crate (`everruns-runtime`) with `InProcessRuntimeBuilder` for in-memory sessions, filesystem, and storage. See [`specs/runtime.md`](specs/runtime.md) and [`specs/embedding.md`](specs/embedding.md).
+Need to run Everruns harnesses in-process? Use the embedded runtime crate (`everruns-runtime`) with `InProcessRuntimeBuilder` for in-memory sessions, filesystem, and storage. See the [Runtime](https://docs.everruns.com/features/runtime/) and [Embedding Everruns](https://docs.everruns.com/advanced/embedding-everruns/) guides.
 
-A CLI (`everruns-cli`) is also available for scripting against a deployment — see [`specs/cli.md`](specs/cli.md).
+A CLI (`everruns-cli`) is also available for scripting against a deployment — see the [CLI](https://docs.everruns.com/features/cli/) guide.
 
-## Documentation
+Full documentation lives at **[docs.everruns.com](https://docs.everruns.com)**.
 
-- [Getting Started](https://docs.everruns.com/getting-started/introduction/) — concepts and first agent
-- [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/)
+- [Introduction](https://docs.everruns.com/getting-started/introduction/) — what Everruns is and core [concepts](https://docs.everruns.com/getting-started/concepts/)
+- [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/) — run the full stack
+- [How-to guides](https://docs.everruns.com/how-to/) — give agents tools, stream events, publish to Slack, enforce budgets
+- [Capabilities](https://docs.everruns.com/features/capabilities/) and [Harnesses](https://docs.everruns.com/features/harnesses/) — the building blocks
+- [Architecture](https://docs.everruns.com/explanation/architecture/) and [Durable execution](https://docs.everruns.com/explanation/durable-execution/) — how it works under the hood
 - [API Reference](https://docs.everruns.com/api/) — OpenAPI 3.0
-- [Capabilities](https://docs.everruns.com/features/capabilities/)
-- [Specs index](specs/) — architecture, models, APIs, threat model, and every feature in detail
+- [SDKs](https://docs.everruns.com/features/sdk/) — Rust, Python, and TypeScript clients
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and [AGENTS.md](./AGENTS.md) for the conventions used by both human and AI contributors.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and [AGENTS.md](./AGENTS.md) for the conventions used by both human and AI contributors. The [`specs/`](specs/) directory holds the durable design intent — architecture, models, APIs, threat model, and every feature in detail — and is the canonical reference when changing behavior.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,46 @@
 
 Define agents and their tools, compose them into reusable harnesses, then ship them to real users through Slack, web chat, scheduled jobs, webhooks, A2A, MCP, or a plain HTTP API — backed by a Rust + PostgreSQL durable execution engine that survives restarts and scales horizontally.
 
+## Why Everruns
+
+- **Durable by default** — every session is a PostgreSQL-backed workflow that survives restarts, worker crashes, and network partitions. No lost runs, no in-memory state to babysit.
+- **One agent, every channel** — define a harness once, then [publish](https://docs.everruns.com/features/apps/) it to Slack, web chat, A2A, webhooks, cron schedules, voice, or a plain HTTP/[MCP](https://docs.everruns.com/features/mcp/) API.
+- **Open and provider-neutral** — implements the [Open Responses](https://www.openresponses.org/) spec across OpenAI, Anthropic, Gemini, and Azure; register remote MCP servers as tools. MIT-licensed and self-hostable.
+- **Built for production** — multi-tenant orgs, fine-grained permissions, envelope-encrypted secrets, budgets, [observability](https://docs.everruns.com/observability/), and a control-plane / worker split that scales horizontally.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Public["Public surface"]
+        Clients["Clients<br/>SDK · CLI · App"]
+        Proxy["Reverse proxy<br/>TLS · /api · /mcp"]
+    end
+    subgraph CP["Control plane"]
+        Server["Server<br/>REST · gRPC"]
+    end
+    subgraph Workers["Worker pool · stateless"]
+        W1["Worker"]
+        W2["Worker"]
+        Wn["Worker N"]
+    end
+    subgraph Data["State & messaging"]
+        PG["PostgreSQL<br/>required · task queue + event log"]
+        NATS["NATS JetStream<br/>optional · event push"]
+        Valkey["Valkey<br/>optional · rate limiting"]
+    end
+
+    Clients --> Proxy --> Server
+    Server <--> W1
+    Server <--> W2
+    Server <--> Wn
+    Server --> PG
+    Server -.-> NATS
+    Server -.-> Valkey
+```
+
+Workers are stateless and hold no database credentials — they reach the control plane over gRPC only. See [Architecture](https://docs.everruns.com/explanation/architecture/) for the full picture.
+
 ## What's inside
 
 ### Build agents
@@ -24,9 +64,8 @@ Define agents and their tools, compose them into reusable harnesses, then ship t
 ### Connect any model and any tool
 
 - **LLM providers**: OpenAI (Responses + Chat Completions), Azure OpenAI, Anthropic, Gemini, plus `llmsim` for tests. Model resolution is layered: message → session → agent → system default.
-- **MCP client** — register remote MCP servers as virtual capabilities. Tools are auto-discovered, namespaced, and executed over HTTP JSON-RPC.
-- **MCP server** — every Everruns deployment exposes its own MCP endpoint with OAuth 2.1 auth, so agents elsewhere can call yours.
-- **Integrations**: Docker, Daytona, E2B, Deno, Browserless, Brave Search, DuckDuckGo, Parallel, Sprites, Pi, Cursor — auto-registered via the `inventory` plugin system.
+- **[MCP](https://docs.everruns.com/features/mcp/), both ways** — register remote MCP servers as virtual capabilities (auto-discovered and namespaced), and expose your own deployment's MCP endpoint with OAuth 2.1 so other agents can call yours.
+- **[Integrations](https://docs.everruns.com/integrations/)**: Docker, Daytona, E2B, Deno, Browserless, Brave Search, DuckDuckGo, Parallel, Sprites, Cursor — auto-registered via the `inventory` plugin system.
 - **Client-side tools** for SDK/API consumers that want to run tools locally.
 
 ### Ship agents to real channels
@@ -49,7 +88,7 @@ Define an **[App](https://docs.everruns.com/features/apps/)** that binds a Harne
 - **Infinity context** — automatic compaction keeps conversations going past any model's context window.
 - **[Observability](https://docs.everruns.com/observability/)** — OpenTelemetry GenAI semantic conventions, Prometheus `/metrics`, optional Braintrust.
 - **Budgeting, usage tracking, reporting** — token meters, budgets with soft enforcement, and async analytical projections (StarRocks or DuckDB-over-object-storage).
-- **Evals** — user-facing behavioral evals plus a SWE-bench Lite harness.
+- **[Evals](https://docs.everruns.com/features/evals/)** — user-facing behavioral evals plus a SWE-bench Lite harness.
 
 ## Quick start
 
@@ -123,6 +162,8 @@ Need to run Everruns harnesses in-process? Use the embedded runtime crate (`ever
 
 A CLI (`everruns-cli`) is also available for scripting against a deployment — see the [CLI](https://docs.everruns.com/features/cli/) guide.
 
+## Documentation
+
 Full documentation lives at **[docs.everruns.com](https://docs.everruns.com)**.
 
 - [Introduction](https://docs.everruns.com/getting-started/introduction/) — what Everruns is and core [concepts](https://docs.everruns.com/getting-started/concepts/)
@@ -135,7 +176,7 @@ Full documentation lives at **[docs.everruns.com](https://docs.everruns.com)**.
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and [AGENTS.md](./AGENTS.md) for the conventions used by both human and AI contributors. The [`specs/`](specs/) directory holds the durable design intent — architecture, models, APIs, threat model, and every feature in detail — and is the canonical reference when changing behavior.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and [AGENTS.md](./AGENTS.md) for the conventions used by both human and AI contributors.
 
 ## License
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -269,7 +269,7 @@ export default defineConfig({
             },
             {
               label: "Integrations",
-              link: "/integrations/daytona/",
+              link: "/integrations/",
               icon: "laptop",
               items: [
                 {

--- a/docs/features/evals.md
+++ b/docs/features/evals.md
@@ -1,0 +1,40 @@
+---
+title: Evals
+description: Define, run, and track behavioral tests for your agents. Each eval case runs a real session and is scored, so you can compare models, catch regressions, and gate App publishes on pass rates.
+sidebar:
+  label: Evals
+---
+
+Evals let you define, run, and track **behavioral tests** for your agents. An Eval is a named collection of cases; each case sends messages to a fresh session and scores the result. Use them to compare runs across models, catch regressions after a prompt change, and gate App publishes on pass rates.
+
+Because every case runs a **real session** against the target agent and harness, failures are fully debuggable — click into the session to see the conversation, tool calls, and events exactly as they happened.
+
+## Concepts
+
+| Entity | What it is |
+|---|---|
+| **Eval** | Top-level, org-scoped collection of cases. Follows the standard `active → archived → deleted` lifecycle. |
+| **EvalCase** | A single test: input messages, scoring rules, execution bounds, and optional artifact collection. |
+| **EvalRun** | One execution of an eval's cases against a target, producing per-case results. |
+| **EvalTarget** | How a session is instantiated — either a `session` setup (harness, agent, model, system prompt) or a deployed `app`. |
+
+Targets resolve in order `EvalRun → EvalCase → Eval → org default harness`, so you can run the same cases against different models per run or override per case.
+
+## How a case runs
+
+1. A fresh session is created from the resolved target.
+2. The case's `conversation` messages are delivered sequentially (multi-turn supported).
+3. Optional `post` messages run after the session idles — for example, executing a test script.
+4. Optional `artifacts` capture named session files.
+5. `scorers` grade the result, returning `0.0`–`1.0` for nuanced pass/fail.
+
+Eval runs are durable workflows: they reuse the same execution engine as production sessions, so a worker restart mid-run does not lose progress.
+
+## SWE-bench Lite
+
+Beyond user-facing behavioral evals, Everruns ships a **SWE-bench Lite** harness for measuring coding-agent performance against the standard benchmark, using the same eval machinery (`post` verification messages run the test scripts that determine pass/fail).
+
+## Related
+
+- [Harnesses](/features/harnesses/) — what an eval target runs
+- [Apps](/features/apps/) — gating a publish on eval results

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -1,0 +1,36 @@
+---
+title: Model Context Protocol (MCP)
+description: Everruns is both an MCP server — exposing its agents and tools to external clients with OAuth 2.1 — and an MCP client that registers remote servers as virtual capabilities.
+sidebar:
+  label: MCP
+---
+
+Everruns speaks the [Model Context Protocol](https://spec.modelcontextprotocol.io) on **both sides**: it exposes its own agents and tools as an MCP server, and it consumes remote MCP servers as agent capabilities.
+
+## Everruns as an MCP server
+
+Every Everruns deployment exposes an MCP endpoint at `/mcp` so external clients — Claude Desktop, Cursor, VS Code, or another agent — can discover and call your agents and tools over JSON-RPC.
+
+- **Transport** — JSON-RPC 2.0 over Streamable HTTP (`POST /mcp`). Protocol versions `2025-06-18` and `2025-03-26` are supported.
+- **Methods** — `initialize`, `ping`, `tools/list`, `tools/call`, `resources/list`, `resources/read`.
+- **Auth** — the same org resolution as the REST API (API keys, JWT/cookie sessions), plus OAuth 2.1 with mandatory PKCE for dynamic client registration. Discovery metadata is served at `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource/mcp`.
+- **Entity cards** — under protocol `2025-06-18`, tools like `agent_get_card` return a sandboxed `text/html` MCP App resource at the `ui://` scheme alongside a text summary, so MCP-Apps-aware hosts render rich cards while others fall back to text.
+
+Routing is intentionally split: REST under `/api/*`, MCP OAuth under `/oauth/*`, and MCP JSON-RPC at `/mcp`.
+
+## Everruns as an MCP client
+
+Register a remote MCP server and its tools appear as a **virtual capability** — auto-discovered, namespaced, and executed alongside built-in capabilities. No code changes are needed to give an agent new tools.
+
+- **Org-managed servers** — organization-scoped `McpServer` records connect over remote HTTP (Streamable HTTP). `stdio` is rejected by the hosted control plane and is only available to single-tenant runtime/CLI hosts.
+- **Scoped `mcpServers`** — harnesses, agents, and sessions can embed remote MCP config directly (the remote-server subset of `.mcp.json`) for session-local or agent-local wiring without creating an org-global record.
+- **Tool naming** — discovered tools are namespaced per server so they never collide with built-in capabilities.
+
+## Use Everruns from your AI tools
+
+To connect Claude Code, Codex, or Cursor to a deployment via the `everruns-dev` plugin, see [Use in AI tools](/getting-started/use-in-ai-tools/).
+
+## Related
+
+- [Capabilities](/features/capabilities/) — how virtual capabilities fit the capability system
+- [Apps](/features/apps/) — publishing agents to channels

--- a/docs/integrations/e2b.md
+++ b/docs/integrations/e2b.md
@@ -1,0 +1,68 @@
+---
+title: E2B Cloud Sandboxes for Agent Code Execution
+description: Integrate E2B cloud sandboxes for secure, isolated code execution. Bring your own API key, create multiple sandboxes per session, and manage their lifecycle.
+sidebar:
+  label: E2B
+---
+
+Everruns integrates with [E2B](https://e2b.dev/docs) to provide cloud sandbox environments for secure, isolated code execution. Agents can create, pause, resume, delete, and interact with multiple isolated Linux sandboxes per session. You bring your own E2B API key — there is no platform-owned or environment-variable fallback, so sandbox costs and quotas stay scoped to your own E2B account.
+
+## What You Get
+
+- **Isolated Sandboxes**: Each sandbox is a secure, isolated Linux environment
+- **Multi-Sandbox Sessions**: Create and manage multiple sandboxes within a single session
+- **File Operations**: Read and write files in sandbox filesystems
+- **Shell Execution**: Run commands with stdout/stderr/exit-code capture
+- **Lifecycle Control**: Pause, resume, and delete sandboxes; auto-timeout limits cost
+
+## Quick Start
+
+### 1. Get Your API Key
+
+1. Go to the [E2B Dashboard](https://e2b.dev/dashboard)
+2. Create an API key
+3. Copy the key
+
+### 2. Connect in Everruns
+
+1. Go to **Settings** > **Connections**
+2. Find **E2B** in the available providers
+3. Click **Connect** and paste your API key
+
+Once connected, the E2B capability is automatically available in agent sessions. Every E2B operation requires a user-provided key — if none is configured, the agent surfaces an inline connection prompt.
+
+### 3. Use in Sessions
+
+Agents with the E2B capability can use these tools:
+
+| Tool | Description |
+|------|-------------|
+| `e2b_create_sandbox` | Create a sandbox from a template, optionally uploading session files |
+| `e2b_exec` | Execute a shell command |
+| `e2b_read_file` | Read a file from the sandbox filesystem |
+| `e2b_write_file` | Write a file into the sandbox filesystem |
+| `e2b_list_sandboxes` | List sandboxes created in this session |
+| `e2b_manage_sandbox` | Pause, resume, or delete a sandbox |
+
+`e2b_create_sandbox` accepts an optional `template` (default `base`), a `timeout_seconds` (default `3600`), `env_vars`, and `upload_files` mapping session paths into the sandbox.
+
+## How It Works
+
+E2B exposes two surfaces, and the integration uses both:
+
+- **Management API** (`api.e2b.app`) — sandbox lifecycle, metadata, and timeout control.
+- **envd sandbox endpoint** — in-sandbox file access and command execution.
+
+Per-sandbox state (sandbox ID, domain, access token, workspace path, timeout) is stored in encrypted session secrets and registered as a leased resource, so orphaned sandboxes are cleaned up on the worker side. Every sandbox is tagged with Everruns ownership metadata (session, harness, org, and agent IDs) for dashboard traceability and audit review.
+
+## Security
+
+- API keys resolve fresh from your user connection on each tool call — never stored in sandbox state, env vars, or emitted in tool output
+- envd access tokens are session-scoped and stored only in encrypted session secrets (AES-256-GCM envelope encryption)
+- Sandbox isolation depends on E2B's runtime boundaries plus Everruns session-scoped secret lookups
+- Resource leaks are mitigated by E2B timeouts and auto-pause plus Everruns leased-resource cleanup
+
+## Links
+
+- [E2B Documentation](https://e2b.dev/docs)
+- [E2B Dashboard](https://e2b.dev/dashboard)

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -15,6 +15,7 @@ Give agents an isolated environment to run code, edit files, and persist state.
 | Integration | What it provides |
 |---|---|
 | [Daytona](/integrations/daytona/) | Cloud sandbox environments via the Daytona REST API |
+| [E2B](/integrations/e2b/) | Cloud sandboxes via the E2B management + runtime APIs (bring your own key) |
 | [Container Sandbox](/integrations/container-sandbox/) | Self-hosted container sandboxes via Docker Engine — no external SaaS |
 | [Deno](/integrations/deno/) | Cloud sandboxes via the Deno websocket sandbox API |
 | [Sprites](/integrations/sprites/) | Persistent Firecracker microVMs with checkpoints and HTTP services |

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,0 +1,46 @@
+---
+title: Integrations
+description: Connect Everruns agents to cloud sandboxes, browsers, search providers, and messaging channels. Integrations are auto-registered and surface as agent capabilities.
+sidebar:
+  label: Overview
+  order: 0
+---
+
+Integrations connect Everruns agents to external services — cloud sandboxes, browsers, search providers, and messaging channels. Each is auto-registered via the `inventory` plugin system and, once a connection is configured, surfaces to agents as a [capability](/features/capabilities/) or [App channel](/features/apps/).
+
+## Sandboxes & execution
+
+Give agents an isolated environment to run code, edit files, and persist state.
+
+| Integration | What it provides |
+|---|---|
+| [Daytona](/integrations/daytona/) | Cloud sandbox environments via the Daytona REST API |
+| [Container Sandbox](/integrations/container-sandbox/) | Self-hosted container sandboxes via Docker Engine — no external SaaS |
+| [Deno](/integrations/deno/) | Cloud sandboxes via the Deno websocket sandbox API |
+| [Sprites](/integrations/sprites/) | Persistent Firecracker microVMs with checkpoints and HTTP services |
+| [Cursor](/integrations/cursor/) | Launch and manage asynchronous Cursor Cloud coding agents |
+
+## Browser & web
+
+| Integration | What it provides |
+|---|---|
+| [Browserless](/integrations/browserless/) | Cloud browser automation — screenshots, DOM, scraping, multi-step flows |
+| [Brave Search](/integrations/brave-search/) | Web search via the Brave Search API |
+| [DuckDuckGo](/integrations/duckduckgo/) | Instant answers via the DuckDuckGo API |
+| [Parallel](/integrations/parallel/) | Web search, extract, and task APIs (free and paid tiers) |
+
+## Messaging channels
+
+| Integration | What it provides |
+|---|---|
+| [Slack](/integrations/slack/) | Deploy an agent as a Slack bot via an [App](/features/apps/) |
+
+## Discovery
+
+| Integration | What it provides |
+|---|---|
+| [ARD](/integrations/ard/) | Client-side discovery of external MCP servers and A2A agents at runtime |
+
+## Adding an integration
+
+New integrations follow a parity checklist (connection provider, tests, live-API coverage, docs, and a threat-model section) before they ship. Daytona is the reference implementation. See the in-repo [`specs/integrations.md`](https://github.com/everruns/everruns/blob/main/specs/integrations.md) for the full contract.


### PR DESCRIPTION
## What

Reworks the top-level `README.md` so learn-more links point at the published docs site (`docs.everruns.com`) instead of in-repo `specs/`, and closes the doc gaps that repointing exposed:

- README: every feature link now resolves to `docs.everruns.com`; dropped the in-repo `specs/` references.
- README: added a **Why Everruns** section (4 differentiators) and an **Architecture** Mermaid diagram (GitHub renders it natively); tightened "What's inside"; removed a phantom integration (`Pi`).
- New docs pages so no README link 404s:
  - `docs/features/mcp.md` → `/features/mcp/` (Everruns as MCP server + client)
  - `docs/features/evals.md` → `/features/evals/` (behavioral evals + SWE-bench Lite)
  - `docs/integrations/index.md` → `/integrations/` (integrations overview; the Integrations sidebar topic now lands here instead of `/integrations/daytona/`)
  - `docs/integrations/e2b.md` → `/integrations/e2b/` (E2B cloud sandbox integration)

## Why

The README sent readers into `specs/` (internal design intent) rather than the user-facing docs, and pointed at external `docs.everruns.com` pages inconsistently. A reader landing on GitHub should reach the public docs, not the spec tree. Repointing surfaced three features (MCP, Evals, the Integrations overview) and one integration (E2B) that had no public page to link to.

## How

Edited `README.md` and added four Starlight markdown pages under `docs/`. The new pages are written from the corresponding `specs/` and `integrations/*/SPEC.md` sources and match the tone/frontmatter of sibling docs pages. Updated the Integrations sidebar topic `link` in `apps/docs/astro.config.mjs` to the new overview; the Integrations and Features sidebars autogenerate from their directories, so the new pages appear automatically.

## Risk

- Low. Docs and README content plus a one-line docs-site sidebar link. No runtime code, API, schema, or migration changes.

## Validation

- `pnpm run check` (astro check): **0 errors, 0 warnings** (2 pre-existing unrelated hints in `scripts/generate-og-image.mjs`).
- `pnpm run build`: full site build succeeded — **409 pages**; confirmed `/features/mcp/`, `/features/evals/`, `/integrations/`, and `/integrations/e2b/` emitted to `dist`.
- No migrations touched; `check-migration-ordering.sh` reports sequential `001..080`.
- Runtime smoke test intentionally skipped: docs/config-only change with no effect on server behavior; the docs build is the relevant proof.

## Security

- Threat categories reviewed: **No security-relevant code changes.** The diff is documentation content plus a single docs-site sidebar `link` string in `apps/docs/astro.config.mjs`; no auth, API, tool, tenant, or data-handling code is touched.
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated (docs build is the relevant check; no code tests applicable)
- [x] Backward compatibility considered (no API/behavior change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01Pj1LEmMUGmPBWXocTP6XMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj1LEmMUGmPBWXocTP6XMp)_