### PR TITLE
docs: add cross-site footer links and expand bashkit page

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -109,6 +109,7 @@ export default defineConfig({
       ],
       components: {
         Header: "./src/components/Header.astro",
+        Footer: "./src/components/Footer.astro",
         TableOfContents: "./src/components/TableOfContents.astro",
         MobileTableOfContents: "./src/components/MobileTableOfContents.astro",
       },

--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -1,0 +1,57 @@
+---
+import DefaultFooter from "@astrojs/starlight/components/Footer.astro";
+
+// Cross-site links surfaced on every docs page. Keeping them here (rather than
+// per-page markdown) guarantees the marketing site and the bashkit project are
+// always one click away and discoverable to crawlers from any docs URL.
+const crossLinks = [
+  { label: "Everruns", href: "https://everruns.com" },
+  { label: "Bashkit", href: "https://bashkit.sh" },
+  { label: "GitHub", href: "https://github.com/everruns/everruns" },
+];
+---
+
+<div class="site-footer-links">
+  <nav aria-label="Everruns sites">
+    <ul>
+      {
+        crossLinks.map((link) => (
+          <li>
+            <a href={link.href} rel="noopener">
+              {link.label}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </nav>
+</div>
+
+<DefaultFooter {...Astro.props} />
+
+<style>
+  .site-footer-links {
+    margin-block-end: 1rem;
+    padding-block-end: 1rem;
+    border-bottom: 1px solid var(--sl-color-hairline-light);
+  }
+
+  .site-footer-links ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .site-footer-links a {
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-2);
+    text-decoration: none;
+  }
+
+  .site-footer-links a:hover {
+    color: var(--sl-color-text-accent);
+  }
+</style>

--- a/docs/capabilities/bashkit-shell.md
+++ b/docs/capabilities/bashkit-shell.md
@@ -1,40 +1,105 @@
 ---
 title: Bashkit Shell
-description: Sandboxed Bash command execution in an isolated environment. Agents can run shell commands safely with process isolation, timeouts, and output capture.
+description: Sandboxed Bash command execution in an isolated environment. Agents can run shell commands safely with process isolation, resource limits, streaming output, and workspace-only filesystem access.
 ---
 
 | | |
 |---|---|
 | **ID** | `bashkit_shell` (legacy alias: `virtual_bash`) |
 | **Category** | Execution |
-| **Features** | `file_system` (unlocks Workspace tab) |
+| **Risk** | High — assignment requires an org **Admin** |
+| **Features** | `file_system` (unlocks the Workspace tab) |
 | **Dependencies** | [`session_file_system`](/capabilities/file-system/) |
 
-Execute bash commands in a sandboxed environment with no access to the host system. Powered by [bashkit](https://github.com/everruns/bashkit), a WASM-like execution sandbox. The session filesystem is mounted at `/workspace`.
+Execute bash commands in a sandboxed environment with no access to the host
+system. The session filesystem is mounted at `/workspace`, so commands read and
+write the same files as the [File System](/capabilities/file-system/) tools.
+
+## Powered by Bashkit
+
+This capability runs on [**bashkit**](https://bashkit.sh) — an embeddable bash
+interpreter that executes shell scripts in-process inside a WASM-like sandbox,
+with no real shell, no subprocess spawning, and no host access. Learn more at
+[bashkit.sh](https://bashkit.sh) or browse the source on
+[GitHub](https://github.com/everruns/bashkit).
+
+Because the interpreter is sandboxed by construction, bash here is **not** a
+shell-out to the host: there is no `/bin/bash` process, no network stack, and no
+filesystem beyond the session workspace.
 
 ## Tools
 
 ### `bash`
 
-Execute a shell command.
+Execute a shell command (or a multi-line script).
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `command` | string | yes | Shell command to execute |
+| `commands` | string | yes | Shell command(s) to execute |
 | `working_dir` | string | no | Working directory (default: `/workspace`) |
-| `timeout` | integer | no | Timeout in seconds |
+| `timeout_ms` | integer | no | Timeout in milliseconds (default: `30000`, max: `60000`) |
+| `output` | string | no | Output verbosity (`auto`, `normal`, …; default: `auto`) |
 
-Returns stdout, stderr, and exit code.
+Returns `stdout`, `stderr`, `exit_code`, and a `success` flag. Output streams
+live to the UI and CLI via `tool.output.delta` events while the command runs.
+On timeout, any partial output captured so far is returned alongside the error.
+
+This tool also supports background execution — long scripts can run detached and
+report progress without blocking the agent loop.
+
+## Filesystem
+
+The interpreter exposes a single mount:
+
+- **`/workspace`** maps to the session file store. Reads and writes are live —
+  files created by bash are immediately visible to the File System tools and
+  vice versa.
+- Paths outside `/workspace` (for example `/etc`, `/home/agent`, `/tmp`) do not
+  exist and cannot be written.
+- Symlinks are unsupported; `chmod` is a no-op (the session filesystem does not
+  track Unix permissions, and files are executable by default).
+
+Default environment: `HOME=/home/agent`, `SHELL=/bin/bash`,
+`PATH=/usr/local/bin:/usr/bin:/bin`, `WORKSPACE=/workspace`, user and host
+`everruns`.
+
+## Resource limits
+
+Every invocation runs under fixed limits to prevent runaway scripts:
+
+| Limit | Value |
+|---|---|
+| Max commands per run | 1,000 |
+| Max loop iterations | 10,000 |
+| Max function depth | 100 |
+| Max script size | 1 MB |
+| Max memory | 10 MB |
+| Parser timeout | 5 s |
+| Wall-clock timeout | `timeout_ms` (default 30 s, max 60 s) |
+
+## Security
+
+- **Sandboxed** — no network access, no host filesystem, no subprocess spawning.
+- **High risk** — because it exposes arbitrary scripted code execution, assigning
+  `bashkit_shell` to an agent requires an org **Admin**. Existing agents that
+  already had it keep working; the gate applies to new assignments only.
+- Built-in observability hooks emit structured `tracing` events per builtin and
+  on interpreter errors (tagged with the session ID) without logging argument
+  values or command output.
 
 ## Notes
 
-- **Sandboxed** — no network access, no host filesystem access
-- Commands operate on the same `/workspace` as [File System](/capabilities/file-system/) tools
-- Files written by bash are immediately visible to file system tools and vice versa
-- Built-in shell commands: `cd`, `ls`, `cat`, `echo`, `grep`, `head`, `tail`, etc.
-- Resource limits prevent infinite loops
+- Commands operate on the same `/workspace` as
+  [File System](/capabilities/file-system/) tools.
+- Built-in commands support `<command> --help`, and many also support
+  `<command> --version`.
+- Common builtins: `cd`, `ls`, `cat`, `echo`, `grep`, `head`, `tail`, `sed`,
+  `find`, plus shell features like pipes, redirections, and command
+  substitution. `grep` is backed by the session's indexed search.
 
 ## See Also
 
+- [Bashkit project](https://bashkit.sh) — the interpreter powering this capability
 - [File System](/capabilities/file-system/) — file operations on the same workspace
+- [Sub Agents](/capabilities/sub-agents/) — background and parallel execution
 - [Capabilities Overview](/capabilities/)


### PR DESCRIPTION
## What
- Add a site-wide footer to the docs site (`docs.everruns.com`) with cross-links to **everruns.com**, **bashkit.sh**, and **GitHub**, rendered on every page.
- Expand the **Bashkit Shell** capability page and give it a visible link to `bashkit.sh`.

## Why
The docs site previously had no outbound link to the `everruns.com` marketing site or the `bashkit.sh` project — the only references were self-referencing subdomains (`docs.`/`app.`/`dev.everruns.com`). This adds discoverable, crawlable cross-links from every docs page for SEO and navigation. The Bashkit Shell page was also thin and slightly inaccurate (wrong tool param names/units) and didn't point readers at the bashkit project.

## How
- New `apps/docs/src/components/Footer.astro` wraps Starlight's default `Footer`, prepending a small links row (hardcoded constants). Registered via the `Footer` component override in `astro.config.mjs`, mirroring the existing `Header` override pattern.
- Logo link intentionally left pointing at docs home (standard Starlight UX); the marketing cross-link lives in the footer instead.
- Rewrote `docs/capabilities/bashkit-shell.md` from the capability source (`crates/core/src/capabilities/bashkit_shell.rs`): corrected tool params (`commands`, `working_dir`, `timeout_ms`, `output` — previously documented as `command`/`timeout`-in-seconds), and added sections on the `/workspace` mount semantics, resource limits, streaming/background execution, the High-risk admin-only assignment gate, and a "Powered by Bashkit" section linking to `bashkit.sh`.

## Risk
- **Low.** Docs-site content and a static frontend component only; no backend/runtime behavior changes.
- What could break: the docs build. Verified green below.

## Security
- Threat categories reviewed: **TM-WEB**. The footer renders hardcoded, first-party link constants — no user/dynamic input, no XSS surface; links use `rel="noopener"`. No `target="_blank"`, so reverse-tabnabbing is not applicable. No auth/API/tenant/SQL/bash/LLM surface touched. The Bashkit page only documents existing security posture; no behavior change.
- Findings and resolutions: none.

## Validation
- `pnpm run build` in `apps/docs` succeeded: 405 pages built, og-image generation and `verify-notebooks` postbuild passed.
- `astro check`: no diagnostics on the new `Footer.astro` or config (one pre-existing unrelated error about a missing generated `notebook-manifest.json`).
- Verified the rendered `dist/` HTML contains the `everruns.com` and `bashkit.sh` footer links on all 405 pages.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (docs/static-content change; validated via docs build + rendered-output check)
- [x] Backward compatibility considered — no API/behavior change
- [x] Security review performed against relevant threat model categories (TM-WEB)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)