### PR TITLE
docs: drop env-var credential note from providers overview

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -73,14 +73,6 @@ run an A/B comparison per session.
 - Credentials are encrypted at rest with AES-256-GCM envelope encryption.
 - Credential values are never returned by the API — only a "configured" flag is
   exposed.
-- Resolution is **fail-closed**: tenant agent turns resolve keys from the
-  database only. A turn with no configured provider fails with a clear error
-  rather than silently falling back to a platform environment variable.
-
-For self-hosted and single-tenant deployments, provider credentials for the
-default organization can be seeded from environment variables at startup.
-Key-based providers use `DEFAULT_<PROVIDER>_API_KEY` (for example
-`DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`); AWS Bedrock reads
-standard `AWS_*` (or `AWS_BEDROCK_*`) credentials instead. See the
-[environment variables reference](/sre/environment-variables/) for the exact
-names per provider.
+- Resolution is **fail-closed**: each organization resolves its own configured
+  credentials. A turn with no configured provider fails with a clear error
+  rather than running on another organization's credentials.


### PR DESCRIPTION
## What
Remove the self-hosted environment-variable credential-seeding note from the Model Providers overview (`docs/providers/index.md`), and reframe the fail-closed bullet around per-organization credential isolation rather than environment-variable fallback.

## Why
Providers are organization-scoped and intended for multitenant use. Documenting `DEFAULT_*_API_KEY` / `AWS_*` env-var seeding on the providers overview implied an env-based configuration path that should not be the user-facing story here. Per maintainer feedback, this should never be how org providers are configured.

## How
Deleted the "For self-hosted and single-tenant deployments…" paragraph and rewrote the fail-closed credential-security bullet to say each org resolves its own configured credentials and a missing provider fails closed rather than running on another org's credentials. No other env-var references remain in `docs/providers/`.

## Risk
- Low — single documentation page; no runtime code touched. Docs build passes (417 pages).

## Security
- No security-relevant code changes. Removes an env-var configuration note from public docs; the remaining text still accurately describes encryption-at-rest and fail-closed per-org resolution.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (docs build is the relevant proof)
- [x] Backward compatibility considered (docs-only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_0151YjE2Nft1EDeoP95ZUNbs)_