### PR TITLE
docs(fireworks): provider guide, publishable README, UI taglines

### DIFF
--- a/apps/ui/src/__tests__/provider-icon.test.tsx
+++ b/apps/ui/src/__tests__/provider-icon.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
+import {
+  ProviderIcon,
+  getProviderLabel,
+  getProviderDescription,
+} from "@/components/providers/provider-icon";
 import type { DriverId } from "@/lib/api/types";
 
 describe("ProviderIcon", () => {
@@ -118,5 +122,31 @@ describe("getProviderLabel", () => {
 
   it("returns type string for unknown provider", () => {
     expect(getProviderLabel("unknown" as DriverId)).toBe("unknown");
+  });
+});
+
+describe("getProviderDescription", () => {
+  const knownProviders: DriverId[] = [
+    "openai",
+    "openrouter",
+    "azure_openai",
+    "openai_completions",
+    "anthropic",
+    "gemini",
+    "bedrock",
+    "mai",
+    "fireworks",
+  ];
+
+  it.each(knownProviders)("returns a non-empty tagline for %s", (providerType) => {
+    expect(getProviderDescription(providerType).length).toBeGreaterThan(0);
+  });
+
+  it("returns the Fireworks tagline", () => {
+    expect(getProviderDescription("fireworks")).toBe("Fast, low-cost inference for open models.");
+  });
+
+  it("returns an empty string for an unknown provider", () => {
+    expect(getProviderDescription("unknown" as DriverId)).toBe("");
   });
 });

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -14,7 +14,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useCreateProvider, useUpdateProvider } from "@/hooks/use-providers";
-import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
+import {
+  ProviderIcon,
+  getProviderLabel,
+  getProviderDescription,
+} from "@/components/providers/provider-icon";
 import type { Provider, DriverId, CreateProviderRequest } from "@/lib/api/types";
 
 const PROVIDER_TYPES: { value: DriverId; label: string }[] = [
@@ -139,12 +143,18 @@ export function AddProviderDialog({
                   <SelectItem key={type.value} value={type.value}>
                     <div className="flex items-center gap-2">
                       <ProviderIcon providerType={type.value} size="sm" showBackground={false} />
-                      <span>{type.label}</span>
+                      <div className="flex flex-col">
+                        <span>{type.label}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {getProviderDescription(type.value)}
+                        </span>
+                      </div>
                     </div>
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
+            <p className="text-sm text-muted-foreground">{getProviderDescription(providerType)}</p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="base-url">Base URL (optional)</Label>

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -21,16 +21,19 @@ import {
 } from "@/components/providers/provider-icon";
 import type { Provider, DriverId, CreateProviderRequest } from "@/lib/api/types";
 
-const PROVIDER_TYPES: { value: DriverId; label: string }[] = [
-  { value: "openai", label: "OpenAI (Responses API)" },
-  { value: "openrouter", label: "OpenRouter" },
-  { value: "azure_openai", label: "Azure OpenAI" },
-  { value: "openai_completions", label: "OpenAI (Completions API)" },
-  { value: "anthropic", label: "Anthropic" },
-  { value: "gemini", label: "Google Gemini" },
-  { value: "bedrock", label: "AWS Bedrock" },
-  { value: "mai", label: "Microsoft MAI" },
-  { value: "fireworks", label: "Fireworks AI" },
+// Ordered list of provider types for the picker. Labels and descriptions come
+// from the centralized `getProviderLabel` / `getProviderDescription` mappings so
+// the dropdown and the selected-value trigger never diverge.
+const PROVIDER_TYPES: DriverId[] = [
+  "openai",
+  "openrouter",
+  "azure_openai",
+  "openai_completions",
+  "anthropic",
+  "gemini",
+  "bedrock",
+  "mai",
+  "fireworks",
 ];
 
 // Get API key placeholder based on provider type
@@ -140,13 +143,13 @@ export function AddProviderDialog({
               </SelectTrigger>
               <SelectContent>
                 {PROVIDER_TYPES.map((type) => (
-                  <SelectItem key={type.value} value={type.value}>
+                  <SelectItem key={type} value={type}>
                     <div className="flex items-center gap-2">
-                      <ProviderIcon providerType={type.value} size="sm" showBackground={false} />
+                      <ProviderIcon providerType={type} size="sm" showBackground={false} />
                       <div className="flex flex-col">
-                        <span>{type.label}</span>
+                        <span>{getProviderLabel(type)}</span>
                         <span className="text-xs text-muted-foreground">
-                          {getProviderDescription(type.value)}
+                          {getProviderDescription(type)}
                         </span>
                       </div>
                     </div>

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -145,6 +145,19 @@ const PROVIDER_LABELS: Record<DriverId, string> = {
   fireworks: "Fireworks AI",
 };
 
+// Short, accurate one-line taglines shown next to each provider in pickers.
+const PROVIDER_DESCRIPTIONS: Record<DriverId, string> = {
+  openai: "GPT and o-series models via the Responses API.",
+  openrouter: "One key for a large multi-vendor model catalog.",
+  azure_openai: "OpenAI models deployed in your Azure resource.",
+  openai_completions: "OpenAI-compatible Chat Completions endpoints.",
+  anthropic: "Claude models with extended thinking.",
+  gemini: "Google Gemini models with context caching.",
+  bedrock: "Models hosted on Amazon Bedrock.",
+  mai: "Microsoft MAI models via Azure AI Foundry.",
+  fireworks: "Fast, low-cost inference for open models.",
+};
+
 interface ProviderIconProps {
   providerType: DriverId;
   size?: "sm" | "md" | "lg";
@@ -185,4 +198,8 @@ export function ProviderIcon({
 
 export function getProviderLabel(providerType: DriverId): string {
   return PROVIDER_LABELS[providerType] || providerType;
+}
+
+export function getProviderDescription(providerType: DriverId): string {
+  return PROVIDER_DESCRIPTIONS[providerType] || "";
 }

--- a/crates/fireworks/README.md
+++ b/crates/fireworks/README.md
@@ -1,32 +1,52 @@
 # everruns-fireworks
 
-Fireworks AI provider driver for [Everruns](https://everruns.com).
+> Fireworks AI LLM provider for Everruns agents.
 
-[Fireworks AI](https://fireworks.ai) serves open models (Llama, Qwen, DeepSeek,
-GLM, Kimi, gpt-oss, ...) behind an OpenAI-compatible Chat Completions API. This
-crate implements the `ChatDriver` contract from `everruns-core` by wrapping the
-core `OpenAIProtocolChatDriver` and tagging it with `DriverId::Fireworks`.
+[![Crates.io](https://img.shields.io/crates/v/everruns-fireworks.svg)](https://crates.io/crates/everruns-fireworks)
+[![Documentation](https://docs.rs/everruns-fireworks/badge.svg)](https://docs.rs/everruns-fireworks)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-## Capabilities
+`everruns-fireworks` registers the Fireworks AI driver with
+[`everruns-core`](https://crates.io/crates/everruns-core) so the same Everruns
+agent loop can run against [Fireworks AI](https://fireworks.ai/)'s open-model
+catalog (Llama, Qwen, DeepSeek, Kimi, GLM, gpt-oss, ...). Fireworks exposes an
+OpenAI-compatible Chat Completions API, so the driver wraps the core Chat
+Completions protocol driver and parses Fireworks' richer `/models` metadata
+(chat, tools, image input, context window) into capability profiles.
 
-- **Chat completions** — streaming, tool calling, vision, and structured output,
-  via the OpenAI-compatible Chat Completions API.
-- **Model discovery** — Fireworks' `/models` endpoint advertises rich metadata
-  (`supports_chat`, `supports_tools`, `supports_image_input`, `context_length`),
-  which this crate parses into capability profiles at sync time.
+Part of the [Everruns](https://everruns.com) ecosystem — the durable agentic
+harness engine for building unstoppable agents. Providers are swappable: see
+[`everruns-openai`](https://crates.io/crates/everruns-openai) for OpenAI models,
+or [`everruns-anthropic`](https://crates.io/crates/everruns-anthropic) for Claude
+models.
 
-## Authentication
-
-Fireworks authenticates with a single API key, sent as a bearer token. Create a
-key at <https://fireworks.ai> under **Account → API Keys**.
-
-## Usage
+## Driver-Only Example
 
 ```rust
-use everruns_core::DriverRegistry;
-use everruns_fireworks::register_driver;
+use everruns_fireworks::FireworksChatDriver;
 
-let mut registry = DriverRegistry::new();
-register_driver(&mut registry);
-assert!(registry.has_driver(&everruns_core::DriverId::Fireworks));
+let driver = FireworksChatDriver::new("your-api-key");
+assert_eq!(
+    driver.api_url(),
+    "https://api.fireworks.ai/inference/v1/chat/completions",
+);
 ```
+
+## What It Provides
+
+- A Fireworks AI Chat Completions driver wrapping the Everruns core protocol driver
+- Registration into the Everruns `DriverRegistry` via `register_driver`
+- `base_url` override for Fireworks-compatible / proxy endpoints
+- Capability profiling derived from Fireworks' `/models` metadata, gated to the
+  Fireworks host
+
+## Documentation
+
+- [API reference (docs.rs)](https://docs.rs/everruns-fireworks)
+- [Fireworks AI provider guide](https://docs.everruns.com/providers/fireworks/)
+- [Migrate between LLM providers](https://docs.everruns.com/how-to/migrate-providers/)
+- [Everruns documentation](https://docs.everruns.com)
+
+## License
+
+Licensed under the [MIT License](https://github.com/everruns/everruns/blob/main/LICENSE).

--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -1,0 +1,51 @@
+---
+title: Fireworks AI
+description: Run Everruns agents on Fireworks AI's fast, low-cost inference for open models — Llama, Qwen, DeepSeek, Kimi, GLM, gpt-oss, and more — with automatic model discovery.
+sidebar:
+  label: Fireworks AI
+---
+
+Everruns runs agents on [Fireworks AI](https://fireworks.ai/) through its
+OpenAI-compatible Chat Completions API. Fireworks serves frontier **open
+models** — Llama, Qwen, DeepSeek, Kimi, GLM, gpt-oss, and more — on a fast,
+cost-efficient inference platform, so the same Everruns agent, prompt, and
+capabilities run unchanged on open weights.
+
+## What you get
+
+- **One key, many open models** — a single provider exposing Fireworks' serverless
+  model catalog.
+- **Automatic model discovery** — Fireworks' `/models` endpoint advertises rich
+  metadata (chat, tool calling, image input, context window), which Everruns
+  parses into capability profiles on sync, so tool and vision support surface
+  correctly per model.
+- **Full chat capabilities** — streaming, tool/function calling, vision, and
+  structured output, through the same uniform driver as every other provider.
+- **Host-gated discovery** — model sync runs only against Fireworks' own host, so
+  a custom proxy base URL is never probed.
+
+## Configure in Everruns
+
+1. Go to **Settings** → **Providers** and click **Add provider**.
+2. Choose **Fireworks AI**.
+3. Paste your Fireworks API key. Create one from the
+   [Fireworks API keys page](https://fireworks.ai/account/api-keys).
+4. Save. Everruns discovers available models and their capability profiles
+   automatically.
+
+You can optionally set a base URL to route through a proxy; leave it blank to use
+Fireworks' hosted API (`https://api.fireworks.ai/inference/v1`).
+
+## Models
+
+Fireworks model ids are namespaced, for example
+`accounts/fireworks/models/llama-v3p1-70b-instruct`. After a sync, models appear
+in the agent and session model pickers with their discovered capabilities. Only
+chat models are imported — image and other non-chat endpoints are filtered out.
+
+## Links
+
+- [Fireworks AI](https://fireworks.ai/)
+- [Fireworks docs](https://docs.fireworks.ai/)
+- [`everruns-fireworks` on crates.io](https://crates.io/crates/everruns-fireworks)
+- [Migrate between providers](/how-to/migrate-providers/)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,6 +1,6 @@
 ---
 title: Model Providers
-description: Connect Everruns to OpenAI, Anthropic, Google Gemini, AWS Bedrock, OpenRouter, and more. Configure provider credentials once and run any agent on any model.
+description: Connect Everruns to OpenAI, Anthropic, Google Gemini, AWS Bedrock, OpenRouter, Fireworks AI, and more. Configure provider credentials once and run any agent on any model.
 sidebar:
   label: Overview
   order: 0
@@ -24,6 +24,7 @@ served by OpenAI, Claude, Gemini, or any OpenAI-compatible endpoint.
 | [AWS Bedrock](/providers/bedrock/) | `bedrock` | Models hosted on Amazon Bedrock via the `ConverseStream` API. |
 | [OpenRouter](/providers/openrouter/) | `openrouter` | One key for a large multi-vendor catalog, with provider routing controls. |
 | [Microsoft MAI](/providers/mai/) | `mai` | Microsoft MAI models via Azure AI Foundry, with API-key or Entra ID (OAuth) auth. |
+| [Fireworks AI](/providers/fireworks/) | `fireworks` | Fast, low-cost inference for open models (Llama, Qwen, DeepSeek, Kimi, GLM, gpt-oss, ...), with automatic model discovery. |
 
 Need a vendor that isn't listed? Any OpenAI-compatible endpoint works through the
 [OpenAI](/providers/openai/) provider with a custom base URL (use the dedicated


### PR DESCRIPTION
## What
Follow-up polish for the Fireworks AI provider (shipped in #2344), closing gaps against the providers-docs convention added in #2343 and improving the Settings → Providers UX.

- **Public provider guide** — new `docs/providers/fireworks.md` (matching the OpenAI/OpenRouter/MAI pages: positioning, "what you get", configure steps, and a Links section with the [Fireworks landing page](https://fireworks.ai/), docs, and crates.io). Listed in the providers overview table. The docs sidebar auto-generates from the `providers/` directory, so no sidebar wiring is needed.
- **Publishing-grade crate README** — `crates/fireworks/README.md` rewritten to match the other provider crates: crates.io/docs.rs/license badges, ecosystem links, a driver example, and a Documentation section linking the provider guide.
- **UI provider taglines** — short, accurate one-liners for every provider, surfaced in the "Add provider" dialog (per-option subtitle in the dropdown plus a description under the selected type). Previously the picker showed only a name; now each provider has an at-a-glance description.

## Why
Answers a review of the merged Fireworks PR: the provider had no public integrations doc, the crate README wasn't publish-ready or linked to the provider landing page, and the provider picker carried no descriptions/taglines.

## How
Docs/README are content-only. The UI adds a `getProviderDescription()` helper (a `Record<DriverId, string>` map alongside the existing labels) and renders it in the dialog.

## Risk
- **Low.** Docs + README + a presentational UI addition. No backend, API, or schema changes.

## Security
- No security-relevant code changes (docs/README/presentational UI only).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing UI provider suites cover the dialog; 49 pass)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01TQBm8opjonErwtLepqKk24

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQBm8opjonErwtLepqKk24)_