### PR TITLE
feat(email): app-styled minimal template and branded basic template

### DIFF
--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -188,7 +188,8 @@ impl MinimalEmailTemplate {
         validate_body(&self.text, &self.html)?;
         Ok(RenderedEmail {
             text: self.text.clone(),
-            html: wrap_email_html(None, &self.html, None),
+            // Neutral title keeps the minimal template free of any branding.
+            html: wrap_email_html("Notification", None, &self.html, None),
         })
     }
 }
@@ -216,7 +217,12 @@ impl BasicEmailTemplate {
                 "Everruns\n\n{}\n\n—\nSent by Everruns · {EVERRUNS_SITE_URL}",
                 self.text
             ),
-            html: wrap_email_html(Some(&branded_header()), &self.html, Some(&branded_footer())),
+            html: wrap_email_html(
+                "Everruns",
+                Some(&branded_header()),
+                &self.html,
+                Some(&branded_footer()),
+            ),
         })
     }
 }
@@ -429,10 +435,17 @@ const EMAIL_FONT_STACK: &str =
 const EVERRUNS_SITE_URL: &str = "https://everruns.com";
 const EVERRUNS_LOGO_URL: &str = "https://everruns.com/logo.png";
 
-// App-styled HTML shell shared by every template. `header` and `footer` are
-// optional pre-rendered table rows so branded templates can add a logo header
-// and a footer link while the minimal template stays bare.
-fn wrap_email_html(header: Option<&str>, inner_html: &str, footer: Option<&str>) -> String {
+// App-styled HTML shell shared by every template. `title` sets the document
+// `<title>` (kept neutral for the unbranded minimal template, since some clients
+// surface it in previews). `header` and `footer` are optional pre-rendered table
+// rows so branded templates can add a logo header and a footer link while the
+// minimal template stays bare.
+fn wrap_email_html(
+    title: &str,
+    header: Option<&str>,
+    inner_html: &str,
+    footer: Option<&str>,
+) -> String {
     let header = header.unwrap_or("");
     let footer = footer.unwrap_or("");
     format!(
@@ -441,7 +454,7 @@ fn wrap_email_html(header: Option<&str>, inner_html: &str, footer: Option<&str>)
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Everruns</title>
+  <title>{title}</title>
 </head>
 <body style="margin:0;background:{APP_BACKGROUND};color:{APP_FOREGROUND};font-family:{EMAIL_FONT_STACK};">
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:{APP_BACKGROUND};padding:32px 16px;">
@@ -536,8 +549,9 @@ mod tests {
         // App styling: sharp corners and app surface/background colors.
         assert!(rendered.html.contains("border-radius:0"));
         assert!(rendered.html.contains(APP_BACKGROUND));
-        // No visible branding in the minimal template: no logo, no site link
-        // (header or footer), and no footer attribution line.
+        // No branding at all in the minimal template — not even the document
+        // <title>, which some clients surface in previews.
+        assert!(!rendered.html.contains("Everruns"));
         assert!(!rendered.html.contains(EVERRUNS_LOGO_URL));
         assert!(!rendered.html.contains(EVERRUNS_SITE_URL));
         assert!(!rendered.html.contains("Sent by"));

--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -142,24 +142,41 @@ pub struct EmailTag {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EmailTemplate {
-    Generic(GenericEmailTemplate),
+    Minimal(MinimalEmailTemplate),
+    Basic(BasicEmailTemplate),
 }
 
 impl EmailTemplate {
     fn render(&self) -> EmailResult<RenderedEmail> {
         match self {
-            Self::Generic(template) => template.render(),
+            Self::Minimal(template) => template.render(),
+            Self::Basic(template) => template.render(),
         }
     }
 }
 
+// Validates the caller-supplied body shared by every template. Each template
+// wraps this body differently, but all require non-empty text and HTML.
+fn validate_body(text: &str, html: &str) -> EmailResult<()> {
+    if text.trim().is_empty() {
+        return Err(EmailError::invalid("email text is required"));
+    }
+    if html.trim().is_empty() {
+        return Err(EmailError::invalid("email html is required"));
+    }
+    Ok(())
+}
+
+// Unbranded transactional template styled to match the app (sharp corners,
+// grayscale surface, app foreground color). No Everruns wordmark, logo, or
+// footer link — use this when the surrounding flow already carries branding.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GenericEmailTemplate {
+pub struct MinimalEmailTemplate {
     pub text: String,
     pub html: String,
 }
 
-impl GenericEmailTemplate {
+impl MinimalEmailTemplate {
     pub fn new(text: impl Into<String>, html: impl Into<String>) -> Self {
         Self {
             text: text.into(),
@@ -168,16 +185,38 @@ impl GenericEmailTemplate {
     }
 
     fn render(&self) -> EmailResult<RenderedEmail> {
-        if self.text.trim().is_empty() {
-            return Err(EmailError::invalid("generic email text is required"));
-        }
-        if self.html.trim().is_empty() {
-            return Err(EmailError::invalid("generic email html is required"));
-        }
-
+        validate_body(&self.text, &self.html)?;
         Ok(RenderedEmail {
-            text: format!("Everruns\n\n{}", self.text),
-            html: wrap_generic_html(&self.html),
+            text: self.text.clone(),
+            html: wrap_email_html(None, &self.html, None),
+        })
+    }
+}
+
+// Branded transactional template. Same app styling as `MinimalEmailTemplate`,
+// plus an Everruns logo + wordmark header and a footer linking to everruns.com.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BasicEmailTemplate {
+    pub text: String,
+    pub html: String,
+}
+
+impl BasicEmailTemplate {
+    pub fn new(text: impl Into<String>, html: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            html: html.into(),
+        }
+    }
+
+    fn render(&self) -> EmailResult<RenderedEmail> {
+        validate_body(&self.text, &self.html)?;
+        Ok(RenderedEmail {
+            text: format!(
+                "Everruns\n\n{}\n\n—\nSent by Everruns · {EVERRUNS_SITE_URL}",
+                self.text
+            ),
+            html: wrap_email_html(Some(&branded_header()), &self.html, Some(&branded_footer())),
         })
     }
 }
@@ -200,7 +239,7 @@ pub struct EmailMessage {
 }
 
 impl EmailMessage {
-    pub fn generic(
+    pub fn minimal(
         to: impl Into<EmailAddress>,
         subject: impl Into<String>,
         text: impl Into<String>,
@@ -209,7 +248,22 @@ impl EmailMessage {
         Self {
             to: vec![to.into()],
             subject: subject.into(),
-            template: EmailTemplate::Generic(GenericEmailTemplate::new(text, html)),
+            template: EmailTemplate::Minimal(MinimalEmailTemplate::new(text, html)),
+            tags: Vec::new(),
+            idempotency_key: None,
+        }
+    }
+
+    pub fn basic(
+        to: impl Into<EmailAddress>,
+        subject: impl Into<String>,
+        text: impl Into<String>,
+        html: impl Into<String>,
+    ) -> Self {
+        Self {
+            to: vec![to.into()],
+            subject: subject.into(),
+            template: EmailTemplate::Basic(BasicEmailTemplate::new(text, html)),
             tags: Vec::new(),
             idempotency_key: None,
         }
@@ -355,7 +409,32 @@ fn env_opt(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|value| !value.is_empty())
 }
 
-fn wrap_generic_html(inner_html: &str) -> String {
+// Brand tokens mirrored from apps/ui/src/app/design-system.css. Email clients
+// cannot load the Geist webfont or resolve CSS variables, so the app's colors
+// and sharp-corner (0px radius) shapes are inlined here as literals. Keep these
+// in sync with the design system if the brand palette changes.
+const BRAND_NAVY: &str = "#0A1636";
+const BRAND_GOLD: &str = "#D4A43A";
+const APP_BACKGROUND: &str = "#fafafa";
+const APP_SURFACE: &str = "#ffffff";
+const APP_BORDER: &str = "#e0e0e0";
+const APP_FOREGROUND: &str = "#1a1a1a";
+const APP_MUTED_FOREGROUND: &str = "#737373";
+const EMAIL_FONT_STACK: &str =
+    "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif";
+
+// Public Everruns surfaces. The logo must be a hosted absolute URL (most email
+// clients block SVG and inline data URIs), so we reference the PNG served by
+// the marketing site rather than the in-repo SVG.
+const EVERRUNS_SITE_URL: &str = "https://everruns.com";
+const EVERRUNS_LOGO_URL: &str = "https://everruns.com/logo.png";
+
+// App-styled HTML shell shared by every template. `header` and `footer` are
+// optional pre-rendered table rows so branded templates can add a logo header
+// and a footer link while the minimal template stays bare.
+fn wrap_email_html(header: Option<&str>, inner_html: &str, footer: Option<&str>) -> String {
+    let header = header.unwrap_or("");
+    let footer = footer.unwrap_or("");
     format!(
         r#"<!doctype html>
 <html>
@@ -364,23 +443,15 @@ fn wrap_generic_html(inner_html: &str) -> String {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Everruns</title>
 </head>
-<body style="margin:0;background:#f6f7f9;color:#111827;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f6f7f9;padding:32px 16px;">
+<body style="margin:0;background:{APP_BACKGROUND};color:{APP_FOREGROUND};font-family:{EMAIL_FONT_STACK};">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:{APP_BACKGROUND};padding:32px 16px;">
     <tr>
       <td align="center">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;background:#ffffff;border:1px solid #e5e7eb;border-radius:8px;">
-          <tr>
-            <td style="padding:24px 28px 8px;font-size:18px;font-weight:700;color:#111827;">Everruns</td>
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;background:{APP_SURFACE};border:1px solid {APP_BORDER};border-radius:0;">
+{header}          <tr>
+            <td style="padding:28px;font-size:15px;line-height:1.6;color:{APP_FOREGROUND};">{inner_html}</td>
           </tr>
-          <tr>
-            <td style="padding:12px 28px 28px;font-size:15px;line-height:1.6;color:#1f2937;">{inner_html}</td>
-          </tr>
-          <tr>
-            <td style="padding:18px 28px;border-top:1px solid #e5e7eb;font-size:12px;line-height:1.5;color:#6b7280;">
-              This email was sent by Everruns.
-            </td>
-          </tr>
-        </table>
+{footer}        </table>
       </td>
     </tr>
   </table>
@@ -389,15 +460,42 @@ fn wrap_generic_html(inner_html: &str) -> String {
     )
 }
 
+// Logo + wordmark header row, linking to everruns.com.
+fn branded_header() -> String {
+    format!(
+        r#"          <tr>
+            <td style="padding:24px 28px;border-bottom:1px solid {APP_BORDER};">
+              <a href="{EVERRUNS_SITE_URL}" style="text-decoration:none;display:inline-block;">
+                <img src="{EVERRUNS_LOGO_URL}" width="28" height="28" alt="Everruns" style="vertical-align:middle;border:0;">
+                <span style="vertical-align:middle;margin-left:10px;font-size:18px;font-weight:700;color:{BRAND_NAVY};letter-spacing:-0.02em;">Everruns</span>
+              </a>
+            </td>
+          </tr>
+"#
+    )
+}
+
+// Footer row linking back to everruns.com, with a gold accent link.
+fn branded_footer() -> String {
+    format!(
+        r#"          <tr>
+            <td style="padding:18px 28px;border-top:1px solid {APP_BORDER};font-size:12px;line-height:1.5;color:{APP_MUTED_FOREGROUND};">
+              Sent by <a href="{EVERRUNS_SITE_URL}" style="color:{BRAND_GOLD};text-decoration:none;font-weight:600;">everruns.com</a>
+            </td>
+          </tr>
+"#
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn generic_template_requires_text_content() {
+    async fn minimal_template_requires_text_content() {
         let sender = NoopEmailSender;
         let error = sender
-            .send_email(EmailMessage::generic(
+            .send_email(EmailMessage::minimal(
                 "user@example.com",
                 "Empty",
                 "",
@@ -411,20 +509,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn generic_template_wraps_branding() {
-        let message = EmailMessage::generic("user@example.com", "Hi", "Hello", "<p>Hello</p>");
+    async fn minimal_template_requires_html_content() {
+        let sender = NoopEmailSender;
+        let error = sender
+            .send_email(EmailMessage::minimal(
+                "user@example.com",
+                "Empty",
+                "Hello",
+                "  ",
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::InvalidRequest(_)));
+        assert!(error.to_string().contains("html"));
+    }
+
+    #[tokio::test]
+    async fn minimal_template_is_app_styled_without_branding() {
+        let message = EmailMessage::minimal("user@example.com", "Hi", "Hello", "<p>Hello</p>");
         let rendered = message.validate().unwrap();
 
-        assert!(rendered.text.starts_with("Everruns\n\nHello"));
-        assert!(rendered.html.contains("Everruns"));
+        // Body is passed through verbatim — no branding prefix.
+        assert_eq!(rendered.text, "Hello");
         assert!(rendered.html.contains("<p>Hello</p>"));
+        // App styling: sharp corners and app surface/background colors.
+        assert!(rendered.html.contains("border-radius:0"));
+        assert!(rendered.html.contains(APP_BACKGROUND));
+        // No visible branding in the minimal template: no logo, no site link
+        // (header or footer), and no footer attribution line.
+        assert!(!rendered.html.contains(EVERRUNS_LOGO_URL));
+        assert!(!rendered.html.contains(EVERRUNS_SITE_URL));
+        assert!(!rendered.html.contains("Sent by"));
+    }
+
+    #[tokio::test]
+    async fn basic_template_adds_branding_logo_and_site_link() {
+        let message = EmailMessage::basic("user@example.com", "Hi", "Hello", "<p>Hello</p>");
+        let rendered = message.validate().unwrap();
+
+        // Branded plain text: wordmark prefix and site link footer.
+        assert!(rendered.text.starts_with("Everruns\n\nHello"));
+        assert!(rendered.text.contains(EVERRUNS_SITE_URL));
+        // Branded HTML: shares the app shell, plus logo, wordmark, and link.
+        assert!(rendered.html.contains("<p>Hello</p>"));
+        assert!(rendered.html.contains("border-radius:0"));
+        assert!(rendered.html.contains("Everruns"));
+        assert!(rendered.html.contains(EVERRUNS_LOGO_URL));
+        assert!(
+            rendered
+                .html
+                .contains(&format!(r#"href="{EVERRUNS_SITE_URL}""#))
+        );
     }
 
     #[tokio::test]
     async fn disabled_sender_returns_configuration_error() {
         let sender = DisabledEmailSender;
         let error = sender
-            .send_email(EmailMessage::generic(
+            .send_email(EmailMessage::minimal(
                 "user@example.com",
                 "Hi",
                 "hello",
@@ -442,7 +585,7 @@ mod tests {
         let sender = NoopEmailSender;
         let error = sender
             .send_email(
-                EmailMessage::generic("user@example.com", "Hi", "hello", "<p>hello</p>")
+                EmailMessage::minimal("user@example.com", "Hi", "hello", "<p>hello</p>")
                     .with_idempotency_key("welcome\r\nX-Other: value"),
             )
             .await
@@ -456,7 +599,7 @@ mod tests {
     async fn rejects_multi_recipient_in_single_to_field() {
         let sender = NoopEmailSender;
         let error = sender
-            .send_email(EmailMessage::generic(
+            .send_email(EmailMessage::minimal(
                 "victim@example.com, attacker@example.com",
                 "Hi",
                 "hello",
@@ -473,7 +616,7 @@ mod tests {
     async fn rejects_structured_mailbox_syntax_in_raw_email_field() {
         let sender = NoopEmailSender;
         let error = sender
-            .send_email(EmailMessage::generic(
+            .send_email(EmailMessage::minimal(
                 "Victim <victim@example.com>",
                 "Hi",
                 "hello",
@@ -490,7 +633,7 @@ mod tests {
     async fn rejects_email_with_surrounding_whitespace() {
         let sender = NoopEmailSender;
         let error = sender
-            .send_email(EmailMessage::generic(
+            .send_email(EmailMessage::minimal(
                 " user@example.com ",
                 "Hi",
                 "hello",

--- a/crates/core/src/email/resend.rs
+++ b/crates/core/src/email/resend.rs
@@ -232,7 +232,7 @@ mod tests {
         let sender = ResendEmailSender::new(test_config(server.uri()));
         let sent = sender
             .send_email(
-                EmailMessage::generic("delivered@example.com", "Welcome", "hello", "<p>hello</p>")
+                EmailMessage::minimal("delivered@example.com", "Welcome", "hello", "<p>hello</p>")
                     .with_idempotency_key("welcome/user_123")
                     .with_tag("kind", "welcome"),
             )
@@ -247,7 +247,7 @@ mod tests {
         assert_eq!(body["from"], "Everruns <no-replay@everruns.com>");
         assert_eq!(body["to"], json!(["delivered@example.com"]));
         assert_eq!(body["subject"], "Welcome");
-        assert_eq!(body["text"], "Everruns\n\nhello");
+        assert_eq!(body["text"], "hello");
         assert!(body["html"].as_str().unwrap().contains("<p>hello</p>"));
         assert_eq!(
             body["tags"],

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -260,8 +260,8 @@ pub use system_allowlist::{AllowGroup, SYSTEM_ALLOWLIST_ENABLED_ENV, SystemAllow
 
 // System email re-exports
 pub use email::{
-    DisabledEmailSender, EmailAddress, EmailError, EmailMessage, EmailResult, EmailSender,
-    EmailTag, EmailTemplate, GenericEmailTemplate, NoopEmailSender, RenderedEmail,
+    BasicEmailTemplate, DisabledEmailSender, EmailAddress, EmailError, EmailMessage, EmailResult,
+    EmailSender, EmailTag, EmailTemplate, MinimalEmailTemplate, NoopEmailSender, RenderedEmail,
     ResendEmailConfig, ResendEmailSender, SYSTEM_EMAIL_FROM, SentEmail, SystemEmailConfig,
     system_email_from,
 };

--- a/crates/server/src/api/org_invitations.rs
+++ b/crates/server/src/api/org_invitations.rs
@@ -316,7 +316,9 @@ async fn deliver_invite_email(
          <p><a href=\"{url_html}\">Accept your invitation</a></p>\
          <p>This link expires in {INVITE_TTL_DAYS} days.</p>"
     );
-    let message = EmailMessage::generic(to, subject, text, html);
+    // Branded template: this is an external-facing invitation, so it carries
+    // the Everruns logo, wordmark, and a link back to everruns.com.
+    let message = EmailMessage::basic(to, subject, text, html);
     match email_sender.send_email(message).await {
         Ok(_) => EmailDelivery::Sent,
         // A disabled/unconfigured sender reports a configuration error.

--- a/specs/email.md
+++ b/specs/email.md
@@ -39,14 +39,21 @@ At least one `to` recipient, a subject, and a valid template are required.
 
 ### Templates
 
-Email sends use explicit templates. V1 includes one template:
+Email sends use explicit templates. Callers select a template by constructing the matching `EmailTemplate` variant (or its `EmailMessage` constructor); there is no runtime template registry. Both templates accept a caller-supplied `text` and `html` body and require both to be non-empty.
 
-- `EmailTemplate::Generic(GenericEmailTemplate)`
-  - accepts `text` and `html`
-  - prefixes plain text with Everruns branding
-  - wraps HTML in a small Everruns-branded shell
+All templates share an app-styled HTML shell whose colors and shapes mirror `apps/ui/src/app/design-system.css` (grayscale surface, navy/gold brand accents, sharp 0px corners). Brand tokens are inlined as literals in `crates/core/src/email.rs` because email clients cannot load the app's webfont or CSS variables; keep them in sync if the palette changes.
 
-The generic template is for internal transactional emails that do not yet need their own dedicated template.
+- `EmailTemplate::Minimal(MinimalEmailTemplate)`
+  - app-styled shell, but **unbranded**: no wordmark, logo, or footer link
+  - plain text body is passed through verbatim
+  - use when the surrounding flow already carries Everruns branding
+- `EmailTemplate::Basic(BasicEmailTemplate)`
+  - same app-styled shell as `Minimal`, plus branding
+  - header with the Everruns logo (`https://everruns.com/logo.png`) and wordmark, linking to everruns.com
+  - footer linking back to everruns.com
+  - plain text body is prefixed with the Everruns wordmark and gets a site-link footer
+
+The logo is referenced as a hosted absolute PNG URL rather than the in-repo SVG, because most email clients block SVG and inline data URIs. The marketing site must serve `logo.png` at the apex domain.
 
 ## System Configuration
 


### PR DESCRIPTION
## What
Reworks the system email templates in `everruns-core`:
- Renames `EmailTemplate::Generic` → `EmailTemplate::Minimal` (`GenericEmailTemplate` → `MinimalEmailTemplate`, `EmailMessage::generic` → `EmailMessage::minimal`).
- Restyles the shared HTML shell to match the app design system: grayscale surface, navy (`#0A1636`) / gold (`#D4A43A`) brand accents, and sharp `0px` corners (mirrors `apps/ui/src/app/design-system.css`).
- Makes `Minimal` **unbranded** — no wordmark, logo, footer link, or branded document `<title>`; plain text passes through verbatim.
- Adds `EmailTemplate::Basic` (`EmailMessage::basic`), built on the same shell, with Everruns branding: a logo + wordmark header and a footer, both linking to everruns.com.
- Migrates the one existing caller — the org-invitation email (`crates/server/src/api/org_invitations.rs`) — from `generic` to the branded `basic` template.

## Why
The previous single `Generic` template was lightly branded (text wordmark, "sent by Everruns" footer) but did not match the app's look, carried no logo, and provided no link back to everruns.com. We want two clear choices: a clean app-styled shell with no branding, and a fully branded one.

## How
Both templates share `wrap_email_html(title, header, inner, footer)`, which takes a document title plus optional pre-rendered header/footer rows. `Basic` supplies a `branded_header()` (logo `<img>` + wordmark linking to everruns.com) and `branded_footer()` (gold "everruns.com" link) and the "Everruns" title; `Minimal` passes a neutral "Notification" title and no header/footer. Brand colors and the font stack are inlined as constants because email clients cannot load the Geist webfont or resolve CSS variables. The logo is referenced as a hosted absolute PNG (`https://everruns.com/logo.png`) since most clients block SVG and inline data URIs. Template selection stays a compile-time choice at the call site via the enum variant / constructor.

## Risk
- Low. Pure rendering change in `everruns-core` plus a one-line template swap in the invitation flow. The org-invitation email is the only caller; its mock-based unit tests don't assert on rendered body, so behavior is unchanged apart from the new branded styling. The one runtime dependency introduced is the hosted `logo.png` asset, which the marketing site must serve for the `Basic` header image to load (a missing image degrades gracefully to the `alt="Everruns"` text).

## Security
- Threat categories reviewed: **TM-WEB**. The templates interpolate caller-supplied `text`/`html` into an HTML document without escaping — unchanged from the prior `Generic` template. Per `specs/email.md`, email is a system-owned service with no agent capability, public API, or user-facing surface, so the body is trusted internal content. The one caller (org invitations) already HTML-escapes its user-controlled values (org name, URL) before interpolation, so the template swap introduces no new injection surface. Brand tokens, logo URL, and site URL are static literals. No new dependencies, no auth/authz/tenant logic touched.
- Findings and resolutions: none.

## Follow-ups
- Ensure the marketing site serves `https://everruns.com/logo.png` (apex domain) so the `Basic` header logo renders; until then it falls back to alt text. Noted in `specs/email.md`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal-only API; no external consumers per `specs/email.md` non-goals)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_017im8HqUGBF3pKsVqkmBMDW