### PR TITLE
fix(guardrails): scope mcp guardrail invoker

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -435,7 +435,7 @@ pub use harness::{Harness, HarnessStatus, merge_harness, merge_harness_chain};
 pub use leased_resource::{
     LEASED_RESOURCES_FEATURE, LeasedResource, LeasedResourceStatus, UpsertLeasedResource,
 };
-pub use mcp_proxy::{McpProxyTool, McpToolInvoker, build_mcp_proxy_tools};
+pub use mcp_proxy::{McpProxyTool, McpToolInvoker, ScopedMcpToolInvoker, build_mcp_proxy_tools};
 pub use mcp_server::{
     McpContent, McpError, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
     McpToolAnnotations, McpToolCallParams, McpToolCallRequest, McpToolCallResponse,

--- a/crates/core/src/mcp_proxy.rs
+++ b/crates/core/src/mcp_proxy.rs
@@ -20,6 +20,7 @@ use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Host-provided backend that executes an MCP tool call against the right
@@ -31,6 +32,44 @@ pub trait McpToolInvoker: Send + Sync {
     /// Execute a single MCP tool call (its `name` is the prefixed `mcp_*` name)
     /// and return the raw tool result.
     async fn invoke(&self, tool_call: &ToolCall) -> Result<crate::tool_types::ToolResult>;
+}
+
+/// MCP invoker wrapper that only permits calls to MCP tools included in the
+/// current turn's tool definitions. Guardrails use this wrapper because their
+/// configured `server`/`tool` references are out-of-band; without this check a
+/// config edit could invoke an org MCP server that was not scoped to the
+/// current agent/session.
+pub struct ScopedMcpToolInvoker {
+    inner: Arc<dyn McpToolInvoker>,
+    allowed_tool_names: HashSet<String>,
+}
+
+impl ScopedMcpToolInvoker {
+    pub fn new(definitions: &[ToolDefinition], inner: Arc<dyn McpToolInvoker>) -> Self {
+        let allowed_tool_names = definitions
+            .iter()
+            .map(ToolDefinition::name)
+            .filter(|name| is_mcp_tool(name))
+            .map(str::to_string)
+            .collect();
+        Self {
+            inner,
+            allowed_tool_names,
+        }
+    }
+}
+
+#[async_trait]
+impl McpToolInvoker for ScopedMcpToolInvoker {
+    async fn invoke(&self, tool_call: &ToolCall) -> Result<crate::tool_types::ToolResult> {
+        if !self.allowed_tool_names.contains(&tool_call.name) {
+            return Err(crate::AgentLoopError::tool(format!(
+                "MCP tool '{}' is not allowed in this session",
+                tool_call.name
+            )));
+        }
+        self.inner.invoke(tool_call).await
+    }
 }
 
 /// A registry [`Tool`] backed by an MCP server tool definition.
@@ -311,6 +350,43 @@ mod tests {
             ToolExecutionResult::ToolError(m) => assert!(m.contains("MCP server not found")),
             other => panic!("expected ToolError, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn scoped_invoker_allows_only_current_turn_mcp_tools() {
+        let inner = Arc::new(RecordingInvoker {
+            calls: Mutex::new(vec![]),
+            result: ok_result(serde_json::json!({ "ok": true })),
+        });
+        let scoped = ScopedMcpToolInvoker::new(&[mcp_def("mcp_docs__search")], inner.clone());
+
+        let allowed = ToolCall {
+            id: "call_1".to_string(),
+            name: "mcp_docs__search".to_string(),
+            arguments: serde_json::json!({ "q": "hello" }),
+        };
+        let result = scoped.invoke(&allowed).await.expect("allowed MCP tool");
+        assert_eq!(result.result, Some(serde_json::json!({ "ok": true })));
+
+        let denied = ToolCall {
+            id: "call_2".to_string(),
+            name: "mcp_secret__capture".to_string(),
+            arguments: serde_json::json!({ "content": "sensitive" }),
+        };
+        let error = scoped
+            .invoke(&denied)
+            .await
+            .expect_err("unlisted MCP tool must be denied");
+        assert!(
+            error
+                .to_string()
+                .contains("MCP tool 'mcp_secret__capture' is not allowed"),
+            "unexpected error: {error}"
+        );
+
+        let calls = inner.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "denied call must not reach backend");
+        assert_eq!(calls[0].name, "mcp_docs__search");
     }
 
     #[test]

--- a/crates/core/src/mcp_proxy.rs
+++ b/crates/core/src/mcp_proxy.rs
@@ -64,7 +64,7 @@ impl McpToolInvoker for ScopedMcpToolInvoker {
     async fn invoke(&self, tool_call: &ToolCall) -> Result<crate::tool_types::ToolResult> {
         if !self.allowed_tool_names.contains(&tool_call.name) {
             return Err(crate::AgentLoopError::tool(format!(
-                "MCP tool '{}' is not allowed in this session",
+                "MCP tool '{}' is not allowed in the current tool scope",
                 tool_call.name
             )));
         }

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -1197,7 +1197,10 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
         for tool in everruns_core::build_mcp_proxy_tools(&input.tool_definitions, invoker.clone()) {
             tool_registry.register_boxed(tool);
         }
-        mcp_invoker = Some(invoker);
+        mcp_invoker = Some(Arc::new(everruns_core::ScopedMcpToolInvoker::new(
+            &input.tool_definitions,
+            invoker,
+        )));
     }
 
     let builtin_tool_registry = Arc::new(tool_registry.clone());


### PR DESCRIPTION
### Motivation
- Guardrail `mcp` checks could call the shared MCP invoker with an arbitrary `server`/`tool` name from agent config, which could reach org-level MCP servers not scoped to the current session and exfiltrate sensitive tool arguments/output.
- The runtime previously registered per-turn MCP proxy tools but also exposed the raw invoker to guardrails, creating an out-of-band path that bypassed the current-turn allowlist.

### Description
- Add `ScopedMcpToolInvoker` in `crates/core/src/mcp_proxy.rs` that wraps an existing `McpToolInvoker` and allows only MCP tool names present in the current turn's `ToolDefinition` list. The wrapper returns a tool error for disallowed names before invoking the backend.
- Wire the scoped wrapper into the runtime guardrail path in `crates/runtime/src/host.rs` so guardrail MCP invocations use `ScopedMcpToolInvoker::new(&input.tool_definitions, invoker)` while leaving normal registered MCP proxy tool execution unchanged.
- Export the scoped invoker from core via `crates/core/src/lib.rs` so the runtime can construct it.
- Add a focused unit test `scoped_invoker_allows_only_current_turn_mcp_tools` in `crates/core/src/mcp_proxy.rs` proving allowed current-turn MCP calls reach the backend and unlisted MCP calls are denied before backend invocation.

### Testing
- Ran the focused core tests with `cargo test -p everruns-core mcp_proxy::tests` and the new test `scoped_invoker_allows_only_current_turn_mcp_tools` passed along with existing proxy tests (`6 passed; 0 failed`).
- Ran `cargo fmt` (fixing formatting) and `cargo fmt --check && cargo check -p everruns-runtime`, both of which completed successfully.
- The change is narrowly scoped to the MCP invoker boundary and covered by the new unit test demonstrating the authorization barrier works as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346f3fda10832ba64d8ff7e0ca9186)