### PR TITLE
fix(context): make infinity anchor opt-in

### DIFF
--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -95,7 +95,7 @@ impl Capability for InfinityContextCapability {
                 "keep_first_messages": {
                     "type": "integer",
                     "title": "Anchored first messages",
-                    "description": "Leading messages always kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages. The anchor is fetched as a bounded head+tail load, so it is guaranteed even for histories far longer than the candidate load window. Keep it small (the default 1 anchors the original task) and raise it only when more leading context is genuinely needed.",
+                    "description": "Optional leading messages kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages. The anchor is fetched as a bounded head+tail load (capped at 16), so it is guaranteed even for histories far longer than the candidate load window. Defaults to 0 so untrusted first messages cannot bypass the configured token budget or recent-message cap; raise it only for trusted sessions where anchoring leading context is worth the extra prompt cost.",
                     "minimum": 0,
                     "maximum": MAX_KEEP_FIRST_MESSAGES,
                     "default": default_keep_first_messages()
@@ -195,10 +195,10 @@ struct InfinityContextConfig {
     #[serde(default)]
     max_recent_messages: Option<usize>,
 
-    /// Number of leading messages always kept as an anchor (the original task /
-    /// goal), regardless of token budget. Defaults to 1 so the model never loses
-    /// what it is doing when the window slides. The anchor is additional to
-    /// `max_recent_messages`.
+    /// Optional leading messages kept as an anchor (the original task / goal),
+    /// regardless of token budget. Defaults to 0 so untrusted first messages
+    /// cannot bypass the configured token budget or recent-message cap. The
+    /// anchor is additional to `max_recent_messages` when explicitly enabled.
     #[serde(default = "default_keep_first_messages")]
     keep_first_messages: usize,
 
@@ -219,7 +219,7 @@ fn default_min_recent_messages() -> usize {
 }
 
 fn default_keep_first_messages() -> usize {
-    1
+    0
 }
 
 impl Default for InfinityContextConfig {
@@ -247,10 +247,13 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
             serde_json::from_value(config.clone()).unwrap_or_default();
 
         query.limit = Some(resolve_candidate_load_limit(&config) as i64);
-        // Always fetch the first `keep_first_messages` alongside the latest-N tail
-        // so the task/goal anchor survives even when the history is far longer than
-        // the candidate load window (the tail-only LIMIT would otherwise never
-        // fetch the genuine first message).
+        // When explicitly configured (`keep_first_messages > 0`), fetch the first
+        // messages alongside the latest-N tail so the task/goal anchor survives
+        // even when history is far longer than the candidate load window (the
+        // tail-only LIMIT would otherwise never fetch the genuine first message).
+        // The default is 0 so an untrusted first message cannot bypass the token
+        // budget or recent-message cap, and the value is clamped to
+        // `MAX_KEEP_FIRST_MESSAGES` to bound the extra head load.
         let keep_first_messages = resolve_keep_first_messages(&config);
         if keep_first_messages > 0 {
             query.keep_head = Some(keep_first_messages);
@@ -811,9 +814,9 @@ mod tests {
 
         assert_eq!(query.limit, Some(16));
         assert!(query.prepend_transform.is_some());
-        // Default keep_first_messages (1) is loaded as a head anchor so the task
-        // goal survives even for histories longer than the candidate window.
-        assert_eq!(query.keep_head, Some(1));
+        // The safe default omits the head anchor so a large untrusted first
+        // message cannot bypass the configured budget or recent-message cap.
+        assert_eq!(query.keep_head, None);
     }
 
     #[test]
@@ -931,16 +934,20 @@ mod tests {
             &json!({"context_budget_tokens": 1, "min_recent_messages": 2}),
         );
 
-        // Layout: [task anchor] -> [N hidden notice] -> [recent window].
-        // The original task survives even under a 1-token budget.
-        assert_eq!(messages.len(), 4);
-        assert_eq!(extract_text_content(&messages[0]), "the original task");
+        // Default configuration has no head anchor: a first user message must not
+        // bypass the configured token budget or recent-message cap.
+        assert_eq!(messages.len(), 3);
         assert!(
-            extract_text_content(&messages[1])
-                .contains("1 earlier messages are NOT visible in this context")
+            extract_text_content(&messages[0])
+                .contains("2 earlier messages are NOT visible in this context")
         );
-        assert_eq!(extract_text_content(&messages[2]), "recent one");
-        assert_eq!(extract_text_content(&messages[3]), "recent two");
+        assert_eq!(extract_text_content(&messages[1]), "recent one");
+        assert_eq!(extract_text_content(&messages[2]), "recent two");
+        assert!(
+            !messages
+                .iter()
+                .any(|m| extract_text_content(m) == "the original task")
+        );
     }
 
     #[test]
@@ -963,15 +970,14 @@ mod tests {
             }),
         );
 
-        // Hard cap keeps 2 recent; the head anchor ("one") is additional to it.
-        assert_eq!(messages.len(), 4);
-        assert_eq!(extract_text_content(&messages[0]), "one");
+        // Hard cap keeps only the 2 recent messages by default.
+        assert_eq!(messages.len(), 3);
         assert!(
-            extract_text_content(&messages[1])
-                .contains("2 earlier messages are NOT visible in this context")
+            extract_text_content(&messages[0])
+                .contains("3 earlier messages are NOT visible in this context")
         );
-        assert_eq!(extract_text_content(&messages[2]), "four");
-        assert_eq!(extract_text_content(&messages[3]), "five");
+        assert_eq!(extract_text_content(&messages[1]), "four");
+        assert_eq!(extract_text_content(&messages[2]), "five");
     }
 
     #[test]
@@ -981,7 +987,8 @@ mod tests {
         // small enough that the big middle turns are dropped by token budget.
         let config = json!({
             "context_budget_tokens": 600,
-            "min_recent_messages": 2
+            "min_recent_messages": 2,
+            "keep_first_messages": 1
         });
         let mut query = MessageQuery::new(SessionId::new());
         provider.apply_filters(&mut query, &config);
@@ -1064,6 +1071,39 @@ mod tests {
         );
         assert!(extract_text_content(&messages[MAX_KEEP_FIRST_MESSAGES]).contains("NOT visible"));
         assert_eq!(extract_text_content(messages.last().unwrap()), "message 19");
+    }
+
+    #[test]
+    fn test_filter_provider_default_drops_oversized_first_message() {
+        let provider = InfinityContextFilterProvider;
+        let mut messages = vec![
+            Message::user("attacker ".repeat(20_000)),
+            Message::assistant("middle"),
+            Message::user("recent one"),
+            Message::assistant("recent two"),
+        ];
+
+        provider.post_load(
+            &mut messages,
+            &json!({
+                "context_budget_tokens": 10,
+                "min_recent_messages": 2,
+                "max_recent_messages": 2
+            }),
+        );
+
+        assert_eq!(messages.len(), 3);
+        assert!(
+            extract_text_content(&messages[0])
+                .contains("2 earlier messages are NOT visible in this context")
+        );
+        assert_eq!(extract_text_content(&messages[1]), "recent one");
+        assert_eq!(extract_text_content(&messages[2]), "recent two");
+        assert!(
+            !messages
+                .iter()
+                .any(|m| extract_text_content(m).starts_with("attacker"))
+        );
     }
 
     #[test]

--- a/specs/infinity-context.md
+++ b/specs/infinity-context.md
@@ -84,12 +84,14 @@ When searching history:
     "context_budget_tokens": 100000,
     "min_recent_messages": 10,
     "max_recent_messages": null,
-    "keep_first_messages": 1
+    "keep_first_messages": 0
   }
   ```
-- `keep_first_messages` (default 1, maximum 16) is the number of leading messages
-  always kept as an anchor — the original task/goal. The anchor is **additional**
-  to `max_recent_messages` (which caps only the recent tail).
+- `keep_first_messages` (default 0, maximum 16) is the number of leading messages
+  kept as an anchor — the original task/goal. It is opt-in because the anchor is
+  **additional** to `max_recent_messages` (which caps only the recent tail) and is
+  preserved outside the token budget when configured. The value is capped at 16 to
+  bound the extra head fetch and the always-preserved prompt anchor.
 
 ## Design
 
@@ -131,8 +133,9 @@ More accurate estimation can use tiktoken for OpenAI or anthropic-tokenizer for 
 
 Selection is "protect the head + tail, drop the middle" (see
 `anchored_window` in `crates/core/src/message_filter.rs`). The agent system
-prompt is assembled separately and is never part of this list, so the head
-anchor here protects the **first conversation message — the original task/goal**.
+prompt is assembled separately and is never part of this list. When
+`keep_first_messages` is explicitly configured, the head anchor protects the
+**first conversation message — the original task/goal**.
 
 ```python
 def select_messages(all_messages, budget, keep_head, min_tail, max_tail=None):
@@ -165,20 +168,24 @@ The notice is inserted between the anchor and the recent block, so the live
 prompt reads `[task anchor] -> [N earlier messages hidden] -> [recent window]`.
 
 `max_recent_messages` is a hard cap for constrained surfaces such as public
-support chat; it bounds only the recent tail (the head anchor is additional).
+support chat; it bounds only the recent tail (any explicitly configured head
+anchor is additional).
 Message limits always mean the latest N messages, returned in chronological
 order; older excluded messages remain available through `query_history`.
 
 **Head+tail load.** The candidate set is fetched as a head+tail window, not a
 tail-only "latest N". `apply_filters` sets `MessageQuery::keep_head =
-keep_first_messages` alongside the candidate `limit`, and every storage backend
-honors it: the first `keep_head` messages (the task anchor) are loaded **in
-addition to** the latest `limit` tail, de-duplicated when the windows overlap
-and returned in chronological order. So the genuine first message is always
-fetched, and the anchor never silently degrades to a mid-conversation message —
-even for conversations far longer than the candidate window or when
-`max_recent_messages` is set very low. `keep_first_messages` is capped at 16 to
-bound the extra head fetch and the always-preserved prompt anchor.
+keep_first_messages` alongside the candidate `limit` when the value is greater
+than zero, and every storage backend honors it: the first `keep_head` messages
+(the task anchor) are loaded **in addition to** the latest `limit` tail,
+de-duplicated when the windows overlap and returned in chronological order. When
+enabled, the genuine first message is always fetched, and the anchor never
+silently degrades to a mid-conversation message — even for conversations far
+longer than the candidate window or when `max_recent_messages` is set very low.
+The default is 0 so public or multi-user endpoints do not keep an
+attacker-controlled first message beyond configured prompt resource limits, and
+the value is capped at 16 to bound the extra head fetch and the always-preserved
+prompt anchor.
 
 ### History Notice Format
 

--- a/specs/infinity-context.md
+++ b/specs/infinity-context.md
@@ -164,8 +164,11 @@ def select_messages(all_messages, budget, keep_head, min_tail, max_tail=None):
     return kept, excluded
 ```
 
-The notice is inserted between the anchor and the recent block, so the live
-prompt reads `[task anchor] -> [N earlier messages hidden] -> [recent window]`.
+The notice is inserted between any head anchor and the recent block. With an
+explicitly configured `keep_first_messages > 0` the live prompt reads
+`[task anchor] -> [N earlier messages hidden] -> [recent window]`; under the
+default (`keep_first_messages = 0`) there is no anchor, so it reads
+`[N earlier messages hidden] -> [recent window]` and the notice leads the prompt.
 
 `max_recent_messages` is a hard cap for constrained surfaces such as public
 support chat; it bounds only the recent tail (any explicitly configured head


### PR DESCRIPTION
### Motivation

- Prevent attacker-controlled first messages from bypassing configured prompt token budgets and `max_recent_messages` by default. 
- The prior default (`keep_first_messages = 1`) always preserved the first conversation message outside budget/cap, creating a resource-exhaustion/availability risk for public or multi-tenant endpoints.

### Description

- Change default anchoring so `default_keep_first_messages()` returns `0` instead of `1`, making head anchoring opt-in (`crates/core/src/capabilities/infinity_context.rs`).
- Only set `MessageQuery::keep_head` when `keep_first_messages > 0`, preserving explicit anchoring behavior for trusted configurations while preventing implicit retention of the first (potentially untrusted) message.
- Update capability schema and human-facing docs to document the safer default and rationale (`crates/core/src/capabilities/infinity_context.rs`, `specs/infinity-context.md`).
- Adjust and add unit tests to assert the new default behavior and to keep existing coverage for explicit anchoring; added a regression test `test_filter_provider_default_drops_oversized_first_message` and updated expectations in existing tests (`crates/core/src/capabilities/infinity_context.rs` tests).

### Testing

- Ran formatting check with `cargo fmt --check` and `git diff --check`; checks passed.
- Ran focused capability tests with `cargo test -p everruns-core capabilities::infinity_context --all-features`; all tests passed (28 passed, 0 failed).
- Ran anchored-window unit tests with `cargo test -p everruns-core message_filter::tests::test_anchored_window --all-features`; all tests passed (6 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3475a63d6c832bad94bb68288872a6)