### PR TITLE
fix(core): preserve legacy agent run records

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -521,6 +521,7 @@ struct AgentRunRecord {
     kind: String,
     external_agent_id: String,
     external_agent_name: String,
+    #[serde(alias = "task")]
     instructions: String,
     mode: AgentRunMode,
     status: AgentRunStatus,
@@ -2639,6 +2640,28 @@ mod tests {
             err.to_string().contains("remote_task_id"),
             "error should mention remote_task_id: {err}"
         );
+    }
+
+    /// Legacy records written before the task-to-instructions rename should
+    /// still load from durable session storage.
+    #[test]
+    fn agent_run_record_accepts_legacy_task_field() {
+        let legacy = json!({
+            "run_id": "legacy-run",
+            "kind": "external_a2a",
+            "external_agent_id": "echo",
+            "external_agent_name": "Echo",
+            "task": "legacy instructions",
+            "mode": "wait",
+            "status": "submitted"
+        });
+
+        let record: AgentRunRecord = serde_json::from_value(legacy).unwrap();
+        assert_eq!(record.instructions, "legacy instructions");
+
+        let serialized = serde_json::to_value(&record).unwrap();
+        assert_eq!(serialized["instructions"], "legacy instructions");
+        assert!(serialized.get("task").is_none());
     }
 
     /// Roundtrip: save_run → load_run → load_run_for_task all resolve consistently.


### PR DESCRIPTION
### Motivation
- A field rename from `task` to `instructions` made `AgentRunRecord` deserialization incompatible with legacy persisted JSON stored under `agent_run:{run_id}`. 
- Preserve storage/backwards compatibility so older A2A runs continue to load and listings/resumption are not broken after upgrade.

### Description
- Add `#[serde(alias = "task")]` to the `instructions` field on `AgentRunRecord` so legacy `task` keys deserialize into `instructions` while serialization still emits `instructions`.
- Add a regression unit test `agent_run_record_accepts_legacy_task_field` that deserializes legacy JSON containing `task`, checks `instructions` is populated, and verifies reserialization uses the canonical `instructions` key.

### Testing
- Ran `cargo fmt --check`, which passed.
- Ran the focused unit test with `cargo test -p everruns-core agent_run_record_accepts_legacy_task_field`, which passed.
- The added test verifies both legacy deserialization and canonical reserialization succeeded (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3475a60e94832bb7679565bb9763c1)