### PR TITLE
fix(runtime): preserve capability narration hooks in act execution

### DIFF
--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -483,17 +483,17 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         ));
     }
 
-    let tool_call_hooks = resolved
-        .resolved_capability_configs
-        .iter()
-        .flat_map(|config| {
-            capability_registry
-                .get(config.capability_id())
-                .filter(|capability| capability.status() == CapabilityStatus::Available)
-                .map(|capability| capability.tool_call_hooks())
-                .unwrap_or_default()
-        })
-        .collect();
+    // Use the hook list assembled by `collect_capabilities_with_configs` as the
+    // single source of truth. It already contains every explicit capability
+    // `tool_call_hooks()` followed by the generated `CapabilityNarrationHook`
+    // adapters — one per collected capability plus any auto-activated
+    // cross-cutting capability such as `background_execution`. Re-deriving only
+    // the explicit subset here dropped capability-owned narration, so tools fell
+    // back to generic `Ran {display_name}` lines (EVE-601). Explicit hooks stay
+    // first in this list, so model-authored narration (`human_intent`) keeps its
+    // precedence over default `Tool::narrate()`, and only available capabilities
+    // contributed because collection skips non-available ones.
+    let tool_call_hooks = collected.tool_call_hooks;
 
     Ok(RuntimeExecutionCapabilities {
         tool_registry: registry,

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -374,6 +374,138 @@ impl Capability for OverlayAliasCapability {
     }
 }
 
+/// Tool whose `Tool::narrate()` returns a distinctive line, so the act path
+/// must surface capability-owned narration rather than the generic
+/// `Running {display_name}` / `Ran {display_name}` fallback (EVE-601).
+struct NarratingTool;
+
+#[async_trait]
+impl Tool for NarratingTool {
+    fn name(&self) -> &str {
+        "narrating_tool"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        // Distinct from the narration so a generic fallback is detectable.
+        Some("Narrating Tool")
+    }
+
+    fn description(&self) -> &str {
+        "Returns the provided value with capability-owned narration."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+            "additionalProperties": false
+        })
+    }
+
+    fn narrate(
+        &self,
+        _tool_call: &ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        use everruns_core::tool_narration::ToolNarrationPhase;
+        match phase {
+            ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                Some("Narrating tool: starting work".to_string())
+            }
+            ToolNarrationPhase::Completed => Some("Narrating tool: finished work".to_string()),
+            ToolNarrationPhase::Failed => Some("Narrating tool: failed".to_string()),
+        }
+    }
+
+    async fn execute(&self, arguments: serde_json::Value) -> ToolExecutionResult {
+        ToolExecutionResult::success(json!({
+            "value": arguments["value"].as_str().unwrap_or_default(),
+        }))
+    }
+}
+
+/// Capability contributing `NarratingTool`. Relies on the default
+/// `Capability::narrate()` dispatch to the tool's `narrate()`, which the runtime
+/// act path must consult via the collected `CapabilityNarrationHook`.
+struct NarratingCapability;
+
+impl Capability for NarratingCapability {
+    fn id(&self) -> &str {
+        "narrating"
+    }
+
+    fn name(&self) -> &str {
+        "Narrating"
+    }
+
+    fn description(&self) -> &str {
+        "Test capability whose tool owns its narration."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(NarratingTool)]
+    }
+}
+
+/// Explicit `ToolCallHook` whose narration must win over the default capability
+/// `Tool::narrate()` when both are present (AC #7: model-authored narration such
+/// as `human_intent` keeps precedence).
+struct ExplicitNarrationHook;
+
+impl everruns_core::capabilities::ToolCallHook for ExplicitNarrationHook {
+    fn narration(
+        &self,
+        _tool_def: Option<&everruns_core::ToolDefinition>,
+        tool_call: &ToolCall,
+        _phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        if tool_call.name == "narrating_tool" {
+            Some("Explicit hook narration wins".to_string())
+        } else {
+            None
+        }
+    }
+}
+
+/// Capability contributing both `NarratingTool` (which owns `Tool::narrate()`)
+/// and an explicit `tool_call_hooks()` entry. Collection orders the explicit
+/// hook before the generated `CapabilityNarrationHook`, so the explicit hook
+/// must take precedence on the act path.
+struct ExplicitNarrationCapability;
+
+impl Capability for ExplicitNarrationCapability {
+    fn id(&self) -> &str {
+        "explicit_narration"
+    }
+
+    fn name(&self) -> &str {
+        "Explicit Narration"
+    }
+
+    fn description(&self) -> &str {
+        "Test capability with an explicit tool-call narration hook."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(NarratingTool)]
+    }
+
+    fn tool_call_hooks(&self) -> Vec<Arc<dyn everruns_core::capabilities::ToolCallHook>> {
+        vec![Arc::new(ExplicitNarrationHook)]
+    }
+}
+
 fn harness(harness_id: HarnessId) -> Harness {
     Harness {
         id: harness_id,
@@ -650,6 +782,164 @@ async fn act_activity_executes_capability_tools_from_harness_registry() {
     assert_eq!(result.success_count, 1);
     assert_eq!(result.error_count, 0);
     assert_eq!(result.results.len(), 1);
+}
+
+/// EVE-601: the runtime act path must surface capability-owned `Tool::narrate()`
+/// output (via the collected `CapabilityNarrationHook`) on `tool.started` /
+/// `tool.completed`, not the generic `Running {display_name}` fallback.
+#[tokio::test]
+async fn act_activity_uses_capability_tool_narration_on_act_path() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(NarratingCapability);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("narrating")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+    let tool_definitions = build_registry(
+        &adapter.capability_registry,
+        session_id,
+        &[AgentCapabilityConfig::new("narrating")],
+    )
+    .await
+    .unwrap()
+    .tool_definitions();
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: None,
+            tool_calls: vec![ToolCall {
+                id: "call_narrate".into(),
+                name: "narrating_tool".into(),
+                arguments: json!({"value": "x"}),
+            }],
+            tool_definitions,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.success_count, 1);
+
+    let events = adapter.event_emitter.events().await;
+    let started = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::ToolStarted(data) => Some(data.narration.clone()),
+            _ => None,
+        })
+        .expect("tool.started event");
+    let completed = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::ToolCompleted(data) => Some(data.narration.clone()),
+            _ => None,
+        })
+        .expect("tool.completed event");
+    assert_eq!(
+        started.as_deref(),
+        Some("Narrating tool: starting work"),
+        "tool.started must use capability-owned narration, not the generic fallback"
+    );
+    assert_eq!(
+        completed.as_deref(),
+        Some("Narrating tool: finished work"),
+        "tool.completed must use capability-owned narration, not the generic fallback"
+    );
+}
+
+/// AC #7: an explicit `Capability::tool_call_hooks()` narration must win over the
+/// default capability `Tool::narrate()` when both are present, because collection
+/// orders explicit hooks before the generated `CapabilityNarrationHook`.
+#[tokio::test]
+async fn act_activity_explicit_tool_call_hook_wins_over_capability_narration() {
+    let mut adapter = mock_host();
+    adapter
+        .capability_registry
+        .register(ExplicitNarrationCapability);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("explicit_narration")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+    let tool_definitions = build_registry(
+        &adapter.capability_registry,
+        session_id,
+        &[AgentCapabilityConfig::new("explicit_narration")],
+    )
+    .await
+    .unwrap()
+    .tool_definitions();
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: None,
+            tool_calls: vec![ToolCall {
+                id: "call_narrate".into(),
+                name: "narrating_tool".into(),
+                arguments: json!({"value": "x"}),
+            }],
+            tool_definitions,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.success_count, 1);
+
+    let events = adapter.event_emitter.events().await;
+    let started = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::ToolStarted(data) => Some(data.narration.clone()),
+            _ => None,
+        })
+        .expect("tool.started event");
+    assert_eq!(
+        started.as_deref(),
+        Some("Explicit hook narration wins"),
+        "explicit tool-call hook narration must take precedence over default Tool::narrate()"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What
Runtime act execution now preserves capability-owned tool narration. `load_execution_capabilities` in `crates/runtime/src/host.rs` uses the `tool_call_hooks` list assembled by `collect_capabilities_with_configs` instead of re-deriving a narrower subset from `resolved_capability_configs`.

## Why
Fixes [EVE-601](https://linear.app/everruns/issue/EVE-601). The runtime rebuilt `RuntimeExecutionCapabilities.tool_call_hooks` by collecting only explicit `Capability::tool_call_hooks()`, dropping the `CapabilityNarrationHook` adapters that core collection generates per capability (and for auto-activated capabilities like `background_execution`). So `ActAtom::render_tool_narration()` never saw capability-owned `Tool::narrate()` and tools fell back to generic `Running {display_name}` / `Ran {display_name}` lines (e.g. Yolop `record_approval` rendered `Ran Record approval` instead of `Record approval: create …`).

## How
- Replace the re-derivation with `let tool_call_hooks = collected.tool_call_hooks;`. The collected list already contains explicit capability hooks **first** (so model-authored narration such as `human_intent` keeps precedence over default `Tool::narrate()`), followed by the narration adapters, and only includes available capabilities because collection skips non-available ones.
- Add two runtime-host regression tests:
  - `act_activity_uses_capability_tool_narration_on_act_path`: a test capability whose tool implements `Tool::narrate()` is executed through `execute_act_activity`; asserts `tool.started`/`tool.completed` carry the distinctive narration, not the generic fallback. Verified to fail before the fix (`Running Narrating Tool`) and pass after.
  - `act_activity_explicit_tool_call_hook_wins_over_capability_narration`: a capability providing both an explicit `tool_call_hooks()` narration and a tool `narrate()`; asserts the explicit hook wins (AC #7).

Acceptance criteria 1–9 are covered: collected hooks are the source of truth (#1), explicit hooks keep precedence (#2, #7), unavailable capabilities are still skipped by collection (#3), `effective`/`resolve_for_model` selection is untouched (#4), `background_execution` narration hooks ride the act path (#5), regression tests added (#6, #7), and existing pre/post-tool, guardrail, approval, and user-hook tests continue to pass (#9). The full `runtime_host_test` suite (24 tests) passes.

## Risk
- Low.
- The act path now runs additional `ToolCallHook::narration()` calls (pure, side-effect-free string rendering) and the per-capability `CapabilityNarrationHook` adapters. `transform_for_execution` for these adapters is the default no-op, so tool execution arguments are unchanged. Explicit hooks retain ordering/precedence.

## Security
- Threat categories reviewed: TM-TOOL. The change only widens which **narration** hooks are consulted for UI timeline rendering; it does not alter tool authorization, argument transformation, approval gating, guardrails, or output persistence. Availability filtering is preserved (collection skips non-`Available` capabilities), so an unavailable capability still contributes no hooks. No new external input, no injection surface.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_019ei3mDBb8wr2URnW1Fk6rH

---
_Generated by [Claude Code](https://claude.ai/code/session_019ei3mDBb8wr2URnW1Fk6rH)_