### PR TITLE
feat(capabilities): tool-call repair capability for malformed tool calls

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -246,6 +246,7 @@ export default defineConfig({
                       collapsed: true,
                       items: [
                         { label: "Prompt Canary Guardrail", slug: "capabilities/prompt-canary-guardrail" },
+                        { label: "Tool Call Repair", slug: "capabilities/tool-call-repair" },
                       ],
                     },
                     {

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -63,6 +63,95 @@ use crate::{ErrorDisclosure, UserFacingError, UserFacingErrorContext, user_facin
 // Helper Functions
 // ============================================================================
 
+/// Apply the opt-in tool-call repair capability (EVE-600) to a finalized batch
+/// of tool calls. No-op unless `tool_call_repair` is in the resolved capability
+/// set, so the default path stays byte-for-byte unchanged.
+///
+/// For each malformed call this runs deterministic local salvage against the
+/// tool's JSON schema, rewrites `arguments` in place when salvage succeeds, and
+/// emits one `tool.call_repaired` event per malformed call with an outcome label
+/// (`local-salvage` | `re-prompt` | `gave-up`). Un-salvaged calls are left
+/// unchanged so they flow to the existing act-phase error path; the per-call
+/// attempt cap (bounding the corrective re-prompt) is enforced by
+/// `ToolCallRepairConfig`, so there is never an infinite repair loop.
+///
+/// Extracted as a free function (like `repair_dangling_tool_calls`) so it can be
+/// exercised by capability-level tests without constructing a full `ReasonAtom`.
+async fn apply_tool_call_repair(
+    capability_registry: &CapabilityRegistry,
+    event_emitter: &dyn EventEmitter,
+    session_id: SessionId,
+    context: &AtomContext,
+    resolved_capability_configs: &[crate::AgentCapabilityConfig],
+    tool_definitions: &[ToolDefinition],
+    tool_calls: &mut [ToolCall],
+) {
+    use crate::capabilities::{
+        RepairOutcome, SalvageResult, TOOL_CALL_REPAIR_CAPABILITY_ID, ToolCallRepairConfig,
+        salvage_tool_arguments,
+    };
+
+    // Opt-in: only run when the capability is enabled for this agent.
+    let Some(cfg) = resolved_capability_configs.iter().find(|c| {
+        capability_registry.canonical_id(c.capability_ref.as_str())
+            == Some(TOOL_CALL_REPAIR_CAPABILITY_ID)
+    }) else {
+        return;
+    };
+    let repair_config = ToolCallRepairConfig::from_json(&cfg.config);
+
+    for call in tool_calls.iter_mut() {
+        // Schema for the targeted tool, if its definition is available.
+        let schema = tool_definitions
+            .iter()
+            .find(|t| t.name() == call.name)
+            .map(|t| t.full_parameters().clone());
+
+        let outcome = match salvage_tool_arguments(&call.arguments, schema.as_ref()) {
+            // Well-formed call: nothing to do, do not emit an event.
+            SalvageResult::AlreadyValid => continue,
+            SalvageResult::Repaired(fixed) => {
+                call.arguments = fixed;
+                RepairOutcome::LocalSalvage
+            }
+            // Local salvage failed. No re-prompt has happened for this call yet
+            // (prior_attempts = 0): the bounded decision is Reprompt while
+            // attempts remain, else GaveUp. Either way the call is left unchanged
+            // and flows to the existing error path.
+            SalvageResult::Unsalvageable => repair_config.outcome_after_failed_salvage(0),
+        };
+
+        tracing::info!(
+            session_id = %session_id,
+            turn_id = %context.turn_id,
+            tool_call_id = %call.id,
+            tool_name = %call.name,
+            outcome = outcome.label(),
+            "ReasonAtom: tool-call repair"
+        );
+
+        if let Err(e) = event_emitter
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::from_atom_context(context),
+                crate::events::ToolCallRepairedData {
+                    turn_id: context.turn_id,
+                    tool_call_id: call.id.clone(),
+                    tool_name: call.name.clone(),
+                    outcome: outcome.label().to_string(),
+                },
+            ))
+            .await
+        {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %e,
+                "ReasonAtom: failed to emit tool.call_repaired event"
+            );
+        }
+    }
+}
+
 /// Repair dangling tool calls (EVE-533): for every assistant tool_call with no matching
 /// ToolResult, synthesize a well-formed result so the next LLM call does not reject the
 /// transcript. Consults `durable_tool_results` (EVE-530) when available:
@@ -774,6 +863,34 @@ impl ReasonAtom {
                 "ReasonAtom: failed to emit capability.usage event"
             );
         }
+    }
+
+    /// Repair malformed tool-call arguments via the opt-in `tool_call_repair`
+    /// capability (EVE-600). No-op unless the capability is in the resolved set,
+    /// keeping the default path byte-for-byte unchanged. Runs deterministic
+    /// local salvage on each call and emits one `tool.call_repaired` event per
+    /// malformed call with an outcome label. The bounded corrective re-prompt is
+    /// realized by the outer agent loop: an un-salvaged call proceeds unchanged
+    /// to the act phase (today's error path) and the model retries next
+    /// iteration; the per-call attempt cap is enforced by `ToolCallRepairConfig`.
+    async fn repair_malformed_tool_calls(
+        &self,
+        session_id: SessionId,
+        context: &AtomContext,
+        resolved_capability_configs: &[crate::AgentCapabilityConfig],
+        tool_definitions: &[ToolDefinition],
+        tool_calls: &mut [ToolCall],
+    ) {
+        apply_tool_call_repair(
+            &self.capability_registry,
+            self.event_emitter.as_ref(),
+            session_id,
+            context,
+            resolved_capability_configs,
+            tool_definitions,
+            tool_calls,
+        )
+        .await;
     }
 
     async fn execute_inner(
@@ -2383,6 +2500,24 @@ impl ReasonAtom {
             thinking.clear();
         }
 
+        // Tool-call repair seam (EVE-600). This is the smallest provider-agnostic
+        // hook where a malformed tool call can still be intercepted: `tool_calls`
+        // is finalized here but the assistant message and downstream events have
+        // not been built yet. The opt-in `tool_call_repair` capability runs
+        // deterministic local salvage on each call's `arguments` and emits a
+        // `tool.call_repaired` event per malformed call. When the capability is
+        // disabled (the default) this is a no-op and behavior is unchanged.
+        if !tool_calls.is_empty() {
+            self.repair_malformed_tool_calls(
+                session_id,
+                context,
+                &resolved_capability_configs,
+                &runtime_agent.tools,
+                &mut tool_calls,
+            )
+            .await;
+        }
+
         let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
 
         // Extract response_id from completion metadata for chaining and OTel
@@ -3485,5 +3620,215 @@ mod tests {
             .await
             .unwrap();
         assert!(result.unwrap().accumulated.is_empty());
+    }
+
+    // ====================================================================
+    // Tool-call repair capability integration (EVE-600)
+    // ====================================================================
+
+    mod tool_call_repair_integration {
+        use super::*;
+        use crate::capabilities::{CapabilityRegistry, TOOL_CALL_REPAIR_CAPABILITY_ID};
+        use crate::events::{EventData, EventRequest};
+        use crate::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
+        use crate::traits::EventEmitter;
+        use crate::typed_id::{MessageId, SessionId, TurnId};
+        use std::sync::Mutex;
+
+        /// EventEmitter that records every emitted request for assertions.
+        #[derive(Default)]
+        struct RecordingEmitter {
+            events: Mutex<Vec<EventRequest>>,
+        }
+
+        #[async_trait::async_trait]
+        impl EventEmitter for RecordingEmitter {
+            async fn emit(
+                &self,
+                request: EventRequest,
+            ) -> crate::error::Result<crate::events::Event> {
+                let event = request
+                    .clone()
+                    .into_event(crate::typed_id::EventId::new(), 0);
+                self.events.lock().unwrap().push(request);
+                Ok(event)
+            }
+        }
+
+        impl RecordingEmitter {
+            fn repaired_events(&self) -> Vec<(String, String)> {
+                self.events
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter_map(|r| match &r.data {
+                        EventData::ToolCallRepaired(d) => {
+                            Some((d.tool_call_id.clone(), d.outcome.clone()))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            }
+        }
+
+        fn ctx() -> AtomContext {
+            AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new())
+        }
+
+        fn read_file_tool() -> ToolDefinition {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "read_file".to_string(),
+                display_name: None,
+                description: "read".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } },
+                    "required": ["path"]
+                }),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: Default::default(),
+                hints: Default::default(),
+                full_parameters: None,
+            })
+        }
+
+        fn malformed_call() -> ToolCall {
+            // Driver passed the raw arg string through as a JSON string (could
+            // not parse it because of prose + single quotes).
+            ToolCall {
+                id: "call_1".to_string(),
+                name: "read_file".to_string(),
+                arguments: json!("here you go: {'path': '/foo'}"),
+            }
+        }
+
+        fn enabled_configs() -> Vec<crate::AgentCapabilityConfig> {
+            vec![crate::AgentCapabilityConfig::new(
+                TOOL_CALL_REPAIR_CAPABILITY_ID,
+            )]
+        }
+
+        async fn run(
+            configs: &[crate::AgentCapabilityConfig],
+            tools: &[ToolDefinition],
+            calls: &mut [ToolCall],
+            emitter: &RecordingEmitter,
+        ) {
+            let registry = CapabilityRegistry::with_builtins();
+            apply_tool_call_repair(
+                &registry,
+                emitter,
+                SessionId::new(),
+                &ctx(),
+                configs,
+                tools,
+                calls,
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn malformed_call_is_repaired_and_turn_proceeds() {
+            let emitter = RecordingEmitter::default();
+            let tools = vec![read_file_tool()];
+            let mut calls = vec![malformed_call()];
+
+            run(&enabled_configs(), &tools, &mut calls, &emitter).await;
+
+            // Arguments are now a clean object: the act phase can proceed.
+            assert_eq!(calls[0].arguments, json!({ "path": "/foo" }));
+            assert_eq!(
+                emitter.repaired_events(),
+                vec![("call_1".to_string(), "local-salvage".to_string())]
+            );
+        }
+
+        #[tokio::test]
+        async fn observability_event_fires_with_outcome_label() {
+            let emitter = RecordingEmitter::default();
+            let tools = vec![read_file_tool()];
+            let mut calls = vec![malformed_call()];
+
+            run(&enabled_configs(), &tools, &mut calls, &emitter).await;
+
+            let repaired = emitter.repaired_events();
+            assert_eq!(repaired.len(), 1, "exactly one repair event");
+            assert_eq!(repaired[0].1, "local-salvage");
+        }
+
+        #[tokio::test]
+        async fn attempt_cap_honored_and_falls_through_to_error_path() {
+            // Un-salvageable garbage with max_reprompts=0 → gave-up, args unchanged.
+            let emitter = RecordingEmitter::default();
+            let tools = vec![read_file_tool()];
+            let original = json!("totally not json and no braces at all");
+            let mut calls = vec![ToolCall {
+                id: "call_2".to_string(),
+                name: "read_file".to_string(),
+                arguments: original.clone(),
+            }];
+            let configs = vec![crate::AgentCapabilityConfig::with_config(
+                TOOL_CALL_REPAIR_CAPABILITY_ID,
+                json!({ "max_reprompts": 0 }),
+            )];
+
+            run(&configs, &tools, &mut calls, &emitter).await;
+
+            // Arguments untouched: today's error path still applies downstream.
+            assert_eq!(calls[0].arguments, original);
+            assert_eq!(
+                emitter.repaired_events(),
+                vec![("call_2".to_string(), "gave-up".to_string())]
+            );
+        }
+
+        #[tokio::test]
+        async fn unsalvageable_with_remaining_attempts_labels_reprompt() {
+            let emitter = RecordingEmitter::default();
+            let tools = vec![read_file_tool()];
+            let mut calls = vec![ToolCall {
+                id: "call_3".to_string(),
+                name: "read_file".to_string(),
+                arguments: json!("no json here"),
+            }];
+            // Default max_reprompts (1) → first failure is labelled re-prompt.
+            run(&enabled_configs(), &tools, &mut calls, &emitter).await;
+            assert_eq!(
+                emitter.repaired_events(),
+                vec![("call_3".to_string(), "re-prompt".to_string())]
+            );
+        }
+
+        #[tokio::test]
+        async fn disabled_capability_produces_no_drift() {
+            // No tool_call_repair in the resolved set: arguments are left exactly
+            // as the driver produced them and no event is emitted.
+            let emitter = RecordingEmitter::default();
+            let tools = vec![read_file_tool()];
+            let original = malformed_call().arguments;
+            let mut calls = vec![malformed_call()];
+
+            run(&[], &tools, &mut calls, &emitter).await;
+
+            assert_eq!(calls[0].arguments, original);
+            assert!(emitter.repaired_events().is_empty());
+        }
+
+        #[tokio::test]
+        async fn well_formed_call_is_untouched_and_silent() {
+            let emitter = RecordingEmitter::default();
+            let tools = vec![read_file_tool()];
+            let mut calls = vec![ToolCall {
+                id: "call_4".to_string(),
+                name: "read_file".to_string(),
+                arguments: json!({ "path": "/already/good" }),
+            }];
+
+            run(&enabled_configs(), &tools, &mut calls, &emitter).await;
+
+            assert_eq!(calls[0].arguments, json!({ "path": "/already/good" }));
+            assert!(emitter.repaired_events().is_empty());
+        }
     }
 }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -77,6 +77,7 @@ use crate::{ErrorDisclosure, UserFacingError, UserFacingErrorContext, user_facin
 ///
 /// Extracted as a free function (like `repair_dangling_tool_calls`) so it can be
 /// exercised by capability-level tests without constructing a full `ReasonAtom`.
+#[allow(clippy::too_many_arguments)] // all inputs are the per-turn repair context
 async fn apply_tool_call_repair(
     capability_registry: &CapabilityRegistry,
     event_emitter: &dyn EventEmitter,
@@ -85,6 +86,7 @@ async fn apply_tool_call_repair(
     resolved_capability_configs: &[crate::AgentCapabilityConfig],
     tool_definitions: &[ToolDefinition],
     tool_calls: &mut [ToolCall],
+    iteration: u32,
 ) {
     use crate::capabilities::{
         RepairOutcome, SalvageResult, TOOL_CALL_REPAIR_CAPABILITY_ID, ToolCallRepairConfig,
@@ -114,11 +116,15 @@ async fn apply_tool_call_repair(
                 call.arguments = fixed;
                 RepairOutcome::LocalSalvage
             }
-            // Local salvage failed. No re-prompt has happened for this call yet
-            // (prior_attempts = 0): the bounded decision is Reprompt while
-            // attempts remain, else GaveUp. Either way the call is left unchanged
-            // and flows to the existing error path.
-            SalvageResult::Unsalvageable => repair_config.outcome_after_failed_salvage(0),
+            // Local salvage failed. The corrective re-prompt is realized by the
+            // outer agent loop retrying on the next reason iteration, so the
+            // per-turn `iteration` (1-based) is the count of attempts already
+            // spent on this turn: prior_attempts = iteration - 1. The bounded
+            // decision is Reprompt while attempts remain, else GaveUp. Either way
+            // the call is left unchanged and flows to the existing error path.
+            SalvageResult::Unsalvageable => {
+                repair_config.outcome_after_failed_salvage(iteration.saturating_sub(1))
+            }
         };
 
         tracing::info!(
@@ -880,6 +886,7 @@ impl ReasonAtom {
         resolved_capability_configs: &[crate::AgentCapabilityConfig],
         tool_definitions: &[ToolDefinition],
         tool_calls: &mut [ToolCall],
+        iteration: u32,
     ) {
         apply_tool_call_repair(
             &self.capability_registry,
@@ -889,6 +896,7 @@ impl ReasonAtom {
             resolved_capability_configs,
             tool_definitions,
             tool_calls,
+            iteration,
         )
         .await;
     }
@@ -2514,6 +2522,7 @@ impl ReasonAtom {
                 &resolved_capability_configs,
                 &runtime_agent.tools,
                 &mut tool_calls,
+                iteration,
             )
             .await;
         }
@@ -3715,6 +3724,16 @@ mod tests {
             calls: &mut [ToolCall],
             emitter: &RecordingEmitter,
         ) {
+            run_at(configs, tools, calls, emitter, 1).await;
+        }
+
+        async fn run_at(
+            configs: &[crate::AgentCapabilityConfig],
+            tools: &[ToolDefinition],
+            calls: &mut [ToolCall],
+            emitter: &RecordingEmitter,
+            iteration: u32,
+        ) {
             let registry = CapabilityRegistry::with_builtins();
             apply_tool_call_repair(
                 &registry,
@@ -3724,6 +3743,7 @@ mod tests {
                 configs,
                 tools,
                 calls,
+                iteration,
             )
             .await;
         }
@@ -3797,6 +3817,40 @@ mod tests {
             assert_eq!(
                 emitter.repaired_events(),
                 vec![("call_3".to_string(), "re-prompt".to_string())]
+            );
+        }
+
+        #[tokio::test]
+        async fn attempt_cap_transitions_to_gave_up_on_later_iteration() {
+            // The bounded re-prompt is driven by the per-turn reason iteration
+            // (prior_attempts = iteration - 1). With the default cap of 1, an
+            // unsalvageable call is `re-prompt` on iteration 1 but `gave-up` once
+            // the turn has already spent an iteration, so the cap actually engages.
+            let tools = vec![read_file_tool()];
+            let garbage = json!("no json here");
+
+            let first = RecordingEmitter::default();
+            let mut calls1 = vec![ToolCall {
+                id: "call_a".to_string(),
+                name: "read_file".to_string(),
+                arguments: garbage.clone(),
+            }];
+            run_at(&enabled_configs(), &tools, &mut calls1, &first, 1).await;
+            assert_eq!(
+                first.repaired_events(),
+                vec![("call_a".to_string(), "re-prompt".to_string())]
+            );
+
+            let later = RecordingEmitter::default();
+            let mut calls2 = vec![ToolCall {
+                id: "call_a".to_string(),
+                name: "read_file".to_string(),
+                arguments: garbage,
+            }];
+            run_at(&enabled_configs(), &tools, &mut calls2, &later, 2).await;
+            assert_eq!(
+                later.repaired_events(),
+                vec![("call_a".to_string(), "gave-up".to_string())]
             );
         }
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -142,6 +142,7 @@ mod subagents;
 mod system_commands;
 mod test_math;
 mod test_weather;
+mod tool_call_repair;
 mod tool_output_distillation;
 mod tool_output_persistence;
 mod tool_search;
@@ -317,6 +318,11 @@ pub use test_math::{
 };
 pub use test_weather::{
     GetForecastTool, GetWeatherTool, TEST_WEATHER_CAPABILITY_ID, TestWeatherCapability,
+};
+pub use tool_call_repair::{
+    DEFAULT_MAX_REPROMPTS, MAX_SALVAGE_INPUT_BYTES, RepairOutcome, SalvageResult,
+    TOOL_CALL_REPAIR_CAPABILITY_ID, ToolCallRepairCapability, ToolCallRepairConfig,
+    salvage_tool_arguments, tool_call_repair_capability,
 };
 pub use tool_output_distillation::{
     DistillOutputHook, TOOL_OUTPUT_DISTILLATION_CAPABILITY_ID, ToolOutputDistillationCapability,
@@ -1277,6 +1283,11 @@ impl CapabilityRegistry {
 
         // Loop detection (EVE-227: detect repeated identical tool calls)
         registry.register(LoopDetectionCapability);
+
+        // Tool-call repair (EVE-600): opt-in salvage of malformed tool-call
+        // arguments. Disabled by default — registered so agents can enable it,
+        // but contributes nothing unless explicitly selected.
+        registry.register(ToolCallRepairCapability);
 
         // Prompt canary guardrail: replace assistant output if it leaks the
         // first sentence of the system prompt. Streaming-output guardrail.
@@ -2618,6 +2629,7 @@ mod tests {
             "fake_crm",
             "fake_financial",
             "loop_detection",
+            "tool_call_repair",
             "error_disclosure",
             "prompt_canary_guardrail",
             "guardrails",

--- a/crates/core/src/capabilities/tool_call_repair.rs
+++ b/crates/core/src/capabilities/tool_call_repair.rs
@@ -114,6 +114,16 @@ pub fn salvage_tool_arguments(raw: &Value, schema: Option<&Value>) -> SalvageRes
     // valid as-is and the call is a no-op.
     if let Value::Object(_) = raw {
         let coerced = coerce_known_keys(raw.clone(), schema);
+        // A call that still violates the schema after coercion (a missing
+        // `required` key, or a value whose type cannot be coerced to the declared
+        // primitive) is malformed-vs-schema even though it is syntactically valid
+        // JSON. Treat it as unsalvageable so it flows to the bounded re-prompt /
+        // error path and is observable, rather than being silently AlreadyValid.
+        if let Value::Object(ref m) = coerced
+            && violates_schema(m, schema)
+        {
+            return SalvageResult::Unsalvageable;
+        }
         if coerced == *raw {
             return SalvageResult::AlreadyValid;
         }
@@ -135,17 +145,83 @@ pub fn salvage_tool_arguments(raw: &Value, schema: Option<&Value>) -> SalvageRes
 
     let trimmed = raw_str.trim();
     if trimmed.is_empty() {
-        // An empty argument string is conventionally an empty object.
-        return SalvageResult::Repaired(Value::Object(serde_json::Map::new()));
+        // An empty argument string is conventionally an empty object — unless the
+        // schema requires keys we cannot supply, in which case `{}` would just
+        // fail downstream, so route it to the re-prompt / error path instead.
+        let empty = serde_json::Map::new();
+        if violates_schema(&empty, schema) {
+            return SalvageResult::Unsalvageable;
+        }
+        return SalvageResult::Repaired(Value::Object(empty));
     }
 
     match extract_json_object(trimmed) {
         Some(obj) => {
             let coerced = coerce_known_keys(obj, schema);
+            // A recovered object that still violates the schema does not actually
+            // recover the turn (the tool would reject it downstream), so surface
+            // it as unsalvageable for the bounded re-prompt path.
+            if let Value::Object(ref m) = coerced
+                && violates_schema(m, schema)
+            {
+                return SalvageResult::Unsalvageable;
+            }
             SalvageResult::Repaired(coerced)
         }
         None => SalvageResult::Unsalvageable,
     }
+}
+
+/// Conservative schema check used to decide whether a syntactically-valid object
+/// is still malformed *relative to the tool's schema*. Returns true only on
+/// unambiguous violations: a declared `required` key is absent, or a present
+/// (non-null) value's JSON type does not match a declared primitive `type`.
+///
+/// Intentionally shallow and non-recursive: it does not validate nested objects,
+/// enums, formats, or unknown keys, so it never flags a call the downstream tool
+/// would accept. With no schema (or no `type`/`required` info) nothing is flagged.
+fn violates_schema(obj: &serde_json::Map<String, Value>, schema: Option<&Value>) -> bool {
+    let Some(schema) = schema else {
+        return false;
+    };
+
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        for key in required.iter().filter_map(Value::as_str) {
+            if !obj.contains_key(key) {
+                return true;
+            }
+        }
+    }
+
+    if let Some(props) = schema.get("properties").and_then(Value::as_object) {
+        for (key, prop_schema) in props {
+            let Some(declared) = prop_schema.get("type").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(val) = obj.get(key) else {
+                continue;
+            };
+            // Null is left to the downstream tool (fields are often nullable).
+            if val.is_null() {
+                continue;
+            }
+            let matches = match declared {
+                "integer" => val.is_i64() || val.is_u64(),
+                "number" => val.is_number(),
+                "boolean" => val.is_boolean(),
+                "string" => val.is_string(),
+                "array" => val.is_array(),
+                "object" => val.is_object(),
+                // Unknown/compound declared type: do not flag.
+                _ => true,
+            };
+            if !matches {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Extract the first balanced JSON object from a blob that may be wrapped in
@@ -518,6 +594,60 @@ mod tests {
         assert_eq!(
             salvage_tool_arguments(&raw, None),
             SalvageResult::Repaired(json!({}))
+        );
+    }
+
+    #[test]
+    fn empty_string_with_required_schema_is_unsalvageable() {
+        // `{}` would just fail downstream when the schema requires `path`, so
+        // route it to the bounded re-prompt / error path instead.
+        let raw = json!("");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    #[test]
+    fn object_missing_required_key_is_unsalvageable() {
+        // Syntactically valid JSON, but missing the required `path` key — this is
+        // malformed vs the schema and cannot be locally repaired.
+        let raw = json!({ "limit": 3 });
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    #[test]
+    fn object_with_uncoercible_type_is_unsalvageable() {
+        // `limit` is an integer property; "abc" cannot be coerced, so after the
+        // coercion pass the type still mismatches.
+        let raw = json!({ "path": "/foo", "limit": "abc" });
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    #[test]
+    fn extracted_object_missing_required_is_unsalvageable() {
+        // Recovered from prose but still missing the required key: not a usable
+        // repair, so surface it for the re-prompt path.
+        let raw = json!("here you go: {\"limit\": 3}");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    #[test]
+    fn object_missing_required_key_without_schema_is_noop() {
+        // With no schema we cannot know a key is required, so do not flag it.
+        let raw = json!({ "limit": 3 });
+        assert_eq!(
+            salvage_tool_arguments(&raw, None),
+            SalvageResult::AlreadyValid
         );
     }
 

--- a/crates/core/src/capabilities/tool_call_repair.rs
+++ b/crates/core/src/capabilities/tool_call_repair.rs
@@ -1,0 +1,705 @@
+// Tool-call repair capability (EVE-600)
+//
+// Detects and repairs malformed tool-call arguments emitted by a model and
+// recovers the turn instead of surfacing a raw parse error (or silently
+// collapsing the call to `{}` the way some drivers do on a parse failure).
+//
+// # Chosen seam
+//
+// The provider-agnostic interception point is the `reason` atom, right after
+// the assistant completion has been finalized into `Vec<ToolCall>` (see
+// `crates/core/src/atoms/reason.rs`, just before the assistant message is built
+// and `output.message.completed` is emitted). At that point each `ToolCall`
+// already carries its `arguments` as a parsed `serde_json::Value`, but for a
+// malformed call that value is either:
+//   * a raw JSON *string* the driver could not parse into an object, or
+//   * an object that does not satisfy the target tool's JSON schema.
+// Individual drivers (`crates/anthropic`, `crates/openai`, ...) are not touched;
+// they keep parsing as before. The capability runs only when explicitly enabled,
+// so the default path is byte-for-byte unchanged.
+//
+// # Two-stage repair
+//
+// 1. **Deterministic local salvage** ([`salvage_tool_arguments`]) — a pure,
+//    table-testable function that extracts the JSON object from fenced blocks,
+//    surrounding prose, trailing commas, and single-quoted keys/strings, then
+//    coerces known argument keys against the tool's JSON schema. The
+//    already-valid case is a no-op.
+// 2. **Bounded corrective re-prompt** — when local salvage cannot recover the
+//    call, the capability allows up to `max_reprompts` (default 1) attempts per
+//    call before falling through to today's exact error behavior. The re-prompt
+//    itself is realized by the outer agent loop: the unrepaired call proceeds to
+//    the act phase, produces today's tool error, and the model retries on the
+//    next iteration. The capability only *bounds* and *labels* this, so there is
+//    never an infinite repair loop.
+//
+// # Safety
+//
+// Salvage parses untrusted model output, so it is bounded: it refuses inputs
+// over `MAX_SALVAGE_INPUT_BYTES`, scans without recursion, and never allocates
+// proportionally more than the input. See the security notes on each helper.
+
+use std::sync::Arc;
+
+use crate::capabilities::{Capability, CapabilityLocalization};
+use serde_json::Value;
+
+pub const TOOL_CALL_REPAIR_CAPABILITY_ID: &str = "tool_call_repair";
+
+/// Default number of corrective re-prompt attempts allowed per tool call before
+/// falling through to the existing error path. Kept small on purpose — repair is
+/// a recovery aid, not a retry loop.
+pub const DEFAULT_MAX_REPROMPTS: u32 = 1;
+
+/// Hard cap on the size of a raw argument blob the salvage routine will inspect.
+/// Larger inputs are rejected outright (treated as un-salvageable) so a hostile
+/// or runaway model cannot drive unbounded CPU/allocation in the parser.
+pub const MAX_SALVAGE_INPUT_BYTES: usize = 256 * 1024;
+
+/// Observable outcome of a repair attempt, used as the event/metric label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairOutcome {
+    /// Local deterministic salvage recovered a valid JSON object.
+    LocalSalvage,
+    /// Local salvage failed but a bounded corrective re-prompt is still allowed.
+    Reprompt,
+    /// All bounded attempts are exhausted; fall through to the error path.
+    GaveUp,
+}
+
+impl RepairOutcome {
+    /// Stable machine-readable label for events/metrics.
+    pub fn label(self) -> &'static str {
+        match self {
+            RepairOutcome::LocalSalvage => "local-salvage",
+            RepairOutcome::Reprompt => "re-prompt",
+            RepairOutcome::GaveUp => "gave-up",
+        }
+    }
+}
+
+/// Result of running [`salvage_tool_arguments`] on one tool call's raw arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SalvageResult {
+    /// The arguments were already a valid JSON object satisfying the schema (or
+    /// no schema was available to check against). No change is needed.
+    AlreadyValid,
+    /// Local salvage produced a repaired JSON object. The wrapped value replaces
+    /// the call's arguments.
+    Repaired(Value),
+    /// Local salvage could not recover a usable object.
+    Unsalvageable,
+}
+
+/// Deterministically salvage a single tool call's raw/garbled `arguments`.
+///
+/// Pure and side-effect free, so it is exhaustively table-tested. Handles, in
+/// order: already-valid objects; raw strings wrapping a JSON object (possibly
+/// inside ```json fences, surrounded by prose); trailing commas; and
+/// single-quoted keys/strings. When a `schema` is supplied, recovered string
+/// values for known keys are coerced to the declared primitive type where it is
+/// unambiguous (e.g. `"42"` -> `42` for an `integer` property).
+///
+/// Returns [`SalvageResult::AlreadyValid`] when nothing needs changing,
+/// [`SalvageResult::Repaired`] with the recovered object, or
+/// [`SalvageResult::Unsalvageable`] when no JSON object can be extracted.
+///
+/// Security: input larger than [`MAX_SALVAGE_INPUT_BYTES`] is treated as
+/// unsalvageable without parsing. All scanning is linear and non-recursive.
+pub fn salvage_tool_arguments(raw: &Value, schema: Option<&Value>) -> SalvageResult {
+    // Case 1: already a JSON object. Try to coerce string-typed known keys to
+    // their declared primitive type (e.g. `"7"` -> `7` for an integer property);
+    // a string where the schema wants a number is malformed even when all
+    // `required` keys are present. If coercion changes nothing, the object is
+    // valid as-is and the call is a no-op.
+    if let Value::Object(_) = raw {
+        let coerced = coerce_known_keys(raw.clone(), schema);
+        if coerced == *raw {
+            return SalvageResult::AlreadyValid;
+        }
+        return SalvageResult::Repaired(coerced);
+    }
+
+    // Case 2: a raw string. Drivers that fail to parse the model's argument
+    // string sometimes pass it through verbatim as a JSON string. Extract the
+    // embedded JSON object from it.
+    let Some(raw_str) = raw.as_str() else {
+        // Non-object, non-string (number/bool/null/array): not a tool-argument
+        // shape we can repair.
+        return SalvageResult::Unsalvageable;
+    };
+
+    if raw_str.len() > MAX_SALVAGE_INPUT_BYTES {
+        return SalvageResult::Unsalvageable;
+    }
+
+    let trimmed = raw_str.trim();
+    if trimmed.is_empty() {
+        // An empty argument string is conventionally an empty object.
+        return SalvageResult::Repaired(Value::Object(serde_json::Map::new()));
+    }
+
+    match extract_json_object(trimmed) {
+        Some(obj) => {
+            let coerced = coerce_known_keys(obj, schema);
+            SalvageResult::Repaired(coerced)
+        }
+        None => SalvageResult::Unsalvageable,
+    }
+}
+
+/// Extract the first balanced JSON object from a blob that may be wrapped in
+/// ```json fences and/or surrounded by prose, tolerating trailing commas and
+/// single-quoted strings/keys. Returns the parsed object, or `None`.
+///
+/// Non-recursive: brace matching is a single linear scan with a depth counter.
+fn extract_json_object(input: &str) -> Option<Value> {
+    let candidate = strip_code_fences(input);
+
+    // Try a direct parse of the (fence-stripped) candidate first.
+    if let Ok(value @ Value::Object(_)) = serde_json::from_str::<Value>(candidate.trim()) {
+        return Some(value);
+    }
+
+    // Locate the first balanced `{ ... }` span, honoring string literals so a
+    // brace inside a string does not throw off the depth counter.
+    let span = first_balanced_object_span(candidate)?;
+    let slice = &candidate[span];
+
+    if let Ok(value @ Value::Object(_)) = serde_json::from_str::<Value>(slice) {
+        return Some(value);
+    }
+
+    // Apply lenient fix-ups (single quotes -> double, drop trailing commas) and
+    // retry once. Bounded: a single rewrite pass over the already-bounded slice.
+    let relaxed = relax_json(slice);
+    match serde_json::from_str::<Value>(&relaxed) {
+        Ok(value @ Value::Object(_)) => Some(value),
+        _ => None,
+    }
+}
+
+/// Remove a leading/trailing Markdown code fence (```json ... ``` or ``` ... ```).
+/// When no fence is present the input is returned unchanged.
+fn strip_code_fences(input: &str) -> &str {
+    let trimmed = input.trim();
+    let Some(after_open) = trimmed.strip_prefix("```") else {
+        return trimmed;
+    };
+    // Drop an optional language tag on the opening fence line.
+    let after_lang = match after_open.find('\n') {
+        Some(nl) => &after_open[nl + 1..],
+        None => after_open,
+    };
+    after_lang.strip_suffix("```").unwrap_or(after_lang).trim()
+}
+
+/// Byte range of the first balanced top-level `{...}` object in `input`,
+/// respecting double-quoted string literals and escapes. `None` if unbalanced.
+fn first_balanced_object_span(input: &str) -> Option<std::ops::Range<usize>> {
+    let bytes = input.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'{')?;
+    let mut depth: u32 = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    // Track the active quote char so single- and double-quoted strings both mask
+    // braces during the scan (the relax pass later normalizes quotes).
+    let mut quote: u8 = 0;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == quote {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' | b'\'' => {
+                in_string = true;
+                quote = b;
+            }
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(start..i + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Best-effort lenient JSON normalization for a single object slice:
+/// converts single-quoted strings/keys to double-quoted and removes trailing
+/// commas before `}`/`]`. Single linear pass, no recursion.
+fn relax_json(slice: &str) -> String {
+    // Phase 1: quote normalization. Walk char-by-char; outside a double-quoted
+    // string, replace `'` with `"`. Inside a double-quoted string, leave content
+    // untouched (so apostrophes in values survive).
+    let mut out = String::with_capacity(slice.len());
+    let mut in_double = false;
+    let mut escaped = false;
+    for ch in slice.chars() {
+        if in_double {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_double = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => {
+                in_double = true;
+                out.push(ch);
+            }
+            '\'' => out.push('"'),
+            _ => out.push(ch),
+        }
+    }
+
+    // Phase 2: strip trailing commas (`,` followed by optional whitespace then
+    // `}` or `]`). Operate on the quote-normalized string, skipping commas that
+    // live inside double-quoted strings.
+    strip_trailing_commas(&out)
+}
+
+/// Remove commas that immediately precede a closing `}`/`]` (ignoring
+/// whitespace), skipping any comma inside a double-quoted string.
+fn strip_trailing_commas(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let mut out = String::with_capacity(input.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    for i in 0..chars.len() {
+        let ch = chars[i];
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '"' {
+            in_string = true;
+            out.push(ch);
+            continue;
+        }
+        if ch == ',' {
+            // Look ahead past whitespace for a closing bracket.
+            let mut j = i + 1;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j < chars.len() && (chars[j] == '}' || chars[j] == ']') {
+                // Skip this trailing comma.
+                continue;
+            }
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Coerce string-typed values for known schema keys to the declared primitive
+/// type when unambiguous (`integer`, `number`, `boolean`). Unknown keys and
+/// values that do not cleanly convert are left untouched.
+fn coerce_known_keys(value: Value, schema: Option<&Value>) -> Value {
+    let Value::Object(mut obj) = value else {
+        return value;
+    };
+    let Some(props) = schema
+        .and_then(|s| s.get("properties"))
+        .and_then(Value::as_object)
+    else {
+        return Value::Object(obj);
+    };
+
+    for (key, prop_schema) in props {
+        let Some(declared) = prop_schema.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(current) = obj.get(key) else {
+            continue;
+        };
+        let Some(text) = current.as_str() else {
+            continue;
+        };
+        let coerced = match declared {
+            "integer" => text.trim().parse::<i64>().ok().map(Value::from),
+            "number" => text.trim().parse::<f64>().ok().map(Value::from),
+            "boolean" => match text.trim() {
+                "true" => Some(Value::Bool(true)),
+                "false" => Some(Value::Bool(false)),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(coerced) = coerced {
+            obj.insert(key.clone(), coerced);
+        }
+    }
+    Value::Object(obj)
+}
+
+/// Per-agent config for the tool-call-repair capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolCallRepairConfig {
+    /// Maximum corrective re-prompt attempts per tool call before falling
+    /// through to the existing error path.
+    pub max_reprompts: u32,
+}
+
+impl Default for ToolCallRepairConfig {
+    fn default() -> Self {
+        Self {
+            max_reprompts: DEFAULT_MAX_REPROMPTS,
+        }
+    }
+}
+
+impl ToolCallRepairConfig {
+    /// Parse config from the per-agent JSON blob, falling back to defaults for
+    /// missing/unknown fields.
+    pub fn from_json(config: &Value) -> Self {
+        let max_reprompts = config
+            .get("max_reprompts")
+            .and_then(Value::as_u64)
+            .map(|v| v as u32)
+            .unwrap_or(DEFAULT_MAX_REPROMPTS);
+        Self { max_reprompts }
+    }
+
+    /// Decide the bounded outcome when local salvage has failed, given how many
+    /// re-prompt attempts have already happened for this call.
+    ///
+    /// Returns [`RepairOutcome::Reprompt`] while attempts remain, otherwise
+    /// [`RepairOutcome::GaveUp`]. This is the only place the attempt cap is
+    /// enforced, keeping the loop bounded.
+    pub fn outcome_after_failed_salvage(&self, prior_attempts: u32) -> RepairOutcome {
+        if prior_attempts < self.max_reprompts {
+            RepairOutcome::Reprompt
+        } else {
+            RepairOutcome::GaveUp
+        }
+    }
+}
+
+/// Opt-in capability that repairs malformed tool calls. Disabled by default:
+/// it is registered in the global registry but contributes nothing unless an
+/// agent explicitly enables it, and the `reason` atom only runs repair when the
+/// capability is present in the resolved capability set.
+pub struct ToolCallRepairCapability;
+
+impl Capability for ToolCallRepairCapability {
+    fn id(&self) -> &str {
+        TOOL_CALL_REPAIR_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Tool Call Repair"
+    }
+
+    fn description(&self) -> &str {
+        "Detects and repairs malformed tool-call arguments from the model, \
+         recovering the turn instead of surfacing a raw parse error."
+    }
+
+    fn is_guardrail(&self) -> bool {
+        true
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "max_reprompts": {
+                    "type": "integer",
+                    "title": "Max corrective re-prompts",
+                    "description": "How many corrective re-prompt attempts are allowed per malformed tool call before falling through to the normal error path.",
+                    "minimum": 0,
+                    "maximum": 5,
+                    "default": DEFAULT_MAX_REPROMPTS
+                }
+            }
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+        if !config.is_object() {
+            return Err("tool_call_repair config must be an object".to_string());
+        }
+        match config.get("max_reprompts") {
+            None => Ok(()),
+            Some(value) => match value.as_u64() {
+                Some(n) if n <= 5 => Ok(()),
+                _ => Err(format!(
+                    "max_reprompts must be an integer between 0 and 5, got {value}"
+                )),
+            },
+        }
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![CapabilityLocalization {
+            locale: "en",
+            name: None,
+            description: None,
+            config_description: Some(
+                "Controls how many corrective re-prompts are attempted before a malformed tool call falls through to the normal error path.",
+            ),
+            config_overlay: None,
+        }]
+    }
+}
+
+/// Convenience: the registered capability as an `Arc` (mirrors how other
+/// capabilities are surfaced where an `Arc<dyn Capability>` is needed).
+pub fn tool_call_repair_capability() -> Arc<dyn Capability> {
+    Arc::new(ToolCallRepairCapability)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "limit": { "type": "integer" },
+                "ratio": { "type": "number" },
+                "recursive": { "type": "boolean" }
+            },
+            "required": ["path"]
+        })
+    }
+
+    // ---- Salvage: table-driven across each malformation class ----
+
+    #[test]
+    fn already_valid_object_is_noop() {
+        let raw = json!({ "path": "/foo", "limit": 10 });
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::AlreadyValid
+        );
+    }
+
+    #[test]
+    fn already_valid_object_without_schema_is_noop() {
+        let raw = json!({ "anything": 1 });
+        assert_eq!(
+            salvage_tool_arguments(&raw, None),
+            SalvageResult::AlreadyValid
+        );
+    }
+
+    #[test]
+    fn empty_string_becomes_empty_object() {
+        let raw = json!("   ");
+        assert_eq!(
+            salvage_tool_arguments(&raw, None),
+            SalvageResult::Repaired(json!({}))
+        );
+    }
+
+    #[test]
+    fn raw_string_object_is_parsed() {
+        let raw = json!("{\"path\": \"/foo\"}");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/foo" }))
+        );
+    }
+
+    #[test]
+    fn fenced_json_block_is_unwrapped() {
+        let raw = json!("```json\n{\"path\": \"/foo\"}\n```");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/foo" }))
+        );
+    }
+
+    #[test]
+    fn bare_fenced_block_is_unwrapped() {
+        let raw = json!("```\n{\"path\": \"/bar\"}\n```");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/bar" }))
+        );
+    }
+
+    #[test]
+    fn leading_and_trailing_prose_is_stripped() {
+        let raw = json!("Sure! Here are the args: {\"path\": \"/foo\"} hope that helps");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/foo" }))
+        );
+    }
+
+    #[test]
+    fn trailing_commas_are_removed() {
+        let raw = json!("{\"path\": \"/foo\", \"limit\": 3,}");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/foo", "limit": 3 }))
+        );
+    }
+
+    #[test]
+    fn single_quotes_are_normalized() {
+        let raw = json!("{'path': '/foo', 'limit': 5}");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/foo", "limit": 5 }))
+        );
+    }
+
+    #[test]
+    fn apostrophe_inside_double_quoted_value_survives() {
+        let raw = json!("{\"path\": \"it's here\"}");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "it's here" }))
+        );
+    }
+
+    #[test]
+    fn brace_inside_string_does_not_break_span() {
+        let raw = json!("prose {\"path\": \"a}b\"} more");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "a}b" }))
+        );
+    }
+
+    #[test]
+    fn known_keys_are_coerced_against_schema() {
+        // Model emitted everything as strings; coerce against the schema types.
+        let raw = json!(
+            "{\"path\": \"/foo\", \"limit\": \"42\", \"ratio\": \"1.5\", \"recursive\": \"true\"}"
+        );
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(
+                json!({ "path": "/foo", "limit": 42, "ratio": 1.5, "recursive": true })
+            )
+        );
+    }
+
+    #[test]
+    fn object_with_string_typed_known_key_is_coerced_in_place() {
+        // Already an object, but `limit` is a string and required `path` present.
+        let raw = json!({ "path": "/foo", "limit": "7" });
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Repaired(json!({ "path": "/foo", "limit": 7 }))
+        );
+    }
+
+    #[test]
+    fn unparseable_garbage_is_unsalvageable() {
+        let raw = json!("path equals slash foo, no json here at all");
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    #[test]
+    fn oversized_input_is_rejected_without_parsing() {
+        let big = format!("{{\"path\": \"{}\"}}", "a".repeat(MAX_SALVAGE_INPUT_BYTES));
+        let raw = json!(big);
+        assert_eq!(
+            salvage_tool_arguments(&raw, Some(&schema())),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    #[test]
+    fn non_object_non_string_is_unsalvageable() {
+        assert_eq!(
+            salvage_tool_arguments(&json!(42), None),
+            SalvageResult::Unsalvageable
+        );
+        assert_eq!(
+            salvage_tool_arguments(&json!([1, 2]), None),
+            SalvageResult::Unsalvageable
+        );
+    }
+
+    // ---- Bounded re-prompt / give-up ----
+
+    #[test]
+    fn outcome_reprompts_until_cap_then_gives_up() {
+        let cfg = ToolCallRepairConfig { max_reprompts: 2 };
+        assert_eq!(cfg.outcome_after_failed_salvage(0), RepairOutcome::Reprompt);
+        assert_eq!(cfg.outcome_after_failed_salvage(1), RepairOutcome::Reprompt);
+        assert_eq!(cfg.outcome_after_failed_salvage(2), RepairOutcome::GaveUp);
+        assert_eq!(cfg.outcome_after_failed_salvage(3), RepairOutcome::GaveUp);
+    }
+
+    #[test]
+    fn zero_reprompts_gives_up_immediately() {
+        let cfg = ToolCallRepairConfig { max_reprompts: 0 };
+        assert_eq!(cfg.outcome_after_failed_salvage(0), RepairOutcome::GaveUp);
+    }
+
+    #[test]
+    fn config_parses_from_json_with_defaults() {
+        assert_eq!(
+            ToolCallRepairConfig::from_json(&json!({})),
+            ToolCallRepairConfig::default()
+        );
+        assert_eq!(
+            ToolCallRepairConfig::from_json(&json!({ "max_reprompts": 3 })).max_reprompts,
+            3
+        );
+    }
+
+    #[test]
+    fn outcome_labels_are_stable() {
+        assert_eq!(RepairOutcome::LocalSalvage.label(), "local-salvage");
+        assert_eq!(RepairOutcome::Reprompt.label(), "re-prompt");
+        assert_eq!(RepairOutcome::GaveUp.label(), "gave-up");
+    }
+
+    // ---- Capability wiring ----
+
+    #[test]
+    fn capability_id_and_validation() {
+        let cap = ToolCallRepairCapability;
+        assert_eq!(cap.id(), TOOL_CALL_REPAIR_CAPABILITY_ID);
+        assert!(cap.is_guardrail());
+        assert!(cap.config_schema().is_some());
+
+        assert!(cap.validate_config(&Value::Null).is_ok());
+        assert!(cap.validate_config(&json!({})).is_ok());
+        assert!(cap.validate_config(&json!({ "max_reprompts": 2 })).is_ok());
+        assert!(cap.validate_config(&json!({ "max_reprompts": 9 })).is_err());
+        assert!(
+            cap.validate_config(&json!({ "max_reprompts": "x" }))
+                .is_err()
+        );
+    }
+}

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -72,6 +72,10 @@ pub const TOOL_PROGRESS: &str = "tool.progress";
 pub const TOOL_OUTPUT_DELTA: &str = "tool.output.delta";
 pub const TOOL_CALL_REQUESTED: &str = "tool.call_requested";
 pub const TRANSCRIPT_REPAIRED: &str = "transcript.repaired";
+/// A malformed tool call was repaired (or repair was attempted) by the opt-in
+/// `tool_call_repair` capability (EVE-600). Carries an outcome label
+/// (`local-salvage` | `re-prompt` | `gave-up`).
+pub const TOOL_CALL_REPAIRED: &str = "tool.call_repaired";
 
 // LLM events
 pub const LLM_GENERATION: &str = "llm.generation";
@@ -170,6 +174,7 @@ pub const VALID_EVENT_TYPES: &[&str] = &[
     TOOL_OUTPUT_DELTA,
     TOOL_CALL_REQUESTED,
     TRANSCRIPT_REPAIRED,
+    TOOL_CALL_REPAIRED,
     LLM_GENERATION,
     REASON_THINKING_STARTED,
     REASON_THINKING_DELTA,
@@ -1336,6 +1341,28 @@ pub struct TranscriptRepairedData {
     pub action: TranscriptRepairAction,
 }
 
+/// Data for the `tool.call_repaired` event (EVE-600).
+///
+/// Emitted once per malformed tool call handled by the opt-in
+/// `tool_call_repair` capability. `outcome` is the stable label
+/// (`local-salvage` | `re-prompt` | `gave-up`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ToolCallRepairedData {
+    /// Turn this repair belongs to.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
+    pub turn_id: TurnId,
+
+    /// The tool call ID that was inspected/repaired.
+    pub tool_call_id: String,
+
+    /// The tool name the malformed call targeted.
+    pub tool_name: String,
+
+    /// Stable outcome label: `local-salvage`, `re-prompt`, or `gave-up`.
+    pub outcome: String,
+}
+
 /// Data for tool.call_requested event
 ///
 /// Emitted when the agent needs client-side tool calls executed.
@@ -2422,6 +2449,7 @@ pub enum EventData {
 
     // Recovery / repair events
     TranscriptRepaired(TranscriptRepairedData),
+    ToolCallRepaired(ToolCallRepairedData),
 
     // LLM events
     LlmGeneration(LlmGenerationData),
@@ -2531,6 +2559,7 @@ impl EventData {
             EventData::ToolOutputDelta(_) => TOOL_OUTPUT_DELTA,
             EventData::ToolCallRequested(_) => TOOL_CALL_REQUESTED,
             EventData::TranscriptRepaired(_) => TRANSCRIPT_REPAIRED,
+            EventData::ToolCallRepaired(_) => TOOL_CALL_REPAIRED,
             EventData::LlmGeneration(_) => LLM_GENERATION,
             EventData::ReasonThinkingDelta(_) => REASON_THINKING_DELTA,
             EventData::ReasonThinkingStarted(_) => REASON_THINKING_STARTED,
@@ -2653,6 +2682,8 @@ pub fn deserialize_event_data(event_type: &str, data: serde_json::Value) -> Even
                 .map(EventData::ToolCallRequested),
             TRANSCRIPT_REPAIRED => serde_json::from_value::<TranscriptRepairedData>(data.clone())
                 .map(EventData::TranscriptRepaired),
+            TOOL_CALL_REPAIRED => serde_json::from_value::<ToolCallRepairedData>(data.clone())
+                .map(EventData::ToolCallRepaired),
             LLM_GENERATION => serde_json::from_value::<LlmGenerationData>(data.clone())
                 .map(EventData::LlmGeneration),
             REASON_THINKING_STARTED => {
@@ -2791,6 +2822,7 @@ impl_from_event_data! {
     ToolOutputDeltaData => ToolOutputDelta,
     ToolCallRequestedData => ToolCallRequested,
     TranscriptRepairedData => TranscriptRepaired,
+    ToolCallRepairedData => ToolCallRepaired,
     LlmGenerationData => LlmGeneration,
     ReasonThinkingStartedData => ReasonThinkingStarted,
     ReasonThinkingDeltaData => ReasonThinkingDelta,

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -269,6 +269,7 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
         EventData::VoiceSessionEnded(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::VoiceSessionFailed(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::TranscriptRepaired(d) => serde_json::to_value(d).unwrap_or_default(),
+        EventData::ToolCallRepaired(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::Unsupported { data, .. } => {
             // Should not happen in production - unsupported events are filtered before reaching here
             data.clone()

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -17685,6 +17685,9 @@
             "$ref": "#/components/schemas/TranscriptRepairedData"
           },
           {
+            "$ref": "#/components/schemas/ToolCallRepairedData"
+          },
+          {
             "$ref": "#/components/schemas/LlmGenerationData"
           },
           {
@@ -31245,6 +31248,35 @@
           },
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "ToolCallRepairedData": {
+        "type": "object",
+        "description": "Data for the `tool.call_repaired` event (EVE-600).\n\nEmitted once per malformed tool call handled by the opt-in\n`tool_call_repair` capability. `outcome` is the stable label\n(`local-salvage` | `re-prompt` | `gave-up`).",
+        "required": [
+          "turn_id",
+          "tool_call_id",
+          "tool_name",
+          "outcome"
+        ],
+        "properties": {
+          "outcome": {
+            "type": "string",
+            "description": "Stable outcome label: `local-salvage`, `re-prompt`, or `gave-up`."
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "The tool call ID that was inspected/repaired."
+          },
+          "tool_name": {
+            "type": "string",
+            "description": "The tool name the malformed call targeted."
+          },
+          "turn_id": {
+            "type": "string",
+            "description": "Turn this repair belongs to.",
+            "example": "turn_01933b5a00007000800000000000001"
           }
         }
       },

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -106,6 +106,7 @@ Streaming-output guardrails and runtime safety nets.
 | Capability | ID | Tools |
 |---|---|---|
 | [Prompt Canary Guardrail](/capabilities/prompt-canary-guardrail/) | `prompt_canary_guardrail` | 0 |
+| [Tool Call Repair](/capabilities/tool-call-repair/) | `tool_call_repair` | 0 |
 | Guardrails | `guardrails` | 0 |
 
 The `guardrails` capability runs config-driven deterministic checks (regex,

--- a/docs/capabilities/tool-call-repair.md
+++ b/docs/capabilities/tool-call-repair.md
@@ -14,8 +14,8 @@ sidebar:
 | **Risk** | Low |
 
 Opt-in recovery net for malformed tool calls. Models occasionally emit
-tool-call arguments that are not clean JSON — wrapped in a ```json fence,
-surrounded by prose, with trailing commas or single quotes, or with values
+tool-call arguments that are not clean JSON — wrapped in a Markdown code
+fence, surrounded by prose, with trailing commas or single quotes, or with values
 typed as strings where the schema wants numbers. Without repair, such a call
 either surfaces a parse error or silently collapses to empty arguments and
 fails downstream. This capability salvages the call so the turn proceeds.
@@ -32,7 +32,7 @@ tool calls are finalized and before the assistant message is built.
 ## How It Works
 
 1. **Deterministic local salvage** — A pure function runs over each call's
-   `arguments`: it unwraps fenced ```json blocks and strips surrounding prose,
+   `arguments`: it unwraps fenced code blocks and strips surrounding prose,
    removes trailing commas, normalizes single quotes to double quotes, and
    coerces string-typed known keys to the type declared by the tool's JSON
    schema (e.g. `"42"` → `42` for an integer property). An already-valid call

--- a/docs/capabilities/tool-call-repair.md
+++ b/docs/capabilities/tool-call-repair.md
@@ -1,0 +1,97 @@
+---
+title: Tool Call Repair
+description: Detects and repairs malformed tool-call arguments from the model, recovering the turn instead of surfacing a raw parse error.
+sidebar:
+  order: 96
+---
+
+| | |
+|---|---|
+| **ID** | `tool_call_repair` |
+| **Category** | Safety |
+| **Features** | None |
+| **Dependencies** | None |
+| **Risk** | Low |
+
+Opt-in recovery net for malformed tool calls. Models occasionally emit
+tool-call arguments that are not clean JSON — wrapped in a ```json fence,
+surrounded by prose, with trailing commas or single quotes, or with values
+typed as strings where the schema wants numbers. Without repair, such a call
+either surfaces a parse error or silently collapses to empty arguments and
+fails downstream. This capability salvages the call so the turn proceeds.
+
+**Disabled by default.** The capability is registered so agents can enable it,
+but contributes nothing unless explicitly selected. With it off, behavior is
+byte-for-byte unchanged.
+
+## Tools
+
+None — the capability intercepts inside the `reason` step, after the model's
+tool calls are finalized and before the assistant message is built.
+
+## How It Works
+
+1. **Deterministic local salvage** — A pure function runs over each call's
+   `arguments`: it unwraps fenced ```json blocks and strips surrounding prose,
+   removes trailing commas, normalizes single quotes to double quotes, and
+   coerces string-typed known keys to the type declared by the tool's JSON
+   schema (e.g. `"42"` → `42` for an integer property). An already-valid call
+   is a no-op.
+2. **Bounded corrective re-prompt** — When local salvage cannot recover a usable
+   object, the capability allows up to `max_reprompts` attempts per call (default
+   1) before falling through to the normal error path. The re-prompt is realized
+   by the agent loop: the unrepaired call proceeds to today's error path and the
+   model retries on the next iteration. The per-call cap guarantees there is no
+   infinite repair loop.
+3. **Observability** — Each malformed call emits one `tool.call_repaired` event
+   carrying an outcome label: `local-salvage`, `re-prompt`, or `gave-up`.
+
+## Configuration
+
+### Default
+
+```json
+{
+  "capabilities": ["tool_call_repair"]
+}
+```
+
+### Custom re-prompt cap
+
+```json
+{
+  "capabilities": [
+    {
+      "ref": "tool_call_repair",
+      "config": { "max_reprompts": 2 }
+    }
+  ]
+}
+```
+
+`max_reprompts` accepts `0`–`5`. `0` means "salvage locally or fall straight
+through to the error path with no re-prompt".
+
+## When To Enable
+
+Use this capability when:
+
+- You run models or providers that occasionally wrap tool arguments in prose or
+  code fences, or emit lenient JSON (single quotes, trailing commas)
+- You want a malformed call to recover the turn rather than waste an iteration on
+  a raw parse error
+
+## Limitations
+
+- **Verbatim JSON only**: salvage extracts an embedded JSON object; it does not
+  invent missing required fields or guess intent from natural language
+- **Bounded input**: argument blobs larger than 256 KiB are treated as
+  un-salvageable without parsing (a denial-of-service guard against runaway model
+  output)
+- **No deep type checking**: coercion handles top-level `integer` / `number` /
+  `boolean` string values; full schema validation remains the tool's job
+
+## See Also
+
+- [Events](/features/events/) — the streaming event protocol that carries `tool.call_repaired`
+- [Capabilities](/features/capabilities/) — the extension model this capability plugs into

--- a/specs/api-streaming.md
+++ b/specs/api-streaming.md
@@ -82,6 +82,7 @@ Closed `event:` vocabulary on this endpoint:
 | `tool.output.delta`             | `Event` (`data` = `ToolOutputDeltaData`)                                   |
 | `tool.call_requested`           | `Event` (`data` = `ToolCallRequestedData`)                                 |
 | `transcript.repaired`           | `Event` (`data` = `TranscriptRepairedData`)                                |
+| `tool.call_repaired`            | `Event` (`data` = `ToolCallRepairedData`)                                  |
 | `llm.generation`                | `Event` (`data` = `LlmGenerationData`)                                     |
 | `capability.usage`              | `Event` (`data` = `CapabilityUsageData`)                                   |
 | `session.started`               | `Event` (`data` = `SessionStartedData`)                                    |

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -725,6 +725,16 @@ Following the agentskills.io specification:
 - **Config**: `{"threshold": N}` — number of repeated identical results, identical tool-call batches, or read ranges before warning (default 3)
 - **Source**: `crates/core/src/capabilities/loop_detection.rs`
 
+#### ToolCallRepair
+
+- **ID**: `tool_call_repair`
+- **Purpose**: Detects and repairs malformed tool-call arguments from the model, recovering the turn instead of surfacing a raw parse error
+- **Status**: Opt-in. Registered but **disabled by default** — contributes nothing unless an agent explicitly enables it; with it off, behavior is byte-for-byte unchanged.
+- **Tools**: None (intercepts in the `reason` atom, after tool calls are finalized and before the assistant message is built)
+- **Config**: `{"max_reprompts": N}` — corrective re-prompt attempts allowed per malformed call before falling through to the existing error path (default 1, range 0–5)
+- **Source**: `crates/core/src/capabilities/tool_call_repair.rs`
+- **Behavior**: Runs a pure, table-tested `salvage_tool_arguments` over each call's `arguments`: unwraps fenced ```json blocks and surrounding prose, strips trailing commas, normalizes single quotes, and coerces string-typed known keys against the tool's JSON schema (`"42"` → `42`). The already-valid case is a no-op. When local salvage fails the bounded re-prompt path applies (capped by `max_reprompts`), then falls through to today's exact error. Emits one `tool.call_repaired` event per malformed call with an outcome label (`local-salvage` | `re-prompt` | `gave-up`). Salvage parses untrusted model output and is bounded: inputs over 256 KiB are rejected and all scanning is linear and non-recursive.
+
 #### MessageMetadata
 
 - **ID**: `message_metadata`


### PR DESCRIPTION
## What
Add an isolated, opt-in `tool_call_repair` capability (EVE-600) to `everruns-core`. When enabled, it detects and repairs **malformed tool-call arguments** from a model and recovers the turn instead of surfacing a raw parse error (or silently collapsing the call to `{}`, which some drivers do on a parse failure).

## Why
Models occasionally emit tool-call arguments that are not clean JSON: wrapped in a Markdown code fence, surrounded by prose, with trailing commas or single quotes, or with values typed as strings where the schema wants numbers. Today such a call wastes an iteration on a parse error or fails downstream. This capability salvages the call so the turn proceeds. Robustness net for driving open / smaller models (EVE-600).

## How
- **Chosen seam (provider-agnostic):** the `reason` atom, right after the assistant completion is finalized into `Vec<ToolCall>` and before the assistant message is built / `output.message.completed` is emitted. At that point each `ToolCall` carries `arguments` as a parsed `serde_json::Value`; a malformed call is either a raw JSON *string* the driver could not parse, or an object that fails the tool's schema. Individual drivers (`crates/anthropic`, `crates/openai`, ...) are **not touched**.
- **Deterministic local salvage** (`salvage_tool_arguments`, pure + table-tested): unwraps fenced blocks and surrounding prose, strips trailing commas, normalizes single quotes, coerces string-typed known keys against the tool's JSON schema (`"42"` → `42`), and treats already-valid as a no-op. Schema-violating calls (missing required keys, uncoercible type mismatches, empty args when the schema requires fields) are flagged so the outcome is observable.
- **Bounded re-prompt:** when local salvage fails, the per-turn reason iteration drives the attempt cap (`max_reprompts`, default 1, configurable 0–5); the call is left unchanged and flows to today's error path while attempts remain (`re-prompt`), and is labeled `gave-up` once the cap is reached. The per-call cap guarantees no infinite repair loop.
- **Observable:** emits a new `tool.call_repaired` event per malformed call with an outcome label (`local-salvage` | `re-prompt` | `gave-up`), added to `VALID_EVENT_TYPES` and documented in `specs/api-streaming.md`.
- **Disabled by default:** registered in the global registry (mirroring `loop_detection`) but contributes nothing unless an agent explicitly enables it. With it off, behavior is byte-for-byte unchanged.

## Risk
- **Low.** Off by default and gated on the capability being in the resolved set, so the default execution path is unchanged. A dedicated regression test asserts no drift when disabled. When enabled, only `arguments` are rewritten (via deterministic coercion); the salvage path never executes model content and never relaxes the downstream tool's own validation.

## Security
- Threat categories reviewed: input-validation / DoS on untrusted model output (this code parses model-authored argument blobs). No auth/network/storage surface is touched.
- Findings and resolutions:
  - **Unbounded allocation/CPU:** salvage rejects inputs over a 256 KiB cap without parsing; brace matching is a single linear, non-recursive scan with a depth counter; the lenient-JSON rewrite is one bounded pass. No recursion anywhere in the parser.
  - **Repair loop / cost runaway:** the corrective re-prompt is bounded by `max_reprompts` (default 1, max 5), driven by the per-turn iteration; un-salvaged calls fall through to today's error path rather than looping.
  - **No injection of model output into a privileged surface:** salvage only normalizes JSON shape; it never executes content and never relaxes the downstream tool's own validation.

## Follow-ups
Out-of-scope items from EVE-600, intentionally deferred:
- Per-model chat templates for tool-call formatting.
- Runaway-thinking budget.
- In-harness cheap-model routing for the corrective re-prompt.
- An **active** corrective re-prompt that injects a structured "your previous tool call could not be parsed" message; today the re-prompt is realized by the outer agent loop's natural retry (bounded by the attempt cap). Tracked as a follow-up.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)