### PR TITLE
test(core): bump data_knowledge prompt-budget cap for OKF content

### DIFF
--- a/crates/core/tests/prompt_budget.rs
+++ b/crates/core/tests/prompt_budget.rs
@@ -97,7 +97,12 @@ async fn session_sandbox_prompt_within_budget() {
 #[tokio::test]
 async fn mounted_data_prompts_within_budget() {
     assert_contribution_under(&SampleDataCapability, 250).await;
-    assert_contribution_under(&DataKnowledgeCapability, 300).await;
+    // Bumped 300 → 350: the Open Knowledge Format (OKF) adoption (#2321) added a
+    // short description of the mounted bundle layout (markdown + YAML frontmatter,
+    // index.md navigation) to the system-prompt contribution, taking it to 342
+    // bytes. The content is intentional first-turn guidance, so ratchet the cap up
+    // per this file's policy rather than trimming it.
+    assert_contribution_under(&DataKnowledgeCapability, 350).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What
Bump the `DataKnowledgeCapability` cap in `crates/core/tests/prompt_budget.rs` from 300 → 350 bytes.

## Why
The `mounted_data_prompts_within_budget` test has been **failing on `main`** since #2321 adopted the Open Knowledge Format (OKF): `DataKnowledgeCapability`'s `system_prompt_contribution` grew to 342 bytes against the 300-byte cap. It went unnoticed because the CI "Unit Tests (Pure)" job runs `cargo test -p everruns-core --lib`, which excludes integration tests under `crates/core/tests/` — so this `tests/prompt_budget.rs` failure is not covered by CI. I hit it while validating an unrelated branch and confirmed it reproduces on a clean `origin/main` (`data_knowledge.rs` unchanged between the two).

## How
The OKF layout guidance added in #2321 (mounted bundle format, `index.md` navigation, "read before writing SQL") is intentional first-turn context. Per this test file's stated ratcheting policy ("if you intentionally need more bytes, bump the cap in the same PR and explain why"), I bumped the cap to 350 with a justifying comment rather than trimming the prompt. No runtime/behavior change.

## Risk
- Very low. Test-only cap change; the capability's prompt is unchanged. The cap stays tight (350 bytes ≈ 87 tokens).

## Security
- No security-relevant code changes (test threshold only).

## Follow-ups
- The broader gap — `crates/core/tests/` integration tests (including `prompt_budget.rs`) are not run by CI's `--lib` job — is worth addressing separately so budget regressions are caught automatically. Noted here; not fixed in this PR to keep it focused.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)