### PR TITLE
fix(email): point basic template logo at hosted 64px PNG

### DIFF
--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -431,9 +431,10 @@ const EMAIL_FONT_STACK: &str =
 
 // Public Everruns surfaces. The logo must be a hosted absolute URL (most email
 // clients block SVG and inline data URIs), so we reference the PNG served by
-// the marketing site rather than the in-repo SVG.
+// the marketing site rather than the in-repo SVG. The 64px asset is sized for
+// the 28px header logo at 2x retina (~3 KB) to keep messages small.
 const EVERRUNS_SITE_URL: &str = "https://everruns.com";
-const EVERRUNS_LOGO_URL: &str = "https://everruns.com/logo.png";
+const EVERRUNS_LOGO_URL: &str = "https://everruns.com/logo-64.png";
 
 // App-styled HTML shell shared by every template. `title` sets the document
 // `<title>` (kept neutral for the unbranded minimal template, since some clients

--- a/specs/email.md
+++ b/specs/email.md
@@ -49,11 +49,11 @@ All templates share an app-styled HTML shell whose colors and shapes mirror `app
   - use when the surrounding flow already carries Everruns branding
 - `EmailTemplate::Basic(BasicEmailTemplate)`
   - same app-styled shell as `Minimal`, plus branding
-  - header with the Everruns logo (`https://everruns.com/logo.png`) and wordmark, linking to everruns.com
+  - header with the Everruns logo (`https://everruns.com/logo-64.png`) and wordmark, linking to everruns.com
   - footer linking back to everruns.com
   - plain text body is prefixed with the Everruns wordmark and gets a site-link footer
 
-The logo is referenced as a hosted absolute PNG URL rather than the in-repo SVG, because most email clients block SVG and inline data URIs. The marketing site must serve `logo.png` at the apex domain.
+The logo is referenced as a hosted absolute PNG URL rather than the in-repo SVG, because most email clients block SVG and inline data URIs. The marketing site serves `logo-64.png` at the apex domain — a 64px PNG sized for the 28px header at 2x retina.
 
 ## System Configuration
 


### PR DESCRIPTION
## What
Points the Basic email template's logo at the now-hosted `https://everruns.com/logo-64.png` (was `https://everruns.com/logo.png`, which 404'd) and updates `specs/email.md` to match.

## Why
The original `feat(email)` PR (#2354) referenced `https://everruns.com/logo.png` as a forward-looking placeholder; that asset returned 404, so the Basic header logo fell back to alt text. The marketing site now serves `logo-64.png` — a 64px PNG sized for the 28px header at 2x retina (~3 KB, verified 200 `image/png`), keeping email payloads small.

## How
One-line constant change to `EVERRUNS_LOGO_URL` plus its explanatory comment, and the corresponding spec line.

## Risk
- Very low. Pure string-constant change; covered by existing `everruns-core` email unit tests (11 passing). The URL is verified live (200, `image/png`, ~3 KB). Worst case if the asset moves again: graceful fallback to `alt="Everruns"`.

## Security
- No security-relevant code changes. Static, trusted constant pointing at the first-party apex domain; no input handling, auth, or new dependencies touched.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing email tests cover the constant)
- [x] Backward compatibility considered (internal-only API)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_017im8HqUGBF3pKsVqkmBMDW

---
_Generated by [Claude Code](https://claude.ai/code/session_017im8HqUGBF3pKsVqkmBMDW)_