### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-### Added
+## [0.16.0] - 2026-06-20
 
-- **Fireworks AI provider** — first-class `fireworks` driver (`everruns-fireworks`) for Fireworks AI open models (Llama, Qwen, DeepSeek, GLM, Kimi, gpt-oss, ...) over the OpenAI-compatible Chat Completions API, with automatic model discovery (tools, vision, and context-window capabilities) and Settings → Providers UI support.
-- **everruns-local published to crates.io** — the SQLite-backed runtime backend stores (`LocalSessionTaskRegistry`, `LocalScheduleStore`, `LocalPlatformStore`, `LocalProfile`, `LocalBackends`, `LocalRuntimeBuilder`) are now a published crate, so external embedders can add durable, restart-survivable local persistence to an `everruns-runtime` host. Includes a crate README and a "Local backends" section in the runtime docs.
+### Highlights
+
+- **Tool-Call Repair** — New capability that automatically detects and repairs malformed tool calls from LLMs, improving reliability across providers ([#2364](https://github.com/everruns/everruns/pull/2364)).
+- **OAuth Connect Flow for Providers** — Connect model providers via OAuth, starting with OpenRouter ([#2353](https://github.com/everruns/everruns/pull/2353)).
+- **Organization Invitations** — OSS-owned org invitation system with optional email delivery ([#2350](https://github.com/everruns/everruns/pull/2350)).
+- **Fireworks AI Provider** — New built-in Fireworks AI provider for open models (Llama, Qwen, DeepSeek, and more) with automatic model discovery ([#2344](https://github.com/everruns/everruns/pull/2344)).
+- **Environment Credential Injection** — Inject provider credentials via `CredentialProvider` for zero-config deployments ([#2348](https://github.com/everruns/everruns/pull/2348)).
+
+### What's Changed
+
+- feat(capabilities): tool-call repair capability for malformed tool calls ([#2364](https://github.com/everruns/everruns/pull/2364)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): OAuth connect flow for drivers, starting with OpenRouter ([#2353](https://github.com/everruns/everruns/pull/2353)) by [@chaliy](https://github.com/chaliy)
+- feat(email): app-styled minimal template and branded basic template ([#2354](https://github.com/everruns/everruns/pull/2354)) by [@chaliy](https://github.com/chaliy)
+- feat(orgs): add OSS-owned organization invitations with optional email ([#2350](https://github.com/everruns/everruns/pull/2350)) by [@chaliy](https://github.com/chaliy)
+- feat(local): publish everruns-local crate to crates.io ([#2351](https://github.com/everruns/everruns/pull/2351)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): inject env credentials via CredentialProvider ([#2348](https://github.com/everruns/everruns/pull/2348)) by [@chaliy](https://github.com/chaliy)
+- feat(fireworks): add Fireworks AI provider with model sync ([#2344](https://github.com/everruns/everruns/pull/2344)) by [@chaliy](https://github.com/chaliy)
+- fix(email): point basic template logo at hosted 64px PNG ([#2367](https://github.com/everruns/everruns/pull/2367)) by [@chaliy](https://github.com/chaliy)
+- fix(context): make infinity anchor opt-in ([#2360](https://github.com/everruns/everruns/pull/2360)) by [@chaliy](https://github.com/chaliy)
+- fix(events): allow transcript repair filters ([#2362](https://github.com/everruns/everruns/pull/2362)) by [@chaliy](https://github.com/chaliy)
+- fix(core): sanitize narrated fetch URLs ([#2358](https://github.com/everruns/everruns/pull/2358)) by [@chaliy](https://github.com/chaliy)
+- fix(guardrails): scope mcp guardrail invoker ([#2357](https://github.com/everruns/everruns/pull/2357)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): preserve capability narration hooks in act execution ([#2363](https://github.com/everruns/everruns/pull/2363)) by [@chaliy](https://github.com/chaliy)
+- fix(infinity-context): cap anchored head messages ([#2359](https://github.com/everruns/everruns/pull/2359)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve legacy agent run records ([#2361](https://github.com/everruns/everruns/pull/2361)) by [@chaliy](https://github.com/chaliy)
+- fix(openrouter): admin-gate server web tools ([#2356](https://github.com/everruns/everruns/pull/2356)) by [@chaliy](https://github.com/chaliy)
+- chore(security): adopt security policy, testing spec, and process wiring ([#2368](https://github.com/everruns/everruns/pull/2368)) by [@chaliy](https://github.com/chaliy)
+- docs,ui: use official OpenRouter logo ([#2355](https://github.com/everruns/everruns/pull/2355)) by [@chaliy](https://github.com/chaliy)
+- docs,ui: fix OpenRouter icon and add provider sidebar icons ([#2352](https://github.com/everruns/everruns/pull/2352)) by [@chaliy](https://github.com/chaliy)
+- docs(fireworks): provider guide, publishable README, UI taglines ([#2349](https://github.com/everruns/everruns/pull/2349)) by [@chaliy](https://github.com/chaliy)
+- docs: add model providers section under integrations ([#2343](https://github.com/everruns/everruns/pull/2343)) by [@chaliy](https://github.com/chaliy)
+- docs: point README links to docs.everruns.com and fill doc gaps ([#2341](https://github.com/everruns/everruns/pull/2341)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.15.0] - 2026-06-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,11 +2302,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2393,14 +2393,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2864,11 +2864,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -145,10 +145,10 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.15.0" }
-everruns-mcp = { path = "crates/mcp", version = "0.15.0" }
-everruns-openai = { path = "crates/openai", version = "0.15.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.15.0" }
+everruns-core = { path = "crates/core", version = "0.16.0" }
+everruns-mcp = { path = "crates/mcp", version = "0.16.0" }
+everruns-openai = { path = "crates/openai", version = "0.16.0" }
+everruns-runtime = { path = "crates/runtime", version = "0.16.0" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.14.0",
+  "version": "0.16.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["development-tools", "asynchronous"]
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.15.0" }
+everruns-config = { path = "../config", version = "0.16.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -111,10 +111,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.15.0", optional = true }
+everruns-openui = { path = "../openui", version = "0.16.0", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.15.0", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.16.0", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## Release v0.16.0

This PR prepares the v0.16.0 release.

### Highlights

- **Tool-Call Repair** — New capability that automatically detects and repairs malformed tool calls from LLMs
- **OAuth Connect Flow for Providers** — Connect model providers via OAuth, starting with OpenRouter
- **Organization Invitations** — OSS-owned org invitation system with optional email delivery
- **Fireworks AI Provider** — Built-in Fireworks AI provider for open models (Llama, Qwen, DeepSeek, and more)
- **Environment Credential Injection** — Inject provider credentials via `CredentialProvider`

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Version numbers updated (Cargo.toml, apps/ui/package.json, crates/core/Cargo.toml)
- [x] Lock files regenerated (Cargo.lock, pnpm-lock.yaml)
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.16.0`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4WnGgok93KbpmKFybshz2)_