### PR TITLE
ci: cut redundant rust recompiles to speed up cold CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,10 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
+              # The prebuilt runtime image is assembled by the docker-build job
+              # (gated on `rust`); list it here so editing it alone still runs
+              # build-binaries + docker-build and validates the assembly.
+              - 'docker/Dockerfile.prebuilt'
             sdk_compat:
               - 'crates/**'
               - '.github/scripts/sdk-compat/**'
@@ -1441,9 +1445,8 @@ jobs:
           name: everruns-worker
           path: ./bin
 
-      - name: Make binaries executable
-        run: chmod +x ./bin/*
-
+      # No host chmod needed: Dockerfile.prebuilt uses COPY --chmod, and the
+      # image is only built here (never run in CI).
       - name: Build server Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Incremental compilation only helps when recompiling edited source on a
+  # persistent machine. CI runners are ephemeral (fresh checkout per job), so
+  # incremental artifacts are never reused — they just bloat the rust-cache
+  # save/restore. Dependency caching (Swatinem/rust-cache) is unaffected.
+  CARGO_INCREMENTAL: 0
   # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope: PR code
   # would inherit it and could exfiltrate the whole Doppler vault via
   # build.rs, proc-macros, or tests. Inject it per step under a push-only
@@ -283,6 +288,11 @@ jobs:
       - name: Install Rust MSRV toolchain
         uses: dtolnay/rust-toolchain@1.94.0
 
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "msrv"
+
       - name: Check published crates against MSRV
         run: |
           cargo check --locked --all-features \
@@ -331,7 +341,11 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          # Distinct from the test jobs: clippy compiles --all-targets
+          # --all-features, a different feature set than the default-feature
+          # test builds. rust-cache keys ignore feature flags, so sharing one
+          # key would make the two profiles thrash each other's target/ cache.
+          shared-key: "clippy"
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -353,7 +367,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Run pure unit tests
         run: |
@@ -398,7 +412,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Run worker library tests
         run: cargo test -p everruns-worker --lib -- --test-threads=1
@@ -460,7 +474,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Run Daytona live integration tests
         run: doppler run -- cargo test -p everruns-integrations-daytona --features daytona-live-tests --test live_api_test -- --test-threads=1
@@ -487,7 +501,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Run Browserless live integration tests
         run: doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests --test live_api -- --test-threads=1
@@ -514,7 +528,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Run E2B live integration tests
         run: doppler run -- cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test -- --test-threads=1
@@ -542,7 +556,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Run Deno live integration tests
         run: doppler run -- cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
@@ -589,7 +603,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -747,7 +761,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -836,37 +850,40 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "release"
+          shared-key: "ci-bins"
 
-      - name: Build release binaries
-        run: cargo build --release -p everruns-server -p everruns-worker -p everruns-cli
+      # release-ci profile: opt-level=1, no LTO — these binaries only drive the
+      # e2e/workflow/openapi CI jobs, so we trade optimization for ~2x faster
+      # builds. Published binaries/images still use `release` (Dockerfile.unified).
+      - name: Build CI binaries
+        run: cargo build --profile release-ci -p everruns-server -p everruns-worker -p everruns-cli
 
       - name: Upload server binary
         uses: actions/upload-artifact@v4
         with:
           name: everruns-server
-          path: target/release/everruns-server
+          path: target/release-ci/everruns-server
           retention-days: 1
 
       - name: Upload worker binary
         uses: actions/upload-artifact@v4
         with:
           name: everruns-worker
-          path: target/release/everruns-worker
+          path: target/release-ci/everruns-worker
           retention-days: 1
 
       - name: Upload CLI binary
         uses: actions/upload-artifact@v4
         with:
           name: everruns-cli
-          path: target/release/everruns
+          path: target/release-ci/everruns
           retention-days: 1
 
       - name: Upload export-openapi binary
         uses: actions/upload-artifact@v4
         with:
           name: export-openapi
-          path: target/release/export-openapi
+          path: target/release-ci/export-openapi
           retention-days: 1
 
   # Gated to push events: this job launches PR-built `everruns-server` and
@@ -913,7 +930,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -1337,7 +1354,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "debug"
+          shared-key: "test"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -1388,13 +1405,23 @@ jobs:
       - name: Build docs
         run: pnpm run build
 
-  # Docker builds — server and worker share builder-all stage, so build on
-  # one runner to compile shared dependencies once instead of 2x.
+  # Docker image validation for PRs. Instead of recompiling the whole workspace
+  # inside Docker (~28 min), this packages the binaries already built by
+  # `build-binaries` into the runtime images via docker/Dockerfile.prebuilt —
+  # validating the runtime layer (base image, COPY, ENV, CMD) in seconds.
+  #
+  # The full build-from-source, multi-arch images are produced at release time
+  # by docker-publish.yml (which also validates the Dockerfile.unified builder
+  # stage from-source on PRs that touch docker/** paths). This job therefore
+  # gates on `rust` (not the broader `docker` filter) so the build-binaries
+  # artifacts it consumes are guaranteed to exist.
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.docker == 'true' && needs.changes.outputs.skip_docker != 'true'
+    needs:
+      - changes
+      - build-binaries
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_docker != 'true'
 
     steps:
       - uses: actions/checkout@v5
@@ -1402,27 +1429,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: everruns-server
+          path: ./bin
+
+      - name: Download worker binary
+        uses: actions/download-artifact@v4
+        with:
+          name: everruns-worker
+          path: ./bin
+
+      - name: Make binaries executable
+        run: chmod +x ./bin/*
+
       - name: Build server Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: docker/Dockerfile.unified
+          file: docker/Dockerfile.prebuilt
           target: server
           push: false
           tags: everruns-server:ci
-          cache-from: type=gha,scope=docker-rust
-          cache-to: type=gha,mode=max,scope=docker-rust
 
       - name: Build worker Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: docker/Dockerfile.unified
+          file: docker/Dockerfile.prebuilt
           target: worker
           push: false
           tags: everruns-worker:ci
-          cache-from: type=gha,scope=docker-rust
-          cache-to: type=gha,mode=max,scope=docker-rust
 
   ci-opt-out-policy:
     name: CI Opt-Out Policy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,5 +225,8 @@ inherits = "release"
 opt-level = 1
 lto = false
 codegen-units = 256
-debug = false
-strip = true
+# Keep cheap line-number debug info and don't strip: these binaries are executed
+# by CI jobs (workflow/e2e/openapi) under RUST_BACKTRACE=1, so panic backtraces
+# must stay actionable. line-tables-only matches the dev profile — small and fast.
+debug = "line-tables-only"
+strip = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,10 +214,16 @@ opt-level = 3
 lto = "thin"
 codegen-units = 16
 
-# CI-optimized profile: faster builds, still optimized
+# CI binary profile: builds the server/worker/cli binaries that only feed the
+# e2e/workflow/openapi CI jobs, where runtime performance is irrelevant. Trades
+# optimization for compile speed — opt-level=1 keeps codegen cheap, no LTO drops
+# the thin-LTO link step entirely, and codegen-units=256 maximizes parallelism.
+# Roughly ~2x faster to build than `release`. NOT for published artifacts:
+# release images/binaries use `release` (see docker/Dockerfile.unified).
 [profile.release-ci]
 inherits = "release"
-lto = "thin"
-codegen-units = 16
+opt-level = 1
+lto = false
+codegen-units = 256
 debug = false
 strip = true

--- a/docker/Dockerfile.prebuilt
+++ b/docker/Dockerfile.prebuilt
@@ -25,7 +25,9 @@ FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be5
 
 WORKDIR /app
 
-COPY bin/everruns-server /app/everruns-server
+# --chmod so the image doesn't depend on the host file mode (CI artifacts can
+# arrive as 0644). Requires BuildKit (enabled via the syntax directive above).
+COPY --chmod=0755 bin/everruns-server /app/everruns-server
 
 EXPOSE 9000
 EXPOSE 9001
@@ -42,7 +44,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be5
 
 WORKDIR /app
 
-COPY bin/everruns-worker /app/everruns-worker
+COPY --chmod=0755 bin/everruns-worker /app/everruns-worker
 
 ENV RUST_LOG=info
 

--- a/docker/Dockerfile.prebuilt
+++ b/docker/Dockerfile.prebuilt
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.4
+#
+# Runtime-only images assembled from pre-built binaries.
+#
+# CI (`ci.yml` docker-build) uses this for fast PR validation: it packages the
+# server/worker binaries already compiled on the host by the `build-binaries`
+# job instead of recompiling the whole workspace inside Docker (~28 min). The
+# full multi-arch, build-from-source images for releases come from
+# docker/Dockerfile.unified via docker-publish.yml.
+#
+# Expects the binaries in the build context under ./bin/:
+#   docker build -f docker/Dockerfile.prebuilt --target server -t everruns-server:ci .
+#
+# NOTE: this Dockerfile is intentionally build-only in CI — the image is never
+# run there. The CI binaries are compiled on the GitHub runner (newer glibc)
+# while the distroless base ships an older glibc, so a `docker run` smoke test
+# would fail on a glibc mismatch. Production images avoid this by compiling
+# inside the matching bookworm base (Dockerfile.unified). Keep the base digest
+# identical to Dockerfile.unified so this validates the real runtime layer.
+
+# ============================================================================
+# Server runtime (distroless, matches Dockerfile.unified `server` stage)
+# ============================================================================
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985 AS server
+
+WORKDIR /app
+
+COPY bin/everruns-server /app/everruns-server
+
+EXPOSE 9000
+EXPOSE 9001
+
+ENV RUST_LOG=info
+ENV HTTP_ADDR=0.0.0.0:9000
+
+CMD ["/app/everruns-server"]
+
+# ============================================================================
+# Worker runtime (distroless, matches Dockerfile.unified `worker` stage)
+# ============================================================================
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985 AS worker
+
+WORKDIR /app
+
+COPY bin/everruns-worker /app/everruns-worker
+
+ENV RUST_LOG=info
+
+CMD ["/app/everruns-worker"]


### PR DESCRIPTION
## What
Reduce the redundant from-scratch Rust compiles in CI. A full run compiled the
workspace ~5x across mutually-incompatible caches (~105 job-minutes warm, more
when cold). This trims the two biggest jobs and stops the rust-cache thrashing:

- **docker-build**: package the binaries already built by `build-binaries` into
  the runtime images via the new `docker/Dockerfile.prebuilt`, instead of
  recompiling the whole workspace in-container (~28 min). The image is build-only
  in CI (`push: false`, never run).
- **build-binaries**: build under the `release-ci` profile (opt-level=1, no LTO,
  codegen-units=256) — ~2x faster than `release`. These binaries only feed the
  e2e/workflow/openapi jobs where runtime perf is irrelevant. Repurposes the
  previously-unused `release-ci` profile.
- **rust-cache keys**: split the single `"debug"` shared-key into `"clippy"`
  (`--all-targets --all-features`) and `"test"` (default-feature builds). Keys
  ignore feature flags, so the two profiles were overwriting each other's
  `target/`.
- **msrv**: add a `rust-cache` (`"msrv"`) — it had none and did a full cold
  `cargo check --all-features` every run.
- **CARGO_INCREMENTAL=0** at workflow scope — incremental artifacts are never
  reused on ephemeral runners and only bloat cache save/restore.

## Why
Wall-clock CI is ~28–30 min but total job-minutes per run is ~1.5–2h, dominated
by Docker Build (~28 min) and Build Release Binaries (~21 min) — both producing
release server/worker binaries, in different environments. Cold runs (any
`Cargo.lock` change busts every cache key) are worse. The work was duplicated and
the shared cache key was thrashing between feature profiles.

## How
- New `docker/Dockerfile.prebuilt` mirrors the `Dockerfile.unified` distroless
  runtime stages (same pinned base digest) but `COPY`s host-built binaries from
  the build context instead of compiling in a builder stage.
- `docker-build` now `needs: build-binaries`, downloads the server/worker
  artifacts, and assembles both images. It gates on `rust` (not the broader
  `docker` filter) so the artifacts it consumes always exist.
- Full multi-arch build-from-source images still come from `docker-publish.yml`
  at release time, which also validates the `Dockerfile.unified` builder stage
  on PRs touching `docker/**`.

## Risk
- **Low.** No application/runtime code changes — CI config, a build profile, and
  a CI-only Dockerfile.
- Coverage tradeoff: docs-only PRs no longer trigger a from-source Docker build
  (now validated at release); `docker/**` PRs remain covered by
  `docker-publish.yml`. The `release-ci` binaries are functionally identical to
  `release` (optimization level only), and CI itself end-to-end validates this
  change — `build-binaries` must emit `target/release-ci/*` and the downstream
  workflow/cli-e2e/openapi jobs consume them.

## Security
- Threat categories reviewed: **No security-relevant code changes.** Diff is
  limited to CI workflow config, a Cargo build profile, and a CI-only Dockerfile.
  No `TM-*` runtime surface (auth/API/tenant/tools/LLM) is touched.
- Findings and resolutions: none. `Dockerfile.prebuilt` reuses the same pinned
  distroless digest as `Dockerfile.unified` (no new/unpinned base, no
  supply-chain expansion); the image is build-only and never pushed or run. No
  new dependencies; lockfile unchanged. Secret-gating (DOPPLER push-only steps)
  is untouched.

## Follow-ups
- Consider larger (8-core) runners for the remaining long-pole jobs
  (`integration-test`, `unit-test`) — linear wall-clock win but costs money.
  Deferred: separate cost/benefit decision, not required for this speedup.
- sccache was evaluated and intentionally **not** pursued (a prior attempt cost
  ~$60 with no improvement).

## Checklist
- [x] Tests added or updated — N/A (CI/build-config change; validated by CI itself)
- [x] Backward compatibility considered — no runtime/API surface changed
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_019y1WFXQFyNMjZzDhm697ML

---
_Generated by [Claude Code](https://claude.ai/code/session_019y1WFXQFyNMjZzDhm697ML)_