### PR TITLE
fix(worker): bound worker concurrency, claim batch, and idle polling

### DIFF
--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -229,7 +229,9 @@ pub(crate) fn claim_limit(available_slots: usize, claim_batch_size: usize) -> us
 
 /// Next fallback poll interval. Resets to `base` when work was found, otherwise
 /// doubles the current interval up to `max` — so an idle worker backs off
-/// aggressively instead of polling in a tight loop.
+/// aggressively instead of polling in a tight loop. The result is always clamped
+/// to `max`, and the doubling is overflow-safe (a misconfigured huge interval
+/// saturates at `max` rather than panicking).
 pub(crate) fn next_poll_backoff(
     current: Duration,
     base: Duration,
@@ -237,9 +239,9 @@ pub(crate) fn next_poll_backoff(
     found_work: bool,
 ) -> Duration {
     if found_work {
-        base
+        base.min(max)
     } else {
-        (current * 2).min(max)
+        current.checked_mul(2).unwrap_or(max).min(max)
     }
 }
 
@@ -475,7 +477,7 @@ impl DurableWorker {
         // degraded (no-push) mode with an empty queue stops hammering the DB with
         // `claim_task` requests. Reset to the base interval as soon as work is
         // found or the push stream reconnects.
-        let mut poll_backoff = self.config.poll_interval;
+        let mut poll_backoff = self.config.poll_interval.min(self.config.poll_backoff_max);
 
         // Main event loop with push notifications and polling fallback
         loop {
@@ -596,12 +598,22 @@ impl DurableWorker {
                     if executed > 0 {
                         debug!(tasks_executed = executed, "Executed tasks");
                     }
-                    poll_backoff = next_poll_backoff(
-                        poll_backoff,
-                        self.config.poll_interval,
-                        self.config.poll_backoff_max,
-                        executed > 0,
-                    );
+                    // Only grow the backoff in degraded (no-push) polling mode.
+                    // While the push stream is connected, the fallback poll fires
+                    // on a fixed 10s timer (not `poll_backoff`), so keep the
+                    // backoff parked at base — otherwise periodic empty fallback
+                    // polls would inflate it to the cap and delay the first pickup
+                    // if the stream later drops.
+                    poll_backoff = if notification_stream.is_some() {
+                        self.config.poll_interval.min(self.config.poll_backoff_max)
+                    } else {
+                        next_poll_backoff(
+                            poll_backoff,
+                            self.config.poll_interval,
+                            self.config.poll_backoff_max,
+                            executed > 0,
+                        )
+                    };
                 }
                 Err(e) => {
                     error!("Error polling tasks: {}", e);
@@ -1816,6 +1828,11 @@ mod tests {
         // Finding work resets to the base interval.
         let reset = next_poll_backoff(b, base, max, true);
         assert_eq!(reset, base);
+
+        // Misconfiguration safety: base > max is clamped to max, and doubling a
+        // near-max duration saturates at max instead of overflowing/panicking.
+        assert_eq!(next_poll_backoff(base, max * 2, max, true), max);
+        assert_eq!(next_poll_backoff(Duration::MAX, base, max, false), max);
     }
 
     #[test]

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -197,16 +197,66 @@ async fn emit_cancellation_events(
 // =============================================================================
 
 /// Configuration for the durable worker
+/// Default execution concurrency for external/gRPC workers.
+///
+/// Historically 1000, which let a single worker advertise — and a single
+/// `claim_task` demand — up to 1000 tasks. With a few replicas that was enough to
+/// saturate a small managed Postgres once the system was already slow (EVE-606).
+/// 1000-way concurrency is now opt-in via `MAX_CONCURRENT_TASKS`; this default
+/// mirrors the server's default DB pool size (50).
+pub const DEFAULT_MAX_CONCURRENT_TASKS: usize = 50;
+
+/// Upper bound on a single claim request, independent of execution concurrency.
+/// Keeps `claim_task max_tasks=...` bounded even when `MAX_CONCURRENT_TASKS` is
+/// raised, so a slow/contended claim query can never be asked for 1000 rows.
+pub const DEFAULT_CLAIM_BATCH_SIZE: usize = 50;
+
+/// Base fallback poll interval when push notifications are unavailable.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Maximum fallback poll interval. While the queue stays empty the poll interval
+/// backs off exponentially from `poll_interval` up to this cap, so idle workers
+/// stop hammering the DB with `claim_task` requests.
+pub const DEFAULT_POLL_BACKOFF_MAX: Duration = Duration::from_secs(5);
+
+/// How many tasks to claim in one request, given currently-free execution slots
+/// and the configured claim batch size. Bounding by `claim_batch_size` keeps a
+/// single `claim_task` cheap and prevents `max_tasks=<execution concurrency>`
+/// requests (e.g. 1000) that amplify DB pressure (EVE-606).
+pub(crate) fn claim_limit(available_slots: usize, claim_batch_size: usize) -> usize {
+    available_slots.min(claim_batch_size)
+}
+
+/// Next fallback poll interval. Resets to `base` when work was found, otherwise
+/// doubles the current interval up to `max` — so an idle worker backs off
+/// aggressively instead of polling in a tight loop.
+pub(crate) fn next_poll_backoff(
+    current: Duration,
+    base: Duration,
+    max: Duration,
+    found_work: bool,
+) -> Duration {
+    if found_work {
+        base
+    } else {
+        (current * 2).min(max)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DurableWorkerConfig {
     /// Worker ID (unique identifier for this worker instance)
     pub worker_id: String,
     /// Activity types this worker handles
     pub activity_types: Vec<String>,
-    /// Maximum concurrent tasks
+    /// Maximum concurrent tasks (execution concurrency / advertised capacity)
     pub max_concurrent_tasks: usize,
-    /// Poll interval when push notifications unavailable (fallback)
+    /// Maximum tasks claimed in a single request, regardless of available slots.
+    pub claim_batch_size: usize,
+    /// Base poll interval when push notifications unavailable (fallback)
     pub poll_interval: Duration,
+    /// Cap for the exponential poll backoff while the queue is empty.
+    pub poll_backoff_max: Duration,
     /// Heartbeat interval for claimed tasks
     pub heartbeat_interval: Duration,
     /// gRPC address for control-plane communication
@@ -229,8 +279,10 @@ impl Default for DurableWorkerConfig {
                 "session_task_reaper".to_string(),
                 "invoke_scheduled_app_channel".to_string(),
             ],
-            max_concurrent_tasks: 1000, // High default for massive workflow parallelism
-            poll_interval: Duration::from_millis(10), // Fallback when push notifications unavailable
+            max_concurrent_tasks: DEFAULT_MAX_CONCURRENT_TASKS,
+            claim_batch_size: DEFAULT_CLAIM_BATCH_SIZE,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            poll_backoff_max: DEFAULT_POLL_BACKOFF_MAX,
             heartbeat_interval: Duration::from_secs(10),
             grpc_address: "127.0.0.1:9001".to_string(),
             connect_timeout: Duration::from_secs(30),
@@ -239,11 +291,21 @@ impl Default for DurableWorkerConfig {
 }
 
 impl DurableWorkerConfig {
-    /// Create configuration from environment variables
+    /// Create configuration from environment variables.
+    ///
+    /// Execution concurrency (`MAX_CONCURRENT_TASKS`), claim batch size
+    /// (`CLAIM_BATCH_SIZE`), and the fallback poll interval/backoff cap
+    /// (`WORKER_POLL_INTERVAL_MS` / `WORKER_POLL_BACKOFF_MAX_MS`) are configured
+    /// independently. The claim batch is additionally clamped to the execution
+    /// concurrency so a single `claim_task` never asks for more than a worker can
+    /// run.
     pub fn from_env() -> Self {
-        use everruns_config::{env_duration_secs, env_or, env_string_any};
+        use everruns_config::{env_duration_ms, env_duration_secs, env_or, env_string_any};
 
         let defaults = Self::default();
+        let max_concurrent_tasks = env_or("MAX_CONCURRENT_TASKS", defaults.max_concurrent_tasks);
+        let claim_batch_size =
+            env_or("CLAIM_BATCH_SIZE", defaults.claim_batch_size).min(max_concurrent_tasks);
         Self {
             worker_id: std::env::var("WORKER_ID")
                 .unwrap_or_else(|_| format!("worker-{}", Uuid::now_v7())),
@@ -251,7 +313,13 @@ impl DurableWorkerConfig {
                 &["SERVER_GRPC_ADDRESS", "WORKER_GRPC_ADDRESS"],
                 "127.0.0.1:9001",
             ),
-            max_concurrent_tasks: env_or("MAX_CONCURRENT_TASKS", 1000),
+            max_concurrent_tasks,
+            claim_batch_size,
+            poll_interval: env_duration_ms("WORKER_POLL_INTERVAL_MS", defaults.poll_interval),
+            poll_backoff_max: env_duration_ms(
+                "WORKER_POLL_BACKOFF_MAX_MS",
+                defaults.poll_backoff_max,
+            ),
             connect_timeout: env_duration_secs(
                 "WORKER_GRPC_CONNECT_TIMEOUT",
                 defaults.connect_timeout,
@@ -293,7 +361,11 @@ impl DurableWorker {
         info!(
             worker_id = %config.worker_id,
             grpc_address = %config.grpc_address,
-            max_concurrent = config.max_concurrent_tasks,
+            max_concurrent_tasks = config.max_concurrent_tasks,
+            claim_batch_size = config.claim_batch_size,
+            poll_interval_ms = config.poll_interval.as_millis(),
+            poll_backoff_max_ms = config.poll_backoff_max.as_millis(),
+            heartbeat_interval_ms = config.heartbeat_interval.as_millis(),
             "Initializing durable worker (gRPC mode)"
         );
 
@@ -398,6 +470,13 @@ impl DurableWorker {
         let mut reconnect_backoff = Duration::from_secs(1);
         let max_reconnect_backoff = Duration::from_secs(60);
 
+        // Adaptive fallback-poll backoff: starts at `poll_interval` and doubles
+        // up to `poll_backoff_max` each time a poll finds no work, so a worker in
+        // degraded (no-push) mode with an empty queue stops hammering the DB with
+        // `claim_task` requests. Reset to the base interval as soon as work is
+        // found or the push stream reconnects.
+        let mut poll_backoff = self.config.poll_interval;
+
         // Main event loop with push notifications and polling fallback
         loop {
             // Check for shutdown
@@ -464,10 +543,10 @@ impl DurableWorker {
                     }
                 }
                 None => {
-                    // No notification stream - use regular polling with reconnect attempts
+                    // No notification stream - use adaptive backoff polling with
+                    // reconnect attempts.
                     tokio::select! {
-                        // Short poll interval when no notifications
-                        _ = tokio::time::sleep(self.config.poll_interval) => {
+                        _ = tokio::time::sleep(poll_backoff) => {
                             // Try to reconnect periodically
                             let mut store = self.store.lock().await;
                             match store
@@ -484,6 +563,7 @@ impl DurableWorker {
                                     );
                                     notification_stream = Some(stream);
                                     reconnect_backoff = Duration::from_secs(1);
+                                    poll_backoff = self.config.poll_interval;
                                 }
                                 Err(_) => {
                                     // Increase backoff, but still poll
@@ -516,6 +596,12 @@ impl DurableWorker {
                     if executed > 0 {
                         debug!(tasks_executed = executed, "Executed tasks");
                     }
+                    poll_backoff = next_poll_backoff(
+                        poll_backoff,
+                        self.config.poll_interval,
+                        self.config.poll_backoff_max,
+                        executed > 0,
+                    );
                 }
                 Err(e) => {
                     error!("Error polling tasks: {}", e);
@@ -619,14 +705,17 @@ impl DurableWorker {
             return Ok(0);
         }
 
-        // Claim only as many tasks as we have slots for
+        // Claim as many as we have slots for, but never more than the claim batch
+        // size — this keeps `claim_task max_tasks=...` bounded (and the claim query
+        // cheap) even when execution concurrency is configured high.
+        let to_claim = claim_limit(available_slots, self.config.claim_batch_size);
         let tasks = {
             let mut store = self.store.lock().await;
             store
                 .claim_tasks(
                     &self.config.worker_id,
                     &self.config.activity_types,
-                    available_slots,
+                    to_claim,
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to claim tasks: {}", e))?
@@ -1681,8 +1770,52 @@ mod tests {
     fn test_config_default() {
         let config = DurableWorkerConfig::default();
         assert!(config.worker_id.starts_with("worker-"));
-        assert_eq!(config.max_concurrent_tasks, 1000);
+        // Safe-by-default concurrency; 1000-way is opt-in via MAX_CONCURRENT_TASKS.
+        assert_eq!(config.max_concurrent_tasks, DEFAULT_MAX_CONCURRENT_TASKS);
+        assert_eq!(config.claim_batch_size, DEFAULT_CLAIM_BATCH_SIZE);
+        // The claim batch must never exceed execution concurrency.
+        assert!(config.claim_batch_size <= config.max_concurrent_tasks);
         assert_eq!(config.grpc_address, "127.0.0.1:9001");
+    }
+
+    // EVE-606: a single claim must stay bounded by the claim batch size even when
+    // execution concurrency (available slots) is very high, so workers never issue
+    // `claim_task max_tasks=1000`-style requests.
+    #[test]
+    fn test_claim_limit_bounds_to_batch() {
+        // High concurrency, empty/idle worker: claim is capped at the batch size.
+        assert_eq!(
+            claim_limit(1000, DEFAULT_CLAIM_BATCH_SIZE),
+            DEFAULT_CLAIM_BATCH_SIZE
+        );
+        assert_eq!(claim_limit(1000, 50), 50);
+        // Fewer free slots than the batch: claim only what fits.
+        assert_eq!(claim_limit(10, 50), 10);
+        // No free slots: claim nothing.
+        assert_eq!(claim_limit(0, 50), 0);
+    }
+
+    // EVE-606: fallback polling must back off aggressively while the queue is
+    // empty and snap back to the base interval as soon as work appears.
+    #[test]
+    fn test_poll_backoff_grows_and_caps() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+
+        // Empty polls double the interval up to the cap, then stay there.
+        let mut b = base;
+        b = next_poll_backoff(b, base, max, false);
+        assert_eq!(b, Duration::from_millis(200));
+        b = next_poll_backoff(b, base, max, false);
+        assert_eq!(b, Duration::from_millis(400));
+        for _ in 0..20 {
+            b = next_poll_backoff(b, base, max, false);
+        }
+        assert_eq!(b, max, "backoff must saturate at the cap");
+
+        // Finding work resets to the base interval.
+        let reset = next_poll_backoff(b, base, max, true);
+        assert_eq!(reset, base);
     }
 
     #[test]

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -8,6 +8,7 @@
 // It unifies the two worker implementations into one, eliminating code duplication
 // while preserving the different deployment models (in-process vs external).
 
+use crate::durable_worker;
 use anyhow::Result;
 use everruns_core::ActInput;
 use everruns_core::atoms::AtomContext;
@@ -48,10 +49,14 @@ pub struct TaskWorkerConfig {
     pub worker_id: String,
     /// Activity types this worker handles
     pub activity_types: Vec<String>,
-    /// Maximum concurrent tasks
+    /// Maximum concurrent tasks (execution concurrency / advertised capacity)
     pub max_concurrent_tasks: usize,
-    /// Poll interval when no tasks available
+    /// Maximum tasks claimed in a single request, regardless of available slots.
+    pub claim_batch_size: usize,
+    /// Base poll interval when no tasks available
     pub poll_interval: Duration,
+    /// Cap for the exponential poll backoff while the queue is empty.
+    pub poll_backoff_max: Duration,
     /// Heartbeat interval for worker registration
     pub heartbeat_interval: Duration,
     /// Worker group name (optional, for routing)
@@ -70,8 +75,10 @@ impl Default for TaskWorkerConfig {
                 "session_task_reaper".to_string(),
                 activity_types::INVOKE_SCHEDULED_APP_CHANNEL.to_string(),
             ],
-            max_concurrent_tasks: 1000,
-            poll_interval: Duration::from_millis(10),
+            max_concurrent_tasks: durable_worker::DEFAULT_MAX_CONCURRENT_TASKS,
+            claim_batch_size: durable_worker::DEFAULT_CLAIM_BATCH_SIZE,
+            poll_interval: durable_worker::DEFAULT_POLL_INTERVAL,
+            poll_backoff_max: durable_worker::DEFAULT_POLL_BACKOFF_MAX,
             heartbeat_interval: Duration::from_secs(10),
             worker_group: None,
         }
@@ -79,43 +86,56 @@ impl Default for TaskWorkerConfig {
 }
 
 impl TaskWorkerConfig {
-    /// Create dev mode configuration (faster polling, lower concurrency)
+    /// Create dev mode configuration (faster pickup, lower concurrency).
+    /// Keeps a short backoff cap so an idle dev queue still picks up new work
+    /// quickly.
     pub fn dev_mode() -> Self {
         Self {
             worker_id: format!("dev-worker-{}", Uuid::now_v7()),
             worker_group: Some("dev".to_string()),
             max_concurrent_tasks: 10,
             poll_interval: Duration::from_millis(10),
+            poll_backoff_max: Duration::from_millis(250),
             ..Default::default()
         }
     }
 
-    /// Create production configuration (higher concurrency)
+    /// Create a high-concurrency configuration. This is the explicit opt-in for
+    /// 1000-way execution; the claim batch stays bounded by `claim_batch_size`.
     pub fn production() -> Self {
         Self {
             max_concurrent_tasks: 1000,
-            poll_interval: Duration::from_millis(10),
             ..Default::default()
         }
     }
 
-    /// Create configuration from environment variables
+    /// Create configuration from environment variables.
+    ///
+    /// Execution concurrency (`MAX_CONCURRENT_TASKS`), claim batch size
+    /// (`CLAIM_BATCH_SIZE`), and the poll interval/backoff cap
+    /// (`WORKER_POLL_INTERVAL_MS` / `WORKER_POLL_BACKOFF_MAX_MS`) are independent.
+    /// The claim batch is clamped to the execution concurrency.
     pub fn from_env() -> Self {
+        use everruns_config::{env_duration_ms, env_or};
+
         let worker_id =
             std::env::var("WORKER_ID").unwrap_or_else(|_| format!("worker-{}", Uuid::now_v7()));
-
-        let max_concurrent = std::env::var("MAX_CONCURRENT_TASKS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1000);
-
-        let worker_group = std::env::var("WORKER_GROUP").ok();
+        let defaults = Self::default();
+        let max_concurrent_tasks = env_or("MAX_CONCURRENT_TASKS", defaults.max_concurrent_tasks);
+        let claim_batch_size =
+            env_or("CLAIM_BATCH_SIZE", defaults.claim_batch_size).min(max_concurrent_tasks);
 
         Self {
             worker_id,
-            max_concurrent_tasks: max_concurrent,
-            worker_group,
-            ..Default::default()
+            max_concurrent_tasks,
+            claim_batch_size,
+            poll_interval: env_duration_ms("WORKER_POLL_INTERVAL_MS", defaults.poll_interval),
+            poll_backoff_max: env_duration_ms(
+                "WORKER_POLL_BACKOFF_MAX_MS",
+                defaults.poll_backoff_max,
+            ),
+            worker_group: std::env::var("WORKER_GROUP").ok(),
+            ..defaults
         }
     }
 }
@@ -153,7 +173,11 @@ where
 
         info!(
             worker_id = %config.worker_id,
-            max_concurrent = config.max_concurrent_tasks,
+            max_concurrent_tasks = config.max_concurrent_tasks,
+            claim_batch_size = config.claim_batch_size,
+            poll_interval_ms = config.poll_interval.as_millis(),
+            poll_backoff_max_ms = config.poll_backoff_max.as_millis(),
+            heartbeat_interval_ms = config.heartbeat_interval.as_millis(),
             "Initialized unified worker"
         );
 
@@ -226,6 +250,11 @@ where
             }
         });
 
+        // Adaptive poll backoff: doubles from `poll_interval` up to
+        // `poll_backoff_max` while the queue is empty, so an idle worker stops
+        // issuing tight-loop `claim_task` requests. Reset to base on any work.
+        let mut poll_backoff = self.config.poll_interval;
+
         // Main poll loop
         loop {
             if *self.shutdown_rx.borrow() {
@@ -237,13 +266,19 @@ where
                 Ok(executed) => {
                     if executed == 0 {
                         tokio::select! {
-                            _ = tokio::time::sleep(self.config.poll_interval) => {}
+                            _ = tokio::time::sleep(poll_backoff) => {}
                             _ = self.shutdown_rx.changed() => {
                                 info!("Shutdown during poll wait");
                                 break;
                             }
                         }
                     }
+                    poll_backoff = durable_worker::next_poll_backoff(
+                        poll_backoff,
+                        self.config.poll_interval,
+                        self.config.poll_backoff_max,
+                        executed > 0,
+                    );
                 }
                 Err(e) => {
                     error!("Error polling tasks: {}", e);
@@ -290,12 +325,15 @@ where
             return Ok(0);
         }
 
+        // Bound the claim by claim_batch_size so a single claim_task stays cheap
+        // even when execution concurrency is high.
+        let to_claim = durable_worker::claim_limit(available_slots, self.config.claim_batch_size);
         let tasks = self
             .store
             .claim_task(
                 &self.config.worker_id,
                 &self.config.activity_types,
-                available_slots,
+                to_claim,
             )
             .await
             .map_err(|e| anyhow::anyhow!("Failed to claim tasks: {}", e))?;
@@ -904,7 +942,16 @@ mod tests {
     fn test_config_default() {
         let config = TaskWorkerConfig::default();
         assert!(config.worker_id.starts_with("worker-"));
-        assert_eq!(config.max_concurrent_tasks, 1000);
+        // Safe-by-default concurrency; 1000-way is opt-in.
+        assert_eq!(
+            config.max_concurrent_tasks,
+            durable_worker::DEFAULT_MAX_CONCURRENT_TASKS
+        );
+        assert_eq!(
+            config.claim_batch_size,
+            durable_worker::DEFAULT_CLAIM_BATCH_SIZE
+        );
+        assert!(config.claim_batch_size <= config.max_concurrent_tasks);
     }
 
     #[test]
@@ -916,7 +963,14 @@ mod tests {
 
     #[test]
     fn test_config_production() {
+        // production() is the explicit opt-in for high concurrency, but the claim
+        // batch stays bounded independently of execution concurrency.
         let config = TaskWorkerConfig::production();
         assert_eq!(config.max_concurrent_tasks, 1000);
+        assert_eq!(
+            config.claim_batch_size,
+            durable_worker::DEFAULT_CLAIM_BATCH_SIZE
+        );
+        assert!(config.claim_batch_size < config.max_concurrent_tasks);
     }
 }

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -90,10 +90,13 @@ impl TaskWorkerConfig {
     /// Keeps a short backoff cap so an idle dev queue still picks up new work
     /// quickly.
     pub fn dev_mode() -> Self {
+        let max_concurrent_tasks = 10;
         Self {
             worker_id: format!("dev-worker-{}", Uuid::now_v7()),
             worker_group: Some("dev".to_string()),
-            max_concurrent_tasks: 10,
+            max_concurrent_tasks,
+            // Keep the claim batch within execution concurrency.
+            claim_batch_size: durable_worker::DEFAULT_CLAIM_BATCH_SIZE.min(max_concurrent_tasks),
             poll_interval: Duration::from_millis(10),
             poll_backoff_max: Duration::from_millis(250),
             ..Default::default()
@@ -253,7 +256,7 @@ where
         // Adaptive poll backoff: doubles from `poll_interval` up to
         // `poll_backoff_max` while the queue is empty, so an idle worker stops
         // issuing tight-loop `claim_task` requests. Reset to base on any work.
-        let mut poll_backoff = self.config.poll_interval;
+        let mut poll_backoff = self.config.poll_interval.min(self.config.poll_backoff_max);
 
         // Main poll loop
         loop {
@@ -959,6 +962,8 @@ mod tests {
         let config = TaskWorkerConfig::dev_mode();
         assert!(config.worker_id.starts_with("dev-worker-"));
         assert_eq!(config.worker_group, Some("dev".to_string()));
+        // Claim batch must stay within execution concurrency in every preset.
+        assert!(config.claim_batch_size <= config.max_concurrent_tasks);
     }
 
     #[test]

--- a/specs/durable-execution-engine.md
+++ b/specs/durable-execution-engine.md
@@ -106,6 +106,24 @@ Reasoning:
 - PostgreSQL `LISTEN/NOTIFY` through a pooler/proxy can fail intermittently and surface as protocol errors on unrelated query traffic
 - failing fast on an invalid listener URL is better than allowing a deployment that corrupts the control-plane's normal database interactions
 
+### Worker Concurrency & Sizing
+
+External/gRPC workers (`crates/worker/src/durable_worker.rs`) and the in-process worker (`crates/worker/src/unified_worker.rs`) expose three independent knobs so concurrency, claim batch size, and idle polling can be tuned separately:
+
+| Setting | Env var | Default | Purpose |
+| --- | --- | --- | --- |
+| Execution concurrency | `MAX_CONCURRENT_TASKS` | `50` | Tasks a worker runs at once / advertised capacity. |
+| Claim batch size | `CLAIM_BATCH_SIZE` | `50` (clamped to concurrency) | Upper bound on `claim_task max_tasks`, regardless of free slots. |
+| Fallback poll interval | `WORKER_POLL_INTERVAL_MS` | `100` | Base interval when push notifications are unavailable. |
+| Fallback poll backoff cap | `WORKER_POLL_BACKOFF_MAX_MS` | `5000` | Idle polling backs off exponentially from the base up to this cap. |
+
+Guidance:
+
+- **The default concurrency is intentionally modest (50, matching the default DB pool).** Historically it was `1000`, so a few replicas advertised thousands of slots and a single idle poll issued `claim_task max_tasks=1000`; when the DB was already slow this amplified pool pressure into acquire timeouts (EVE-606). 1000-way concurrency is now opt-in via `MAX_CONCURRENT_TASKS`.
+- **Raising concurrency does not raise claim cost:** the claim batch is bounded by `CLAIM_BATCH_SIZE` independently, so a high-concurrency worker still claims in modest batches.
+- **Pool sizing, not pool inflation, is the lever.** Size `DATABASE_POOL_MAX` to your managed Postgres `max_connections` (`pg_max_connections / replicas − margin`); do not raise it to mask worker over-claiming. Worker-side concurrency and claim batch should be tuned down first for small instances.
+- Effective worker settings (id, concurrency, claim batch, poll interval/backoff) are logged at worker init for troubleshooting.
+
 ### Generic Queue (Standalone Tasks)
 
 The task queue supports standalone tasks that run independently of any workflow. `TaskDefinition.workflow_id` is `Option<Uuid>` — when `None`, the task is a standalone queue entry.


### PR DESCRIPTION
## What
External/gRPC workers no longer default to 1000-way concurrency or issue `claim_task max_tasks=1000` on idle polls. Execution concurrency, claim batch size, and fallback poll interval/backoff are now independent, with safe defaults for small managed Postgres.

Resolves **EVE-606**.

## Why
`DurableWorkerConfig`/`TaskWorkerConfig` defaulted to `MAX_CONCURRENT_TASKS=1000` and a fixed 10ms fallback poll. So each worker advertised 1000 capacity, a few replicas advertised thousands, and every idle poll issued `claim_task max_tasks=1000`. Live evidence (2026-06-20): `claim_task{max_tasks=1000}` taking 3.5–4.5s alongside `pool timed out while waiting for an open connection`. The claim SQL itself is fast (~2ms via `idx_durable_task_queue_pending`); the problem is oversized defaults amplifying DB/pool pressure once the system is already slow.

## How
Three independent knobs, safe by default:

| Setting | Env var | Default |
| --- | --- | --- |
| Execution concurrency | `MAX_CONCURRENT_TASKS` | `50` (was 1000) |
| Claim batch size | `CLAIM_BATCH_SIZE` | `50`, clamped to concurrency |
| Fallback poll interval | `WORKER_POLL_INTERVAL_MS` | `100` |
| Fallback poll backoff cap | `WORKER_POLL_BACKOFF_MAX_MS` | `5000` |

- **Default concurrency 50** (mirrors the default DB pool); 1000-way is opt-in via `MAX_CONCURRENT_TASKS`.
- **Bounded claim batch**, independent of concurrency: claims are `min(free_slots, claim_batch_size)`, so even a high-concurrency worker claims in modest batches — no more `max_tasks=1000`.
- **Adaptive idle backoff**: the fallback poll doubles from the base interval up to the cap while the queue is empty, and snaps back to base on any work. Idle workers stop tight-looping `claim_task`.
- **Effective settings logged at init** (worker id, concurrency, claim batch, poll/backoff).
- Same bounding + backoff applied to the in-process unified worker. The two behaviors are pure, unit-tested helpers (`claim_limit`, `next_poll_backoff`) shared by both workers.
- Spec updated with the knobs and sizing guidance: size `DATABASE_POOL_MAX` to the managed instance; don't inflate the pool to mask over-claiming.

## Risk
- **Low–Medium.** Default concurrency drops from 1000 to 50, a deliberate behavior change (per the issue); deployments needing more set `MAX_CONCURRENT_TASKS`. No protocol/schema changes. The in-process worker is dev-only (`dev_mode()`); `production()` remains an explicit 1000-concurrency opt-in but now claims in bounded batches.
- Validated: `cargo test -p everruns-worker --lib` (103 passed, incl. new helper tests), `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`.

## Security
- Threat categories reviewed: **TM-DOS** — this change *removes* a self-inflicted DB-pool-starvation amplifier (oversized default concurrency + unbounded idle claim requests). No auth/authz/tenant/injection surface: changes are worker-side config defaults, a bounded claim count, and poll timing. New env vars are numeric (`env_or`/`env_duration_ms`), not interpolated into queries.
- Findings and resolutions: none.

## Follow-ups
No follow-ups. A true multi-worker gRPC load test was considered but `WorkerAdapters` has 30+ methods (impractical to mock); the bounded-claim and backoff guarantees are instead covered by deterministic unit tests on the shared pure helpers plus config invariants.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — default concurrency change is intentional and documented; opt back in via env
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018BtyeBwns85kyidqaHxLs4)_