### PR TITLE
feat(orgs): add org creation policy extension point for wrappers

### DIFF
--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -22,9 +22,69 @@ use everruns_durable::UpdateField;
 use super::common::{
     ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, impl_auth_state,
 };
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
+
+// ============================================================================
+// Org creation policy extension point (EVE-607)
+// ============================================================================
+
+/// Context handed to an [`OrgCreatePolicy`] before any org or membership row is
+/// written.
+///
+/// Wrappers (e.g. the SaaS distribution) use this to gate org creation on product
+/// policy — verified email, account/resource limits — without forking the OSS
+/// create-org handler or mounting a parallel `/v1/saas/orgs` endpoint. OSS remains
+/// the owner of org creation; wrappers only supply policy. See `specs/embedding.md`.
+pub struct OrgCreateContext<'a> {
+    /// The authenticated user requesting creation.
+    pub user: &'a AuthUser,
+    /// The requested organization display name (already validated non-empty and
+    /// ≤255 chars by the handler).
+    pub org_name: &'a str,
+}
+
+/// Fail-closed rejection returned by an [`OrgCreatePolicy`].
+///
+/// The `status` and `message` are surfaced directly to the API client, so the
+/// message must be safe and suitable for UI display — for example
+/// `403 Please verify your email address before continuing.`
+pub struct OrgCreateRejection {
+    /// HTTP status returned to the client (e.g. `StatusCode::FORBIDDEN`).
+    pub status: StatusCode,
+    /// User-facing message rendered by the UI.
+    pub message: String,
+}
+
+impl OrgCreateRejection {
+    /// Reject with an explicit status and user-facing message.
+    pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+        }
+    }
+
+    /// Reject with `403 Forbidden` — the common case for policy gating.
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::FORBIDDEN, message)
+    }
+}
+
+/// Pre-create policy hook for organization creation.
+///
+/// Registered via [`ServerAppBuilder::org_create_policy`](crate::ServerAppBuilder::org_create_policy).
+/// When a policy is present, OSS runs [`check`](OrgCreatePolicy::check) before
+/// persisting any org or membership row; returning `Err` aborts creation with the
+/// rejection's status and body and writes nothing. When no policy is registered,
+/// default OSS create-org behavior is unchanged.
+#[async_trait]
+pub trait OrgCreatePolicy: Send + Sync {
+    /// Decide whether the given user may create the requested organization.
+    async fn check(&self, ctx: OrgCreateContext<'_>) -> Result<(), OrgCreateRejection>;
+}
 
 /// App state for organization routes
 #[derive(Clone)]
@@ -34,6 +94,9 @@ pub struct AppState {
     pub built_in_harnesses: Vec<BuiltInHarnessDefinition>,
     pub resource_limits: crate::server::ResourceLimitsConfig,
     pub org_rate_limiter: OrgRateLimiter,
+    /// Optional wrapper-supplied pre-create policy (EVE-607). Runs before any
+    /// org/membership row is written; `None` keeps default OSS behavior.
+    pub org_create_policy: Option<Arc<dyn OrgCreatePolicy>>,
 }
 
 impl AppState {
@@ -44,6 +107,7 @@ impl AppState {
             built_in_harnesses: crate::platform::oss_built_in_harnesses(),
             resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             org_rate_limiter: OrgRateLimiter::default(),
+            org_create_policy: None,
         }
     }
 
@@ -58,6 +122,7 @@ impl AppState {
             built_in_harnesses,
             resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             org_rate_limiter: OrgRateLimiter::default(),
+            org_create_policy: None,
         }
     }
 }
@@ -246,6 +311,20 @@ pub async fn create_organization(
             ErrorResponse::new("Organization name cannot exceed 255 characters")
                 .into_response(StatusCode::BAD_REQUEST),
         );
+    }
+
+    // Pre-create policy hook (EVE-607). Wrappers gate creation here — before any
+    // org or membership row is written — and may fail closed with a UI-facing
+    // status/body. No-op when no policy is registered (default OSS behavior).
+    if let Some(policy) = &state.org_create_policy
+        && let Err(rejection) = policy
+            .check(OrgCreateContext {
+                user: &user,
+                org_name: &req.name,
+            })
+            .await
+    {
+        return Err(ErrorResponse::new(rejection.message).into_response(rejection.status));
     }
 
     // Enforce org-per-user limit (counts orgs created by this user, not memberships)
@@ -935,6 +1014,166 @@ pub async fn remove_member(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::backend::AuthBackend;
+    use crate::auth::config::{AuthConfig, AuthMode, JwtConfig};
+    use crate::auth::middleware::{AuthError, AuthMethod};
+    use crate::auth::routes::AuthConfigResponse;
+    use axum::body::Body;
+    use axum::http::Request;
+    use everruns_core::OrgMembership;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    // ---- Org create policy extension point (EVE-607) ----
+
+    /// Minimal auth backend that authenticates every request as one fixed user.
+    #[derive(Clone)]
+    struct MockAuthBackend {
+        user_id: Uuid,
+    }
+
+    #[async_trait]
+    impl AuthBackend for MockAuthBackend {
+        async fn validate_token(&self, _token: &str) -> Result<AuthUser, AuthError> {
+            Ok(AuthUser {
+                id: self.user_id,
+                email: "test@example.com".to_string(),
+                name: "Test User".to_string(),
+                roles: vec!["user".to_string()],
+                is_platform_user: true,
+                auth_method: AuthMethod::Jwt,
+                organizations: vec![OrgMembership {
+                    org_id: DEFAULT_ORG_ID,
+                    public_id: "org_00000000000000000000000000000001".to_string(),
+                    name: "Default Organization".to_string(),
+                    role: OrgRole::Owner,
+                }],
+            })
+        }
+
+        async fn validate_personal_access_token(
+            &self,
+            _token: &str,
+        ) -> Result<AuthUser, AuthError> {
+            Err(AuthError::unauthorized("not supported"))
+        }
+
+        fn auth_routes(&self) -> Option<Router> {
+            None
+        }
+
+        fn auth_config_response(&self) -> AuthConfigResponse {
+            AuthConfigResponse {
+                mode: "full".to_string(),
+                password_auth_enabled: false,
+                signup_enabled: false,
+                oauth_providers: vec![],
+            }
+        }
+    }
+
+    /// Policy that always rejects with `403` and a UI-facing message.
+    struct RejectAllPolicy {
+        message: &'static str,
+    }
+
+    #[async_trait]
+    impl OrgCreatePolicy for RejectAllPolicy {
+        async fn check(&self, _ctx: OrgCreateContext<'_>) -> Result<(), OrgCreateRejection> {
+            Err(OrgCreateRejection::forbidden(self.message))
+        }
+    }
+
+    /// Build a create-org router over an in-memory DB, optionally with a policy.
+    fn create_org_app(
+        policy: Option<Arc<dyn OrgCreatePolicy>>,
+    ) -> (Router, Arc<StorageBackend>, Uuid) {
+        let user_id = Uuid::now_v7();
+        let db = Arc::new(StorageBackend::in_memory());
+        let config = AuthConfig {
+            mode: AuthMode::Full,
+            jwt: JwtConfig {
+                secret: "test-secret-for-unit-tests-only".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let auth = AuthState::new(config, Arc::new(MockAuthBackend { user_id }));
+        let mut state = AppState::new(db.clone(), auth);
+        state.org_create_policy = policy;
+        (routes(state), db, user_id)
+    }
+
+    fn create_org_request(name: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/orgs")
+            .header("Authorization", "Bearer test-token")
+            .header("content-type", "application/json")
+            .body(Body::from(format!(r#"{{"name":"{name}"}}"#)))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_organization_succeeds_without_policy() {
+        // Default OSS behavior: no policy registered, creation proceeds.
+        let (app, db, user_id) = create_org_app(None);
+
+        let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // The org row and owner membership were persisted.
+        let count = db.count_user_created_organizations(user_id).await.unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn org_create_policy_rejects_before_db_write() {
+        let policy: Arc<dyn OrgCreatePolicy> = Arc::new(RejectAllPolicy {
+            message: "Please verify your email address before continuing.",
+        });
+        let (app, db, user_id) = create_org_app(Some(policy));
+
+        let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["detail"],
+            "Please verify your email address before continuing."
+        );
+
+        // Fail-closed: no org or membership row was written.
+        let count = db.count_user_created_organizations(user_id).await.unwrap();
+        assert_eq!(count, 0);
+        assert!(
+            db.list_user_organizations(user_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn org_create_policy_allows_creation() {
+        // A policy that returns Ok must not change default behavior.
+        struct AllowPolicy;
+        #[async_trait]
+        impl OrgCreatePolicy for AllowPolicy {
+            async fn check(&self, _ctx: OrgCreateContext<'_>) -> Result<(), OrgCreateRejection> {
+                Ok(())
+            }
+        }
+        let policy: Arc<dyn OrgCreatePolicy> = Arc::new(AllowPolicy);
+        let (app, db, user_id) = create_org_app(Some(policy));
+
+        let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let count = db.count_user_created_organizations(user_id).await.unwrap();
+        assert_eq!(count, 1);
+    }
 
     #[test]
     fn test_organization_response_fields() {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -185,6 +185,7 @@ pub struct ServerAppBuilder {
     migrations: Vec<MigrationFn>,
     background_tasks: Vec<BackgroundTaskFn>,
     personal_access_token_routes_wrap: Option<PersonalAccessTokenRoutesWrapFn>,
+    org_create_policy: Option<Arc<dyn api::organizations::OrgCreatePolicy>>,
 }
 
 impl ServerAppBuilder {
@@ -200,6 +201,7 @@ impl ServerAppBuilder {
             migrations: Vec::new(),
             background_tasks: Vec::new(),
             personal_access_token_routes_wrap: None,
+            org_create_policy: None,
         }
     }
 
@@ -281,6 +283,25 @@ impl ServerAppBuilder {
         F: FnOnce(Router) -> Router + Send + 'static,
     {
         self.personal_access_token_routes_wrap = Some(Box::new(wrap));
+        self
+    }
+
+    /// Register a pre-create policy for organization creation (EVE-607).
+    ///
+    /// The policy runs inside the OSS `POST /v1/orgs` handler before any org or
+    /// membership row is written, with access to the authenticated user and the
+    /// requested org name. Returning a rejection fails creation closed with a
+    /// UI-facing status/body and persists nothing.
+    ///
+    /// This lets wrappers (e.g. SaaS) gate creation on product policy — verified
+    /// email, account/resource limits — without forking the create-org handler or
+    /// mounting a parallel `/v1/saas/orgs` route. When not set, default OSS
+    /// behavior is unchanged. See `specs/embedding.md`.
+    pub fn org_create_policy(
+        mut self,
+        policy: Arc<dyn api::organizations::OrgCreatePolicy>,
+    ) -> Self {
+        self.org_create_policy = Some(policy);
         self
     }
 
@@ -1128,6 +1149,7 @@ impl ServerAppBuilder {
             platform_definition.built_in_harnesses().to_vec(),
         );
         organizations_state.org_rate_limiter = org_rate_limiter.clone();
+        organizations_state.org_create_policy = self.org_create_policy;
         let org_invitations_state = api::org_invitations::AppState::new(
             db.clone(),
             auth_state.clone(),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -127,6 +127,10 @@ pub mod slack_delivery;
 pub mod app_builder;
 pub use app_builder::{ServerAppBuilder, ServerContext};
 
+// Org creation policy extension point (EVE-607) — wrappers gate org creation
+// before any DB write without forking the OSS handler. See `specs/embedding.md`.
+pub use api::organizations::{OrgCreateContext, OrgCreatePolicy, OrgCreateRejection};
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -332,6 +332,51 @@ Some(my_auth_routes.merge(cli_auth_routes(cli_state)))
 
 See `crates/server/src/auth/cli_auth.rs` for the full implementation.
 
+## Org Creation Policy Extension Point
+
+OSS owns organization creation (`POST /v1/orgs`). Wrappers that must run product policy before a tenant exists — verified-email gates, account/resource limits — supply that policy through OSS instead of forking the route. This keeps OSS as the owning boundary: wrappers provide policy, not a parallel create-org handler or a `/v1/saas/orgs` shadow endpoint.
+
+`everruns-server` defines:
+
+- `OrgCreatePolicy` — async trait with `check(OrgCreateContext) -> Result<(), OrgCreateRejection>`
+- `OrgCreateContext` — borrows the authenticated `AuthUser` and the requested org name
+- `OrgCreateRejection` — `status` + user-facing `message`, with an `OrgCreateRejection::forbidden(..)` helper for the common `403` case
+
+`ServerAppBuilder::org_create_policy(Arc<dyn OrgCreatePolicy>)` installs the policy. When present, OSS runs `check` inside the create-org handler **before any org or membership row is written**. A rejection aborts creation with the rejection's status/body and persists nothing; the message is surfaced verbatim to the client, so it must be safe for UI display (e.g. `403 Please verify your email address before continuing.`). When no policy is registered, default OSS create-org behavior is unchanged.
+
+```rust,ignore
+use everruns_server::{OrgCreateContext, OrgCreatePolicy, OrgCreateRejection};
+use everruns_server::app_builder::ServerAppBuilder;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+struct VerifiedEmailPolicy;
+
+#[async_trait]
+impl OrgCreatePolicy for VerifiedEmailPolicy {
+    async fn check(&self, ctx: OrgCreateContext<'_>) -> Result<(), OrgCreateRejection> {
+        // Wrapper-owned: consult the wrapper's identity provider for ctx.user.
+        if wrapper_email_is_verified(ctx.user) {
+            Ok(())
+        } else {
+            Err(OrgCreateRejection::forbidden(
+                "Please verify your email address before continuing.",
+            ))
+        }
+    }
+}
+
+ServerAppBuilder::new(config)
+    .org_create_policy(Arc::new(VerifiedEmailPolicy))
+    .run()
+    .await?;
+```
+
+- **OSS owns**: the `OrgCreatePolicy` trait, `OrgCreateContext` / `OrgCreateRejection` types, the single pre-write call-site in the create-org handler, and the builder hook.
+- **Wrappers own**: the concrete policy (verified-email checks, plan/resource limits), the data sources it consults, and the user-facing rejection copy.
+
+This is the org-creation counterpart to the invitation surface moved into OSS by EVE-602; member management and invitations use the OSS surfaces directly.
+
 ## Non-goals
 
 This spec does not require:
@@ -349,6 +394,7 @@ Those may be added later, but they are outside the current embedding contract.
 - `crates/core/src/error_reporter.rs`
 - `apps/ui/src/providers/error-reporter-provider.tsx`
 - `crates/server/src/auth/cli_auth.rs`
+- `crates/server/src/api/organizations.rs`
 - `crates/server/src/app_builder.rs`
 - `crates/server/src/platform.rs`
 - `crates/server/src/seed.rs`


### PR DESCRIPTION
## What
Add a pre-create policy extension point for organization creation in OSS:

- `OrgCreatePolicy` async trait + `OrgCreateContext` / `OrgCreateRejection` types (`crates/server/src/api/organizations.rs`), re-exported from the crate root.
- `ServerAppBuilder::org_create_policy(Arc<dyn OrgCreatePolicy>)` hook (`crates/server/src/app_builder.rs`).
- A single call-site in the `POST /v1/orgs` handler that runs the policy **before any org or membership row is written**.
- Docs in `specs/embedding.md`.

## Why
SaaS removed PropelAuth orgs/memberships/invitations after adopting OSS invite support (EVE-602), but one workaround remained: a parallel `/v1/saas/orgs` endpoint plus a `useCreateOrganization` UI override, used only to run product policy (verified-email gate, future resource limits) before tenant resources are created. OSS mounted the create-org route directly, so SaaS could not override it without duplicate-route panics, and there was no pre-create hook.

OSS owns org creation; wrappers should supply *policy*, not fork the route. This adds the owning-boundary seam so SaaS can drop its duplicate route and hook override. Fixes EVE-607.

## How
The handler runs `state.org_create_policy.check(ctx)` after input validation and before the resource-limit count / DB writes. A rejection returns the policy's status + UI-facing message and persists nothing. The hook is an `Option`, defaulting to `None`, so default OSS behavior is unchanged. The context borrows the authenticated `AuthUser` and the requested org name; `OrgCreateRejection::forbidden(..)` covers the common `403` case (e.g. `403 Please verify your email address before continuing.`).

## Validation
- New handler-level tests (router + `oneshot` with a mock auth backend, in-memory DB):
  - `create_organization_succeeds_without_policy` — default path returns 201 and persists the org.
  - `org_create_policy_rejects_before_db_write` — policy rejection returns 403 with the message and **no** org/membership row is written (fail-closed).
  - `org_create_policy_allows_creation` — an allowing policy returns 201.
- `cargo test -p everruns-server --lib api::organizations::tests` — 7 passed.
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Smoke test (dev mode, `AUTH_MODE=none`, no policy registered): `POST /api/v1/orgs` → 201, `GET /api/v1/orgs` lists the new + default org, empty name → 400. Confirms default behavior is unchanged.

## Risk
- Low. Purely additive: a new optional hook that can only *tighten* org creation, never loosen it. Defaults to `None`, so OSS runtime behavior is byte-for-byte the same unless a wrapper registers a policy.
- The SaaS-side migration (removing `/v1/saas/orgs` and the `useCreateOrganization` override) lives in the SaaS repo and is out of scope for this OSS PR.

## Security
- Threat categories reviewed: TM-AUTHZ (policy enforcement), TM-API (`POST /v1/orgs`), TM-TENANT (org creation boundary).
- Findings and resolutions:
  - Fail-closed verified: on rejection the handler returns before any DB write (covered by `org_create_policy_rejects_before_db_write`).
  - Strictly additive gating — the policy runs alongside, not in place of, the existing per-user rate limit and org-per-user resource limit; it cannot bypass them.
  - No injection surface: the rejection `message` is wrapper-owned trusted code returned as problem+json `detail`, not reflected client input.
  - No new dependencies (`async-trait` already in use). No threat-model changes warranted (no new threat introduced).

## Follow-ups
No follow-ups. The SaaS-side removal of the duplicate route/hook is a separate change in the SaaS repository, enabled by this seam.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive, default-off)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01LXKRYGGiqPL5VQLqg3RRbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXKRYGGiqPL5VQLqg3RRbf)_