### PR TITLE
docs(session-tasks): defer recurrence/TaskDefinition primitive

### DIFF
--- a/docs/capabilities/session-schedules.md
+++ b/docs/capabilities/session-schedules.md
@@ -38,6 +38,15 @@ Cancel an active schedule.
 
 List all schedules for the current session.
 
+## Recurring background tasks
+
+Recurrence is built on schedules — there is no separate "recurring task" object to
+configure. A recurring (`cron_expression`) schedule either delivers a scheduled
+turn to the session, or, when paired with a background **monitor** task, runs a
+probe on each fire and records the result on the task's thread. This composition
+(recurring schedule + monitor) is the supported way to run periodic background
+work; see the Session Tasks documentation for monitors.
+
 ## Notes
 
 - Maximum 5 active schedules per session

--- a/docs/capabilities/session-schedules.md
+++ b/docs/capabilities/session-schedules.md
@@ -45,7 +45,7 @@ configure. A recurring (`cron_expression`) schedule either delivers a scheduled
 turn to the session, or, when paired with a background **monitor** task, runs a
 probe on each fire and records the result on the task's thread. This composition
 (recurring schedule + monitor) is the supported way to run periodic background
-work; see the Session Tasks documentation for monitors.
+work — there is no separate recurring-task primitive to configure.
 
 ## Notes
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -454,8 +454,8 @@ cadence), or is the existing schedule + monitor composition sufficient?
 **Decision: no dedicated primitive in v1 — recurrence is expressed by
 composition.** Two existing primitives already cover recurring background work:
 
-- A recurring **session schedule** (`cron_expression`, see
-  `specs/scheduled-tasks.md` / the `session_schedule` capability) fires on a cadence.
+- A recurring **session schedule** (`cron_expression`, via the `session_schedule`
+  capability — `docs/capabilities/session-schedules.md`) fires on a cadence.
 - A **monitor** task (`spawn_background` with a `schedule` arg) binds that
   schedule to a long-lived task: each fire runs the probe tool and records the
   result on the task thread (recurring monitors stay `running`; one-shot ones go

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -445,8 +445,40 @@ No backward compatibility is required; data migrates forward once:
 - `LLMSIM_DEMO=tasks` drives the full lifecycle end-to-end without an LLM
   key (see `crates/core/src/llmsim_driver.rs`).
 
+## Recurrence and task definitions (decision: defer — EVE-584)
+
+**Question:** does the system need a first-class `TaskDefinition` (a reusable
+*template* + *recurrence* primitive that instantiates fresh task instances on a
+cadence), or is the existing schedule + monitor composition sufficient?
+
+**Decision: no dedicated primitive in v1 — recurrence is expressed by
+composition.** Two existing primitives already cover recurring background work:
+
+- A recurring **session schedule** (`cron_expression`, see
+  `specs/scheduled-tasks.md` / the `session_schedule` capability) fires on a cadence.
+- A **monitor** task (`spawn_background` with a `schedule` arg) binds that
+  schedule to a long-lived task: each fire runs the probe tool and records the
+  result on the task thread (recurring monitors stay `running`; one-shot ones go
+  `succeeded`). A bare recurring schedule without a monitor simply delivers a
+  scheduled turn to the session.
+
+A separate `TaskDefinition` primitive would add a parallel concept plus
+schema/API/UI surface. Its only capability beyond the monitor model is
+"**each fire yields a distinct task instance** with its own lifecycle, result,
+and retention" (versus one long-lived monitor that accumulates messages), plus
+reusable templates instantiated across sessions. There is no concrete demand for
+either today, so building it now would be speculative surface area.
+
+**Revisit if** any of these appear: (1) a need for each recurrence to produce an
+independent task instance (own result/retention/success-history) rather than a
+single long-lived monitor; (2) reusable, parameterized task templates
+instantiated across sessions or agents; (3) a need to define the cadence
+independently of a specific session's monitor wiring. Until then, recurrence
+stays as `schedule + monitor` composition.
+
 ## Out of scope (v1)
 
 - Webhooks / push notifications on task transitions.
 - Per-org retention TTL overrides (global TTL ships first; see Retention).
-- Task definitions / recurrence (monitors ship as long-lived tasks first).
+- A dedicated task-definition / recurrence primitive — see the decision above;
+  recurrence ships as schedule + monitor composition.


### PR DESCRIPTION
## What
Records the design decision for **EVE-584**: Session Tasks will **not** get a dedicated `TaskDefinition` (template + recurrence) primitive in v1. Recurrence is expressed by composition — a recurring cron **session schedule**, optionally bound to a long-lived **monitor** task.

Resolves **EVE-584** (decision-gated; approved to proceed). The issue scoped this as "evaluate whether warranted… likely starts as a design note."

## Why
Monitors already ship as long-lived tasks linked to a session schedule, so recurring background work is achievable today. The open question was whether a first-class template/recurrence primitive is warranted. The only capability such a primitive adds over the monitor model is **distinct-per-fire task instances** (each with its own lifecycle/result/retention) plus reusable cross-session templates — and there is no concrete demand for either yet. Building it now would be speculative API/schema/UI surface.

## How
Docs/spec only — no code change:
- `specs/session-tasks.md`: replaces the bare "Task definitions / recurrence" out-of-scope bullet with a **"Recurrence and task definitions (decision: defer)"** section that states the conclusion, the composition that provides recurrence today (`schedule + monitor`), and explicit **revisit triggers** (independent per-fire task instances; reusable templates; cadence decoupled from monitor wiring).
- `docs/capabilities/session-schedules.md` (public docs): adds a short "Recurring background tasks" note clarifying that recurrence is built on schedules (+ monitors), with no separate recurring-task object to configure.

## Risk
- **None** (documentation/decision only).

## Security
- No security-relevant code changes — docs/spec only.

## Follow-ups
No follow-ups. The revisit triggers are recorded in the spec for if/when a dedicated primitive becomes warranted.

## Checklist
- [x] Tests added or updated — N/A (docs/decision only)
- [x] Backward compatibility considered — no behavior change
- [x] Security review performed against relevant threat model categories — N/A, documented
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018BtyeBwns85kyidqaHxLs4)_