### PR TITLE
feat(ui): per-task drill-down on the session Tasks tab

### DIFF
--- a/apps/ui/src/__tests__/resources-tasks-drilldown.test.tsx
+++ b/apps/ui/src/__tests__/resources-tasks-drilldown.test.tsx
@@ -1,0 +1,106 @@
+// EVE-581: the Tasks tab exposes a per-task drill-down (lifecycle + message
+// thread). These tests mock the task hooks and assert the drill-down renders the
+// thread on demand.
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import type { SessionTask, SessionTaskDetail } from "@/lib/api/types";
+
+const mockUseSessionTasks = jest.fn();
+const mockUseSessionTask = jest.fn();
+const mockUseCancelSessionTask = jest.fn(() => ({ mutate: jest.fn(), isPending: false }));
+const mockUseSendTaskMessage = jest.fn(() => ({
+  mutate: jest.fn(),
+  isPending: false,
+  isError: false,
+  error: null,
+}));
+const mockUseSessionResources = jest.fn(() => ({ data: [], isLoading: false, error: null }));
+
+jest.mock("@/hooks/use-session-tasks", () => ({
+  useSessionTasks: (...args: unknown[]) => mockUseSessionTasks(...args),
+  useSessionTask: (...args: unknown[]) => mockUseSessionTask(...args),
+  useCancelSessionTask: (...args: unknown[]) => mockUseCancelSessionTask(...args),
+  useSendTaskMessage: (...args: unknown[]) => mockUseSendTaskMessage(...args),
+}));
+
+jest.mock("@/hooks/use-session-resources", () => ({
+  useSessionResources: (...args: unknown[]) => mockUseSessionResources(...args),
+}));
+
+jest.mock("../app/(main)/sessions/[sessionId]/session-context", () => ({
+  useSessionContext: () => ({ sessionId: "session-1" }),
+}));
+
+// eslint-disable-next-line import/first
+import ResourcesPage from "../app/(main)/sessions/[sessionId]/resources/page";
+
+const baseTask: SessionTask = {
+  id: "task_abc",
+  session_id: "session-1",
+  kind: "subagent",
+  display_name: "Test Runner",
+  state: "running",
+  attempt: 1,
+  wake_policy: "always",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+} as SessionTask;
+
+const detail: SessionTaskDetail = {
+  task: baseTask,
+  messages: [
+    {
+      id: "tmsg_1",
+      task_id: "task_abc",
+      direction: "outbound",
+      content: [{ type: "text", text: "Working on the test suite" }],
+      created_at: new Date().toISOString(),
+    },
+    {
+      id: "tmsg_2",
+      task_id: "task_abc",
+      direction: "inbound",
+      content: [{ type: "text", text: "Focus on the failing case" }],
+      created_at: new Date().toISOString(),
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseSessionTasks.mockReturnValue({ data: [baseTask], isLoading: false, error: null });
+  mockUseSessionTask.mockReturnValue({ data: detail, isLoading: false, error: null });
+});
+
+describe("Tasks tab drill-down", () => {
+  it("shows the task summary but hides the thread until expanded", () => {
+    render(<ResourcesPage />);
+    expect(screen.getByText("Test Runner")).toBeInTheDocument();
+    // Thread content is not rendered before expansion.
+    expect(screen.queryByText("Working on the test suite")).not.toBeInTheDocument();
+    expect(screen.queryByText("Message thread")).not.toBeInTheDocument();
+  });
+
+  it("reveals the lifecycle timeline and bidirectional thread when expanded", () => {
+    render(<ResourcesPage />);
+    fireEvent.click(screen.getByRole("button", { name: /show task details/i }));
+
+    expect(screen.getByText("Message thread")).toBeInTheDocument();
+    expect(screen.getByText("Working on the test suite")).toBeInTheDocument();
+    expect(screen.getByText("Focus on the failing case")).toBeInTheDocument();
+    // Direction labels distinguish inbound vs outbound.
+    expect(screen.getByText(/Session → task/)).toBeInTheDocument();
+    expect(screen.getByText(/Task → session/)).toBeInTheDocument();
+  });
+
+  it("shows an empty-thread message when a task has no messages", () => {
+    mockUseSessionTask.mockReturnValue({
+      data: { task: baseTask, messages: [] },
+      isLoading: false,
+      error: null,
+    });
+    render(<ResourcesPage />);
+    fireEvent.click(screen.getByRole("button", { name: /show task details/i }));
+    expect(screen.getByText(/No messages exchanged with this task yet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/resources-tasks-drilldown.test.tsx
+++ b/apps/ui/src/__tests__/resources-tasks-drilldown.test.tsx
@@ -16,15 +16,18 @@ const mockUseSendTaskMessage = jest.fn(() => ({
 }));
 const mockUseSessionResources = jest.fn(() => ({ data: [], isLoading: false, error: null }));
 
+// Wrappers defer the reference (the mock factory is hoisted above the consts).
+// They take no args — the mocks return via mockReturnValue and the page uses the
+// real hook types — so callers passing args at runtime is harmless.
 jest.mock("@/hooks/use-session-tasks", () => ({
-  useSessionTasks: (...args: unknown[]) => mockUseSessionTasks(...args),
-  useSessionTask: (...args: unknown[]) => mockUseSessionTask(...args),
-  useCancelSessionTask: (...args: unknown[]) => mockUseCancelSessionTask(...args),
-  useSendTaskMessage: (...args: unknown[]) => mockUseSendTaskMessage(...args),
+  useSessionTasks: () => mockUseSessionTasks(),
+  useSessionTask: () => mockUseSessionTask(),
+  useCancelSessionTask: () => mockUseCancelSessionTask(),
+  useSendTaskMessage: () => mockUseSendTaskMessage(),
 }));
 
 jest.mock("@/hooks/use-session-resources", () => ({
-  useSessionResources: (...args: unknown[]) => mockUseSessionResources(...args),
+  useSessionResources: () => mockUseSessionResources(),
 }));
 
 jest.mock("../app/(main)/sessions/[sessionId]/session-context", () => ({
@@ -44,7 +47,7 @@ const baseTask: SessionTask = {
   wake_policy: "always",
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
-} as SessionTask;
+} as unknown as SessionTask;
 
 const detail: SessionTaskDetail = {
   task: baseTask,

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
@@ -11,8 +11,11 @@ import {
   AlertCircle,
   Bot,
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   Clock3,
   ListTodo,
+  MessageSquare,
   ServerCrash,
   Wrench,
   XCircle,
@@ -21,6 +24,7 @@ import { useSessionResources } from "@/hooks/use-session-resources";
 import {
   useCancelSessionTask,
   useSendTaskMessage,
+  useSessionTask,
   useSessionTasks,
 } from "@/hooks/use-session-tasks";
 import { useSessionContext } from "../session-context";
@@ -31,7 +35,12 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/formatting";
 import { isTerminalTaskState } from "@/lib/api/types";
-import type { SessionResourceEntry, SessionTask, SessionTaskState } from "@/lib/api/types";
+import type {
+  SessionResourceEntry,
+  SessionTask,
+  SessionTaskState,
+  TaskMessage,
+} from "@/lib/api/types";
 
 // ============================================
 // Tasks
@@ -127,8 +136,88 @@ function TaskInputPrompt({
   );
 }
 
+/** One message in a task's bidirectional thread. */
+function TaskMessageRow({ message }: { message: TaskMessage }) {
+  const inbound = message.direction === "inbound";
+  return (
+    <div className={`flex ${inbound ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[85%] rounded-lg px-3 py-1.5 ${
+          inbound ? "bg-primary/10 text-foreground" : "bg-muted text-foreground"
+        }`}
+      >
+        <div className="mb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+          {inbound ? "Session → task" : "Task → session"} · {formatRelativeTime(message.created_at)}
+        </div>
+        {message.content.map((part, index) =>
+          part.type === "text" ? (
+            <div key={index} className="whitespace-pre-wrap break-words text-sm">
+              {part.text}
+            </div>
+          ) : (
+            <pre
+              key={index}
+              className="overflow-x-auto whitespace-pre-wrap break-words text-xs text-muted-foreground"
+            >
+              {JSON.stringify(part.data, null, 2)}
+            </pre>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Per-task drill-down: lifecycle timeline + the live message thread.
+ *  Fetched lazily when the card is expanded; the list hook's SSE stream keeps
+ *  the thread fresh by invalidating this task's detail key on task.message.*. */
+function TaskDrilldown({ task, sessionId }: { task: SessionTask; sessionId: string | undefined }) {
+  const { data: detail, isLoading, error } = useSessionTask(sessionId, task.id);
+  const messages = detail?.messages ?? [];
+
+  return (
+    <div className="mt-3 space-y-3 border-t border-border/60 pt-3">
+      <div className="grid gap-0.5 text-xs text-muted-foreground">
+        <div>Created {formatRelativeTime(task.created_at)}</div>
+        {task.started_at ? <div>Started {formatRelativeTime(task.started_at)}</div> : null}
+        {task.finished_at ? (
+          <div>Finished {formatRelativeTime(task.finished_at)}</div>
+        ) : (
+          <div>Last update {formatRelativeTime(task.updated_at)}</div>
+        )}
+        {task.state_detail ? <div>Detail: {task.state_detail}</div> : null}
+        {task.attempt > 1 ? <div>Attempt: {task.attempt}</div> : null}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <MessageSquare className="h-3.5 w-3.5" /> Message thread
+        </div>
+        {isLoading ? (
+          <Skeleton className="h-16 w-full" />
+        ) : error ? (
+          <div className="text-xs text-destructive">
+            {error instanceof Error ? error.message : "Failed to load thread"}
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="text-xs text-muted-foreground">
+            No messages exchanged with this task yet.
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            {messages.map((message) => (
+              <TaskMessageRow key={message.id} message={message} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function TaskCard({ task, sessionId }: { task: SessionTask; sessionId: string | undefined }) {
   const cancelTask = useCancelSessionTask(sessionId);
+  const [expanded, setExpanded] = useState(false);
   const terminal = isTerminalTaskState(task.state);
   const artifacts = task.artifacts ?? [];
   const childSessionId = task.links?.child_session_id;
@@ -160,6 +249,20 @@ function TaskCard({ task, sessionId }: { task: SessionTask; sessionId: string | 
                 Cancel
               </Button>
             )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+              aria-label={expanded ? "Hide task details" : "Show task details"}
+            >
+              {expanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              Details
+            </Button>
           </div>
         </div>
       </CardHeader>
@@ -240,6 +343,7 @@ function TaskCard({ task, sessionId }: { task: SessionTask; sessionId: string | 
           </div>
         ) : null}
         <TaskInputPrompt task={task} sessionId={sessionId} />
+        {expanded ? <TaskDrilldown task={task} sessionId={sessionId} /> : null}
       </CardContent>
     </Card>
   );

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
@@ -174,19 +174,22 @@ function TaskMessageRow({ message }: { message: TaskMessage }) {
 function TaskDrilldown({ task, sessionId }: { task: SessionTask; sessionId: string | undefined }) {
   const { data: detail, isLoading, error } = useSessionTask(sessionId, task.id);
   const messages = detail?.messages ?? [];
+  // Render the timeline from the freshly-fetched snapshot when available so the
+  // lifecycle and the thread stay consistent; fall back to the list snapshot.
+  const snapshot = detail?.task ?? task;
 
   return (
     <div className="mt-3 space-y-3 border-t border-border/60 pt-3">
       <div className="grid gap-0.5 text-xs text-muted-foreground">
-        <div>Created {formatRelativeTime(task.created_at)}</div>
-        {task.started_at ? <div>Started {formatRelativeTime(task.started_at)}</div> : null}
-        {task.finished_at ? (
-          <div>Finished {formatRelativeTime(task.finished_at)}</div>
+        <div>Created {formatRelativeTime(snapshot.created_at)}</div>
+        {snapshot.started_at ? <div>Started {formatRelativeTime(snapshot.started_at)}</div> : null}
+        {snapshot.finished_at ? (
+          <div>Finished {formatRelativeTime(snapshot.finished_at)}</div>
         ) : (
-          <div>Last update {formatRelativeTime(task.updated_at)}</div>
+          <div>Last update {formatRelativeTime(snapshot.updated_at)}</div>
         )}
-        {task.state_detail ? <div>Detail: {task.state_detail}</div> : null}
-        {task.attempt > 1 ? <div>Attempt: {task.attempt}</div> : null}
+        {snapshot.state_detail ? <div>Detail: {snapshot.state_detail}</div> : null}
+        {snapshot.attempt > 1 ? <div>Attempt: {snapshot.attempt}</div> : null}
       </div>
 
       <div className="space-y-2">

--- a/apps/ui/src/hooks/use-session-tasks.ts
+++ b/apps/ui/src/hooks/use-session-tasks.ts
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   cancelSessionTask,
+  getSessionTask,
   listSessionTasks,
   postSessionTaskMessage,
 } from "@/lib/api/session-tasks";
@@ -148,6 +149,21 @@ export function useSessionTasks(sessionId: string | undefined) {
     ...query,
     isLoading: orgLoading || query.isLoading,
   };
+}
+
+/** Fetch one task's snapshot plus its message thread.
+ *
+ * Live updates arrive through the list hook's SSE stream, which invalidates this
+ * detail key on `task.message.*` events — so mount `useSessionTasks` on the same
+ * view (the Tasks tab does) for the thread to stay current. */
+export function useSessionTask(sessionId: string | undefined, taskId: string | undefined) {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+  return useQuery({
+    queryKey: queryKeys.sessionTasks.detail(sessionId!, taskId!),
+    queryFn: () => getSessionTask(sessionId!, taskId!),
+    enabled: !!org && !!sessionId && !!taskId,
+  });
 }
 
 /** Request cooperative cancellation of a task; patches the returned snapshot into the list cache. */


### PR DESCRIPTION
## What
Adds a per-task **drill-down** to the session **Tasks** tab (`/sessions/{id}/resources`). Each task card now expands to show its full activity, not just the summary.

Resolves **EVE-581**.

## Why
The Tasks tab shipped with summary cards (state, progress, summary, artifacts, input prompt), but the original requirement — "UI showing session activity with live changes" — also wanted a per-task drill-down: the bidirectional message thread, the lifecycle, and live `task.*` updates. The detail endpoint (`getSessionTask`, returning the task snapshot + message thread) existed but was unused in the UI.

## How
- **`useSessionTask(sessionId, taskId)`** detail hook (`getSessionTask`). The thread stays live with **no new SSE wiring**: the existing list hook (`useSessionTasks`, mounted on the same tab) already invalidates the per-task detail key on `task.message.sent` / `task.message.received` events.
- **Drill-down** on each `TaskCard`, behind a "Details" expand toggle (lazily fetched on expand):
  - **Lifecycle timeline** — created / started / finished (or last-update) timestamps, `state_detail`, and attempt count.
  - **Bidirectional message thread** — inbound (session → task) vs outbound (task → session) bubbles, rendering text and data parts.
- Reuses existing primitives (`Card`, `Badge`, `Skeleton`, query keys, API client) and the established snapshot-then-delta live-update pattern.

## Risk
- **Low.** Additive, presentational; no API/schema changes. Reuses proven hooks/components.
- Validated: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build` all clean; `pnpm test` → **1002 tests pass** (999 existing + 3 new for the drill-down expand/collapse + thread rendering).

## Security
- Threat categories reviewed: **none materially affected.** Frontend-only; reads the existing org-scoped, authenticated `GET /v1/sessions/{id}/tasks/{taskId}` endpoint via the shared API client. No new endpoints, inputs, or rendering of untrusted HTML (text/data parts render as text / pretty-printed JSON, not `dangerouslySetInnerHTML`).

## Follow-ups
No follow-ups. (Per-fire/state *history* beyond current `state_detail` + timestamps is not persisted in the task model — only the current snapshot is — so it is intentionally not shown; the lifecycle timeline covers the available lifecycle data.)

## Checklist
- [x] Tests added or updated — 3 new tests for the drill-down
- [x] Backward compatibility considered — additive UI
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018BtyeBwns85kyidqaHxLs4)_