### PR TITLE
feat(onboarding): add OSS-owned zero-org onboarding surface

### DIFF
--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -34,6 +34,9 @@ const authState = {
 
 const orgState = {
   isLoading: false,
+  // Non-empty so the zero-org onboarding redirect doesn't fire in these
+  // auth-availability scenarios.
+  organizations: [{ public_id: "org-1" }] as Array<{ public_id: string }>,
 };
 
 jest.mock("next/navigation", () => ({

--- a/apps/ui/src/__tests__/onboarding-layout.test.tsx
+++ b/apps/ui/src/__tests__/onboarding-layout.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import OnboardingLayout from "@/app/(onboarding)/layout";
+
+const mockReplace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/onboarding",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const authState = {
+  isAuthenticated: true,
+  isLoading: false,
+  requiresAuth: true,
+  authUnavailable: false,
+};
+const orgState = {
+  organizations: [] as Array<{ public_id: string }>,
+  isLoading: false,
+};
+jest.mock("@/providers/auth-provider", () => ({ useAuth: () => authState }));
+jest.mock("@/providers/org-provider", () => ({ useOrg: () => orgState }));
+
+describe("OnboardingLayout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    authState.requiresAuth = true;
+    authState.authUnavailable = false;
+    orgState.organizations = [];
+    orgState.isLoading = false;
+  });
+
+  it("renders children for an authenticated zero-org user", () => {
+    render(
+      <OnboardingLayout>
+        <div>Onboarding</div>
+      </OnboardingLayout>,
+    );
+    expect(screen.getByText("Onboarding")).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("shows the auth-unavailable state instead of a blank screen", () => {
+    authState.authUnavailable = true;
+    authState.isAuthenticated = false;
+
+    render(
+      <OnboardingLayout>
+        <div>Onboarding</div>
+      </OnboardingLayout>,
+    );
+
+    expect(screen.getByText("Authentication unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Onboarding")).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("redirects users who already have an org to the dashboard", async () => {
+    orgState.organizations = [{ public_id: "org-1" }];
+
+    render(
+      <OnboardingLayout>
+        <div>Onboarding</div>
+      </OnboardingLayout>,
+    );
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/dashboard"));
+    expect(screen.queryByText("Onboarding")).not.toBeInTheDocument();
+  });
+
+  it("redirects unauthenticated users to login", async () => {
+    authState.isAuthenticated = false;
+
+    render(
+      <OnboardingLayout>
+        <div>Onboarding</div>
+      </OnboardingLayout>,
+    );
+
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining("/login")),
+    );
+    expect(screen.queryByText("Onboarding")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/use-zero-org-redirect.test.tsx
+++ b/apps/ui/src/__tests__/use-zero-org-redirect.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from "@testing-library/react";
+import { useZeroOrgRedirect } from "@/components/onboarding/use-zero-org-redirect";
+
+const mockReplace = jest.fn();
+const mockPathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => mockPathname(),
+}));
+
+const authState = {
+  isAuthenticated: true,
+  requiresAuth: true,
+  isLoading: false,
+};
+const orgState = {
+  organizations: [] as Array<{ public_id: string }>,
+  isLoading: false,
+};
+jest.mock("@/providers/auth-provider", () => ({ useAuth: () => authState }));
+jest.mock("@/providers/org-provider", () => ({ useOrg: () => orgState }));
+
+describe("useZeroOrgRedirect", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockPathname.mockReturnValue("/dashboard");
+    authState.isAuthenticated = true;
+    authState.requiresAuth = true;
+    authState.isLoading = false;
+    orgState.organizations = [];
+    orgState.isLoading = false;
+  });
+
+  it("redirects authenticated zero-org users to onboarding", () => {
+    const { result } = renderHook(() => useZeroOrgRedirect());
+    expect(result.current).toBe(true);
+    expect(mockReplace).toHaveBeenCalledWith("/onboarding");
+  });
+
+  it("does not redirect when the user has an org", () => {
+    orgState.organizations = [{ public_id: "org-1" }];
+    const { result } = renderHook(() => useZeroOrgRedirect());
+    expect(result.current).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect while auth or org state is loading", () => {
+    orgState.isLoading = true;
+    const { result } = renderHook(() => useZeroOrgRedirect());
+    expect(result.current).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect when auth is not required (OSS none mode)", () => {
+    authState.requiresAuth = false;
+    const { result } = renderHook(() => useZeroOrgRedirect());
+    expect(result.current).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect when already on the onboarding route", () => {
+    mockPathname.mockReturnValue("/onboarding");
+    const { result } = renderHook(() => useZeroOrgRedirect());
+    expect(result.current).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/__tests__/zero-org-onboarding.test.tsx
+++ b/apps/ui/src/__tests__/zero-org-onboarding.test.tsx
@@ -76,6 +76,19 @@ describe("ZeroOrgOnboarding", () => {
     expect(screen.getByText(/failed to create organization: boom/i)).toBeInTheDocument();
   });
 
+  it("swallows a create rejection without redirecting (no unhandled rejection)", async () => {
+    mockMutateAsync.mockRejectedValue(new Error("boom"));
+
+    render(<ZeroOrgOnboarding />);
+
+    fireEvent.change(screen.getByLabelText("Organization name"), { target: { value: "Acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /create organization/i }));
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledWith({ name: "Acme" }));
+    expect(mockSetCurrentOrg).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("renders a wrapper policy-blocked gate instead of the form", () => {
     const usePolicy: UseZeroOrgPolicy = () => ({
       status: "blocked",

--- a/apps/ui/src/__tests__/zero-org-onboarding.test.tsx
+++ b/apps/ui/src/__tests__/zero-org-onboarding.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  ZeroOrgOnboarding,
+  type UseZeroOrgPolicy,
+} from "@/components/onboarding/zero-org-onboarding";
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+}));
+
+// Mock org provider
+const mockSetCurrentOrg = jest.fn();
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({ setCurrentOrg: mockSetCurrentOrg }),
+}));
+
+// Mock the default create-organization hook
+const mockMutateAsync = jest.fn();
+const createOrgState = {
+  mutateAsync: mockMutateAsync,
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+};
+jest.mock("@/hooks/use-organizations", () => ({
+  useCreateOrganization: () => createOrgState,
+}));
+
+describe("ZeroOrgOnboarding", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockMutateAsync.mockClear();
+    mockSetCurrentOrg.mockClear();
+    createOrgState.isPending = false;
+    createOrgState.isError = false;
+    createOrgState.error = null;
+  });
+
+  it("creates the first org and redirects to setup (default OSS flow)", async () => {
+    mockMutateAsync.mockResolvedValue({ id: "org_new123", name: "Acme" });
+
+    render(<ZeroOrgOnboarding />);
+
+    const input = screen.getByLabelText("Organization name");
+    fireEvent.change(input, { target: { value: "Acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /create organization/i }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({ name: "Acme" });
+      expect(mockSetCurrentOrg).toHaveBeenCalledWith({
+        public_id: "org_new123",
+        name: "Acme",
+        role: "owner",
+      });
+      expect(mockPush).toHaveBeenCalledWith("/orgs/org_new123/setup");
+    });
+  });
+
+  it("does not submit when the name is blank", () => {
+    render(<ZeroOrgOnboarding />);
+
+    const submit = screen.getByRole("button", { name: /create organization/i });
+    expect(submit).toBeDisabled();
+    fireEvent.click(submit);
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a create error", () => {
+    createOrgState.isError = true;
+    createOrgState.error = new Error("boom");
+
+    render(<ZeroOrgOnboarding />);
+
+    expect(screen.getByText(/failed to create organization: boom/i)).toBeInTheDocument();
+  });
+
+  it("renders a wrapper policy-blocked gate instead of the form", () => {
+    const usePolicy: UseZeroOrgPolicy = () => ({
+      status: "blocked",
+      title: "Verify your email",
+      body: "Confirm your email before creating an organization.",
+      actions: <button type="button">Resend email</button>,
+    });
+
+    render(<ZeroOrgOnboarding usePolicy={usePolicy} />);
+
+    expect(screen.getByText("Verify your email")).toBeInTheDocument();
+    expect(
+      screen.getByText("Confirm your email before creating an organization."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resend email" })).toBeInTheDocument();
+    // Form is hidden while blocked
+    expect(screen.queryByLabelText("Organization name")).not.toBeInTheDocument();
+  });
+
+  it("renders a loading state from the policy hook", () => {
+    const usePolicy: UseZeroOrgPolicy = () => ({ status: "loading" });
+
+    render(<ZeroOrgOnboarding usePolicy={usePolicy} />);
+
+    expect(screen.queryByLabelText("Organization name")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create organization/i })).not.toBeInTheDocument();
+  });
+
+  it("honors a wrapper create-org override", async () => {
+    const overrideMutate = jest.fn().mockResolvedValue({ id: "org_saas", name: "SaaS Co" });
+    const useCreateOrg = (() => ({
+      mutateAsync: overrideMutate,
+      isPending: false,
+      isError: false,
+      error: null,
+    })) as unknown as typeof import("@/hooks/use-organizations").useCreateOrganization;
+
+    render(<ZeroOrgOnboarding useCreateOrg={useCreateOrg} />);
+
+    fireEvent.change(screen.getByLabelText("Organization name"), {
+      target: { value: "SaaS Co" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create organization/i }));
+
+    await waitFor(() => {
+      expect(overrideMutate).toHaveBeenCalledWith({ name: "SaaS Co" });
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/orgs/org_saas/setup");
+    });
+  });
+});

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -3,11 +3,10 @@
 // Main app layout with sidebar, auth guard, and global command palette
 import { Suspense, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { Sidebar } from "@/components/layout/sidebar";
 import { CommandPalette } from "@/components/command-palette";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AuthUnavailableState } from "@/components/layout/auth-unavailable-state";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
 import {
   getLoginRedirectPath,
@@ -22,28 +21,6 @@ import { useZeroOrgRedirect } from "@/components/onboarding/use-zero-org-redirec
 
 interface MainLayoutProps {
   children: React.ReactNode;
-}
-
-function AuthUnavailableState() {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
-      <Card className="w-full max-w-lg">
-        <CardHeader className="items-center text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-            <AlertTriangle className="h-6 w-6 text-destructive" />
-          </div>
-          <CardTitle>Authentication unavailable</CardTitle>
-          <CardDescription>
-            We couldn&apos;t verify your authentication state. Protected routes stay blocked until
-            auth bootstrap succeeds.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex justify-center">
-          <Button onClick={() => window.location.reload()}>Retry</Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
 }
 
 function MainLayoutInner({ children }: MainLayoutProps) {

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -18,6 +18,7 @@ import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { NotificationsProvider } from "@/providers/notifications-provider";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { useZeroOrgRedirect } from "@/components/onboarding/use-zero-org-redirect";
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -53,6 +54,10 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   const { isLoading: orgLoading } = useOrg();
   const notificationsEnabled = useFeatureFlag("notifications");
   const commandPalette = useCommandPaletteState();
+
+  // Authenticated users with zero orgs are redirected to onboarding. Reuses the
+  // OSS redirect hook so SaaS-style wrappers don't duplicate it.
+  const redirectingToOnboarding = useZeroOrgRedirect();
 
   // Combined loading state - wait for both auth and org to initialize
   const isLoading = authLoading || orgLoading;
@@ -97,6 +102,11 @@ function MainLayoutInner({ children }: MainLayoutProps) {
 
   // If auth required but not authenticated, show nothing (will redirect)
   if (requiresAuth && !isAuthenticated) {
+    return null;
+  }
+
+  // Zero-org users are being redirected to onboarding; don't flash the shell.
+  if (redirectingToOnboarding) {
     return null;
   }
 

--- a/apps/ui/src/app/(onboarding)/layout.tsx
+++ b/apps/ui/src/app/(onboarding)/layout.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// Onboarding layout — centered, no sidebar. Guards the zero-org onboarding
+// surface: requires auth, and bounces users who already belong to an org back
+// to the app so onboarding only renders for genuine zero-org users.
+import { Suspense, useEffect } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { getLoginRedirectPath } from "@/lib/auth-redirect";
+import { useAuth } from "@/providers/auth-provider";
+import { useOrg } from "@/providers/org-provider";
+
+function LoadingScreen() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+function OnboardingLayoutInner({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { isAuthenticated, isLoading: authLoading, requiresAuth, authUnavailable } = useAuth();
+  const { organizations, isLoading: orgLoading } = useOrg();
+
+  const isLoading = authLoading || orgLoading;
+
+  // Redirect to login if auth is required but the user is not authenticated.
+  useEffect(() => {
+    if (!authLoading && !authUnavailable && requiresAuth && !isAuthenticated) {
+      router.replace(getLoginRedirectPath(pathname, searchParams));
+    }
+  }, [authLoading, authUnavailable, requiresAuth, isAuthenticated, router, pathname, searchParams]);
+
+  // Users that already have an org don't belong on onboarding — send them in.
+  useEffect(() => {
+    if (!isLoading && isAuthenticated && organizations.length > 0) {
+      router.replace("/dashboard");
+    }
+  }, [isLoading, isAuthenticated, organizations.length, router]);
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  // Will redirect to login; render nothing in the meantime.
+  if (requiresAuth && !isAuthenticated) {
+    return null;
+  }
+
+  // Will redirect to the app; render nothing in the meantime.
+  if (organizations.length > 0) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+
+export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <OnboardingLayoutInner>{children}</OnboardingLayoutInner>
+    </Suspense>
+  );
+}

--- a/apps/ui/src/app/(onboarding)/layout.tsx
+++ b/apps/ui/src/app/(onboarding)/layout.tsx
@@ -6,6 +6,7 @@
 import { Suspense, useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
+import { AuthUnavailableState } from "@/components/layout/auth-unavailable-state";
 import { getLoginRedirectPath } from "@/lib/auth-redirect";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
@@ -43,6 +44,12 @@ function OnboardingLayoutInner({ children }: { children: React.ReactNode }) {
 
   if (isLoading) {
     return <LoadingScreen />;
+  }
+
+  // Auth bootstrap failed — show the recoverable error instead of a blank
+  // screen (mirrors the main layout).
+  if (authUnavailable) {
+    return <AuthUnavailableState />;
   }
 
   // Will redirect to login; render nothing in the meantime.

--- a/apps/ui/src/app/(onboarding)/onboarding/page.tsx
+++ b/apps/ui/src/app/(onboarding)/onboarding/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { ZeroOrgOnboarding } from "@/components/onboarding/zero-org-onboarding";
+import { usePageTitle } from "@/hooks";
+
+export default function OnboardingPage() {
+  usePageTitle("Get started");
+  return <ZeroOrgOnboarding />;
+}

--- a/apps/ui/src/components/layout/auth-unavailable-state.tsx
+++ b/apps/ui/src/components/layout/auth-unavailable-state.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Shown when auth bootstrap fails (config or current-user fetch errors that are
+ * not a plain 401). Shared by the main and onboarding layouts so protected
+ * surfaces present the same recoverable error instead of a blank screen.
+ */
+export function AuthUnavailableState() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-lg">
+        <CardHeader className="items-center text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <AlertTriangle className="h-6 w-6 text-destructive" />
+          </div>
+          <CardTitle>Authentication unavailable</CardTitle>
+          <CardDescription>
+            We couldn&apos;t verify your authentication state. Protected routes stay blocked until
+            auth bootstrap succeeds.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button onClick={() => window.location.reload()}>Retry</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/components/onboarding/use-zero-org-redirect.ts
+++ b/apps/ui/src/components/onboarding/use-zero-org-redirect.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useAuth } from "@/providers/auth-provider";
+import { useOrg } from "@/providers/org-provider";
+
+/** Route for the OSS-owned zero-org onboarding surface. */
+export const ONBOARDING_PATH = "/onboarding";
+
+/**
+ * Redirects authenticated users with zero organizations to the onboarding
+ * surface, returning `true` while the redirect is pending so callers can avoid
+ * flashing the app shell.
+ *
+ * Decision: exported so SaaS-style wrappers reuse the OSS redirect from their
+ * own main layout instead of duplicating it. No-op while auth/org state is
+ * loading, when auth is not required (OSS seeds a default org so there is never
+ * a zero-org state), once the user belongs to at least one org, or while
+ * already on the onboarding route.
+ */
+export function useZeroOrgRedirect(): boolean {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isAuthenticated, requiresAuth, isLoading: authLoading } = useAuth();
+  const { organizations, isLoading: orgLoading } = useOrg();
+
+  const shouldRedirect =
+    !authLoading &&
+    !orgLoading &&
+    requiresAuth &&
+    isAuthenticated &&
+    organizations.length === 0 &&
+    pathname !== ONBOARDING_PATH;
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      router.replace(ONBOARDING_PATH);
+    }
+  }, [shouldRedirect, router]);
+
+  return shouldRedirect;
+}

--- a/apps/ui/src/components/onboarding/zero-org-onboarding.tsx
+++ b/apps/ui/src/components/onboarding/zero-org-onboarding.tsx
@@ -66,9 +66,14 @@ export function ZeroOrgOnboarding({
     event.preventDefault();
     const trimmed = name.trim();
     if (!trimmed) return;
-    const org = await createOrg.mutateAsync({ name: trimmed });
-    setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
-    router.push(`/orgs/${org.id}/setup`);
+    try {
+      const org = await createOrg.mutateAsync({ name: trimmed });
+      setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
+      router.push(`/orgs/${org.id}/setup`);
+    } catch {
+      // Failure is surfaced via createOrg.isError / createOrg.error below;
+      // swallow the rejection so it isn't an unhandled promise rejection.
+    }
   };
 
   return (

--- a/apps/ui/src/components/onboarding/zero-org-onboarding.tsx
+++ b/apps/ui/src/components/onboarding/zero-org-onboarding.tsx
@@ -1,0 +1,128 @@
+/**
+ * OSS-owned zero-organization onboarding surface.
+ *
+ * Decision: SaaS-style wrappers compose this surface through extension points
+ * instead of forking the whole page. The OSS component owns the layout, the
+ * org-name form, current-org selection after create, and the `/orgs/{id}/setup`
+ * redirect. Wrappers only supply policy/status and (optionally) a create
+ * override:
+ *  - `usePolicy` decides whether the form is shown, replaced by a blocked gate
+ *    (e.g. "Verify your email"), or still loading.
+ *  - `useCreateOrg` overrides the create mutation while keeping the OSS layout,
+ *    current-org selection, and setup redirect.
+ */
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { Building2, Loader2 } from "lucide-react";
+import { useCreateOrganization } from "@/hooks/use-organizations";
+import { useOrg } from "@/providers/org-provider";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/** State returned by a zero-org policy hook. */
+export type ZeroOrgPolicyState =
+  | { status: "loading" }
+  | { status: "ready" }
+  | {
+      /** Block org creation behind a wrapper gate (e.g. email verification). */
+      status: "blocked";
+      title: string;
+      body?: ReactNode;
+      actions?: ReactNode;
+    };
+
+export type UseZeroOrgPolicy = () => ZeroOrgPolicyState;
+
+/** Default OSS policy: any authenticated user may create their first org. */
+export const useReadyZeroOrgPolicy: UseZeroOrgPolicy = () => ({ status: "ready" });
+
+export interface ZeroOrgOnboardingProps {
+  /** Policy hook gating the form. Defaults to always-ready (OSS behavior). */
+  usePolicy?: UseZeroOrgPolicy;
+  /**
+   * Create-organization mutation hook. Defaults to the OSS
+   * `useCreateOrganization`. Overrides must expose the same
+   * `{ mutateAsync, isPending, isError, error }` shape and resolve to
+   * `{ id, name }`.
+   */
+  useCreateOrg?: typeof useCreateOrganization;
+}
+
+export function ZeroOrgOnboarding({
+  usePolicy = useReadyZeroOrgPolicy,
+  useCreateOrg = useCreateOrganization,
+}: ZeroOrgOnboardingProps = {}) {
+  const router = useRouter();
+  const { setCurrentOrg } = useOrg();
+  const createOrg = useCreateOrg();
+  const policy = usePolicy();
+  const [name, setName] = useState("");
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const org = await createOrg.mutateAsync({ name: trimmed });
+    setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
+    router.push(`/orgs/${org.id}/setup`);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background bg-brand-dots p-4">
+      <Card className="w-full max-w-md p-8">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="flex h-12 w-12 items-center justify-center bg-primary/10">
+            <Building2 className="h-6 w-6 text-primary" />
+          </div>
+          <h1 className="text-xl font-semibold">Create your organization</h1>
+          <p className="text-sm text-muted-foreground">
+            Organizations own your agents, sessions, and settings. Create one to get started.
+          </p>
+        </div>
+
+        <div className="mt-8">
+          {policy.status === "loading" ? (
+            <div className="flex justify-center py-6">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : policy.status === "blocked" ? (
+            <div className="space-y-4 text-center" role="alert">
+              <h2 className="text-base font-semibold">{policy.title}</h2>
+              {policy.body && <div className="text-sm text-muted-foreground">{policy.body}</div>}
+              {policy.actions && <div className="flex justify-center gap-2">{policy.actions}</div>}
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="onboarding-org-name">Organization name</Label>
+                <Input
+                  id="onboarding-org-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="Acme Inc."
+                  required
+                />
+              </div>
+              {createOrg.isError && (
+                <p className="text-sm text-destructive">
+                  Failed to create organization: {createOrg.error.message}
+                </p>
+              )}
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={createOrg.isPending || !name.trim()}
+              >
+                {createOrg.isPending ? "Creating..." : "Create organization"}
+              </Button>
+            </form>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -377,6 +377,37 @@ ServerAppBuilder::new(config)
 
 This is the org-creation counterpart to the invitation surface moved into OSS by EVE-602; member management and invitations use the OSS surfaces directly.
 
+## Zero-Org Onboarding Surface
+
+OSS owns the first screen a user sees after login when they have no organizations. Wrappers compose it instead of forking a full onboarding page plus the main-layout redirect.
+
+OSS provides:
+
+- `ZeroOrgOnboarding` (`apps/ui/src/components/onboarding/zero-org-onboarding.tsx`) — owns the layout, org-name form, current-org selection after create, and the `/orgs/{orgId}/setup` redirect. Default behavior lets any authenticated user create their first org.
+- `useZeroOrgRedirect` (`apps/ui/src/components/onboarding/use-zero-org-redirect.ts`) — redirects authenticated zero-org users to `/onboarding`; consumed by the OSS `(main)` layout and reusable by wrappers so the redirect is not duplicated.
+- The `(onboarding)/onboarding` route, which renders `ZeroOrgOnboarding`.
+
+Wrappers configure two extension points on `ZeroOrgOnboarding`:
+
+- `usePolicy: () => ZeroOrgPolicyState` returning `{ status: "loading" }`, `{ status: "ready" }`, or `{ status: "blocked", title, body?, actions? }`. A blocked state renders a gate (e.g. "Verify your email") in place of the form before any org is created. Defaults to always-ready.
+- `useCreateOrg` — overrides the create mutation (e.g. to call a wrapper alias) while keeping the OSS layout and redirect. Defaults to the OSS `useCreateOrganization`.
+
+A SaaS wrapper replaces its local onboarding page with an OSS re-export plus a small policy adapter:
+
+```tsx
+// Wrapper-owned policy adapter; the page is just OSS + this hook.
+import { ZeroOrgOnboarding } from "everruns-ui/components/onboarding/zero-org-onboarding";
+
+export default function Onboarding() {
+  return <ZeroOrgOnboarding usePolicy={useVerifiedEmailPolicy} />;
+}
+```
+
+- **OSS owns**: the `ZeroOrgOnboarding` component and layout, the `ZeroOrgPolicyState` / `UseZeroOrgPolicy` types, the always-ready default policy, the create-and-redirect flow, and the zero-org redirect hook.
+- **Wrappers own**: the concrete policy hook (verified-email gate, plan limits) and any create-org override.
+
+This is the UI counterpart to the server-side org-creation policy above; the policy-blocked copy a wrapper shows here should mirror the `OrgCreatePolicy` rejection that remains the authoritative backstop.
+
 ## Non-goals
 
 This spec does not require:


### PR DESCRIPTION
## What
Adds a first-class OSS-owned zero-organization onboarding surface so SaaS-style wrappers compose it instead of forking a full onboarding page plus the main-layout redirect.

- `ZeroOrgOnboarding` (`apps/ui/src/components/onboarding/zero-org-onboarding.tsx`) — owns the layout, org-name form, current-org selection after create, and the `/orgs/{orgId}/setup` redirect. Default OSS behavior lets any authenticated user create their first org.
- `usePolicy` extension — returns `loading` / `ready` / `blocked {title, body?, actions?}`; a blocked state renders a wrapper gate (e.g. "Verify your email") in place of the form before any org is created. Defaults to always-ready.
- `useCreateOrg` extension — overrides the create mutation (wrapper alias/override) while keeping the OSS layout and redirect. Defaults to `useCreateOrganization`.
- `useZeroOrgRedirect` (`apps/ui/src/components/onboarding/use-zero-org-redirect.ts`) — redirects authenticated zero-org users to `/onboarding`; wired into the OSS `(main)` layout and reusable by wrappers so the redirect isn't duplicated.
- New `(onboarding)` route group + `/onboarding` page rendering `ZeroOrgOnboarding`, with an auth-guarded layout that bounces users who already have an org back to `/dashboard`.
- Documents the extension points in `specs/embedding.md`.

Resolves [EVE-609](https://linear.app/everruns/issue/EVE-609/add-oss-owned-zero-organization-onboarding-surface).

## Why
The zero-org onboarding screen was the remaining UI ownership gap after EVE-602 (OSS invitations) and EVE-607 (server-side org-creation policy). Wrappers like SaaS had to fork the whole page and the `(main)` → onboarding redirect just to decide whether a zero-org user may create an org, accept an invite, or see a policy gate — so UX and layout drift from OSS. This makes OSS the owner of the layout and create-and-redirect flow, leaving wrappers to provide only policy/status (and an optional create override). The SaaS driver (show "Verify your email" before first org creation while `POST /v1/saas/orgs` stays the backstop) becomes a small policy adapter rather than a page fork.

## How
- The OSS component renders one of three states from `usePolicy()`: spinner (loading), a centered gate (blocked), or the org-name form (ready). On submit it calls the (overridable) create hook, selects the new org via `setCurrentOrg`, and pushes to `/orgs/{id}/setup` — matching the existing sidebar create-org dialog behavior, which is left untouched.
- `useZeroOrgRedirect` centralizes the zero-org → `/onboarding` redirect and returns a boolean so the `(main)` layout can avoid flashing the app shell. It is a no-op when auth isn't required (OSS seeds a default org, so the zero-org state is unreachable in `none` mode), while loading, when the user already has an org, or when already on `/onboarding`.

## Risk
- Low. Additive UI-only change plus a spec section. No backend, API, schema, or migration changes.
- Possible breakage is limited to the `(main)` layout redirect; it's gated on `requiresAuth && isAuthenticated && organizations.length === 0` and covered by tests including the existing main-layout auth scenarios.

## Security
- Threat categories reviewed: TM-WEB, TM-AUTH/TM-AUTHZ.
- Findings and resolutions:
  - **TM-WEB**: No `dangerouslySetInnerHTML`; the org name is a controlled input. Blocked-state `title/body/actions` are wrapper-supplied ReactNodes (trusted wrapper code), not untrusted user input — no XSS surface introduced.
  - **TM-AUTH/TM-AUTHZ**: The onboarding layout requires auth (redirects unauthenticated users to login) and the redirect hook gates on `requiresAuth && isAuthenticated`. Org creation still flows through the existing OSS `useCreateOrganization` → `POST /v1/orgs`; the server-side `OrgCreatePolicy` from EVE-607 remains the authoritative backstop. The client-side policy gate is advisory UX only and grants no new capability. No new endpoints, dependencies, or secret handling.

## Validation
- `apps/ui` jest: **1010 passed / 114 suites**, including new `zero-org-onboarding` (default create→setup flow, blank-name guard, create error, policy-blocked gate, loading state, create-override) and `use-zero-org-redirect` (redirect/no-redirect across all branches), plus the updated `main-layout-auth` suite.
- `pnpm lint`, `pnpm typecheck`, `pnpm run format:check`: clean.
- `pnpm run build`: succeeds; `/onboarding` route is registered.
- Live smoke not run: the genuine zero-org authenticated state is unreachable in default dev mode (`auth=none` seeds a default org, so the onboarding layout redirects to `/dashboard`). The create→select→`/orgs/{id}/setup` flow, the policy-blocked/loading gates, and every redirect branch are covered by unit tests, and the production build verifies route registration and client boundaries.

## Follow-ups
No follow-ups. The SaaS-side adoption (replace its local onboarding page with this re-export + a verified-email policy adapter) lands in the SaaS repo and is tracked by the related EVE-610.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal UI; default behavior unchanged, sidebar dialog untouched)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01BRmj8WrdyFrYux39PvJ9W6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRmj8WrdyFrYux39PvJ9W6)_