### PR TITLE
docs(skills): add public everruns-runtime skill

### DIFF
--- a/skills/everruns-runtime/SKILL.md
+++ b/skills/everruns-runtime/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: everruns-runtime
+description: Embed the Everruns agent engine directly in a Rust process with the everruns-runtime crate — run harnesses in-process with no PostgreSQL, server, or worker. Use when building local agentic apps (coding agents, personal agents, CLIs), writing in-process agent tests, registering custom capabilities/drivers/backends, or wiring optional provider and integration crates (OpenAI, Anthropic, Daytona, E2B, …).
+license: MIT
+compatibility: Rust 1.94+ (edition 2024)
+metadata:
+  category: agent-runtime
+  version: "1.0"
+  homepage: https://everruns.com
+  docs: https://docs.everruns.com/features/runtime/
+  api-reference: https://docs.rs/everruns-runtime
+  repository: https://github.com/everruns/everruns
+---
+
+# everruns-runtime
+
+> Embed Everruns agents directly in your Rust process — no server, worker, or database required.
+
+`everruns-runtime` is the public, in-process entrypoint for [Everruns](https://everruns.com),
+the open-source durable agentic harness engine. It runs an Everruns **harness**
+entirely inside your own binary, using the same `input → reason → act` loop as
+the worker- and server-backed runtime, but **in-memory by default** — no
+PostgreSQL, no control-plane server, no gRPC worker boundary.
+
+It is the Rust-native counterpart to the [SDKs](https://docs.everruns.com/features/sdk/):
+where the SDKs talk to a *running* Everruns server over HTTP, the runtime **is**
+the engine, linked straight into your code.
+
+## When to Use
+
+Use this skill when you want to:
+
+- Run an agent harness in-process with no external services
+- Build a local agentic application — coding agent, personal agent, CLI, daemon
+- Write fast, deterministic in-process agent tests (with the built-in `llmsim` driver)
+- Register your own **capabilities**, LLM **drivers**, and tools
+- Provide custom backend stores (files, messages, sessions, …) instead of the in-memory defaults
+- Inspect the assembled turn context before execution
+- Pull in optional **provider** or **integration** crates (OpenAI, Anthropic, Daytona, E2B, …)
+
+If instead you want to call a *hosted* Everruns deployment over HTTP, use an
+[SDK](https://docs.everruns.com/features/sdk/), not this crate.
+
+## Install
+
+Requires Rust **1.94+** (edition 2024).
+
+```bash
+cargo add everruns-runtime
+# Shared types (capabilities, drivers, models) live in everruns-core:
+cargo add everruns-core
+```
+
+The runtime ships in-memory by default, so the smallest useful host is a single
+`build().await?` away.
+
+## Quickstart
+
+Build an in-process runtime with an in-memory backend and the deterministic LLM
+simulator (no API key needed), then run a turn:
+
+```rust
+use everruns_core::{
+    CapabilityRegistry, DriverId, DriverRegistry, PlatformDefinition, ResolvedModel,
+};
+use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_runtime::InProcessRuntimeBuilder;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let platform = PlatformDefinition::new(CapabilityRegistry::new(), DriverRegistry::new());
+
+let runtime = InProcessRuntimeBuilder::new()
+    .platform_definition(platform)
+    .llm_sim(LlmSimConfig::fixed("hello from everruns-runtime"))
+    .default_model(ResolvedModel {
+        model: "llmsim-model".into(),
+        provider_type: DriverId::LlmSim,
+        api_key: Some("fake-key".into()),
+        base_url: None,
+        provider_metadata: None,
+    })
+    .single_session(|s| {
+        s.harness("assistant", "You are a concise, helpful assistant.")
+            .agent("assistant-agent", "Answer in one short sentence.")
+            .session_title("Quickstart")
+    })
+    .build()
+    .await?;
+
+let session_id = runtime.default_session_id().expect("single_session id");
+let result = runtime.run_text_turn(session_id, "Say hi.").await?;
+println!("{}", result.response);
+# Ok(())
+# }
+```
+
+`single_session(...)` is the compact path for the common one-harness,
+one-agent, one-session shape; it records the generated id for
+`default_session_id()`.
+
+## Talk to a real model provider
+
+A real provider needs **two** things: the provider's **driver must be
+registered** in the `DriverRegistry`, *and* `default_model` must select it.
+Setting `default_model` alone is not enough — the runtime resolves
+`provider_type` against the registry at turn time.
+
+```bash
+cargo add everruns-openai
+```
+
+```rust
+use everruns_core::driver_registry::DriverRegistry;
+use everruns_core::{CapabilityRegistry, DriverId, PlatformDefinition, ResolvedModel};
+use everruns_runtime::InProcessRuntimeBuilder;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+// 1. Register the OpenAI driver so `DriverId::OpenAI` resolves.
+let mut drivers = DriverRegistry::new();
+everruns_openai::register_driver(&mut drivers);
+
+// 2. Build the platform from that registry.
+let platform = PlatformDefinition::new(CapabilityRegistry::new(), drivers);
+
+// 3. Point the runtime's default model at OpenAI.
+let runtime = InProcessRuntimeBuilder::new()
+    .platform_definition(platform)
+    .default_model(ResolvedModel {
+        model: "gpt-5.5".into(),
+        provider_type: DriverId::OpenAI,
+        api_key: Some(std::env::var("OPENAI_API_KEY")?),
+        base_url: None,
+        provider_metadata: None,
+    })
+    .single_session(|s| {
+        s.harness("assistant", "You are a concise, helpful assistant.")
+            .agent("assistant-agent", "Answer in one short sentence.")
+            .session_title("OpenAI Session")
+    })
+    .build()
+    .await?;
+# Ok(())
+# }
+```
+
+Swap `everruns-openai` for any provider crate, matching the crate to its
+`DriverId` (`everruns-anthropic` → `DriverId::Anthropic`, etc. — see
+[`references/crates.md`](references/crates.md)). To reach an OpenAI-compatible
+endpoint (a local gateway, Ollama, …), set `base_url` and pick the `DriverId`
+matching the API the server speaks: `DriverId::OpenAI` (Responses API) or
+`DriverId::OpenAICompletions` (Chat Completions API).
+
+## Register capabilities (tools)
+
+Capabilities are the tools and behaviors an agent can use. Register them on a
+`CapabilityRegistry`, then reference them by name on a harness:
+
+```rust,ignore
+let mut capabilities = CapabilityRegistry::new();
+capabilities.register(FileSystemCapability);   // from everruns-core
+capabilities.register(DuckDuckGoCapability);   // from everruns-integrations-duckduckgo
+
+let platform = PlatformDefinition::new(capabilities, drivers);
+// ...
+.single_session(|s| {
+    s.harness("coder", "You are a coding agent.")
+        .with_capability("session_file_system")
+        .with_capability("duckduckgo")
+        .agent("coder-agent", "Use tools when they help.")
+})
+```
+
+Built-in capabilities live in `everruns-core`; optional ones ship as separate
+**integration crates** (see below). Active capabilities are resolved from the
+effective harness/agent/session overlay, not the full platform registry.
+
+## Optional crates (providers, integrations, backends)
+
+The runtime is provider- and tool-neutral; you pull in only what you use. The
+full catalog with crate names, `DriverId`s, and capability names is in
+[`references/crates.md`](references/crates.md). Highlights:
+
+- **LLM providers**: `everruns-openai`, `everruns-anthropic`, `everruns-gemini`,
+  `everruns-openrouter`, `everruns-mai`, `everruns-bedrock`.
+- **Sandbox / compute integrations**: `everruns-integrations-daytona` (Daytona
+  cloud sandbox), `everruns-integrations-e2b` (E2B), `everruns-integrations-docker`,
+  `everruns-integrations-deno`, `everruns-integrations-sprites`,
+  `everruns-integrations-cursor`.
+- **Search / web integrations**: `everruns-integrations-duckduckgo` (no key),
+  `everruns-integrations-brave-search`, `everruns-integrations-parallel`,
+  `everruns-integrations-browserless`, `everruns-integrations-ard`.
+- **Durable local backends**: `everruns-local` — SQLite-backed,
+  restart-survivable stores for single-process hosts (task registry, schedules,
+  platform store).
+
+> **Daytona example**: add `everruns-integrations-daytona`, register
+> `DaytonaCapability`, and supply a credential source via
+> `RuntimeBackends::with_connection_resolver(...)` so the connection-aware tool
+> resolves the user's Daytona token at execution time. See
+> [`references/crates.md`](references/crates.md).
+
+## Inspect the turn context
+
+`load_context(session_id)` returns the exact merged context the reason phase
+will use — before the first turn or after messages already exist:
+
+```rust,ignore
+let context = runtime.load_context(session_id).await?;
+println!("messages = {}", context.messages.len());
+println!("model    = {}", context.runtime_agent.model);
+println!("tools    = {}", context.runtime_agent.tools.len());
+```
+
+The context bundles the harness chain, optional agent, session, filtered message
+history, resolved model, and the assembled `RuntimeAgent`.
+
+## Custom backends
+
+The runtime ships in-memory defaults, but public extension traits let you supply
+your own stores via `RuntimeBackends`; any store you don't override stays
+in-memory:
+
+```rust,ignore
+use everruns_runtime::{InProcessRuntimeBuilder, RuntimeBackends};
+
+let runtime = InProcessRuntimeBuilder::new()
+    .backends(
+        RuntimeBackends::in_memory()
+            .with_message_store(my_message_store)
+            .with_event_bus(my_event_bus),
+    )
+    .build()
+    .await?;
+```
+
+Overridable stores: `RuntimeHarnessStore`, `RuntimeAgentStore`,
+`RuntimeSessionStore`, `RuntimeMessageStore`, `RuntimeProviderStore`, and
+`EventBus` (extends `EventEmitter`). Session files are selected through the
+platform's `SessionFileSystemFactory` (`InMemory...`, `RealDisk...`, or custom).
+
+## Local MCP servers
+
+MCP server tools are first-class runtime tools. Local-process (stdio) MCP
+servers are gated behind the `mcp-stdio` feature, off by default:
+
+```bash
+cargo add everruns-runtime --features mcp-stdio
+```
+
+## Domain language
+
+A short glossary — the full version with relationships is in
+[`references/glossary.md`](references/glossary.md):
+
+- **Harness** — the reusable agent template: system prompt + capabilities +
+  config. Harnesses can chain (parent → child overlay).
+- **Agent** — a configuration overlay on a harness (instructions, model, max
+  iterations) that composes into a runtime agent.
+- **Session** — a single conversation/run; holds message history and workspace.
+- **Capability** — a registered tool or behavior (e.g. `session_file_system`,
+  `duckduckgo`, `infinity_context`).
+- **Driver** — an LLM provider implementation, keyed by `DriverId`.
+- **PlatformDefinition** — the shared bundle (capabilities + drivers + harness
+  templates + filesystem factory) consumed by runtime, server, and worker alike.
+- **Turn** — one `input → reason → act` cycle.
+- **Atom** — the shared core execution units (`InputAtom`, `ReasonAtom`,
+  `ActAtom`) the runtime and worker both run.
+
+## Runnable examples
+
+In-tree examples that depend on the public crate exactly as an external embedder
+would:
+
+```bash
+cargo run -p everruns-runtime --example in_process_runtime
+cargo run -p everruns-runtime --example inspect_context
+cargo run -p everruns-runtime --example openai_runtime          # needs OPENAI_API_KEY
+cargo run -p everruns-runtime --example real_disk_file_system_tools
+cargo run --manifest-path examples/coding-cli/Cargo.toml        # ratatui TUI coding agent (`ercode`)
+cargo run --manifest-path examples/weekend-concierge-host/Cargo.toml
+```
+
+Built **with** the runtime:
+
+- **[yolop](https://github.com/everruns/yolop)** — a minimal terminal coding
+  agent on `everruns-runtime` (codex/claude-code in spirit); interactive TUI,
+  real-filesystem tools, multi-provider LLMs, MCP (stdio + HTTP), resumable
+  sessions, Zed/ACP integration.
+
+  ```bash
+  brew install everruns/tap/yolop   # or: cargo install yolop --locked
+  ```
+
+## References
+
+- [API reference (docs.rs)](https://docs.rs/everruns-runtime)
+- [Runtime guide](https://docs.everruns.com/features/runtime/)
+- [Tutorial: build your first agent](https://docs.everruns.com/tutorials/building-agents-using-sdk/)
+- [Embedding Everruns](https://docs.everruns.com/advanced/embedding-everruns/) — compose your own `PlatformDefinition`, server, and worker
+- [Capabilities](https://docs.everruns.com/capabilities/) · [Harnesses](https://docs.everruns.com/features/harnesses/) · [Integrations](https://docs.everruns.com/integrations/)
+- [Everruns documentation](https://docs.everruns.com) · [GitHub](https://github.com/everruns/everruns)
+- In-repo specs: `specs/runtime.md`, `specs/embedding.md`, `specs/file-store.md`
+- [`references/crates.md`](references/crates.md) — optional provider/integration/backend crate catalog
+- [`references/glossary.md`](references/glossary.md) — domain language
+
+## License
+
+Licensed under the [MIT License](https://github.com/everruns/everruns/blob/main/LICENSE).

--- a/skills/everruns-runtime/SKILL.md
+++ b/skills/everruns-runtime/SKILL.md
@@ -57,7 +57,8 @@ The runtime ships in-memory by default, so the smallest useful host is a single
 ## Quickstart
 
 Build an in-process runtime with an in-memory backend and the deterministic LLM
-simulator (no API key needed), then run a turn:
+simulator (no *real* API key needed — `llmsim` ignores it, so any placeholder
+works), then run a turn:
 
 ```rust
 use everruns_core::{
@@ -145,10 +146,12 @@ let runtime = InProcessRuntimeBuilder::new()
 
 Swap `everruns-openai` for any provider crate, matching the crate to its
 `DriverId` (`everruns-anthropic` → `DriverId::Anthropic`, etc. — see
-[`references/crates.md`](references/crates.md)). To reach an OpenAI-compatible
-endpoint (a local gateway, Ollama, …), set `base_url` and pick the `DriverId`
-matching the API the server speaks: `DriverId::OpenAI` (Responses API) or
-`DriverId::OpenAICompletions` (Chat Completions API).
+[`references/crates.md`](references/crates.md)). `everruns-openai::register_driver`
+actually registers three drivers — `DriverId::OpenAI` (Responses API),
+`DriverId::AzureOpenAI` (Azure OpenAI Responses API), and
+`DriverId::OpenAICompletions` (Chat Completions API) — so select the one matching
+your deployment. To reach an OpenAI-compatible endpoint (a local gateway, Ollama,
+…), set `base_url` and pick the `DriverId` matching the API the server speaks.
 
 ## Register capabilities (tools)
 
@@ -180,8 +183,9 @@ The runtime is provider- and tool-neutral; you pull in only what you use. The
 full catalog with crate names, `DriverId`s, and capability names is in
 [`references/crates.md`](references/crates.md). Highlights:
 
-- **LLM providers**: `everruns-openai`, `everruns-anthropic`, `everruns-gemini`,
-  `everruns-openrouter`, `everruns-mai`, `everruns-bedrock`.
+- **LLM providers**: `everruns-openai` (OpenAI + Azure OpenAI + Chat
+  Completions), `everruns-anthropic`, `everruns-gemini`, `everruns-openrouter`,
+  `everruns-fireworks`, `everruns-mai`, `everruns-bedrock`.
 - **Sandbox / compute integrations**: `everruns-integrations-daytona` (Daytona
   cloud sandbox), `everruns-integrations-e2b` (E2B), `everruns-integrations-docker`,
   `everruns-integrations-deno`, `everruns-integrations-sprites`,

--- a/skills/everruns-runtime/references/crates.md
+++ b/skills/everruns-runtime/references/crates.md
@@ -1,0 +1,127 @@
+# Optional crates for everruns-runtime
+
+`everruns-runtime` is provider- and tool-neutral: you add only the crates you
+use. This catalog lists the optional crates that extend an in-process runtime,
+how to register them, and what they contribute.
+
+The two required crates are always:
+
+- `everruns-runtime` — the in-process engine ([docs.rs](https://docs.rs/everruns-runtime))
+- `everruns-core` — shared types (capabilities, drivers, models, `PlatformDefinition`)
+
+## LLM provider crates (drivers)
+
+Each provider crate registers a driver keyed by a `DriverId`. Register the
+driver, then point `default_model.provider_type` at the matching `DriverId`.
+
+| Crate | `DriverId` | Notes |
+|---|---|---|
+| `everruns-openai` | `DriverId::OpenAI` (Responses API), `DriverId::OpenAICompletions` (Chat Completions) | Also covers Azure OpenAI and OpenAI-compatible endpoints via `base_url` |
+| `everruns-anthropic` | `DriverId::Anthropic` | Supports prompt caching |
+| `everruns-gemini` | `DriverId::Gemini` | Google Gemini |
+| `everruns-openrouter` | `DriverId::OpenRouter` | OpenRouter model gateway |
+| `everruns-mai` | `DriverId::Mai` | — |
+| `everruns-bedrock` | `DriverId::Bedrock` | AWS Bedrock |
+| built into `everruns-core` | `DriverId::LlmSim` | Deterministic simulator for tests/examples; no API key |
+
+Registration pattern:
+
+```rust,ignore
+let mut drivers = DriverRegistry::new();
+everruns_openai::register_driver(&mut drivers);
+let platform = PlatformDefinition::new(capabilities, drivers);
+```
+
+For an OpenAI-compatible local server (e.g. Ollama, a gateway), keep the
+matching `DriverId` and set `base_url` on the `ResolvedModel`.
+
+## Integration crates (capabilities / tools)
+
+Integration crates ship optional capabilities. Construct the capability and
+`register` it on a `CapabilityRegistry`, then reference it by name on a harness.
+
+### Sandbox / compute
+
+| Crate | Capability | Notes |
+|---|---|---|
+| `everruns-integrations-daytona` | `DaytonaCapability` | Daytona cloud sandbox. Connection-aware — see "Connection-aware integrations" below |
+| `everruns-integrations-e2b` | E2B sandbox capability | E2B cloud sandbox |
+| `everruns-integrations-docker` | Docker capability | Local Docker container sandbox |
+| `everruns-integrations-deno` | Deno capability | Deno sandbox |
+| `everruns-integrations-sprites` | Sprites capability | Sprites cloud sandbox |
+| `everruns-integrations-cursor` | Cursor capability | Cursor Cloud Agents |
+
+### Search / web
+
+| Crate | Capability | Notes |
+|---|---|---|
+| `everruns-integrations-duckduckgo` | `DuckDuckGoCapability` | Free web search (`duckduckgo_search`); **no API key** |
+| `everruns-integrations-brave-search` | Brave Search capability | Requires Brave API key |
+| `everruns-integrations-parallel` | Parallel capability | Parallel web search MCP |
+| `everruns-integrations-browserless` | Browserless capability | Headless browser automation |
+| `everruns-integrations-ard` | ARD capability | Agentic Resource Discovery client |
+
+### Blueprints
+
+| Crate | Contributes | Notes |
+|---|---|---|
+| `everruns-integrations-github` | Agent blueprints | GitHub-backed agent blueprints |
+
+Registration pattern:
+
+```rust,ignore
+let mut capabilities = CapabilityRegistry::new();
+capabilities.register(DuckDuckGoCapability);
+capabilities.register(DaytonaCapability);
+let platform = PlatformDefinition::new(capabilities, drivers);
+```
+
+## Connection-aware integrations (credentials)
+
+Some integrations — Daytona is the canonical example — need a per-user
+credential resolved at tool-execution time. Supply a credential source through
+`RuntimeBackends`:
+
+```rust,ignore
+let backends = RuntimeBackends::in_memory()
+    .with_connection_resolver(my_connection_resolver); // Arc<dyn UserConnectionResolver>
+```
+
+The runtime then exposes it via `ToolContext.connection_resolver`. There is no
+in-memory default: a resolver implies a real credential source the embedder
+owns. When unset, connection-aware tools fall back to their own guidance
+(session secret, then "connect the provider"). See
+`crates/server/specs/user-connections.md` in the repo.
+
+## Durable local backends
+
+| Crate | Provides |
+|---|---|
+| `everruns-local` | SQLite-backed, restart-survivable stores for single-process hosts: `LocalSessionTaskRegistry`, `LocalScheduleStore`, `LocalPlatformStore`, a `LocalProfile`, a composable `LocalBackends`, and an optional `LocalRuntimeBuilder` |
+
+`everruns-local` populates the runtime's optional host-backend slots
+(`session_task_registry`, `schedule_store_factory`, `platform_store_factory`),
+which otherwise default to in-memory. Use it when background tasks, schedules, or
+session state must survive a process restart.
+
+## Runtime crate features
+
+| Feature | Effect | Default |
+|---|---|---|
+| `mcp-stdio` | Enables local-process (stdio) MCP servers | off |
+| `lua` | Compiles the experimental sandboxed Lua execution engine (`lua` / `lua_code_mode` capabilities) | off |
+
+```bash
+cargo add everruns-runtime --features mcp-stdio
+```
+
+## Backend store override traits (in `everruns-runtime`)
+
+Supply your own implementation of any of these via `RuntimeBackends`; anything
+not overridden stays in-memory:
+
+`RuntimeHarnessStore`, `RuntimeAgentStore`, `RuntimeSessionStore`,
+`RuntimeMessageStore`, `RuntimeProviderStore`, `EventBus`. Session files come
+from the platform's `SessionFileSystemFactory`
+(`InMemorySessionFileSystemFactory`, `RealDiskSessionFileSystemFactory`, or a
+custom factory such as S3).

--- a/skills/everruns-runtime/references/crates.md
+++ b/skills/everruns-runtime/references/crates.md
@@ -16,13 +16,14 @@ driver, then point `default_model.provider_type` at the matching `DriverId`.
 
 | Crate | `DriverId` | Notes |
 |---|---|---|
-| `everruns-openai` | `DriverId::OpenAI` (Responses API), `DriverId::OpenAICompletions` (Chat Completions) | Also covers Azure OpenAI and OpenAI-compatible endpoints via `base_url` |
+| `everruns-openai` | `DriverId::OpenAI` (Responses API), `DriverId::AzureOpenAI` (Azure OpenAI Responses API), `DriverId::OpenAICompletions` (Chat Completions) | One `register_driver` call registers all three; also reaches OpenAI-compatible endpoints via `base_url` |
 | `everruns-anthropic` | `DriverId::Anthropic` | Supports prompt caching |
 | `everruns-gemini` | `DriverId::Gemini` | Google Gemini |
 | `everruns-openrouter` | `DriverId::OpenRouter` | OpenRouter model gateway |
-| `everruns-mai` | `DriverId::Mai` | — |
+| `everruns-fireworks` | `DriverId::Fireworks` | Fireworks AI — open-model inference (Llama, Qwen, DeepSeek, GLM, …) |
+| `everruns-mai` | `DriverId::Mai` | Microsoft MAI |
 | `everruns-bedrock` | `DriverId::Bedrock` | AWS Bedrock |
-| built into `everruns-core` | `DriverId::LlmSim` | Deterministic simulator for tests/examples; no API key |
+| built into `everruns-core` | `DriverId::LlmSim` | Deterministic simulator for tests/examples; no real API key |
 
 Registration pattern:
 

--- a/skills/everruns-runtime/references/glossary.md
+++ b/skills/everruns-runtime/references/glossary.md
@@ -1,0 +1,102 @@
+# everruns-runtime domain language
+
+The vocabulary you need to read and write code against `everruns-runtime`.
+These concepts are shared with the worker- and server-backed runtime, so they
+transfer to the rest of Everruns.
+
+## Composition
+
+- **PlatformDefinition** — the shared runtime bundle consumed by the runtime,
+  server, and worker alike. Owns the capability registry, LLM driver registry,
+  connection-provider registry, built-in harness templates, and the
+  `SessionFileSystemFactory`. Lives in `everruns-core` so any binary can build
+  one. `PlatformDefinition::new(capabilities, drivers)` is the minimal form.
+
+- **Harness** — the reusable agent template: a stable `name`, optional system
+  prompt, a set of capabilities, optional MCP servers, and config. Harnesses
+  can **chain** (a child harness overlays a parent). The system prompt is
+  optional — a harness may contribute only capabilities or MCP servers.
+
+- **Agent** — a configuration overlay on a harness (instructions, model
+  selection, max iterations, …). Folded over the harness chain via
+  `AgentConfigOverlay` to produce the effective configuration.
+
+- **Session** — a single conversation / run. Holds message history and a
+  workspace (virtual filesystem). Created from a harness + agent.
+
+- **Capability** — a registered tool or behavior the agent can use, addressed by
+  name (e.g. `session_file_system`, `agent_instructions`, `skills`,
+  `infinity_context`, `duckduckgo`). Built-ins live in `everruns-core`; optional
+  ones ship as integration crates. Active capabilities are resolved from the
+  effective harness/agent/session overlay, **not** the full platform registry.
+
+- **Driver** — an LLM provider implementation, keyed by a `DriverId`
+  (`OpenAI`, `Anthropic`, `Gemini`, `OpenRouter`, `Mai`, `Bedrock`, `LlmSim`,
+  `OpenAICompletions`, …). Registered in a `DriverRegistry`.
+
+- **ResolvedModel** — a concrete model selection: `model` name, `provider_type`
+  (`DriverId`), `api_key`, optional `base_url`, optional `provider_metadata`.
+  The runtime requires a **default model**; `build()` fails without one.
+
+## Execution
+
+- **Turn** — one unit of execution: `input → reason → act`. Driven by
+  `run_turn(session_id, input)` or the `run_text_turn(session_id, text)`
+  convenience.
+
+- **Atoms** — the shared core execution units the runtime and worker both run:
+  `InputAtom` (records the input message, emits `input.message`), `ReasonAtom`
+  (assembles context, calls the LLM), `ActAtom` (executes tool calls). Atom
+  construction lives host-side so improvements flow to both embedded and durable
+  hosts.
+
+- **TurnStateMachine** — the shared `everruns-core` state machine the runtime
+  executes; keeps embedded turns behaviorally aligned with worker turns.
+
+- **Assembled turn context** — the merged context the reason phase uses: harness
+  chain + agent + session overlay, resolved capabilities (with dependency
+  resolution and message filtering), resolved model and locale, and the
+  constructed `RuntimeAgent`. Built by `everruns_core::assemble_turn_context(...)`
+  at execution time and `inspect_turn_context(...)` for read-only inspection
+  (`InProcessRuntime::load_context`).
+
+- **RuntimeAgent** — the fully-resolved agent the LLM step runs against: final
+  system prompt, model, and tool set.
+
+## In-process runtime API surface
+
+- **InProcessRuntimeBuilder** — the public entrypoint. Set the
+  `PlatformDefinition`, register extra capabilities/drivers, seed
+  harnesses/agents/sessions, configure the default model, optionally register
+  `llmsim`, and swap stores via `RuntimeBackends`.
+
+- **HarnessBuilder / AgentBuilder / SessionBuilder** — supported construction
+  path for seed models. Prefer these over raw struct literals so new optional
+  core fields can be defaulted inside the runtime crate.
+
+- **single_session(...)** — compact path for the common one-harness, one-agent,
+  one-session shape. Records the generated id for `default_session_id()`.
+
+- **InProcessRuntime** — the built runtime. Key methods: `run_turn`,
+  `run_text_turn`, `default_session_id`, `load_context`, `messages`,
+  `read_file`, `events`.
+
+- **RuntimeBackends** — the bundle of overridable stores. Start from
+  `RuntimeBackends::in_memory()` and chain `.with_message_store(...)`,
+  `.with_event_bus(...)`, `.with_connection_resolver(...)`, etc.
+
+## Host execution (for durable / server-backed embedders)
+
+The runtime also owns a reusable host contract so durable or server-backed hosts
+reuse runtime phase orchestration instead of duplicating atom wiring:
+
+- **RuntimeHostAdapter** / **RuntimeSessionLifecycle** — host seams.
+- **execute_input_activity / execute_reason_activity / execute_act_activity** —
+  phase-local orchestration entrypoints.
+- **plan_next_host_turn(...)** with **RuntimeTurnState**, **RuntimeActPlan**,
+  **RuntimeTurnPlan** — durable-agnostic turn-strategy planning. The runtime
+  decides the next semantic step; the host owns queueing, retries, scheduling,
+  persistence, and resumption.
+
+`InProcessRuntime` itself implements `RuntimeHostAdapter` and drives its own turn
+loop by calling these activity functions directly.


### PR DESCRIPTION
## What
Adds a public, agentskills.io-format skill at `skills/everruns-runtime/` documenting how to embed the in-process `everruns-runtime` crate:

- `SKILL.md` — frontmatter (name, description, license, compatibility, homepage/docs/api/repo metadata), when-to-use, install steps, quickstart (`llmsim`), real-provider wiring, capability registration, custom backends, local MCP, domain language, and runnable examples.
- `references/crates.md` — catalog of optional provider/integration/backend crates (OpenAI/Azure/Completions, Anthropic, Gemini, OpenRouter, Fireworks, Mai, Bedrock; Daytona, E2B, Docker, DuckDuckGo, …; `everruns-local`), with `DriverId`s, capability names, connection-aware credential wiring, and feature flags.
- `references/glossary.md` — runtime domain vocabulary (PlatformDefinition, Harness, Agent, Session, Capability, Driver, Turn, Atoms, host-execution APIs).

This is a **public runtime skill**, intentionally distinct from dev skills in `.agents/skills` and `./plugins`. It is first-party, so it is not added to `skills-lock.json` (which tracks externally-downloaded skills only).

## Why
Embedders need a single, accurate, self-contained entry point for using `everruns-runtime` — install, quickstart, the optional-crate matrix, and domain language — surfaced as an invokable skill.

## How
Authored the skill and reference docs from the runtime spec (`specs/runtime.md`), embedding spec (`specs/embedding.md`), the crate README/`lib.rs`, the docs site runtime page, and the in-tree `coding-cli` example. All factual claims were verified against source: `DriverId` variants, each provider crate's `register_driver` (incl. OpenAI registering OpenAI/AzureOpenAI/OpenAICompletions), and integration crate names/descriptions.

## Risk
- Low. Docs/markdown only; no code, config, infrastructure, or migrations. No runtime behavior changes.

## Security
- Threat categories reviewed: No security-relevant code changes — the diff is markdown-only (a public skill doc plus two reference files). No code, config, infra, endpoints, auth, or data paths are touched.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (docs-only); validated frontmatter parses and internal links resolve
- [x] Backward compatibility considered — additive new files only
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)