### PR TITLE
feat(ui): add Create app shortcut from harness and agent pages

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -206,7 +206,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
             </Link>
           )}
           {agent.status === "active" && (
-            <Link href={`/apps/new?agent_id=${agentId}`}>
+            <Link href={{ pathname: "/apps/new", query: { agent_id: agentId } }}>
               <Button variant="outline">
                 <Rocket className="w-4 h-4 mr-2" />
                 Create app

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -38,6 +38,7 @@ import {
   LayoutDashboard,
   BarChart3,
   GitBranch,
+  Rocket,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
@@ -201,6 +202,14 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
               <Button variant="outline">
                 <Pencil className="w-4 h-4 mr-2" />
                 Edit
+              </Button>
+            </Link>
+          )}
+          {agent.status === "active" && (
+            <Link href={`/apps/new?agent_id=${agentId}`}>
+              <Button variant="outline">
+                <Rocket className="w-4 h-4 mr-2" />
+                Create app
               </Button>
             </Link>
           )}

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCreateApp } from "@/hooks/use-apps";
 import { usePageTitle } from "@/hooks";
 import { Button } from "@/components/ui/button";
@@ -46,12 +46,15 @@ import {
 export default function NewAppPage() {
   usePageTitle("New App", "Apps");
   const router = useRouter();
+  const searchParams = useSearchParams();
   const createApp = useCreateApp();
 
+  // Prefill harness/agent when arriving via a "Create app" shortcut from a
+  // harness or agent detail page (e.g. /apps/new?harness_id=...&agent_id=...).
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [agentId, setAgentId] = useState("");
-  const [harnessId, setHarnessId] = useState("");
+  const [agentId, setAgentId] = useState(() => searchParams.get("agent_id") ?? "");
+  const [harnessId, setHarnessId] = useState(() => searchParams.get("harness_id") ?? "");
   const [agentIdentityId, setAgentIdentityId] = useState("");
   const [channelType, setChannelType] = useState<ChannelType | "">("");
   const [slackSigningSecret, setSlackSigningSecret] = useState("");

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -152,7 +152,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
         </div>
         <div className="flex gap-2">
           {harness.status === "active" && (
-            <Link href={`/apps/new?harness_id=${harnessId}`}>
+            <Link href={{ pathname: "/apps/new", query: { harness_id: harnessId } }}>
               <Button variant="accent">
                 <Rocket className="w-4 h-4 mr-2" />
                 Create app

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -24,7 +24,16 @@ import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
-import { ArrowLeft, Pencil, Copy, Trash2, Eye, LayoutDashboard, BarChart3 } from "lucide-react";
+import {
+  ArrowLeft,
+  Pencil,
+  Copy,
+  Trash2,
+  Eye,
+  LayoutDashboard,
+  BarChart3,
+  Rocket,
+} from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
 import type { Capability, ModelWithProvider } from "@/lib/api/types";
@@ -142,6 +151,14 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
           </h1>
         </div>
         <div className="flex gap-2">
+          {harness.status === "active" && (
+            <Link href={`/apps/new?harness_id=${harnessId}`}>
+              <Button variant="accent">
+                <Rocket className="w-4 h-4 mr-2" />
+                Create app
+              </Button>
+            </Link>
+          )}
           <Button variant="outline" onClick={handleCopy} disabled={copyHarness.isPending}>
             <Copy className="w-4 h-4 mr-2" />
             {copyHarness.isPending ? "Copying..." : "Copy"}

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -209,6 +209,15 @@ The channels-first page folds App configuration into the header, renders a Healt
 
 Schedule labels in rows, headers, breadcrumbs, summaries, and other read-only UI must render a human-readable cron description plus timezone. Raw cron expressions are only shown inside the editable Cron input.
 
+### Create-app entry points
+
+Apps are the publish surface for Harnesses and Agents. To avoid forcing users to leave the building block they just configured, the Harness and Agent detail pages each expose a **Create app** shortcut (active status only) that links to the App create form with the originating building block prefilled:
+
+- Harness detail → `/apps/new?harness_id={harness_id}`
+- Agent detail → `/apps/new?agent_id={agent_id}`
+
+The create form reads `harness_id` and `agent_id` from the query string to seed its selectors. Because a Harness is required, the harness shortcut yields a directly submittable draft; the agent shortcut still requires the user to pick a harness.
+
 ## Data Model
 
 See `crates/core/src/app.rs` for the complete `App` and `AppChannel` definitions.


### PR DESCRIPTION
## What
Adds a **Create app** shortcut button to the Harness and Agent detail pages. Each links to the App create form (`/apps/new`) with the originating building block prefilled via query params:

- Harness detail → `/apps/new?harness_id={harness_id}` (accent button — harness is the required binding, so the draft is directly submittable)
- Agent detail → `/apps/new?agent_id={agent_id}` (outline button — user still picks a harness)

The create form now reads `harness_id`/`agent_id` from the query string to seed its selectors. Buttons render only for `active` entities.

## Why
Apps are the publish surface for harnesses and agents, but today you have to leave the building block you just configured, navigate to Apps → New, and re-find/re-select it. The shortcut removes that context switch at the exact moment of intent. The harness/agent detail pages already surface an "apps" usage count, so a create action belongs there.

This intentionally seeds the existing create form rather than doing a one-click publish: publishing needs a channel (Slack creds, webhook token, schedule cron, …) and an explicit publish step, which are real decisions that should stay visible.

## How
- `apps/new/page.tsx`: initialize `harnessId`/`agentId` state from `useSearchParams()`.
- `harnesses/[harnessId]/page.tsx` and `agents/[agentId]/page.tsx`: add a `Rocket`-icon "Create app" button (matching the Apps nav icon) to the header action row, gated on `status === "active"`.
- `specs/apps.md`: document the create-app entry points.

## Risk
- Low. Purely additive client-side navigation + form prefill. No backend, API, or data-model changes; the create flow reuses the existing, server-validated `POST /v1/apps` path. The forged-param worst case is a pre-selected value the server rejects on submit.

## Security
- Threat categories reviewed: **TM-WEB**. Query-param values flow into controlled `<Select>` state and the existing `createApp` JSON request body — never rendered as raw HTML and never used in `dangerouslySetInnerHTML`, so no XSS. Link `href`s are built from the entity's own route id, not free text, so no open-redirect/injection. AuthZ is unchanged: the server still validates harness/agent existence and org ownership on submit (`validate_harness`/`validate_agent`), so cross-tenant access is not possible. No new endpoints, dependencies, or resource limits.
- Findings: none.

## Follow-ups
- Optional: the agent-page shortcut could also pre-select the org's default harness so it too becomes one-submit. Deferred as a UX nicety, not required for correctness; left out to avoid silently choosing a harness the user didn't pick. No other follow-ups.

## Validation
- `bash scripts/lib/pre-push.sh` → all 9 checks pass (Rust fmt/clippy, UI format/lint, migrations, specs index, attribution).
- `pnpm run build` (UI production build) → compiles; `/apps/new`, `/harnesses/[harnessId]`, `/agents/[agentId]` render dynamically (confirms `useSearchParams` needs no extra Suspense boundary here).
- `tsc --noEmit`, `oxlint`, `oxfmt --check` clean on the touched files.
- End-to-end smoke test against a live in-memory dev stack with a headless browser: "Create app" button renders on both detail pages; clicking the harness button lands on `/apps/new?harness_id=…` with the Harness selector showing "Generic"; clicking the agent button lands on `/apps/new?agent_id=…` with the Agent selector showing the agent and the Harness left for the user to choose.

## Checklist
- [x] Tests added or updated — n/a (no test-targetable logic; covered by build + e2e smoke test)
- [x] Backward compatibility considered — additive only
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FFmH1aqZbRjBLgg2YctJNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFmH1aqZbRjBLgg2YctJNa)_