### PR TITLE
chore(release): prepare v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.16.1] - 2026-06-21
+
+### What's Changed
+
+- feat(server): add per-org limits for harnesses, agents, sessions ([#2383](https://github.com/everruns/everruns/pull/2383)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add Create app shortcut from harness and agent pages ([#2382](https://github.com/everruns/everruns/pull/2382)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): link session chats to provider trace/logs ([#2380](https://github.com/everruns/everruns/pull/2380)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): per-task drill-down on the session Tasks tab ([#2378](https://github.com/everruns/everruns/pull/2378)) by [@chaliy](https://github.com/chaliy)
+- feat(onboarding): add OSS-owned zero-org onboarding surface ([#2379](https://github.com/everruns/everruns/pull/2379)) by [@chaliy](https://github.com/chaliy)
+- feat(orgs): add org creation policy extension point for wrappers ([#2375](https://github.com/everruns/everruns/pull/2375)) by [@chaliy](https://github.com/chaliy)
+- fix(worker): bound worker concurrency, claim batch, and idle polling ([#2373](https://github.com/everruns/everruns/pull/2373)) by [@chaliy](https://github.com/chaliy)
+- fix(durable): serve system-health totals from maintained counters ([#2372](https://github.com/everruns/everruns/pull/2372)) by [@chaliy](https://github.com/chaliy)
+- fix(brand): center all logos on the rings centroid ([#2370](https://github.com/everruns/everruns/pull/2370)) by [@chaliy](https://github.com/chaliy)
+- chore(events): retire subagent.* event types ([#2376](https://github.com/everruns/everruns/pull/2376)) by [@chaliy](https://github.com/chaliy)
+- docs(skills): add public everruns-runtime skill ([#2381](https://github.com/everruns/everruns/pull/2381)) by [@chaliy](https://github.com/chaliy)
+- docs: expand OpenRouter docs and add server-tools capability ([#2374](https://github.com/everruns/everruns/pull/2374)) by [@chaliy](https://github.com/chaliy)
+- ci: cut redundant rust recompiles to speed up cold CI ([#2371](https://github.com/everruns/everruns/pull/2371)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.16.0] - 2026-06-20
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "assert-json-diff"
@@ -1844,6 +1844,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,11 +2334,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.16.0"
+version = "0.16.1"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2322,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2339,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2393,14 +2425,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2420,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2476,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2516,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2530,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2547,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2563,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2584,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2599,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2616,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2639,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2654,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2669,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2696,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2713,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2726,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2742,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2759,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2781,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2799,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2815,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2829,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2849,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2864,11 +2896,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.16.0"
+version = "0.16.1"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2908,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3004,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3021,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3037,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4423,10 +4455,11 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -4438,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4764,9 +4797,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -6068,6 +6101,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -145,10 +145,10 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.16.0" }
-everruns-mcp = { path = "crates/mcp", version = "0.16.0" }
-everruns-openai = { path = "crates/openai", version = "0.16.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.16.0" }
+everruns-core = { path = "crates/core", version = "0.16.1" }
+everruns-mcp = { path = "crates/mcp", version = "0.16.1" }
+everruns-openai = { path = "crates/openai", version = "0.16.1" }
+everruns-runtime = { path = "crates/runtime", version = "0.16.1" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["development-tools", "asynchronous"]
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.16.0" }
+everruns-config = { path = "../config", version = "0.16.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -111,10 +111,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.16.0", optional = true }
+everruns-openui = { path = "../openui", version = "0.16.1", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.16.0", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.16.1", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## Release v0.16.1

This PR prepares the v0.16.1 release.

### Checklist
- [ ] Review CHANGELOG.md entries
- [ ] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.16.1`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01TV39ds3Y8axzoUkweSUXoT)_