### PR TITLE
test(runtime): make crate-level example a tested doctest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,10 @@ jobs:
           # which fails closed without TURBOPUFFER_API_KEY. Live tests run separately.
           cargo test -p everruns-turbopuffer --lib
           cargo test -p everruns-runtime --test in_process_runtime_test --test runtime_host_test -- --test-threads=1
+          # Doctests are excluded by the target-filtered runs above (--test/--lib
+          # skip the Doc-tests target), so run them explicitly to guard the
+          # crate-level embedding example in crates/runtime/src/lib.rs.
+          cargo test -p everruns-runtime --doc
           # Lua code-mode capability: compiles the mlua engine (`lua` feature) and
           # exercises the end-to-end routing contract + runnable example.
           cargo test -p everruns-runtime --features lua --test lua_code_mode_test -- --test-threads=1

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -24,7 +24,9 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), everruns_core::AgentLoopError> {
 //! use everruns_core::{
 //!     CapabilityRegistry, DriverRegistry, InputMessage, DriverId, ResolvedModel,
 //!     PlatformDefinition,
@@ -54,6 +56,7 @@
 //!         provider_type: DriverId::LlmSim,
 //!         api_key: Some("fake-key".into()),
 //!         base_url: None,
+//!         provider_metadata: None,
 //!     })
 //!     .build()
 //!     .await?;
@@ -66,7 +69,8 @@
 //!     )
 //!     .await?;
 //! assert!(result.success);
-//! # Ok::<(), everruns_core::AgentLoopError>(())
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Real-disk workspace


### PR DESCRIPTION
## What
Convert the crate-level `# Example` in `crates/runtime/src/lib.rs` from a `` ```ignore `` block into a runnable doctest, and wire `cargo test -p everruns-runtime --doc` into CI's unit-test job.

## Why
The example was marked `` ```ignore ``, so rustdoc never compiled or ran it. It had also drifted out of sync with the API — it omitted the `provider_metadata` field on `ResolvedModel`, so it would not have compiled as written. Documented examples that aren't tested rot silently.

Separately, the CI runtime test step is target-filtered (`--test in_process_runtime_test ...`), and `--test`/`--lib` skip Cargo's `Doc-tests` target. So even once the example compiled, nothing in CI would run it — it would only execute on a bare local `cargo test`.

## How
- Wrap the async body in a hidden `#[tokio::main]` `main` returning `AgentLoopError` so the top-level `.await?` calls compile and run (hidden `#` lines keep the rendered example unchanged).
- Add the missing `provider_metadata: None`.
- Add `cargo test -p everruns-runtime --doc` to the `unit-test` job so the example is guarded on every PR.

## Risk
- Low
- Worst case is a flaky/failing doctest step; it uses the in-memory LLM sim, no external services.

## Security
- Threat categories reviewed: No security-relevant code changes. The diff is a doc comment and a CI test invocation — no runtime code, secrets, network, auth, or data paths.
- Findings and resolutions: None.

## Follow-ups
- Optional: broaden to `cargo test --workspace --doc` to guard every crate's doctests, once we confirm other crates' doctests don't require external services/credentials (the unit-test job is intentionally dependency-free). No follow-ups otherwise.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01A4AJT8VH6vGQLsdXnuCchm

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4AJT8VH6vGQLsdXnuCchm)_