### PR TITLE
fix(ui): use accent variant for MCP Servers add button

### DIFF
--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -705,7 +705,7 @@ export default function McpServersPage() {
         </div>
         <div className="flex items-center gap-2">
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
-          <Button onClick={() => setAddServerOpen(true)}>
+          <Button variant="accent" onClick={() => setAddServerOpen(true)}>
             <Plus className="mr-2 h-4 w-4" />
             Add Server
           </Button>
@@ -731,7 +731,7 @@ export default function McpServersPage() {
             <p className="mb-4 text-muted-foreground">
               Add an MCP server to extend your agents with external tools and resources.
             </p>
-            <Button onClick={() => setAddServerOpen(true)}>
+            <Button variant="accent" onClick={() => setAddServerOpen(true)}>
               <Plus className="mr-2 h-4 w-4" />
               Add Server
             </Button>


### PR DESCRIPTION
## What
Use the `accent` button variant for the primary **"Add Server"** action on the MCP Servers page — in both the page header and the empty state.

## Why
The MCP Servers page was the odd one out. Nearly every other list page (`agents`, `apps`, `memory`, `knowledge-indexes`, `skills`, `harnesses`, `evals`, `agent-identities`, `dashboard`) uses `variant="accent"` for its primary create CTA, while MCP Servers used a plain `<Button>`. This made the page visually inconsistent with the rest of the app.

## How
Added `variant="accent"` to the two "Add Server" buttons in `apps/ui/src/app/(main)/mcp-servers/page.tsx`. No behavior change — purely a styling alignment.

## Risk
- Low
- Visual-only change to a single page's primary button styling. No logic, data, or API changes.

## Security
- Threat categories reviewed: No security-relevant code changes. The diff only adds a CSS variant prop to two buttons — no auth/authz, no new inputs, no rendering of untrusted data, no new dependencies.
- Findings and resolutions: None.

## Follow-ups
- The **Plugins** page shares the same deviation (its primary buttons aren't `accent` either). Deferred because the user only flagged MCP Servers; it's a safe, independent follow-up that can be aligned in a separate PR.

## Checklist
- [x] Tests added or updated (existing `mcp-servers-page.test.tsx` covers the page; no behavior change so no new assertions needed)
- [x] Backward compatibility considered (none affected)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vfrqn5eJLFRFBtTqMNfymT)_