### PR TITLE
feat(ui): add shared SearchInput for consistent search box height

### DIFF
--- a/apps/ui/src/app/(main)/agents/examples/page.tsx
+++ b/apps/ui/src/app/(main)/agents/examples/page.tsx
@@ -5,8 +5,8 @@ import { useAgentExamples, useImportAgentExample, useCapabilities, usePageTitle 
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { ArrowLeft, Search } from "lucide-react";
+import { SearchInput } from "@/components/ui/search-input";
+import { ArrowLeft } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ExampleCard } from "@/components/agents";
 
@@ -57,15 +57,12 @@ export default function AllExamplesPage() {
           </Link>
           <h1 className="text-2xl font-bold">Example Agents</h1>
         </div>
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search examples..."
-            value={exampleSearch}
-            onChange={(e) => setExampleSearch(e.target.value)}
-            className="pl-8 w-64"
-          />
-        </div>
+        <SearchInput
+          containerClassName="w-64"
+          placeholder="Search examples..."
+          value={exampleSearch}
+          onChange={(e) => setExampleSearch(e.target.value)}
+        />
       </div>
 
       <QueryStateWrapper

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -10,10 +10,10 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
-import { CircleOff, Search as SearchIcon, Bot, Layers, X, Plus, Pencil } from "lucide-react";
+import { CircleOff, Bot, Layers, X, Plus, Pencil } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, CapabilityStatus, DeclarativeCapability } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -331,14 +331,13 @@ export default function CapabilitiesPage() {
       )}
 
       {/* Search */}
-      <div className="relative max-w-xl">
-        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <Input
-          placeholder="Search by name, description, ID, or category..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="pl-9 pr-9"
-        />
+      <SearchInput
+        containerClassName="max-w-xl"
+        className="pr-9"
+        placeholder="Search by name, description, ID, or category..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      >
         {searchQuery && (
           <button
             type="button"
@@ -349,7 +348,7 @@ export default function CapabilitiesPage() {
             <X className="w-4 h-4" />
           </button>
         )}
-      </div>
+      </SearchInput>
 
       {/* Category filter */}
       {!isLoading && (

--- a/apps/ui/src/app/(main)/durable/queues/page.tsx
+++ b/apps/ui/src/app/(main)/durable/queues/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import {
   Select,
   SelectContent,
@@ -31,7 +31,6 @@ import {
   XCircle,
   Activity,
   RefreshCw,
-  Search,
   Inbox,
   ListTodo,
   Plus,
@@ -366,15 +365,12 @@ export default function QueuesPage() {
           <div className="space-y-4">
             {/* Filters */}
             <div className="flex items-center gap-4">
-              <div className="relative flex-1 max-w-sm">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search tasks..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-8"
-                />
-              </div>
+              <SearchInput
+                containerClassName="flex-1 max-w-sm"
+                placeholder="Search tasks..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
               <Select value={statusFilter} onValueChange={setStatusFilter}>
                 <SelectTrigger className="w-40">
                   <SelectValue placeholder="Status" />

--- a/apps/ui/src/app/(main)/durable/schedules/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import {
   Select,
   SelectContent,
@@ -48,7 +49,6 @@ import {
   Clock,
   AlertTriangle,
   Plus,
-  Search,
   RefreshCw,
   Play,
   Pause,
@@ -443,15 +443,12 @@ export default function SchedulesPage() {
         {/* Filters and Actions */}
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-4 flex-1">
-            <div className="relative flex-1 max-w-sm">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search schedules..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-8"
-              />
-            </div>
+            <SearchInput
+              containerClassName="flex-1 max-w-sm"
+              placeholder="Search schedules..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
             <Select value={statusFilter} onValueChange={setStatusFilter}>
               <SelectTrigger className="w-40">
                 <SelectValue placeholder="Status" />

--- a/apps/ui/src/app/(main)/durable/workflows/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import {
   Select,
   SelectContent,
@@ -39,7 +39,6 @@ import {
   XCircle,
   Activity,
   RefreshCw,
-  Search,
   ExternalLink,
   RotateCcw,
   Inbox,
@@ -429,15 +428,12 @@ export default function WorkflowsPage() {
           <div className="space-y-4">
             {/* Filters */}
             <div className="flex items-center gap-4">
-              <div className="relative flex-1 max-w-sm">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search workflows..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-8"
-                />
-              </div>
+              <SearchInput
+                containerClassName="flex-1 max-w-sm"
+                placeholder="Search workflows..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
               <Select value={statusFilter} onValueChange={setStatusFilter}>
                 <SelectTrigger className="w-40">
                   <SelectValue placeholder="Status" />

--- a/apps/ui/src/app/(main)/harnesses/examples/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/examples/page.tsx
@@ -10,8 +10,8 @@ import {
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { ArrowLeft, Search } from "lucide-react";
+import { SearchInput } from "@/components/ui/search-input";
+import { ArrowLeft } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { HarnessExampleCard } from "@/components/harnesses";
 
@@ -62,15 +62,12 @@ export default function AllHarnessExamplesPage() {
           </Link>
           <h1 className="text-2xl font-bold">Example Harnesses</h1>
         </div>
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search examples..."
-            value={exampleSearch}
-            onChange={(e) => setExampleSearch(e.target.value)}
-            className="pl-8 w-64"
-          />
-        </div>
+        <SearchInput
+          containerClassName="w-64"
+          placeholder="Search examples..."
+          value={exampleSearch}
+          onChange={(e) => setExampleSearch(e.target.value)}
+        />
       </div>
 
       <QueryStateWrapper

--- a/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
@@ -11,7 +11,6 @@ import {
   Pencil,
   Plus,
   RefreshCw,
-  Search,
 } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ArchiveFilter } from "@/components/archive-filter";
@@ -22,7 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import {
   useArchiveKnowledgeIndex,
   useCreateKnowledgeIndex,
@@ -66,16 +65,13 @@ export default function KnowledgeIndexesPage() {
       <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <h1 className="flex items-center gap-3 text-2xl font-bold">Knowledge Indexes</h1>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="relative sm:w-64">
-            <Search className="pointer-events-none absolute left-2.5 top-2 h-4 w-4 text-muted-foreground" />
-            <Input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search knowledge indexes"
-              className="pl-8"
-              aria-label="Search knowledge indexes"
-            />
-          </div>
+          <SearchInput
+            containerClassName="sm:w-64"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search knowledge indexes"
+            aria-label="Search knowledge indexes"
+          />
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Button variant="accent" onClick={() => setCreateOpen(true)}>
             <Plus className="h-4 w-4" />

--- a/apps/ui/src/app/(main)/memory/page.tsx
+++ b/apps/ui/src/app/(main)/memory/page.tsx
@@ -11,7 +11,6 @@ import {
   Pencil,
   Plus,
   RefreshCw,
-  Search,
 } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ArchiveFilter } from "@/components/archive-filter";
@@ -22,7 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import {
   useArchiveMemory,
   useCreateMemory,
@@ -57,16 +56,13 @@ export default function MemoryPage() {
       <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <h1 className="flex items-center gap-3 text-2xl font-bold">Memory</h1>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="relative sm:w-64">
-            <Search className="pointer-events-none absolute left-2.5 top-2 h-4 w-4 text-muted-foreground" />
-            <Input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search memory"
-              className="pl-8"
-              aria-label="Search memory"
-            />
-          </div>
+          <SearchInput
+            containerClassName="sm:w-64"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search memory"
+            aria-label="Search memory"
+          />
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Button variant="accent" onClick={() => setCreateOpen(true)}>
             <Plus className="h-4 w-4" />

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -27,7 +27,7 @@ import {
   useUploadSkill,
 } from "@/hooks/use-skills";
 import { usePolicies } from "@/hooks/use-policies";
-import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box, Eye, Search } from "lucide-react";
+import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box, Eye } from "lucide-react";
 import type { Skill, SkillUsage } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { ArchiveFilter } from "@/components/archive-filter";
@@ -284,16 +284,13 @@ export default function SkillsPageClient() {
       <div className="flex items-center justify-between mb-6 gap-2 flex-wrap">
         <h1 className="text-2xl font-bold">Skills</h1>
         <div className="flex items-center gap-2 flex-wrap">
-          <div className="relative">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search skills..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-8 w-64"
-              aria-label="Search skills"
-            />
-          </div>
+          <SearchInput
+            containerClassName="w-64"
+            placeholder="Search skills..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search skills"
+          />
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
             <Upload className="h-4 w-4 mr-2" />

--- a/apps/ui/src/components/agents/capability-dialog.tsx
+++ b/apps/ui/src/components/agents/capability-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -14,7 +14,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Plus, Search, ChevronRight, Plug, Link, Lock, Shield } from "lucide-react";
+import { Plus, ChevronRight, Plug, Link, Lock, Shield } from "lucide-react";
 import type { Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -121,18 +121,14 @@ export function CapabilityDialog({
         </DialogHeader>
 
         {/* Search input */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <Input
-            // eslint-disable-next-line jsx-a11y/no-autofocus -- search-input inside an opened dialog is a deliberate focus target
-            autoFocus
-            placeholder="Search capabilities..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
-            aria-label="Search capabilities"
-          />
-        </div>
+        <SearchInput
+          // eslint-disable-next-line jsx-a11y/no-autofocus -- search-input inside an opened dialog is a deliberate focus target
+          autoFocus
+          placeholder="Search capabilities..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label="Search capabilities"
+        />
 
         {/* Capability list */}
         <div className="flex-1 overflow-y-auto min-h-0 -mx-6 px-6">

--- a/apps/ui/src/components/ui/search-input.tsx
+++ b/apps/ui/src/components/ui/search-input.tsx
@@ -1,0 +1,29 @@
+import { Search } from "lucide-react";
+import * as React from "react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+type SearchInputProps = React.ComponentProps<typeof Input> & {
+  /** Classes for the wrapping element. Put width/flex utilities here (e.g. `w-64`). */
+  containerClassName?: string;
+};
+
+/**
+ * Search field used across list/index pages. Wraps {@link Input} with a
+ * vertically-centered magnifier icon so every search box renders at the same
+ * height as sibling buttons (the underlying Input is `h-8`, matching the
+ * default Button). Centralizing this keeps icon alignment and height
+ * consistent instead of each page hand-rolling the `relative`/`absolute` markup.
+ */
+function SearchInput({ className, containerClassName, children, ...props }: SearchInputProps) {
+  return (
+    <div className={cn("relative", containerClassName)}>
+      <Search className="text-muted-foreground pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
+      <Input data-slot="search-input" className={cn("pl-8", className)} {...props} />
+      {children}
+    </div>
+  );
+}
+
+export { SearchInput };


### PR DESCRIPTION
## What
Add a reusable `SearchInput` component and adopt it on every page/dialog that has a search box, replacing the duplicated `relative`/`absolute` icon-over-`Input` markup.

## Why
Search boxes were hand-rolled in ~10 places. The underlying `Input` and the default `Button` both already use `h-8`, so heights matched — but the duplicated markup had drifted: the magnifier icon was positioned three different ways (`top-2`, `top-2.5`, `top-1/2 -translate-y-1/2`) and left offsets varied (`left-2.5` vs `left-3`). Each copy was a chance for height/alignment to break. Centralizing guarantees every search box renders at the same height as sibling buttons with a consistently centered icon.

## How
- New `apps/ui/src/components/ui/search-input.tsx`: wraps `Input` with a vertically-centered (`top-1/2 -translate-y-1/2`) magnifier icon and `pl-8`. Exposes `containerClassName` for width/flex utilities and accepts `children` for trailing actions (e.g. a clear button).
- Replaced the bespoke search markup in: knowledge-indexes, memory, skills, capabilities, agents/examples, harnesses/examples, durable queues/workflows/schedules, and the agents capability dialog. Removed the now-unused `Input`/`Search` imports per file.
- The command-palette input is intentionally left alone — it's a borderless full-width cmdk-style field, not the toolbar search-next-to-buttons pattern.

## Risk
- Low / UI-only.
- What can break: visual layout of search boxes. Verified the rendered search box + Filter + New Index toolbar are all exactly 32px with the icon centered (measured via DevTools + screenshot).

## Security
- Threat categories reviewed: TM-WEB. No new endpoints, auth, data access, or input handling — this is a presentational refactor of existing client inputs (same `value`/`onChange` wiring, no `dangerouslySetInnerHTML`, no new dependencies).
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — presentational refactor; verified via build + live browser smoke test)
- [x] Backward compatibility considered (internal UI only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation: `pnpm run format:check`, `pnpm run lint`, `tsc --noEmit`, and `pnpm run build` all pass. Rendered the toolbar in a headless browser: search box, Filter, and New Index all measure 32px with the icon centered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G58phpL2VLWEehCgPqZVih)_