### PR TITLE
feat(ui): integration guides for agents, harnesses, and apps

### DIFF
--- a/apps/ui/src/__tests__/webhook-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/webhook-setup-guidance.test.tsx
@@ -18,6 +18,11 @@ describe("WebhookSetupGuidance", () => {
       screen.getByText("https://example.com/api/v1/apps/app-123/webhooks/appchan-123"),
     ).toBeInTheDocument();
     expect(screen.getByText("Session Per Invocation")).toBeInTheDocument();
-    expect(screen.getByText(/Authorization: Bearer/)).toBeInTheDocument();
+    // Auth guidance plus the generated code samples and coding-agent prompt all
+    // reference the bearer header, so there are multiple matches by design.
+    expect(screen.getAllByText(/Authorization: Bearer/).length).toBeGreaterThan(0);
+    // Integration snippets are surfaced for callers.
+    expect(screen.getByText("Call it from your app")).toBeInTheDocument();
+    expect(screen.getByText("Let a coding agent wire it up")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -27,6 +27,7 @@ import { SessionCard } from "@/components/session/session-card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { AgentVersionHistory } from "@/components/agents/agent-version-history";
+import { IntegrationGuide } from "@/components/integration/integration-guide";
 import {
   ArrowLeft,
   Plus,
@@ -39,6 +40,7 @@ import {
   BarChart3,
   GitBranch,
   Rocket,
+  Terminal,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
@@ -233,6 +235,10 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
           <TabsTrigger value="preview">
             <Eye className="w-4 h-4 mr-2" />
             Preview
+          </TabsTrigger>
+          <TabsTrigger value="integrate">
+            <Terminal className="w-4 h-4 mr-2" />
+            Integrate
           </TabsTrigger>
           <TabsTrigger value="stats">
             <BarChart3 className="w-4 h-4 mr-2" />
@@ -455,6 +461,10 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
             initialFiles={agent.initial_files}
             tools={agent.tools ?? []}
           />
+        </TabsContent>
+
+        <TabsContent value="integrate">
+          <IntegrationGuide kind="agent" id={agent.id} name={getDisplayName(agent)} />
         </TabsContent>
 
         <TabsContent value="stats">

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -23,6 +23,7 @@ import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
+import { IntegrationGuide } from "@/components/integration/integration-guide";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import {
   ArrowLeft,
@@ -33,6 +34,7 @@ import {
   LayoutDashboard,
   BarChart3,
   Rocket,
+  Terminal,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
@@ -203,6 +205,10 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
           <TabsTrigger value="preview">
             <Eye className="w-4 h-4 mr-2" />
             Preview
+          </TabsTrigger>
+          <TabsTrigger value="integrate">
+            <Terminal className="w-4 h-4 mr-2" />
+            Integrate
           </TabsTrigger>
           <TabsTrigger value="stats">
             <BarChart3 className="w-4 h-4 mr-2" />
@@ -379,6 +385,10 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
             }))}
             initialFiles={harness.initial_files}
           />
+        </TabsContent>
+
+        <TabsContent value="integrate">
+          <IntegrationGuide kind="harness" id={harness.id} name={getDisplayName(harness)} />
         </TabsContent>
 
         <TabsContent value="stats">

--- a/apps/ui/src/components/apps/a2a-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/a2a-setup-guidance.tsx
@@ -4,8 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import { CodeBlock } from "@/components/ui/code-block";
 import { A2aAgentCard, A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
 import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
+import { a2aSamples, codingAgentPrompt } from "@/lib/integration/snippets";
 import type { InvocationSessionMode } from "@/lib/api/types";
 import { Bot, Globe, KeyRound, RefreshCw } from "lucide-react";
 
@@ -44,6 +46,7 @@ export function A2aSetupGuidance({
   const [agentCardError, setAgentCardError] = useState<string | null>(null);
   const [agentCardLoading, setAgentCardLoading] = useState(false);
   const canFetchAgentCard = isPublished && channelEnabled;
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
 
   const fetchAgentCard = useCallback(async () => {
     if (!canFetchAgentCard) return;
@@ -201,6 +204,28 @@ export function A2aSetupGuidance({
           Templates can reference <code>{"{{a2a.text}}"}</code>, <code>{"{{payload}}"}</code>, and
           app metadata.
         </p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Call it from your app</p>
+        <div className="mt-2">
+          <CodeBlock samples={a2aSamples({ origin, endpointUrl })} />
+        </div>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Let a coding agent wire it up</p>
+        <div className="mt-2">
+          <CodeBlock
+            samples={[
+              {
+                label: "Prompt",
+                language: "text",
+                code: codingAgentPrompt({ origin, kind: "a2a", endpointUrl }),
+              },
+            ]}
+          />
+        </div>
       </div>
 
       <div className="flex flex-wrap gap-2 pt-1">

--- a/apps/ui/src/components/apps/webhook-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/webhook-setup-guidance.tsx
@@ -1,7 +1,9 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import { CodeBlock } from "@/components/ui/code-block";
 import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
+import { codingAgentPrompt, webhookSamples } from "@/lib/integration/snippets";
 import type { InvocationSessionMode } from "@/lib/api/types";
 import { Globe, KeyRound } from "lucide-react";
 
@@ -22,6 +24,7 @@ export function WebhookSetupGuidance({
   isPublished,
   onConfigure,
 }: WebhookSetupGuidanceProps) {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
@@ -70,6 +73,28 @@ export function WebhookSetupGuidance({
       <div className="space-y-1 text-sm text-muted-foreground">
         <p>Templates can reference payload, webhook headers, and app metadata.</p>
         <p>Each request injects a user message into the app-owned session flow.</p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Call it from your app</p>
+        <div className="mt-2">
+          <CodeBlock samples={webhookSamples({ origin, endpointUrl })} />
+        </div>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Let a coding agent wire it up</p>
+        <div className="mt-2">
+          <CodeBlock
+            samples={[
+              {
+                label: "Prompt",
+                language: "text",
+                code: codingAgentPrompt({ origin, kind: "webhook", endpointUrl }),
+              },
+            ]}
+          />
+        </div>
       </div>
 
       {onConfigure && (

--- a/apps/ui/src/components/integration/integration-guide.tsx
+++ b/apps/ui/src/components/integration/integration-guide.tsx
@@ -30,8 +30,7 @@ export function IntegrationGuide({ kind, id, name }: IntegrationGuideProps) {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
 
   const sdkSamples = useMemo(
-    () =>
-      sdkSessionSamples(kind === "agent" ? { origin, agentId: id } : { origin, harnessId: id }),
+    () => sdkSessionSamples(kind === "agent" ? { origin, agentId: id } : { origin, harnessId: id }),
     [origin, kind, id],
   );
 

--- a/apps/ui/src/components/integration/integration-guide.tsx
+++ b/apps/ui/src/components/integration/integration-guide.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { KeyRound, Package, Rocket, Sparkles, Terminal } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CodeBlock } from "@/components/ui/code-block";
+import {
+  codingAgentPrompt,
+  openApiUrl,
+  sdkSessionSamples,
+  sessionFlowSamples,
+  tokensUrl,
+} from "@/lib/integration/snippets";
+
+interface IntegrationGuideProps {
+  kind: "agent" | "harness";
+  id: string;
+  name?: string;
+}
+
+/**
+ * "Integrate" tab content shared by the Agent and Harness detail pages. This is
+ * the headless-platform payoff screen: it turns a composed entity into the code
+ * an external application needs to call it (create session -> send message ->
+ * stream), plus a prompt to hand a coding agent.
+ */
+export function IntegrationGuide({ kind, id, name }: IntegrationGuideProps) {
+  // Resolved at render so snippets point at this deployment's host.
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+
+  const sdkSamples = useMemo(
+    () =>
+      sdkSessionSamples(kind === "agent" ? { origin, agentId: id } : { origin, harnessId: id }),
+    [origin, kind, id],
+  );
+
+  const flowSamples = useMemo(
+    () =>
+      sessionFlowSamples(kind === "agent" ? { origin, agentId: id } : { origin, harnessId: id }),
+    [origin, kind, id],
+  );
+
+  const prompt = useMemo(
+    () => codingAgentPrompt({ origin, kind, id, name }),
+    [origin, kind, id, name],
+  );
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-3">
+      <div className="lg:col-span-2 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Package className="h-4 w-4" />
+              Use the SDK
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Everruns is headless — you compose the {kind} here and invoke it from your own code.
+              The official SDKs give you typed models and SSE streaming with automatic reconnection.
+              Same three steps everywhere: start a session bound to this {kind}, send a message,
+              stream the response.
+            </p>
+            <CodeBlock samples={sdkSamples} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Terminal className="h-4 w-4" />
+              Or call the HTTP API directly
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              No SDK required — any HTTP client works. Create a session, send a message, then stream
+              events.
+            </p>
+            <CodeBlock samples={flowSamples} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4" />
+              Let a coding agent wire it up
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Paste this into Claude Code, Cursor, or any coding agent to have it add a client to
+              your codebase. It includes the endpoint, auth, exact flow, and a link to the OpenAPI
+              spec for precise schemas.
+            </p>
+            <CodeBlock samples={[{ label: "Prompt", language: "text", code: prompt }]} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4" />
+              Authentication
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              Authenticate with a personal access token (prefix <code>evr_pat_</code>) sent as{" "}
+              <code>Authorization: Bearer &lt;token&gt;</code>.
+            </p>
+            <Link
+              href="/settings/personal-access-tokens"
+              className="inline-block text-primary hover:underline"
+            >
+              Manage personal access tokens →
+            </Link>
+            <p className="break-all text-xs">
+              Token page: <code>{tokensUrl(origin)}</code>
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Rocket className="h-4 w-4" />
+              Going to production
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            {kind === "agent" ? (
+              <p>
+                For external-facing or unattended use, deploy this agent as an{" "}
+                <Link href="/apps/new" className="text-primary hover:underline">
+                  App
+                </Link>{" "}
+                with a webhook, A2A, or AG-UI channel. Each channel gets its own scoped token and
+                ready-made integration snippets.
+              </p>
+            ) : (
+              <p>
+                Harnesses are infrastructure. Most integrations call an{" "}
+                <Link href="/agents" className="text-primary hover:underline">
+                  agent
+                </Link>{" "}
+                that runs on this harness, or deploy one as an{" "}
+                <Link href="/apps/new" className="text-primary hover:underline">
+                  App
+                </Link>
+                . Calling a harness directly (no agent) uses the org defaults for prompt and model.
+              </p>
+            )}
+            <p className="break-all text-xs">
+              OpenAPI spec: <code>{openApiUrl(origin)}</code>
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/ui/code-block.tsx
+++ b/apps/ui/src/components/ui/code-block.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { Button } from "./button";
+import { cn } from "@/lib/utils";
+
+export interface CodeBlockSample {
+  /** Tab label shown when there is more than one sample. */
+  label: string;
+  /** Optional language hint (currently informational; no highlighting theme). */
+  language?: string;
+  code: string;
+}
+
+interface CodeBlockProps {
+  samples: CodeBlockSample[];
+  className?: string;
+}
+
+/**
+ * Monospaced code block with optional language tabs and a copy button. The app
+ * styles code as plain `<pre>`/`<code>` over `bg-muted`; this keeps that look
+ * while adding multi-language switching and copy-to-clipboard in one place.
+ */
+export function CodeBlock({ samples, className }: CodeBlockProps) {
+  const [active, setActive] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const current = samples[active] ?? samples[0];
+
+  if (!current) return null;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(current.code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className={cn("overflow-hidden rounded-md border bg-muted", className)}>
+      <div className="flex items-center justify-between gap-2 border-b bg-muted/50 px-2 py-1">
+        <div className="flex flex-wrap gap-0.5">
+          {samples.length > 1 &&
+            samples.map((sample, index) => (
+              <button
+                key={sample.label}
+                type="button"
+                onClick={() => setActive(index)}
+                className={cn(
+                  "px-2 py-1 text-xs font-medium transition-colors",
+                  index === active
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {sample.label}
+              </button>
+            ))}
+          {samples.length === 1 && (
+            <span className="px-2 py-1 text-xs font-medium text-muted-foreground">
+              {current.label}
+            </span>
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0 p-0"
+          onClick={handleCopy}
+          title={copied ? "Copied!" : "Copy"}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-green-500" />
+          ) : (
+            <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-relaxed">
+        <code>{current.code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/ui/src/components/ui/code-block.tsx
+++ b/apps/ui/src/components/ui/code-block.tsx
@@ -31,20 +31,26 @@ export function CodeBlock({ samples, className }: CodeBlockProps) {
   if (!current) return null;
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(current.code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    try {
+      await navigator.clipboard.writeText(current.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can reject in insecure contexts or when permission is denied;
+      // swallow so the click never surfaces an unhandled rejection.
+    }
   };
 
   return (
     <div className={cn("overflow-hidden rounded-md border bg-muted", className)}>
       <div className="flex items-center justify-between gap-2 border-b bg-muted/50 px-2 py-1">
-        <div className="flex flex-wrap gap-0.5">
+        <div className="flex flex-wrap gap-0.5" role="group" aria-label="Code language">
           {samples.length > 1 &&
             samples.map((sample, index) => (
               <button
-                key={sample.label}
+                key={`${index}-${sample.label}`}
                 type="button"
+                aria-pressed={index === active}
                 onClick={() => setActive(index)}
                 className={cn(
                   "px-2 py-1 text-xs font-medium transition-colors",

--- a/apps/ui/src/lib/__tests__/integration-snippets.test.ts
+++ b/apps/ui/src/lib/__tests__/integration-snippets.test.ts
@@ -79,4 +79,19 @@ describe("integration snippets", () => {
     expect(prompt).toContain("everruns-sdk");
     expect(prompt).toContain(openApiUrl(ORIGIN));
   });
+
+  it("opens the coding-agent prompt with a subject matching the kind", () => {
+    expect(codingAgentPrompt({ origin: ORIGIN, kind: "agent", id: "a" })).toMatch(
+      /^I want to integrate an Everruns agent /,
+    );
+    expect(codingAgentPrompt({ origin: ORIGIN, kind: "harness", id: "h" })).toMatch(
+      /^I want to integrate an Everruns harness /,
+    );
+    expect(codingAgentPrompt({ origin: ORIGIN, kind: "webhook", endpointUrl: "/w" })).toMatch(
+      /^I want to integrate an Everruns app \(webhook channel\) /,
+    );
+    expect(codingAgentPrompt({ origin: ORIGIN, kind: "a2a", endpointUrl: "/a" })).toMatch(
+      /^I want to integrate an Everruns app \(A2A channel\) /,
+    );
+  });
 });

--- a/apps/ui/src/lib/__tests__/integration-snippets.test.ts
+++ b/apps/ui/src/lib/__tests__/integration-snippets.test.ts
@@ -1,0 +1,82 @@
+import {
+  a2aSamples,
+  apiBaseUrl,
+  codingAgentPrompt,
+  openApiUrl,
+  sdkSessionSamples,
+  sessionFlowSamples,
+  webhookSamples,
+} from "@/lib/integration/snippets";
+
+const ORIGIN = "https://app.example.com";
+
+describe("integration snippets", () => {
+  it("derives REST and OpenAPI URLs from the origin", () => {
+    expect(apiBaseUrl(ORIGIN)).toBe("https://app.example.com/api/v1");
+    expect(openApiUrl(ORIGIN)).toBe("https://app.example.com/api-doc/openapi.json");
+  });
+
+  it("falls back to a placeholder host when origin is empty", () => {
+    expect(apiBaseUrl("")).toContain("your-everruns-host");
+  });
+
+  it("binds the session flow to an agent across all four languages", () => {
+    const samples = sessionFlowSamples({ origin: ORIGIN, agentId: "agent_123" });
+    expect(samples.map((s) => s.label)).toEqual(["curl", "TypeScript", "Python", "Rust"]);
+    for (const sample of samples) {
+      expect(sample.code).toContain("agent_123");
+      expect(sample.code).not.toContain("harness_id");
+    }
+  });
+
+  it("binds the session flow to a harness when given a harness id", () => {
+    const samples = sessionFlowSamples({ origin: ORIGIN, harnessId: "harness_9" });
+    for (const sample of samples) {
+      expect(sample.code).toContain("harness_id");
+      expect(sample.code).toContain("harness_9");
+    }
+  });
+
+  it("does not leak unresolved template interpolation into generated code", () => {
+    const all = [
+      ...sessionFlowSamples({ origin: ORIGIN, agentId: "a" }),
+      ...sdkSessionSamples({ origin: ORIGIN, agentId: "a" }),
+      ...webhookSamples({ origin: ORIGIN, endpointUrl: "/api/v1/apps/x/webhooks/y" }),
+      ...a2aSamples({ origin: ORIGIN, endpointUrl: "https://h/api/v1/apps/x/a2a/y" }),
+    ];
+    for (const sample of all) {
+      expect(sample.code).not.toContain("${");
+    }
+  });
+
+  it("emits SDK install hints and the /api base for the SDK samples", () => {
+    const samples = sdkSessionSamples({ origin: ORIGIN, agentId: "agent_123" });
+    expect(samples.map((s) => s.label)).toEqual(["Python", "TypeScript", "Rust"]);
+    expect(samples.find((s) => s.label === "Python")?.code).toContain("pip install everruns-sdk");
+    expect(samples.find((s) => s.label === "Rust")?.code).toContain("cargo add everruns-sdk");
+    expect(samples.find((s) => s.label === "TypeScript")?.code).toContain(
+      "npm install @everruns/sdk",
+    );
+    // SDK base URL is the /api root, not /api/v1.
+    expect(samples.find((s) => s.label === "Python")?.code).toContain(`${ORIGIN}/api"`);
+  });
+
+  it("absolutizes relative webhook endpoints", () => {
+    const [curl] = webhookSamples({ origin: ORIGIN, endpointUrl: "/api/v1/apps/x/webhooks/y" });
+    expect(curl.code).toContain("https://app.example.com/api/v1/apps/x/webhooks/y");
+  });
+
+  it("builds a coding-agent prompt that references the entity, flow, and SDKs", () => {
+    const prompt = codingAgentPrompt({
+      origin: ORIGIN,
+      kind: "agent",
+      id: "agent_123",
+      name: "Support Bot",
+    });
+    expect(prompt).toContain("agent_123");
+    expect(prompt).toContain("Support Bot");
+    expect(prompt).toContain("/sessions");
+    expect(prompt).toContain("everruns-sdk");
+    expect(prompt).toContain(openApiUrl(ORIGIN));
+  });
+});

--- a/apps/ui/src/lib/integration/snippets.ts
+++ b/apps/ui/src/lib/integration/snippets.ts
@@ -1,0 +1,556 @@
+// Integration snippet generators.
+//
+// Everruns is a headless platform: people compose Agents / Harnesses / Apps in
+// this management UI but invoke them from their own applications over the HTTP
+// API. These pure functions turn a composed entity into copy-paste integration
+// material (curl / TypeScript / Python) plus a ready-to-paste prompt for a
+// coding agent. Keeping them pure (string in, string out) makes them trivially
+// unit-testable and reusable across the Agent, Harness, and App surfaces.
+
+export interface CodeSample {
+  /** Tab label, e.g. "curl", "TypeScript", "Python". */
+  label: string;
+  /** Highlight hint / fenced-code language, e.g. "bash", "ts", "python". */
+  language: string;
+  code: string;
+}
+
+/** Placeholder token rendered in snippets; users swap in a real PAT. */
+export const TOKEN_PLACEHOLDER = "evr_pat_xxx";
+
+const FALLBACK_ORIGIN = "https://your-everruns-host";
+
+function resolveOrigin(origin: string): string {
+  return origin || FALLBACK_ORIGIN;
+}
+
+/** REST base URL. The UI mounts the backend under `/api`; public base is `/api/v1`. */
+export function apiBaseUrl(origin: string): string {
+  return `${resolveOrigin(origin)}/api/v1`;
+}
+
+/** OpenAPI document URL — the source of truth external integrators should read. */
+export function openApiUrl(origin: string): string {
+  return `${resolveOrigin(origin)}/api-doc/openapi.json`;
+}
+
+/** Personal-access-token management page in this UI. */
+export function tokensUrl(origin: string): string {
+  return `${resolveOrigin(origin)}/settings/personal-access-tokens`;
+}
+
+/** Make a possibly-relative endpoint absolute against the given origin. */
+function absolutize(endpointUrl: string, origin: string): string {
+  if (endpointUrl.startsWith("http://") || endpointUrl.startsWith("https://")) {
+    return endpointUrl;
+  }
+  return `${resolveOrigin(origin)}${endpointUrl.startsWith("/") ? "" : "/"}${endpointUrl}`;
+}
+
+type SessionBinding =
+  | { agentId: string; harnessId?: undefined }
+  | { harnessId: string; agentId?: undefined };
+
+/**
+ * Code samples for the core direct-API flow: create a session bound to this
+ * agent (or harness), send a user message, then stream the response over SSE.
+ *
+ * Generated JS uses string concatenation (not template literals) and bash uses
+ * unbraced `$VARS` so nothing in the emitted code collides with this file's own
+ * `${}` interpolation.
+ */
+export function sessionFlowSamples(opts: { origin: string } & SessionBinding): CodeSample[] {
+  const base = apiBaseUrl(opts.origin);
+  const isAgent = opts.agentId !== undefined;
+  const kind = isAgent ? "agent" : "harness";
+  const bindKey = isAgent ? "agent_id" : "harness_id";
+  const bindVal = isAgent ? opts.agentId! : opts.harnessId!;
+  const bindJson = `{"${bindKey}": "${bindVal}"}`;
+  const bindJs = `{ ${bindKey}: "${bindVal}" }`;
+  const bindPy = `{"${bindKey}": "${bindVal}"}`;
+
+  const curl: CodeSample = {
+    label: "curl",
+    language: "bash",
+    code: [
+      `# 1. Credentials — create a token at ${tokensUrl(opts.origin)}`,
+      `export EVERRUNS_TOKEN="${TOKEN_PLACEHOLDER}"`,
+      `export EVERRUNS_API="${base}"`,
+      ``,
+      `# 2. Create a session bound to this ${kind}`,
+      `SESSION_ID=$(curl -s -X POST "$EVERRUNS_API/sessions" \\`,
+      `  -H "Authorization: Bearer $EVERRUNS_TOKEN" \\`,
+      `  -H "Content-Type: application/json" \\`,
+      `  -d '${bindJson}' | jq -r .id)`,
+      ``,
+      `# 3. Send a user message (triggers a turn)`,
+      `curl -s -X POST "$EVERRUNS_API/sessions/$SESSION_ID/messages" \\`,
+      `  -H "Authorization: Bearer $EVERRUNS_TOKEN" \\`,
+      `  -H "Content-Type: application/json" \\`,
+      `  -d '{"message":{"role":"user","content":[{"type":"text","text":"Hello!"}]}}'`,
+      ``,
+      `# 4. Stream the response (Server-Sent Events)`,
+      `curl -N "$EVERRUNS_API/sessions/$SESSION_ID/sse" \\`,
+      `  -H "Authorization: Bearer $EVERRUNS_TOKEN"`,
+    ].join("\n"),
+  };
+
+  const typescript: CodeSample = {
+    label: "TypeScript",
+    language: "ts",
+    code: [
+      `const API = "${base}";`,
+      `const TOKEN = process.env.EVERRUNS_TOKEN!; // ${TOKEN_PLACEHOLDER}`,
+      `const headers = {`,
+      `  Authorization: "Bearer " + TOKEN,`,
+      `  "Content-Type": "application/json",`,
+      `};`,
+      ``,
+      `// 1. Create a session bound to this ${kind}`,
+      `const session = await fetch(API + "/sessions", {`,
+      `  method: "POST",`,
+      `  headers,`,
+      `  body: JSON.stringify(${bindJs}),`,
+      `}).then((r) => r.json());`,
+      ``,
+      `// 2. Send a user message`,
+      `await fetch(API + "/sessions/" + session.id + "/messages", {`,
+      `  method: "POST",`,
+      `  headers,`,
+      `  body: JSON.stringify({`,
+      `    message: { role: "user", content: [{ type: "text", text: "Hello!" }] },`,
+      `  }),`,
+      `});`,
+      ``,
+      `// 3. Stream events until the turn completes`,
+      `const res = await fetch(API + "/sessions/" + session.id + "/sse", { headers });`,
+      `const reader = res.body!.getReader();`,
+      `const decoder = new TextDecoder();`,
+      `for (;;) {`,
+      `  const { value, done } = await reader.read();`,
+      `  if (done) break;`,
+      `  // Watch the stream for "output.message.completed" (final answer).`,
+      `  process.stdout.write(decoder.decode(value));`,
+      `}`,
+    ].join("\n"),
+  };
+
+  const python: CodeSample = {
+    label: "Python",
+    language: "python",
+    code: [
+      `import requests`,
+      ``,
+      `API = "${base}"`,
+      `TOKEN = "${TOKEN_PLACEHOLDER}"  # create at ${tokensUrl(opts.origin)}`,
+      `headers = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}`,
+      ``,
+      `# 1. Create a session bound to this ${kind}`,
+      `session = requests.post(`,
+      `    f"{API}/sessions", headers=headers, json=${bindPy}`,
+      `).json()`,
+      `session_id = session["id"]`,
+      ``,
+      `# 2. Send a user message`,
+      `requests.post(`,
+      `    f"{API}/sessions/{session_id}/messages",`,
+      `    headers=headers,`,
+      `    json={"message": {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}},`,
+      `)`,
+      ``,
+      `# 3. Stream events until the turn completes`,
+      `with requests.get(f"{API}/sessions/{session_id}/sse", headers=headers, stream=True) as r:`,
+      `    for line in r.iter_lines():`,
+      `        if line:`,
+      `            # Watch the stream for "output.message.completed" (final answer).`,
+      `            print(line.decode())`,
+    ].join("\n"),
+  };
+
+  const rust: CodeSample = {
+    label: "Rust",
+    language: "rust",
+    code: [
+      `// Cargo.toml: reqwest = { version = "0.12", features = ["json", "stream"] }`,
+      `//            tokio = { version = "1", features = ["full"] }; futures-util = "0.3"`,
+      `use futures_util::StreamExt;`,
+      ``,
+      `#[tokio::main]`,
+      `async fn main() -> Result<(), Box<dyn std::error::Error>> {`,
+      `    let api = "${base}";`,
+      `    let token = "${TOKEN_PLACEHOLDER}";`,
+      `    let http = reqwest::Client::new();`,
+      ``,
+      `    // 1. Create a session bound to this ${kind}`,
+      `    let session: serde_json::Value = http`,
+      `        .post(format!("{api}/sessions"))`,
+      `        .bearer_auth(token)`,
+      `        .json(&serde_json::json!({ "${bindKey}": "${bindVal}" }))`,
+      `        .send().await?.json().await?;`,
+      `    let session_id = session["id"].as_str().unwrap();`,
+      ``,
+      `    // 2. Send a user message`,
+      `    http.post(format!("{api}/sessions/{session_id}/messages"))`,
+      `        .bearer_auth(token)`,
+      `        .json(&serde_json::json!({`,
+      `            "message": { "role": "user", "content": [{ "type": "text", "text": "Hello!" }] }`,
+      `        }))`,
+      `        .send().await?;`,
+      ``,
+      `    // 3. Stream events until the turn completes`,
+      `    let mut stream = http`,
+      `        .get(format!("{api}/sessions/{session_id}/sse"))`,
+      `        .bearer_auth(token)`,
+      `        .send().await?`,
+      `        .bytes_stream();`,
+      `    while let Some(chunk) = stream.next().await {`,
+      `        print!("{}", String::from_utf8_lossy(&chunk?)); // watch for output.message.completed`,
+      `    }`,
+      `    Ok(())`,
+      `}`,
+    ].join("\n"),
+  };
+
+  return [curl, typescript, python, rust];
+}
+
+/**
+ * Code samples using the official Everruns SDKs (Python / TypeScript / Rust).
+ * The SDKs add typed models and SSE streaming with automatic reconnection. The
+ * SDK base URL is the `/api` root (the client appends the version itself).
+ */
+export function sdkSessionSamples(opts: { origin: string } & SessionBinding): CodeSample[] {
+  const sdkBase = `${resolveOrigin(opts.origin)}/api`;
+  const isAgent = opts.agentId !== undefined;
+  const kind = isAgent ? "agent" : "harness";
+  const bindKey = isAgent ? "agent_id" : "harness_id";
+  const bindVal = isAgent ? opts.agentId! : opts.harnessId!;
+
+  const python: CodeSample = {
+    label: "Python",
+    language: "python",
+    code: [
+      `# pip install everruns-sdk`,
+      `import asyncio`,
+      `from everruns_sdk import Everruns`,
+      ``,
+      `async def main():`,
+      `    client = Everruns(api_key="${TOKEN_PLACEHOLDER}", base_url="${sdkBase}")`,
+      ``,
+      `    # 1. Start a session bound to this ${kind}`,
+      `    session = await client.sessions.create(${bindKey}="${bindVal}")`,
+      ``,
+      `    # 2. Send a user message`,
+      `    await client.messages.create(session.id, "Hello!")`,
+      ``,
+      `    # 3. Stream the response (auto-reconnecting SSE)`,
+      `    async for event in client.events.stream(session.id):`,
+      `        if event.type == "output.message.delta":`,
+      `            print(event.data.get("delta", ""), end="", flush=True)`,
+      `        elif event.type == "turn.completed":`,
+      `            break`,
+      `    await client.close()`,
+      ``,
+      `asyncio.run(main())`,
+    ].join("\n"),
+  };
+
+  const typescript: CodeSample = {
+    label: "TypeScript",
+    language: "ts",
+    code: [
+      `// npm install @everruns/sdk`,
+      `import { Client } from "@everruns/sdk";`,
+      ``,
+      `const client = new Client({ apiKey: "${TOKEN_PLACEHOLDER}", baseUrl: "${sdkBase}" });`,
+      ``,
+      `// 1. Start a session bound to this ${kind}`,
+      `const session = await client.sessions.create({ ${bindKey}: "${bindVal}" });`,
+      ``,
+      `// 2. Send a user message`,
+      `await client.messages.create(session.id, "Hello!");`,
+      ``,
+      `// 3. Stream the response (auto-reconnecting SSE)`,
+      `for await (const event of client.events.stream(session.id)) {`,
+      `  if (event.type === "output.message.delta") {`,
+      `    process.stdout.write(event.data.delta ?? "");`,
+      `  } else if (event.type === "turn.completed") {`,
+      `    break;`,
+      `  }`,
+      `}`,
+    ].join("\n"),
+  };
+
+  const rust: CodeSample = {
+    label: "Rust",
+    language: "rust",
+    code: [
+      `// cargo add everruns-sdk`,
+      `use everruns_sdk::Client;`,
+      `use futures_util::StreamExt;`,
+      ``,
+      `#[tokio::main]`,
+      `async fn main() -> Result<(), Box<dyn std::error::Error>> {`,
+      `    let client = Client::new("${TOKEN_PLACEHOLDER}").with_base_url("${sdkBase}");`,
+      ``,
+      `    // 1. Start a session bound to this ${kind}`,
+      `    let session = client.sessions().create_for_${kind}("${bindVal}").await?;`,
+      ``,
+      `    // 2. Send a user message`,
+      `    client.messages().create(&session.id, "Hello!").await?;`,
+      ``,
+      `    // 3. Stream the response (auto-reconnecting SSE)`,
+      `    let mut events = client.events().stream(&session.id).await?;`,
+      `    while let Some(event) = events.next().await {`,
+      `        let event = event?;`,
+      `        if event.type_ == "turn.completed" { break; }`,
+      `    }`,
+      `    Ok(())`,
+      `}`,
+    ].join("\n"),
+  };
+
+  return [python, typescript, rust];
+}
+
+/** Code samples for invoking an App webhook channel. */
+export function webhookSamples(opts: { origin: string; endpointUrl: string }): CodeSample[] {
+  const url = absolutize(opts.endpointUrl, opts.origin);
+  return [
+    {
+      label: "curl",
+      language: "bash",
+      code: [
+        `curl -X POST "${url}" \\`,
+        `  -H "Authorization: Bearer YOUR_WEBHOOK_TOKEN" \\`,
+        `  -H "Content-Type: application/json" \\`,
+        `  -d '{"example": "payload"}'`,
+      ].join("\n"),
+    },
+    {
+      label: "TypeScript",
+      language: "ts",
+      code: [
+        `await fetch("${url}", {`,
+        `  method: "POST",`,
+        `  headers: {`,
+        `    Authorization: "Bearer YOUR_WEBHOOK_TOKEN",`,
+        `    "Content-Type": "application/json",`,
+        `  },`,
+        `  body: JSON.stringify({ example: "payload" }),`,
+        `});`,
+      ].join("\n"),
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: [
+        `import requests`,
+        ``,
+        `requests.post(`,
+        `    "${url}",`,
+        `    headers={"Authorization": "Bearer YOUR_WEBHOOK_TOKEN"},`,
+        `    json={"example": "payload"},`,
+        `)`,
+      ].join("\n"),
+    },
+    {
+      label: "Rust",
+      language: "rust",
+      code: [
+        `// reqwest = { version = "0.12", features = ["json"] }`,
+        `reqwest::Client::new()`,
+        `    .post("${url}")`,
+        `    .bearer_auth("YOUR_WEBHOOK_TOKEN")`,
+        `    .json(&serde_json::json!({ "example": "payload" }))`,
+        `    .send().await?;`,
+      ].join("\n"),
+    },
+  ];
+}
+
+/** Code samples for invoking an App A2A channel (JSON-RPC 2.0 message/send). */
+export function a2aSamples(opts: { origin: string; endpointUrl: string }): CodeSample[] {
+  const url = absolutize(opts.endpointUrl, opts.origin);
+  const rpcJson = [
+    `{`,
+    `  "jsonrpc": "2.0",`,
+    `  "id": "1",`,
+    `  "method": "message/send",`,
+    `  "params": {`,
+    `    "message": {`,
+    `      "role": "user",`,
+    `      "parts": [{ "kind": "text", "text": "Hello!" }],`,
+    `      "messageId": "msg-1"`,
+    `    }`,
+    `  }`,
+    `}`,
+  ].join("\n");
+
+  return [
+    {
+      label: "curl",
+      language: "bash",
+      code: [
+        `curl -X POST "${url}" \\`,
+        `  -H "Authorization: Bearer YOUR_A2A_KEY" \\`,
+        `  -H "Content-Type: application/json" \\`,
+        `  -d '${rpcJson.replace(/\n/g, "")}'`,
+      ].join("\n"),
+    },
+    {
+      label: "TypeScript",
+      language: "ts",
+      code: [
+        `await fetch("${url}", {`,
+        `  method: "POST",`,
+        `  headers: {`,
+        `    Authorization: "Bearer YOUR_A2A_KEY",`,
+        `    "Content-Type": "application/json",`,
+        `  },`,
+        `  body: JSON.stringify({`,
+        `    jsonrpc: "2.0",`,
+        `    id: "1",`,
+        `    method: "message/send",`,
+        `    params: {`,
+        `      message: {`,
+        `        role: "user",`,
+        `        parts: [{ kind: "text", text: "Hello!" }],`,
+        `        messageId: "msg-1",`,
+        `      },`,
+        `    },`,
+        `  }),`,
+        `});`,
+      ].join("\n"),
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: [
+        `import requests`,
+        ``,
+        `requests.post(`,
+        `    "${url}",`,
+        `    headers={"Authorization": "Bearer YOUR_A2A_KEY"},`,
+        `    json={`,
+        `        "jsonrpc": "2.0",`,
+        `        "id": "1",`,
+        `        "method": "message/send",`,
+        `        "params": {`,
+        `            "message": {`,
+        `                "role": "user",`,
+        `                "parts": [{"kind": "text", "text": "Hello!"}],`,
+        `                "messageId": "msg-1",`,
+        `            }`,
+        `        },`,
+        `    },`,
+        `)`,
+      ].join("\n"),
+    },
+    {
+      label: "Rust",
+      language: "rust",
+      code: [
+        `// reqwest = { version = "0.12", features = ["json"] }`,
+        `reqwest::Client::new()`,
+        `    .post("${url}")`,
+        `    .bearer_auth("YOUR_A2A_KEY")`,
+        `    .json(&serde_json::json!({`,
+        `        "jsonrpc": "2.0",`,
+        `        "id": "1",`,
+        `        "method": "message/send",`,
+        `        "params": { "message": {`,
+        `            "role": "user",`,
+        `            "parts": [{ "kind": "text", "text": "Hello!" }],`,
+        `            "messageId": "msg-1"`,
+        `        } }`,
+        `    }))`,
+        `    .send().await?;`,
+      ].join("\n"),
+    },
+  ];
+}
+
+export type PromptKind = "agent" | "harness" | "webhook" | "a2a";
+
+/**
+ * A ready-to-paste prompt handed to a coding agent (Claude Code, Cursor, ...) so
+ * it can wire up the integration directly in the user's codebase. It states the
+ * endpoint, auth, exact flow, and links the OpenAPI spec for precise schemas.
+ */
+export function codingAgentPrompt(opts: {
+  origin: string;
+  kind: PromptKind;
+  id?: string;
+  name?: string;
+  endpointUrl?: string;
+}): string {
+  const intro = [
+    `I want to integrate an Everruns agent into my application.`,
+    ``,
+    `Everruns is a headless agent platform that I call over its HTTP API.`,
+    `- OpenAPI spec (authoritative schemas): ${openApiUrl(opts.origin)}`,
+  ];
+
+  if (opts.kind === "agent" || opts.kind === "harness") {
+    const bindKey = opts.kind === "agent" ? "agent_id" : "harness_id";
+    return [
+      ...intro,
+      `- Base URL: ${apiBaseUrl(opts.origin)}`,
+      `- Auth: header \`Authorization: Bearer <token>\` (a personal access token, prefix \`evr_pat_\`).`,
+      ``,
+      `Target ${opts.kind}:`,
+      `- ${bindKey}: ${opts.id ?? "<id>"}${opts.name ? `\n- name: ${opts.name}` : ""}`,
+      ``,
+      `Integration flow:`,
+      `1. POST /sessions with body {"${bindKey}": "${opts.id ?? "<id>"}"} -> returns a session; keep its "id".`,
+      `2. POST /sessions/{id}/messages with body`,
+      `   {"message": {"role": "user", "content": [{"type": "text", "text": "<user text>"}]}}`,
+      `   to trigger a turn.`,
+      `3. GET /sessions/{id}/sse (Server-Sent Events) to stream the response. Watch for`,
+      `   "output.message.completed" (final agent message) and "session.idled" (turn done).`,
+      `   Alternatively poll GET /sessions/{id}/messages.`,
+      ``,
+      `Official SDKs are available — prefer them if my project uses one of these:`,
+      `- Rust: \`cargo add everruns-sdk\``,
+      `- Python: \`pip install everruns-sdk\``,
+      `- TypeScript: \`npm install @everruns/sdk\``,
+      `They expose sub-clients (sessions, messages, events) and SSE streaming with`,
+      `automatic reconnection. The SDK base URL is the \`/api\` root (it appends the`,
+      `version). Otherwise call the REST API directly per the flow above.`,
+      ``,
+      `Please add a small typed client to my codebase that creates a session once,`,
+      `sends a user message, waits for the final agent message, and returns it as a`,
+      `string. Read the OpenAPI spec above for exact request/response schemas.`,
+    ].join("\n");
+  }
+
+  if (opts.kind === "webhook") {
+    return [
+      ...intro,
+      ``,
+      `I have an Everruns App with a webhook channel:`,
+      `- Endpoint: POST ${absolutize(opts.endpointUrl ?? "", opts.origin)}`,
+      `- Auth: header \`Authorization: Bearer <webhook-token>\` (or \`X-Everruns-Webhook-Token\`).`,
+      ``,
+      `Please add code to my application that POSTs a JSON payload to this endpoint`,
+      `whenever <my trigger> happens. The payload fields are referenced by the app's`,
+      `message template, so include the fields my template expects. The endpoint`,
+      `returns 202 with a session id. Use my project's existing language and HTTP library.`,
+    ].join("\n");
+  }
+
+  // a2a
+  return [
+    ...intro,
+    ``,
+    `I have an Everruns App exposed as an A2A (Agent2Agent) agent:`,
+    `- JSON-RPC endpoint: POST ${absolutize(opts.endpointUrl ?? "", opts.origin)}`,
+    `- Auth: header \`Authorization: Bearer <api-key>\`.`,
+    `- Protocol: A2A JSON-RPC 2.0, method "message/send" with a user message part.`,
+    ``,
+    `Please add an A2A client to my application that sends a text message to this`,
+    `agent and reads the resulting task/message back. Use my project's existing`,
+    `language and HTTP library.`,
+  ].join("\n");
+}

--- a/apps/ui/src/lib/integration/snippets.ts
+++ b/apps/ui/src/lib/integration/snippets.ts
@@ -485,8 +485,14 @@ export function codingAgentPrompt(opts: {
   name?: string;
   endpointUrl?: string;
 }): string {
+  const subject: Record<PromptKind, string> = {
+    agent: "an Everruns agent",
+    harness: "an Everruns harness",
+    webhook: "an Everruns app (webhook channel)",
+    a2a: "an Everruns app (A2A channel)",
+  };
   const intro = [
-    `I want to integrate an Everruns agent into my application.`,
+    `I want to integrate ${subject[opts.kind]} into my application.`,
     ``,
     `Everruns is a headless agent platform that I call over its HTTP API.`,
     `- OpenAPI spec (authoritative schemas): ${openApiUrl(opts.origin)}`,


### PR DESCRIPTION
## What
Everruns is a headless platform: people compose agents/harnesses/apps in the management UI but invoke them from their own applications. This adds a "how to call this" surface where it was missing.

- **New shared `CodeBlock`** (`components/ui/code-block.tsx`) — language tabs + copy. The first reusable code block in the UI; previously every snippet was ad-hoc `<pre>`/`<code>`.
- **Snippet generators** (`lib/integration/snippets.ts`) — pure, unit-tested functions producing the create-session → send-message → stream-SSE flow in **curl, TypeScript, Python, and Rust**, plus **official-SDK** samples (Python/TS/Rust), plus a ready-to-paste **coding-agent prompt**.
- **Agent & Harness detail pages** — new **Integrate** tab (SDK-first, raw-HTTP fallback, auth/PAT card, production/App nudge, coding-agent prompt).
- **App webhook & A2A channel guidance** — now show curl/TS/Python/Rust calls and a coding-agent prompt.

Snippets resolve the deployment origin at render and link the personal-access-token page and the OpenAPI spec.

## Why
The Agent and Harness detail pages were configuration-only — the sole integration affordance was a copy-ID button. For a headless product, "how do I call this from my app" is the core user need, and that knowledge lived only in docs. App channels had endpoint/auth hints but no runnable code.

## How
A presentational layer over existing API/SDK contracts. Pure string generators (no network, no new deps) feed a shared CodeBlock. Wired into the existing Tabs on the Agent/Harness pages and into the existing per-channel setup-guidance components.

## Risk
- **Low.** UI-only, additive. No API/schema/DB/migration changes, no new dependencies.
- What can break: nothing server-side. Generated SDK call shapes for **TypeScript/Rust are extrapolated** from the docs' documented "consistent cross-language API" (the Python SDK shape is verified against the tutorial); the SDK source lives in a separate repo. See Follow-ups.

## Security
- Threat categories reviewed: **TM-WEB** (only relevant surface).
- Findings and resolutions:
  - **No XSS:** all generated strings render as escaped React text inside `<pre><code>{…}</code></pre>` / `<code>`; no `dangerouslySetInnerHTML`. Confirmed by render tests (`&lt;token&gt;` escaped).
  - **No secret exposure:** snippets use placeholders only (`evr_pat_xxx`, `YOUR_WEBHOOK_TOKEN`, `YOUR_A2A_KEY`); no real tokens are fetched or rendered.
  - **No new trust boundaries:** no endpoints, auth/authz, queries, or network calls added. `clipboard.writeText` copies only the displayed code.
- No threat-model update required (no new/changed mitigation).

## Validation
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` — clean.
- `pnpm run test` — **1023 passed** (added 8 snippet unit tests; updated the webhook-guidance render test for the new sections).
- `pnpm run build` — full production build compiles all routes (agents/harnesses/apps).
- The guidance components are exercised end-to-end via jsdom render tests; the change is presentational (string generation + rendering).

## Follow-ups
- **Verify TS/Rust SDK call signatures** against the SDK repo (`github.com/everruns/sdk`) and pin the snippets to the real method names; the Python sample is already verified. Low risk: examples are clearly labeled and link the OpenAPI spec for authoritative schemas.
- **Optional:** extend the same multi-language snippets + coding-agent prompt to the AG-UI and FCP channel guidance (this PR covers webhook + A2A, the API-callable JSON channels).
- **Optional:** add syntax highlighting to `CodeBlock` (`prismjs` is already a dependency but unused; needs a theme). Kept plain monospace to match the existing UI aesthetic.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WugJhBRdnnTwUTGvoiZGCq)_