### PR TITLE
refactor(ui): unify list cards behind shared EntityCard

### DIFF
--- a/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Key, Trash2, RefreshCw, Boxes, ExternalLink } from "lucide-react";
@@ -37,21 +38,16 @@ export function ProviderCard({
   const modelsHref = `/models?provider=${encodeURIComponent(provider.id)}`;
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <ProviderIcon providerType={provider.provider_type} size="md" />
-          <div>
-            <CardTitle className="text-lg">
-              <Link href={`/settings/providers/${provider.id}`} className="hover:underline">
-                {provider.name}
-              </Link>
-            </CardTitle>
-            <CardDescription className="text-sm">
-              {getProviderLabel(provider.provider_type)}
-            </CardDescription>
-          </div>
-        </div>
+    <EntityCard
+      icon={<ProviderIcon providerType={provider.provider_type} size="md" />}
+      title={provider.name}
+      href={`/settings/providers/${provider.id}`}
+      subtitle={
+        <span className="text-sm text-muted-foreground">
+          {getProviderLabel(provider.provider_type)}
+        </span>
+      }
+      headerActions={
         <Badge
           variant="outline"
           className={
@@ -62,67 +58,73 @@ export function ProviderCard({
         >
           {provider.status}
         </Badge>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2 text-sm">
-          {provider.base_url && (
-            <p className="text-muted-foreground truncate">URL: {provider.base_url}</p>
-          )}
-          <div className="flex items-center gap-2">
-            <Key className="h-4 w-4 text-muted-foreground" />
-            <span className="text-muted-foreground">
-              API Key: {provider.api_key_set ? "Configured" : "Not set"}
-            </span>
-          </div>
-          <div className="flex items-start gap-2">
-            <Boxes className="h-4 w-4 text-muted-foreground mt-0.5" />
-            {modelsLoading ? (
-              <Skeleton className="h-4 w-40" />
-            ) : (
-              <div className="text-muted-foreground">
-                <span>
-                  {formatCountLabel(modelCounts.total, "model")} available, {modelCounts.enabled}{" "}
-                  enabled
-                </span>
-                <Link
-                  href={modelsHref}
-                  className="ml-2 inline-flex items-center gap-1 text-foreground hover:underline"
+      }
+      footer={
+        <EntityCardFooter
+          className="mt-4"
+          actions={
+            <div className="flex items-center gap-2">
+              {canSync && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onSyncModels(provider.id)}
+                  disabled={isSyncing}
+                  title="Discover available models from provider API"
                 >
-                  View models
-                  <ExternalLink className="h-3 w-3" />
-                </Link>
-              </div>
-            )}
-          </div>
+                  <RefreshCw className={`h-4 w-4 mr-1 ${isSyncing ? "animate-spin" : ""}`} />
+                  {isSyncing ? "Syncing..." : "Sync Models"}
+                </Button>
+              )}
+              <Button variant="outline" size="sm" onClick={() => onSetApiKey(provider)}>
+                <Key className="h-4 w-4 mr-1" />
+                {provider.api_key_set ? "Update Key" : "Set Key"}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive"
+                onClick={() => onDelete(provider.id)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          }
+        />
+      }
+    >
+      <div className="space-y-2 text-sm">
+        {provider.base_url && (
+          <p className="text-muted-foreground truncate">URL: {provider.base_url}</p>
+        )}
+        <div className="flex items-center gap-2">
+          <Key className="h-4 w-4 text-muted-foreground" />
+          <span className="text-muted-foreground">
+            API Key: {provider.api_key_set ? "Configured" : "Not set"}
+          </span>
         </div>
-        <div className="flex items-center justify-end gap-2 mt-4">
-          {canSync && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onSyncModels(provider.id)}
-              disabled={isSyncing}
-              title="Discover available models from provider API"
-            >
-              <RefreshCw className={`h-4 w-4 mr-1 ${isSyncing ? "animate-spin" : ""}`} />
-              {isSyncing ? "Syncing..." : "Sync Models"}
-            </Button>
+        <div className="flex items-start gap-2">
+          <Boxes className="h-4 w-4 text-muted-foreground mt-0.5" />
+          {modelsLoading ? (
+            <Skeleton className="h-4 w-40" />
+          ) : (
+            <div className="text-muted-foreground">
+              <span>
+                {formatCountLabel(modelCounts.total, "model")} available, {modelCounts.enabled}{" "}
+                enabled
+              </span>
+              <Link
+                href={modelsHref}
+                className="ml-2 inline-flex items-center gap-1 text-foreground hover:underline"
+              >
+                View models
+                <ExternalLink className="h-3 w-3" />
+              </Link>
+            </div>
           )}
-          <Button variant="outline" size="sm" onClick={() => onSetApiKey(provider)}>
-            <Key className="h-4 w-4 mr-1" />
-            {provider.api_key_set ? "Update Key" : "Set Key"}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive"
-            onClick={() => onDelete(provider.id)}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
-import { Button, buttonVariants } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
@@ -27,7 +27,7 @@ import {
   useUploadSkill,
 } from "@/hooks/use-skills";
 import { usePolicies } from "@/hooks/use-policies";
-import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box, Eye } from "lucide-react";
+import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box } from "lucide-react";
 import type { Skill, SkillUsage } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { ArchiveFilter } from "@/components/archive-filter";
@@ -49,67 +49,64 @@ function SkillCard({
   const isDeleted = skill.status === "deleted";
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
-            {skill.source_type === "archive" ? (
-              <Archive className="h-5 w-5 text-primary" />
-            ) : (
-              <FileText className="h-5 w-5 text-primary" />
-            )}
-          </div>
-          <div>
-            <CardTitle className={`text-lg ${getEntityNameClassName(skill.status)}`}>
-              {skill.name}
-            </CardTitle>
-            <CardDescription className="text-sm">{skill.description}</CardDescription>
-          </div>
+    <EntityCard
+      icon={
+        <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
+          {skill.source_type === "archive" ? (
+            <Archive className="h-5 w-5 text-primary" />
+          ) : (
+            <FileText className="h-5 w-5 text-primary" />
+          )}
         </div>
+      }
+      title={skill.name}
+      href={`/skills/${skill.id}`}
+      titleClassName={getEntityNameClassName(skill.status)}
+      subtitle={<span className="text-sm text-muted-foreground">{skill.description}</span>}
+      headerActions={
         <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2 text-sm">
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs">
-              {skill.source_type}
-            </Badge>
-            <span className="text-muted-foreground">v{skill.version}</span>
-          </div>
-          {skill.license && <div className="text-muted-foreground">License: {skill.license}</div>}
-          {skill.allowed_tools && (
-            <div className="text-muted-foreground">Tools: {skill.allowed_tools}</div>
-          )}
-          <SkillUsageRow usage={usage} />
+      }
+      footer={
+        <EntityCardFooter
+          className="mt-4"
+          actions={
+            <div className="flex items-center gap-2">
+              {!isArchived && !isDeleted && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => updateSkill.mutate({ status: "archived" })}
+                  disabled={updateSkill.isPending}
+                >
+                  <Archive className="h-4 w-4 mr-1" />
+                  {updateSkill.isPending ? "Archiving..." : "Archive"}
+                </Button>
+              )}
+              {isArchived && canDestroy && (
+                <Button variant="destructive" size="sm" onClick={() => onDelete(skill)}>
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Delete
+                </Button>
+              )}
+            </div>
+          }
+        />
+      }
+    >
+      <div className="space-y-2 text-sm">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" className="text-xs">
+            {skill.source_type}
+          </Badge>
+          <span className="text-muted-foreground">v{skill.version}</span>
         </div>
-        <div className="flex items-center justify-end gap-2 mt-4">
-          <Link
-            href={`/skills/${skill.id}`}
-            className={buttonVariants({ variant: "outline", size: "sm" })}
-          >
-            <Eye className="h-4 w-4 mr-1" />
-            View
-          </Link>
-          {!isArchived && !isDeleted && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => updateSkill.mutate({ status: "archived" })}
-              disabled={updateSkill.isPending}
-            >
-              <Archive className="h-4 w-4 mr-1" />
-              {updateSkill.isPending ? "Archiving..." : "Archive"}
-            </Button>
-          )}
-          {isArchived && canDestroy && (
-            <Button variant="destructive" size="sm" onClick={() => onDelete(skill)}>
-              <Trash2 className="h-4 w-4 mr-1" />
-              Delete
-            </Button>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+        {skill.license && <div className="text-muted-foreground">License: {skill.license}</div>}
+        {skill.allowed_tools && (
+          <div className="text-muted-foreground">Tools: {skill.allowed_tools}</div>
+        )}
+        <SkillUsageRow usage={usage} />
+      </div>
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Pencil } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -48,87 +47,85 @@ export function AgentCard({
   const appCount = agent.app_count ?? 0;
 
   return (
-    <Card className="bg-background transition-colors hover:bg-card">
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex flex-col gap-0.5">
-          <div className="flex items-center gap-2">
-            <CardTitle className={`text-lg ${getEntityNameClassName(agent.status)}`}>
-              <Link href={`/agents/${agent.id}`} className="hover:underline">
-                {getDisplayName(agent)}
-              </Link>
-            </CardTitle>
-            <CopyButton value={agent.id} />
-          </div>
-          <span className="text-xs text-muted-foreground font-mono">{agent.name}</span>
-        </div>
+    <EntityCard
+      title={getDisplayName(agent)}
+      href={`/agents/${agent.id}`}
+      titleClassName={getEntityNameClassName(agent.status)}
+      copyValue={agent.id}
+      subtitle={<span className="text-xs text-muted-foreground font-mono">{agent.name}</span>}
+      headerActions={
         <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
-      </CardHeader>
-      <CardContent>
-        {agent.description ? (
-          <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
-            <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
-        )}
-
-        {/* Capabilities display */}
-        {agentCapabilities.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            <TooltipProvider>
-              {agentCapabilities.map((capConfig) => {
-                const cap = getCapabilityInfo(capConfig.ref);
-                if (!cap) return null;
-                const IconComponent = getCapabilityIcon(cap.icon);
-
-                return (
-                  <Tooltip key={capConfig.ref}>
-                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
-                      <IconComponent className="icon-sharp h-3 w-3" />
-                      {!compact && <span>{localizedCapabilityName(cap, locale)}</span>}
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {localizedCapabilityDescription(cap, locale)}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </TooltipProvider>
-          </div>
-        )}
-
-        {/* Tags */}
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            {tags.map((tag) => (
-              <Badge key={tag} variant="outline" className="text-xs">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        )}
-
-        {/* Footer */}
-        <div className="flex items-center justify-between">
-          <div className="min-w-0 text-xs text-muted-foreground">
-            <span>Created {new Date(agent.created_at).toLocaleDateString()}</span>
-            <span className="mx-2">·</span>
-            <span>
-              {formatCountLabel(sessionCount, "session")} · {formatCountLabel(appCount, "app")}
-            </span>
-          </div>
-          {showEditButton && agent.status === "active" && (
-            <Link href={`/agents/${agent.id}/edit`}>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <Pencil className="icon-sharp h-4 w-4" />
-              </Button>
-            </Link>
-          )}
+      }
+      footer={
+        <EntityCardFooter
+          meta={
+            <>
+              <span>Created {new Date(agent.created_at).toLocaleDateString()}</span>
+              <span className="mx-2">·</span>
+              <span>
+                {formatCountLabel(sessionCount, "session")} · {formatCountLabel(appCount, "app")}
+              </span>
+            </>
+          }
+          actions={
+            showEditButton &&
+            agent.status === "active" && (
+              <Link href={`/agents/${agent.id}/edit`}>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Pencil className="icon-sharp h-4 w-4" />
+                </Button>
+              </Link>
+            )
+          }
+        />
+      }
+    >
+      {agent.description ? (
+        <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
+          <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
         </div>
-      </CardContent>
-    </Card>
+      ) : (
+        <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
+      )}
+
+      {/* Capabilities display */}
+      {agentCapabilities.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          <TooltipProvider>
+            {agentCapabilities.map((capConfig) => {
+              const cap = getCapabilityInfo(capConfig.ref);
+              if (!cap) return null;
+              const IconComponent = getCapabilityIcon(cap.icon);
+
+              return (
+                <Tooltip key={capConfig.ref}>
+                  <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                    <IconComponent className="icon-sharp h-3 w-3" />
+                    {!compact && <span>{localizedCapabilityName(cap, locale)}</span>}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {localizedCapabilityDescription(cap, locale)}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
+        </div>
+      )}
+
+      {/* Tags */}
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </EntityCard>
   );
 }

--- a/apps/ui/src/components/agents/example-card.tsx
+++ b/apps/ui/src/components/agents/example-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Import } from "lucide-react";
 import type { AgentExample, Capability, CapabilityId } from "@/lib/api/types";
@@ -31,70 +31,71 @@ export function ExampleCard({
     allCapabilities?.find((c) => c.id === capabilityId);
 
   return (
-    <Card className="bg-background transition-colors hover:bg-card">
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <CardTitle className="text-lg">{example.display_name}</CardTitle>
-        {example.dev_only && (
+    <EntityCard
+      title={example.display_name}
+      headerActions={
+        example.dev_only && (
           <Badge variant="outline" className="text-xs">
             dev
           </Badge>
-        )}
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{example.description}</p>
+        )
+      }
+      footer={
+        <EntityCardFooter
+          actions={
+            <Button
+              variant="accent"
+              size="sm"
+              onClick={() => onImport(example.name)}
+              disabled={adopting}
+            >
+              <Import className="w-4 h-4 mr-2" />
+              {adopting ? "Importing..." : "Import"}
+            </Button>
+          }
+        />
+      }
+    >
+      <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{example.description}</p>
 
-        {/* Capabilities display */}
-        {example.capabilities.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            <TooltipProvider>
-              {example.capabilities.map((capConfig) => {
-                const cap = getCapabilityInfo(capConfig.ref);
-                if (!cap) return null;
-                const IconComponent = getCapabilityIcon(cap.icon);
+      {/* Capabilities display */}
+      {example.capabilities.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          <TooltipProvider>
+            {example.capabilities.map((capConfig) => {
+              const cap = getCapabilityInfo(capConfig.ref);
+              if (!cap) return null;
+              const IconComponent = getCapabilityIcon(cap.icon);
 
-                return (
-                  <Tooltip key={capConfig.ref}>
-                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
-                      <IconComponent className="icon-sharp h-3 w-3" />
-                      <span>{localizedCapabilityName(cap, locale)}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {localizedCapabilityDescription(cap, locale)}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </TooltipProvider>
-          </div>
-        )}
-
-        {/* Tags */}
-        {example.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            {example.tags.map((tag) => (
-              <Badge key={tag} variant="outline" className="text-xs">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        )}
-
-        {/* Import button */}
-        <div className="flex items-center justify-end">
-          <Button
-            variant="accent"
-            size="sm"
-            onClick={() => onImport(example.name)}
-            disabled={adopting}
-          >
-            <Import className="w-4 h-4 mr-2" />
-            {adopting ? "Importing..." : "Import"}
-          </Button>
+              return (
+                <Tooltip key={capConfig.ref}>
+                  <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                    <IconComponent className="icon-sharp h-3 w-3" />
+                    <span>{localizedCapabilityName(cap, locale)}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {localizedCapabilityDescription(cap, locale)}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
         </div>
-      </CardContent>
-    </Card>
+      )}
+
+      {/* Tags */}
+      {example.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {example.tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </EntityCard>
   );
 }

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Boxes, Plus } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getDisplayName } from "@/lib/entity-lifecycle";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -54,54 +54,48 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
               const agentCapabilities = agent.capabilities ?? [];
 
               return (
-                <Link
+                <EntityCard
                   key={agent.id}
+                  variant="row"
                   href={`/agents/${agent.id}`}
-                  className="flex items-center justify-between border bg-card p-3 transition-colors hover:bg-muted/50"
+                  title={getDisplayName(agent)}
+                  copyValue={agent.id}
+                  icon={<Boxes className="icon-sharp h-5 w-5 text-muted-foreground" />}
+                  headerActions={
+                    <Badge variant="outline" className="border-border bg-muted text-foreground">
+                      Active
+                    </Badge>
+                  }
                 >
-                  <div className="flex items-center gap-3">
-                    <Boxes className="icon-sharp h-5 w-5 text-muted-foreground" />
-                    <div>
-                      <div className="flex items-center gap-1">
-                        <p className="font-medium">{getDisplayName(agent)}</p>
-                        <CopyButton value={agent.id} />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {/* Capabilities icons */}
-                        {agentCapabilities.length > 0 && (
-                          <TooltipProvider>
-                            <div className="flex gap-0.5">
-                              {agentCapabilities.slice(0, 3).map((capConfig) => {
-                                const cap = getCapabilityInfo(capConfig.ref);
-                                if (!cap) return null;
-                                const IconComponent = getCapabilityIcon(cap.icon);
+                  {/* Capabilities icons */}
+                  {agentCapabilities.length > 0 && (
+                    <TooltipProvider>
+                      <div className="mt-1 flex gap-0.5">
+                        {agentCapabilities.slice(0, 3).map((capConfig) => {
+                          const cap = getCapabilityInfo(capConfig.ref);
+                          if (!cap) return null;
+                          const IconComponent = getCapabilityIcon(cap.icon);
 
-                                return (
-                                  <Tooltip key={capConfig.ref}>
-                                    <TooltipTrigger className="cursor-default border bg-muted p-0.5">
-                                      <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>{localizedCapabilityName(cap, locale)}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                );
-                              })}
-                              {agentCapabilities.length > 3 && (
-                                <span className="text-xs text-muted-foreground ml-1">
-                                  +{agentCapabilities.length - 3}
-                                </span>
-                              )}
-                            </div>
-                          </TooltipProvider>
+                          return (
+                            <Tooltip key={capConfig.ref}>
+                              <TooltipTrigger className="cursor-default border bg-muted p-0.5">
+                                <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>{localizedCapabilityName(cap, locale)}</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          );
+                        })}
+                        {agentCapabilities.length > 3 && (
+                          <span className="text-xs text-muted-foreground ml-1">
+                            +{agentCapabilities.length - 3}
+                          </span>
                         )}
                       </div>
-                    </div>
-                  </div>
-                  <Badge variant="outline" className="border-border bg-muted text-foreground">
-                    Active
-                  </Badge>
-                </Link>
+                    </TooltipProvider>
+                  )}
+                </EntityCard>
               );
             })}
             <Link

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { MessageSquare, Loader2, Zap, Sparkles, Bot } from "lucide-react";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
@@ -85,27 +85,20 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                   })
                 : null;
               return (
-                <Link
+                <EntityCard
                   key={session.id}
+                  variant="row"
                   href={`/sessions/${session.id}`}
-                  className="flex items-start gap-3 border bg-card p-3 transition-colors hover:bg-muted/50"
-                >
-                  {/* Icon */}
-                  <div className="flex-shrink-0 mt-0.5">
-                    {isRunning(session) ? (
+                  title={session.title || `Session ${shortenId(session.id)}`}
+                  icon={
+                    isRunning(session) ? (
                       <Loader2 className="w-4 h-4 text-primary animate-spin" />
                     ) : (
                       <MessageSquare className="icon-sharp h-4 w-4 text-muted-foreground" />
-                    )}
-                  </div>
-
-                  {/* Content */}
-                  <div className="flex-1 min-w-0">
-                    {/* Title row */}
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-medium truncate">
-                        {session.title || `Session ${shortenId(session.id)}`}
-                      </span>
+                    )
+                  }
+                  inlineBadges={
+                    <>
                       {getStatusBadge(session)}
                       {agentLabel && (
                         <span className="text-xs text-muted-foreground flex items-center gap-1">
@@ -115,41 +108,41 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                           </span>
                         </span>
                       )}
-                    </div>
+                    </>
+                  }
+                >
+                  {/* Input preview */}
+                  {session.preview && (
+                    <p className="text-sm text-muted-foreground mt-1 truncate">
+                      {truncateText(session.preview)}
+                    </p>
+                  )}
 
-                    {/* Input preview */}
-                    {session.preview && (
-                      <p className="text-sm text-muted-foreground mt-1 truncate">
-                        {truncateText(session.preview)}
-                      </p>
+                  {/* Output preview */}
+                  {session.output_preview && (
+                    <p className="text-sm text-muted-foreground/70 mt-0.5 truncate italic">
+                      {truncateText(session.output_preview)}
+                    </p>
+                  )}
+
+                  {/* Meta row */}
+                  <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                    <span>{formatRelativeTime(session.created_at)}</span>
+                    {model && (
+                      <span className="flex items-center gap-1">
+                        <Sparkles className="icon-sharp h-3 w-3" />
+                        {model.display_name}
+                      </span>
                     )}
-
-                    {/* Output preview */}
-                    {session.output_preview && (
-                      <p className="text-sm text-muted-foreground/70 mt-0.5 truncate italic">
-                        {truncateText(session.output_preview)}
-                      </p>
-                    )}
-
-                    {/* Meta row */}
-                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-                      <span>{formatRelativeTime(session.created_at)}</span>
-                      {model && (
+                    {session.usage &&
+                      (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
                         <span className="flex items-center gap-1">
-                          <Sparkles className="icon-sharp h-3 w-3" />
-                          {model.display_name}
+                          <Zap className="icon-sharp h-3 w-3" />
+                          {formatTotalTokens(session.usage)}
                         </span>
                       )}
-                      {session.usage &&
-                        (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
-                          <span className="flex items-center gap-1">
-                            <Zap className="icon-sharp h-3 w-3" />
-                            {formatTotalTokens(session.usage)}
-                          </span>
-                        )}
-                    </div>
                   </div>
-                </Link>
+                </EntityCard>
               );
             })}
           </div>

--- a/apps/ui/src/components/harnesses/example-card.tsx
+++ b/apps/ui/src/components/harnesses/example-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Import } from "lucide-react";
 import type { Capability, CapabilityId, HarnessExample } from "@/lib/api/types";
@@ -31,67 +31,69 @@ export function HarnessExampleCard({
     allCapabilities?.find((c) => c.id === capabilityId);
 
   return (
-    <Card className="bg-background transition-colors hover:bg-card">
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <CardTitle className="text-lg">{example.display_name}</CardTitle>
-        {example.dev_only && (
+    <EntityCard
+      title={example.display_name}
+      headerActions={
+        example.dev_only && (
           <Badge variant="outline" className="text-xs">
             dev
           </Badge>
-        )}
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{example.description}</p>
+        )
+      }
+      footer={
+        <EntityCardFooter
+          actions={
+            <Button
+              variant="accent"
+              size="sm"
+              onClick={() => onImport(example.name)}
+              disabled={adopting}
+            >
+              <Import className="w-4 h-4 mr-2" />
+              {adopting ? "Importing..." : "Import"}
+            </Button>
+          }
+        />
+      }
+    >
+      <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{example.description}</p>
 
-        {example.capabilities.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            <TooltipProvider>
-              {example.capabilities.map((capConfig) => {
-                const cap = getCapabilityInfo(capConfig.ref);
-                if (!cap) return null;
-                const IconComponent = getCapabilityIcon(cap.icon);
+      {example.capabilities.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          <TooltipProvider>
+            {example.capabilities.map((capConfig) => {
+              const cap = getCapabilityInfo(capConfig.ref);
+              if (!cap) return null;
+              const IconComponent = getCapabilityIcon(cap.icon);
 
-                return (
-                  <Tooltip key={capConfig.ref}>
-                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
-                      <IconComponent className="icon-sharp h-3 w-3" />
-                      <span>{localizedCapabilityName(cap, locale)}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {localizedCapabilityDescription(cap, locale)}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </TooltipProvider>
-          </div>
-        )}
-
-        {example.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            {example.tags.map((tag) => (
-              <Badge key={tag} variant="outline" className="text-xs">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        )}
-
-        <div className="flex items-center justify-end">
-          <Button
-            variant="accent"
-            size="sm"
-            onClick={() => onImport(example.name)}
-            disabled={adopting}
-          >
-            <Import className="w-4 h-4 mr-2" />
-            {adopting ? "Importing..." : "Import"}
-          </Button>
+              return (
+                <Tooltip key={capConfig.ref}>
+                  <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                    <IconComponent className="icon-sharp h-3 w-3" />
+                    <span>{localizedCapabilityName(cap, locale)}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {localizedCapabilityDescription(cap, locale)}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
         </div>
-      </CardContent>
-    </Card>
+      )}
+
+      {example.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {example.tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </EntityCard>
   );
 }

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Pencil } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
 import type { Harness, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -46,91 +45,92 @@ export function HarnessCard({
   const appCount = harness.app_count ?? 0;
 
   return (
-    <Card className="bg-background transition-colors hover:bg-card">
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-2">
-          <CardTitle className={`text-lg ${getEntityNameClassName(harness.status)}`}>
-            <Link href={`/harnesses/${harness.id}`} className="hover:underline">
-              {getDisplayName(harness)}
-            </Link>
-          </CardTitle>
-          <CopyButton value={harness.id} />
-        </div>
-        <div className="flex items-center gap-1">
+    <EntityCard
+      title={getDisplayName(harness)}
+      href={`/harnesses/${harness.id}`}
+      titleClassName={getEntityNameClassName(harness.status)}
+      copyValue={harness.id}
+      headerActions={
+        <>
           {harness.is_built_in && (
             <Badge variant="outline" className="text-xs">
               Built-in
             </Badge>
           )}
           <Badge variant={getEntityStatusBadgeVariant(harness.status)}>{harness.status}</Badge>
+        </>
+      }
+      footer={
+        <EntityCardFooter
+          meta={
+            <>
+              <span>Created {new Date(harness.created_at).toLocaleDateString()}</span>
+              <span className="mx-2">·</span>
+              <span>
+                {formatCountLabel(sessionCount, "session")} · {formatCountLabel(appCount, "app")}
+              </span>
+            </>
+          }
+          actions={
+            showEditButton &&
+            !harness.is_built_in &&
+            harness.status === "active" && (
+              <Link href={`/harnesses/${harness.id}/edit`}>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Pencil className="icon-sharp h-4 w-4" />
+                </Button>
+              </Link>
+            )
+          }
+        />
+      }
+    >
+      {harness.description ? (
+        <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
+          <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
         </div>
-      </CardHeader>
-      <CardContent>
-        {harness.description ? (
-          <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
-            <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
-        )}
+      ) : (
+        <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
+      )}
 
-        {/* Capabilities display */}
-        {harnessCapabilities.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            <TooltipProvider>
-              {harnessCapabilities.map((capConfig) => {
-                const cap = getCapabilityInfo(capConfig.ref);
-                if (!cap) return null;
-                const IconComponent = getCapabilityIcon(cap.icon);
+      {/* Capabilities display */}
+      {harnessCapabilities.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          <TooltipProvider>
+            {harnessCapabilities.map((capConfig) => {
+              const cap = getCapabilityInfo(capConfig.ref);
+              if (!cap) return null;
+              const IconComponent = getCapabilityIcon(cap.icon);
 
-                return (
-                  <Tooltip key={capConfig.ref}>
-                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
-                      <IconComponent className="icon-sharp h-3 w-3" />
-                      {!compact && <span>{localizedCapabilityName(cap, locale)}</span>}
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {localizedCapabilityDescription(cap, locale)}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </TooltipProvider>
-          </div>
-        )}
-
-        {/* Tags */}
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mb-3">
-            {tags.map((tag) => (
-              <Badge key={tag} variant="outline" className="text-xs">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        )}
-
-        {/* Footer */}
-        <div className="flex items-center justify-between">
-          <div className="min-w-0 text-xs text-muted-foreground">
-            <span>Created {new Date(harness.created_at).toLocaleDateString()}</span>
-            <span className="mx-2">·</span>
-            <span>
-              {formatCountLabel(sessionCount, "session")} · {formatCountLabel(appCount, "app")}
-            </span>
-          </div>
-          {showEditButton && !harness.is_built_in && harness.status === "active" && (
-            <Link href={`/harnesses/${harness.id}/edit`}>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <Pencil className="icon-sharp h-4 w-4" />
-              </Button>
-            </Link>
-          )}
+              return (
+                <Tooltip key={capConfig.ref}>
+                  <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                    <IconComponent className="icon-sharp h-3 w-3" />
+                    {!compact && <span>{localizedCapabilityName(cap, locale)}</span>}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="font-medium">{localizedCapabilityName(cap, locale)}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {localizedCapabilityDescription(cap, locale)}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
         </div>
-      </CardContent>
-    </Card>
+      )}
+
+      {/* Tags */}
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </EntityCard>
   );
 }

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import {
   Info,
   MessageSquare,
@@ -12,6 +11,7 @@ import {
   Download,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { EntityCard } from "@/components/ui/entity-card";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn, shortenId } from "@/lib/utils";
@@ -159,117 +159,108 @@ export function SessionCard({
   const isPinned = session.is_pinned === true;
 
   return (
-    <Link
+    <EntityCard
+      variant="row"
       href={sessionUrl}
-      className="flex items-start justify-between p-3 border hover:bg-muted transition-colors group"
-    >
-      <div className="flex items-start gap-3 flex-1 min-w-0">
-        <div className="flex-shrink-0 mt-0.5">
-          {statusInfo.isRunning ? (
-            <Loader2 className="w-4 h-4 text-primary animate-spin" />
-          ) : (
-            <MessageSquare className="w-4 h-4 text-muted-foreground" />
-          )}
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <p className="font-medium truncate">{displayTitle}</p>
-            <CopyButton value={session.id} />
-            <Badge variant={statusInfo.variant} className="flex-shrink-0 text-xs">
-              {statusInfo.label}
-            </Badge>
-            {agentName && (
-              <Badge variant="outline" className="flex-shrink-0 text-xs">
-                <span className={getEntityReferenceClassName(agentStatus)}>
-                  {getEntityReferenceLabel({
-                    kind: "Agent",
-                    name: agentName,
-                    status: agentStatus,
-                  })}
-                </span>
-              </Badge>
-            )}
-          </div>
-          {/* Input preview: first user message */}
-          {inputPreview && (
-            <p className="text-sm text-muted-foreground mt-1 line-clamp-1">
-              {truncateToLines(inputPreview, 1)}
-            </p>
-          )}
-          {/* Output preview: last assistant response */}
-          {outputPreview && (
-            <p className="text-sm text-muted-foreground/70 mt-0.5 line-clamp-1 italic">
-              {truncateToLines(outputPreview, 1)}
-            </p>
-          )}
-          <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-            <span>{formatRelativeTime(session.created_at)}</span>
-            {session.usage &&
-              (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
-                <span className="flex items-center gap-1" title="Token usage">
-                  <Zap className="w-3 h-3" />
-                  {formatTotalTokens(session.usage)}
-                </span>
-              )}
-            {(session.active_schedule_count ?? 0) > 0 && (
-              <span className="flex items-center gap-1" title="Active schedules">
-                <CalendarClock className="w-3 h-3" />
-                {session.active_schedule_count}
-              </span>
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-        {model && (
-          <Badge variant="outline" className="gap-1 text-xs">
-            <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
-            {model.display_name}
+      title={displayTitle}
+      copyValue={session.id}
+      icon={
+        statusInfo.isRunning ? (
+          <Loader2 className="w-4 h-4 text-primary animate-spin" />
+        ) : (
+          <MessageSquare className="w-4 h-4 text-muted-foreground" />
+        )
+      }
+      inlineBadges={
+        <>
+          <Badge variant={statusInfo.variant} className="flex-shrink-0 text-xs">
+            {statusInfo.label}
           </Badge>
+          {agentName && (
+            <Badge variant="outline" className="flex-shrink-0 text-xs">
+              <span className={getEntityReferenceClassName(agentStatus)}>
+                {getEntityReferenceLabel({
+                  kind: "Agent",
+                  name: agentName,
+                  status: agentStatus,
+                })}
+              </span>
+            </Badge>
+          )}
+        </>
+      }
+      headerActions={
+        <>
+          {model && (
+            <Badge variant="outline" className="gap-1 text-xs">
+              <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
+              {model.display_name}
+            </Badge>
+          )}
+          {onExport && (
+            <Tooltip>
+              <TooltipTrigger
+                className={cn(
+                  "p-0.5 rounded transition-colors flex-shrink-0",
+                  "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
+                )}
+                aria-label="Export session as JSONL"
+                onClick={() => onExport(session.id)}
+              >
+                <Download className="w-3.5 h-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>Export JSONL</TooltipContent>
+            </Tooltip>
+          )}
+          {onTogglePin && (
+            <Tooltip>
+              <TooltipTrigger
+                className={cn(
+                  "p-0.5 rounded transition-colors flex-shrink-0",
+                  isPinned
+                    ? "text-primary hover:text-primary/80 hover:bg-muted/80"
+                    : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
+                )}
+                aria-label={isPinned ? "Unpin session" : "Pin session"}
+                onClick={() => onTogglePin(session.id, !isPinned)}
+              >
+                {isPinned ? <PinOff className="w-3.5 h-3.5" /> : <Pin className="w-3.5 h-3.5" />}
+              </TooltipTrigger>
+              <TooltipContent>{isPinned ? "Unpin session" : "Pin session"}</TooltipContent>
+            </Tooltip>
+          )}
+          <SessionInfoIcon session={session} />
+        </>
+      }
+    >
+      {/* Input preview: first user message */}
+      {inputPreview && (
+        <p className="text-sm text-muted-foreground mt-1 line-clamp-1">
+          {truncateToLines(inputPreview, 1)}
+        </p>
+      )}
+      {/* Output preview: last assistant response */}
+      {outputPreview && (
+        <p className="text-sm text-muted-foreground/70 mt-0.5 line-clamp-1 italic">
+          {truncateToLines(outputPreview, 1)}
+        </p>
+      )}
+      <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+        <span>{formatRelativeTime(session.created_at)}</span>
+        {session.usage && (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
+          <span className="flex items-center gap-1" title="Token usage">
+            <Zap className="w-3 h-3" />
+            {formatTotalTokens(session.usage)}
+          </span>
         )}
-        {onExport && (
-          <Tooltip>
-            <TooltipTrigger
-              className={cn(
-                "p-0.5 rounded transition-colors flex-shrink-0",
-                "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
-              )}
-              aria-label="Export session as JSONL"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onExport(session.id);
-              }}
-            >
-              <Download className="w-3.5 h-3.5" />
-            </TooltipTrigger>
-            <TooltipContent>Export JSONL</TooltipContent>
-          </Tooltip>
+        {(session.active_schedule_count ?? 0) > 0 && (
+          <span className="flex items-center gap-1" title="Active schedules">
+            <CalendarClock className="w-3 h-3" />
+            {session.active_schedule_count}
+          </span>
         )}
-        {onTogglePin && (
-          <Tooltip>
-            <TooltipTrigger
-              className={cn(
-                "p-0.5 rounded transition-colors flex-shrink-0",
-                isPinned
-                  ? "text-primary hover:text-primary/80 hover:bg-muted/80"
-                  : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
-              )}
-              aria-label={isPinned ? "Unpin session" : "Pin session"}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onTogglePin(session.id, !isPinned);
-              }}
-            >
-              {isPinned ? <PinOff className="w-3.5 h-3.5" /> : <Pin className="w-3.5 h-3.5" />}
-            </TooltipTrigger>
-            <TooltipContent>{isPinned ? "Unpin session" : "Pin session"}</TooltipContent>
-          </Tooltip>
-        )}
-        <SessionInfoIcon session={session} />
       </div>
-    </Link>
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/components/ui/entity-card.tsx
+++ b/apps/ui/src/components/ui/entity-card.tsx
@@ -152,9 +152,9 @@ export function EntityCardFooter({
   className?: string;
 }) {
   return (
-    <div className={cn("flex items-center justify-between", className)}>
-      {meta ? <div className="min-w-0 text-xs text-muted-foreground">{meta}</div> : <div />}
-      {actions}
+    <div className={cn("flex items-center gap-2", className)}>
+      {meta && <div className="min-w-0 text-xs text-muted-foreground">{meta}</div>}
+      {actions && <div className="ml-auto">{actions}</div>}
     </div>
   );
 }

--- a/apps/ui/src/components/ui/entity-card.tsx
+++ b/apps/ui/src/components/ui/entity-card.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared card for entity list/grid views (agents, harnesses, skills, providers,
+ * sessions, examples, dashboard rows). It standardizes the parts that should feel
+ * the same everywhere — the leading icon, the (optionally linked) title with a
+ * copy button, the right-aligned header actions, and the click affordance — while
+ * leaving the body content fully up to the caller via `children`.
+ *
+ * Navigation is title-link-only by design: only the title navigates (when `href`
+ * is set); the rest of the card is inert so action buttons stay unambiguous.
+ */
+export interface EntityCardProps {
+  /** Layout: vertical grid card (default) or horizontal list row. */
+  variant?: "grid" | "row";
+  /** Leading icon or avatar rendered before the title. */
+  icon?: React.ReactNode;
+  /** Title content. */
+  title: React.ReactNode;
+  /** When set, the title becomes a link to this href (the only clickable target). */
+  href?: string;
+  /** Extra classes for the title — e.g. entity lifecycle styling. */
+  titleClassName?: string;
+  /** When set, renders a copy button next to the title. */
+  copyValue?: string;
+  /** Secondary line under the title (grid) — e.g. mono id/name or description. */
+  subtitle?: React.ReactNode;
+  /** Content rendered inline after the title (row) — e.g. status/reference badges. */
+  inlineBadges?: React.ReactNode;
+  /**
+   * Right-aligned header content. In the grid variant this is the status badge
+   * area; in the row variant this is the trailing actions column.
+   */
+  headerActions?: React.ReactNode;
+  /** Body content. */
+  children?: React.ReactNode;
+  /** Footer content (grid only). Use {@link EntityCardFooter} for the common split. */
+  footer?: React.ReactNode;
+  className?: string;
+}
+
+function EntityCardTitleLink({
+  href,
+  className,
+  children,
+}: {
+  href?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  if (href) {
+    return (
+      <Link href={href} className={cn("hover:underline", className)}>
+        {children}
+      </Link>
+    );
+  }
+  if (className) {
+    return <span className={className}>{children}</span>;
+  }
+  return <>{children}</>;
+}
+
+export function EntityCard({
+  variant = "grid",
+  icon,
+  title,
+  href,
+  titleClassName,
+  copyValue,
+  subtitle,
+  inlineBadges,
+  headerActions,
+  children,
+  footer,
+  className,
+}: EntityCardProps) {
+  if (variant === "row") {
+    return (
+      <div
+        className={cn(
+          "group flex items-start justify-between border p-3 transition-colors hover:bg-muted",
+          className,
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          {icon && <div className="mt-0.5 flex-shrink-0">{icon}</div>}
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <EntityCardTitleLink
+                href={href}
+                className={cn("truncate font-medium", titleClassName)}
+              >
+                {title}
+              </EntityCardTitleLink>
+              {copyValue && <CopyButton value={copyValue} />}
+              {inlineBadges}
+            </div>
+            {children}
+          </div>
+        </div>
+        {headerActions && (
+          <div className="ml-2 flex flex-shrink-0 items-center gap-2">{headerActions}</div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Card className={cn("bg-background transition-colors hover:bg-card", className)}>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="flex min-w-0 items-start gap-3">
+          {icon && <div className="flex-shrink-0">{icon}</div>}
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <CardTitle className={cn("text-lg", titleClassName)}>
+                <EntityCardTitleLink href={href}>{title}</EntityCardTitleLink>
+              </CardTitle>
+              {copyValue && <CopyButton value={copyValue} />}
+            </div>
+            {subtitle && <div className="min-w-0">{subtitle}</div>}
+          </div>
+        </div>
+        {headerActions && (
+          <div className="flex flex-shrink-0 items-center gap-1">{headerActions}</div>
+        )}
+      </CardHeader>
+      <CardContent>
+        {children}
+        {footer}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Common grid-card footer: muted metadata on the left, actions on the right.
+ */
+export function EntityCardFooter({
+  meta,
+  actions,
+  className,
+}: {
+  meta?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex items-center justify-between", className)}>
+      {meta ? <div className="min-w-0 text-xs text-muted-foreground">{meta}</div> : <div />}
+      {actions}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Introduce a shared `EntityCard` component and migrate every entity list/grid card onto it, so the header, title link, copy button, status/actions area, and click behavior are consistent across the app while each card keeps its own body content.

Migrated:
- Grid cards: agent, harness, agent-example, harness-example, skill, provider
- Row cards: session card, dashboard "Active Agents" rows, dashboard "Recent Sessions" rows

## Why
The card surfaces (agents, harnesses, skills, providers, sessions, examples, dashboard widgets) each implemented their own markup with divergent behavior: some titles were links, some whole rows were links, skills used a separate "View" button, provider/skill cards lacked the hover affordance, and footer/action placement varied. There was no common design language for cards. This unifies the interaction model and removes duplicated structure.

## How
- New `apps/ui/src/components/ui/entity-card.tsx` exposes `EntityCard` (`variant: "grid" | "row"`) plus an `EntityCardFooter` helper.
  - Standardized slots: `icon`, `title`, `href` (title link), `copyValue` (copy button), `subtitle`, `inlineBadges` (row), `headerActions`, `children` (body), `footer`.
  - Navigation is **title-link-only** by design: only the title navigates; the rest of the card is inert so action buttons are unambiguous.
- Each card was rewritten to render through `EntityCard`, keeping its existing body content (capabilities, tags, previews, metadata) unchanged.

Behavior alignments that fell out of the consolidation:
- Skill cards now navigate via the title link (dropped the redundant "View" button), matching agents/harnesses.
- Session and dashboard rows changed from whole-row links to title-only links, consistent with the rest. Their action buttons no longer need `preventDefault`/`stopPropagation`.
- Grid cards that previously lacked it (skill, provider) gained the shared `hover:bg-card` affordance.

## Risk
- Low. UI-only, presentational refactor. No API, data, or auth changes.
- Possible breakage would be purely visual/interaction; mitigated by typecheck, lint, the full UI test suite, a production build, and a live smoke test of every migrated surface.

## Security
- Threat categories reviewed: TM-WEB. No other categories touched (no API/auth/authz/SQL/tooling changes).
- Findings and resolutions: None. No `dangerouslySetInnerHTML`/`eval`/external-href usage introduced; titles render as escaped React nodes, links are built from entity IDs exactly as before, and `InlineStreamdownMessage`/`CopyButton` rendering paths are unchanged. No new input or trust boundary.

## Follow-ups
- Provider status badge still uses hardcoded green/gray classes instead of the shared `getEntityStatusBadgeVariant`. Deferred: provider status values differ from the standard entity lifecycle enum, so unifying the badge variant needs a small mapping decision that is out of scope for this structural pass. Safe to defer — purely cosmetic, no behavior impact.

## Checklist
- [x] Tests added or updated (existing UI suite: 979 tests pass; this is a structural refactor with no new branching logic)
- [x] Backward compatibility considered (internal UI; title-link-only is the agreed unified behavior)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `tsc --noEmit` clean
- `oxlint` clean, `oxfmt --check` clean
- `next build` succeeds
- `jest` — 979 tests / 108 suites pass
- Live smoke test (`just start-dev`): imported an example agent and verified the agent grid card, harness cards (incl. built-in dual badges / no edit), example cards, agent detail, and dashboard row widgets render with no console errors.
