### PR TITLE
fix(chat): enforce global_chat flag end-to-end; clarify description

### DIFF
--- a/apps/ui/src/__tests__/global-chat-page.test.tsx
+++ b/apps/ui/src/__tests__/global-chat-page.test.tsx
@@ -37,7 +37,7 @@ describe("GlobalChatPage", () => {
 
     render(<GlobalChatPage />);
 
-    expect(screen.getByText("Global Chat is not enabled")).toBeInTheDocument();
+    expect(screen.getByText("Platform Chat is not enabled")).toBeInTheDocument();
     expect(mockUseGlobalChat).not.toHaveBeenCalled();
   });
 

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -53,7 +53,7 @@ export default function GlobalChatPage() {
     return (
       <div className="flex h-full items-center justify-center">
         <div className="text-center text-muted-foreground">
-          <p className="text-lg font-medium">Global Chat is not enabled</p>
+          <p className="text-lg font-medium">Platform Chat is not enabled</p>
           <p className="text-sm">This feature is currently disabled.</p>
         </div>
       </div>

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -19,7 +19,11 @@ use crate::deployment::DeploymentGrade;
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FeatureFlags {
-    /// Global chat (per-user singleton chat session). Experimental.
+    /// Platform Chat: the per-user singleton assistant chat surface — sidebar
+    /// entry, the `/chat` page, and the `POST /v1/sessions/chat` (+ voice)
+    /// endpoints. When off, the whole Platform Chat feature is disabled
+    /// (UI hidden and APIs return 404); other chat surfaces (per-session,
+    /// agent, channel) are unaffected. Experimental.
     pub global_chat: bool,
     /// In-app notifications (bell, toasts, notification SSE). Experimental.
     pub notifications: bool,
@@ -63,10 +67,12 @@ pub struct FeatureFlagDefinition {
 pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
     FeatureFlagDefinition {
         name: "global_chat",
-        label: "Global chat",
-        description: "Adds a personal chat session you can open from the sidebar anywhere in the \
-             app. It's always available as a quick scratchpad to talk to your agents without \
-             first setting up a dedicated app or channel.",
+        label: "Platform Chat",
+        description: "Adds a personal Platform Chat assistant you can open from the sidebar or the \
+             /chat page anywhere in the app. It's a quick scratchpad to talk to your agents \
+             without first setting up a dedicated app or channel. Turning it off disables the \
+             whole feature — the chat page, the sidebar entry, and its session and voice APIs all \
+             become unavailable.",
         experimental: true,
     },
     FeatureFlagDefinition {

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -527,6 +527,7 @@ pub(crate) fn ensure_global_chat_enabled(
     responses(
         (status = 200, description = "Chat session returned", body = WithUrls<Session>),
         (status = 401, description = "Authentication required"),
+        (status = 404, description = "Platform Chat feature (global_chat) is disabled for the org"),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -500,10 +500,26 @@ pub async fn create_session(
     Ok((StatusCode::CREATED, Json(urls.wrap(session))))
 }
 
+/// Guard the Platform Chat feature behind the org-effective `global_chat` flag.
+///
+/// Mirrors `ensure_voice_enabled`: when the feature is off we answer 404 so the
+/// surface is fully hidden rather than advertising a disabled endpoint. This is
+/// the backend half of the feature flag — the UI gate alone is not enforcement.
+pub(crate) fn ensure_global_chat_enabled(
+    org: &ResolvedOrg,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if org.feature_flags.global_chat {
+        Ok(())
+    } else {
+        Err(ErrorResponse::not_found("Chat"))
+    }
+}
+
 /// POST /v1/sessions/chat - Get or create global chat session
 ///
 /// Returns the user's singleton global chat session. Creates one if it doesn't exist.
 /// Uses the Platform Chat harness and tags for per-user singleton management.
+/// Gated by the `global_chat` feature flag; returns 404 when disabled.
 #[utoipa::path(
     post,
     path = "/v1/sessions/chat",
@@ -520,6 +536,7 @@ pub async fn get_or_create_chat_session(
     State(state): State<AppState>,
     payload: Option<Json<GetOrCreateChatSessionRequest>>,
 ) -> ApiResult<WithUrls<Session>> {
+    ensure_global_chat_enabled(&org)?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let session = GetOrCreateChatSession {
         locale: payload.and_then(|Json(body)| body.locale),

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -548,6 +548,8 @@ pub async fn create_chat_voice_session(
     State(state): State<AppState>,
     Json(req): Json<VoiceCallRequest>,
 ) -> Result<Json<VoiceSessionResponse<VoiceCallResponse>>, (StatusCode, Json<ErrorResponse>)> {
+    // Platform Chat voice requires both the chat feature and voice to be enabled.
+    super::sessions::ensure_global_chat_enabled(&org)?;
     ensure_voice_enabled(&org)?;
     let session = GetOrCreateChatSession { locale: None }
         .run(&state.ctx(&org))

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -533,11 +533,14 @@ pub async fn create_agent_voice_session(
 }
 
 #[utoipa::path(
-    description = "Create a voice session for the user's global chat. Returns connection details for the realtime audio channel.",
+    description = "Create a voice session for the user's Platform Chat. Returns connection details for the realtime audio channel. Requires both the `global_chat` and `voice` feature flags; returns 404 when either is disabled.",
     post,
     path = "/v1/sessions/chat/voice",
     request_body = VoiceCallRequest,
-    responses((status = 200, description = "Platform chat session and realtime call created", body = VoiceSessionResponse<VoiceCallResponse>)),
+    responses(
+        (status = 200, description = "Platform chat session and realtime call created", body = VoiceSessionResponse<VoiceCallResponse>),
+        (status = 404, description = "Platform Chat (global_chat) or voice feature is disabled for the org"),
+    ),
     extensions(
         ("x-cost-tier" = json!("paid")),
     ),

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3250,6 +3250,13 @@ async fn test_global_chat_disabled_returns_not_found() {
         .post("/v1/sessions/chat", json!({}))
         .await
         .assert_status(StatusCode::NOT_FOUND);
+
+    // The voice variant is gated by the same flag and is rejected before any
+    // external provider call, so it also returns 404 when the flag is off.
+    server
+        .post("/v1/sessions/chat/voice", json!({ "sdp": "v=0" }))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3232,6 +3232,27 @@ async fn test_global_chat_has_chat_harness() {
 }
 
 #[tokio::test]
+async fn test_global_chat_disabled_returns_not_found() {
+    let server = TestServer::in_memory().await;
+    let org_id = "org_00000000000000000000000000000001";
+
+    // Turn the Platform Chat feature off for the org (it is opted in by the
+    // harness by default). The backend must enforce the flag, not just the UI.
+    server
+        .patch(
+            &format!("/v1/orgs/{org_id}/feature-flags"),
+            json!({ "flags": { "global_chat": false } }),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    server
+        .post("/v1/sessions/chat", json!({}))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn test_global_chat_ignores_tag_match_owned_by_other_principal() {
     let server = TestServer::in_memory().await;
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -261,11 +261,12 @@ impl TestServer {
         feature_flags.mcp_endpoint = true;
         feature_flags.agent_versions = true;
         feature_flags.app_budgets = true;
+        feature_flags.global_chat = true;
 
         // Org-effective flags are `system && org-opt-in`, so opt the default
         // test org into the experimental flags whose runtime gates now consult
         // the org-effective flags (evals, voice, mcp_endpoint, agent_versions,
-        // app_budgets). Without this those gates reject requests in tests even
+        // app_budgets, global_chat). Without this those gates reject requests in tests even
         // though the system flags are on. Deliberately scoped to these flags —
         // e.g. `notifications` is left off so tests asserting its default-off
         // org state still hold.
@@ -275,6 +276,7 @@ impl TestServer {
             "mcp_endpoint",
             "agent_versions",
             "app_budgets",
+            "global_chat",
         ]
         .into_iter()
         .map(|name| (name.to_string(), true))

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10035,6 +10035,9 @@
           "401": {
             "description": "Authentication required"
           },
+          "404": {
+            "description": "Platform Chat feature (global_chat) is disabled for the org"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -10046,7 +10049,7 @@
         "tags": [
           "voice"
         ],
-        "description": "Create a voice session for the user's global chat. Returns connection details for the realtime audio channel.",
+        "description": "Create a voice session for the user's Platform Chat. Returns connection details for the realtime audio channel. Requires both the `global_chat` and `voice` feature flags; returns 404 when either is disabled.",
         "operationId": "create_chat_voice_session",
         "requestBody": {
           "content": {
@@ -10068,6 +10071,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Platform Chat (global_chat) or voice feature is disabled for the org"
           }
         },
         "x-cost-tier": "paid"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10003,7 +10003,7 @@
           "sessions"
         ],
         "summary": "POST /v1/sessions/chat - Get or create global chat session",
-        "description": "Returns the user's singleton global chat session. Creates one if it doesn't exist.\nUses the Platform Chat harness and tags for per-user singleton management.",
+        "description": "Returns the user's singleton global chat session. Creates one if it doesn't exist.\nUses the Platform Chat harness and tags for per-user singleton management.\nGated by the `global_chat` feature flag; returns 404 when disabled.",
         "operationId": "get_or_create_chat_session",
         "requestBody": {
           "content": {
@@ -18813,7 +18813,7 @@
           },
           "global_chat": {
             "type": "boolean",
-            "description": "Global chat (per-user singleton chat session). Experimental."
+            "description": "Platform Chat: the per-user singleton assistant chat surface — sidebar\nentry, the `/chat` page, and the `POST /v1/sessions/chat` (+ voice)\nendpoints. When off, the whole Platform Chat feature is disabled\n(UI hidden and APIs return 404); other chat surfaces (per-session,\nagent, channel) are unaffected. Experimental."
           },
           "mcp_endpoint": {
             "type": "boolean",

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -230,9 +230,11 @@ Session creation and any other assignment flow must reject archived or deleted h
 
 Returns the calling user's singleton global chat session. Creates one with the Platform Chat harness if none exists. Uses tag-based lookup (`global-chat` + `user:{user_id}`) for per-user singleton management.
 
+Gated by the org-effective `global_chat` feature flag (the same gate applies to the voice variant `POST /v1/sessions/chat/voice`). When the feature is disabled the endpoint returns `404 Not Found` so the surface is fully hidden — the UI gate is not the enforcement boundary.
+
 **Request:** `POST /v1/sessions/chat` (no body required)
 
-**Response:** `200 OK` with the `Session` object.
+**Response:** `200 OK` with the `Session` object, or `404 Not Found` when `global_chat` is disabled.
 
 #### List Sessions
 


### PR DESCRIPTION
## What
Make `global_chat` (Platform Chat) a real feature flag instead of a UI-only toggle, and rewrite its label/description to state what it controls.

- Gate `POST /v1/sessions/chat` and `POST /v1/sessions/chat/voice` on the org-effective `global_chat` flag, returning **404** when disabled (mirrors `ensure_voice_enabled`).
- Rename the catalog label **"Global chat" → "Platform Chat"** and rewrite the description so it makes clear that disabling turns the whole feature off (page, sidebar, session + voice APIs).
- Update the struct doc comment, the `/chat` disabled-page message, and the spec/OpenAPI artifacts.

## Why
The flag was only checked in the UI (sidebar item + `/chat` page). The backend endpoints had no guard, so the singleton chat session — and its voice variant — were created regardless of whether the org had the feature enabled. That means it wasn't actually a feature flag, just a navigation toggle. The old description ("Per-user singleton chat session in the sidebar") also implied a sidebar-only switch and led to confusion about whether it controlled all platform chat.

Scope is **Platform Chat only**: per-session chat (`/sessions/{id}/chat`), agent chat, and channel messaging are intentionally unaffected.

## How
- Added `ensure_global_chat_enabled(&org)` in `api/sessions.rs` and call it from the chat handler; reused it from the voice chat handler (which now requires both `global_chat` and `voice`).
- The guard reads `org.feature_flags.global_chat`, the per-request org-effective value already resolved by `ResolvedOrg`.
- Seeded the test org's `global_chat` opt-in in the test harness so existing chat tests keep passing.
- Regenerated `docs/api/openapi.json` and updated `specs/apis.md`.

## Risk
- **Low.** Adds an access gate; the only behavior change is that disabled orgs now get 404 from the chat endpoints (previously served). Test org is opted in, so existing flows are unchanged.

## Security
- Threat categories reviewed: **TM-AUTHZ**, **TM-API**, **TM-TENANT**.
- Findings and resolutions: No issues. The change strengthens access control by enforcing the feature gate server-side. Returns 404 (not 403) to avoid advertising a disabled surface, consistent with the existing voice gate. The flag is the per-request org-effective value from `ResolvedOrg`, so tenant scoping is correct. No injection, new untrusted inputs, data exposure, new dependencies, or DOS surface. No existing `THREAT` comments in the touched regions; no new threat surface introduced, so no `specs/threat-model.md` update required.

## Validation
- `cargo clippy --all-targets --all-features -D warnings` — clean; `cargo fmt --check` — clean.
- `cargo test -p everruns-core feature_flags` — pass.
- Integration tests exercise the full HTTP stack (router → auth → `ResolvedOrg` flag resolution → handler → storage): new `test_global_chat_disabled_returns_not_found` (disabled → 404) plus existing enabled-path chat tests pass on the in-memory backend.
- `scripts/lib/pre-push.sh` — all checks pass (UI fmt/lint skipped locally: no `node_modules`; covered by CI).
- Regenerated OpenAPI shows no drift beyond the intended description changes.

**Smoke test note:** The affected runtime behavior is the backend gate, which is covered end-to-end by the integration tests above (they drive the real axum router with auth). The UI change is a one-word static string with a matching unit test. A `just start-dev` stack run wasn't feasible in this environment (`just` not installed, UI deps not installed) and would add no signal beyond the integration coverage.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal-only flag; no compat requirement)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01LatJqT4H436MSDNx18qCyL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LatJqT4H436MSDNx18qCyL)_