### PR TITLE
feat(mcp): always expose MCP endpoint, drop mcp_endpoint flag

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -70,7 +70,6 @@ jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => ({
     global_chat: true,
     notifications: true,
-    mcp_endpoint: true,
   }),
 }));
 

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
-import { useFeatureFlags } from "@/providers/feature-flags-provider";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
   Dialog,
@@ -18,8 +17,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 const McpIcon = capabilityIconMap.mcp;
 
 function useMcpConfig() {
-  const featureFlags = useFeatureFlags();
-  const enabled = featureFlags.mcp_endpoint;
   const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/mcp` : "/mcp";
   const configSnippet = JSON.stringify(
     {
@@ -33,7 +30,7 @@ function useMcpConfig() {
     2,
   );
 
-  return { enabled, mcpUrl, configSnippet };
+  return { mcpUrl, configSnippet };
 }
 
 function CopySnippetButton({ value }: { value: string }) {
@@ -117,11 +114,7 @@ export function McpConnectDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { enabled, mcpUrl, configSnippet } = useMcpConfig();
-
-  if (!enabled) {
-    return null;
-  }
+  const { mcpUrl, configSnippet } = useMcpConfig();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -131,11 +124,7 @@ export function McpConnectDialog({
 }
 
 export function McpConnectButton() {
-  const { enabled, mcpUrl, configSnippet } = useMcpConfig();
-
-  if (!enabled) {
-    return null;
-  }
+  const { mcpUrl, configSnippet } = useMcpConfig();
 
   return (
     <Dialog>
@@ -157,12 +146,6 @@ export function McpConnectButton() {
 }
 
 export function McpConnectMenuItem({ onSelect }: { onSelect: () => void }) {
-  const { enabled } = useMcpConfig();
-
-  if (!enabled) {
-    return null;
-  }
-
   return (
     <DropdownMenuItem
       onClick={() => {

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -9,7 +9,6 @@ export type AuthMode = "none" | "admin" | "full" | "external";
 export interface FeatureFlags {
   global_chat: boolean;
   notifications: boolean;
-  mcp_endpoint: boolean;
   evals: boolean;
   app_budgets: boolean;
   agent_versions: boolean;

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -15,7 +15,6 @@ import { useOrg } from "@/providers/org-provider";
 const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
   notifications: false,
-  mcp_endpoint: false,
   evals: false,
   app_budgets: false,
   agent_versions: false,

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -33,8 +33,6 @@ pub struct FeatureFlags {
     pub global_chat: bool,
     /// In-app notifications (bell, toasts, notification SSE). Experimental.
     pub notifications: bool,
-    /// MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental.
-    pub mcp_endpoint: bool,
     /// Evals (user-facing behavioral evals for agents). Experimental.
     pub evals: bool,
     /// App / channel scoped budgets and periodic budget resets (`5h`, `1d`, ...).
@@ -110,14 +108,6 @@ pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
         experimental: true,
     },
     FeatureFlagDefinition {
-        name: "mcp_endpoint",
-        label: "MCP server endpoint",
-        description: "Lets Everruns act as an MCP server so external tools and assistants can \
-             connect to it. Other MCP-compatible clients can then reach your agents and data \
-             through a standard endpoint.",
-        experimental: true,
-    },
-    FeatureFlagDefinition {
         name: "evals",
         label: "Evals",
         description: "Lets you define and run behavioral evals against your agents. Use it to \
@@ -170,7 +160,6 @@ impl FeatureFlags {
         Self {
             global_chat: opt_in("global_chat", system.global_chat),
             notifications: opt_in("notifications", system.notifications),
-            mcp_endpoint: opt_in("mcp_endpoint", system.mcp_endpoint),
             evals: opt_in("evals", system.evals),
             app_budgets: opt_in("app_budgets", system.app_budgets),
             agent_versions: opt_in("agent_versions", system.agent_versions),
@@ -185,7 +174,6 @@ impl FeatureFlags {
         Self {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
             notifications: experimental_flag("FEATURE_NOTIFICATIONS", grade),
-            mcp_endpoint: experimental_flag("FEATURE_MCP_ENDPOINT", grade),
             evals: experimental_flag("FEATURE_EVALS", grade),
             app_budgets: experimental_flag("FEATURE_APP_BUDGETS", grade),
             agent_versions: experimental_flag("FEATURE_AGENT_VERSIONS", grade),
@@ -211,7 +199,6 @@ impl FeatureFlags {
         FeatureFlagMap(BTreeMap::from([
             ("global_chat".to_string(), self.global_chat),
             ("notifications".to_string(), self.notifications),
-            ("mcp_endpoint".to_string(), self.mcp_endpoint),
             ("evals".to_string(), self.evals),
             ("app_budgets".to_string(), self.app_budgets),
             ("agent_versions".to_string(), self.agent_versions),
@@ -226,7 +213,6 @@ impl FeatureFlags {
         match flag {
             "global_chat" => self.global_chat,
             "notifications" => self.notifications,
-            "mcp_endpoint" => self.mcp_endpoint,
             "evals" => self.evals,
             "app_budgets" => self.app_budgets,
             "agent_versions" => self.agent_versions,
@@ -243,7 +229,6 @@ impl FeatureFlags {
         Self {
             global_chat: true,
             notifications: true,
-            mcp_endpoint: true,
             evals: true,
             app_budgets: true,
             agent_versions: true,
@@ -400,7 +385,6 @@ mod tests {
         let flags = FeatureFlags {
             global_chat: true,
             notifications: true,
-            mcp_endpoint: true,
             evals: true,
             app_budgets: true,
             agent_versions: true,
@@ -410,7 +394,6 @@ mod tests {
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("notifications"));
-        assert!(flags.is_enabled("mcp_endpoint"));
         assert!(flags.is_enabled("evals"));
         assert!(flags.is_enabled("app_budgets"));
         assert!(flags.is_enabled("agent_versions"));
@@ -425,7 +408,6 @@ mod tests {
         let flags = FeatureFlags {
             global_chat: true,
             notifications: true,
-            mcp_endpoint: true,
             evals: true,
             app_budgets: true,
             agent_versions: true,

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -429,14 +429,6 @@ async fn handle_mcp(
     headers: HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> Response {
-    if !org.feature_flags.mcp_endpoint {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(JsonRpcResponse::method_not_found(req.id)),
-        )
-            .into_response();
-    }
-
     let protocol_version = if req.method == "initialize" {
         None
     } else {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1449,11 +1449,9 @@ impl ServerAppBuilder {
 
         let mut root_routes = Router::new();
 
-        if feature_flags.mcp_endpoint {
-            root_routes = root_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
-        } else {
-            tracing::info!("MCP endpoint disabled via feature flag");
-        }
+        // MCP endpoint (POST /mcp) is always available; access is gated per-request
+        // by authentication, not a feature flag.
+        root_routes = root_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
 
         if let Some(public_routes) = auth_backend.public_routes() {
             root_routes = root_routes.merge(public_routes);

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -258,14 +258,13 @@ impl TestServer {
         // Org-effective = system && org-opt-in, so both must be on (see the
         // org opt-in seeded just below).
         feature_flags.voice = true;
-        feature_flags.mcp_endpoint = true;
         feature_flags.agent_versions = true;
         feature_flags.app_budgets = true;
         feature_flags.global_chat = true;
 
         // Org-effective flags are `system && org-opt-in`, so opt the default
         // test org into the experimental flags whose runtime gates now consult
-        // the org-effective flags (evals, voice, mcp_endpoint, agent_versions,
+        // the org-effective flags (evals, voice, agent_versions,
         // app_budgets, global_chat). Without this those gates reject requests in tests even
         // though the system flags are on. Deliberately scoped to these flags —
         // e.g. `notifications` is left off so tests asserting its default-off
@@ -273,7 +272,6 @@ impl TestServer {
         let org_flag_overrides: std::collections::HashMap<String, bool> = [
             "evals",
             "voice",
-            "mcp_endpoint",
             "agent_versions",
             "app_budgets",
             "global_chat",

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -4,6 +4,8 @@
 
 Everruns exposes an MCP server endpoint (`/mcp`) so external MCP clients — Claude Desktop, Cursor, VS Code, etc. — can interact with Everruns agents and tools over the [Model Context Protocol](https://spec.modelcontextprotocol.io). Authentication uses the same mechanisms as other API routes (`ResolvedOrg` extractor — API keys, JWT/cookie sessions), including OAuth 2.1-issued JWTs with mandatory PKCE for MCP client registration flows.
 
+The endpoint is always mounted (no feature flag); access is gated per request by authentication and per-call org resolution, not by deployment- or org-level opt-in.
+
 Routing is intentionally split:
 
 - REST API lives under `/api/*`


### PR DESCRIPTION
## What
Make the MCP server endpoint (`POST /mcp`) always available and remove the `mcp_endpoint` feature flag entirely (deployment-level and per-org opt-in).

## Why
The flag only controlled *availability*, not *authorization*. Exposing the endpoint is a single global `/mcp` route, so a per-org toggle was misleading — it couldn't meaningfully scope who the endpoint exists for, and access is already gated per request by authentication + per-call org resolution. We want MCP available to everybody, so the flag adds confusion without value.

## How
- Remove `mcp_endpoint` from `FeatureFlags` (struct field, `API_FEATURE_FLAG_DEFINITIONS`, `to_map`/`for_org`/`from_env`/`is_enabled`, test constructors). Dropping the definition removes it from the org feature-flag settings UI automatically.
- Mount the `/mcp` route unconditionally in `app_builder.rs` and drop the per-request `if !org.feature_flags.mcp_endpoint { 404 }` check in the handler (auth/org-resolution extractors unchanged).
- Remove the flag from UI feature-flag types/defaults; stop gating the MCP connect button/dialog/menu on it.
- Update the test harness and `specs/mcp.md`. (The public API exposes flags as an untyped map, so `docs/api/openapi.json` is unaffected.)

## Risk
- Low
- The `/mcp` route is now always mounted. Authorization is unchanged: every request still resolves the caller's org and applies `Command::run` policy checks and audience-bound MCP tokens. No new data exposure — orgs that hadn't opted in previously got a 404; they now reach the same authenticated, org-scoped handler as everyone else.

## Security
- Threat categories reviewed: TM-MCP (TM-MCP-001..006). The removed flag was an availability gate, not a security control. Per-request org resolution, read-only `query` scoping, `execute`/tier-1 policy checks, MCP OAuth audience binding (`mcp_access` + `/mcp` resource), and card XSS/CSP mitigations are all unchanged.
- Findings and resolutions: No security-relevant authorization paths changed. No findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01UYE3wkXeuwMUANWPeFD2Cf