### PR TITLE
refactor(api): expose feature flags as untyped key→bool map

### DIFF
--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -8,6 +8,8 @@
 // Decision: Future extensibility: per-org/per-user flags, external providers (LaunchDarkly).
 // Decision: No database storage needed yet — env vars + deployment grade suffice.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::deployment::DeploymentGrade;
@@ -16,8 +18,12 @@ use crate::deployment::DeploymentGrade;
 ///
 /// Currently backed by environment variables and deployment grade.
 /// Future: per-org flags, per-user flags, external providers.
+///
+/// Decision: this is the type-safe representation used throughout the backend.
+/// The API does not serialize it directly — it exposes the untyped
+/// [`FeatureFlagMap`] instead, so adding/removing a flag never changes
+/// `docs/api/openapi.json`.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FeatureFlags {
     /// Platform Chat: the per-user singleton assistant chat surface — sidebar
     /// entry, the `/chat` page, and the `POST /v1/sessions/chat` (+ voice)
@@ -45,6 +51,29 @@ pub struct FeatureFlags {
     pub agent_delegation: bool,
     /// Observers (online scoring of production sessions). Experimental.
     pub observers: bool,
+}
+
+/// Untyped API representation of feature flags: a generic `{ "<flag>": bool }` map.
+///
+/// Decision: the public API is intentionally untyped. The set of flags churns
+/// frequently; encoding each flag as a named schema property would force a
+/// `docs/api/openapi.json` change on every add/remove. A generic string→bool map
+/// keeps the API spec stable. The frontend layers its own typed view on top.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(transparent)]
+pub struct FeatureFlagMap(pub BTreeMap<String, bool>);
+
+impl From<&FeatureFlags> for FeatureFlagMap {
+    fn from(flags: &FeatureFlags) -> Self {
+        flags.to_map()
+    }
+}
+
+impl From<FeatureFlags> for FeatureFlagMap {
+    fn from(flags: FeatureFlags) -> Self {
+        flags.to_map()
+    }
 }
 
 /// Metadata for an API-visible feature flag (org opt-in UI + catalog).
@@ -170,6 +199,26 @@ impl FeatureFlags {
     /// Convenience for callers that don't have a `FeatureFlags` instance handy.
     pub fn current() -> Self {
         Self::from_env(&DeploymentGrade::from_env())
+    }
+
+    /// Generic `name -> enabled` map for the untyped API representation.
+    ///
+    /// Keys and values match the JSON wire format of the typed `FeatureFlags`
+    /// response body. The JSON content is equivalent; only the key order differs
+    /// (`BTreeMap` sorts keys, whereas the struct serializes in field order), which
+    /// is irrelevant to JSON consumers.
+    pub fn to_map(&self) -> FeatureFlagMap {
+        FeatureFlagMap(BTreeMap::from([
+            ("global_chat".to_string(), self.global_chat),
+            ("notifications".to_string(), self.notifications),
+            ("mcp_endpoint".to_string(), self.mcp_endpoint),
+            ("evals".to_string(), self.evals),
+            ("app_budgets".to_string(), self.app_budgets),
+            ("agent_versions".to_string(), self.agent_versions),
+            ("voice".to_string(), self.voice),
+            ("agent_delegation".to_string(), self.agent_delegation),
+            ("observers".to_string(), self.observers),
+        ]))
     }
 
     /// Look up a flag by name (for dynamic/string-based access).
@@ -395,6 +444,24 @@ mod tests {
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
         assert_eq!(flags, parsed);
+    }
+
+    #[test]
+    fn test_to_map_matches_serialized_flags() {
+        // `to_map` must produce the same keys/values as the struct's JSON form
+        // (compared as `serde_json::Value`, so key order is ignored). If a field is
+        // added to `FeatureFlags` but not to `to_map`, this fails — keeping the
+        // untyped API representation in sync with the struct.
+        let flags = FeatureFlags::all_enabled();
+        let typed: serde_json::Value = serde_json::to_value(&flags).unwrap();
+        let map: serde_json::Value = serde_json::to_value(flags.to_map()).unwrap();
+        assert_eq!(typed, map);
+
+        let default_typed: serde_json::Value =
+            serde_json::to_value(FeatureFlags::default()).unwrap();
+        let default_map: serde_json::Value =
+            serde_json::to_value(FeatureFlags::default().to_map()).unwrap();
+        assert_eq!(default_typed, default_map);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -517,7 +517,8 @@ pub use deployment::DeploymentGrade;
 
 // Feature flags
 pub use feature_flags::{
-    API_FEATURE_FLAG_DEFINITIONS, FeatureFlagDefinition, FeatureFlags, InternalFeatureFlags,
+    API_FEATURE_FLAG_DEFINITIONS, FeatureFlagDefinition, FeatureFlagMap, FeatureFlags,
+    InternalFeatureFlags,
 };
 
 // Observation backends

--- a/crates/server/src/api/feature_flags.rs
+++ b/crates/server/src/api/feature_flags.rs
@@ -5,7 +5,7 @@
 // Decision: Flags computed once at startup and served from memory (no DB query).
 
 use axum::{Json, Router, extract::State, routing::get};
-use everruns_core::FeatureFlags;
+use everruns_core::{FeatureFlagMap, FeatureFlags};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -19,6 +19,6 @@ pub fn routes(state: AppState) -> Router {
     )
 }
 
-async fn get_feature_flags(State(state): State<AppState>) -> Json<FeatureFlags> {
-    Json(state.flags.clone())
+async fn get_feature_flags(State(state): State<AppState>) -> Json<FeatureFlagMap> {
+    Json(state.flags.to_map())
 }

--- a/crates/server/src/api/org_feature_flags.rs
+++ b/crates/server/src/api/org_feature_flags.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::{Path, State},
     routing::get,
 };
-use everruns_core::{FeatureFlags, validate_org_public_id};
+use everruns_core::{FeatureFlagMap, FeatureFlags, validate_org_public_id};
 
 use crate::auth::middleware::{AuthState, OrgAdmin};
 use crate::services::org_feature_flags::{
@@ -92,7 +92,7 @@ async fn resolve_path_org(
     tag = "Organizations",
     params(("org" = String, Path, description = "Organization public id")),
     responses(
-        (status = 200, description = "Effective feature flags", body = FeatureFlags),
+        (status = 200, description = "Effective feature flags", body = FeatureFlagMap),
         (status = 404, description = "Organization not found", body = ErrorResponse),
     ),
     security(("bearerAuth" = []), ("cookieAuth" = []))
@@ -101,7 +101,7 @@ pub async fn get_org_feature_flags(
     State(state): State<AppState>,
     Path(org_public_id): Path<String>,
     user: crate::auth::AuthUser,
-) -> ApiResult<FeatureFlags> {
+) -> ApiResult<FeatureFlagMap> {
     let org_id = resolve_path_org(&state, user.id, &org_public_id).await?;
     let flags = crate::services::org_feature_flags::resolve_org_feature_flags(
         &state.db,
@@ -110,7 +110,7 @@ pub async fn get_org_feature_flags(
     )
     .await
     .log_internal_error_json("resolve org feature flags")?;
-    Ok(Json(flags))
+    Ok(Json(flags.to_map()))
 }
 
 /// GET /v1/orgs/{org}/feature-flags/settings — catalog with system/org/effective state.
@@ -149,7 +149,7 @@ pub async fn get_org_feature_flag_settings(
     params(("org" = String, Path, description = "Organization public id")),
     request_body = UpdateOrgFeatureFlagsRequest,
     responses(
-        (status = 200, description = "Updated effective flags", body = FeatureFlags),
+        (status = 200, description = "Updated effective flags", body = FeatureFlagMap),
         (status = 400, description = "Invalid flag", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Organization not found", body = ErrorResponse),
@@ -161,7 +161,7 @@ pub async fn update_org_feature_flags(
     Path(org_public_id): Path<String>,
     OrgAdmin(org): OrgAdmin,
     Json(req): Json<UpdateOrgFeatureFlagsRequest>,
-) -> ApiResult<FeatureFlags> {
+) -> ApiResult<FeatureFlagMap> {
     if org.public_id != org_public_id {
         return Err(ErrorResponse::not_found("Organization"));
     }
@@ -182,5 +182,5 @@ pub async fn update_org_feature_flags(
     )
     .await
     .log_internal_error_json("resolve org feature flags")?;
-    Ok(Json(flags))
+    Ok(Json(flags.to_map()))
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8211,7 +8211,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FeatureFlags"
+                  "$ref": "#/components/schemas/FeatureFlagMap"
                 }
               }
             }
@@ -8269,7 +8269,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FeatureFlags"
+                  "$ref": "#/components/schemas/FeatureFlagMap"
                 }
               }
             }
@@ -18781,57 +18781,14 @@
           }
         }
       },
-      "FeatureFlags": {
+      "FeatureFlagMap": {
         "type": "object",
-        "description": "Feature flags exposed via `GET /v1/feature-flags` and consumed by the frontend.\n\nCurrently backed by environment variables and deployment grade.\nFuture: per-org flags, per-user flags, external providers.",
-        "required": [
-          "global_chat",
-          "notifications",
-          "mcp_endpoint",
-          "evals",
-          "app_budgets",
-          "agent_versions",
-          "voice",
-          "agent_delegation",
-          "observers"
-        ],
-        "properties": {
-          "agent_delegation": {
-            "type": "boolean",
-            "description": "Outbound agent delegation capabilities (`a2a_agent_delegation`, `agent_handoff`).\nExperimental: auto-enabled in dev, off in prod by default.\nWhen off, these capabilities are not registered and cannot be assigned to agents."
-          },
-          "agent_versions": {
-            "type": "boolean",
-            "description": "Immutable agent versions, snapshots, forks, and app version binding.\nExperimental."
-          },
-          "app_budgets": {
-            "type": "boolean",
-            "description": "App / channel scoped budgets and periodic budget resets (`5h`, `1d`, ...).\nExperimental."
-          },
-          "evals": {
-            "type": "boolean",
-            "description": "Evals (user-facing behavioral evals for agents). Experimental."
-          },
-          "global_chat": {
-            "type": "boolean",
-            "description": "Platform Chat: the per-user singleton assistant chat surface — sidebar\nentry, the `/chat` page, and the `POST /v1/sessions/chat` (+ voice)\nendpoints. When off, the whole Platform Chat feature is disabled\n(UI hidden and APIs return 404); other chat surfaces (per-session,\nagent, channel) are unaffected. Experimental."
-          },
-          "mcp_endpoint": {
-            "type": "boolean",
-            "description": "MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental."
-          },
-          "notifications": {
-            "type": "boolean",
-            "description": "In-app notifications (bell, toasts, notification SSE). Experimental."
-          },
-          "observers": {
-            "type": "boolean",
-            "description": "Observers (online scoring of production sessions). Experimental."
-          },
-          "voice": {
-            "type": "boolean",
-            "description": "Realtime voice endpoints and microphone controls. Experimental."
-          }
+        "description": "Untyped API representation of feature flags: a generic `{ \"<flag>\": bool }` map.\n\nDecision: the public API is intentionally untyped. The set of flags churns\nfrequently; encoding each flag as a named schema property would force a\n`docs/api/openapi.json` change on every add/remove. A generic string→bool map\nkeeps the API spec stable. The frontend layers its own typed view on top.",
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "propertyNames": {
+          "type": "string"
         }
       },
       "FileInfo": {


### PR DESCRIPTION
## What
The feature-flag API endpoints (`GET /v1/feature-flags`, `GET`/`PATCH /v1/orgs/{org}/feature-flags`) now serialize their response as a generic `{ "<flag>": bool }` map instead of the typed `FeatureFlags` struct. The OpenAPI schema for these responses is now a generic `object` with `additionalProperties: { type: boolean }` (`FeatureFlagMap`), replacing the typed `FeatureFlags` schema that enumerated every named flag.

## Why
With the typed schema, every flag was a named property in `docs/api/openapi.json`, so **adding or removing a feature flag churned the API spec**. Feature flags are an internal, fast-changing set; the public API should treat them as generic key→flag data. Typing can live in the UI where it's useful. After this change, adding/removing a flag no longer affects the API spec.

## How
- Dropped `utoipa::ToSchema` from the internal `FeatureFlags` struct — it stays the type-safe representation used throughout the backend.
- Added `FeatureFlagMap(BTreeMap<String, bool>)` (a `#[serde(transparent)]` newtype that is the API schema) plus `FeatureFlags::to_map()` and `From` conversions.
- Handlers return `FeatureFlagMap`; utoipa response bodies reference it.
- The PATCH request body was already a generic `HashMap<String, bool>` — unchanged.
- Regenerated `docs/api/openapi.json`.

The JSON response content is **equivalent** to before (same keys/values, including the `apps.detailV2` rename and `agent_delegation`); only the key ordering differs (`BTreeMap` sorts keys vs. struct field order), which is irrelevant to JSON consumers. So the UI keeps its existing hand-maintained typed `FeatureFlags` interface with no change.

## Risk
- **Low.** Pure serialization-representation change on existing endpoints. No auth/authz, DB, migration, or request-parsing changes. Response content unchanged, so no client breakage. A new unit test (`test_to_map_matches_serialized_flags`) fails if `to_map()` ever drifts from the struct's JSON shape.

## Security
- Threat categories reviewed: **TM-API**. The change only swaps the response *representation* of three existing endpoints; the same boolean flags (same keys/values) are returned, exposing no new data. Auth (`OrgAdmin` extractor), org-membership/public-id validation, and the PATCH input validator (`validate_org_feature_flag_updates`) are untouched. `FeatureFlagMap` is fixed-size (one entry per flag) — no unbounded input or resource concern. No new dependencies. No nearby `THREAT` comments affected; no threat-model update needed.
- Findings and resolutions: None.

## Follow-ups
- The UI's hand-maintained `FeatureFlags` interface and `DEFAULT_FLAGS` (in `apps/ui`) omit the `observers` flag that the backend returns. Pre-existing and harmless (the extra key is ignored), so deferred — add the field only if/when the UI needs to gate on `observers`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_015wvGJteuzq3t5TPDbGT1KW