### PR TITLE
feat(evals): reward-labeled trajectory dataset export from eval runs

### DIFF
--- a/crates/server/src/api/evals.rs
+++ b/crates/server/src/api/evals.rs
@@ -19,11 +19,12 @@ use crate::api::dispatch::{Dispatchable, impl_dispatchable};
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::{Command, Ctx};
 use crate::domains::evals::EvalService;
+use crate::domains::evals::dataset::ExportEvalRunDatasetRequest;
 use crate::domains::evals::runner::EvalRunContext;
 use crate::domains::evals::{
     BulkUpdateEvalRunScores, CancelEvalRun, CreateEval, CreateEvalCase, CreateEvalRun, DeleteEval,
-    DeleteEvalCase, ExportEvalRunArtifacts, GetEval, GetEvalCase, GetEvalRun, ListEvalCases,
-    ListEvalRuns, ListEvals, UpdateEval, UpdateEvalCase, UpdateEvalResultScores,
+    DeleteEvalCase, ExportEvalRunArtifacts, ExportEvalRunDataset, GetEval, GetEvalCase, GetEvalRun,
+    ListEvalCases, ListEvalRuns, ListEvals, UpdateEval, UpdateEvalCase, UpdateEvalResultScores,
 };
 use crate::storage::StorageBackend;
 use everruns_core::Caller;
@@ -266,6 +267,10 @@ pub fn routes(state: AppState) -> Router {
             "/v1/evals/{eval_id}/runs/{run_id}/artifacts",
             get(export_run_artifacts),
         )
+        .route(
+            "/v1/evals/{eval_id}/runs/{run_id}/dataset",
+            post(export_run_dataset),
+        )
         .route("/v1/evals/{eval_id}/runs/{run_id}/cancel", post(cancel_run))
         .route(
             "/v1/evals/{eval_id}/runs/{run_id}/results/{result_id}/scores",
@@ -446,6 +451,31 @@ async fn export_run_artifacts(
     let export = ExportEvalRunArtifacts { eval_id, run_id }
         .run(&state.ctx(&org))
         .await?;
+    let body = Body::from(Bytes::from(export.body));
+
+    Ok((
+        StatusCode::OK,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/x-ndjson".to_string(),
+        )],
+        body,
+    ))
+}
+
+async fn export_run_dataset(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((eval_id, run_id)): Path<(String, String)>,
+    Json(req): Json<ExportEvalRunDatasetRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let export = ExportEvalRunDataset {
+        eval_id,
+        run_id,
+        req,
+    }
+    .run(&state.ctx(&org))
+    .await?;
     let body = Body::from(Bytes::from(export.body));
 
     Ok((

--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -560,6 +560,98 @@ impl Command for ExportEvalRunArtifacts {
 
 inventory::submit! { CommandDescriptor::of::<ExportEvalRunArtifacts>() }
 
+/// Export a completed eval run as a reward-labeled trajectory dataset (NDJSON).
+///
+/// One record per case that survives the filters: model-view messages (faithful
+/// to what the model saw, via the compaction model-view masking) joined with the
+/// case reward and efficiency metadata. Gated by `DATASET_EXPORT` and org-scoped
+/// through `get_run` (which resolves only runs owned by the caller's org).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ExportEvalRunDataset {
+    pub eval_id: String,
+    pub run_id: String,
+    pub req: super::dataset::ExportEvalRunDatasetRequest,
+}
+
+impl Command for ExportEvalRunDataset {
+    type Output = EvalArtifactExport;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "export_eval_run_dataset",
+            category: "evals",
+            description: "Export a completed eval run as a reward-labeled trajectory dataset (NDJSON).",
+            method: "POST",
+            path: "/v1/evals/{eval_id}/runs/{run_id}/dataset",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::DATASET_EXPORT)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<EvalArtifactExport, CommandError> {
+        use everruns_core::capabilities::compaction::{
+            CompactionConfig, build_model_view_messages,
+        };
+        use everruns_core::message_retriever::MessageRetriever;
+
+        require_evals_enabled(ctx)?;
+        let eval_id = q::parse_eval_id(&self.eval_id)?;
+        let run_id = q::parse_run_id(&self.run_id)?;
+        let run = q::service(ctx)
+            .get_run(&ctx.caller, &eval_id.to_string(), &run_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("EvalRun"))?;
+
+        if run.status != everruns_core::eval::EvalRunStatus::Completed {
+            return Err(CommandError::bad_request(
+                "Dataset export requires a completed eval run",
+            ));
+        }
+
+        // Reconstruct each case's conversation from session events, then apply the
+        // compaction model-view masking so the dataset matches what the model saw
+        // (not the lossless durable log). Default config is used here; honoring the
+        // exact per-run compaction config is a documented follow-up.
+        let retriever = crate::storage::message_store::DbMessageRetriever::new(ctx.db.clone());
+        let compaction = CompactionConfig::default();
+
+        let mut body = String::new();
+        for result in &run.results {
+            if !super::dataset::case_passes_filters(result, &self.req.filters) {
+                continue;
+            }
+            // Phase 1 exports eval-run case trajectories, which always have a
+            // session; skip any result without one rather than emitting an empty
+            // trajectory.
+            let Some(session_id) = result.session_id else {
+                continue;
+            };
+            let stored = retriever.load(session_id).await.map_err(|e| {
+                CommandError::internal(anyhow::anyhow!("load session messages: {e}"))
+            })?;
+            let messages = build_model_view_messages(&stored, &compaction, None).messages;
+            let record = super::dataset::build_record(
+                self.req.format,
+                &run,
+                result,
+                &messages,
+                &self.req.redaction,
+            );
+            let line =
+                serde_json::to_string(&record).map_err(|e| CommandError::internal(e.into()))?;
+            body.push_str(&line);
+            body.push('\n');
+        }
+
+        Ok(EvalArtifactExport { body })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ExportEvalRunDataset>() }
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CancelEvalRun {
     pub eval_id: String,

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -65,7 +65,17 @@ pub struct ExportEvalRunDatasetRequest {
 
 /// Keys whose string values carry raw model content (as opposed to structural
 /// fields like `role`, `id`, `name`, `type`). Used for full-content redaction.
-const CONTENT_KEYS: [&str; 5] = ["text", "arguments", "result", "error", "thinking"];
+/// Includes image payload keys (`url`, `base64`) so `redact_content` also blanks
+/// inline image data, not just text/tool content.
+const CONTENT_KEYS: [&str; 7] = [
+    "text",
+    "arguments",
+    "result",
+    "error",
+    "thinking",
+    "url",
+    "base64",
+];
 
 /// High-signal credential patterns scrubbed from every exported string, always.
 /// Deliberately conservative to avoid mangling legitimate content.
@@ -208,11 +218,14 @@ fn metadata(run: &EvalRun, result: &EvalCaseResult) -> Value {
 }
 
 fn model_of_target(target: &everruns_core::eval::EvalTarget) -> Option<String> {
-    // EvalTarget variants carry an optional model override in different arms;
-    // fall back to serializing and reading a "model" field generically.
-    serde_json::to_value(target)
-        .ok()
-        .and_then(|v| v.get("model").and_then(Value::as_str).map(str::to_string))
+    // `EvalTarget::Session` carries the model as `model_id`; read that first and
+    // fall back to a generic `model` field for other arms.
+    let value = serde_json::to_value(target).ok()?;
+    value
+        .get("model_id")
+        .or_else(|| value.get("model"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// SFT chat role string for a message role.
@@ -261,29 +274,28 @@ pub fn build_record(
     messages: &[Message],
     redaction: &RedactionOptions,
 ) -> Value {
-    match format {
-        DatasetFormat::Trajectory => {
-            let mut msgs = serde_json::to_value(messages).unwrap_or_else(|_| json!([]));
-            sanitize_value(&mut msgs, redaction.redact_content);
-            json!({
-                "source_key": source_key(run, result),
-                "eval_run_id": run.public_id.to_string(),
-                "case_id": result.eval_case_id.to_string(),
-                "case_name": result.case_name,
-                "session_id": result.session_id.map(|s| s.to_string()),
-                "reward": reward(result),
-                "messages": msgs,
-                "metadata": metadata(run, result),
-            })
-        }
+    let mut record = match format {
+        DatasetFormat::Trajectory => json!({
+            "source_key": source_key(run, result),
+            "eval_run_id": run.public_id.to_string(),
+            "case_id": result.eval_case_id.to_string(),
+            "case_name": result.case_name,
+            "session_id": result.session_id.map(|s| s.to_string()),
+            "reward": reward(result),
+            "messages": serde_json::to_value(messages).unwrap_or_else(|_| json!([])),
+            "metadata": metadata(run, result),
+        }),
         DatasetFormat::Sft => {
             let chat: Vec<Value> = messages
                 .iter()
                 .map(|m| {
+                    // The SFT `content` key is not in CONTENT_KEYS (trajectory uses
+                    // `content` as the message-array container), so blank it here
+                    // when redacting; the whole-record pass below still secret-scrubs.
                     let content = if redaction.redact_content {
                         REDACTED.to_string()
                     } else {
-                        scrub_secrets(&message_text(m))
+                        message_text(m)
                     };
                     json!({ "role": sft_role(&m.role), "content": content })
                 })
@@ -294,7 +306,13 @@ pub fn build_record(
                 "reward": reward(result),
             })
         }
-    }
+    };
+
+    // Always-on secret scrubbing across *every* exported string (case_name,
+    // scorer reasons, metadata, messages, …); additionally blank content-bearing
+    // fields (incl. image payloads) when redaction is requested.
+    sanitize_value(&mut record, redaction.redact_content);
+    record
 }
 
 #[cfg(test)]
@@ -493,5 +511,47 @@ mod tests {
             },
         );
         assert_eq!(rec["messages"][0]["content"], json!(REDACTED));
+    }
+
+    #[test]
+    fn secret_scrubbing_covers_case_name_and_scorer_reason() {
+        let mut r = result_with(
+            CaseResultStatus::Passed,
+            json!([{"value": 1.0, "pass": true, "reason": "leaked sk-abcdef0123456789ABCDEF"}]),
+        );
+        r.case_name = Some("case AKIAABCDEFGHIJKLMNOP".into());
+        let rec = build_record(
+            DatasetFormat::Trajectory,
+            &run(),
+            &r,
+            &[],
+            &RedactionOptions::default(),
+        );
+        let serialized = serde_json::to_string(&rec).unwrap();
+        // Secrets outside `messages` (case_name, scorer reason) are scrubbed too.
+        assert!(!serialized.contains("sk-abcdef0123456789ABCDEF"));
+        assert!(!serialized.contains("AKIAABCDEFGHIJKLMNOP"));
+        assert!(serialized.contains(REDACTED));
+    }
+
+    #[test]
+    fn redact_content_blanks_image_payload() {
+        use everruns_core::message::ImageContentPart;
+        let r = result_with(CaseResultStatus::Passed, json!([{"value": 1.0}]));
+        let mut msg = text_msg(MessageRole::User, "x");
+        msg.content = vec![ContentPart::Image(ImageContentPart::from_url(
+            "https://example.com/SECRETIMAGEDATA.png",
+        ))];
+        let rec = build_record(
+            DatasetFormat::Trajectory,
+            &run(),
+            &r,
+            &[msg],
+            &RedactionOptions {
+                redact_content: true,
+            },
+        );
+        let serialized = serde_json::to_string(&rec).unwrap();
+        assert!(!serialized.contains("SECRETIMAGEDATA"));
     }
 }

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -1,0 +1,497 @@
+// Dataset export: turn a completed eval run into a reward-labeled trajectory
+// dataset (NDJSON). See `specs/dataset-export.md`.
+//
+// This module is pure (no IO): the command in `commands.rs` loads the run and
+// each case's model-view messages, then calls into here to filter, redact, and
+// serialize one NDJSON record per surviving case.
+
+use std::sync::LazyLock;
+
+use everruns_core::eval::{CaseResultStatus, EvalCaseResult, EvalRun};
+use everruns_core::message::{ContentPart, Message, MessageRole};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use utoipa::ToSchema;
+
+/// Output schema for the exported dataset.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DatasetFormat {
+    /// Generic, canonical trajectory record (full model-view messages + reward +
+    /// metadata).
+    #[default]
+    Trajectory,
+    /// Chat-message shape loadable by common SFT pipelines, with reward carried
+    /// in a sidecar field for verifiable-reward filtering before training.
+    Sft,
+}
+
+/// Selection filters applied per case. `org_id` is never part of this — it is
+/// injected by the command from the authenticated caller, so a filter can never
+/// widen the org scope.
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
+pub struct DatasetFilters {
+    /// Keep only cases whose pass/fail equals this.
+    #[serde(default)]
+    pub pass: Option<bool>,
+    /// Keep only cases whose mean scorer value is >= this (0.0–1.0).
+    #[serde(default)]
+    pub min_score: Option<f64>,
+}
+
+/// Redaction controls. Secret scrubbing is always applied regardless of these.
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
+pub struct RedactionOptions {
+    /// When true, replace message text/tool content with a placeholder, keeping
+    /// only structure (roles, tool names, ids). Secret scrubbing still runs.
+    #[serde(default)]
+    pub redact_content: bool,
+}
+
+/// Request body for `POST /v1/evals/{eval_id}/runs/{run_id}/dataset`.
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
+pub struct ExportEvalRunDatasetRequest {
+    /// Output schema (defaults to `trajectory`).
+    #[serde(default)]
+    pub format: DatasetFormat,
+    /// Per-case selection filters.
+    #[serde(default)]
+    pub filters: DatasetFilters,
+    /// Redaction controls.
+    #[serde(default)]
+    pub redaction: RedactionOptions,
+}
+
+/// Keys whose string values carry raw model content (as opposed to structural
+/// fields like `role`, `id`, `name`, `type`). Used for full-content redaction.
+const CONTENT_KEYS: [&str; 5] = ["text", "arguments", "result", "error", "thinking"];
+
+/// High-signal credential patterns scrubbed from every exported string, always.
+/// Deliberately conservative to avoid mangling legitimate content.
+static SECRET_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    [
+        // OpenAI / Anthropic style keys: sk-..., sk-ant-...
+        r"\bsk-[A-Za-z0-9_-]{16,}\b",
+        // AWS access key id
+        r"\bAKIA[0-9A-Z]{16}\b",
+        // GitHub tokens
+        r"\bgh[pousr]_[A-Za-z0-9]{20,}\b",
+        // Bearer tokens
+        r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{16,}",
+        // key/secret/password/token assignments: api_key=..., "secret": "..."
+        r#"(?i)\b(api[_-]?key|secret|password|passwd|token|access[_-]?key)\b\s*["']?\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{6,}"#,
+    ]
+    .iter()
+    .map(|p| Regex::new(p).expect("valid secret regex"))
+    .collect()
+});
+
+const REDACTED: &str = "[REDACTED]";
+
+/// Scrub credential-looking substrings from a single string.
+pub fn scrub_secrets(input: &str) -> String {
+    let mut out = input.to_string();
+    for re in SECRET_PATTERNS.iter() {
+        out = re.replace_all(&out, REDACTED).into_owned();
+    }
+    out
+}
+
+/// Recursively scrub secrets in every string leaf of `value`. When
+/// `redact_content` is set, content-bearing fields are first replaced wholesale
+/// with a placeholder (structure is preserved).
+fn sanitize_value(value: &mut Value, redact_content: bool) {
+    match value {
+        Value::String(s) => *s = scrub_secrets(s),
+        Value::Array(items) => {
+            for item in items {
+                sanitize_value(item, redact_content);
+            }
+        }
+        Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                if redact_content && CONTENT_KEYS.contains(&key.as_str()) {
+                    *val = Value::String(REDACTED.to_string());
+                } else {
+                    sanitize_value(val, redact_content);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Mean scorer value for a case, or 0.0 when no numeric scores are present.
+pub fn mean_score(result: &EvalCaseResult) -> f64 {
+    let values: Vec<f64> = result
+        .scores
+        .as_ref()
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| s.get("value").and_then(Value::as_f64))
+                .collect()
+        })
+        .unwrap_or_default();
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f64>() / values.len() as f64
+    }
+}
+
+/// Whether a case result survives the selection filters.
+pub fn case_passes_filters(result: &EvalCaseResult, filters: &DatasetFilters) -> bool {
+    if let Some(want) = filters.pass
+        && (result.status == CaseResultStatus::Passed) != want
+    {
+        return false;
+    }
+    if let Some(min) = filters.min_score
+        && mean_score(result) < min
+    {
+        return false;
+    }
+    true
+}
+
+/// Stable per-record key for idempotent re-export: run + case-result public ids.
+pub fn source_key(run: &EvalRun, result: &EvalCaseResult) -> String {
+    format!("{}/{}", run.public_id, result.public_id)
+}
+
+/// The reward block shared by both formats.
+fn reward(result: &EvalCaseResult) -> Value {
+    let scorers: Vec<Value> = result
+        .scores
+        .as_ref()
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .enumerate()
+                .map(|(i, s)| {
+                    json!({
+                        // Scorer names are not persisted on the result (only the
+                        // ordered Vec<Score>), so index positionally; joining the
+                        // case's scorer names is a follow-up.
+                        "name": s.get("name").cloned().unwrap_or_else(|| json!(format!("scorer_{i}"))),
+                        "value": s.get("value"),
+                        "pass": s.get("pass"),
+                        "reason": s.get("reason"),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    json!({
+        "pass": result.status == CaseResultStatus::Passed,
+        "score": mean_score(result),
+        "scorers": scorers,
+    })
+}
+
+/// Efficiency / provenance metadata.
+fn metadata(run: &EvalRun, result: &EvalCaseResult) -> Value {
+    json!({
+        "model": result
+            .target
+            .as_ref()
+            .or(result.target_snapshot.as_ref())
+            .and_then(model_of_target)
+            .or_else(|| run.model_override.clone()),
+        "turns": result.turns,
+        "input_tokens": result.input_tokens,
+        "output_tokens": result.output_tokens,
+        "latency_ms": result.latency_ms,
+    })
+}
+
+fn model_of_target(target: &everruns_core::eval::EvalTarget) -> Option<String> {
+    // EvalTarget variants carry an optional model override in different arms;
+    // fall back to serializing and reading a "model" field generically.
+    serde_json::to_value(target)
+        .ok()
+        .and_then(|v| v.get("model").and_then(Value::as_str).map(str::to_string))
+}
+
+/// SFT chat role string for a message role.
+fn sft_role(role: &MessageRole) -> &'static str {
+    match role {
+        MessageRole::System => "system",
+        MessageRole::User => "user",
+        MessageRole::Agent => "assistant",
+        MessageRole::ToolResult => "tool",
+    }
+}
+
+/// Best-effort flat text for a message in the SFT shape.
+fn message_text(msg: &Message) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(thinking) = &msg.thinking {
+        parts.push(format!("[thinking] {thinking}"));
+    }
+    for part in &msg.content {
+        match part {
+            ContentPart::Text(t) => parts.push(t.text.clone()),
+            ContentPart::ToolCall(c) => parts.push(format!(
+                "[tool_call {} {}]",
+                c.name,
+                serde_json::to_string(&c.arguments).unwrap_or_default()
+            )),
+            ContentPart::ToolResult(r) => {
+                if let Some(result) = &r.result {
+                    parts.push(serde_json::to_string(result).unwrap_or_default());
+                }
+                if let Some(err) = &r.error {
+                    parts.push(format!("[error] {err}"));
+                }
+            }
+            ContentPart::Image(_) | ContentPart::ImageFile(_) => parts.push("[image]".to_string()),
+        }
+    }
+    parts.join("\n")
+}
+
+/// Build one NDJSON record for a case in the requested format.
+pub fn build_record(
+    format: DatasetFormat,
+    run: &EvalRun,
+    result: &EvalCaseResult,
+    messages: &[Message],
+    redaction: &RedactionOptions,
+) -> Value {
+    match format {
+        DatasetFormat::Trajectory => {
+            let mut msgs = serde_json::to_value(messages).unwrap_or_else(|_| json!([]));
+            sanitize_value(&mut msgs, redaction.redact_content);
+            json!({
+                "source_key": source_key(run, result),
+                "eval_run_id": run.public_id.to_string(),
+                "case_id": result.eval_case_id.to_string(),
+                "case_name": result.case_name,
+                "session_id": result.session_id.map(|s| s.to_string()),
+                "reward": reward(result),
+                "messages": msgs,
+                "metadata": metadata(run, result),
+            })
+        }
+        DatasetFormat::Sft => {
+            let chat: Vec<Value> = messages
+                .iter()
+                .map(|m| {
+                    let content = if redaction.redact_content {
+                        REDACTED.to_string()
+                    } else {
+                        scrub_secrets(&message_text(m))
+                    };
+                    json!({ "role": sft_role(&m.role), "content": content })
+                })
+                .collect();
+            json!({
+                "source_key": source_key(run, result),
+                "messages": chat,
+                "reward": reward(result),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::eval::EvalCaseResult;
+    use everruns_core::message::{Message, MessageRole, TextContentPart};
+    use everruns_core::typed_id::{EvalCaseId, EvalResultId, EvalRunId};
+
+    fn result_with(status: CaseResultStatus, scores: Value) -> EvalCaseResult {
+        EvalCaseResult {
+            public_id: EvalResultId::new(),
+            internal_id: uuid::Uuid::nil(),
+            eval_case_id: EvalCaseId::new(),
+            case_name: Some("case".into()),
+            session_id: None,
+            target: None,
+            target_snapshot: None,
+            status,
+            scores: Some(scores),
+            metadata: None,
+            turns: Some(3),
+            latency_ms: Some(1200),
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+            error_message: None,
+            artifacts: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn text_msg(role: MessageRole, text: &str) -> Message {
+        Message {
+            id: uuid::Uuid::now_v7().into(),
+            role,
+            content: vec![ContentPart::Text(TextContentPart::new(text))],
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            external_actor: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    fn run() -> EvalRun {
+        EvalRun {
+            public_id: EvalRunId::new(),
+            internal_id: uuid::Uuid::nil(),
+            org_id: 1,
+            target: None,
+            model_override: Some("gpt-test".into()),
+            filter_tags: None,
+            status: everruns_core::eval::EvalRunStatus::Completed,
+            triggered_by: "test".into(),
+            started_at: None,
+            completed_at: None,
+            summary: None,
+            results: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn mean_score_averages_values() {
+        let r = result_with(
+            CaseResultStatus::Passed,
+            json!([{"pass": true, "value": 1.0, "reason": "ok"}, {"pass": false, "value": 0.0, "reason": "no"}]),
+        );
+        assert_eq!(mean_score(&r), 0.5);
+    }
+
+    #[test]
+    fn filters_pass_and_min_score() {
+        let passed = result_with(CaseResultStatus::Passed, json!([{"value": 0.8}]));
+        let failed = result_with(CaseResultStatus::Failed, json!([{"value": 0.2}]));
+
+        assert!(case_passes_filters(
+            &passed,
+            &DatasetFilters {
+                pass: Some(true),
+                min_score: None
+            }
+        ));
+        assert!(!case_passes_filters(
+            &failed,
+            &DatasetFilters {
+                pass: Some(true),
+                min_score: None
+            }
+        ));
+        assert!(case_passes_filters(
+            &passed,
+            &DatasetFilters {
+                pass: None,
+                min_score: Some(0.5)
+            }
+        ));
+        assert!(!case_passes_filters(
+            &failed,
+            &DatasetFilters {
+                pass: None,
+                min_score: Some(0.5)
+            }
+        ));
+    }
+
+    #[test]
+    fn scrub_secrets_redacts_keys() {
+        let scrubbed =
+            scrub_secrets("here is sk-abcdef0123456789ABCDEF and AKIAABCDEFGHIJKLMNOP done");
+        assert!(scrubbed.contains(REDACTED));
+        assert!(!scrubbed.contains("sk-abcdef0123456789"));
+        assert!(!scrubbed.contains("AKIAABCDEFGHIJKLMNOP"));
+    }
+
+    #[test]
+    fn trajectory_record_has_reward_and_messages() {
+        let r = result_with(
+            CaseResultStatus::Passed,
+            json!([{"pass": true, "value": 1.0, "reason": "ok"}]),
+        );
+        let msgs = vec![
+            text_msg(MessageRole::User, "hello"),
+            text_msg(MessageRole::Agent, "hi there"),
+        ];
+        let rec = build_record(
+            DatasetFormat::Trajectory,
+            &run(),
+            &r,
+            &msgs,
+            &RedactionOptions::default(),
+        );
+        assert_eq!(rec["reward"]["pass"], json!(true));
+        assert_eq!(rec["reward"]["score"], json!(1.0));
+        assert_eq!(rec["messages"].as_array().unwrap().len(), 2);
+        assert_eq!(rec["metadata"]["turns"], json!(3));
+        assert!(rec["source_key"].as_str().unwrap().contains('/'));
+    }
+
+    #[test]
+    fn sft_record_is_chat_shaped() {
+        let r = result_with(CaseResultStatus::Passed, json!([{"value": 1.0}]));
+        let msgs = vec![
+            text_msg(MessageRole::User, "q"),
+            text_msg(MessageRole::Agent, "a"),
+        ];
+        let rec = build_record(
+            DatasetFormat::Sft,
+            &run(),
+            &r,
+            &msgs,
+            &RedactionOptions::default(),
+        );
+        let chat = rec["messages"].as_array().unwrap();
+        assert_eq!(chat[0]["role"], json!("user"));
+        assert_eq!(chat[1]["role"], json!("assistant"));
+        assert_eq!(chat[1]["content"], json!("a"));
+        assert!(rec["reward"].is_object());
+    }
+
+    #[test]
+    fn redact_content_blanks_text_but_keeps_structure() {
+        let r = result_with(CaseResultStatus::Passed, json!([{"value": 1.0}]));
+        let msgs = vec![text_msg(MessageRole::User, "secret business content")];
+        let rec = build_record(
+            DatasetFormat::Trajectory,
+            &run(),
+            &r,
+            &msgs,
+            &RedactionOptions {
+                redact_content: true,
+            },
+        );
+        let serialized = serde_json::to_string(&rec).unwrap();
+        assert!(!serialized.contains("secret business content"));
+        assert!(serialized.contains(REDACTED));
+        // Structure preserved: role still present.
+        assert_eq!(rec["messages"][0]["role"], json!("user"));
+    }
+
+    #[test]
+    fn sft_redacts_content_when_requested() {
+        let r = result_with(CaseResultStatus::Passed, json!([{"value": 1.0}]));
+        let msgs = vec![text_msg(MessageRole::User, "private text")];
+        let rec = build_record(
+            DatasetFormat::Sft,
+            &run(),
+            &r,
+            &msgs,
+            &RedactionOptions {
+                redact_content: true,
+            },
+        );
+        assert_eq!(rec["messages"][0]["content"], json!(REDACTED));
+    }
+}

--- a/crates/server/src/domains/evals/mod.rs
+++ b/crates/server/src/domains/evals/mod.rs
@@ -1,6 +1,7 @@
 // Evals domain — commands, queries, service, and background runner.
 
 pub mod commands;
+pub mod dataset;
 pub mod limits;
 pub mod queries;
 pub mod runner;

--- a/crates/server/src/domains/evals/service.rs
+++ b/crates/server/src/domains/evals/service.rs
@@ -47,6 +47,20 @@ pub const EVAL_RUN: Policy = Policy {
     ],
 };
 
+/// Policy: Export reward-labeled trajectory datasets from eval runs.
+///
+/// Distinct from `EVAL_VIEW`/`REPORT_VIEW` because this surface exports raw
+/// model-view message content (more sensitive than aggregate reporting). Gated
+/// more tightly than read-only eval viewing by requiring both agent- and
+/// session-management permissions, matching the privilege of starting runs.
+pub const DATASET_EXPORT: Policy = Policy {
+    id: "dataset.export",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgAgentsManage),
+        Rule::UserHasPermission(Permission::OrgSessionsManage),
+    ],
+};
+
 pub struct EvalService {
     db: Arc<StorageBackend>,
     run_context: Option<Arc<EvalRunContext>>,

--- a/specs/README.md
+++ b/specs/README.md
@@ -138,6 +138,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/online-evals.md` - Online evals (Observers) over production sessions (proposed)
 - `specs/swe-bench-lite.md` - SWE-bench Lite evaluation harness
 - `specs/reporting.md` - Async reporting
+- `specs/dataset-export.md` - Reward-labeled trajectory dataset export from eval runs
 - `specs/reporting-backends.md` - Phase 3 reference evaluation
 - `specs/fail-rs-testing.md` - Failure injection testing with fail-rs
 

--- a/specs/dataset-export.md
+++ b/specs/dataset-export.md
@@ -115,7 +115,7 @@ authenticated caller and cannot be widened by a filter.
 - Datasets are derived artifacts: deleting the underlying session/eval removes
   the source, so re-export reflects deletions.
 
-See `specs/threat-model.md` (TM-DATASET-001) for the threat review.
+See `specs/threat-model.md` (TM-OBS-008) for the threat review.
 
 ## Follow-ups
 

--- a/specs/dataset-export.md
+++ b/specs/dataset-export.md
@@ -1,0 +1,127 @@
+# Dataset Export Specification
+
+## Abstract
+
+Dataset export turns a completed eval run into a **reward-labeled trajectory
+dataset**: for each case, "what the model saw → what it did → how good it was",
+serialized as newline-delimited JSON (NDJSON). It is the connective tissue
+between running evals and improving the models behind them (post-training), and
+it immediately improves trace-driven harness iteration (diffing passing vs.
+failing trajectories).
+
+This is an ETL/join over data Everruns already persists: reward from
+`EvalCaseResult.scores` + status, trajectory content from the eval-tagged
+session's events, and efficiency metadata from the case result. It is gated for
+privacy because, unlike aggregate reporting, it exports raw model-view content.
+
+## Goals
+
+1. Export a completed `EvalRun` as reward-labeled NDJSON, one record per case.
+2. Be faithful to what the model saw — use the **model view** (post-compaction
+   masking), not the lossless durable log.
+3. Be privacy- and tenant-safe by construction: org-scoped, behind an explicit
+   policy, with redaction controls and always-on secret scrubbing.
+4. Reuse existing infrastructure (the NDJSON artifact-export precedent, the
+   compaction model-view masking, the message reconstruction-from-events path).
+
+## Non-Goals
+
+- Continuous capture from arbitrary production sessions (Phase 1 is eval runs
+  only — bounded, consented, already labeled).
+- RL-style preference-pair / DPO construction (Phase 1 is SFT-shaped single
+  trajectories).
+- The post-training / fine-tune orchestration itself (this only produces its
+  input).
+- Cross-org or platform-wide datasets.
+
+## Source-of-truth join
+
+| Field | Source |
+|-------|--------|
+| reward (pass/fail, scorer values) | `EvalCaseResult.status` + `EvalCaseResult.scores` |
+| trajectory (messages, tool calls/results) | session `events`, reconstructed to `Vec<Message>` then masked to the model view |
+| efficiency metadata (turns, tokens, latency) | `EvalCaseResult` |
+
+Reporting facts (`specs/reporting.md`) deliberately exclude prompts / messages /
+tool args / results per `TM-OBS`, so they are the right source for *filtering*,
+not *content*. Trajectory content therefore comes from the session events, not
+reporting.
+
+### Model-view faithfulness
+
+Trajectories use the compaction **model-view masking**
+(`build_model_view_messages` in `crates/core/src/capabilities/compaction.rs`) so
+the exported messages match training reality rather than a lossless log the
+model never read. Phase 1 applies the default `CompactionConfig`; honoring the
+exact per-run compaction config is a follow-up (see Follow-ups).
+
+## API
+
+`POST /v1/evals/{eval_id}/runs/{run_id}/dataset`
+
+Body:
+
+```json
+{
+  "format": "trajectory" | "sft",
+  "filters": { "pass": true, "min_score": 0.5 },
+  "redaction": { "redact_content": false }
+}
+```
+
+Returns `application/x-ndjson` — one record per surviving case. The run must be
+`Completed`. This mirrors the synchronous artifacts export
+(`GET …/runs/{run_id}/artifacts`). An async dataset-handle + status API
+(`POST` enqueues, `GET …/dataset/{dataset_id}`) is a deferred follow-up; Phase 1
+returns the NDJSON inline.
+
+### Output schema
+
+- `trajectory` (generic, canonical):
+  `{ source_key, eval_run_id, case_id, case_name, session_id, reward: { pass, score, scorers: [{name, value, pass, reason}] }, messages: [...model-view messages...], metadata: { model, turns, input_tokens, output_tokens, latency_ms } }`
+- `sft`: `{ source_key, messages: [{role, content}], reward: { pass, score, scorers } }` — chat-message shape loadable by common SFT pipelines, with reward in a sidecar field so verifiable-reward filtering happens before training.
+
+Scorer names are not persisted on the result (only the ordered `Vec<Score>`), so
+they are indexed positionally (`scorer_0`, …); joining the case's scorer names
+is a follow-up.
+
+### Idempotency
+
+Each record carries a stable `source_key` (`{eval_run_id}/{case_result_id}`) so
+re-export is idempotent and records can be deduplicated downstream.
+
+### Selection filters
+
+- `pass` — keep only cases whose pass/fail equals this.
+- `min_score` — keep only cases whose mean scorer value is ≥ this.
+
+Filters never reference `org_id`; the org scope is injected from the
+authenticated caller and cannot be widened by a filter.
+
+## Privacy / security
+
+- Gated by a dedicated `DATASET_EXPORT` policy (`dataset.export`), distinct from
+  `EVAL_VIEW` / `REPORT_VIEW` because this exports raw content. It requires both
+  `OrgAgentsManage` and `OrgSessionsManage`, matching the privilege of starting
+  runs.
+- Org-scoped end-to-end: the run is resolved through `get_run` with the caller's
+  org, so cases from other orgs are never reachable.
+- **Secret scrubbing is always on**: credential-looking substrings (provider
+  keys, AWS keys, GitHub tokens, bearer tokens, `key/secret/password/token`
+  assignments) are removed from every exported string.
+- **Configurable redaction** (`redact_content`): replaces message text and tool
+  content with a placeholder while preserving structure (roles, tool names,
+  ids). Off by default.
+- Datasets are derived artifacts: deleting the underlying session/eval removes
+  the source, so re-export reflects deletions.
+
+See `specs/threat-model.md` (TM-DATASET-001) for the threat review.
+
+## Follow-ups
+
+- Async dataset-handle API with status + stored dataset artifacts.
+- Honor the exact per-run compaction config for model-view reconstruction.
+- Join scorer names from the eval case definition.
+- Optional cost (`cost_usd`) via reporting-fact join.
+- Preference-pair / DPO dataset construction.
+- Continuous capture from production sessions (opt-in).

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -674,6 +674,7 @@ All `/v1/durable/*` HTTP endpoints require explicit platform-user auth. The auth
 | TM-OBS-005 | Log injection | Low | Structured logging via `tracing` crate; no raw string interpolation in log output | MITIGATED |
 | TM-OBS-006 | Sensitive data in error logs | Medium | Errors logged server-side only; API keys and passwords excluded from tracing fields | MITIGATED |
 | TM-OBS-007 | No security audit logging | Medium | Structured audit_logs table with fire-and-forget writes for auth events; admin-only query API | MITIGATED |
+| TM-OBS-008 | Raw trajectory content leak via dataset export | High | Dataset export (`POST /v1/evals/{eval_id}/runs/{run_id}/dataset`, `specs/dataset-export.md`) exports raw model-view message content, so it is gated by a dedicated `DATASET_EXPORT` policy (`dataset.export`, requires `OrgAgentsManage` + `OrgSessionsManage`) distinct from read-only `EVAL_VIEW`/`REPORT_VIEW`; org-scoped through `get_run` (cross-org runs are 404, see TM-TENANT-001/002); always-on secret scrubbing strips credential patterns from every exported string; optional `redact_content` blanks message/tool content while preserving structure. Datasets are derived (no new at-rest store in Phase 1), so session/eval deletion removes the source | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Export a completed `EvalRun` as a **reward-labeled trajectory dataset** (NDJSON): one record per case joining the case reward (scorer values + pass/fail) and efficiency metadata with the case's **model-view** message timeline. Phase 1 of EVE-603.

## Why
Everruns already runs evals with deterministic reward and persists trajectory content in session events, but there was no way to export them as a single training-ready artifact — the prerequisite for post-training and for trace-driven harness iteration (diffing passing vs. failing trajectories). This is an ETL/join over data we already persist, gated for privacy.

## How
- **API:** `POST /v1/evals/{eval_id}/runs/{run_id}/dataset` → `application/x-ndjson`, mirroring the synchronous artifacts-export precedent. Body `{ format, filters, redaction }`. Requires a `Completed` run.
- **Serializers:** `trajectory` (canonical: `source_key`, `reward`, model-view `messages`, `metadata`) and `sft` (chat-shaped `messages` + reward sidecar). New `crates/server/src/domains/evals/dataset.rs` (pure, unit-tested).
- **Model-view faithfulness:** messages are reconstructed from session events (`DbMessageRetriever`) then masked through the compaction model view (`build_model_view_messages`), so the dataset matches what the model saw, not the lossless durable log.
- **Filters:** `pass` and minimum mean-scorer `min_score`.
- **Idempotency:** stable `source_key = {run_id}/{case_result_id}` per record.
- **Docs:** `specs/dataset-export.md` added, `specs/README.md` indexed.

## Risk
- **Low–medium.** Additive, read-only endpoint; no migration, no change to existing eval/run behavior. New `DATASET_EXPORT` policy gates a new content-exporting surface.

## Security
- Threat categories reviewed: **TM-OBS** (new `TM-OBS-008`), **TM-TENANT**, **TM-AUTHZ**.
- New `DATASET_EXPORT` policy (`dataset.export`), distinct from read-only `EVAL_VIEW`/`REPORT_VIEW` because this exports raw model-view content; requires `OrgAgentsManage` **and** `OrgSessionsManage`.
- Org-scoped end-to-end via `get_run` (cross-org → 404, per TM-TENANT-001/002). Filters cannot reference `org_id`.
- **Always-on secret scrubbing** strips credential patterns (provider/AWS/GitHub/bearer tokens, `key/secret/password/token` assignments) from every exported string; optional `redact_content` blanks message/tool content while preserving structure. Both covered by unit tests.

## Follow-ups
- **Tests:** unit tests cover the novel logic (serializers, filters, secret scrubbing, `redact_content`). A full **llmsim end-to-end** export test and a **command-level tenant-isolation** test are deferred: org-scoping is structurally inherited from `get_run` (the standard org-scoped eval read) and the policy is enforced by the shared command framework, so the remaining risk is low — happy to add the seeded-run e2e if preferred.
- **Async dataset-handle API** (`POST` enqueues + `GET …/dataset/{dataset_id}` status) — Phase 1 returns NDJSON inline.
- **Exact per-run compaction config** for model-view reconstruction (Phase 1 uses the default config).
- **Scorer-name join** from the case definition (names aren't persisted on the result; indexed positionally for now).
- Optional `cost_usd` via reporting-fact join.
- **Landing blog post** (`everruns/landing`) — separate repo, out of scope for this PR.

## Checklist
- [x] Tests added or updated (unit; integration/e2e deferred — see Follow-ups)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01GDw8evR5xi3yWX3AiX66Ao

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDw8evR5xi3yWX3AiX66Ao)_