### PR TITLE
feat(capabilities): parallel_tool_calls preference, unify drivers

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -246,6 +246,7 @@ export default defineConfig({
                         { label: "Tool Search", slug: "capabilities/tool-search" },
                         { label: "Budgeting", slug: "capabilities/budgeting" },
                         { label: "Self-Budget", slug: "capabilities/self-budget" },
+                        { label: "Parallel Tool Calls", slug: "capabilities/parallel-tool-calls" },
                       ],
                     },
                     {

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -562,7 +562,10 @@ impl ChatDriver for AnthropicChatDriver {
         // `tool_choice.disable_parallel_tool_use`. `tool_choice` is only valid
         // when tools are present, so skip it for tool-less requests.
         let tool_choice = if tools.is_some() {
-            AnthropicToolChoice::from_parallel_preference(config.parallel_tool_calls)
+            AnthropicToolChoice::from_parallel_preference(
+                config
+                    .resolved_parallel_tool_calls(self.supports_parallel_tool_calls(&config.model)),
+            )
         } else {
             None
         };
@@ -976,6 +979,12 @@ impl ChatDriver for AnthropicChatDriver {
         }));
 
         Ok(converted_stream)
+    }
+
+    /// Anthropic maps the preference onto `tool_choice.disable_parallel_tool_use`
+    /// for every tool-capable Claude model.
+    fn supports_parallel_tool_calls(&self, _model: &str) -> bool {
+        true
     }
 
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
@@ -1832,8 +1841,15 @@ impl AnthropicModelInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::driver_registry::ChatDriver;
     use everruns_core::model::Modality;
     use everruns_core::{BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy};
+
+    #[test]
+    fn supports_parallel_tool_calls_is_true() {
+        let driver = AnthropicChatDriver::new("test-key");
+        assert!(driver.supports_parallel_tool_calls("claude-opus-4-8"));
+    }
 
     // These tests verify that empty text blocks are filtered out to avoid
     // Anthropic API error: "text content blocks must be non-empty"

--- a/crates/anthropic/tests/parallel_tool_calls_live.rs
+++ b/crates/anthropic/tests/parallel_tool_calls_live.rs
@@ -1,0 +1,101 @@
+//! Live tests for the request-level `parallel_tool_calls` preference against the
+//! real Anthropic Messages API.
+//!
+//! Proves the wire mapping (`tool_choice.disable_parallel_tool_use`) is accepted
+//! by the provider and has effect:
+//! - `Some(false)` (avoid) is accepted and the provider returns at most one tool
+//!   call in a single completion.
+//! - `Some(true)` (prefer) is accepted and the provider returns tool calls.
+//!
+//! Ignored by default (requires network + `ANTHROPIC_API_KEY`); run manually:
+//!   `doppler run -- cargo test -p everruns-anthropic --test parallel_tool_calls_live -- --ignored --nocapture`
+
+use everruns_anthropic::AnthropicChatDriver;
+use everruns_core::driver_registry::{ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_core::tool_types::{
+    BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
+};
+
+const LIVE_MODEL: &str = "claude-haiku-4-5-20251001";
+
+fn api_key() -> String {
+    std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set for the live test")
+}
+
+fn tool(name: &str, description: &str) -> ToolDefinition {
+    ToolDefinition::Builtin(BuiltinTool {
+        name: name.to_string(),
+        display_name: None,
+        description: description.to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        }),
+        policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
+        full_parameters: None,
+    })
+}
+
+fn config_with(parallel: Option<bool>) -> LlmCallConfig {
+    LlmCallConfig {
+        model: LIVE_MODEL.to_string(),
+        temperature: Some(0.0),
+        max_tokens: Some(1024),
+        tools: vec![
+            tool("get_weather", "Get the current weather for a city."),
+            tool("get_local_time", "Get the current local time for a city."),
+        ],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: parallel,
+    }
+}
+
+async fn tool_call_count(parallel: Option<bool>) -> usize {
+    let driver = AnthropicChatDriver::new(api_key());
+    let messages = vec![
+        LlmMessage::text(
+            LlmMessageRole::System,
+            "Use the tools to answer. Always call the tools rather than guessing.",
+        ),
+        LlmMessage::text(
+            LlmMessageRole::User,
+            "Get both the current weather and the current local time in Paris.",
+        ),
+    ];
+    let response = driver
+        .chat_completion(messages, &config_with(parallel))
+        .await
+        .expect("Anthropic should accept the request");
+    response.tool_calls.map(|calls| calls.len()).unwrap_or(0)
+}
+
+#[tokio::test]
+#[ignore = "live network + ANTHROPIC_API_KEY"]
+async fn anthropic_avoid_caps_tool_calls_at_one() {
+    let count = tool_call_count(Some(false)).await;
+    eprintln!("anthropic avoid: {count} tool call(s)");
+    assert!(
+        count <= 1,
+        "avoid (disable_parallel_tool_use) should yield at most one tool call, got {count}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "live network + ANTHROPIC_API_KEY"]
+async fn anthropic_prefer_is_accepted_and_calls_tools() {
+    let count = tool_call_count(Some(true)).await;
+    eprintln!("anthropic prefer: {count} tool call(s)");
+    assert!(
+        count >= 1,
+        "prefer should be accepted and produce at least one tool call, got {count}"
+    );
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -123,6 +123,7 @@ mod openrouter_server_tools;
 mod openrouter_workspace;
 #[cfg(feature = "ui-capabilities")]
 mod openui;
+mod parallel_tool_calls;
 mod platform_management;
 mod prompt_caching;
 mod prompt_canary_guardrail;
@@ -266,6 +267,10 @@ pub use openrouter_workspace::{
 };
 #[cfg(feature = "ui-capabilities")]
 pub use openui::{OPENUI_CAPABILITY_ID, OpenUiCapability};
+pub use parallel_tool_calls::{
+    PARALLEL_TOOL_CALLS_CAPABILITY_ID, ParallelToolCallsCapability, ParallelToolCallsMode,
+    parallel_tool_calls_from_config,
+};
 pub use platform_management::{
     ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool, PLATFORM_MANAGEMENT_CAPABILITY_ID,
     PlatformManagementCapability, ReadAgentsTool, ReadCapabilitiesTool, ReadHarnessesTool,
@@ -1253,6 +1258,9 @@ impl CapabilityRegistry {
         registry.register(AutoToolSearchCapability::new());
         registry.register(PromptCachingCapability::new());
 
+        // Request-level parallel tool calls preference (none/prefer/avoid).
+        registry.register(ParallelToolCallsCapability);
+
         // Skills (filesystem-based discovery + activation, all environments)
         registry.register(SkillsCapability);
 
@@ -1568,6 +1576,10 @@ pub struct CollectedCapabilities {
     /// OpenRouter routing controls (set when the `openrouter_server_tools`
     /// capability is present). Carries provider-executed server tools.
     pub openrouter_routing: Option<crate::driver_registry::OpenRouterRoutingConfig>,
+    /// Request-level parallel tool calls preference (set when the
+    /// `parallel_tool_calls` capability is present with mode `prefer`/`avoid`).
+    /// `None` when absent or mode `none`.
+    pub parallel_tool_calls: Option<bool>,
     /// Hooks that transform the final runtime tool definition list.
     pub tool_definition_hooks: Vec<Arc<dyn ToolDefinitionHook>>,
     /// Hooks that inspect or transform model-produced tool calls.
@@ -2212,6 +2224,7 @@ pub async fn collect_capabilities_with_configs(
     let mut tool_search: Option<crate::driver_registry::ToolSearchConfig> = None;
     let mut prompt_cache: Option<crate::driver_registry::PromptCacheConfig> = None;
     let mut openrouter_routing: Option<crate::driver_registry::OpenRouterRoutingConfig> = None;
+    let mut parallel_tool_calls: Option<bool> = None;
     let mut tool_definition_hooks: Vec<Arc<dyn ToolDefinitionHook>> = Vec::new();
     let mut tool_call_hooks: Vec<Arc<dyn ToolCallHook>> = Vec::new();
     // Per-capability narration adapters, appended after explicit tool-call
@@ -2367,6 +2380,11 @@ pub async fn collect_capabilities_with_configs(
                 });
             }
 
+            if cap_id == PARALLEL_TOOL_CALLS_CAPABILITY_ID {
+                parallel_tool_calls =
+                    parallel_tool_calls::parallel_tool_calls_from_config(&cap_config.config);
+            }
+
             if cap_id == OPENROUTER_SERVER_TOOLS_CAPABILITY_ID {
                 let server_tools =
                     openrouter_server_tools::server_tools_from_config(&cap_config.config);
@@ -2456,6 +2474,7 @@ pub async fn collect_capabilities_with_configs(
         tool_search,
         prompt_cache,
         openrouter_routing,
+        parallel_tool_calls,
         tool_definition_hooks,
         tool_call_hooks,
         mcp_servers,
@@ -2549,7 +2568,11 @@ pub async fn apply_capabilities(
         prompt_cache: collected.prompt_cache,
         openrouter_routing: collected.openrouter_routing,
         network_access: base_runtime_agent.network_access,
-        parallel_tool_calls: base_runtime_agent.parallel_tool_calls,
+        // Explicit request-level preference (escape hatch) wins; otherwise the
+        // `parallel_tool_calls` capability supplies the preference.
+        parallel_tool_calls: base_runtime_agent
+            .parallel_tool_calls
+            .or(collected.parallel_tool_calls),
     };
 
     AppliedCapabilities {
@@ -5061,6 +5084,75 @@ mod tests {
             prompt_cache.gemini_cached_content.as_deref(),
             Some("cachedContents/demo-cache")
         );
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_parallel_tool_calls_modes() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // Default (no explicit mode) => prefer => Some(true).
+        let collected = collect_capabilities_with_configs(
+            &[AgentCapabilityConfig::new("parallel_tool_calls")],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+        assert_eq!(collected.parallel_tool_calls, Some(true));
+
+        // avoid => Some(false).
+        let collected = collect_capabilities_with_configs(
+            &[AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("parallel_tool_calls"),
+                config: serde_json::json!({"mode": "avoid"}),
+            }],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+        assert_eq!(collected.parallel_tool_calls, Some(false));
+
+        // none => None (provider default).
+        let collected = collect_capabilities_with_configs(
+            &[AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("parallel_tool_calls"),
+                config: serde_json::json!({"mode": "none"}),
+            }],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+        assert_eq!(collected.parallel_tool_calls, None);
+
+        // Capability absent => None.
+        let collected = collect_capabilities_with_configs(&[], &registry, &test_ctx()).await;
+        assert_eq!(collected.parallel_tool_calls, None);
+    }
+
+    #[tokio::test]
+    async fn test_apply_capabilities_parallel_tool_calls_precedence() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        // Capability supplies the preference when no explicit field is set.
+        let applied = apply_capabilities(
+            RuntimeAgent::new("p", "gpt-5.2"),
+            &["parallel_tool_calls".to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+        assert_eq!(applied.runtime_agent.parallel_tool_calls, Some(true));
+
+        // Explicit field (escape hatch) wins over the capability.
+        let mut base = RuntimeAgent::new("p", "gpt-5.2");
+        base.parallel_tool_calls = Some(false);
+        let applied = apply_capabilities(
+            base,
+            &["parallel_tool_calls".to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+        assert_eq!(applied.runtime_agent.parallel_tool_calls, Some(false));
     }
 
     // ========================================================================

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -2637,6 +2637,7 @@ mod tests {
             "tool_search",
             "auto_tool_search",
             "prompt_caching",
+            "parallel_tool_calls",
             "session_tasks",
             "skills",
             "subagents",

--- a/crates/core/src/capabilities/parallel_tool_calls.rs
+++ b/crates/core/src/capabilities/parallel_tool_calls.rs
@@ -64,16 +64,26 @@ impl ParallelToolCallsMode {
 }
 
 /// Resolve the `parallel_tool_calls` capability config into a request-level
-/// preference. Returns `None` when the capability is absent, when its mode is
-/// `none`, or when the config is malformed. When the capability is present
-/// without an explicit `mode`, the default is `prefer`.
+/// preference.
+///
+/// - Capability present with no explicit `mode` (empty/`null` config) → `prefer`.
+/// - Valid `mode` → that mode (`none` resolves to no preference).
+/// - Malformed config (not an object) or an invalid/non-string `mode` → `None`,
+///   so a bad runtime config neutralizes the capability rather than silently
+///   enabling parallel tool calls. (`validate_config` already rejects these on
+///   the write path; this is the defensive runtime fallback.)
 pub fn parallel_tool_calls_from_config(config: &serde_json::Value) -> Option<bool> {
-    let mode = config
-        .get("mode")
-        .and_then(|value| value.as_str())
-        .and_then(ParallelToolCallsMode::parse)
-        .unwrap_or(ParallelToolCallsMode::Prefer);
-    mode.to_preference()
+    if config.is_null() {
+        return ParallelToolCallsMode::Prefer.to_preference();
+    }
+    let object = config.as_object()?;
+    match object.get("mode") {
+        None => ParallelToolCallsMode::Prefer.to_preference(),
+        Some(serde_json::Value::String(mode)) => {
+            ParallelToolCallsMode::parse(mode).and_then(ParallelToolCallsMode::to_preference)
+        }
+        Some(_) => None,
+    }
 }
 
 /// Parallel tool calls capability.
@@ -227,6 +237,24 @@ mod tests {
         );
         assert_eq!(
             parallel_tool_calls_from_config(&serde_json::json!({"mode": "none"})),
+            None
+        );
+    }
+
+    #[test]
+    fn from_config_malformed_neutralizes() {
+        // Invalid/non-string mode and non-object configs do not silently enable
+        // parallel tool calls — they resolve to no preference.
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!({"mode": "loud"})),
+            None
+        );
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!({"mode": 5})),
+            None
+        );
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!([])),
             None
         );
     }

--- a/crates/core/src/capabilities/parallel_tool_calls.rs
+++ b/crates/core/src/capabilities/parallel_tool_calls.rs
@@ -1,0 +1,262 @@
+// Parallel tool calls capability
+//
+// Controls whether the agent asks the provider to emit multiple tool calls per
+// turn (and whether the local tool scheduler runs a batch concurrently):
+//
+// - `prefer`: explicitly request parallel tool calls. On providers that expose
+//   a wire control (OpenAI/Anthropic families) this is sent on the request; the
+//   local scheduler keeps its class-aware concurrent default. Lets the model
+//   batch independent reads/searches instead of relying on each provider's
+//   undocumented default.
+// - `avoid`: ask the provider to emit at most one tool call per turn AND force
+//   the local tool scheduler to serialize the batch. The local serialization
+//   applies to every driver, so `avoid` is honored even on providers without a
+//   wire control (Gemini/Bedrock).
+// - `none`: no preference — omit the field and keep the provider default and the
+//   scheduler's concurrent schedule. Same effect as not enabling the capability;
+//   useful to neutralize an inherited preference from a parent harness.
+//
+// The resolved preference threads through `RuntimeAgent.parallel_tool_calls`
+// into both the LLM request (provider-gated, see `ChatDriver::
+// supports_parallel_tool_calls`) and `ActInput.parallel_tool_calls` (the local
+// scheduler). An explicit `parallel_tool_calls` field on harness/agent/session
+// is a lower-level escape hatch and takes precedence over this capability.
+
+use super::{Capability, CapabilityLocalization, SystemPromptContext};
+use async_trait::async_trait;
+
+/// Capability ID for the request-level parallel tool calls preference.
+pub const PARALLEL_TOOL_CALLS_CAPABILITY_ID: &str = "parallel_tool_calls";
+
+/// Resolved preference mode for the `parallel_tool_calls` capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParallelToolCallsMode {
+    /// Request parallel tool calls (provider + concurrent scheduler).
+    Prefer,
+    /// Disable parallel tool calls (provider hint + serialized scheduler).
+    Avoid,
+    /// No preference — provider default and concurrent scheduler.
+    None,
+}
+
+impl ParallelToolCallsMode {
+    /// Parse a config string into a mode. Unknown values yield `None`.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "prefer" => Some(Self::Prefer),
+            "avoid" => Some(Self::Avoid),
+            "none" => Some(Self::None),
+            _ => None,
+        }
+    }
+
+    /// Map the mode onto the request-level `parallel_tool_calls` preference
+    /// carried by `RuntimeAgent`/`LlmCallConfig`/`ActInput`.
+    ///
+    /// `None` mode resolves to `None` (omit, provider default).
+    pub fn to_preference(self) -> Option<bool> {
+        match self {
+            Self::Prefer => Some(true),
+            Self::Avoid => Some(false),
+            Self::None => None,
+        }
+    }
+}
+
+/// Resolve the `parallel_tool_calls` capability config into a request-level
+/// preference. Returns `None` when the capability is absent, when its mode is
+/// `none`, or when the config is malformed. When the capability is present
+/// without an explicit `mode`, the default is `prefer`.
+pub fn parallel_tool_calls_from_config(config: &serde_json::Value) -> Option<bool> {
+    let mode = config
+        .get("mode")
+        .and_then(|value| value.as_str())
+        .and_then(ParallelToolCallsMode::parse)
+        .unwrap_or(ParallelToolCallsMode::Prefer);
+    mode.to_preference()
+}
+
+/// Parallel tool calls capability.
+///
+/// Adds no tools or prompt text; it only configures the outbound LLM request
+/// and the local tool scheduler.
+pub struct ParallelToolCallsCapability;
+
+#[async_trait]
+impl Capability for ParallelToolCallsCapability {
+    fn id(&self) -> &str {
+        PARALLEL_TOOL_CALLS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Parallel Tool Calls"
+    }
+
+    fn description(&self) -> &str {
+        "Controls whether the agent requests multiple tool calls per turn and \
+         runs them concurrently: prefer (request parallel), avoid (one at a \
+         time, serialized), or none (provider default)."
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Optimization")
+    }
+
+    fn config_schema(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "title": "Parallel tool calls",
+                    "description": "prefer: request parallel tool calls (default); avoid: one tool call per turn, serialized locally; none: provider default.",
+                    "enum": ["prefer", "avoid", "none"],
+                    "default": "prefer"
+                }
+            }
+        }))
+    }
+
+    fn validate_config(&self, config: &serde_json::Value) -> Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+        if !config.is_object() {
+            return Err("parallel_tool_calls config must be an object".to_string());
+        }
+        match config.get("mode") {
+            None => Ok(()),
+            Some(serde_json::Value::String(mode))
+                if ParallelToolCallsMode::parse(mode).is_some() =>
+            {
+                Ok(())
+            }
+            Some(value) => Err(format!(
+                "mode must be one of \"prefer\", \"avoid\", \"none\", got {value}"
+            )),
+        }
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![
+            CapabilityLocalization {
+                locale: "en",
+                name: None,
+                description: None,
+                config_description: Some(
+                    "Chooses whether the agent batches independent tool calls or runs them one at a time.",
+                ),
+                config_overlay: None,
+            },
+            CapabilityLocalization {
+                locale: "uk",
+                name: Some("Паралельні виклики інструментів"),
+                description: Some(
+                    "Визначає, чи запитує агент кілька викликів інструментів за хід і чи виконує їх одночасно: prefer (запитувати паралельні), avoid (по одному, послідовно) або none (типова поведінка провайдера).",
+                ),
+                config_description: Some(
+                    "Обирає, чи агент об'єднує незалежні виклики інструментів, чи виконує їх по одному.",
+                ),
+                config_overlay: Some(serde_json::json!({
+                    "properties": {
+                        "mode": {
+                            "title": "Паралельні виклики інструментів",
+                            "description": "prefer: запитувати паралельні виклики (типово); avoid: один виклик за хід, послідовно; none: типова поведінка провайдера."
+                        }
+                    }
+                })),
+            },
+        ]
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_known_modes() {
+        assert_eq!(
+            ParallelToolCallsMode::parse("prefer"),
+            Some(ParallelToolCallsMode::Prefer)
+        );
+        assert_eq!(
+            ParallelToolCallsMode::parse("avoid"),
+            Some(ParallelToolCallsMode::Avoid)
+        );
+        assert_eq!(
+            ParallelToolCallsMode::parse("none"),
+            Some(ParallelToolCallsMode::None)
+        );
+        assert_eq!(ParallelToolCallsMode::parse("loud"), None);
+    }
+
+    #[test]
+    fn mode_to_preference() {
+        assert_eq!(ParallelToolCallsMode::Prefer.to_preference(), Some(true));
+        assert_eq!(ParallelToolCallsMode::Avoid.to_preference(), Some(false));
+        assert_eq!(ParallelToolCallsMode::None.to_preference(), None);
+    }
+
+    #[test]
+    fn from_config_defaults_to_prefer() {
+        // Capability present without explicit mode => prefer.
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!({})),
+            Some(true)
+        );
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::Value::Null),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn from_config_honors_mode() {
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!({"mode": "prefer"})),
+            Some(true)
+        );
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!({"mode": "avoid"})),
+            Some(false)
+        );
+        assert_eq!(
+            parallel_tool_calls_from_config(&serde_json::json!({"mode": "none"})),
+            None
+        );
+    }
+
+    #[test]
+    fn validate_config_accepts_known_modes_only() {
+        let cap = ParallelToolCallsCapability;
+        assert!(cap.validate_config(&serde_json::Value::Null).is_ok());
+        assert!(cap.validate_config(&serde_json::json!({})).is_ok());
+        assert!(
+            cap.validate_config(&serde_json::json!({"mode": "prefer"}))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"mode": "avoid"}))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"mode": "loud"}))
+                .is_err()
+        );
+        assert!(cap.validate_config(&serde_json::json!([])).is_err());
+    }
+
+    #[test]
+    fn localizations_resolve_uk() {
+        let cap = ParallelToolCallsCapability;
+        assert_eq!(
+            cap.localized_name(Some("uk-UA")),
+            "Паралельні виклики інструментів"
+        );
+    }
+}

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -239,6 +239,20 @@ pub trait ChatDriver: Send + Sync {
         false
     }
 
+    /// Whether this driver can express the request-level `parallel_tool_calls`
+    /// preference on the wire for `model`.
+    ///
+    /// Drivers that map the preference onto a request field (OpenAI/Anthropic
+    /// families) return `true`; drivers whose provider API has no such control
+    /// (Gemini, Bedrock) return `false`. When `false`, the preference is omitted
+    /// from the request and is honored only by the local tool scheduler, so an
+    /// `avoid` preference still serializes tool execution on every provider.
+    ///
+    /// The default is `false` (conservative: omit unless a driver opts in).
+    fn supports_parallel_tool_calls(&self, _model: &str) -> bool {
+        false
+    }
+
     /// Compact a conversation to reduce context size
     ///
     /// This method compresses conversation history by calling the provider's
@@ -289,6 +303,10 @@ impl ChatDriver for Box<dyn ChatDriver> {
 
     fn supports_compact(&self) -> bool {
         (**self).supports_compact()
+    }
+
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        (**self).supports_parallel_tool_calls(model)
     }
 
     async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
@@ -1155,6 +1173,25 @@ pub struct LlmCallConfig {
     /// `tool_choice.disable_parallel_tool_use = true`. `None` preserves
     /// provider defaults (no field sent).
     pub parallel_tool_calls: Option<bool>,
+}
+
+impl LlmCallConfig {
+    /// Resolve the effective wire value for `parallel_tool_calls`, gated by
+    /// whether the driver/model can express it on the request.
+    ///
+    /// Returns `None` (omit the field, keep the provider default) when the
+    /// preference is unset or `supported` is `false`. Drivers call this with
+    /// `self.supports_parallel_tool_calls(&config.model)` so the preference is
+    /// only serialized where the provider has a control for it. The local tool
+    /// scheduler honors the preference independently, so `Some(false)` still
+    /// serializes execution even when this returns `None`.
+    pub fn resolved_parallel_tool_calls(&self, supported: bool) -> Option<bool> {
+        if supported {
+            self.parallel_tool_calls
+        } else {
+            None
+        }
+    }
 }
 
 impl From<&RuntimeAgent> for LlmCallConfig {
@@ -2054,6 +2091,41 @@ fn truncate_tool_result(text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_resolved_parallel_tool_calls_gating() {
+        let mut config = LlmCallConfig::from(&RuntimeAgent::new("p", "gpt-5.2"));
+
+        // No preference => always None.
+        assert_eq!(config.resolved_parallel_tool_calls(true), None);
+        assert_eq!(config.resolved_parallel_tool_calls(false), None);
+
+        // Preference passes through only when the driver/model supports it.
+        config.parallel_tool_calls = Some(true);
+        assert_eq!(config.resolved_parallel_tool_calls(true), Some(true));
+        assert_eq!(config.resolved_parallel_tool_calls(false), None);
+
+        config.parallel_tool_calls = Some(false);
+        assert_eq!(config.resolved_parallel_tool_calls(true), Some(false));
+        assert_eq!(config.resolved_parallel_tool_calls(false), None);
+    }
+
+    #[test]
+    fn test_chat_driver_default_omits_parallel_tool_calls() {
+        // Default trait impl is conservative: drivers opt in.
+        struct DefaultDriver;
+        #[async_trait]
+        impl ChatDriver for DefaultDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unreachable!()
+            }
+        }
+        assert!(!DefaultDriver.supports_parallel_tool_calls("any-model"));
+    }
 
     #[test]
     fn test_fold_system_messages_none_when_absent() {

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -395,7 +395,8 @@ impl ChatDriver for OpenAIProtocolChatDriver {
                 include_usage: true,
             }),
             tools,
-            parallel_tool_calls: config.parallel_tool_calls,
+            parallel_tool_calls: config
+                .resolved_parallel_tool_calls(self.supports_parallel_tool_calls(&config.model)),
             // Skip "none" — sending reasoning_effort to non-thinking models causes API errors
             reasoning_effort: config
                 .reasoning_effort
@@ -685,6 +686,13 @@ impl ChatDriver for OpenAIProtocolChatDriver {
         );
 
         Ok(converted_stream)
+    }
+
+    /// OpenAI-compatible Chat Completions accept the top-level
+    /// `parallel_tool_calls` boolean, so the preference maps directly onto the
+    /// wire for every model served through this protocol.
+    fn supports_parallel_tool_calls(&self, _model: &str) -> bool {
+        true
     }
 }
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -883,7 +883,8 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             reasoning,
             metadata,
             prompt_cache_key,
-            parallel_tool_calls: config.parallel_tool_calls,
+            parallel_tool_calls: config
+                .resolved_parallel_tool_calls(self.supports_parallel_tool_calls(&config.model)),
         };
 
         // Log request details for debugging LLM errors.
@@ -1367,6 +1368,11 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
     fn supports_compact(&self) -> bool {
         // Delegate to the inherent method
         OpenResponsesProtocolChatDriver::supports_compact(self)
+    }
+
+    /// The Responses API accepts the top-level `parallel_tool_calls` boolean.
+    fn supports_parallel_tool_calls(&self, _model: &str) -> bool {
+        true
     }
 
     async fn compact(

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -191,8 +191,13 @@ impl RuntimeAgentBuilder {
         // Set merged network_access
         builder = builder.network_access(layer.network_access);
 
-        // Set merged request-level parallel_tool_calls preference (EVE-598)
-        builder = builder.parallel_tool_calls(layer.parallel_tool_calls);
+        // Set merged request-level parallel_tool_calls preference (EVE-598).
+        // The explicit field is an escape hatch and wins over the
+        // `parallel_tool_calls` capability applied during capability collection;
+        // when unset, the capability-derived preference (if any) stands.
+        if let Some(explicit) = layer.parallel_tool_calls {
+            builder = builder.parallel_tool_calls(Some(explicit));
+        }
 
         builder
     }
@@ -314,6 +319,12 @@ impl RuntimeAgentBuilder {
 
         if let Some(routing) = collected.openrouter_routing {
             self.runtime_agent.openrouter_routing = Some(routing);
+        }
+
+        // Apply the `parallel_tool_calls` capability preference. An explicit
+        // request-level field set later (see `from_overlay`) takes precedence.
+        if let Some(ptc) = collected.parallel_tool_calls {
+            self.runtime_agent.parallel_tool_calls = Some(ptc);
         }
 
         self.tool_definition_hooks

--- a/crates/fireworks/src/driver.rs
+++ b/crates/fireworks/src/driver.rs
@@ -118,6 +118,10 @@ impl ChatDriver for FireworksChatDriver {
         self.inner.chat_completion_stream(messages, config).await
     }
 
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        self.inner.supports_parallel_tool_calls(model)
+    }
+
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
         // Discovery only runs against Fireworks' own host. A custom proxy URL may
         // resolve to private infrastructure at request time (mirrors the

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1082,6 +1082,15 @@ mod tests {
     use super::*;
     use everruns_core::FileSystemCapability;
     use everruns_core::capabilities::Capability;
+    use everruns_core::driver_registry::ChatDriver;
+
+    #[test]
+    fn supports_parallel_tool_calls_is_false() {
+        // Gemini has no request control; the preference is honored only by the
+        // local tool scheduler.
+        let driver = GeminiChatDriver::new("test-key");
+        assert!(!driver.supports_parallel_tool_calls("gemini-2.5-pro"));
+    }
 
     #[test]
     fn test_convert_content_text() {

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -130,6 +130,15 @@ impl ChatDriver for MaiChatDriver {
         self.ready()?.chat_completion_stream(messages, config).await
     }
 
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        // MAI is OpenAI-compatible Chat Completions; the inner protocol driver
+        // maps the preference onto the wire when the provider is configured.
+        match self.ready() {
+            Ok(inner) => inner.supports_parallel_tool_calls(model),
+            Err(_) => false,
+        }
+    }
+
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
         let DriverState::Ready {
             inner,

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -144,6 +144,10 @@ impl ChatDriver for OpenAIChatDriver {
         self.inner.supports_compact()
     }
 
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        self.inner.supports_parallel_tool_calls(model)
+    }
+
     async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
         Ok(Some(self.inner.compact(request).await?))
     }
@@ -239,6 +243,10 @@ impl ChatDriver for OpenAICompletionsChatDriver {
 
         let models_url = models_url_for_api_url(self.api_url());
         list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
+    }
+
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        self.inner.supports_parallel_tool_calls(model)
     }
 }
 

--- a/crates/openai/tests/parallel_tool_calls_live.rs
+++ b/crates/openai/tests/parallel_tool_calls_live.rs
@@ -1,0 +1,100 @@
+//! Live tests for the request-level `parallel_tool_calls` preference against the
+//! real OpenAI API (Responses).
+//!
+//! Proves the wire mapping is accepted by the provider and has effect:
+//! - `Some(false)` (avoid) is accepted and the provider returns at most one tool
+//!   call in a single completion.
+//! - `Some(true)` (prefer) is accepted and the provider returns tool calls.
+//!
+//! Ignored by default (requires network + `OPENAI_API_KEY`); run manually:
+//!   `doppler run -- cargo test -p everruns-openai --test parallel_tool_calls_live -- --ignored --nocapture`
+
+use everruns_core::driver_registry::{ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_core::tool_types::{
+    BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
+};
+use everruns_openai::OpenAIChatDriver;
+
+const LIVE_MODEL: &str = "gpt-4o-mini";
+
+fn api_key() -> String {
+    std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set for the live test")
+}
+
+fn tool(name: &str, description: &str) -> ToolDefinition {
+    ToolDefinition::Builtin(BuiltinTool {
+        name: name.to_string(),
+        display_name: None,
+        description: description.to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        }),
+        policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
+        full_parameters: None,
+    })
+}
+
+fn config_with(parallel: Option<bool>) -> LlmCallConfig {
+    LlmCallConfig {
+        model: LIVE_MODEL.to_string(),
+        temperature: Some(0.0),
+        max_tokens: Some(512),
+        tools: vec![
+            tool("get_weather", "Get the current weather for a city."),
+            tool("get_local_time", "Get the current local time for a city."),
+        ],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: parallel,
+    }
+}
+
+async fn tool_call_count(parallel: Option<bool>) -> usize {
+    let driver = OpenAIChatDriver::new(api_key());
+    let messages = vec![
+        LlmMessage::text(
+            LlmMessageRole::System,
+            "Use the tools to answer. Always call the tools rather than guessing.",
+        ),
+        LlmMessage::text(
+            LlmMessageRole::User,
+            "Get both the current weather and the current local time in Paris.",
+        ),
+    ];
+    let response = driver
+        .chat_completion(messages, &config_with(parallel))
+        .await
+        .expect("OpenAI should accept the request");
+    response.tool_calls.map(|calls| calls.len()).unwrap_or(0)
+}
+
+#[tokio::test]
+#[ignore = "live network + OPENAI_API_KEY"]
+async fn openai_avoid_caps_tool_calls_at_one() {
+    let count = tool_call_count(Some(false)).await;
+    eprintln!("openai avoid: {count} tool call(s)");
+    assert!(
+        count <= 1,
+        "avoid (disable parallel) should yield at most one tool call, got {count}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "live network + OPENAI_API_KEY"]
+async fn openai_prefer_is_accepted_and_calls_tools() {
+    let count = tool_call_count(Some(true)).await;
+    eprintln!("openai prefer: {count} tool call(s)");
+    assert!(
+        count >= 1,
+        "prefer should be accepted and produce at least one tool call, got {count}"
+    );
+}

--- a/crates/openrouter/src/driver.rs
+++ b/crates/openrouter/src/driver.rs
@@ -91,6 +91,10 @@ impl ChatDriver for OpenRouterChatDriver {
         self.inner.chat_completion_stream(messages, config).await
     }
 
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        self.inner.supports_parallel_tool_calls(model)
+    }
+
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
         // OpenRouter discovery is only safe against OpenRouter's own host.
         // Custom proxy URLs may resolve to private infrastructure at request time.

--- a/crates/server/src/harnesses/coding_session_sandbox.rs
+++ b/crates/server/src/harnesses/coding_session_sandbox.rs
@@ -29,6 +29,10 @@ pub fn definition() -> BuiltInHarnessDefinition {
         BuiltInCapabilityDefinition::new("budgeting"),
         BuiltInCapabilityDefinition::new("self_budget"),
         BuiltInCapabilityDefinition::with_config(
+            "parallel_tool_calls",
+            serde_json::json!({"mode": "prefer"}),
+        ),
+        BuiltInCapabilityDefinition::with_config(
             "compaction",
             serde_json::json!({
                 "strategy": "auto",

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -6,7 +6,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
     BuiltInHarnessDefinition::new(
         "generic",
         "Generic",
-        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, tool output distillation, loop detection, message timestamp annotations, detailed error disclosure, and agent skills. Recommended default for most use cases.",
+        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, tool output distillation, loop detection, message timestamp annotations, detailed error disclosure, parallel tool calls, and agent skills. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
     .with_tags(["generic", "default", "built-in"])
@@ -30,6 +30,13 @@ pub fn definition() -> BuiltInHarnessDefinition {
         BuiltInCapabilityDefinition::new("budgeting"),
         BuiltInCapabilityDefinition::new("self_budget"),
         BuiltInCapabilityDefinition::new("loop_detection"),
+        // Batch independent reads/searches: request parallel tool calls where the
+        // provider supports it; the local scheduler already runs batches
+        // concurrently by class.
+        BuiltInCapabilityDefinition::with_config(
+            "parallel_tool_calls",
+            serde_json::json!({"mode": "prefer"}),
+        ),
         // Trusted, operator-facing default harness: show full provider error
         // detail so failures (bad key, quota, outage) are self-explanatory.
         BuiltInCapabilityDefinition::with_config(

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2996,7 +2996,7 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
-        assert_eq!(cap_ids.len(), 20);
+        assert_eq!(cap_ids.len(), 21);
         assert!(cap_ids.contains(&"human_intent"));
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"bashkit_shell"));
@@ -3017,6 +3017,7 @@ mod tests {
         assert!(cap_ids.contains(&"compaction"));
         assert!(cap_ids.contains(&"tool_output_persistence"));
         assert!(cap_ids.contains(&"tool_output_distillation"));
+        assert!(cap_ids.contains(&"parallel_tool_calls"));
         // Verify compaction default config
         let compaction_cap = generic
             .capabilities

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1957,8 +1957,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        20,
-        "Generic harness should have 20 capabilities"
+        21,
+        "Generic harness should have 21 capabilities"
     );
     assert!(
         cap_ids.contains(&"human_intent"),
@@ -2504,8 +2504,8 @@ async fn test_copy_seed_generic_harness() {
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
-        20,
-        "Copied harness should have same 20 capabilities"
+        21,
+        "Copied harness should have same 21 capabilities"
     );
     assert!(
         copied

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -106,6 +106,7 @@ Performance and cost optimization for LLM interactions.
 | [Tool Search](/capabilities/tool-search/) | `tool_search` | 1 |
 | [Budgeting](/capabilities/budgeting/) | `budgeting` | 1 |
 | [Self-Budget](/capabilities/self-budget/) | `self_budget` | 0 |
+| [Parallel Tool Calls](/capabilities/parallel-tool-calls/) | `parallel_tool_calls` | 0 |
 
 ### Safety
 

--- a/docs/capabilities/parallel-tool-calls.md
+++ b/docs/capabilities/parallel-tool-calls.md
@@ -1,0 +1,107 @@
+---
+title: Parallel Tool Calls
+description: Controls whether the agent requests multiple tool calls per turn and runs them concurrently — prefer parallel, avoid (serialize), or leave the provider default.
+sidebar:
+  order: 97
+---
+
+| | |
+|---|---|
+| **ID** | `parallel_tool_calls` |
+| **Category** | Optimization |
+| **Features** | None |
+| **Dependencies** | None |
+| **Risk** | Low |
+
+Controls the agent's request-level preference for parallel (multiple per turn)
+tool calls, and whether the local tool scheduler runs a batch concurrently.
+
+Most providers emit several tool calls in a single turn by default, and Everruns
+runs independent tool calls concurrently. This capability makes that behavior
+explicit and configurable: turn it up to actively request batching of
+independent reads and searches, or turn it down to force strictly one tool call
+at a time.
+
+## Tools
+
+None — this capability only configures the outbound LLM request and the local
+tool scheduler.
+
+## How It Works
+
+The capability resolves a `mode` into a request-level preference that threads
+through two places:
+
+1. **The LLM request.** On providers that expose a wire control, the preference
+   is sent on the request:
+   - **OpenAI** (Chat Completions and Responses), and the OpenAI-compatible
+     **MAI** and **Fireworks** providers — the top-level `parallel_tool_calls`
+     boolean.
+   - **OpenRouter** — forwarded on the Responses body; ignored by routed
+     providers that do not support it.
+   - **Anthropic** — `tool_choice.disable_parallel_tool_use` (sent only when the
+     request carries tools).
+   - **Gemini** and **Bedrock** have no equivalent request control, so nothing
+     is sent. The local scheduler (below) still honors the preference.
+2. **The local tool scheduler.** `avoid` forces the scheduler to run the turn's
+   tool calls strictly sequentially. This applies to **every** provider, so
+   `avoid` is honored even where there is no wire control.
+
+Whether the preference is sent on the wire is gated per provider/model: a driver
+that cannot express it omits the field rather than risking an API error.
+
+## Config
+
+```json
+{
+  "capabilities": [
+    {
+      "ref": "parallel_tool_calls",
+      "config": { "mode": "prefer" }
+    }
+  ]
+}
+```
+
+### Modes
+
+| Mode | Provider request | Local scheduler |
+|---|---|---|
+| `prefer` (default) | Request parallel tool calls where supported | Concurrent (class-aware, the default) |
+| `avoid` | Ask for one tool call per turn where supported | Serialized |
+| `none` | Omit — provider default | Concurrent (class-aware, the default) |
+
+When the capability is enabled without an explicit `mode`, the default is
+`prefer`. `none` is equivalent to not enabling the capability; it is useful to
+neutralize a preference inherited from a parent harness.
+
+The **Generic** harness and the built-in **coding** harnesses enable this
+capability with `mode: "prefer"` by default.
+
+## Precedence
+
+An explicit `parallel_tool_calls` field set directly on a harness, agent, or
+session is a lower-level escape hatch and takes precedence over this capability.
+
+## When To Use
+
+- **`prefer`** — workloads that issue many independent reads or searches per
+  turn benefit from batching (faster turns, fewer round-trips).
+- **`avoid`** — when tool calls must be observed and applied one at a time, or
+  when a model produces lower-quality parallel batches for your workload.
+
+## Limitations
+
+- **Provider gating.** `prefer` only changes the wire request on providers with
+  a control for it (OpenAI/Anthropic families). Elsewhere providers already
+  parallelize by default, so `prefer` is a no-op on the wire.
+- **Durable mode.** A harness/agent-level `mode` other than the default
+  (`prefer`) is applied with full fidelity in the in-process runtime; in durable
+  worker mode, harness/agent capability config falls back to the default — set
+  the mode at the session level, or use the explicit `parallel_tool_calls`
+  field, to override durably. (This matches other config-bearing capabilities.)
+
+## See Also
+
+- [Capabilities](/features/capabilities/) — the extension model this capability plugs into
+- [Agentic Loop](/explanation/agentic-loop/) — how the runtime schedules a batch of tool calls

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -341,13 +341,30 @@ This logic is shared by all execution paths — the in-process runtime/host loop
 - **`Some(true)`** explicitly signals the provider that parallel tool calls are wanted. This lets an embedder opt into batching independent reads/searches instead of relying on each provider's undocumented default.
 - **`Some(false)`** asks the provider to emit at most one tool call per turn *and* forces the act scheduler to serialize the batch.
 
-Provider wire mapping (only sent when `Some(_)`):
+This field is a lower-level escape hatch. The user-facing surface is the [`parallel_tool_calls` capability](#parallel_tool_calls-capability) below; the explicit field takes precedence over the capability when both are set.
 
-- **OpenAI** (Responses, and the Chat Completions `OpenAiRequest` shape used by the OpenAI Chat driver and MAI): `parallel_tool_calls` top-level boolean.
-- **Anthropic** (Messages): `tool_choice` with `type: "auto"` and `disable_parallel_tool_use = !value`. Sent only when the request carries tools (Anthropic rejects `tool_choice` without tools).
-- **OpenRouter**: wraps the Open Responses driver, so the request body inherits the Responses serialization (already includes `parallel_tool_calls`); the OpenRouter decoration layer does not strip it.
+Provider wire mapping is gated by `ChatDriver::supports_parallel_tool_calls(model)` and only emitted when the resolved preference is `Some(_)`:
+
+- **OpenAI** (Responses, and the Chat Completions `OpenAiRequest` shape used by the OpenAI Chat driver, MAI, and Fireworks): `parallel_tool_calls` top-level boolean. `supports_parallel_tool_calls` → `true`.
+- **Anthropic** (Messages): `tool_choice` with `type: "auto"` and `disable_parallel_tool_use = !value`. Sent only when the request carries tools (Anthropic rejects `tool_choice` without tools). `supports_parallel_tool_calls` → `true`.
+- **OpenRouter**: wraps the Open Responses driver, so the request body inherits the Responses serialization; the OpenRouter decoration layer does not strip it. `supports_parallel_tool_calls` → `true`.
+- **Gemini** and **Bedrock**: their provider APIs have no request control for parallel tool calls. `supports_parallel_tool_calls` → `false`, so the field is omitted. The preference is still honored by the act scheduler (an `avoid`/`Some(false)` preference serializes execution on every provider).
+
+`LlmCallConfig::resolved_parallel_tool_calls(supported)` performs the gating: it returns the preference when `supported` is `true`, else `None` (omit). Each driver calls it with `self.supports_parallel_tool_calls(&config.model)` while building the request.
 
 Durable parity: the worker builds `RuntimeAgent` from gRPC-fetched schema objects, so the proto `Agent` and `Session` messages carry `parallel_tool_calls`. The server schema→proto and worker proto→schema adapters round-trip the value, preserving the operator setting through `RuntimeAgent` → `ReasonResult` → provider in durable mode.
+
+### `parallel_tool_calls` capability
+
+The `parallel_tool_calls` capability is the user-facing way to set the preference above. It carries a `mode`:
+
+- **`prefer`** (default when the capability is enabled without explicit config) → `Some(true)`.
+- **`avoid`** → `Some(false)`.
+- **`none`** → `None` (provider default; neutralizes an inherited preference).
+
+The capability resolves its `mode` to a preference during capability collection (`CollectedCapabilities.parallel_tool_calls`) and applies it to `RuntimeAgent.parallel_tool_calls`. An explicit `parallel_tool_calls` field on any layer wins over the capability. The **Generic** harness and the built-in **coding** harnesses enable the capability with `mode: "prefer"`.
+
+Because harness/agent capability config is reconstructed from IDs over gRPC (durable worker), a non-default harness/agent `mode` falls back to the default (`prefer`) in durable mode; set the mode at the session level or use the explicit `parallel_tool_calls` field to override durably. This matches other config-bearing capabilities.
 
 ### Step-Based Execution (Durable Mode)
 


### PR DESCRIPTION
## What
Adds a `parallel_tool_calls` capability that controls whether the agent requests
multiple tool calls per turn and runs them concurrently, with three modes:

- `prefer` (default when enabled) — request parallel tool calls where the
  provider supports it; scheduler stays class-aware concurrent.
- `avoid` — ask the provider for one tool call per turn **and** force the local
  tool scheduler to serialize the batch.
- `none` — no preference (provider default); neutralizes an inherited mode.

Enabled with `mode: "prefer"` by default on the **Generic** harness and the
built-in **coding** harnesses.

It also unifies the request-level preference across **all** drivers and adds the
missing per-driver support metadata.

## Why
The request-level `parallel_tool_calls` field (EVE-598) defaulted to `None`
(provider default) and was only wired for some drivers — Gemini and Bedrock
silently ignored it, and there was no user-facing, discoverable way to set it or
make it a harness default. There was also no per-driver/model metadata recording
which providers can actually express the preference on the wire.

## How
- New `parallel_tool_calls` capability (`crates/core/src/capabilities/parallel_tool_calls.rs`):
  parses `mode` → `Option<bool>` and feeds `RuntimeAgent.parallel_tool_calls`
  through the existing capability-collection seam (`CollectedCapabilities`).
  An explicit `parallel_tool_calls` field on any layer remains a lower-level
  escape hatch and wins over the capability.
- `ChatDriver::supports_parallel_tool_calls(model)` (default `false`) +
  `LlmCallConfig::resolved_parallel_tool_calls(supported)` gate the wire param.
  Drivers that map it (OpenAI Chat + Responses, MAI, Fireworks, OpenRouter,
  Anthropic) return `true`; Gemini and Bedrock return `false` and omit the
  field. The **local tool scheduler honors `avoid` on every provider**, so
  serialization works even where there is no wire control.
- Defaulted the capability on in `generic`, `coding-session-sandbox`, and (via
  the `generic` parent) `coding-container` / `coding-daytona` harnesses.
- Docs: new `docs/capabilities/parallel-tool-calls.md` + index entry; spec
  updated in `specs/tool-execution.md`.

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`
  (pre-push gate) — clean.
- Unit tests: capability mode resolution, precedence (explicit field wins),
  wire gating helper, per-driver support flags, harness definitions.
- **Real-API live tests** (`crates/{openai,anthropic}/tests/parallel_tool_calls_live.rs`,
  `#[ignore]`), run via Doppler against OpenAI (`gpt-4o-mini`) and Anthropic
  (`claude-haiku-4-5`):
  - `avoid` → exactly **1** tool call (provider-enforced) on both.
  - `prefer` → request accepted, **2** parallel tool calls on both.

## Risk
- Low. Default behavior change is intentional and scoped: built-in harnesses now
  request parallel tool calls (`prefer`), which providers already do by default;
  `avoid`/`none` are opt-in. The explicit `parallel_tool_calls` field is
  unchanged and still wins.

## Security
- Threat categories reviewed: **TM-LLM** (model request parameters). The change
  adds a validated, enum-constrained `mode` and a boolean request field; no
  injection, auth, tenant, or data-exposure surface. The wire gating reduces
  risk by never sending an unsupported parameter. No `THREAT` comments needed.

## Follow-ups
- Durable mode: harness/agent capability *config* is reconstructed from IDs over
  gRPC, so a non-default harness/agent `mode` falls back to `prefer` durably
  (the default and session-level config both work). This is a pre-existing
  limitation shared by all config-bearing capabilities (`compaction`,
  `error_disclosure`); a general fix would add per-capability config to the
  proto `Agent`/`Harness` messages — out of scope here.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01429cf2Nxp8erzwipGEXU1V)_