### PR TITLE
refactor(core): gate telemetry, a2a, web-fetch behind cargo features

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,9 +46,11 @@ rand.workspace = true
 # Cron parsing for session-schedule minimum-interval enforcement
 cron = "0.15"
 
-# Tracing
+# Tracing. `tracing` instrumentation is unconditional; the `tracing-subscriber`
+# registry/fmt layers are only used by telemetry init, so the dep is optional
+# and pulled in by the `telemetry` feature.
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, optional = true }
 
 # OpenTelemetry (optional; behind the `telemetry` feature). The OTLP exporter
 # pulls a large dependency subtree, so provider crates that opt out of core
@@ -142,6 +144,7 @@ telemetry = [
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
+    "dep:tracing-subscriber",
 ]
 # Outbound A2A agent delegation (tonic/prost gRPC stack).
 a2a = ["dep:a2a", "dep:a2a-client"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,11 +50,13 @@ cron = "0.15"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-# OpenTelemetry
-opentelemetry.workspace = true
-opentelemetry_sdk.workspace = true
-opentelemetry-otlp.workspace = true
-tracing-opentelemetry.workspace = true
+# OpenTelemetry (optional; behind the `telemetry` feature). The OTLP exporter
+# pulls a large dependency subtree, so provider crates that opt out of core
+# defaults skip it. Plain `tracing` instrumentation stays unconditional.
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 
 # Encoding
 base64.workspace = true
@@ -69,12 +71,13 @@ similar = "2"
 # URL parsing
 url = "2"
 
-# Web fetching
+# Web fetching (optional; behind the `web-fetch` feature). fetchkit + the
+# ed25519 bot-auth key derivation pull a sizable HTTP/crypto subtree.
 bytes = "1"
-fetchkit = { version = "=0.4.0", features = ["bot-auth"] }
+fetchkit = { version = "=0.4.0", features = ["bot-auth"], optional = true }
 
 # Ed25519 key derivation (bot-auth public key registration)
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
 
 # Bash interpreter backing the bashkit_shell capability
 bashkit = { version = "0.10.0", features = ["jq"] }
@@ -119,15 +122,31 @@ everruns-openui = { path = "../openui", version = "0.16.1", optional = true }
 # A2UI component catalog and prompt generator
 everruns-a2ui = { path = "../a2ui", version = "0.16.1", optional = true }
 
-# A2A outbound agent delegation
-a2a.workspace = true
-a2a-client.workspace = true
+# A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
+# tonic/prost gRPC stack and a second reqwest major, so it is the largest single
+# subtree a provider-only consumer can shed.
+a2a = { workspace = true, optional = true }
+a2a-client = { workspace = true, optional = true }
 
 # Compile-time directory embedding for virtual mounts (platform docs)
 include_dir = { version = "0.7", optional = true }
 
 [features]
-default = ["llm-tests"]
+# Heavy subtrees stay ON by default so the application crates (server, worker,
+# cli, runtime) and core's own test suite are unchanged. Provider crates depend
+# on core with `default-features = false` to shed them — see crates/openrouter.
+default = ["llm-tests", "telemetry", "a2a", "web-fetch"]
+# OTLP telemetry exporter (OpenTelemetry SDK + tracing-opentelemetry bridge).
+telemetry = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+]
+# Outbound A2A agent delegation (tonic/prost gRPC stack).
+a2a = ["dep:a2a", "dep:a2a-client"]
+# WebFetch capability (fetchkit HTTP pipeline + ed25519 bot-auth).
+web-fetch = ["dep:fetchkit", "dep:ed25519-dalek"]
 embedded-platform-docs = ["dep:include_dir"]
 # Experimental sandboxed Lua execution capability (mlua, vendored Lua 5.4).
 # Off by default; enabling compiles the C sources. See specs/lua-execution.md.

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -38,7 +38,10 @@ use std::time::Duration;
 use tokio::time::{Instant, sleep};
 use url::Url;
 
-pub const A2A_AGENT_DELEGATION_CAPABILITY_ID: &str = "a2a_agent_delegation";
+// The capability-ID constant lives ungated in `capabilities::mod` so session
+// attachment logic (ard_attachment) can reference it even in builds that gate
+// out the A2A delegation implementation. See the `a2a` feature.
+pub use super::A2A_AGENT_DELEGATION_CAPABILITY_ID;
 const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1_000;
 
@@ -620,7 +623,7 @@ fn require_storage(
 /// builds keys from it, and `session_storage` reserves it from the user-facing
 /// `kv_store` tool (see `is_internal_session_kv_key`) so session/tool actors
 /// cannot forge or read A2A run records.
-pub(crate) const AGENT_RUN_KEY_PREFIX: &str = "agent_run:";
+pub(crate) use super::AGENT_RUN_KEY_PREFIX;
 
 /// KV key for a specific agent run record.
 fn run_key(run_id: &str) -> String {

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1278,6 +1278,9 @@ impl CapabilityRegistry {
         // Gated by FEATURE_AGENT_DELEGATION; auto-enabled in dev, off in prod.
         if crate::FeatureFlags::from_env(&grade).agent_delegation {
             registry.register(AgentHandoffCapability);
+            // Additionally compile-gated behind the `a2a` cargo feature: in
+            // provider builds that disable core defaults the delegation
+            // capability is absent even when FEATURE_AGENT_DELEGATION is set.
             #[cfg(feature = "a2a")]
             registry.register(A2aAgentDelegationCapability);
         }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -82,6 +82,7 @@ pub use crate::capability_types::{
 // Capability Modules
 // ============================================================================
 
+#[cfg(feature = "a2a")]
 mod a2a_delegation;
 #[cfg(feature = "ui-capabilities")]
 mod a2ui;
@@ -147,12 +148,20 @@ mod tool_output_distillation;
 mod tool_output_persistence;
 mod tool_search;
 pub mod user_hooks;
+#[cfg(feature = "web-fetch")]
 mod web_fetch;
 
 // Re-export capabilities
-pub use a2a_delegation::{
-    A2A_AGENT_DELEGATION_CAPABILITY_ID, A2aAgentDelegationCapability, SpawnAgentTool,
-};
+/// Capability ID for outbound A2A agent delegation. Defined ungated so session
+/// attachment logic can reference it even when the `a2a` feature (and the
+/// delegation implementation) is compiled out.
+pub const A2A_AGENT_DELEGATION_CAPABILITY_ID: &str = "a2a_agent_delegation";
+/// KV key prefix for A2A delegation run records. Defined ungated so the
+/// session-storage internal-prefix reservation (a TM-TOOL/TM-AGENT mitigation
+/// against forged attachments) holds even when the `a2a` feature is compiled out.
+pub(crate) const AGENT_RUN_KEY_PREFIX: &str = "agent_run:";
+#[cfg(feature = "a2a")]
+pub use a2a_delegation::{A2aAgentDelegationCapability, SpawnAgentTool};
 #[cfg(feature = "ui-capabilities")]
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};
 pub use agent_handoff::{
@@ -334,6 +343,7 @@ pub use tool_search::{
     TOOL_SEARCH_CAPABILITY_ID, TOOL_SEARCH_TOOL_NAME, ToolSearchCapability, ToolSearchTool,
 };
 pub use user_hooks::{USER_HOOKS_CAPABILITY_ID, UserHooksCapability};
+#[cfg(feature = "web-fetch")]
 pub use web_fetch::{
     BotAuthPublicKey, WEB_FETCH_CAPABILITY_ID, WebFetchCapability, WebFetchTool,
     derive_bot_auth_public_key,
@@ -1232,6 +1242,7 @@ impl CapabilityRegistry {
         registry.register(TestMathCapability);
         registry.register(TestWeatherCapability);
         registry.register(StatelessTodoListCapability);
+        #[cfg(feature = "web-fetch")]
         registry.register(WebFetchCapability::from_env());
         registry.register(BashkitShellCapability);
         registry.register(BackgroundExecutionCapability);
@@ -1267,6 +1278,7 @@ impl CapabilityRegistry {
         // Gated by FEATURE_AGENT_DELEGATION; auto-enabled in dev, off in prod.
         if crate::FeatureFlags::from_env(&grade).agent_delegation {
             registry.register(AgentHandoffCapability);
+            #[cfg(feature = "a2a")]
             registry.register(A2aAgentDelegationCapability);
         }
 

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 // attachments / discovery cache (`ard_attachment`). Reserving the ARD prefixes
 // stops a session/tool actor forging attachments via kv_store (TM-TOOL/TM-AGENT).
 const INTERNAL_KV_PREFIXES: &[&str] = &[
-    super::a2a_delegation::AGENT_RUN_KEY_PREFIX,
+    super::AGENT_RUN_KEY_PREFIX,
     crate::ard_attachment::ARD_ATTACHMENT_KV_PREFIX,
     crate::ard_attachment::ARD_DISCOVERY_KV_PREFIX,
 ];

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -268,6 +268,18 @@ impl Drop for TelemetryGuard {
     }
 }
 
+/// Install the rustls crypto provider (ring) for TLS.
+///
+/// Must be called before any TLS usage. Without this, concurrent TLS
+/// connections (e.g. parallel tool execution in ActAtom) panic because
+/// rustls 0.23 cannot auto-detect the provider when multiple threads race.
+///
+/// Safe to call multiple times — subsequent calls are no-ops.
+pub fn install_crypto_provider() {
+    // Already-installed is expected if called from multiple init paths
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 /// Initialize OpenTelemetry with the given configuration
 ///
 /// Returns a guard that will shut down the tracer provider when dropped.
@@ -285,18 +297,6 @@ impl Drop for TelemetryGuard {
 ///     // ... your application code
 /// }
 /// ```
-/// Install the rustls crypto provider (ring) for TLS.
-///
-/// Must be called before any TLS usage. Without this, concurrent TLS
-/// connections (e.g. parallel tool execution in ActAtom) panic because
-/// rustls 0.23 cannot auto-detect the provider when multiple threads race.
-///
-/// Safe to call multiple times — subsequent calls are no-ops.
-pub fn install_crypto_provider() {
-    // Already-installed is expected if called from multiple init paths
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
 #[cfg(feature = "telemetry")]
 pub fn init_telemetry(config: TelemetryConfig) -> TelemetryGuard {
     install_crypto_provider();

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -5,14 +5,23 @@
 // - Initialization helpers for OTLP exporters
 // - Span creation helpers with proper attribute naming
 
+// OTLP exporter wiring lives behind the `telemetry` feature so provider crates
+// that only need the gen-AI span conventions (below) do not pull the
+// OpenTelemetry SDK + exporter dependency tree. See crates/core/Cargo.toml.
+#[cfg(feature = "telemetry")]
 use opentelemetry::KeyValue;
+#[cfg(feature = "telemetry")]
 use opentelemetry::trace::TracerProvider as _;
+#[cfg(feature = "telemetry")]
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+#[cfg(feature = "telemetry")]
 use opentelemetry_sdk::{
     Resource,
     trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
+#[cfg(feature = "telemetry")]
 use std::time::Duration;
+#[cfg(feature = "telemetry")]
 use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 // ============================================================================
@@ -243,10 +252,12 @@ impl TelemetryConfig {
 // ============================================================================
 
 /// Guard that shuts down the tracer provider when dropped
+#[cfg(feature = "telemetry")]
 pub struct TelemetryGuard {
     _provider: Option<SdkTracerProvider>,
 }
 
+#[cfg(feature = "telemetry")]
 impl Drop for TelemetryGuard {
     fn drop(&mut self) {
         if let Some(provider) = self._provider.take()
@@ -286,6 +297,7 @@ pub fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
+#[cfg(feature = "telemetry")]
 pub fn init_telemetry(config: TelemetryConfig) -> TelemetryGuard {
     install_crypto_provider();
 
@@ -357,6 +369,7 @@ pub fn init_telemetry(config: TelemetryConfig) -> TelemetryGuard {
     }
 }
 
+#[cfg(feature = "telemetry")]
 fn build_otlp_tracer(
     endpoint: &str,
     resource: Resource,

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -644,11 +644,11 @@ impl ToolRegistry {
         use crate::capabilities::{
             AddTool, DeleteFileTool, DivideTool, EditFileTool, GetCurrentTimeTool, GetForecastTool,
             GetWeatherTool, GrepFilesTool, ListDirectoryTool, MultiplyTool, ReadFileTool,
-            StatFileTool, SubtractTool, WebFetchTool, WriteFileTool, WriteTodosTool,
+            StatFileTool, SubtractTool, WriteFileTool, WriteTodosTool,
         };
         use crate::progress_reporting::ReportProgressTool;
 
-        ToolRegistry::builder()
+        let builder = ToolRegistry::builder()
             .tool(GetCurrentTimeTool)
             .tool(EchoTool)
             // NOTE: `spawn_background` is intentionally NOT a default tool —
@@ -678,10 +678,14 @@ impl ToolRegistry {
             .tool(ListDirectoryTool)
             .tool(GrepFilesTool)
             .tool(DeleteFileTool)
-            .tool(StatFileTool)
-            // WebFetch capability tools
-            .tool(WebFetchTool::default())
-            .build()
+            .tool(StatFileTool);
+
+        // WebFetch capability tools (gated behind the `web-fetch` feature so
+        // provider crates that opt out of core defaults skip the fetchkit tree).
+        #[cfg(feature = "web-fetch")]
+        let builder = builder.tool(crate::capabilities::WebFetchTool::default());
+
+        builder.build()
     }
 
     /// Register a tool with the registry.

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -639,7 +639,9 @@ impl ToolRegistry {
     /// - TestWeather tools: get_weather, get_forecast
     /// - TaskList tools: write_todos
     /// - FileSystem tools: read_file, write_file, edit_file, list_directory, grep_files, delete_file, stat_file
-    /// - WebFetch tools: web_fetch
+    /// - WebFetch tools: web_fetch — only when the `web-fetch` cargo feature is
+    ///   enabled (on by default; absent in provider builds that disable core
+    ///   default features)
     pub fn with_defaults() -> Self {
         use crate::capabilities::{
             AddTool, DeleteFileTool, DivideTool, EditFileTool, GetCurrentTimeTool, GetForecastTool,

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -31,7 +31,10 @@ serde_json.workspace = true
 chrono.workspace = true
 
 # Internal dependencies
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
+# a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
+# is what keeps the standalone `everruns-openrouter` dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What

Make the three heaviest dependency subtrees of `everruns-core` optional, default-on cargo features, and have `everruns-openrouter` opt out of them:

- `telemetry` — OpenTelemetry SDK + OTLP exporter (`opentelemetry*`, `tracing-opentelemetry`, `tracing-subscriber`)
- `a2a` — outbound A2A delegation (the `tonic`/`prost` gRPC stack + a second `reqwest` major)
- `web-fetch` — the WebFetch capability (`fetchkit` HTTP pipeline + `ed25519` bot-auth)

`everruns-openrouter` now depends on core with `default-features = false`.

## Why

A consumer that only wanted an OpenRouter client was pulling **287 crates**, almost entirely because `everruns-openrouter` → `everruns-core` dragged in OTLP/gRPC/fetchkit unconditionally. Those subtrees are irrelevant to a provider crate. The provider crates are published to docs.rs, so this is a real cost for external users.

Standalone `everruns-openrouter` dependency tree now: **287 → 222 crates** (−65). `tonic`, `prost`, `opentelemetry-otlp`, `fetchkit`, `ed25519-dalek` are all gone.

## How

- The three dep groups become `optional = true` and are wired into named features that are **kept in `default`**. So the application crates (`server`, `worker`, `cli`, `runtime`) and core's own test suite are unchanged — only consumers that pass `default-features = false` shed the subtrees.
- `telemetry.rs` is split: the pure `gen_ai` span-convention constants, `TelemetryConfig`, `install_crypto_provider`, and span-name helpers stay unconditional (used by always-compiled `observation/otel.rs`); only `init_telemetry`/`build_otlp_tracer`/`TelemetryGuard` (which touch the OTel SDK + `tracing-subscriber`) are gated.
- `capabilities::mod` gates the `a2a_delegation` and `web_fetch` modules, their `pub use` re-exports, and their registry registrations. `ToolRegistry::with_defaults()` gates the `WebFetchTool` step.
- Two constants used by ungated code moved ungated into `capabilities::mod`:
  - `A2A_AGENT_DELEGATION_CAPABILITY_ID` (used by session attachment in `ard_attachment.rs`)
  - `AGENT_RUN_KEY_PREFIX` (used by the `session_storage` internal-kv-prefix reservation)

## Risk

- **Low.** No runtime behavior change for the app: every feature is on by default and the app crates keep core's defaults. The diff is cargo-feature plumbing + `#[cfg]` gates; no logic changed.
- The one new build configuration (core with features off) is verified to compile and lint clean, so the gates are correct.

Validation:
- `cargo build -p everruns-core --no-default-features` — compiles (exercises every gate)
- `cargo clippy -p everruns-core --no-default-features -- -D warnings` — clean
- `cargo clippy -p everruns-openrouter --all-targets -- -D warnings` — clean
- `bash scripts/lib/pre-push.sh` — all green (fmt, `clippy --all-targets --all-features -D warnings`, Cargo.lock fresh, migrations, specs index, attribution)
- `everruns-server`/`worker`/`runtime`/`cli` build with default core features
- Focused core tests pass: `capabilities::` (1078), `tools::tests` (45), `telemetry::` (7), `session_storage::tests` (11), `ard_attachment::tests` (6)
- `cargo tree -p everruns-openrouter`: 287 → 222 crates

## Security

- Threat categories reviewed: **TM-TOOL / TM-AGENT**, **TM-API / TM-WEB**, dependency risk.
  - `AGENT_RUN_KEY_PREFIX` backs the `is_internal_session_kv_key` reservation that stops a session/tool actor forging A2A run records via `kv_store`. It is moved **ungated** so the reservation holds even when `a2a` is compiled out. No weakening.
  - WebFetch SSRF mitigations (`THREAT[TM-API-008/009]`, fetchkit DNS policy) are unchanged; when `web-fetch` is off the capability and its tool simply do not exist, which is strictly safer.
  - Dependency surface is **reduced** for provider consumers; no dependency versions changed and `Cargo.lock` is unchanged.
- No new threat surface introduced.

## Follow-ups

- **`llmsim` gate** — the remaining heavy bit in the openrouter tree (`axum` + `tokio-tungstenite` + `tiktoken-rs`, and it still re-pulls `tracing-subscriber`) comes from `llmsim`. It is deferred because the `LlmSim` driver is woven into the real runtime (`DriverId::LlmSim`, `in_memory_loop`, consumed by `durable`/`runtime`; ~240 references), so gating it is a behavior-affecting change that deserves its own focused PR.
- **`bashkit` gate** — deliberately left default-on. It backs core capabilities (skills, hooks, file_system, guardrails) across 20+ files; gating it would change the product surface, not just the dependency tree, for ~no default-build win.
- Applying `default-features = false` to the **sibling provider crates** (`openai`, `anthropic`, `gemini`, `bedrock`, `mai`, `fireworks`, `local`) for the same benefit — straightforward but each needs its own build verification.

## Checklist
- [x] Tests added or updated (existing core tests cover the registry/tooling surface; behavior unchanged)
- [x] Backward compatibility considered (app crates unchanged; only opt-out consumers affected)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)