### PR TITLE
refactor(providers): shed core default features in thin provider crates

### DIFF
--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -40,7 +40,10 @@ chrono.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees
+# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
+# need, keeping the standalone crate's dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -36,7 +36,10 @@ tracing.workspace = true
 
 # Internal dependencies
 base64.workspace = true
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees
+# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
+# need, keeping the standalone crate's dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/fireworks/Cargo.toml
+++ b/crates/fireworks/Cargo.toml
@@ -32,7 +32,10 @@ serde_json.workspace = true
 chrono.workspace = true
 
 # Internal dependencies
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees
+# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
+# need, keeping the standalone crate's dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -40,5 +40,6 @@ tracing.workspace = true
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
 everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -36,6 +36,9 @@ serde_json.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees
+# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
+# need, keeping the standalone crate's dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/local/Cargo.toml
+++ b/crates/local/Cargo.toml
@@ -18,6 +18,10 @@ categories = ["development-tools", "database"]
 rusqlite = { version = "0.39", features = ["bundled"] }
 
 # Everruns crates
+# NOTE: core defaults are intentionally NOT disabled here. everruns-local pulls
+# in everruns-runtime (and via it everruns-mcp), which depend on core with full
+# defaults, so feature unification re-enables the heavy subtrees regardless —
+# default-features = false would be a no-op. This is not a thin provider crate.
 everruns-core.workspace = true
 everruns-runtime.workspace = true
 

--- a/crates/mai/Cargo.toml
+++ b/crates/mai/Cargo.toml
@@ -37,7 +37,10 @@ chrono.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees
+# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
+# need, keeping the standalone crate's dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -43,7 +43,10 @@ tracing.workspace = true
 inventory.workspace = true
 
 # Internal dependencies
-everruns-core.workspace = true
+# default-features = false sheds core's heavy optional subtrees
+# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
+# need, keeping the standalone crate's dependency tree small.
+everruns-core = { path = "../core", version = "0.16.1", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }


### PR DESCRIPTION
## What

Follow-up to #2399. Have the thin LLM provider crates depend on `everruns-core` with `default-features = false`, mirroring what `everruns-openrouter` already does:

- `everruns-openai`
- `everruns-anthropic`
- `everruns-gemini`
- `everruns-bedrock`
- `everruns-mai`
- `everruns-fireworks`

## Why

After #2399, only `everruns-openrouter` opted out of core's heavy optional subtrees (telemetry/OTLP, `a2a` gRPC, web-fetch/fetchkit). The sibling provider crates still dragged in `tonic`/`prost`/`opentelemetry-otlp`/`fetchkit`/`ed25519-dalek` unconditionally even though none of them use those code paths. These crates are published to docs.rs, so the bloat is a real cost for external users.

Standalone dependency trees after this change (`tonic`, `opentelemetry-otlp`, `fetchkit`, `ed25519-dalek` are **gone** from all of them):

| crate | crates in tree |
|---|---|
| openai | 224 |
| anthropic | 222 |
| gemini | 222 |
| mai | 222 |
| fireworks | 222 |
| bedrock | 257 (the extra is the AWS SDK, bedrock's own dependency) |

(For reference, `everruns-openrouter` is 222 after #2399; before that work these all sat at ~287.)

## How

Switch each provider's `everruns-core.workspace = true` to `{ path = "../core", version = "0.16.1", default-features = false }`. The explicit `path + version` form is required because Cargo rejects `workspace = true` combined with `default-features = false`; it matches the existing convention for path deps that need extra options (`everruns-config`, `everruns-openui`, `everruns-a2ui` in `crates/core/Cargo.toml`).

`everruns-local` is **intentionally excluded** and left on full core defaults: it depends on `everruns-runtime` (and via it `everruns-mcp`), which require full core, so feature unification re-enables the subtrees regardless — the opt-out would be a no-op. This is documented inline in `crates/local/Cargo.toml`; it is not a thin provider crate.

## Risk

- **Low.** Cargo-metadata only; no source changes. Providers don't reference any gated core item. In the full workspace/app build, the app crates still enable core's defaults, so unification keeps core full there — behavior is unchanged. The lean configuration only applies when a provider is built standalone (the published/docs.rs case).

Validation:
- `cargo build -p everruns-{openai,anthropic,gemini,bedrock,mai,fireworks,local}` — all compile against lean core
- `cargo clippy --all-targets -- -D warnings` for the same set — clean
- `bash scripts/lib/pre-push.sh` — all green (`Cargo.lock` unchanged; default-features resolution does not alter the lockfile)
- `cargo tree` per crate — heavy subtrees removed (table above)

## Security

- Threat categories reviewed: **dependency risk** only. The dependency surface for standalone provider consumers is **reduced**; no dependency versions changed and `Cargo.lock` is unchanged. No code, auth, API, or data-path changes. No new threat surface.

## Follow-ups

- `llmsim` gate in core — still the remaining heavy bit (`axum`/websockets/`tiktoken-rs`) in these trees; deferred in #2399 because it is woven into the real runtime. Tracked separately.

## Checklist
- [x] Tests added or updated (metadata-only; existing provider tests compile/lint against lean core)
- [x] Backward compatibility considered (app build unchanged via feature unification; only standalone consumers shed deps)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)