### PR TITLE
fix(ui): preserve AG-UI endpoint auth on edit

### DIFF
--- a/apps/ui/src/__tests__/app-channel-redesign.test.tsx
+++ b/apps/ui/src/__tests__/app-channel-redesign.test.tsx
@@ -50,6 +50,36 @@ describe("app channel redesign", () => {
     expect(config).toEqual(expect.objectContaining({ anonymous: true, token: state.agUiToken }));
   });
 
+  it("preserves AG-UI endpoint auth and anonymous settings when editing", () => {
+    const preservedAuth = {
+      mode: "google_oidc",
+      provider: { type: "google_oidc", client_id: "client-123" },
+      requirements: { domains: ["example.com"] },
+    } as const;
+    const channel: AppChannel = {
+      id: "appchan_agui",
+      channel_type: "ag_ui",
+      channel_config: {
+        anonymous: false,
+        session_expiration_seconds: 3600,
+        tool_visibility: "narrated",
+        auth: preservedAuth,
+      },
+      enabled: true,
+      created_at: "2026-05-10T00:00:00Z",
+      updated_at: "2026-05-10T00:00:00Z",
+    };
+
+    const state = getDefaultChannelFormState("ag_ui", channel);
+
+    expect(buildChannelConfig(state)).toEqual(
+      expect.objectContaining({
+        anonymous: false,
+        auth: preservedAuth,
+      }),
+    );
+  });
+
   it("renders cron labels as human-readable text with timezone", () => {
     render(<CronLabel expr="0 30 * * * * *" tz="America/Chicago" />);
 

--- a/apps/ui/src/components/apps/channel-form.tsx
+++ b/apps/ui/src/components/apps/channel-form.tsx
@@ -23,6 +23,7 @@ import {
 import type {
   AgUiChannelConfig,
   AgUiToolVisibility,
+  AppEndpointAuthConfig,
   App,
   AppChannel,
   ChannelType,
@@ -66,6 +67,8 @@ export type ChannelFormState = {
   channelMessage: string;
   webhookToken: string;
   agUiToken: string;
+  agUiAnonymous: boolean;
+  agUiAuth?: AppEndpointAuthConfig;
   agUiExpirationHours: number;
   agUiRateLimitPerMinute: string;
   agUiToolVisibility: AgUiToolVisibility;
@@ -102,6 +105,8 @@ export function getDefaultChannelFormState(
     channelMessage: "",
     webhookToken: "",
     agUiToken: kind === "ag_ui" && !channel ? generateChannelToken() : "",
+    agUiAnonymous: true,
+    agUiAuth: undefined,
     agUiExpirationHours: DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600,
     agUiRateLimitPerMinute: "",
     agUiToolVisibility: "generic",
@@ -143,6 +148,8 @@ export function getDefaultChannelFormState(
       ...base,
       kind: "ag_ui",
       agUiToken: secretValue(config.token, config.token_configured),
+      agUiAnonymous: config.anonymous ?? true,
+      agUiAuth: config.auth,
       agUiExpirationHours:
         typeof config.session_expiration_seconds === "number"
           ? config.session_expiration_seconds / 3600
@@ -211,7 +218,8 @@ export function buildChannelConfig(state: ChannelFormState) {
     case "ag_ui": {
       const rateLimit = Number.parseInt(state.agUiRateLimitPerMinute, 10);
       return {
-        anonymous: true,
+        anonymous: state.agUiAnonymous,
+        ...(state.agUiAuth ? { auth: state.agUiAuth } : {}),
         ...(state.agUiToken.trim() ? { token: state.agUiToken.trim() } : {}),
         session_expiration_seconds: Math.max(0, Math.round(state.agUiExpirationHours * 3600)),
         ...(Number.isFinite(rateLimit) && rateLimit > 0


### PR DESCRIPTION
### Motivation
- Editing an existing AG-UI channel rebuilt `channel_config` from visible form fields and omitted `auth`/`anonymous`, which could silently downgrade protected endpoints to public anonymous access.

### Description
- Add hidden form-state fields `agUiAnonymous` and `agUiAuth` to `ChannelFormState` and populate them from existing `AgUiChannelConfig` in `getDefaultChannelFormState` (`apps/ui/src/components/apps/channel-form.tsx`).
- Include the preserved `anonymous` and `auth` values when producing the PATCH payload via `buildChannelConfig` for `ag_ui` channels (`apps/ui/src/components/apps/channel-form.tsx`).
- Add a regression test that verifies an AG-UI channel with `anonymous: false` and a Google OIDC `auth` object round-trips through `getDefaultChannelFormState` and `buildChannelConfig` (`apps/ui/src/__tests__/app-channel-redesign.test.tsx`).
- Commit message: `fix(ui): preserve AG-UI endpoint auth on edit`.

### Testing
- Installed UI deps with `pnpm --dir apps/ui install --frozen-lockfile` and formatted sources with `pnpm --dir apps/ui format` and `pnpm --dir apps/ui format:check`, both successful.
- Ran the focused UI test with `pnpm --dir apps/ui test -- --runTestsByPath src/__tests__/app-channel-redesign.test.tsx` and the suite passed (`1` suite, `10` tests passed).
- Performed TypeScript check with `pnpm --dir apps/ui typecheck` which passed and ran linter with `pnpm --dir apps/ui lint` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a0c4d030832b8cee675d9a5d2807)