### PR TITLE
fix(ard): enforce egress controls

### DIFF
--- a/integrations/ard/src/client.rs
+++ b/integrations/ard/src/client.rs
@@ -9,7 +9,10 @@
 //! and must run the trust gate before attaching.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use everruns_core::network_access::NetworkAccessList;
+use everruns_core::{EgressRequest, EgressRequestKind, EgressService};
 use serde::{Deserialize, Serialize};
 
 /// IANA media type for an MCP server catalog entry.
@@ -276,7 +279,11 @@ impl ArdRegistryClient {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             auth_token,
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .no_proxy()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .expect("build ARD registry HTTP client"),
         }
     }
 
@@ -313,6 +320,44 @@ impl ArdRegistryClient {
             .map_err(|e| format!("failed to parse ARD search response: {e}"))
     }
 
+    /// `POST /search` through the platform egress boundary.
+    pub async fn search_with_egress(
+        &self,
+        body: &SearchRequest,
+        egress: Arc<dyn EgressService>,
+        network_access: Option<NetworkAccessList>,
+        dns_pinning_required: bool,
+    ) -> Result<SearchResponse, String> {
+        let url = format!("{}/search", self.base_url);
+        let request_body = serde_json::to_vec(body)
+            .map_err(|e| format!("failed to encode ARD search request: {e}"))?;
+        let mut request = EgressRequest::new("POST", url, EgressRequestKind::Integration)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .body(request_body)
+            .network_access(network_access);
+        if dns_pinning_required {
+            request = request.require_dns_pinning();
+        }
+        if let Some(token) = &self.auth_token {
+            request = request.header("Authorization", format!("Bearer {token}"));
+        }
+        let resp = egress
+            .send(request)
+            .await
+            .map_err(|e| format!("ARD registry search request failed: {e}"))?;
+        if !(200..300).contains(&resp.status) {
+            let detail = String::from_utf8_lossy(&resp.body);
+            return Err(format!(
+                "ARD registry search returned HTTP {}: {}",
+                resp.status,
+                truncate(&detail, 500)
+            ));
+        }
+        serde_json::from_slice::<SearchResponse>(&resp.body)
+            .map_err(|e| format!("failed to parse ARD search response: {e}"))
+    }
+
     /// Fetch an artifact document referenced by an entry `url`. The URL MUST be
     /// SSRF-validated by the caller before invoking this.
     pub async fn fetch_artifact(
@@ -322,7 +367,9 @@ impl ArdRegistryClient {
     ) -> Result<serde_json::Value, String> {
         // Pin the connection to the validated IPs to close the DNS-rebinding
         // TOCTOU window (mirrors the scoped-MCP path).
-        let mut builder = reqwest::Client::builder();
+        let mut builder = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none());
         if let (Ok(parsed), false) = (url::Url::parse(url), resolved_addrs.is_empty())
             && let Some(host) = parsed.host_str()
         {
@@ -344,6 +391,41 @@ impl ArdRegistryClient {
         }
         resp.json::<serde_json::Value>()
             .await
+            .map_err(|e| format!("failed to parse artifact document: {e}"))
+    }
+
+    /// Fetch an artifact document through the platform egress boundary.
+    pub async fn fetch_artifact_with_egress(
+        &self,
+        url: &str,
+        resolved_addrs: &[std::net::SocketAddr],
+        egress: Arc<dyn EgressService>,
+        network_access: Option<NetworkAccessList>,
+    ) -> Result<serde_json::Value, String> {
+        let mut request = EgressRequest::new("GET", url, EgressRequestKind::Integration)
+            .header("Accept", "application/json")
+            .network_access(network_access);
+        if let Ok(parsed) = url::Url::parse(url)
+            && let Some(host) = parsed.host_str()
+        {
+            request = request.pinned_addrs(host, resolved_addrs.to_vec());
+        }
+        if let Some(token) = &self.auth_token {
+            request = request.header("Authorization", format!("Bearer {token}"));
+        }
+        let resp = egress
+            .send(request)
+            .await
+            .map_err(|e| format!("artifact fetch failed: {e}"))?;
+        if !(200..300).contains(&resp.status) {
+            let detail = String::from_utf8_lossy(&resp.body);
+            return Err(format!(
+                "artifact fetch returned HTTP {}: {}",
+                resp.status,
+                truncate(&detail, 500)
+            ));
+        }
+        serde_json::from_slice::<serde_json::Value>(&resp.body)
             .map_err(|e| format!("failed to parse artifact document: {e}"))
     }
 }

--- a/integrations/ard/src/config.rs
+++ b/integrations/ard/src/config.rs
@@ -5,6 +5,7 @@
 //! attachment type allowlist, an attachment cap, and a local-URL escape hatch
 //! for tests.
 
+use everruns_core::validate_safe_url;
 use serde::{Deserialize, Serialize};
 
 use crate::client::{Federation, MEDIA_TYPE_A2A_AGENT_CARD, MEDIA_TYPE_MCP_SERVER};
@@ -86,14 +87,20 @@ impl ArdConfig {
             if !seen.insert(reg.id.clone()) {
                 return Err(format!("duplicate registry id '{}'", reg.id));
             }
-            // Registry URLs are operator-provided; require a parseable http(s) URL.
-            // SSRF for registries is enforced by the network-access policy + the
-            // resolved-artifact checks at attach time; local registries are only
-            // permitted when allow_local_urls is set.
-            let parsed = url::Url::parse(&reg.url)
-                .map_err(|e| format!("registry '{}' has invalid url: {e}", reg.id))?;
-            if !matches!(parsed.scheme(), "http" | "https") {
-                return Err(format!("registry '{}' url must be http(s)", reg.id));
+            // Registry URLs are operator-provided, but still drive server-side
+            // HTTP. Reject static SSRF targets unless explicitly enabled for
+            // local/dev registries; runtime DNS pinning happens before search.
+            if self.allow_local_urls {
+                let parsed = url::Url::parse(&reg.url)
+                    .map_err(|e| format!("registry '{}' has invalid url: {e}", reg.id))?;
+                if !matches!(parsed.scheme(), "http" | "https") {
+                    return Err(format!("registry '{}' url must be http(s)", reg.id));
+                }
+            } else if let Err(e) = validate_safe_url(&reg.url) {
+                return Err(format!(
+                    "registry '{}' url blocked by SSRF policy: {e}",
+                    reg.id
+                ));
             }
         }
         if self.max_attachments == 0 {
@@ -161,6 +168,23 @@ mod tests {
         }))
         .unwrap();
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_local_registry_urls_unless_allowed() {
+        let cfg = ArdConfig::from_value(&serde_json::json!({
+            "registries": [{"id": "local", "url": "http://127.0.0.1:8080"}],
+            "allow_local_urls": false
+        }))
+        .unwrap();
+        assert!(cfg.validate().unwrap_err().contains("SSRF policy"));
+
+        let cfg = ArdConfig::from_value(&serde_json::json!({
+            "registries": [{"id": "local", "url": "http://127.0.0.1:8080"}],
+            "allow_local_urls": true
+        }))
+        .unwrap();
+        cfg.validate().unwrap();
     }
 
     #[test]

--- a/integrations/ard/src/tools.rs
+++ b/integrations/ard/src/tools.rs
@@ -26,7 +26,7 @@ use everruns_core::session_resource::{RegisterSessionResource, SessionResourceSt
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
-use everruns_core::{validate_safe_url, validate_url_dns_pinned};
+use everruns_core::{DirectEgressService, validate_safe_url, validate_url_dns_pinned};
 
 use crate::client::{
     ArdRegistryClient, CatalogEntry, MEDIA_TYPE_A2A_AGENT_CARD, MEDIA_TYPE_MCP_SERVER, SearchQuery,
@@ -162,6 +162,21 @@ impl Tool for DiscoverResourcesTool {
             Err(e) => return e,
         };
 
+        if let Some(acl) = &context.network_access
+            && !acl.is_url_allowed(&registry.url)
+        {
+            return ToolExecutionResult::tool_error(
+                "registry URL blocked by network access policy",
+            );
+        }
+        if !self.config.allow_local_urls
+            && let Err(e) = validate_safe_url(&registry.url)
+        {
+            return ToolExecutionResult::tool_error(format!(
+                "registry URL blocked by SSRF policy: {e}"
+            ));
+        }
+
         let token = resolve_token(context).await;
         let client = ArdRegistryClient::new(registry.url.clone(), token);
         let request = SearchRequest {
@@ -173,7 +188,23 @@ impl Tool for DiscoverResourcesTool {
             page_size: Some(10),
         };
 
-        let response = match client.search(&request).await {
+        let response = if self.config.allow_local_urls && context.egress_service.is_none() {
+            client.search(&request).await
+        } else {
+            let egress = context
+                .egress_service
+                .clone()
+                .unwrap_or_else(|| std::sync::Arc::new(DirectEgressService::from_env()));
+            client
+                .search_with_egress(
+                    &request,
+                    egress,
+                    context.network_access.clone(),
+                    !self.config.allow_local_urls,
+                )
+                .await
+        };
+        let response = match response {
             Ok(r) => r,
             Err(e) => return ToolExecutionResult::tool_error(e),
         };
@@ -461,8 +492,18 @@ impl AttachResourceTool {
         let addrs = self.validate_url(context, url).await?;
         let token = resolve_token(context).await;
         let client = ArdRegistryClient::new(entry.source.clone().unwrap_or_default(), token);
+        if self.config.allow_local_urls && context.egress_service.is_none() {
+            return client
+                .fetch_artifact(url, &addrs)
+                .await
+                .map_err(ToolExecutionResult::tool_error);
+        }
+        let egress = context
+            .egress_service
+            .clone()
+            .unwrap_or_else(|| std::sync::Arc::new(DirectEgressService::from_env()));
         client
-            .fetch_artifact(url, &addrs)
+            .fetch_artifact_with_egress(url, &addrs, egress, context.network_access.clone())
             .await
             .map_err(ToolExecutionResult::tool_error)
     }
@@ -523,9 +564,16 @@ impl AttachResourceTool {
     /// DNS-pinned SSRF validation; bypassed (parse-only) when allow_local_urls.
     async fn validate_url(
         &self,
-        _context: &ToolContext,
+        context: &ToolContext,
         url: &str,
     ) -> Result<Vec<std::net::SocketAddr>, ToolExecutionResult> {
+        if let Some(acl) = &context.network_access
+            && !acl.is_url_allowed(url)
+        {
+            return Err(ToolExecutionResult::tool_error(
+                "URL blocked by network access policy",
+            ));
+        }
         if self.config.allow_local_urls {
             // Still require a syntactically valid http(s) URL.
             url::Url::parse(url)

--- a/integrations/ard/tests/tool_integration.rs
+++ b/integrations/ard/tests/tool_integration.rs
@@ -272,13 +272,15 @@ async fn blocks_local_urls_unless_allowed() {
     let session_id = SessionId::new();
     let store = Arc::new(MockStorage::default());
     let context = ctx(session_id, store.clone());
-    // allow_local_urls = false → the loopback endpoint must be rejected.
-    let cfg = config_for(&base, false, vec![]);
+    // Discover through the local test registry with an explicit local-dev opt-in,
+    // then attach with local URLs disabled so the loopback endpoint is rejected.
+    let discover_cfg = config_for(&base, true, vec![]);
+    let attach_cfg = config_for("https://registry.example.test", false, vec![]);
 
-    DiscoverResourcesTool::new(cfg.clone())
+    DiscoverResourcesTool::new(discover_cfg)
         .execute_with_context(json!({ "text": "internal" }), &context)
         .await;
-    let res = AttachResourceTool::new(cfg)
+    let res = AttachResourceTool::new(attach_cfg)
         .execute_with_context(json!({ "urn": "urn:ai:acme.com:mcp:internal" }), &context)
         .await;
     match res {


### PR DESCRIPTION
### Motivation

- Close an SSRF/network-access gap where the ARD integration performed outbound HTTP with raw `reqwest` clients and followed redirects, bypassing platform egress ACLs and DNS-pinning protections.
- Ensure registry URLs and artifact fetches are subject to the same `ToolContext.network_access` and SSRF rules as other outbound traffic, while preserving an explicit local-dev opt-in (`allow_local_urls`).

### Description

- Add static SSRF validation for configured registries so registry URLs are rejected by `validate_safe_url` unless `allow_local_urls` is enabled (changes in `integrations/ard/src/config.rs`).
- Route registry `POST /search` calls and artifact fetches through the platform `EgressService` when available, propagating `network_access` and enabling DNS pinning; new helper wrappers `search_with_egress` and `fetch_artifact_with_egress` were added to `integrations/ard/src/client.rs` and used from `tools.rs`.
- Disable automatic redirects and ensure direct `reqwest` clients use `.redirect(Policy::none())` and `.no_proxy()` to avoid redirect-based SSRF and proxy-induced loopback bypasses (in `integrations/ard/src/client.rs`).
- Enforce per-session `ToolContext.network_access` during registry validation and URL validation before fetching artifacts (in `integrations/ard/src/tools.rs`).
- Preserve explicit local-dev fallback behavior: when `allow_local_urls` is true and no `egress_service` is provided, the code uses the direct, non-redirecting client path to keep test/dev ergonomics.
- Add and update regression/integration tests to cover rejected local registries and the discover→attach flow with endpoint blocking (changes in `integrations/ard/tests/tool_integration.rs` and `integrations/ard/src/config.rs` tests).

### Testing

- Ran `cargo fmt --check` and formatting checks passed.
- Ran `cargo test -p everruns-integrations-ard` (unit + integration tests for the ARD crate); all tests passed after fixes (previous failing tests were iteratively addressed during the change). 
- Ran `cargo clippy -p everruns-integrations-ard --all-targets --all-features -- -D warnings` and addressed lints; Clippy checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a362cb7df64832bb0582cfcc81de9c7)