### PR TITLE
fix(storage): use immutable session file blob keys

### DIFF
--- a/crates/server/src/blob_gc.rs
+++ b/crates/server/src/blob_gc.rs
@@ -560,8 +560,8 @@ mod tests {
         let orphan_file = uuid::Uuid::from_u128(11);
         let img = uuid::Uuid::from_u128(20);
 
-        let live_key = workspace_file_key(ws, live_file);
-        let orphan_key = workspace_file_key(ws, orphan_file);
+        let live_key = workspace_file_key(ws, live_file, "live");
+        let orphan_key = workspace_file_key(ws, orphan_file, "orphan");
         let img_data = image_data_key(7, img);
         let img_thumb = image_thumbnail_key(7, img);
 
@@ -614,7 +614,7 @@ mod tests {
     async fn sweep_within_grace_deletes_nothing() {
         let store: SharedBlobStore = Arc::new(ObjectStoreBlobStore::in_memory());
         let ws = uuid::Uuid::from_u128(1);
-        let orphan_key = workspace_file_key(ws, uuid::Uuid::from_u128(2));
+        let orphan_key = workspace_file_key(ws, uuid::Uuid::from_u128(2), "orphan");
         store
             .put(&orphan_key, b"x".to_vec(), &dr_meta())
             .await

--- a/crates/server/src/storage/blob_store.rs
+++ b/crates/server/src/storage/blob_store.rs
@@ -156,10 +156,11 @@ impl BlobMetadata {
 /// Object key for a workspace file's content blob.
 ///
 /// `workspace_id` is the per-tenant partition (org ownership is enforced above
-/// this layer), and `file_id` keys the individual object so deletes and
-/// overwrites are unambiguous.
-pub fn workspace_file_key(workspace_id: Uuid, file_id: Uuid) -> String {
-    format!("workspaces/{workspace_id}/files/{file_id}")
+/// this layer), `file_id` keys the logical file, and `content_sha256` makes each
+/// revision immutable. This prevents object-store overwrites from racing ahead
+/// of the PostgreSQL sidecar pointer that selects the current revision.
+pub fn workspace_file_key(workspace_id: Uuid, file_id: Uuid, content_sha256: &str) -> String {
+    format!("workspaces/{workspace_id}/files/{file_id}/sha256/{content_sha256}")
 }
 
 /// Object key for an image's primary data blob.
@@ -573,8 +574,8 @@ mod tests {
         let ws = Uuid::nil();
         let file = Uuid::from_u128(1);
         assert_eq!(
-            workspace_file_key(ws, file),
-            "workspaces/00000000-0000-0000-0000-000000000000/files/00000000-0000-0000-0000-000000000001"
+            workspace_file_key(ws, file, "abc123"),
+            "workspaces/00000000-0000-0000-0000-000000000000/files/00000000-0000-0000-0000-000000000001/sha256/abc123"
         );
         assert_eq!(
             image_data_key(7, file),

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -52,18 +52,24 @@ impl Database {
         let Some(blob) = self.blob_store() else {
             return Ok(());
         };
-        let key: Option<(String,)> =
-            sqlx::query_as("SELECT blob_key FROM workspace_file_blobs WHERE file_id = $1")
-                .bind(row.id)
-                .fetch_optional(&self.pool)
-                .await?;
-        if let Some((key,)) = key {
+        let pointer: Option<(String, String)> = sqlx::query_as(
+            "SELECT blob_key, content_sha256 FROM workspace_file_blobs WHERE file_id = $1",
+        )
+        .bind(row.id)
+        .fetch_optional(&self.pool)
+        .await?;
+        if let Some((key, expected_sha)) = pointer {
             // A sidecar pointer exists, so a missing object means data loss —
             // surface it as an error rather than silently returning empty content.
             let bytes = blob
                 .get(&key)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("offloaded file blob missing for {key}"))?;
+            let actual_sha = content_sha256(&bytes);
+            anyhow::ensure!(
+                actual_sha == expected_sha,
+                "offloaded file blob hash mismatch for {key}: expected {expected_sha}, got {actual_sha}"
+            );
             row.content = Some(bytes);
         }
         Ok(())
@@ -80,8 +86,8 @@ impl Database {
             && !input.is_directory
         {
             let file_id = Uuid::now_v7();
-            let key = workspace_file_key(workspace_id, file_id);
             let sha = content_sha256(content);
+            let key = workspace_file_key(workspace_id, file_id, &sha);
 
             // Write the blob first; if the row insert then fails (e.g. duplicate
             // path) we clean the orphan object up rather than leaving it behind.
@@ -284,8 +290,8 @@ impl Database {
         // Offload path: a content update with a configured blob backend. Write
         // the new blob first, then update the row + sidecar in one transaction,
         // so a failed object write never leaves the row pointing at missing
-        // content. The blob key is addressed by file id, so the put overwrites
-        // the file's existing object in place.
+        // content. The blob key embeds the content SHA-256, so each revision
+        // writes to a distinct, immutable object instead of overwriting in place.
         if let (Some(blob), Some(content)) = (self.blob_store(), input.content.as_ref()) {
             let size_bytes = content.len() as i64;
 
@@ -301,8 +307,8 @@ impl Database {
                 return Ok(None);
             };
 
-            let key = workspace_file_key(session_id, file_id);
             let sha = content_sha256(content);
+            let key = workspace_file_key(session_id, file_id, &sha);
             blob.put(
                 &key,
                 content.clone(),
@@ -439,8 +445,8 @@ impl Database {
             }
 
             let size_bytes = new_content.len() as i64;
-            let key = workspace_file_key(session_id, existing.id);
             let sha = content_sha256(&new_content);
+            let key = workspace_file_key(session_id, existing.id, &sha);
             blob.put(
                 &key,
                 new_content.clone(),
@@ -681,8 +687,8 @@ impl Database {
             // the row + sidecar can be inserted in one transaction with the blob
             // already durable; clean the blob up on any DB failure.
             let written_key = if let Some(content) = source.content.clone() {
-                let key = workspace_file_key(session_id, dest_id);
                 let sha = content_sha256(&content);
+                let key = workspace_file_key(session_id, dest_id, &sha);
                 blob.put(
                     &key,
                     content,

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -298,21 +298,27 @@ async fn offloaded_file_delete_removes_object_and_sidecar() {
 }
 
 #[tokio::test]
-async fn offloaded_file_update_overwrites_blob_and_hash() {
+async fn offloaded_file_update_writes_immutable_blob_revision_and_hash() {
     let (backend, pool) = create_offload_backend().await;
     let session_id = create_test_session(&backend).await;
     let workspace_id: Uuid = session_id.into();
 
+    let original_body = b"v1".to_vec();
     backend
         .create_session_file(CreateSessionFileRow {
             session_id,
             path: "/edit.txt".to_string(),
             is_directory: false,
-            content: Some(b"v1".to_vec()),
+            content: Some(original_body.clone()),
             is_readonly: false,
         })
         .await
         .expect("create file");
+
+    let (old_key, old_sha) = file_sidecar(&pool, workspace_id, "/edit.txt")
+        .await
+        .expect("initial sidecar exists");
+    assert_eq!(old_sha, content_sha256(&original_body));
 
     let new_body = b"v2 longer content".to_vec();
     let updated = backend
@@ -335,10 +341,25 @@ async fn offloaded_file_update_overwrites_blob_and_hash() {
         raw_file_content(&pool, workspace_id, "/edit.txt").await,
         None
     );
-    let (_, sha) = file_sidecar(&pool, workspace_id, "/edit.txt")
+    let (new_key, sha) = file_sidecar(&pool, workspace_id, "/edit.txt")
         .await
         .expect("sidecar exists");
     assert_eq!(sha, content_sha256(&new_body));
+    assert_ne!(
+        new_key, old_key,
+        "content updates must point at an immutable blob revision"
+    );
+
+    let blob = blob_store_under_test();
+    assert_eq!(
+        blob.get(&old_key).await.expect("old blob get").as_deref(),
+        Some(original_body.as_slice()),
+        "the previous revision must not be overwritten in place"
+    );
+    assert_eq!(
+        blob.get(&new_key).await.expect("new blob get").as_deref(),
+        Some(new_body.as_slice())
+    );
 
     // Read returns the new bytes from the blob store.
     let fetched = backend


### PR DESCRIPTION
### Motivation
- Prevent a race where offloaded S3-compatible writes overwrite a stable object key before PostgreSQL metadata is committed, causing DB metadata to point at different bytes than the object store serves. 
- Ensure offloaded reads verify integrity so callers cannot be silently served mismatched content when concurrent writers interleave. 

### Description
- Make workspace file object keys revision-immutable by adding the content SHA-256 to `workspace_file_key` and update all callsites to compute `content_sha256` before deriving the key. 
- Compute `sha` and derive the object `key` prior to every `blob.put` in the create, update, CAS update, and copy paths so each revision writes to a distinct object. 
- Add read-time verification in `materialize_file_content` by selecting `content_sha256` from `workspace_file_blobs` and ensuring the fetched object hash matches the sidecar before returning bytes. 
- Update unit expectations and blob-GC tests for the new key shape and extend the offload integration test to assert that updates create immutable revisions instead of overwriting the prior object. 

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran focused unit tests: `storage::blob_store::tests::keys_are_tenant_scoped`, `blob_gc::tests::sweep_deletes_old_orphans_keeps_live`, and `blob_gc::tests::sweep_within_grace_deletes_nothing`, and all three passed. 
- Compiled the offload integration test binary with `cargo test -p everruns-server --test blob_offload_integration_test --no-run`, which built successfully but was not executed end-to-end because it requires a running PostgreSQL test instance. 
- Note: `git fetch origin main` could not be performed in this environment because the `origin` remote is unavailable; changes were committed locally and a PR record was created (`fix(storage): use immutable session file blob keys`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3632040d90832b85bcce84e3cd3c4f)