### PR TITLE
fix(llm-tests): narrow quota detector for 429s

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -200,17 +200,17 @@ pub fn is_quota_exhausted(err: &str) -> bool {
         return true;
     }
 
-    let billing_words = e.contains("billing")
-        || e.contains("exceeded")
-        || e.contains("credit")
-        || e.contains("out of quota");
-    if e.contains("quota") && billing_words {
+    let quota_signal = e.contains("quota") || e.contains("out of quota");
+    let billing_signal = e.contains("billing") || e.contains("credit");
+    let exceeded_signal = e.contains("exceeded");
+    if quota_signal && (billing_signal || exceeded_signal) {
         return true;
     }
 
-    // HTTP 429 only counts when paired with a quota/billing signal, so plain
-    // rate limiting (which should be retried/flagged, not skipped) still fails.
-    if e.contains("429") && (e.contains("quota") || billing_words) {
+    // HTTP 429 only counts when paired with an explicit quota/billing signal,
+    // so plain rate limiting (which should be retried/flagged, not skipped)
+    // still fails even if the provider says a rate limit was "exceeded".
+    if e.contains("429") && (quota_signal || billing_signal) {
         return true;
     }
 
@@ -301,6 +301,12 @@ mod quota_detector_tests {
         assert!(!is_quota_exhausted(""));
         // Plain rate limiting (no billing/quota signal) should NOT be skipped.
         assert!(!is_quota_exhausted("HTTP 429 Too Many Requests: slow down"));
+        assert!(!is_quota_exhausted(
+            "HTTP 429 Too Many Requests: rate limit exceeded"
+        ));
+        assert!(!is_quota_exhausted(
+            "HTTP 429 Too Many Requests: requests per minute exceeded"
+        ));
         assert!(!is_quota_exhausted("rate_limit_exceeded"));
         // Auth/permission failures must never be swallowed as quota.
         assert!(!is_quota_exhausted("401 Unauthorized: invalid api key"));


### PR DESCRIPTION
### Motivation
- The LLM test skip classifier was overbroad because the substring "exceeded" caused HTTP 429 rate-limit messages like "429 Rate limit exceeded" to be treated as quota exhaustion and skipped. 
- The intent is to skip only genuine billing/quota exhaustion (insufficient credits/quota/billing) while letting plain rate-limit failures surface as test failures.

### Description
- Replace the single `billing_words` predicate with explicit signals: `quota_signal`, `billing_signal`, and `exceeded_signal`, and require a quota signal together with billing or exceeded signals to classify as quota exhaustion.
- Change the HTTP 429 rule to require an explicit quota or billing signal (so a bare 429 + "exceeded" no longer implies quota exhaustion). 
- Add negative unit test coverage for common combined 429 messages such as `HTTP 429 Too Many Requests: rate limit exceeded` and `HTTP 429 Too Many Requests: requests per minute exceeded`.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo test -p everruns-llm-tests quota_detector_tests --all-features` and the quota detector tests passed. 
- No production-facing code or auth/secret handling was changed; the change is limited to test-skip classification and unit coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a363203a8e8832bb5020862265ce4b0)