### PR TITLE
fix(providers): classify provider type validation

### DIFF
--- a/crates/server/src/domains/providers/service.rs
+++ b/crates/server/src/domains/providers/service.rs
@@ -3,6 +3,7 @@
 // On create/update/delete, the LLM resolver cache is invalidated so that
 // subsequent model resolutions pick up the new provider config.
 
+use crate::errors::BadRequestError;
 use crate::services::ProviderResolverService;
 use crate::storage::{
     EncryptionService, StorageBackend,
@@ -270,16 +271,17 @@ fn resolve_trace_config(
 fn validate_provider_type(provider_type: &DriverId) -> Result<()> {
     let raw = provider_type.as_str();
     if raw.trim().is_empty() {
-        return Err(anyhow!("Provider type cannot be empty"));
+        return Err(BadRequestError::new("Provider type cannot be empty").into());
     }
     // `DriverId::external` preserves the string verbatim, so a padded id like
     // " openai " is non-empty here but later fails driver-registry lookup and
     // persists as a corrupt row. Reject surrounding whitespace outright rather
     // than silently normalizing it.
     if raw != raw.trim() {
-        return Err(anyhow!(
-            "Provider type cannot have leading or trailing whitespace"
-        ));
+        return Err(BadRequestError::new(
+            "Provider type cannot have leading or trailing whitespace",
+        )
+        .into());
     }
     Ok(())
 }
@@ -330,6 +332,7 @@ fn validate_azure_openai_base_url(url: &Url) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{resolve_trace_config, validate_provider_base_url, validate_provider_type};
+    use crate::errors::BadRequestError;
     use everruns_core::DriverId;
     use everruns_core::url_validation::validate_safe_url;
 
@@ -393,12 +396,14 @@ mod tests {
     fn provider_type_rejects_empty_external_id() {
         let err = validate_provider_type(&DriverId::external("")).unwrap_err();
         assert!(err.to_string().contains("Provider type cannot be empty"));
+        assert!(err.downcast_ref::<BadRequestError>().is_some());
     }
 
     #[test]
     fn provider_type_rejects_whitespace_external_id() {
         let err = validate_provider_type(&DriverId::external(" \t\n")).unwrap_err();
         assert!(err.to_string().contains("Provider type cannot be empty"));
+        assert!(err.downcast_ref::<BadRequestError>().is_some());
     }
 
     #[test]
@@ -410,6 +415,7 @@ mod tests {
             err.to_string()
                 .contains("Provider type cannot have leading or trailing whitespace")
         );
+        assert!(err.downcast_ref::<BadRequestError>().is_some());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provider create/update validation used `anyhow` strings for invalid provider types which the domain command classifier did not map to client errors, causing 500 responses for bad input.
- The goal is to ensure invalid provider_type input is classified as a Bad Request through the existing error-classification path.

### Description
- Change `validate_provider_type` to return a typed `BadRequestError` (via `BadRequestError::new(...).into()`) for empty, whitespace-only, and whitespace-padded provider types instead of plain `anyhow` errors.
- Add `use crate::errors::BadRequestError;` and update unit tests to assert that validation failures downcast to `BadRequestError` while preserving existing messages.

### Testing
- Ran the focused provider-type unit tests with `cargo test -p everruns-server --lib domains::providers::service::tests::provider_type_ --all-features` and they passed (`4 passed; 0 failed`).
- Ran `cargo fmt --check` and it succeeded with no formatting issues.
- Verified repository checks with `git diff --check` and local status; no automated check failures were produced during the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a363202d770832bba819080d76c65fb)