### PR TITLE
fix(release): correct provider core version-pins after default-features opt-out

### DIFF
--- a/crates/fireworks/Cargo.toml
+++ b/crates/fireworks/Cargo.toml
@@ -34,8 +34,9 @@ chrono.workspace = true
 # Internal dependencies
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+# need, keeping the dependency tree small. No version pin: this crate is not in
+# the publish set, so it follows the unpublished-crate convention (path only).
+everruns-core = { path = "../core", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;

--- a/crates/mai/Cargo.toml
+++ b/crates/mai/Cargo.toml
@@ -39,8 +39,9 @@ tracing.workspace = true
 # Internal dependencies
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+# need, keeping the dependency tree small. No version pin: this crate is not in
+# the publish set, so it follows the unpublished-crate convention (path only).
+everruns-core = { path = "../core", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -37,6 +37,7 @@ INNER_PINS: dict[str, list[str]] = {
     "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
     "crates/openai/Cargo.toml": ["everruns-core"],
     "crates/anthropic/Cargo.toml": ["everruns-core"],
+    "crates/openrouter/Cargo.toml": ["everruns-core"],
     "crates/bedrock/Cargo.toml": ["everruns-core"],
     "crates/gemini/Cargo.toml": ["everruns-core"],
     "integrations/duckduckgo/Cargo.toml": ["everruns-core"],

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -50,6 +50,27 @@ actually published to crates.io — see the publish list in
 unpublished crate renders as a broken link, so unpublished crates use a
 badge-free header and omit docs.rs links.
 
+### Crate dependency conventions
+
+Thin LLM provider crates (`openai`, `anthropic`, `gemini`, `bedrock`, `mai`,
+`fireworks`, `openrouter`) depend on `everruns-core` with
+`default-features = false`. Core's heavy subtrees (telemetry/OTLP, `a2a` gRPC,
+web-fetch/fetchkit) are opt-in features kept in core's `default`, so the
+application crates stay full while standalone provider builds shed them. Crates
+that pull in the runtime (e.g. `everruns-local` → `everruns-runtime`) cannot
+benefit — feature unification re-enables the subtrees — so they keep full
+defaults.
+
+Two pin conventions follow from the publish set:
+
+- **Unpublished** crates reference path deps without a version
+  (`{ path = "../core", default-features = false }`), matching `server`/`worker`.
+- **Published** crates that pin a sibling by exact version must be registered in
+  *both* `.github/workflows/publish-crates.yml` (`dependency_versions`) and
+  `scripts/sync-publish-pin-versions.py` (`INNER_PINS`). The release process
+  bumps pins via the latter; the publish workflow rejects releases where a pin
+  drifts. Adding a published crate to only one list breaks releases.
+
 ## Formatting
 
 ### Rust


### PR DESCRIPTION
## What

Housekeeping follow-up to #2399 / #2401. Fixes two release-correctness gaps those PRs left behind, and documents the provider dependency convention.

- **`scripts/sync-publish-pin-versions.py`** — add `crates/openrouter/Cargo.toml: ["everruns-core"]` to `INNER_PINS`.
- **`crates/mai/Cargo.toml`, `crates/fireworks/Cargo.toml`** — drop the `version = "0.16.1"` pin on the `everruns-core` path dep (keep `default-features = false`).
- **`specs/code-organization.md`** — document the thin-provider `default-features = false` convention and the published-vs-unpublished pin rules.

## Why

#2399/#2401 gave the provider crates an explicit `everruns-core` version pin (required because Cargo rejects `workspace = true` + `default-features = false`). That introduced two latent problems:

1. **Release-blocking drift for `openrouter`.** `everruns-openrouter` is published and is validated by `publish-crates.yml`'s `dependency_versions`, but it was **missing** from `sync-publish-pin-versions.py`'s `INNER_PINS`. On the next `prepare-release X.Y.Z`, the sync script would bump every other pin to `X.Y.Z` but leave openrouter's core pin at the old version — and the publish workflow rejects releases on pin drift. The two lists are meant to mirror each other; this restores that.
2. **Latent drift for `mai`/`fireworks`.** These two are **not** in the publish set (absent from `publish-crates.yml` entirely), so per repo convention (`server`, `worker`, `container-sandbox` reference path deps without a version) they should not carry a version pin at all. Dropping it removes a pin nothing syncs or validates.

`openai`/`anthropic`/`bedrock`/`gemini` were already present in both lists, so their explicit pins are correctly synced — no change needed.

## How

Verified the full set of version-pinned internal deps and cross-checked against both lists; `openrouter` was the only published gap. `mai`/`fireworks` revert to the unpublished-crate form.

Validation:
- `python3 scripts/sync-publish-pin-versions.py --check` — `all path-dep pins at 0.16.1`
- `cargo metadata` resolves; `bash scripts/lib/pre-push.sh` — all green (fmt, `clippy --all-targets --all-features`, Cargo.lock fresh, migrations, specs index, attribution)

## Risk

- **Low.** Release-tooling + manifest metadata + a spec note. No source or runtime changes. The fix is only exercised at release time, where it prevents a rejected release; `--check` confirms current consistency.

## Security

- Threat categories reviewed: **none applicable** — no code, auth, API, data-path, or dependency-version changes (this only corrects path-pin bookkeeping). No new threat surface.

## Follow-ups

- **Slim `llmsim` (the remaining heavy subtree in provider trees) is an upstream change** in `github.com/chaliy/llmsim`, which is outside this session's repo scope, so it is **not** included here. `llmsim 0.4.0` makes `axum` (with `ws`), `tiktoken-rs`, `tower-http`, and `clap` mandatory deps with no feature to disable them, while `everruns-core` only uses its library modules (`generator`, `latency`, `openai`, `script`, `stream`). The upstream fix is to feature-gate the server/CLI/tokenizer; then core can pin `llmsim` with `default-features = false`. Details handed to the maintainer separately.

## Checklist
- [x] Tests added or updated (release-tooling change verified via `--check`)
- [x] Backward compatibility considered (no behavior change; release tooling only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)