### PR TITLE
feat(evals): join scorer names in dataset export

### DIFF
--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -266,6 +266,28 @@ pub enum Scorer {
     },
 }
 
+impl Scorer {
+    /// Stable kind tag for this scorer, matching the serde `type` discriminant.
+    ///
+    /// Scores are persisted as an ordered `Vec<Score>` that carries no scorer
+    /// identity, so consumers that need a name (e.g. dataset export) join this
+    /// positionally against the case's `scorers`. Keep this exhaustive so adding
+    /// a variant forces a decision here.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Scorer::Contains { .. } => "contains",
+            Scorer::NotContains { .. } => "not_contains",
+            Scorer::Regex { .. } => "regex",
+            Scorer::ToolCalled { .. } => "tool_called",
+            Scorer::ToolNotCalled { .. } => "tool_not_called",
+            Scorer::ToolCallCount { .. } => "tool_call_count",
+            Scorer::TurnsWithin { .. } => "turns_within",
+            Scorer::FileContains { .. } => "file_contains",
+            Scorer::JsonSchema { .. } => "json_schema",
+        }
+    }
+}
+
 fn default_weight() -> f64 {
     1.0
 }

--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -618,6 +618,17 @@ impl Command for ExportEvalRunDataset {
         let retriever = crate::storage::message_store::DbMessageRetriever::new(ctx.db.clone());
         let compaction = CompactionConfig::default();
 
+        // Scorer identities are not persisted on the result (only the ordered
+        // Vec<Score>), so join the case definitions' scorer kinds positionally to
+        // name reward scorers. `list_cases` is org-scoped through the same caller.
+        let scorer_names_by_case: std::collections::HashMap<_, Vec<String>> = q::service(ctx)
+            .list_cases(&ctx.caller, &eval_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .into_iter()
+            .map(|case| (case.public_id, super::dataset::scorer_names(&case.scorers)))
+            .collect();
+
         let mut body = String::new();
         for result in &run.results {
             if !super::dataset::case_passes_filters(result, &self.req.filters) {
@@ -633,12 +644,17 @@ impl Command for ExportEvalRunDataset {
                 CommandError::internal(anyhow::anyhow!("load session messages: {e}"))
             })?;
             let messages = build_model_view_messages(&stored, &compaction, None).messages;
+            let empty = Vec::new();
+            let names = scorer_names_by_case
+                .get(&result.eval_case_id)
+                .unwrap_or(&empty);
             let record = super::dataset::build_record(
                 self.req.format,
                 &run,
                 result,
                 &messages,
                 &self.req.redaction,
+                names,
             );
             let line =
                 serde_json::to_string(&record).map_err(|e| CommandError::internal(e.into()))?;

--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -644,10 +644,10 @@ impl Command for ExportEvalRunDataset {
                 CommandError::internal(anyhow::anyhow!("load session messages: {e}"))
             })?;
             let messages = build_model_view_messages(&stored, &compaction, None).messages;
-            let empty = Vec::new();
             let names = scorer_names_by_case
                 .get(&result.eval_case_id)
-                .unwrap_or(&empty);
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
             let record = super::dataset::build_record(
                 self.req.format,
                 &run,

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -7,7 +7,7 @@
 
 use std::sync::LazyLock;
 
-use everruns_core::eval::{CaseResultStatus, EvalCaseResult, EvalRun};
+use everruns_core::eval::{CaseResultStatus, EvalCaseResult, EvalRun, Scorer};
 use everruns_core::message::{ContentPart, Message, MessageRole};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -171,21 +171,33 @@ pub fn source_key(run: &EvalRun, result: &EvalCaseResult) -> String {
     format!("{}/{}", run.public_id, result.public_id)
 }
 
+/// The case's scorer kinds in definition order, used to name reward scorers.
+pub fn scorer_names(scorers: &[Scorer]) -> Vec<String> {
+    scorers.iter().map(|s| s.kind().to_string()).collect()
+}
+
 /// The reward block shared by both formats.
-fn reward(result: &EvalCaseResult) -> Value {
-    let scorers: Vec<Value> = result
-        .scores
-        .as_ref()
-        .and_then(Value::as_array)
+///
+/// `scorer_names` are the case's scorer kinds in definition order (see
+/// [`scorer_names`]). Scores are persisted as an ordered `Vec<Score>` with no
+/// scorer identity, and the runner emits exactly one score per scorer in order,
+/// so the names join positionally. The join is only applied when the lengths
+/// match; otherwise each scorer falls back to its positional `scorer_{i}` label.
+fn reward(result: &EvalCaseResult, scorer_names: &[String]) -> Value {
+    let scores = result.scores.as_ref().and_then(Value::as_array);
+    let aligned = scores.is_some_and(|arr| arr.len() == scorer_names.len());
+    let scorers: Vec<Value> = scores
         .map(|arr| {
             arr.iter()
                 .enumerate()
                 .map(|(i, s)| {
+                    let name = if aligned {
+                        json!(scorer_names[i])
+                    } else {
+                        json!(format!("scorer_{i}"))
+                    };
                     json!({
-                        // Scorer names are not persisted on the result (only the
-                        // ordered Vec<Score>), so index positionally; joining the
-                        // case's scorer names is a follow-up.
-                        "name": s.get("name").cloned().unwrap_or_else(|| json!(format!("scorer_{i}"))),
+                        "name": name,
                         "value": s.get("value"),
                         "pass": s.get("pass"),
                         "reason": s.get("reason"),
@@ -273,6 +285,7 @@ pub fn build_record(
     result: &EvalCaseResult,
     messages: &[Message],
     redaction: &RedactionOptions,
+    scorer_names: &[String],
 ) -> Value {
     let mut record = match format {
         DatasetFormat::Trajectory => json!({
@@ -281,7 +294,7 @@ pub fn build_record(
             "case_id": result.eval_case_id.to_string(),
             "case_name": result.case_name,
             "session_id": result.session_id.map(|s| s.to_string()),
-            "reward": reward(result),
+            "reward": reward(result, scorer_names),
             "messages": serde_json::to_value(messages).unwrap_or_else(|_| json!([])),
             "metadata": metadata(run, result),
         }),
@@ -303,7 +316,7 @@ pub fn build_record(
             json!({
                 "source_key": source_key(run, result),
                 "messages": chat,
-                "reward": reward(result),
+                "reward": reward(result, scorer_names),
             })
         }
     };
@@ -448,6 +461,7 @@ mod tests {
             &r,
             &msgs,
             &RedactionOptions::default(),
+            &[],
         );
         assert_eq!(rec["reward"]["pass"], json!(true));
         assert_eq!(rec["reward"]["score"], json!(1.0));
@@ -469,6 +483,7 @@ mod tests {
             &r,
             &msgs,
             &RedactionOptions::default(),
+            &[],
         );
         let chat = rec["messages"].as_array().unwrap();
         assert_eq!(chat[0]["role"], json!("user"));
@@ -489,6 +504,7 @@ mod tests {
             &RedactionOptions {
                 redact_content: true,
             },
+            &[],
         );
         let serialized = serde_json::to_string(&rec).unwrap();
         assert!(!serialized.contains("secret business content"));
@@ -509,6 +525,7 @@ mod tests {
             &RedactionOptions {
                 redact_content: true,
             },
+            &[],
         );
         assert_eq!(rec["messages"][0]["content"], json!(REDACTED));
     }
@@ -526,12 +543,66 @@ mod tests {
             &r,
             &[],
             &RedactionOptions::default(),
+            &[],
         );
         let serialized = serde_json::to_string(&rec).unwrap();
         // Secrets outside `messages` (case_name, scorer reason) are scrubbed too.
         assert!(!serialized.contains("sk-abcdef0123456789ABCDEF"));
         assert!(!serialized.contains("AKIAABCDEFGHIJKLMNOP"));
         assert!(serialized.contains(REDACTED));
+    }
+
+    #[test]
+    fn reward_joins_scorer_names_positionally() {
+        use everruns_core::eval::Scorer;
+        let r = result_with(
+            CaseResultStatus::Passed,
+            json!([
+                {"pass": true, "value": 1.0, "reason": "has it"},
+                {"pass": false, "value": 0.0, "reason": "too many turns"},
+            ]),
+        );
+        let names = scorer_names(&[
+            Scorer::Contains {
+                text: "ok".into(),
+                weight: 1.0,
+            },
+            Scorer::TurnsWithin {
+                max: 3,
+                weight: 1.0,
+            },
+        ]);
+        let rec = build_record(
+            DatasetFormat::Trajectory,
+            &run(),
+            &r,
+            &[],
+            &RedactionOptions::default(),
+            &names,
+        );
+        let scorers = rec["reward"]["scorers"].as_array().unwrap();
+        assert_eq!(scorers[0]["name"], json!("contains"));
+        assert_eq!(scorers[1]["name"], json!("turns_within"));
+    }
+
+    #[test]
+    fn reward_falls_back_to_positional_label_on_length_mismatch() {
+        // One score but two scorer names -> misaligned, so fall back to scorer_{i}
+        // rather than risk attaching the wrong name.
+        let r = result_with(
+            CaseResultStatus::Passed,
+            json!([{"pass": true, "value": 1.0, "reason": "ok"}]),
+        );
+        let rec = build_record(
+            DatasetFormat::Trajectory,
+            &run(),
+            &r,
+            &[],
+            &RedactionOptions::default(),
+            &["contains".to_string(), "regex".to_string()],
+        );
+        let scorers = rec["reward"]["scorers"].as_array().unwrap();
+        assert_eq!(scorers[0]["name"], json!("scorer_0"));
     }
 
     #[test]
@@ -550,6 +621,7 @@ mod tests {
             &RedactionOptions {
                 redact_content: true,
             },
+            &[],
         );
         let serialized = serde_json::to_string(&rec).unwrap();
         assert!(!serialized.contains("SECRETIMAGEDATA"));

--- a/specs/dataset-export.md
+++ b/specs/dataset-export.md
@@ -81,9 +81,12 @@ returns the NDJSON inline.
   `{ source_key, eval_run_id, case_id, case_name, session_id, reward: { pass, score, scorers: [{name, value, pass, reason}] }, messages: [...model-view messages...], metadata: { model, turns, input_tokens, output_tokens, latency_ms } }`
 - `sft`: `{ source_key, messages: [{role, content}], reward: { pass, score, scorers } }` — chat-message shape loadable by common SFT pipelines, with reward in a sidecar field so verifiable-reward filtering happens before training.
 
-Scorer names are not persisted on the result (only the ordered `Vec<Score>`), so
-they are indexed positionally (`scorer_0`, …); joining the case's scorer names
-is a follow-up.
+Scorer identities are not persisted on the result (only the ordered
+`Vec<Score>`), but the runner emits exactly one score per scorer in definition
+order, so each scorer's `name` is joined positionally from the case definition's
+`scorers` (the scorer kind, e.g. `contains`, `tool_called`). The join is applied
+only when the scorer count matches the score count; otherwise the export falls
+back to positional `scorer_0`, … labels rather than risk a mislabel.
 
 ### Idempotency
 
@@ -121,7 +124,6 @@ See `specs/threat-model.md` (TM-OBS-008) for the threat review.
 
 - Async dataset-handle API with status + stored dataset artifacts.
 - Honor the exact per-run compaction config for model-view reconstruction.
-- Join scorer names from the eval case definition.
 - Optional cost (`cost_usd`) via reporting-fact join.
 - Preference-pair / DPO dataset construction.
 - Continuous capture from production sessions (opt-in).


### PR DESCRIPTION
## What
Dataset export now labels each reward scorer with its scorer **kind** (e.g. `contains`, `tool_called`) joined from the eval case definition, instead of the positional placeholder `scorer_0`, `scorer_1`, … One slice of EVE-619 (dataset export Phase 2).

## Why
Scorer identities are not persisted on `EvalCaseResult` — only the ordered `Vec<Score>` (`{pass, value, reason}`). Phase 1 therefore indexed scorers positionally as `scorer_N`, which is opaque to anyone consuming the exported reward-labeled dataset. The runner (`run_scorers`) emits exactly one `Score` per scorer in definition order, so the case's `scorers` can be joined positionally to recover a meaningful name.

## How
- **`Scorer::kind()`** in `crates/core/src/eval.rs` — single source of truth mapping each variant to its serde tag, with an exhaustive match so new variants force a decision.
- The export command (`ExportEvalRunDataset`) loads the eval's cases via the existing **org-scoped `list_cases(&caller, …)`** and builds `eval_case_id → [scorer kind]`, passed into `build_record`.
- `reward()` names each scorer from the joined kinds **only when the scorer count equals the score count**; on any mismatch it falls back to `scorer_{i}` rather than risk attaching the wrong name.
- Spec (`specs/dataset-export.md`) updated; the "join scorer names" follow-up is removed from the deferred list.

## Risk
- **Low.** Output-shape refinement (the `name` string value changes; the record schema is unchanged). Server-internal; no API request/response type changes, no migrations. The only new data access reuses an existing org-scoped query.
- The positional join is guarded by a length check and is consistent with the existing `case_result_avg_score` zip in `service.rs`.

## Security
- Threat categories reviewed: **TM-TENANT** (the new `list_cases` load is scoped through the same `ctx.caller` as `get_run`; the case map is keyed within the already org-resolved eval, so no cross-org scorer names can leak), **TM-OBS** (the `DATASET_EXPORT` policy gate is unchanged; scorer `reason` strings are still secret-scrubbed; the new `name` value is a non-sensitive scorer kind).
- No new dependencies. No injection / unbounded-input surface introduced.

## Validation
- `cargo test -p everruns-server --lib domains::evals::dataset` — 11 passed, including new `reward_joins_scorer_names_positionally` and `reward_falls_back_to_positional_label_on_length_mismatch`.
- `cargo clippy` (core + server) clean; `just pre-push` green.
- Smoke note: exercising the export endpoint end-to-end requires seeding a completed eval run with scorers; the join logic is fully covered by unit tests and the data load reuses the org-scoped `list_cases`, so a full-stack smoke is disproportionate for this change.

## Follow-ups
Remaining EVE-619 items, intentionally **deferred** (each is a separate, larger change; the issue stays open):
- Async dataset-handle API (`POST` enqueues a durable workflow returning a handle; `GET …/dataset/{dataset_id}`) with stored dataset artifacts.
- llmsim end-to-end export test + command-level cross-org tenant-isolation test.
- Honor the exact per-run compaction config for model-view reconstruction (currently default `CompactionConfig`).
- Optional `cost_usd` via reporting-fact join (`fact_llm_generation`).
- Landing blog post in `everruns/landing` (separate repo — out of this repo's scope).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (export record schema unchanged; only the `name` value is more descriptive)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Refs EVE-619

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjHAmyToRMBYpfuVBxgx9G)_