### PR TITLE
chore(deps): bump llmsim to 0.5.0 and gate it behind a feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,6 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -758,10 +757,8 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3149,17 +3146,6 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
-dependencies = [
- "bit-set 0.8.0",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
@@ -4766,25 +4752,20 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmsim"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf2c7d8ebf2b6c24175cb89658e4818ca04b98b69a39ee3b5a110d0e7187f80"
+checksum = "539672f1cd48a53f2554427acb6c69cf4e2c24a706acb89c22b4681fe0c4b2a0"
 dependencies = [
  "async-stream",
- "axum",
- "clap",
  "futures-core",
  "futures-util",
  "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tiktoken-rs",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
- "tower-http",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -5103,7 +5084,7 @@ dependencies = [
  "mlua-sys",
  "num-traits",
  "parking_lot",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustversion",
  "serde",
  "serde-value",
@@ -6374,7 +6355,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.4",
  "thiserror 2.0.18",
@@ -6395,7 +6376,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -7027,12 +7008,6 @@ dependencies = [
  "smallvec",
  "sqlite-wasm-rs",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8281,21 +8256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiktoken-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bstr",
- "fancy-regex 0.17.0",
- "lazy_static",
- "regex",
- "rustc-hash 1.1.0",
-]
-
-[[package]]
 name = "time"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8748,16 +8708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8767,15 +8717,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -115,8 +115,14 @@ eventsource-stream = "0.2"
 # Plugin system for external integrations
 inventory.workspace = true
 
-# LLM simulation for testing
-llmsim = "0.4.0"
+# LLM simulation for testing. Optional + behind the `llmsim` feature so the
+# provider-only crates (e.g. openrouter, which depend on core with
+# `default-features = false`) shed it entirely. default-features = false on
+# llmsim itself sheds its server/cli/tui/tokens subtrees (axum, tower-http,
+# tiktoken-rs, clap, tracing-subscriber, crossterm, ratatui) — the driver only
+# uses the in-process library types (generator, latency, openai, script,
+# stream).
+llmsim = { version = "0.5.0", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
 everruns-openui = { path = "../openui", version = "0.16.1", optional = true }
@@ -137,7 +143,7 @@ include_dir = { version = "0.7", optional = true }
 # Heavy subtrees stay ON by default so the application crates (server, worker,
 # cli, runtime) and core's own test suite are unchanged. Provider crates depend
 # on core with `default-features = false` to shed them — see crates/openrouter.
-default = ["llm-tests", "telemetry", "a2a", "web-fetch"]
+default = ["llm-tests", "telemetry", "a2a", "web-fetch", "llmsim"]
 # OTLP telemetry exporter (OpenTelemetry SDK + tracing-opentelemetry bridge).
 telemetry = [
     "dep:opentelemetry",
@@ -159,6 +165,11 @@ sqlx = ["dep:sqlx"]
 tree-sitter-outlines = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript", "dep:tree-sitter-python"]
 ui-capabilities = ["dep:everruns-openui", "dep:everruns-a2ui"]
 llm-tests = []  # LLM integration tests (requires API keys)
+# In-process LLM simulator driver (`llmsim_driver`) plus the in-memory agentic
+# loop that builds on it. On by default so the apps (server/worker/runtime/local)
+# and core's own tests are unchanged; provider-only crates that depend on core
+# with `default-features = false` drop llmsim and its subtree entirely.
+llmsim = ["dep:llmsim"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/core/src/command_host.rs
+++ b/crates/core/src/command_host.rs
@@ -481,7 +481,9 @@ impl CommandHost for StoreCommandHost {
     }
 }
 
-#[cfg(test)]
+// These tests drive the command host through the llmsim simulator, so they
+// follow the `llmsim` feature gate.
+#[cfg(all(test, feature = "llmsim"))]
 mod tests {
     use super::*;
     use crate::agent::{Agent, AgentStatus};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -167,10 +167,13 @@ pub mod user_facing_error;
 // In-memory implementations for examples and testing
 pub mod in_memory;
 
-// LLM Simulator driver for testing
+// LLM Simulator driver for testing (behind the `llmsim` feature)
+#[cfg(feature = "llmsim")]
 pub mod llmsim_driver;
 
-// In-memory agentic loop for testing and prototyping
+// In-memory agentic loop for testing and prototyping. Built on the llmsim
+// driver, so it follows the same feature gate.
+#[cfg(feature = "llmsim")]
 pub mod in_memory_loop;
 
 // Turn orchestration (state machine, context, outcomes)

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -466,6 +466,8 @@ mod tests {
         }
     }
 
+    // Registers the llmsim driver, so it follows the `llmsim` feature gate.
+    #[cfg(feature = "llmsim")]
     #[test]
     fn test_platform_definition_builder() {
         let mut drivers = DriverRegistry::new();

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -55,8 +55,9 @@ badge-free header and omit docs.rs links.
 Thin LLM provider crates (`openai`, `anthropic`, `gemini`, `bedrock`, `mai`,
 `fireworks`, `openrouter`) depend on `everruns-core` with
 `default-features = false`. Core's heavy subtrees (telemetry/OTLP, `a2a` gRPC,
-web-fetch/fetchkit) are opt-in features kept in core's `default`, so the
-application crates stay full while standalone provider builds shed them. Crates
+web-fetch/fetchkit, and the `llmsim` simulator driver) are opt-in features kept
+in core's `default`, so the application crates stay full while standalone
+provider builds shed them. Crates
 that pull in the runtime (e.g. `everruns-local` → `everruns-runtime`) cannot
 benefit — feature unification re-enables the subtrees — so they keep full
 defaults.


### PR DESCRIPTION
## What
Bump `llmsim` `0.4.0 → 0.5.0` and use its new feature gating to trim the dependency tree:

- Depend on llmsim with `default-features = false`, so core only pulls the in-process library types (`generator`, `latency`, `openai`, `script`, `stream`). This drops `tiktoken-rs` (+ `fancy-regex`, `rustc-hash`) and `tracing-serde` from the lockfile workspace-wide, and stops pulling `axum`/`tower-http`/`clap`/`tracing-subscriber`/`crossterm`/`ratatui` via llmsim.
- Make llmsim **optional** behind a new `llmsim` core feature (kept in `default`). The thin provider crates depend on core with `default-features = false`, so they now shed llmsim entirely — `cargo tree -p everruns-openrouter` reports **0** llmsim.

## Why
llmsim 0.5.0 moved its server/cli/tui/tokens stacks behind cargo features. The driver in core only needs the in-process library types, so the heavy HTTP/tokenizer/TUI subtrees were dead weight in every consumer's tree — especially the standalone provider crates (openrouter, openai, anthropic, gemini, bedrock, mai, fireworks) that exist to be small.

## How
- `crates/core/Cargo.toml`: `llmsim = { version = "0.5.0", default-features = false, optional = true }`; add `llmsim` feature (`dep:llmsim`) to `default`.
- `crates/core/src/lib.rs`: gate `llmsim_driver` and `in_memory_loop` (built on the driver) behind `#[cfg(feature = "llmsim")]`.
- Gate the llmsim-using test usages (`command_host.rs` test module, `platform_definition.rs::test_platform_definition_builder`).
- `specs/code-organization.md`: list llmsim among the shed subtrees.

Apps (server/worker/runtime/local) use core with default features, so they keep llmsim unchanged (the worker registers the llmsim driver unconditionally).

## Risk
- **Low.** Build/dependency-tree change; no logic change to `llmsim_driver.rs`. The llmsim library API used (generator/latency/openai/script/stream, `auto_tool_call_id`) is unchanged across 0.4→0.5. Provider crates verified to not reference the driver.

## Security
- Threat categories reviewed: **TM-LLM** (dependency / supply chain). No auth/authz/API/SQL/FS/bash/web surface touched.
- Findings and resolutions: None. llmsim is a test-only fake-LLM driver, never on a production prompt/secret/API path. The bump *reduces* supply-chain surface by removing `tiktoken-rs`, `fancy-regex`, `rustc-hash`, and `tracing-serde` from the tree. No `THREAT` comments affected.

## Validation
- `pre-push` green: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, lockfile freshness, migrations, specs index, attribution.
- Compiles: `openrouter` + all provider crates (no-llmsim path) and `core`/`worker`/`runtime`/`local` (default path).
- Tests: `everruns-runtime` `in_process_runtime_test` (23 tests, full agentic loops via the llmsim simulator) and core llmsim driver tests pass.
- Dependency-only change with no runtime behavior delta, so the loop integration tests through the simulator stand in for a full-stack smoke.

## Follow-ups
- The runtime crate keeps llmsim (its public `llm_sim` builder is a testing ergonomic, and feature unification re-enables it whenever runtime is in the graph). It still benefits from the slimmer 0.5.0. Fully dropping llmsim from runtime would require feature-gating its public API — deferred as out of scope and low value. No issue filed (deliberate design, documented in `specs/code-organization.md`).

## Checklist
- [x] Tests added or updated (existing llmsim suites cover the gated path; default features keep them running)
- [x] Backward compatibility considered (no public API change; apps keep llmsim via default)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_017i5c8vtb3rSY8Hd7b2EZUU)_