### PR TITLE
chore(release): prepare v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.16.2] - 2026-06-23
+
+### Highlights
+
+- **First-class OAuth Credentials** — Providers now support typed multi-field credential schemas, enabling proper OAuth credential configuration ([#2413](https://github.com/everruns/everruns/pull/2413)).
+- **MCP Always On** — The MCP endpoint is now always exposed; the `mcp_endpoint` feature flag has been removed ([#2395](https://github.com/everruns/everruns/pull/2395)).
+- **Parallel Tool Calls** — New `parallel_tool_calls` preference unified across all drivers ([#2398](https://github.com/everruns/everruns/pull/2398)).
+
+### What's Changed
+
+- chore(deps): bump llmsim to 0.5.0 and gate it behind a feature ([#2416](https://github.com/everruns/everruns/pull/2416)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): join scorer names in dataset export ([#2415](https://github.com/everruns/everruns/pull/2415)) by [@chaliy](https://github.com/chaliy)
+- feat(core): pluggable request auth for OpenResponses driver ([#2414](https://github.com/everruns/everruns/pull/2414)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): typed multi-field credential schemas (first-class OAuth) ([#2413](https://github.com/everruns/everruns/pull/2413)) by [@chaliy](https://github.com/chaliy)
+- fix(release): correct provider core version-pins after default-features opt-out ([#2412](https://github.com/everruns/everruns/pull/2412)) by [@chaliy](https://github.com/chaliy)
+- fix(loop-detection): interrupt repeated identical failed mutating calls ([#2411](https://github.com/everruns/everruns/pull/2411)) by [@chaliy](https://github.com/chaliy)
+- fix(session-file-system): make edit_file mixed-mode error corrective ([#2410](https://github.com/everruns/everruns/pull/2410)) by [@chaliy](https://github.com/chaliy)
+- fix(llm-tests): narrow quota detector for 429s ([#2408](https://github.com/everruns/everruns/pull/2408)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): use immutable session file blob keys ([#2407](https://github.com/everruns/everruns/pull/2407)) by [@chaliy](https://github.com/chaliy)
+- fix(ard): enforce egress controls ([#2406](https://github.com/everruns/everruns/pull/2406)) by [@chaliy](https://github.com/chaliy)
+- fix(orgs): require verified email for invites ([#2405](https://github.com/everruns/everruns/pull/2405)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): sign OAuth state cookie ([#2404](https://github.com/everruns/everruns/pull/2404)) by [@chaliy](https://github.com/chaliy)
+- fix(guardrails): reject client-side MCP allowlist entries ([#2403](https://github.com/everruns/everruns/pull/2403)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): preserve AG-UI endpoint auth on edit ([#2402](https://github.com/everruns/everruns/pull/2402)) by [@chaliy](https://github.com/chaliy)
+- refactor(providers): shed core default features in thin provider crates ([#2401](https://github.com/everruns/everruns/pull/2401)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): always expose MCP endpoint, drop mcp_endpoint flag ([#2395](https://github.com/everruns/everruns/pull/2395)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): gate telemetry, a2a, web-fetch behind cargo features ([#2399](https://github.com/everruns/everruns/pull/2399)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): parallel_tool_calls preference, unify drivers ([#2398](https://github.com/everruns/everruns/pull/2398)) by [@chaliy](https://github.com/chaliy)
+- refactor(api): expose feature flags as untyped key→bool map ([#2396](https://github.com/everruns/everruns/pull/2396)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): reward-labeled trajectory dataset export from eval runs ([#2397](https://github.com/everruns/everruns/pull/2397)) by [@chaliy](https://github.com/chaliy)
+- fix(chat): enforce global_chat flag end-to-end; clarify description ([#2392](https://github.com/everruns/everruns/pull/2392)) by [@chaliy](https://github.com/chaliy)
+- feat(schedules): min cron interval + per-org cap on session schedules ([#2394](https://github.com/everruns/everruns/pull/2394)) by [@chaliy](https://github.com/chaliy)
+- refactor(apps): graduate apps.detailV2, remove legacy app detail ([#2393](https://github.com/everruns/everruns/pull/2393)) by [@chaliy](https://github.com/chaliy)
+- docs(feature-flags): humanize org settings flag descriptions ([#2390](https://github.com/everruns/everruns/pull/2390)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): integration guides for agents, harnesses, and apps ([#2389](https://github.com/everruns/everruns/pull/2389)) by [@chaliy](https://github.com/chaliy)
+- refactor(ui): unify list cards behind shared EntityCard ([#2391](https://github.com/everruns/everruns/pull/2391)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add shared SearchInput for consistent search box height ([#2388](https://github.com/everruns/everruns/pull/2388)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): use accent variant for MCP Servers add button ([#2387](https://github.com/everruns/everruns/pull/2387)) by [@chaliy](https://github.com/chaliy)
+- test(runtime): make crate-level example a tested doctest ([#2386](https://github.com/everruns/everruns/pull/2386)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): classify provider type validation ([#2409](https://github.com/everruns/everruns/pull/2409)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.16.1] - 2026-06-21
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,11 +2331,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.16.1"
+version = "0.16.2"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2422,14 +2422,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2894,11 +2894,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.16.1"
+version = "0.16.2"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6346,9 +6346,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -6366,9 +6366,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6402,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -7045,9 +7045,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8257,9 +8257,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "libc",
@@ -8279,9 +8279,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -145,10 +145,10 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.16.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.16.1" }
+everruns-core = { path = "crates/core", version = "0.16.2" }
+everruns-mcp = { path = "crates/mcp", version = "0.16.2" }
 everruns-openai = { path = "crates/openai", version = "0.16.1" }
-everruns-runtime = { path = "crates/runtime", version = "0.16.1" }
+everruns-runtime = { path = "crates/runtime", version = "0.16.2" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+everruns-core = { path = "../core", version = "0.16.2", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+everruns-core = { path = "../core", version = "0.16.2", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["development-tools", "asynchronous"]
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.16.1" }
+everruns-config = { path = "../config", version = "0.16.2" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.0", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.16.1", optional = true }
+everruns-openui = { path = "../openui", version = "0.16.2", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.16.1", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.16.2", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+everruns-core = { path = "../core", version = "0.16.2", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+everruns-core = { path = "../core", version = "0.16.2", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.16.1", default-features = false }
+everruns-core = { path = "../core", version = "0.16.2", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## Release v0.16.2

This PR prepares the v0.16.2 patch release.

### Highlights

- **First-class OAuth Credentials** — Typed multi-field credential schemas for provider OAuth (#2413)
- **MCP Always On** — MCP endpoint always exposed, `mcp_endpoint` flag removed (#2395)
- **Parallel Tool Calls** — `parallel_tool_calls` preference unified across all drivers (#2398)

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Verify version numbers updated
- [x] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.16.2`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag