### PR TITLE
fix(core): serialize session sandbox tools

### DIFF
--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -778,6 +778,22 @@ mod tests {
     }
 
     #[test]
+    fn session_sandbox_tools_share_concurrency_class() {
+        let cap = SessionSandboxCapability;
+        let tools = cap.tools_with_config(&json!({"provider": "daytona"}));
+
+        for tool in tools {
+            let definition = tool.to_definition();
+            assert_eq!(
+                definition.concurrency_class(),
+                Some("session_sandbox"),
+                "{} should serialize against other session sandbox tools",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
     fn session_sandbox_config_schema_and_validation() {
         let cap = SessionSandboxCapability;
 

--- a/crates/core/src/session_sandbox.rs
+++ b/crates/core/src/session_sandbox.rs
@@ -502,6 +502,7 @@ pub async fn run_session_sandbox_init_if_needed(
 /// Shared hints for stateful remote sandbox tools.
 pub fn session_sandbox_tool_hints() -> ToolHints {
     ToolHints::default()
+        .with_concurrency_class("session_sandbox")
         .with_open_world(true)
         .with_requires_secrets(true)
         .with_long_running(true)


### PR DESCRIPTION
### Motivation
- The built-in `coding-session-sandbox` harness preferred `parallel_tool_calls`, but sandbox lifecycle and exec/write/manage tools share session/provider state and could race create/resume/delete/save flows, risking duplicate provider resources and availability issues.

### Description
- Add `with_concurrency_class("session_sandbox")` to `session_sandbox_tool_hints()` so all session sandbox tools are scheduled with the same concurrency class and therefore serialized against each other (file: `crates/core/src/session_sandbox.rs`).
- Add a focused regression test `session_sandbox_tools_share_concurrency_class` that converts each `Tool` to a `ToolDefinition` and asserts `definition.concurrency_class()` is `Some("session_sandbox")` (file: `crates/core/src/capabilities/session_sandbox.rs`).

### Testing
- Ran `cargo test -p everruns-core session_sandbox_tools_share_concurrency_class` and the test passed.
- Ran `cargo fmt --check` and it succeeded.
- Note: `git fetch origin main` was not run because this checkout has no `origin` remote configured (informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381106d598832b9d4a62206ed83026)