### PR TITLE
fix(storage): correct events message index predicate, prune indexes

### DIFF
--- a/crates/server/migrations/084_events_index_optimization.sql
+++ b/crates/server/migrations/084_events_index_optimization.sql
@@ -1,0 +1,53 @@
+-- Events index optimization for the hot read/write paths.
+--
+-- `events` is the highest-volume table (one row per streamed event) and is read
+-- on every agent turn. Three issues hurt under load:
+--
+-- 1. Predicate mismatch made the per-turn message read unable to use its index.
+--    `list_message_events` (storage/repositories/events.rs) filters
+--      event_type IN ('input.message', 'output.message.completed', 'tool.completed')
+--    but the partial index `idx_events_messages` only covered the first two
+--    types. Postgres can only use a partial index when the query predicate is
+--    *implied* by the index predicate; since the query also matches
+--    'tool.completed', the planner fell back to `idx_events_session_sequence`
+--    and scanned every event type in the session (deltas, turn.*, tool.started,
+--    ...) just to filter three. Widen the partial predicate to match the query.
+--
+-- 2. The full-text GIN index indexed streaming `output.message.delta` events.
+--    Deltas are the highest-volume event type and each one paid GIN maintenance
+--    on insert. The final text is already indexed via
+--    'output.message.completed', so indexing partial streaming chunks adds write
+--    cost and noisy partial matches with no search value. Drop 'delta' from the
+--    GIN predicate. (The generated `search_vector` column is unchanged; only its
+--    index footprint shrinks. Skipping tsvector *generation* for deltas needs a
+--    column rewrite and is left as a follow-up.)
+--
+-- 3. Two redundant indexes added write cost for no read benefit:
+--    - `idx_events_session_id` is a strict prefix of
+--      `idx_events_session_sequence(session_id, sequence)`, which also serves the
+--      ON DELETE CASCADE FK lookup. Fully redundant.
+--    - `idx_events_event_type` is a single low-selectivity column; every observed
+--      query that filters event_type also scopes by session_id (and is served by
+--      the session-scoped partial indexes), so the planner has no reason to pick
+--      a global event_type scan.
+
+-- 1. Recreate the message partial index so it matches the per-turn read query.
+DROP INDEX IF EXISTS idx_events_messages;
+CREATE INDEX idx_events_messages ON events(session_id, sequence)
+    WHERE event_type IN ('input.message', 'output.message.completed', 'tool.completed');
+COMMENT ON INDEX idx_events_messages IS
+    'Partial index for message reads (input.message, output.message.completed, tool.completed)';
+
+-- 2. Narrow the search GIN index to drop high-volume streaming deltas.
+DROP INDEX IF EXISTS idx_events_search_vector;
+CREATE INDEX idx_events_search_vector
+    ON events USING GIN (search_vector)
+    WHERE event_type IN (
+        'input.message',
+        'output.message.completed',
+        'tool.completed'
+    );
+
+-- 3. Drop redundant / low-value indexes to cut per-insert write amplification.
+DROP INDEX IF EXISTS idx_events_session_id;
+DROP INDEX IF EXISTS idx_events_event_type;


### PR DESCRIPTION
## What
Migration `084_events_index_optimization.sql` reworks the `events` table indexes:
1. Widen `idx_events_messages` partial predicate to include `tool.completed`.
2. Narrow the `idx_events_search_vector` GIN predicate to drop `output.message.delta`.
3. Drop two redundant/low-value indexes: `idx_events_session_id` and `idx_events_event_type`.

## Why
`events` is the highest-volume table (one row per streamed event) and is read on every agent turn.

- **Index predicate mismatch (the main fix).** The per-turn `list_message_events` read (`storage/repositories/events.rs`) filters `event_type IN ('input.message','output.message.completed','tool.completed')`, but `idx_events_messages` only covered the first two types. A partial index is only usable when the query predicate is *implied* by the index predicate; since the query also matches `tool.completed`, the planner could not use the partial index and fell back to `idx_events_session_sequence`, then **filtered every event type in the session** (deltas, turn.*, tool.started, …) on the hottest read path.
- **GIN write amplification.** The full-text GIN index indexed `output.message.delta` — the highest-volume event type (one per streamed token chunk). The final text is already indexed via `output.message.completed`, so indexing partial streaming chunks only adds insert cost and noisy partial matches.
- **Redundant indexes.** `idx_events_session_id` is a strict prefix of `idx_events_session_sequence` (which also serves the `ON DELETE CASCADE` FK lookup); `idx_events_event_type` is a single low-selectivity column and every observed `event_type` filter is session-scoped.

## How
Single additive SQL migration: `DROP`/`CREATE` the two partial indexes with corrected predicates and `DROP` the two redundant indexes. No application code changes — query shapes are unchanged, only which index serves them.

## Risk
- **Low.**
- Behavior change: `output.message.delta` events are no longer full-text searchable. This is intended — the authoritative final message text (`output.message.completed`) remains indexed.
- Dropping indexes could in theory slow a query that depended on them; verified that all `event_type` filters are session-scoped (served by the session-scoped partial indexes) and all `session_id` lookups (including FK cascade) are served by `idx_events_session_sequence`.
- The GIN rebuild takes a brief lock on `events` at migration time (consistent with how existing index migrations in this repo are written; none use `CONCURRENTLY`).

### Validation
- Applied **all 84 migrations** against a fresh PostgreSQL 16 instance — clean.
- `bash scripts/lib/check-migration-ordering.sh` → sequential `001..084`.
- Verified the resulting index set via `pg_indexes`, and confirmed dropped indexes are gone.
- `EXPLAIN` proof of the core fix:
  - **Old** 2-type predicate → `Index Scan using idx_events_session_sequence` **+ `Filter: event_type = ANY(...)`** (scans all event types in the session).
  - **New** 3-type predicate → `Index Scan using idx_events_messages` with no filter.

## Security
- Threat categories reviewed: **TM-DOS**, **TM-TENANT**, **TM-SQL**.
- Findings and resolutions:
  - TM-DOS: change *reduces* resource use (fewer/narrower indexes, usable index for the hot read). No new unbounded input. No negative impact.
  - TM-TENANT: `idx_events_messages` keeps `(session_id, sequence)` leading; queries still filter `session_id`, so tenant scoping is unchanged.
  - TM-SQL: pure index DDL; no query construction or injection surface touched.
  - No auth/authz/API/tool/LLM/FS surface touched; no `THREAT` comments near the change; no threat-model update needed.

## Follow-ups
- Stop *generating* the `search_vector` tsvector for `output.message.delta` rows (not just un-indexing them). Requires a generated-column rewrite on `events`, which is heavier; deferred to its own change.
- Drop additional likely-redundant global indexes pending `EXPLAIN`-level verification that no cross-org scan path relies on them: `idx_sessions_status`, `idx_llm_generations_created_at`. Deferred because confirming there is no global retention/cleanup scan (e.g. cross-org `DELETE ... WHERE created_at < ...`) needs more analysis than this PR's scope.
- Connection pool hardening (`statement_timeout`, `max_lifetime`) and the `pg_advisory_xact_lock(org_id)` turn-admission serialization are tracked separately as structural changes.

## Checklist
- [x] Tests added or updated — migration validated end-to-end against PG16 with `EXPLAIN` evidence (schema-only change; no unit test harness for index DDL)
- [x] Backward compatibility considered — additive migration; only `delta` FTS searchability changes (intended)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01XmuiqkHpTX9wLx4jXGxs4E

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmuiqkHpTX9wLx4jXGxs4E)_