### PR TITLE
chore(deps): bump bashkit 0.10.0 -> 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,9 +859,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868968c065151d2eec3aaba899f01540723dce112dcb8e23428a0f08aee3d7d6"
+checksum = "1df73e492ac81310360b851abf4b5761df1a6292bd10b53b5589e17a2226880a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -82,7 +82,7 @@ fetchkit = { version = "=0.4.0", features = ["bot-auth"], optional = true }
 ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
 
 # Bash interpreter backing the bashkit_shell capability
-bashkit = { version = "0.10.0", features = ["jq"] }
+bashkit = { version = "0.12.0", features = ["jq"] }
 
 # Sandboxed Lua interpreter for the experimental `lua` capability (vendored Lua
 # 5.4, never LuaJIT). Optional + behind the `lua` cargo feature so the default

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -82,7 +82,7 @@ futures-util.workspace = true
 flate2.workspace = true
 tar.workspace = true
 
-bashkit = { version = "0.10.0", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.12.0", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }


### PR DESCRIPTION
## What
Bumps the `bashkit` dependency from `0.10.0` to `0.12.0` (latest on crates.io, published 2026-06-23) in both `crates/core` (the `bashkit_shell` capability backend) and `crates/server` (the MCP `scripted_tool` execution path), plus the corresponding `Cargo.lock` update.

## Why
`bashkit` is the virtual Bash interpreter backing the `bashkit_shell` agent capability and the MCP-discovered builtin command execution path. Keeping it current picks up the latest upstream sandbox capabilities and hardening.

## How
Updated the two `Cargo.toml` declarations and ran `cargo update -p bashkit --precise 0.12.0`. No source changes were required — the upgrade is API-compatible (features unchanged: `jq` in core, `scripted_tool` + `jq` in server).

## Risk
- Low
- Only the bash sandbox / MCP scripted-tool execution backend is affected. A regression in upstream bashkit could affect agent shell execution, but the bumped library is fully exercised by existing tests and the change carries no source modifications.

Validation:
- `cargo build -p everruns-core -p everruns-server` — clean
- `cargo clippy -p everruns-core -p everruns-server --all-features --all-targets -- -D warnings` — clean
- `cargo test -p everruns-core --all-features --lib capabilities::bashkit_shell` — 77 passed
- `cargo test -p everruns-server --all-features --lib mcp_endpoint` — 61 passed
- Smoke test: booted `just start-dev` with the new dependency; the server compiled, started, and `/health` returned `200` (`{"status":"ok","version":"0.16.2"}`).

## Security
- Threat categories reviewed: **TM-BASH** (sandbox configuration, command execution) and **TM-TOOL** (MCP scripted-tool execution).
- Findings and resolutions: This is a version-only dependency bump with no source changes; the sandbox configuration in `bashkit_shell.rs` is unchanged and no `THREAT` comments are affected. The bump pulls in upstream hardening rather than introducing new threat surface. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing bashkit_shell + mcp_endpoint suites cover the bumped dependency)
- [x] Backward compatibility considered (API-compatible, no source changes)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013VCEzkjF1duaj9hqtsjfdg)_