### PR TITLE
fix(auth): reject MCP OAuth authorization-code replay (TOCTOU)

### DIFF
--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -1098,8 +1098,15 @@ async fn handle_authorization_code_grant(
         });
     }
 
-    // Consume the code (one-time use)
-    state
+    // Consume the code (one-time use). This is an atomic
+    // `UPDATE ... WHERE consumed = FALSE RETURNING ...` that returns `false`
+    // when a concurrent request already consumed this code. The earlier
+    // `auth_code.consumed` check is a stale read taken before PKCE validation,
+    // so relying on it alone lets two concurrent `authorization_code` grants
+    // for the same code both pass and mint tokens (auth-code replay TOCTOU).
+    // Treat losing the atomic consume as `invalid_grant` so only the first
+    // redemption succeeds — mirrors the refresh-token rotation gate above.
+    let consumed = state
         .db
         .consume_oauth_authorization_code(auth_code.id)
         .await
@@ -1107,6 +1114,12 @@ async fn handle_authorization_code_grant(
             error: "server_error".to_string(),
             error_description: None,
         })?;
+    if !consumed {
+        return Err(OAuthErrorResponse {
+            error: "invalid_grant".to_string(),
+            error_description: Some("Authorization code already used".to_string()),
+        });
+    }
 
     // Fetch user to populate token claims
     let user = state

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -2939,6 +2939,141 @@ async fn test_oauth_refresh_token_concurrent_retries_are_single_use() {
     assert_eq!(body["error"], "invalid_grant");
 }
 
+/// Helper: create a single authorization code and return the params needed to
+/// redeem it at `/oauth/token` (so a test can redeem the *same* code twice).
+async fn create_oauth_authorization_code_params(
+    server: &TestServer,
+    client_id: &str,
+) -> (String, String, String) {
+    let user_id = create_oauth_test_user(server).await;
+    let suffix = unique_suffix();
+    let code = format!("oauth-code-{suffix}");
+    let verifier = format!("oauth-verifier-{suffix}");
+    let redirect_uri = "http://localhost:9999/callback".to_string();
+
+    server
+        .db
+        .create_oauth_authorization_code(CreateOAuthAuthorizationCodeRow {
+            code_hash: hash_value(&code),
+            client_id: client_id.to_string(),
+            user_id,
+            org_id: DEFAULT_ORG_ID,
+            redirect_uri: redirect_uri.clone(),
+            code_challenge: pkce_challenge(&verifier),
+            code_challenge_method: "S256".to_string(),
+            scope: "mcp".to_string(),
+            expires_at: chrono::Utc::now() + chrono::Duration::minutes(5),
+        })
+        .await
+        .expect("failed to create OAuth authorization code");
+
+    (code, verifier, redirect_uri)
+}
+
+async fn redeem_oauth_authorization_code(
+    server: &TestServer,
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> test_harness::TestResponse {
+    server
+        .post(
+            "/oauth/token",
+            json!({
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": redirect_uri,
+                "code_verifier": verifier,
+            }),
+        )
+        .await
+}
+
+/// EVE-622: a leaked/intercepted authorization code must be redeemable at most
+/// once. The token endpoint reads `consumed` before PKCE validation, then relies
+/// on the atomic consume to reject replays.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_authorization_code_rejects_reuse() {
+    let server = TestServer::in_memory().await;
+    let (client_id, client_secret) = register_oauth_client(&server).await;
+    let (code, verifier, redirect_uri) =
+        create_oauth_authorization_code_params(&server, &client_id).await;
+
+    redeem_oauth_authorization_code(
+        &server,
+        &client_id,
+        &client_secret,
+        &code,
+        &verifier,
+        &redirect_uri,
+    )
+    .await
+    .assert_success();
+
+    let reuse = redeem_oauth_authorization_code(
+        &server,
+        &client_id,
+        &client_secret,
+        &code,
+        &verifier,
+        &redirect_uri,
+    )
+    .await;
+    assert_eq!(reuse.status(), StatusCode::BAD_REQUEST);
+    let body: Value = reuse.json();
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+/// EVE-622: two concurrent redemptions of the same code (the TOCTOU window) must
+/// resolve to exactly one success — without the atomic-consume check both would
+/// pass the stale `consumed` read and mint tokens.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_authorization_code_concurrent_retries_are_single_use() {
+    let server = TestServer::in_memory().await;
+    let (client_id, client_secret) = register_oauth_client(&server).await;
+    let (code, verifier, redirect_uri) =
+        create_oauth_authorization_code_params(&server, &client_id).await;
+
+    let (first, second) = tokio::join!(
+        redeem_oauth_authorization_code(
+            &server,
+            &client_id,
+            &client_secret,
+            &code,
+            &verifier,
+            &redirect_uri,
+        ),
+        redeem_oauth_authorization_code(
+            &server,
+            &client_id,
+            &client_secret,
+            &code,
+            &verifier,
+            &redirect_uri,
+        ),
+    );
+
+    let statuses = [first.status(), second.status()];
+    assert_eq!(
+        statuses.iter().filter(|status| status.is_success()).count(),
+        1,
+        "exactly one concurrent authorization_code redemption should succeed: {statuses:?}",
+    );
+
+    let failed = if first.status().is_success() {
+        second
+    } else {
+        first
+    };
+    assert_eq!(failed.status(), StatusCode::BAD_REQUEST);
+    let body: Value = failed.json();
+    assert_eq!(body["error"], "invalid_grant");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_oauth_token_invalid_content_type_falls_back_to_form() {
     let server = TestServer::new().await;


### PR DESCRIPTION
## What
Close an MCP OAuth authorization-code replay window. The `/oauth/token`
`authorization_code` grant now rejects any redemption that loses the atomic
single-use consume, instead of discarding that signal.

## Why
`handle_authorization_code_grant` checked `auth_code.consumed` — a value read
before PKCE validation — and then called `consume_oauth_authorization_code(id)`
but discarded the returned bool (the `?` only propagated errors). Two concurrent
`grant_type=authorization_code` requests for the same code could both pass the
stale `consumed` check and both mint access + refresh tokens; only one actually
flipped the flag. A leaked/intercepted authorization code could be redeemed more
than once.

## How
`consume_oauth_authorization_code` is an atomic
`UPDATE ... WHERE consumed = FALSE RETURNING ...` that returns `false` when a
concurrent request already consumed the code. Capture that result and return
`invalid_grant` ("Authorization code already used") when it is `false`, so only
the first redemption succeeds. This mirrors the existing refresh-token rotation
gate (TM-AUTH-018) in the same module.

## Risk
- Low. Behavior is unchanged for legitimate single redemption; only a
  concurrent/replayed redemption of the same code now fails closed.

## Security
- Threat categories reviewed: TM-AUTH (OAuth authorization-code single-use /
  replay; same class as TM-AUTH-018 refresh-token rotation race).
- Findings and resolutions: fixed the discarded atomic-consume result. Secondary
  RFC 6749 §4.1.2 hardening (revoking tokens already derived from a replayed
  code) is not needed to close this window — the loser of the race now never
  mints tokens — and is noted as a follow-up.

## Follow-ups
- Optional: on detected replay, proactively revoke tokens already derived from
  that code (defense-in-depth beyond the single-use gate).

## Checklist
- [x] Tests added or updated (sequential-reuse + concurrent single-use)
- [x] Backward compatibility considered (no change for legitimate flows)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Closes EVE-622
