### PR TITLE
fix(auth): fail closed on AUTH_MODE misconfiguration

### DIFF
--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -37,12 +37,20 @@ pub enum AuthMode {
 }
 
 impl AuthMode {
-    pub fn parse(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "admin" => AuthMode::Admin,
-            "full" => AuthMode::Full,
-            "external" => AuthMode::External,
-            _ => AuthMode::None,
+    /// Parse a recognized `AUTH_MODE` value, returning `None` for anything
+    /// unrecognized so callers can fail closed.
+    ///
+    /// The previous lenient `parse` mapped any unknown value (including typos
+    /// like `AUTH_MODE=production`) to `AuthMode::None` — which resolves every
+    /// request to an anonymous admin. Unknown values must be rejected, not
+    /// silently downgraded to no-auth. See EVE-621 / TM-AUTH-011.
+    pub fn parse_known(s: &str) -> Option<AuthMode> {
+        match s.trim().to_lowercase().as_str() {
+            "none" => Some(AuthMode::None),
+            "admin" => Some(AuthMode::Admin),
+            "full" => Some(AuthMode::Full),
+            "external" => Some(AuthMode::External),
+            _ => None,
         }
     }
 
@@ -54,6 +62,42 @@ impl AuthMode {
             AuthMode::External => "external",
         }
     }
+}
+
+/// Resolve the effective authentication mode from the raw `AUTH_MODE` value and
+/// the deployment grade, failing closed against the fail-open default
+/// (EVE-621 / TM-AUTH-011):
+///
+/// - Unrecognized `AUTH_MODE` values are rejected — a typo such as
+///   `AUTH_MODE=production` must not silently fall back to no-auth.
+/// - `none` mode resolves every request to an anonymous admin, so it is only
+///   permitted in dev deployments. A non-dev deployment that omits `AUTH_MODE`
+///   (or sets it to `none`) fails startup instead of coming up unauthenticated.
+fn resolve_auth_mode(
+    raw: Option<&str>,
+    grade: everruns_core::DeploymentGrade,
+) -> Result<AuthMode, String> {
+    let mode = match raw {
+        Some(s) => AuthMode::parse_known(s).ok_or_else(|| {
+            format!(
+                "AUTH_MODE='{s}' is not a recognized value \
+                 (expected one of: none, admin, full, external)"
+            )
+        })?,
+        None => AuthMode::None,
+    };
+
+    if mode == AuthMode::None && !grade.is_dev() {
+        return Err(format!(
+            "AUTH_MODE=none disables authentication — every request is treated as an \
+             anonymous admin with full access — and is only allowed in dev deployments \
+             (current deployment grade: {grade}). Set AUTH_MODE=admin|full|external for \
+             this deployment, or set DEPLOYMENT_GRADE=dev (or DEV_MODE=true) to explicitly \
+             opt into no-auth dev mode."
+        ));
+    }
+
+    Ok(mode)
 }
 
 /// OAuth provider configuration
@@ -167,9 +211,18 @@ impl Default for AuthConfig {
 impl AuthConfig {
     /// Load configuration from environment variables
     pub fn from_env() -> Self {
-        let mode = std::env::var("AUTH_MODE")
-            .map(|s| AuthMode::parse(&s))
-            .unwrap_or_default();
+        // Fail closed: reject unknown AUTH_MODE values and forbid no-auth
+        // `none` mode outside dev deployments, so a production server cannot
+        // silently come up unauthenticated by omission or typo (EVE-621).
+        let grade = everruns_core::DeploymentGrade::from_env();
+        let mode = resolve_auth_mode(std::env::var("AUTH_MODE").ok().as_deref(), grade)
+            .unwrap_or_else(|err| panic!("{err}"));
+        if mode == AuthMode::None {
+            tracing::warn!(
+                "AUTH_MODE=none: authentication is DISABLED — every request is treated as an \
+                 anonymous admin with full access. Intended for local development only."
+            );
+        }
 
         let api_prefix =
             std::env::var("API_PREFIX").unwrap_or_else(|_| DEFAULT_API_PREFIX.to_string());
@@ -477,15 +530,50 @@ mod tests {
 
     #[test]
     fn test_auth_mode_parsing() {
-        assert_eq!(AuthMode::parse("none"), AuthMode::None);
-        assert_eq!(AuthMode::parse("NONE"), AuthMode::None);
-        assert_eq!(AuthMode::parse("admin"), AuthMode::Admin);
-        assert_eq!(AuthMode::parse("ADMIN"), AuthMode::Admin);
-        assert_eq!(AuthMode::parse("full"), AuthMode::Full);
-        assert_eq!(AuthMode::parse("FULL"), AuthMode::Full);
-        assert_eq!(AuthMode::parse("external"), AuthMode::External);
-        assert_eq!(AuthMode::parse("EXTERNAL"), AuthMode::External);
-        assert_eq!(AuthMode::parse("invalid"), AuthMode::None);
+        assert_eq!(AuthMode::parse_known("none"), Some(AuthMode::None));
+        assert_eq!(AuthMode::parse_known("NONE"), Some(AuthMode::None));
+        assert_eq!(AuthMode::parse_known("admin"), Some(AuthMode::Admin));
+        assert_eq!(AuthMode::parse_known("ADMIN"), Some(AuthMode::Admin));
+        assert_eq!(AuthMode::parse_known("full"), Some(AuthMode::Full));
+        assert_eq!(AuthMode::parse_known("FULL"), Some(AuthMode::Full));
+        assert_eq!(AuthMode::parse_known("external"), Some(AuthMode::External));
+        assert_eq!(AuthMode::parse_known("EXTERNAL"), Some(AuthMode::External));
+        // EVE-621: unknown values are rejected, not silently mapped to no-auth.
+        assert_eq!(AuthMode::parse_known("invalid"), None);
+        assert_eq!(AuthMode::parse_known("production"), None);
+    }
+
+    #[test]
+    fn test_resolve_auth_mode_fails_closed() {
+        use everruns_core::DeploymentGrade;
+
+        // Unknown AUTH_MODE is rejected in every grade (no silent no-auth).
+        assert!(resolve_auth_mode(Some("production"), DeploymentGrade::Dev).is_err());
+        assert!(resolve_auth_mode(Some("production"), DeploymentGrade::Prod).is_err());
+
+        // `none` (explicit or by omission) is only allowed in dev.
+        assert_eq!(
+            resolve_auth_mode(None, DeploymentGrade::Dev),
+            Ok(AuthMode::None)
+        );
+        assert_eq!(
+            resolve_auth_mode(Some("none"), DeploymentGrade::Dev),
+            Ok(AuthMode::None)
+        );
+        assert!(resolve_auth_mode(None, DeploymentGrade::Prod).is_err());
+        assert!(resolve_auth_mode(Some("none"), DeploymentGrade::Prod).is_err());
+        assert!(resolve_auth_mode(None, DeploymentGrade::Preview).is_err());
+        assert!(resolve_auth_mode(None, DeploymentGrade::Poc).is_err());
+
+        // Real auth modes are accepted regardless of grade.
+        for grade in [DeploymentGrade::Dev, DeploymentGrade::Prod] {
+            assert_eq!(resolve_auth_mode(Some("admin"), grade), Ok(AuthMode::Admin));
+            assert_eq!(resolve_auth_mode(Some("full"), grade), Ok(AuthMode::Full));
+            assert_eq!(
+                resolve_auth_mode(Some("external"), grade),
+                Ok(AuthMode::External)
+            );
+        }
     }
 
     #[test]
@@ -538,13 +626,20 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_url_env();
         // SAFETY: this test holds ENV_LOCK.
-        unsafe { std::env::set_var("API_PREFIX", "/custom-api") };
+        // `none` mode (the default) is only permitted in dev deployments, so
+        // pin the grade for this base-URL-derivation test (EVE-621).
+        unsafe {
+            std::env::set_var("DEPLOYMENT_GRADE", "dev");
+            std::env::set_var("API_PREFIX", "/custom-api");
+        }
 
         let config = AuthConfig::from_env();
 
         assert_eq!(config.base_url, "http://localhost:9300/custom-api");
         assert_eq!(config.frontend_url, DEFAULT_PUBLIC_APP_URL);
         clear_auth_url_env();
+        // SAFETY: this test holds ENV_LOCK.
+        unsafe { std::env::remove_var("DEPLOYMENT_GRADE") };
     }
 
     #[test]
@@ -552,13 +647,20 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_url_env();
         // SAFETY: this test holds ENV_LOCK.
-        unsafe { std::env::set_var("API_PREFIX", "") };
+        // `none` mode (the default) is only permitted in dev deployments, so
+        // pin the grade for this base-URL-derivation test (EVE-621).
+        unsafe {
+            std::env::set_var("DEPLOYMENT_GRADE", "dev");
+            std::env::set_var("API_PREFIX", "");
+        }
 
         let config = AuthConfig::from_env();
 
         assert_eq!(config.base_url, DEFAULT_PUBLIC_APP_URL);
         assert_eq!(config.frontend_url, DEFAULT_PUBLIC_APP_URL);
         clear_auth_url_env();
+        // SAFETY: this test holds ENV_LOCK.
+        unsafe { std::env::remove_var("DEPLOYMENT_GRADE") };
     }
 
     #[test]

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -10,7 +10,7 @@ This document defines the authentication system for Everruns, supporting flexibl
 
 Everruns supports four authentication modes:
 
-1. **None** (`AUTH_MODE=none`): No authentication required. All requests use a well-known anonymous user (`ANONYMOUS_USER_ID = 00000000-0000-0000-0000-000000000001`). This is a real database user seeded at startup, so all code paths (org membership, personal access tokens, etc.) work uniformly without special-casing. The anonymous user has admin role and belongs to the default organization. Suitable for local development.
+1. **None** (`AUTH_MODE=none`): No authentication required. All requests use a well-known anonymous user (`ANONYMOUS_USER_ID = 00000000-0000-0000-0000-000000000001`). This is a real database user seeded at startup, so all code paths (org membership, personal access tokens, etc.) work uniformly without special-casing. The anonymous user has admin role and belongs to the default organization. **Local development only:** because `none` disables authentication, it is permitted **only in dev deployments** — `AuthConfig::from_env()` panics at startup if `none` is selected (explicitly or by omitting `AUTH_MODE`) when the deployment grade is not `dev`. Set `DEPLOYMENT_GRADE=dev` (or `DEV_MODE=true`) to opt into no-auth dev mode. Unrecognized `AUTH_MODE` values are likewise rejected at startup rather than falling back to `none`, so a typo such as `AUTH_MODE=production` cannot silently disable auth.
 
 2. **Admin** (`AUTH_MODE=admin`): Single admin user via environment variables. Suitable for local development with basic access control.
 
@@ -162,7 +162,7 @@ Account linking by email is supported (same email = same account).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `AUTH_MODE` | Authentication mode: `none`, `admin`, `full`, `external` | `none` |
+| `AUTH_MODE` | Authentication mode: `none`, `admin`, `full`, `external`. Unknown values are rejected at startup. `none` is allowed only in dev deployments (`DEPLOYMENT_GRADE=dev`/`DEV_MODE=true`); a non-dev deployment that omits or sets `AUTH_MODE=none` fails startup. | `none` (dev only) |
 | `PUBLIC_APP_URL` | Public browser origin for the app | `http://localhost:9300` |
 | `FRONTEND_URL` | Browser redirect origin; set only when different from `PUBLIC_APP_URL` | `PUBLIC_APP_URL` |
 | `AUTH_BASE_URL` | Base URL for OAuth callbacks, including API prefix | `PUBLIC_APP_URL` + `API_PREFIX` |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -102,7 +102,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-AUTH-008 | Session fixation via cookie | Medium | New tokens issued on login; HTTP-only, SameSite=Lax cookies | MITIGATED |
 | TM-AUTH-009 | Refresh token theft | High | Stored hashed in DB; HTTP-only cookie; revocable | MITIGATED |
 | TM-AUTH-010 | Admin password in env var | Low | Limited to admin mode; documented risk; shell history exposure possible | **ACCEPTED** |
-| TM-AUTH-011 | Auth bypass in `none` mode | Info | By design for local development; anonymous user gets admin role | **BY DESIGN** |
+| TM-AUTH-011 | Auth bypass in `none` mode | Info | By design for local development; anonymous user gets admin role. Fail-closed: `none` is gated to dev deployments and unknown `AUTH_MODE` values are rejected at startup (`AuthConfig::from_env`), so production cannot silently come up unauthenticated by omission or typo (EVE-621). | **BY DESIGN** |
 | TM-AUTH-012 | OAuth account linking collision | Medium | Accounts linked by email; if attacker controls email at provider, they gain access | **CALLER RISK** |
 | TM-AUTH-013 | Expired personal access token still in use | Medium | Expiration checked on every request via DB lookup; `last_used_at` tracked | MITIGATED |
 | TM-AUTH-014 | Account enumeration via registration | Medium | Returns generic "Registration failed" for existing emails; password hash computed first for timing consistency | MITIGATED |
@@ -1440,7 +1440,7 @@ path to any management API. Mitigations live in
 | ID | Threat | Rationale |
 |----|--------|-----------|
 | TM-AUTH-010 | Admin password in env var | Limited to development mode; documented |
-| TM-AUTH-011 | Auth bypass in none mode | By design for local development |
+| TM-AUTH-011 | Auth bypass in none mode | By design for local development; gated to dev deployments + unknown AUTH_MODE rejected at startup (EVE-621) |
 | ~~TM-API-008~~ | ~~WebFetch SSRF~~ | Reclassified to **MITIGATED** — fetchkit v0.1.2 DnsPolicy blocks private IPs |
 | TM-FS-006 | File content unencrypted at rest | Relies on infrastructure encryption |
 | TM-FS-007 | No file access audit log | Privacy tradeoff; not compliance-required |


### PR DESCRIPTION
## What
Make `AUTH_MODE` resolution fail closed so a server cannot silently come up
unauthenticated.

## Why
`AuthMode::parse` mapped any unrecognized `AUTH_MODE` value to `AuthMode::None`,
and the mode defaulted to `None` when `AUTH_MODE` was unset. In `none` mode every
request resolves to an anonymous **admin**. A production deployment that forgot
`AUTH_MODE`, or set a typo / unexpected value (e.g. `AUTH_MODE=production`),
silently came up with **no authentication** — full anonymous admin access to all
data and management APIs (EVE-621, TM-AUTH-011).

## How
- Replace lenient `AuthMode::parse` with `AuthMode::parse_known` (returns `None`
  for unrecognized input).
- Add `resolve_auth_mode(raw, grade)` which:
  - rejects unknown `AUTH_MODE` values (startup fails with an actionable error),
  - permits `none` (explicit or by omission) **only** in dev deployments
    (`DeploymentGrade::is_dev()`), failing startup otherwise.
- `AuthConfig::from_env()` routes through it (panicking on misconfiguration,
  consistent with the existing `AUTH_JWT_SECRET` startup panic) and logs a loud
  WARN when running in `none` mode.
- Update `specs/authentication.md` and threat-model TM-AUTH-011.

Dev and CI already set `DEV_MODE=true` / `DEPLOYMENT_GRADE=dev` before
`AUTH_MODE=none` (`scripts/lib/services.sh`, `.github/workflows/ci.yml`), so
local dev and CI flows are unaffected. `TestServer` builds `AuthConfig` directly
(not via `from_env`), and no test boots the real app builder, so the gate only
fires at genuine server startup.

## Risk
- Low–Medium. A non-dev deployment that *intentionally* ran `AUTH_MODE=none`
  must now set `DEPLOYMENT_GRADE=dev`/`DEV_MODE=true` (the whole point). All
  supported auth modes (`admin`/`full`/`external`) are unaffected in any grade.

## Security
- Threat categories reviewed: TM-AUTH (TM-AUTH-011 fail-open `none` default).
- Findings and resolutions: closed the silent fail-open — unknown values and
  non-dev `none` now fail startup. Updated TM-AUTH-011 in the threat model.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (`test_resolve_auth_mode_fails_closed`, updated
      parse + from_env tests)
- [x] Backward compatibility considered (dev/CI already set dev grade)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Closes EVE-621
