### PR TITLE
docs(env): replace real-looking example secrets with placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ DATABASE_URL=postgres://everruns:everruns@localhost:9332/everruns
 # Secrets Encryption (for API keys stored in database)
 # Format: key_id:base64_key (32 bytes, base64 encoded)
 # Generate with: python3 -c "import os, base64; print('kek-v1:' + base64.b64encode(os.urandom(32)).decode())"
-SECRETS_ENCRYPTION_KEY=kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
+SECRETS_ENCRYPTION_KEY=kek-v1:REPLACE_WITH_BASE64_32_BYTES
 # Previous key for rotation (optional, same format as above)
 # SECRETS_ENCRYPTION_KEY_PREVIOUS=kek-v0:...
 
@@ -46,13 +46,13 @@ WORKER_GRPC_ADDRESS=127.0.0.1:9001
 
 # Authentication (Admin Mode) - Single admin user for development
 # AUTH_MODE=admin
-# AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=
+# AUTH_JWT_SECRET=REPLACE_WITH_A_STRONG_RANDOM_SECRET  # e.g. openssl rand -base64 32
 # AUTH_ADMIN_EMAIL=admin@example.com
 # AUTH_ADMIN_PASSWORD=changeme
 
 # Authentication (Full Mode) - User registration + optional OAuth
 # AUTH_MODE=full
-# AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=
+# AUTH_JWT_SECRET=REPLACE_WITH_A_STRONG_RANDOM_SECRET  # e.g. openssl rand -base64 32
 # AUTH_DISABLE_SIGNUP=false
 # AUTH_DISABLE_PASSWORD=false
 #


### PR DESCRIPTION
## What
Replace the concrete `SECRETS_ENCRYPTION_KEY` and `AUTH_JWT_SECRET` values in
`.env.example` with obvious placeholders.

## Why
`.env.example` shipped real-looking base64 values (`kek-v1:8B3uCQ4...`,
`MJ5...`). They are throwaway dev/test values — CI (`.github/workflows/ci.yml`)
and `scripts/lib/services.sh` hold their own literal copies and `.env.example`
is not sourced anywhere — so this is **not** a live leak. But in a soon-to-be
public repo, key-shaped strings in the example invite copy-paste into
production: anyone using `.env.example` as-is would encrypt secrets under a
publicly-known KEK and sign JWTs with a known secret (EVE-633).

## How
- `SECRETS_ENCRYPTION_KEY=kek-v1:REPLACE_WITH_BASE64_32_BYTES`
- `AUTH_JWT_SECRET=REPLACE_WITH_A_STRONG_RANDOM_SECRET  # e.g. openssl rand -base64 32`
- Keep the existing generate-command comments.

CI and `services.sh` keep their functional throwaway test key (encrypted test
fixtures depend on that exact KEK, and the jobs are clearly test-only), so they
are intentionally left unchanged.

## Risk
- Low. `.env.example` is documentation and is not sourced by any script/test.

## Security
- Threat categories reviewed: secret hygiene for a public repo.
- Findings and resolutions: example no longer ships usable key material; the
  retained CI/dev key is clearly test infrastructure, not copy-pasteable config.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (N/A — example env file)
- [x] Backward compatibility considered (`.env.example` not sourced; dev/CI keys unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Closes EVE-633
