### PR TITLE
ci: set dev grade for Workflow Tests server boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,6 +927,11 @@ jobs:
       API_BASE_URL: http://localhost:9000
       WORKER_GRPC_AUTH_TOKEN: test-grpc-token-for-ci
       RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
+      # This job boots the server in no-auth mode for workflow tests. Since
+      # EVE-621, AUTH_MODE=none is only permitted in dev deployments, so the
+      # dev grade must be set explicitly (matching the other server-boot jobs).
+      DEV_MODE: "true"
+      AUTH_MODE: none
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## What
Set `DEV_MODE=true` / `AUTH_MODE=none` on the **Workflow Tests (Server + Worker)**
CI job so its no-auth server boot uses a dev deployment grade.

## Why
EVE-621 (#2428) made `AUTH_MODE=none` permitted only in dev deployments. The
Workflow Tests job boots `everruns-server` with no `AUTH_MODE` set, relying on
the old fail-open default (`none` in prod grade). After EVE-621 the server now
**panics at startup** there:

```
AUTH_MODE=none disables authentication ... only allowed in dev deployments
(current deployment grade: prod)
```

This job is `if: github.event_name == 'push'`, so it does not run on PRs — #2428's
PR CI was green, but the post-merge `main` push run failed (and subsequent pushes
keep failing). This restores main to green.

## How
Add `DEV_MODE: "true"` and `AUTH_MODE: none` to the job `env`, matching the other
server-boot jobs in `ci.yml` (which already set them). No application code change.

## Risk
- Low. CI-config only; makes an existing no-auth test environment an explicit dev
  deployment.

## Security
- Threat categories reviewed: none (CI configuration for a throwaway test server).
  Confirms the EVE-621 gate is enforced; the test env opts into no-auth dev mode
  explicitly.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (N/A — CI config; EVE-621 unit tests already cover the gate)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
