### PR TITLE
fix(auth): use constant-time comparison for credential checks

### DIFF
--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -14,6 +14,7 @@ use super::{
     jwt::JwtService,
     middleware::{AuthError, AuthState, AuthUser},
 };
+use crate::security::constant_time_eq;
 use crate::storage::StorageBackend;
 use crate::storage::models::{
     CreateOAuthAuthorizationCodeRow, CreateOAuthClientRow, CreateOAuthRefreshTokenRow,
@@ -61,7 +62,7 @@ fn verify_pkce_s256(verifier: &str, challenge: &str) -> bool {
     use base64::Engine;
     let hash = Sha256::digest(verifier.as_bytes());
     let computed = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash);
-    computed == challenge
+    constant_time_eq(computed.as_bytes(), challenge.as_bytes())
 }
 
 /// Validate a registered redirect URI for an MCP OAuth client.
@@ -1043,7 +1044,7 @@ async fn handle_authorization_code_grant(
     // Public clients (most MCP clients) rely on PKCE alone.
     if let Some(client_secret) = req.client_secret.as_deref() {
         let secret_hash = hash_value(client_secret);
-        if secret_hash != client.client_secret_hash {
+        if !constant_time_eq(secret_hash.as_bytes(), client.client_secret_hash.as_bytes()) {
             return Err(OAuthErrorResponse {
                 error: "invalid_client".to_string(),
                 error_description: Some("Invalid client_secret".to_string()),
@@ -1230,7 +1231,7 @@ async fn handle_refresh_token_grant(
     // Verify client secret if provided (confidential client).
     if let Some(client_secret) = req.client_secret.as_deref() {
         let secret_hash = hash_value(client_secret);
-        if secret_hash != client.client_secret_hash {
+        if !constant_time_eq(secret_hash.as_bytes(), client.client_secret_hash.as_bytes()) {
             return Err(OAuthErrorResponse {
                 error: "invalid_client".to_string(),
                 error_description: Some("Invalid client_secret".to_string()),

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -29,6 +29,7 @@ use super::{
     middleware::{AuthError, AuthMethod, AuthState, AuthUser, ORG_COOKIE_NAME},
     oauth::{GitHubOAuthService, GoogleOAuthService, OAuthProvider},
 };
+use crate::security::constant_time_eq;
 /// Enable AuthUser extractor when BuiltinAuthBackend is the route state.
 /// AuthUser needs AuthState via FromRef — this converts BuiltinAuthBackend to AuthState.
 impl FromRef<BuiltinAuthBackend> for AuthState {
@@ -318,9 +319,12 @@ pub async fn login(
 
     // In admin mode, check admin credentials directly (no database lookup)
     if state.config.mode == AuthMode::Admin {
+        // Constant-time comparison of both email and password, combined with a
+        // non-short-circuiting `&`, so login timing does not reveal which field
+        // matched or how many leading bytes of the password were correct.
         if let Some(admin) = &state.config.admin
-            && req.email == admin.email
-            && req.password == admin.password
+            && (constant_time_eq(req.email.as_bytes(), admin.email.as_bytes())
+                & constant_time_eq(req.password.as_bytes(), admin.password.as_bytes()))
         {
             // Create or get admin user
             let user = get_or_create_admin_user(&state, admin).await?;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -23,6 +23,9 @@ extern crate everruns_integrations_github;
 extern crate everruns_integrations_parallel;
 extern crate everruns_integrations_sprites;
 
+// Shared low-level security primitives (constant-time comparison, etc.)
+pub mod security;
+
 // API routes and types (shared for OpenAPI generation)
 pub mod api;
 

--- a/crates/server/src/security.rs
+++ b/crates/server/src/security.rs
@@ -1,0 +1,49 @@
+//! Shared low-level security primitives.
+
+/// Compare two byte slices in constant time with respect to their contents.
+///
+/// Secret/credential comparisons (passwords, hashed API keys and client
+/// secrets, PKCE challenges, HMAC signatures) must never use a short-circuiting
+/// `==`/`!=`: those return as soon as the first differing byte is found, leaking
+/// a timing side-channel an attacker can use to recover the secret byte by byte.
+///
+/// This returns `false` immediately when the lengths differ (length is not
+/// treated as secret) and otherwise inspects every byte without short-circuiting
+/// so the running time does not depend on the position of the first mismatch.
+///
+/// This is the single canonical implementation for the server crate — do not
+/// re-roll per-module copies.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::constant_time_eq;
+
+    #[test]
+    fn matches_equal_slices() {
+        assert!(constant_time_eq(b"abcd", b"abcd"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn rejects_differing_contents() {
+        assert!(!constant_time_eq(b"abcd", b"abce"));
+        assert!(!constant_time_eq(b"hello", b"world"));
+    }
+
+    #[test]
+    fn rejects_differing_lengths() {
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(!constant_time_eq(b"abcd", b"abc"));
+        assert!(!constant_time_eq(b"", b"a"));
+    }
+}


### PR DESCRIPTION
## What
Replace short-circuiting `==`/`!=` comparisons on secrets/credentials with a constant-time byte comparison, and add a single canonical `crate::security::constant_time_eq` helper.

## Why
`String ==`/`!=` returns as soon as the first differing byte is found, leaking a timing side-channel that lets an attacker recover a secret byte-by-byte. The admin password and the stored `client_secret_hash` are the highest-value targets (admin login is only IP-rate-limited, not per-credential). Fixes **EVE-629**.

## How
- New `crate::security::constant_time_eq` — length-checked, XOR-fold, no short-circuit — with unit tests. This is the canonical implementation for the server crate.
- **Admin login** (`auth/routes.rs`): compare email and password in constant time, combined with a non-short-circuiting `&` so timing does not reveal which field matched or how many leading password bytes were correct.
- **PKCE S256** (`auth/mcp_oauth.rs`): challenge verification routes through the helper.
- **MCP OAuth `client_secret_hash`** (`auth/mcp_oauth.rs`): both stored-secret checks route through the helper.

## Risk
- **Low.** Behaviour-preserving — identical accept/reject semantics; only comparison timing changes. No API, schema, or migration changes.

## Security
- Threat categories reviewed: **TM-AUTH** (credential/secret comparison timing).
- Findings and resolutions: removed timing side-channels on the four secret comparisons named in the issue; no remaining short-circuit comparisons on these secrets. Existing PKCE unit tests exercise the changed path.

## Follow-ups
- Six other **correct, already constant-time** copies of a local `constant_time_eq` exist in `crates/server/src/api/` (`app_endpoint_auth`, `app_api`, `app_a2a`, `internal_images`, `a2a_signing`, `fcp`, `ag_ui`). They are not vulnerabilities. Consolidating them onto `crate::security::constant_time_eq` is tracked as a follow-up (EVE-658) to keep this security fix small and reviewable.

## Checklist
- [x] Tests added or updated (`security::tests`; existing PKCE tests cover the verifier path)
- [x] Backward compatibility considered (internal; behaviour-preserving)
- [x] Security review performed against relevant threat model categories (TM-AUTH)
- [x] Final CI ran checks affected by this PR (all green; transient cargo-fetch flake re-run clean)
- [x] All review comments addressed (no review comments raised)