### PR TITLE
fix(grpc): constant-time worker token compare; document TM-AUTHZ-002

### DIFF
--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -384,7 +384,16 @@ impl Caller {
     ///
     /// Used for gRPC service calls (worker ↔ server) and other internal
     /// operations that should bypass all policy checks.
-    // THREAT[TM-AUTHZ-002]: Internal caller bypasses policies; only use for gRPC/internal paths
+    ///
+    /// THREAT[TM-AUTHZ-002]: This constructs an Owner / `is_internal` caller
+    /// that bypasses ALL policy evaluation for the given `org_id`. The worker
+    /// control plane builds it from the CLIENT-SUPPLIED `req.org_id` on every
+    /// RPC, so a single valid worker bearer token can act on ANY org — there is
+    /// no per-org token scoping. The full tenant-isolation guarantee on the
+    /// worker boundary therefore rests on (1) network isolation of that
+    /// boundary (it MUST never be reachable from untrusted networks) and (2)
+    /// the shared worker secret, which is constant-time compared in the gRPC
+    /// auth interceptor. Only ever call this from trusted gRPC/internal paths.
     pub fn internal(org_id: i64) -> Self {
         Self {
             org_id,

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -341,6 +341,15 @@ pub fn grpc_server_tls_from_env() -> Option<tonic::transport::ServerTlsConfig> {
 
 /// Tonic interceptor that validates bearer token on every gRPC request.
 /// If `expected_token` is `None`, all requests are allowed (dev mode).
+///
+/// THREAT[TM-AUTHZ-002]: This bearer token is the ONLY thing guarding the
+/// worker control-plane boundary. It is a single shared secret with no
+/// per-org scoping, so any client that presents it is fully trusted: every
+/// worker RPC builds `Caller::internal(req.org_id)` from the client-supplied
+/// `org_id`, which bypasses all policy checks. A single valid token can
+/// therefore act on any org. The worker boundary MUST never be reachable from
+/// untrusted networks. The token is compared in constant time below to avoid
+/// leaking it via a timing side-channel.
 #[derive(Clone)]
 pub struct GrpcAuthInterceptor {
     expected_token: Option<String>,
@@ -365,7 +374,11 @@ impl tonic::service::Interceptor for GrpcAuthInterceptor {
             .and_then(|v| v.strip_prefix("Bearer "));
 
         match token {
-            Some(t) if t == expected => Ok(request),
+            // Constant-time compare: the worker token is a shared secret, so a
+            // short-circuiting `==` would leak it byte-by-byte via timing.
+            Some(t) if crate::security::constant_time_eq(t.as_bytes(), expected.as_bytes()) => {
+                Ok(request)
+            }
             Some(_) => Err(Status::unauthenticated("Invalid gRPC auth token")),
             None => Err(Status::unauthenticated("Missing gRPC auth token")),
         }

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -207,6 +207,20 @@ fn test_interceptor_rejects_wrong_token() {
 }
 
 #[test]
+fn test_interceptor_rejects_same_length_wrong_token() {
+    // Same length as the expected token so the constant-time compare reaches
+    // its byte-comparison branch rather than short-circuiting on length.
+    let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
+    let mut request = Request::new(());
+    request
+        .metadata_mut()
+        .insert("authorization", "Bearer secret124".parse().unwrap());
+    let err = interceptor.call(request).unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    assert!(err.message().contains("Invalid"));
+}
+
+#[test]
 fn test_interceptor_rejects_non_bearer_scheme() {
     let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
     let mut request = Request::new(());

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -229,7 +229,7 @@ ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
 | TM-AUTHZ-001 | Default Owner role grants full access | Medium | By design for phase 1; all users are Owners. Future phases will assign roles via admin UI/invitation flow | **BY DESIGN** |
-| TM-AUTHZ-002 | Policy bypass via internal Caller | Medium | `Caller::internal()` bypasses policies with Owner role; only used in gRPC service (worker ↔ server), not HTTP-accessible | MITIGATED |
+| TM-AUTHZ-002 | Worker control plane trusts client-supplied `org_id`; one shared token grants cross-org authority | Medium | Every worker RPC builds `Caller::internal(req.org_id)` from the **client-supplied** `org_id`, which bypasses all policy (Owner role, `is_internal`). There is **no per-org token scoping**: any holder of the single shared worker bearer token can act on any org. Assumption/mitigation: the worker gRPC boundary is **never reachable from untrusted networks**, and the shared secret is **constant-time compared** in the auth interceptor (`grpc_service/mod.rs`) | **BY ASSUMPTION** (network isolation + shared secret) |
 | TM-AUTHZ-003 | Policy error reveals permission names | Low | 403 response includes policy ID and required permission; acceptable for debugging, no internal state leaked | **ACCEPTED** |
 | TM-AUTHZ-004 | Missing policy on mutating command | Medium | Every caller (HTTP/MCP/gRPC/platform) routes through `Command::run` which evaluates `Command::policy()`. Inventory coverage test (`crates/server/tests/command_policy_enforcement_test.rs`) asserts every non-GET command declares a policy — a missing declaration fails the build | MITIGATED |
 | TM-AUTHZ-005 | Anonymous app channel reaches draft, disabled, or protected app config | High | Public AG-UI ingress requires `AppStatus::Published` and an enabled `ag_ui` channel before any request work. Legacy configs then require `anonymous=true` plus the configured token when present. New inline endpoint auth (`channel_config.auth`) bypasses the legacy anonymous flag only after the shared verifier accepts the configured credential policy. Failures return before session creation or image upload. | MITIGATED |
@@ -246,8 +246,15 @@ ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 **TM-AUTHZ-001 — Default Owner Role (BY DESIGN):**
 Phase 1 assigns `OrgRole::Owner` as the default for all users. This means no permission-based restrictions are active in practice. This is intentional to avoid breaking existing workflows while the role assignment infrastructure is built in phase 2.
 
-**TM-AUTHZ-002 — Internal Caller:**
-`Caller::internal(org_id)` is used exclusively in `grpc_service.rs` for worker-to-server calls. The gRPC endpoint requires a bearer token in production (`TM-DURABLE-002`). HTTP handlers always construct `Caller` from `ResolvedOrg` with the user's actual role.
+**TM-AUTHZ-002 — Worker control plane trusts client-supplied `org_id` (BY ASSUMPTION):**
+Every worker→server RPC (`grpc_service/worker_service_impl.rs`) builds its caller via `Caller::internal(req.org_id)` (`crates/core/src/permissions.rs`), using the `org_id` supplied by the client in the request. `Caller::internal` constructs an Owner / `is_internal` caller that bypasses ALL policy evaluation. There is **no per-org scoping of the worker token**: the worker control plane authenticates with a **single shared bearer token**, so any client that presents a valid token can act on **any org** — the full tenant-isolation guarantee on the worker boundary rests on this one secret.
+
+This is accepted by assumption rather than fixed by per-org token scoping (a large redesign). The two pillars of the assumption are:
+
+1. **Network isolation** — the worker gRPC boundary MUST never be reachable from untrusted networks. HTTP handlers, by contrast, always construct `Caller` from `ResolvedOrg` with the user's actual role and are never able to reach `Caller::internal`.
+2. **Shared secret integrity** — the gRPC auth interceptor (`grpc_service/mod.rs`) requires a bearer token in production (`TM-DURABLE-002`) and now compares it in **constant time** (`crate::security::constant_time_eq`), so the token cannot be recovered via a timing side-channel.
+
+If the worker boundary is ever exposed to untrusted networks, or the shared token leaks, an attacker gains full cross-org Owner authority. Future hardening would scope worker tokens per org.
 
 **TM-AUTHZ-004 — Command Runner as Single Enforcement Point:**
 `Command::run` (`crates/server/src/domains/common.rs`) evaluates `Command::policy()` against the active `PermissionResolver` before dispatching to `execute`. HTTP adapters call `run`; MCP and gRPC `ExecuteCommand` route through `dispatch()` which calls `run`. Coverage is enforced by iterating `inventory::iter::<CommandDescriptor>` in a test, so new mutating commands that forget `policy()` fail the build. The legacy `#[policy]` attribute macro was removed — service-layer checks were redundant with `Command::run` and hardcoded `DefaultPermissionResolver`, re-introducing `TM-AUTHZ-008`.


### PR DESCRIPTION
## What
Two-part security hardening of the gRPC worker control plane (TM-AUTHZ-002):

1. Compare the worker bearer token in **constant time** in the gRPC auth interceptor (`grpc_service/mod.rs`), replacing the short-circuiting `==`.
2. Make the worker **trust assumption** prominent — clarify the `THREAT[TM-AUTHZ-002]` comments at `Caller::internal` and the auth interceptor, and expand the `specs/threat-model.md` entry.

## Why
- The shared control-plane↔worker secret was compared with `t == expected`, which short-circuits on the first differing byte and leaks a timing side-channel. The Slack / PKCE / admin-password paths already use the canonical constant-time helper; this was the inconsistent one.
- Every worker RPC builds `Caller::internal(req.org_id)` from the **client-supplied** `org_id`, and `Caller::internal` bypasses all policy (Owner role, `is_internal`). A single valid worker token can therefore act on **any** org. There is no per-org token scoping. That trust assumption needed to be loud and explicit in code and in the public threat model.

## How
- `grpc_service/mod.rs`: token match arm now uses `crate::security::constant_time_eq(t.as_bytes(), expected.as_bytes())`. Match-arm behaviour is identical (valid → `Ok`, invalid/missing → `unauthenticated`). Added a prominent `THREAT[TM-AUTHZ-002]` doc comment on `GrpcAuthInterceptor`.
- `crates/core/src/permissions.rs`: expanded the `THREAT[TM-AUTHZ-002]` comment on `Caller::internal` to spell out the cross-org authority and the two-pillar mitigation (network isolation + shared secret).
- `specs/threat-model.md`: rewrote the TM-AUTHZ-002 table row and prose to state that the worker control plane trusts the client-supplied `org_id`, that one valid token grants cross-org Owner authority, and that the mitigation/assumption is network isolation of the worker boundary plus the now-constant-time-compared shared secret.
- Added a unit test (`test_interceptor_rejects_same_length_wrong_token`) exercising the byte-comparison branch of the constant-time path.

Per-org worker token scoping is a large redesign and was intentionally **not** attempted; the issue explicitly accepts loud documentation of the trust assumption as the alternative.

## Risk
- Low.
- Auth behaviour is unchanged (only the comparison primitive changed); existing interceptor tests (valid/wrong/missing/non-bearer) plus the new same-length-wrong test all pass.

## Security
- Threat categories reviewed: TM-AUTHZ-002 (worker trust boundary), TM-AUTH (credential comparison). Related: EVE-629 (constant-time comparisons), EVE-634 (tenant-isolation hazards).
- Findings and resolutions:
  - Timing side-channel on the worker token → fixed with constant-time compare.
  - Cross-org authority from a single shared token (client-supplied `org_id`) → documented as a deliberate assumption (network isolation + shared secret); no behaviour change, no token re-scoping attempted.

## Follow-ups
- Per-org worker token scoping (would convert TM-AUTHZ-002 from BY ASSUMPTION to a fully enforced boundary). Deferred as a large redesign, out of scope here.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117eQmQajAuSoDpYHtzkLfZ)_