### PR TITLE
fix(agents): bound custom check rules

### DIFF
--- a/crates/server/src/domains/agents/check_rules/commands.rs
+++ b/crates/server/src/domains/agents/check_rules/commands.rs
@@ -18,8 +18,10 @@ const VALID_CATEGORIES: &[&str] = &[
     "safety",
     "cost",
 ];
-/// Bound custom rule text fields (TM-DOS).
+/// Bound custom rule text fields and identifiers (TM-DOS).
 const MAX_RULE_TEXT: usize = 4_000;
+const MAX_RULE_ID_LEN: usize = 128;
+const MAX_CUSTOM_RULES_PER_ORG: i64 = 100;
 
 /// List the org's effective check-rule configuration (built-ins + custom).
 #[derive(Debug, Deserialize, ToSchema)]
@@ -93,6 +95,7 @@ impl Command for UpsertAgentCheckRule {
 
     async fn execute(self, ctx: &Ctx) -> Result<CheckRulesResponse, CommandError> {
         let row = build_upsert_row(&self.rule_id, &self.req)?;
+        enforce_custom_rule_quota(ctx, &row).await?;
         ctx.db
             .upsert_agent_check_rule(ctx.org_id(), row)
             .await
@@ -218,14 +221,37 @@ fn build_upsert_row(
     }
 }
 
-fn require_custom_id(rule_id: &str) -> Result<(), CommandError> {
-    if rule_id.starts_with("custom.") && rule_id.len() > "custom.".len() {
-        Ok(())
-    } else {
-        Err(CommandError::bad_request(
-            "Custom rule id must start with 'custom.'",
-        ))
+async fn enforce_custom_rule_quota(
+    ctx: &Ctx,
+    row: &UpsertAgentCheckRuleRow,
+) -> Result<(), CommandError> {
+    if row.kind == "builtin_override" {
+        return Ok(());
     }
+
+    let existing_custom_rules = ctx
+        .db
+        .count_custom_agent_check_rules_excluding(ctx.org_id(), &row.rule_id)
+        .await
+        .map_err(classify_anyhow)?;
+    if existing_custom_rules >= MAX_CUSTOM_RULES_PER_ORG {
+        return Err(CommandError::conflict(format!(
+            "Custom agent check rule limit reached ({MAX_CUSTOM_RULES_PER_ORG})"
+        )));
+    }
+    Ok(())
+}
+
+fn require_custom_id(rule_id: &str) -> Result<(), CommandError> {
+    if !rule_id.starts_with("custom.") || rule_id.len() <= "custom.".len() {
+        return Err(CommandError::bad_request(
+            "Custom rule id must start with 'custom.'",
+        ));
+    }
+    if rule_id.len() > MAX_RULE_ID_LEN {
+        return Err(CommandError::bad_request("Custom rule id is too long"));
+    }
+    Ok(())
 }
 
 fn require_category(category: &Option<String>) -> Result<String, CommandError> {
@@ -276,6 +302,12 @@ mod tests {
     fn custom_rules_require_custom_prefix() {
         assert!(build_upsert_row("custom.no_todo", &req("declarative")).is_ok());
         assert!(build_upsert_row("no_todo", &req("declarative")).is_err());
+    }
+
+    #[test]
+    fn custom_rule_ids_are_bounded() {
+        let id = format!("custom.{}", "a".repeat(MAX_RULE_ID_LEN));
+        assert!(build_upsert_row(&id, &req("declarative")).is_err());
     }
 
     #[test]

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3740,6 +3740,19 @@ impl StorageBackend {
         dispatch!(self, list_agent_check_rules, org_id)
     }
 
+    pub async fn count_custom_agent_check_rules_excluding(
+        &self,
+        org_id: i64,
+        excluded_rule_id: &str,
+    ) -> Result<i64> {
+        dispatch!(
+            self,
+            count_custom_agent_check_rules_excluding,
+            org_id,
+            excluded_rule_id
+        )
+    }
+
     pub async fn upsert_agent_check_rule(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/agent_check_rules.rs
+++ b/crates/server/src/storage/memory/agent_check_rules.rs
@@ -6,6 +6,8 @@ use uuid::Uuid;
 use super::InMemoryDatabase;
 use crate::storage::models::*;
 
+const MAX_AGENT_CHECK_RULE_ROWS_PER_ORG_READ: usize = 256;
+
 impl InMemoryDatabase {
     pub async fn list_agent_check_rules(&self, org_id: i64) -> Result<Vec<AgentCheckRuleRow>> {
         let mut rows: Vec<AgentCheckRuleRow> = self
@@ -16,7 +18,24 @@ impl InMemoryDatabase {
             .cloned()
             .collect();
         rows.sort_by(|a, b| a.rule_id.cmp(&b.rule_id));
+        rows.truncate(MAX_AGENT_CHECK_RULE_ROWS_PER_ORG_READ);
         Ok(rows)
+    }
+
+    pub async fn count_custom_agent_check_rules_excluding(
+        &self,
+        org_id: i64,
+        excluded_rule_id: &str,
+    ) -> Result<i64> {
+        let count = self
+            .agent_check_rules
+            .read()
+            .values()
+            .filter(|r| {
+                r.org_id == org_id && r.kind != "builtin_override" && r.rule_id != excluded_rule_id
+            })
+            .count();
+        Ok(i64::try_from(count).unwrap_or(i64::MAX))
     }
 
     pub async fn upsert_agent_check_rule(

--- a/crates/server/src/storage/repositories/agent_check_rules.rs
+++ b/crates/server/src/storage/repositories/agent_check_rules.rs
@@ -5,6 +5,8 @@ use anyhow::Result;
 use crate::storage::Database;
 use crate::storage::models::*;
 
+const MAX_AGENT_CHECK_RULE_ROWS_PER_ORG_READ: i64 = 256;
+
 impl Database {
     pub async fn list_agent_check_rules(&self, org_id: i64) -> Result<Vec<AgentCheckRuleRow>> {
         let rows = sqlx::query_as::<_, AgentCheckRuleRow>(
@@ -14,12 +16,35 @@ impl Database {
             FROM agent_check_rules
             WHERE org_id = $1
             ORDER BY rule_id
+            LIMIT $2
             "#,
         )
         .bind(org_id)
+        .bind(MAX_AGENT_CHECK_RULE_ROWS_PER_ORG_READ)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
+    }
+
+    pub async fn count_custom_agent_check_rules_excluding(
+        &self,
+        org_id: i64,
+        excluded_rule_id: &str,
+    ) -> Result<i64> {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM agent_check_rules
+            WHERE org_id = $1
+              AND kind != 'builtin_override'
+              AND rule_id != $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(excluded_rule_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count)
     }
 
     pub async fn upsert_agent_check_rule(


### PR DESCRIPTION
### Motivation
- A high-privileged org admin could create an unbounded number of custom agent check rules which allowed large, org-scoped `list`/`upsert`/`preview`/`analyze` requests to fetch, serialize, compile, and evaluate arbitrarily many regexes, creating an availability (DoS) risk. 

### Description
- Add application-level quotas and identifier bounds by introducing `MAX_RULE_ID_LEN = 128` and `MAX_CUSTOM_RULES_PER_ORG = 100` and enforcing them in the upsert path via `enforce_custom_rule_quota` and `require_custom_id`.
- Add a backend count helper `count_custom_agent_check_rules_excluding` (Postgres + in-memory) so quota checks do not `SELECT`/serialize all rows before insert. 
- Add a defensive read cap `MAX_AGENT_CHECK_RULE_ROWS_PER_ORG_READ = 256` to `list_agent_check_rules` (Postgres `LIMIT` and in-memory `truncate`) to limit work performed by later preview/analyze paths when over-quota rows already exist.
- Add a unit test `custom_rule_ids_are_bounded` to validate oversized rule IDs are rejected.

### Testing
- Ran focused unit tests for the changed command module with `cargo test -p everruns-server domains::agents::check_rules::commands --lib`, and all tests passed (`6 passed`).
- Ran `cargo fmt --check` to verify formatting and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38149d8314832b86efa92c13899359)