### PR TITLE
fix(agents): persist parallel tool call updates

### DIFF
--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -537,6 +537,7 @@ impl Command for UpdateAgentCmd {
             network_access: req
                 .network_access
                 .map(|na| Some(serde_json::to_value(na).unwrap())),
+            parallel_tool_calls: req.parallel_tool_calls.map(Some),
             ..Default::default()
         };
         let row = ctx
@@ -1956,6 +1957,38 @@ mod tests {
             .expect("latest published lookup succeeds")
             .expect("published version exists");
         assert_eq!(latest_published.id, published.public_id);
+    }
+
+    #[tokio::test]
+    async fn update_agent_updates_parallel_tool_calls() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db, OrgRole::Owner);
+        let agent = CreateAgent(basic_agent_request("parallel-tool-calls-agent"))
+            .run(&ctx)
+            .await
+            .expect("agent is created");
+
+        let mut req = update_prompt_request("enable parallel tool calls");
+        req.parallel_tool_calls = Some(true);
+        let updated = UpdateAgentCmd {
+            id: agent.public_id.to_string(),
+            req,
+        }
+        .run(&ctx)
+        .await
+        .expect("agent enables parallel tool calls");
+        assert_eq!(updated.parallel_tool_calls, Some(true));
+
+        let mut req = update_prompt_request("disable parallel tool calls");
+        req.parallel_tool_calls = Some(false);
+        let updated = UpdateAgentCmd {
+            id: agent.public_id.to_string(),
+            req,
+        }
+        .run(&ctx)
+        .await
+        .expect("agent disables parallel tool calls");
+        assert_eq!(updated.parallel_tool_calls, Some(false));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `UpdateAgentRequest` exposes `parallel_tool_calls` for PATCH callers but the command layer omitted forwarding it into the storage `UpdateAgent`, causing PATCHes to silently leave the setting unchanged.

### Description
- Forward `req.parallel_tool_calls.map(Some)` into the `UpdateAgent` constructed by `UpdateAgentCmd` so the tri-state storage field is populated when present.
- Add a regression test `update_agent_updates_parallel_tool_calls` that PATCHes an agent with `parallel_tool_calls: true` and then `parallel_tool_calls: false` and asserts the returned agent reflects each change.
- Change is localized to `crates/server/src/domains/agents/commands.rs` and preserves existing behavior when the field is omitted.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran the focused unit test `cargo test -p everruns-server --lib update_agent_updates_parallel_tool_calls` which passed (`1 passed; 0 failed`).
- Performed a source/diff check (`git diff --check`) and formatting verification which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3814a07164832bbf589893899774c4)