### PR TITLE
fix(server): avoid canceling fired one-shot monitors

### DIFF
--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -625,6 +625,14 @@ mod tests {
     }
 
     async fn create_schedule(db: &Arc<StorageBackend>, session_id: SessionId) -> ScheduleId {
+        create_schedule_with_cron(db, session_id, Some("0 * * * *".to_string())).await
+    }
+
+    async fn create_schedule_with_cron(
+        db: &Arc<StorageBackend>,
+        session_id: SessionId,
+        cron_expression: Option<String>,
+    ) -> ScheduleId {
         let row = db
             .create_session_schedule(CreateSessionScheduleRow {
                 org_id: DEFAULT_ORG_ID,
@@ -632,7 +640,7 @@ mod tests {
                 owner_principal_id: PrincipalId::new(),
                 resolved_owner_user_id: None,
                 description: "Test schedule".to_string(),
-                cron_expression: Some("0 * * * *".to_string()),
+                cron_expression,
                 scheduled_at: None,
                 timezone: "UTC".to_string(),
                 next_trigger_at: None,
@@ -684,6 +692,37 @@ mod tests {
         assert_eq!(after[0].0, session_id);
         assert_eq!(after[0].1, task.id);
         assert_eq!(after[0].2, schedule_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn query_does_not_return_disabled_one_shot_schedule() {
+        let db = make_db();
+        let session_id = SessionId::new();
+
+        let schedule_id = create_schedule_with_cron(&db, session_id, None).await;
+        create_monitor_task(&db, session_id, schedule_id).await;
+
+        // One-shot firing disables the schedule before the monitor is marked
+        // Succeeded. The orphan sweep must not race that path and cancel it.
+        db.update_session_schedule(
+            DEFAULT_ORG_ID,
+            schedule_id,
+            UpdateSessionScheduleRow {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let results = db
+            .list_monitor_tasks_with_inactive_schedules(50)
+            .await
+            .unwrap();
+        assert!(
+            results.is_empty(),
+            "disabled one-shot schedule monitor must be excluded"
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/memory/session_tasks.rs
+++ b/crates/server/src/storage/memory/session_tasks.rs
@@ -167,7 +167,7 @@ impl InMemoryDatabase {
     }
 
     /// Return (session_id, task_id, schedule_id) triples for running monitor
-    /// tasks whose linked schedule is inactive (missing or enabled=false).
+    /// tasks whose linked schedule is inactive (missing or disabled recurring schedule).
     pub async fn list_monitor_tasks_with_inactive_schedules(
         &self,
         limit: i64,
@@ -190,10 +190,12 @@ impl InMemoryDatabase {
                 // Parse the schedule_id as a UUID/ScheduleId.
                 let schedule_id: everruns_core::ScheduleId = schedule_id_str.parse().ok()?;
 
-                // Inactive = missing row OR enabled=false.
+                // Inactive = missing row OR a disabled recurring schedule. Disabled
+                // one-shots are excluded: firing disables them before the linked
+                // monitor can be marked Succeeded.
                 let is_inactive = schedules
                     .get(&schedule_id)
-                    .map(|s| !s.enabled)
+                    .map(|s| !s.enabled && s.cron_expression.is_some())
                     .unwrap_or(true); // missing row → inactive
 
                 if is_inactive {

--- a/crates/server/src/storage/repositories/session_tasks.rs
+++ b/crates/server/src/storage/repositories/session_tasks.rs
@@ -275,11 +275,12 @@ impl Database {
     }
 
     /// Return (session_id, task_id, schedule_id) triples for running monitor
-    /// tasks whose linked schedule is inactive (missing row or enabled=false).
+    /// tasks whose linked schedule is inactive.
     ///
-    /// "Inactive" = the schedule row does not exist, OR its `enabled` column
-    /// is false.  Both cases mean the schedule will never fire again, so the
-    /// monitor is an orphan that should be canceled.
+    /// "Inactive" = the schedule row does not exist, OR it is a disabled
+    /// recurring schedule. Disabled one-shot schedules are excluded because
+    /// `mark_triggered` disables them before the firing path can complete the
+    /// linked monitor.
     ///
     /// Plain snapshot read — safe for concurrent sweepers because transitions
     /// are applied through `apply_task_update` where terminal states are final.
@@ -303,7 +304,7 @@ impl Database {
             WHERE st.kind = 'monitor'
               AND st.state = 'running'
               AND st.spec->>'schedule_id' ~ '^sched_[0-9a-f]{32}$'
-              AND (ss.id IS NULL OR ss.enabled = false)
+              AND (ss.id IS NULL OR (ss.enabled = false AND ss.cron_expression IS NOT NULL))
             ORDER BY st.id
             LIMIT $1
             "#,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -2737,7 +2737,7 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
     let session_id = session.id;
 
     // ------------------------------------------------------------------
-    // Fixture: a session schedule (enabled = true by default)
+    // Fixture: a recurring session schedule (enabled = true by default)
     // ------------------------------------------------------------------
     let schedule = backend
         .create_session_schedule(CreateSessionScheduleRow {
@@ -2755,6 +2755,26 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
         .expect("Failed to create test schedule");
 
     let schedule_id: ScheduleId = schedule.id;
+
+    // Fixture: a one-shot schedule. A fired one-shot is disabled before its
+    // linked monitor is marked Succeeded, so disabled one-shots are not orphan
+    // candidates.
+    let one_shot_schedule = backend
+        .create_session_schedule(CreateSessionScheduleRow {
+            org_id: TEST_ORG_ID,
+            session_id,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            description: "monitor-disabled-one-shot-test".to_string(),
+            cron_expression: None,
+            scheduled_at: Some(Utc::now()),
+            timezone: "UTC".to_string(),
+            next_trigger_at: None,
+        })
+        .await
+        .expect("Failed to create one-shot test schedule");
+
+    let one_shot_schedule_id: ScheduleId = one_shot_schedule.id;
 
     // ------------------------------------------------------------------
     // Fixture: running monitor task with a valid prefixed schedule_id
@@ -2778,6 +2798,26 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
         .expect("Failed to create monitor task");
 
     let task_id = monitor_task.id.clone();
+
+    let one_shot_monitor_task = new_session_task(
+        CreateSessionTask {
+            session_id,
+            id: None,
+            kind: TASK_KIND_MONITOR.to_string(),
+            display_name: "Test monitor (disabled one-shot pg)".to_string(),
+            spec: json!({ "schedule_id": one_shot_schedule_id.to_string() }),
+            state: SessionTaskState::Running,
+            links: TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+        },
+        Utc::now(),
+    );
+    backend
+        .create_session_task(&one_shot_monitor_task)
+        .await
+        .expect("Failed to create one-shot monitor task");
+
+    let one_shot_task_id = one_shot_monitor_task.id.clone();
 
     // ------------------------------------------------------------------
     // Fixture: a second monitor task with a *malformed* schedule_id.
@@ -2805,8 +2845,12 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
     let malformed_task_id = malformed_task.id.clone();
 
     // Helper: filter the global result list to rows belonging to this test.
-    let our_ids: std::collections::HashSet<String> =
-        [task_id.clone(), malformed_task_id.clone()].into();
+    let our_ids: std::collections::HashSet<String> = [
+        task_id.clone(),
+        one_shot_task_id.clone(),
+        malformed_task_id.clone(),
+    ]
+    .into();
 
     // ------------------------------------------------------------------
     // Step 4: schedule is still enabled → our task must NOT appear.
@@ -2828,8 +2872,8 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
     );
 
     // ------------------------------------------------------------------
-    // Step 5: disable the schedule (enabled = false).
-    // Our valid-spec task must now appear exactly once.
+    // Step 5: disable the recurring schedule and the one-shot schedule.
+    // Only the recurring valid-spec task must now appear exactly once.
     // ------------------------------------------------------------------
     backend
         .update_session_schedule(
@@ -2841,7 +2885,18 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
             },
         )
         .await
-        .expect("Failed to disable schedule");
+        .expect("Failed to disable recurring schedule");
+    backend
+        .update_session_schedule(
+            TEST_ORG_ID,
+            one_shot_schedule_id,
+            UpdateSessionScheduleRow {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Failed to disable one-shot schedule");
 
     let results_after = backend
         .list_monitor_tasks_with_inactive_schedules(500)
@@ -2878,6 +2933,12 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
             .iter()
             .all(|(_, tid, _)| tid != &malformed_task_id),
         "malformed-spec task must never appear in results"
+    );
+    assert!(
+        results_after
+            .iter()
+            .all(|(_, tid, _)| tid != &one_shot_task_id),
+        "disabled one-shot schedule task must never appear in results"
     );
 }
 


### PR DESCRIPTION
### Motivation
- The orphan-monitor sweep could race with the one-shot firing path because `mark_triggered` disables one-shot schedules before the linked monitor is marked `Succeeded`, allowing other scheduler instances to see a disabled one-shot and cancel the still-running monitor.
- The intent is to preserve correct one-shot semantics while still canceling monitors whose schedules are deleted or disabled for recurring schedules.

### Description
- Change inactive-schedule selection so disabled schedules only qualify when they are recurring by requiring `ss.cron_expression IS NOT NULL` in the PostgreSQL query, and mirror this logic in the in-memory backend. (`crates/server/src/storage/repositories/session_tasks.rs`, `crates/server/src/storage/memory/session_tasks.rs`)
- Exclude disabled one-shot schedules from orphan candidates while keeping missing schedule rows eligible. (`crates/server/src/storage/repositories/session_tasks.rs`, `crates/server/src/storage/memory/session_tasks.rs`)
- Add a unit test that verifies disabled one-shot schedules are not returned as orphan candidates: `query_does_not_return_disabled_one_shot_schedule` in `crates/server/src/session_scheduler.rs`.
- Extend the PG integration test `list_monitor_tasks_with_inactive_schedules_pg` to include a disabled one-shot schedule and assert it is excluded. (`crates/server/tests/repository_integration_test.rs`)

### Testing
- Ran `cargo fmt --check` which passed.
- Ran focused library unit tests `cargo test -p everruns-server --lib session_scheduler::tests::query_` which passed (new unit test included).
- Ran the sweep unit test `cargo test -p everruns-server --lib session_scheduler::tests::sweep_cancels_monitor_with_inactive_schedule` which passed.
- Ran the PG integration test `cargo test -p everruns-server --test repository_integration_test list_monitor_tasks_with_inactive_schedules_pg` but it failed to run due to local PostgreSQL being unavailable (`PoolTimedOut`); the test binary built and the failure is environmental, not an assertion failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38149d7da4832b85ef0e0258f311da)