### PR TITLE
fix(cli): validate OAuth CSRF state on login callback

### DIFF
--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -24,7 +24,8 @@ struct CliStartRequest {
 #[derive(Deserialize)]
 struct CliStartResponse {
     auth_url: String,
-    #[allow(dead_code)]
+    /// CSRF state nonce. Echoed back on the loopback callback and validated by
+    /// the CLI to bind the callback to this login attempt.
     state: String,
 }
 
@@ -57,6 +58,46 @@ struct OrgInfo {
     public_id: String,
     name: String,
     role: String,
+}
+
+/// Parsed `code`/`state` query parameters from the loopback OAuth callback.
+#[derive(Debug, Default, PartialEq)]
+struct CallbackParams {
+    code: Option<String>,
+    state: Option<String>,
+}
+
+impl CallbackParams {
+    /// Return the `code` only if a `state` is present and exactly matches the
+    /// `expected` value issued for this login attempt. Missing or mismatched
+    /// `state`, or a missing `code`, yields `None` (fail closed — CSRF defense).
+    fn validated_code(self, expected: &str) -> Option<String> {
+        match (self.code, self.state) {
+            (Some(code), Some(state)) if state == expected => Some(code),
+            _ => None,
+        }
+    }
+}
+
+/// Parse the `code` and `state` query parameters from an HTTP request's first
+/// line (`GET /callback?code=...&state=... HTTP/1.1`).
+fn parse_request_line(request: &str) -> Option<CallbackParams> {
+    let line = request.lines().next()?;
+    let path = line.split_whitespace().nth(1)?;
+
+    let mut params = CallbackParams::default();
+    // A request line with no query string yields empty params (which then fail
+    // validation), rather than `None` — only a malformed request line is `None`.
+    if let Some(query) = path.split('?').nth(1) {
+        for param in query.split('&') {
+            if let Some(value) = param.strip_prefix("code=") {
+                params.code = Some(value.to_string());
+            } else if let Some(value) = param.strip_prefix("state=") {
+                params.state = Some(value.to_string());
+            }
+        }
+    }
+    Some(params)
 }
 
 /// Run the login command
@@ -118,6 +159,10 @@ async fn run_oauth_login(api_url: &str, profile: &str) -> Result<()> {
     // api_url might be "http://localhost:9300/api" or "https://app.everruns.com/api"
     let success_redirect = success_url.clone();
 
+    // CSRF state issued for this login attempt. The loopback callback must echo
+    // it back unchanged; otherwise we refuse to exchange the code.
+    let expected_state = start.state.clone();
+
     let server = tokio::spawn(async move {
         let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
             .await
@@ -134,21 +179,10 @@ async fn run_oauth_login(api_url: &str, profile: &str) -> Result<()> {
             .expect("Failed to read request");
         let request = String::from_utf8_lossy(&buf[..n]);
 
-        // Parse the code from GET /callback?code=...
-        let code = request.lines().next().and_then(|line| {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() >= 2 {
-                let path = parts[1];
-                if let Some(query) = path.split('?').nth(1) {
-                    for param in query.split('&') {
-                        if let Some(value) = param.strip_prefix("code=") {
-                            return Some(value.to_string());
-                        }
-                    }
-                }
-            }
-            None
-        });
+        // Parse `code` and `state` from the GET request line, then enforce that
+        // the returned `state` matches the value we issued (CSRF protection).
+        let code = parse_request_line(&request)
+            .and_then(|callback| callback.validated_code(&expected_state));
 
         // Respond with redirect to success page
         let response = if code.is_some() {
@@ -157,7 +191,7 @@ async fn run_oauth_login(api_url: &str, profile: &str) -> Result<()> {
                 success_redirect
             )
         } else {
-            "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\nMissing code parameter"
+            "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\nInvalid login callback (missing code or state mismatch)"
                 .to_string()
         };
         tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes())
@@ -342,4 +376,69 @@ fn select_org(orgs: &[OrgInfo]) -> Result<String> {
         .context("Failed to select organization")?;
 
     Ok(orgs[selection].public_id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(query: &str) -> String {
+        format!(
+            "GET /callback?{} HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            query
+        )
+    }
+
+    #[test]
+    fn parses_code_and_state() {
+        let params = parse_request_line(&req("code=abc123&state=nonce42")).unwrap();
+        assert_eq!(
+            params,
+            CallbackParams {
+                code: Some("abc123".to_string()),
+                state: Some("nonce42".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn matching_state_yields_code() {
+        let params = parse_request_line(&req("code=abc123&state=nonce42")).unwrap();
+        assert_eq!(params.validated_code("nonce42"), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn mismatched_state_is_rejected() {
+        let params = parse_request_line(&req("code=abc123&state=attacker")).unwrap();
+        assert_eq!(params.validated_code("nonce42"), None);
+    }
+
+    #[test]
+    fn missing_state_is_rejected() {
+        // A callback with only `code` (the pre-fix behavior) must now fail closed.
+        let params = parse_request_line(&req("code=abc123")).unwrap();
+        assert_eq!(params.state, None);
+        assert_eq!(params.validated_code("nonce42"), None);
+    }
+
+    #[test]
+    fn missing_code_is_rejected() {
+        let params = parse_request_line(&req("state=nonce42")).unwrap();
+        assert_eq!(params.validated_code("nonce42"), None);
+    }
+
+    #[test]
+    fn empty_expected_state_does_not_accept_missing_state() {
+        // Defensive: even if the issued state were empty, a callback without a
+        // `state` parameter must not be accepted.
+        let params = parse_request_line(&req("code=abc123")).unwrap();
+        assert_eq!(params.validated_code(""), None);
+    }
+
+    #[test]
+    fn no_query_string_yields_empty_params() {
+        let params = parse_request_line("GET /callback HTTP/1.1\r\n\r\n").unwrap();
+        assert_eq!(params, CallbackParams::default());
+        assert_eq!(params.validated_code("nonce42"), None);
+    }
 }

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -284,10 +284,13 @@ async fn cli_auth_callback(
         serde_json::json!({}),
     );
 
-    // Redirect browser to CLI's localhost server with the exchange code
+    // Redirect browser to CLI's localhost server with the exchange code and the
+    // session `state`. The CLI validates that the returned `state` matches the
+    // value it received from `/cli/start`, binding the callback to the
+    // browser-initiated request (CSRF protection on the loopback callback).
     let redirect_url = format!(
-        "http://localhost:{}/callback?code={}",
-        session.redirect_port, session.exchange_code
+        "http://localhost:{}/callback?code={}&state={}",
+        session.redirect_port, session.exchange_code, session.state
     );
 
     Ok(Redirect::to(&redirect_url).into_response())

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -30,7 +30,7 @@ Interactive authentication. Uses localhost HTTP callback OAuth flow.
 - `login` — Open browser for OAuth login, receive a personal access token via localhost callback
 - `login --token` — Paste a personal access token directly (headless/SSH fallback)
 
-Flow: CLI → `POST /v1/auth/cli/start` → open browser → user logs in → server redirects to `localhost:{port}/callback?code=...` → CLI calls `POST /v1/auth/cli/exchange` → receives a personal access token + user info + orgs → interactive org selection → stores in credential file.
+Flow: CLI → `POST /v1/auth/cli/start` (returns `auth_url` + a CSRF `state` nonce) → open browser → user logs in → server redirects to `localhost:{port}/callback?code=...&state=...` → CLI rejects the callback unless `state` matches the value from `/cli/start` (CSRF binding) → CLI calls `POST /v1/auth/cli/exchange` → receives a personal access token + user info + orgs → interactive org selection → stores in credential file.
 
 ### `everruns logout`
 


### PR DESCRIPTION
## What
Validate the CSRF `state` parameter on the CLI OAuth loopback callback. The CLI now rejects the login (no token exchange) unless the `state` returned to its localhost callback is present and exactly matches the value issued by `/v1/auth/cli/start`. The server's final localhost redirect also forwards the session `state` so the CLI has something to compare against.

## Why
The CLI login flow received a `state` nonce from `/cli/start` but never validated it: the field was marked `#[allow(dead_code)]` and the loopback callback parser extracted only `code`. This left the localhost OAuth callback with no CSRF binding between the browser-initiated request and the callback — a malicious page hitting the local callback with an attacker-obtained `code` could complete login in the victim's CLI (login-CSRF / OAuth CSRF). Fixes EVE-657.

## How
- `crates/cli/src/commands/login.rs`: removed `#[allow(dead_code)]` on `CliStartResponse.state`; capture the issued `state` as the expected value; extract a new unit-testable `parse_request_line` -> `CallbackParams { code, state }`; gate the code on `validated_code(expected)`, which returns the code only when `state` is present and `==` the expected value (constant-string `==` is sufficient for a random nonce, matching codebase style). Failure responds `400` and never exchanges. Added unit tests for match / mismatch / missing-state / missing-code / no-query cases.
- `crates/server/src/auth/cli_auth.rs`: the post-login redirect to `localhost:{port}/callback` now also includes `&state={session.state}`.
- `specs/cli.md`: documented the `state` nonce and CSRF binding in the login flow.

## Risk
- Low.
- Behavior change: the loopback callback is now stricter. A callback missing `state` or with a mismatched `state` is rejected. The server change keeps the callback contract consistent (it now sends `state`), so the standard flow is unaffected. No DB/schema/API-shape changes.

## Security
- Threat categories reviewed: TM-AUTH (OAuth CSRF / login-CSRF on the CLI device-authorization loopback path).
- Findings and resolutions: The loopback callback previously accepted any `code` with no `state` check, dropping CSRF protection. Resolved by failing closed unless the returned `state` equals the per-attempt nonce issued by `/cli/start`. `state` is a 16-byte random hex nonce; the exchange code remains one-time-use server-side (unchanged). Distinct from EVE-622 (MCP replay), EVE-629 (PKCE timing), EVE-631 (DCR rate limit).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_0117eQmQajAuSoDpYHtzkLfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0117eQmQajAuSoDpYHtzkLfZ)_