### PR TITLE
fix(ui): guard /dev showcase pages behind isDev

### DIFF
--- a/apps/ui/src/app/dev/file-tree/page.tsx
+++ b/apps/ui/src/app/dev/file-tree/page.tsx
@@ -12,6 +12,9 @@ import { Button } from "@/components/ui/button";
 import { FileCode, FileJson, FileText, Image, File, Trash2, Plus, FolderPlus } from "lucide-react";
 import { usePageTitle } from "@/hooks";
 
+// Check if we're in development mode
+const isDev = process.env.NODE_ENV === "development";
+
 function getFileIcon(filename: string) {
   const ext = filename.split(".").pop()?.toLowerCase();
   switch (ext) {
@@ -33,9 +36,21 @@ function getFileIcon(filename: string) {
 }
 
 export default function FileTreeDevPage() {
-  usePageTitle("File Tree", "Dev");
+  usePageTitle(isDev ? "File Tree" : "Page not found", isDev ? "Dev" : null);
   const [selectedPath, setSelectedPath] = useState<string | undefined>();
   const [expanded, setExpanded] = useState<Set<string>>(new Set(["/workspace", "/workspace/src"]));
+
+  // Show 404-like message in production
+  if (!isDev) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
+          <p className="text-muted-foreground mt-2">Page not found</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-8 max-w-5xl mx-auto space-y-8">

--- a/apps/ui/src/app/dev/thinking-components/page.tsx
+++ b/apps/ui/src/app/dev/thinking-components/page.tsx
@@ -7,6 +7,9 @@
 import { StreamingThinking } from "@/components/streaming-thinking";
 import { usePageTitle } from "@/hooks";
 
+// Check if we're in development mode
+const isDev = process.env.NODE_ENV === "development";
+
 const SAMPLE_THINKING = `Let me analyze this step by step.
 
 1. First, I need to understand the context of the question. The user is asking about why the sky appears blue.
@@ -31,7 +34,19 @@ const SAMPLE_THINKING = `Let me analyze this step by step.
 const SHORT_THINKING = "This is a simple arithmetic question. 2+2 equals 4.";
 
 export default function ThinkingComponentsPage() {
-  usePageTitle("Thinking Components", "Dev");
+  usePageTitle(isDev ? "Thinking Components" : "Page not found", isDev ? "Dev" : null);
+  // Show 404-like message in production
+  if (!isDev) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
+          <p className="text-muted-foreground mt-2">Page not found</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto p-8 max-w-4xl space-y-8">
       <h1 className="text-3xl font-bold mb-2">Thinking Components</h1>


### PR DESCRIPTION
## What
Add the production `isDev` guard to the two `/dev` showcase pages that were missing it: `dev/file-tree/page.tsx` and `dev/thinking-components/page.tsx`. When `process.env.NODE_ENV !== "development"` they now render the standard 404 "Page not found" state instead of the showcase.

## Why
EVE-655: the `/dev` showcase pages are meant to be dev-only, but these two rendered their content directly without any guard, so they were publicly reachable in production and leaked internal component playgrounds / dev UI surface before public launch.

Note on the issue scope: the issue lists seven pages. On inspection, five of them (`chat-components`, `openui-blocks`, `session-components`, `thinking-animations`, `tool-activity`) already render their entire body inside `DevPageShell` (`dev/_components/dev-page-shell.tsx`), which itself contains the same `if (!isDev)` 404 guard, so they were already protected by construction. Only `file-tree` and `thinking-components` used `usePageTitle` + a bespoke layout and were genuinely unguarded. I grepped the whole `dev/` tree to confirm no other unguarded page exists.

## How
Mirror the existing per-page guard idiom used in `dev/page.tsx`, `dev/model-picker/page.tsx`, and `dev/file-previews/page.tsx` exactly:

```tsx
const isDev = process.env.NODE_ENV === "development";
// ...
usePageTitle(isDev ? "<Title>" : "Page not found", isDev ? "Dev" : null);
if (!isDev) {
  return (
    <div className="flex items-center justify-center min-h-screen">
      <div className="text-center">
        <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
        <p className="text-muted-foreground mt-2">Page not found</p>
      </div>
    </div>
  );
}
```

No new mechanism introduced.

## Risk
- Low
- Only affects two dev-only showcase pages. In development behavior is unchanged; in production they now return a 404-style page instead of the showcase. No production runtime code paths are touched.

## Security
- Threat categories reviewed: information disclosure / unintended public surface (pre-public-launch hardening, per the issue's threat model). The change removes a production information-disclosure surface (internal component playgrounds reachable at `/dev/file-tree` and `/dev/thinking-components`).
- Findings and resolutions: Both pages now gate rendering behind `isDev` and return a 404 state in production, matching the established guard pattern. The other five showcase pages were verified already-guarded via `DevPageShell`.

## Follow-ups
The issue suggests centralizing the guard once in `dev/layout.tsx` (or excluding `/dev` from production builds) to remove per-page duplication and prevent future gaps. That is a larger refactor; this PR takes the minimal, low-risk fix that mirrors the existing idiom and closes the actual exposure. Centralization can be a separate change. Otherwise no follow-ups.

## Checklist
- [ ] Tests added or updated (no test harness for these pure dev showcase pages; behavior verified via typecheck/lint)
- [x] Backward compatibility considered (dev-only pages; no public API change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---

Local UI validation ran successfully in the worktree (pnpm install completed in ~7s): `pnpm lint` (oxlint), `pnpm format:check` (oxfmt), and `pnpm typecheck` (`tsc --noEmit`) all passed clean. CI's "UI Build, Lint & Test" job remains the authoritative gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_0117eQmQajAuSoDpYHtzkLfZ)_