### PR TITLE
fix(container-sandbox): secure Docker-host default; document runtime/egress assumptions

### DIFF
--- a/crates/container-sandbox/src/client.rs
+++ b/crates/container-sandbox/src/client.rs
@@ -1,8 +1,18 @@
 //! Docker Engine REST API client.
 //!
 //! Decision: Uses reqwest for HTTP/TCP connections to Docker Engine API v1.47.
-//! Docker host resolution: config → env `CONTAINER_SANDBOX_DOCKER_HOST` → default `http://localhost:2375`.
-//! Unix socket support is a future enhancement (requires hyper unix transport).
+//! Docker host resolution: config → env `CONTAINER_SANDBOX_DOCKER_HOST` → default
+//! `unix:///var/run/docker.sock` (the secure local default).
+//! Unix socket transport is not yet supported by this reqwest-based client (it
+//! requires a hyper unix connector). Until that lands, leaving the host at the
+//! default fails closed at request time with a clear error instead of silently
+//! falling back to an unauthenticated network endpoint. See TM-SANDBOX-011.
+//!
+//! Security: the default must never be a plaintext, unauthenticated TCP endpoint
+//! (e.g. `http://localhost:2375`). Such an endpoint, if ever reachable over a
+//! network, grants full Docker control of the host (container escape). Operators
+//! that need a TCP daemon must set `CONTAINER_SANDBOX_DOCKER_HOST` explicitly and
+//! protect it with mTLS (`https://`); plaintext TCP must never be networked.
 //!
 //! Decision: All methods return `Result<T, String>` for consistency with the Daytona client
 //! pattern and easy mapping to ToolExecutionResult errors.
@@ -16,7 +26,14 @@ use tracing::{debug, warn};
 const API_VERSION: &str = "/v1.47";
 
 /// Default Docker host when no config or env is set.
-const DEFAULT_DOCKER_HOST: &str = "http://localhost:2375";
+///
+/// The local unix socket is the secure default: it is host-local and protected
+/// by filesystem permissions rather than exposed on the network. It is
+/// deliberately NOT a plaintext TCP endpoint — an unauthenticated
+/// `http://localhost:2375` default would grant full host control if ever
+/// networked (see TM-SANDBOX-011). Unix-socket transport is not yet implemented
+/// by this client, so this default fails closed (see `resolve_docker_host`).
+const DEFAULT_DOCKER_HOST: &str = "unix:///var/run/docker.sock";
 
 /// Environment variable for Docker host override.
 const DOCKER_HOST_ENV: &str = "CONTAINER_SANDBOX_DOCKER_HOST";
@@ -134,7 +151,10 @@ pub struct ExecOutput {
 
 pub struct DockerClient {
     http: reqwest::Client,
-    base_url: String,
+    /// Resolved HTTP base URL, or a deferred fail-closed error if the configured
+    /// host uses a transport this client cannot speak (currently: unix sockets).
+    /// We surface the error on the first request rather than panicking in `new`.
+    base_url: Result<String, String>,
 }
 
 impl DockerClient {
@@ -143,16 +163,26 @@ impl DockerClient {
     /// Host resolution priority:
     /// 1. Explicit `docker_host` parameter (from config)
     /// 2. `CONTAINER_SANDBOX_DOCKER_HOST` env var
-    /// 3. Default: `http://localhost:2375`
+    /// 3. Default: `unix:///var/run/docker.sock` (secure local default)
+    ///
+    /// The default unix socket is not yet supported by this reqwest-based
+    /// transport, so when the resolved host is a unix socket the client fails
+    /// closed: requests return a clear error asking the operator to set
+    /// `CONTAINER_SANDBOX_DOCKER_HOST` to an `http(s)://` daemon (protected with
+    /// mTLS for any non-loopback address). This is deliberately safer than
+    /// silently defaulting to an unauthenticated `http://localhost:2375`.
     pub fn new(docker_host: Option<&str>) -> Self {
-        let base_url = docker_host
+        let raw_host = docker_host
             .map(String::from)
             .or_else(|| std::env::var(DOCKER_HOST_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_DOCKER_HOST.to_string())
-            .trim_end_matches('/')
-            .to_string();
+            .unwrap_or_else(|| DEFAULT_DOCKER_HOST.to_string());
 
-        debug!(base_url = %base_url, "DockerClient initialized");
+        let base_url = resolve_docker_host(&raw_host);
+
+        match &base_url {
+            Ok(url) => debug!(base_url = %url, "DockerClient initialized"),
+            Err(e) => warn!(error = %e, "DockerClient initialized with unusable Docker host"),
+        }
 
         let http = reqwest::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(30))
@@ -166,7 +196,7 @@ impl DockerClient {
     /// For tests: create with explicit base URL.
     #[cfg(test)]
     pub fn with_base_url(base_url: String) -> Self {
-        let base_url = base_url.trim_end_matches('/').to_string();
+        let base_url = Ok(base_url.trim_end_matches('/').to_string());
         let http = reqwest::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(30))
             .timeout(std::time::Duration::from_secs(300))
@@ -175,8 +205,11 @@ impl DockerClient {
         Self { http, base_url }
     }
 
-    fn url(&self, path: &str) -> String {
-        format!("{}{API_VERSION}{path}", self.base_url)
+    /// Build a full request URL, propagating the deferred host-resolution error
+    /// (e.g. an unsupported unix-socket default) as a request-time failure.
+    fn url(&self, path: &str) -> Result<String, String> {
+        let base = self.base_url.as_ref().map_err(|e| e.clone())?;
+        Ok(format!("{base}{API_VERSION}{path}"))
     }
 
     // --- Generic request helpers ---
@@ -187,7 +220,7 @@ impl DockerClient {
         path: &str,
         body: Option<Value>,
     ) -> Result<Value, String> {
-        let url = self.url(path);
+        let url = self.url(path)?;
         let mut req = self
             .http
             .request(method, &url)
@@ -225,7 +258,7 @@ impl DockerClient {
         path: &str,
         body: Option<Value>,
     ) -> Result<T, String> {
-        let url = self.url(path);
+        let url = self.url(path)?;
         let mut req = self
             .http
             .request(method, &url)
@@ -259,7 +292,7 @@ impl DockerClient {
         path: &str,
         max_bytes: usize,
     ) -> Result<Vec<u8>, String> {
-        let url = self.url(path);
+        let url = self.url(path)?;
         let mut resp = self
             .http
             .request(method, &url)
@@ -285,7 +318,7 @@ impl DockerClient {
         path: &str,
         body: Option<Value>,
     ) -> Result<(), String> {
-        let url = self.url(path);
+        let url = self.url(path)?;
         let mut req = self
             .http
             .request(method, &url)
@@ -474,7 +507,7 @@ impl DockerClient {
     /// We demux the stream and combine stdout+stderr into a single string.
     pub async fn exec_start(&self, exec_id: &str) -> Result<String, String> {
         debug!(exec_id = %exec_id, "Starting exec");
-        let url = self.url(&format!("/exec/{exec_id}/start"));
+        let url = self.url(&format!("/exec/{exec_id}/start"))?;
         let resp = self
             .http
             .post(&url)
@@ -576,7 +609,7 @@ impl DockerClient {
         let encoded_path = urlencoding::encode(dir_path);
         let url = self.url(&format!(
             "/containers/{container_id}/archive?path={encoded_path}"
-        ));
+        ))?;
 
         let resp = self
             .http
@@ -603,6 +636,34 @@ impl DockerClient {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/// Resolve a raw Docker host string into an HTTP base URL this client can use.
+///
+/// `http://` and `https://` hosts are accepted (trailing slashes trimmed).
+/// Unix-socket hosts (`unix://`, including the secure default
+/// `unix:///var/run/docker.sock`) and any other unsupported scheme fail closed
+/// with an actionable error: this reqwest-based client cannot speak the unix
+/// transport yet, and we must never silently fall back to an unauthenticated
+/// network endpoint. The error is surfaced at request time. See TM-SANDBOX-011.
+fn resolve_docker_host(raw: &str) -> Result<String, String> {
+    let host = raw.trim();
+    if host.starts_with("http://") || host.starts_with("https://") {
+        return Ok(host.trim_end_matches('/').to_string());
+    }
+    if host.starts_with("unix://") {
+        return Err(format!(
+            "Docker host '{host}' uses a unix socket, which this client does not \
+             support yet. Set CONTAINER_SANDBOX_DOCKER_HOST to an http(s):// Docker \
+             daemon (use https:// with mTLS for any non-loopback address; never \
+             expose plaintext TCP on a network)."
+        ));
+    }
+    Err(format!(
+        "Unsupported Docker host '{host}'. Set CONTAINER_SANDBOX_DOCKER_HOST to an \
+         http(s):// Docker daemon URL (use https:// with mTLS for any non-loopback \
+         address)."
+    ))
+}
 
 /// Validate that a filename is safe for use inside a tar archive.
 /// Rejects path traversal (`..`), absolute paths (`/`), and backslash separators.
@@ -774,9 +835,61 @@ mod tests {
     fn test_url_construction() {
         let client = DockerClient::with_base_url("http://10.0.0.3:2375".to_string());
         assert_eq!(
-            client.url("/containers/json"),
+            client.url("/containers/json").unwrap(),
             "http://10.0.0.3:2375/v1.47/containers/json"
         );
+    }
+
+    #[test]
+    fn test_resolve_docker_host_accepts_http() {
+        assert_eq!(
+            resolve_docker_host("http://localhost:2375").unwrap(),
+            "http://localhost:2375"
+        );
+    }
+
+    #[test]
+    fn test_resolve_docker_host_accepts_https_and_trims_slash() {
+        assert_eq!(
+            resolve_docker_host("https://docker.internal:2376/").unwrap(),
+            "https://docker.internal:2376"
+        );
+    }
+
+    #[test]
+    fn test_resolve_docker_host_default_is_secure_unix_socket() {
+        // The default must be the host-local unix socket, never plaintext TCP.
+        assert_eq!(DEFAULT_DOCKER_HOST, "unix:///var/run/docker.sock");
+    }
+
+    #[test]
+    fn test_resolve_docker_host_unix_socket_fails_closed() {
+        // Unix-socket transport is unsupported today; it must fail closed with an
+        // actionable error rather than fall back to an unauthenticated endpoint.
+        let err = resolve_docker_host(DEFAULT_DOCKER_HOST).unwrap_err();
+        assert!(err.contains("unix socket"), "unexpected error: {err}");
+        assert!(
+            err.contains("CONTAINER_SANDBOX_DOCKER_HOST"),
+            "error should name the override env var: {err}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_docker_host_unknown_scheme_fails_closed() {
+        let err = resolve_docker_host("tcp://10.0.0.3:2375").unwrap_err();
+        assert!(err.contains("Unsupported Docker host"), "got: {err}");
+    }
+
+    #[test]
+    fn test_default_client_fails_closed_at_url_build() {
+        // With no config/env, the default unix socket means url() returns the
+        // deferred fail-closed error instead of building a plaintext-TCP URL.
+        // Note: relies on CONTAINER_SANDBOX_DOCKER_HOST being unset in this env.
+        if std::env::var(DOCKER_HOST_ENV).is_err() {
+            let client = DockerClient::new(None);
+            let err = client.url("/containers/json").unwrap_err();
+            assert!(err.contains("unix socket"), "unexpected error: {err}");
+        }
     }
 
     #[test]
@@ -889,7 +1002,7 @@ mod tests {
     fn test_url_trailing_slash_trimmed() {
         let client = DockerClient::with_base_url("http://10.0.0.3:2375/".to_string());
         assert_eq!(
-            client.url("/containers/json"),
+            client.url("/containers/json").unwrap(),
             "http://10.0.0.3:2375/v1.47/containers/json"
         );
     }

--- a/crates/container-sandbox/src/config.rs
+++ b/crates/container-sandbox/src/config.rs
@@ -21,10 +21,27 @@ const DEFAULT_AUTO_STOP_MINUTES: u64 = 10;
 /// Configuration for the container sandbox capability.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContainerSandboxConfig {
-    /// Docker Engine host URL (config → env → "http://localhost:2375")
+    /// Docker Engine host URL (config → env `CONTAINER_SANDBOX_DOCKER_HOST` →
+    /// default `unix:///var/run/docker.sock`).
+    ///
+    /// Security: the default is the host-local unix socket, never an
+    /// unauthenticated plaintext TCP endpoint. This reqwest-based client cannot
+    /// speak the unix transport yet, so leaving it at the default fails closed
+    /// (see `client::resolve_docker_host`). Operators needing a TCP daemon must
+    /// set an explicit `http(s)://` host and protect any non-loopback address
+    /// with mTLS; plaintext TCP must never be exposed on a network. See
+    /// TM-SANDBOX-011.
     #[serde(default)]
     pub docker_host: Option<String>,
-    /// Container runtime (e.g., "sysbox-runc"). Empty for default runc.
+    /// Container runtime (e.g., "sysbox-runc"). Empty = the host's default OCI
+    /// runtime, i.e. plain `runc`.
+    ///
+    /// Security: plain `runc` shares the host kernel and provides only
+    /// namespace/cgroup isolation. For untrusted or multi-tenant workloads the
+    /// deploying operator is responsible for configuring a hardened runtime
+    /// (`sysbox-runc` for user namespaces, or `gvisor`/`kata` for stronger
+    /// isolation). The default is intentionally `runc` so it works on stock
+    /// Docker and in CI. See TM-SANDBOX-001.
     #[serde(default)]
     pub runtime: String,
     /// Container image.
@@ -43,7 +60,16 @@ pub struct ContainerSandboxConfig {
     #[serde(default = "default_working_dir")]
     pub working_dir: String,
     /// Network mode (e.g., "bridge" or a custom network name).
-    /// TODO: will be wired into container creation in a follow-up.
+    ///
+    /// Note: container creation currently always attaches the sandbox to its own
+    /// per-session isolated bridge network (`sandbox-{org}-{session}`), so this
+    /// field is not yet consulted at create time.
+    ///
+    /// Security: no egress/private-IP/cloud-metadata (169.254.169.254) filtering
+    /// is applied by default — a sandboxed container can reach whatever its
+    /// bridge network can route to. Restricting egress (blocking RFC1918 ranges
+    /// and the metadata endpoint) is the deploying operator's responsibility at
+    /// the network/firewall layer. See TM-SANDBOX-003 and TM-AGENT-019.
     #[serde(default = "default_network_mode")]
     pub network_mode: String,
     /// Auto-stop timeout in minutes (for lease duration).

--- a/crates/container-sandbox/tests/live_api_test.rs
+++ b/crates/container-sandbox/tests/live_api_test.rs
@@ -2,7 +2,10 @@
 //!
 //! Gated behind:
 //! - Feature flag: `container-sandbox-live-tests`
-//! - Daemon availability on `CONTAINER_SANDBOX_DOCKER_HOST` (default `http://localhost:2375`).
+//! - Daemon availability on `CONTAINER_SANDBOX_DOCKER_HOST` (which the workflows
+//!   set explicitly to `http://localhost:2375`). The secure default host is the
+//!   local unix socket, which this client cannot speak yet, so these live tests
+//!   require the env var to point at an http(s):// daemon.
 //!   The workflow `.github/workflows/container-sandbox-integration.yml` runs a
 //!   `docker:dind` service with TLS disabled to provide this endpoint.
 //!

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1163,9 +1163,9 @@ Self-hosted container sandboxes via Docker Engine REST API. Agents create, exec,
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-SANDBOX-001 | Container escape via kernel vulnerability | High | Configurable runtime: default `runc`, production `sysbox-runc` (user namespaces + procfs virtualization); operator chooses isolation level | **ACCEPTED** |
+| TM-SANDBOX-001 | Container escape via kernel vulnerability | High | Configurable runtime (`runtime` config field): default empty = plain `runc`; operator chooses a hardened runtime (`sysbox-runc`, `gvisor`, `kata`) for untrusted/multi-tenant workloads | **ACCEPTED** |
 | TM-SANDBOX-002 | Resource exhaustion (memory/CPU/PIDs) | High | cgroup limits enforced via Docker create flags (`memory_limit`, `cpu_limit`, `pids_limit`); defaults: 2 GiB, 1 CPU, 256 PIDs | MITIGATED |
-| TM-SANDBOX-003 | Network attacks from sandbox | High | Per-sandbox isolated Docker bridge network; egress filtering blocks private IPs and cloud metadata (169.254.0.0/16) | MITIGATED |
+| TM-SANDBOX-003 | Network attacks / SSRF / metadata access from sandbox | High | Per-sandbox isolated Docker bridge network limits cross-sandbox reachability, but **no egress / private-IP / cloud-metadata (169.254.169.254) filtering is implemented**; default bridge networking can route to RFC1918 and metadata endpoints. Egress restriction is the operator's responsibility at the network/firewall layer | **ACCEPTED** |
 | TM-SANDBOX-004 | Cross-session container access | Critical | Container names include `session_id`; all Docker API queries filtered by `session` + `managed-by` labels; sandbox state stored in session-scoped secrets | MITIGATED |
 | TM-SANDBOX-005 | Image supply chain attack | Medium | Image allowlist in capability config; only pre-approved images can be pulled | MITIGATED |
 | TM-SANDBOX-006 | Docker socket exposure inside sandbox | High | Docker socket never mounted into containers; no `--privileged` flag | MITIGATED |
@@ -1173,11 +1173,18 @@ Self-hosted container sandboxes via Docker Engine REST API. Agents create, exec,
 | TM-SANDBOX-008 | Cross-tenant sandbox access | Critical | Tool scoping via `ToolContext.session_id` + per-sandbox network + Docker label filters; container names derived from session UUID, never user input | MITIGATED |
 | TM-SANDBOX-009 | Cross-tenant network reachability | High | Each sandbox gets its own isolated Docker bridge network (`sandbox-{org}-{session}`); sole member is the sandbox container | MITIGATED |
 | TM-SANDBOX-010 | Tenant resource starvation | High | Per-sandbox cgroups + per-org concurrent sandbox limits via leased resources | MITIGATED |
+| TM-SANDBOX-011 | Docker control-plane exposure via insecure host | High | Default Docker host is the host-local unix socket (`unix:///var/run/docker.sock`), never an unauthenticated plaintext TCP endpoint. The client fails closed when it cannot reach a usable daemon rather than defaulting to a network endpoint; TCP daemons must be set explicitly and protected with mTLS | MITIGATED |
 
 ### Mitigation Details
 
 **TM-SANDBOX-001 — Container Escape (ACCEPTED):**
-Container isolation depends on the kernel and runtime. Default `runc` provides namespace + cgroup isolation but shares the host kernel. For production multi-tenant deployments, operators should configure `sysbox-runc` (adds user namespaces, procfs/sysfs virtualization) or `kata`/`gvisor` for stronger isolation. The runtime is a deployment-time config field (`CONTAINER_SANDBOX_RUNTIME`), not baked into code.
+Container isolation depends on the kernel and runtime. The default (empty `runtime`) is plain `runc`, which provides namespace + cgroup isolation but shares the host kernel. This default is intentional so the capability works on stock Docker and in CI. For untrusted or multi-tenant workloads, the deploying operator is responsible for configuring a hardened runtime: `sysbox-runc` (adds user namespaces, procfs/sysfs virtualization) or `kata`/`gvisor` for stronger isolation. The runtime is a deployment-time config field (`runtime` in `ContainerSandboxConfig`), not baked into code.
+
+**TM-SANDBOX-003 — Network Egress (ACCEPTED):**
+Each sandbox runs on its own per-session Docker bridge network, which limits cross-sandbox reachability (TM-SANDBOX-009). However, no application-level egress filtering is implemented: a sandboxed container reaches whatever its bridge can route to, including RFC1918 private ranges and the cloud metadata endpoint (169.254.169.254) — so SSRF / internal-network probing from inside a sandbox is possible (see TM-AGENT-019). The `network_mode` config field is parsed but not yet consulted at container creation. Restricting egress (blocking RFC1918 + metadata) is the operator's responsibility at the network/firewall layer until in-product egress controls land.
+
+**TM-SANDBOX-011 — Docker Host Transport (MITIGATED):**
+The Docker Engine API is the control plane for the host's containers; an unauthenticated, plaintext TCP endpoint (e.g. `http://localhost:2375`) reachable over a network grants full Docker control and therefore host escape. The default host is the local unix socket (`unix:///var/run/docker.sock`), resolved via config → `CONTAINER_SANDBOX_DOCKER_HOST` env → default. The reqwest-based client does not speak the unix transport yet, so the default fails closed at request time with an actionable error rather than silently falling back to a network endpoint. Operators that need a TCP daemon must set `CONTAINER_SANDBOX_DOCKER_HOST` explicitly to an `http(s)://` URL and protect any non-loopback address with mTLS; plaintext TCP must never be exposed on a network. CI/dind sets this env explicitly to `http://localhost:2375` (loopback only), so the secure default does not affect tests.
 
 **TM-SANDBOX-004 — Cross-Session Isolation:**
 ```
@@ -1195,8 +1202,9 @@ Session A cannot access Session B's container:
 2. Per-sandbox Docker network: `sandbox-{org}-{session}`, sole member = the sandbox
 3. Label-filtered API calls: all queries include `session` + `managed-by` labels
 4. Per-org limits: max concurrent sandboxes checked at create time via leased resources
-5. Egress filtering: block private IPs + cloud metadata from sandbox bridges
-6. Runtime isolation: configurable (sysbox adds user-ns + procfs virtualization)
+5. Runtime isolation: configurable (sysbox adds user-ns + procfs virtualization)
+
+Note: egress filtering (blocking private IPs + cloud metadata) is **not** implemented in-product; it is the operator's network-layer responsibility (see TM-SANDBOX-003, TM-AGENT-019).
 
 ## 22. A2A Channel (TM-A2A)
 
@@ -1464,6 +1472,7 @@ path to any management API. Mitigations live in
 | TM-DENO-004 | Network probing from Deno sandbox | Same residual risk as other remote execution capabilities; requires Admin + operator egress controls |
 | TM-E2B-005 | Full-network sandbox misuse | Same residual risk class as other cloud sandboxes; require deployment egress isolation where needed |
 | TM-SANDBOX-001 | Container escape via kernel vulnerability | Configurable runtime; operator chooses isolation level (sysbox/kata/gvisor for production) |
+| TM-SANDBOX-003 | SSRF / metadata / internal-network access from sandbox | No in-product egress filtering; operator must restrict egress (block RFC1918 + 169.254.169.254) at the network/firewall layer |
 
 ### Caller Responsibilities
 


### PR DESCRIPTION
## What
Replace the container-sandbox default Docker host — previously the unauthenticated plaintext TCP endpoint `http://localhost:2375` — with the host-local unix socket `unix:///var/run/docker.sock`, and document the runtime/egress trust assumptions in code and the threat model.

## Why
EVE-626 (Security / Medium). The Docker Engine API is the host's container control plane. An unauthenticated plaintext TCP default, if ever reachable over a network, grants full Docker control and therefore host escape. The default must be the secure host-local socket, not a network endpoint. The issue also flagged that the threat model overstated the runtime/egress posture (claimed egress filtering that is not implemented; referenced a `CONTAINER_SANDBOX_RUNTIME` env that does not exist).

## How
- `client.rs`: default host is now `unix:///var/run/docker.sock`. Host resolution moved into a testable `resolve_docker_host()`. This reqwest-based client cannot speak the unix transport yet, so a unix-socket (or otherwise unsupported) host **fails closed**: `base_url` holds a deferred error that surfaces at request time with an actionable message (set `CONTAINER_SANDBOX_DOCKER_HOST` to an `http(s)://` daemon; use mTLS for any non-loopback address). This is deliberately safer than silently defaulting to an unauthenticated network endpoint. `http(s)://` hosts are accepted unchanged.
- `config.rs`: doc comments on `docker_host`, `runtime`, and `network_mode` now state the security assumptions — runtime default is plain `runc` (operator must opt into sysbox/gvisor/kata for untrusted workloads); no in-product egress/private-IP/metadata filtering is applied (operator's network-layer responsibility).
- `specs/threat-model.md`: added **TM-SANDBOX-011** (Docker host transport, MITIGATED). Corrected **TM-SANDBOX-001** (runtime is the `runtime` config field, not a non-existent env var) and **TM-SANDBOX-003** (egress filtering is **not** implemented → status ACCEPTED, operator responsibility), and fixed the stale "egress filtering" claim in the TM-SANDBOX-008 layer list.
- Added unit tests for `resolve_docker_host` (accepts http/https, fails closed on unix socket + unknown scheme) and a fail-closed-at-`url()` test.

## Risk
- **Low.** Behavior changes only when no host is configured via config or `CONTAINER_SANDBOX_DOCKER_HOST` env. In that case the client now returns a clear error instead of attempting an unauthenticated TCP connection that would only succeed against an insecure daemon.
- Public API of `DockerClient` is unchanged (`new`, request methods still return `Result<_, String>`). `url()` is private. Full-workspace clippy is green, so server/worker are unaffected.

### CI safety — confirmed the default change will not break CI
Both integration workflows set the host **explicitly** via env, so the env-override path is taken and the new default never applies:

- `.github/workflows/container-sandbox-integration.yml`:
  ```yaml
  env:
    CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
  ```
- `.github/workflows/integration-live-sweep.yml`:
  ```yaml
  env:
    CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
  ```

Both run a `docker:dind` service with `DOCKER_TLS_CERTDIR: ""` on loopback `2375`, and `DockerClient::new(None)` in `tests/live_api_test.rs` resolves that env. The host string is loopback-only, so the secure default is irrelevant to CI.

## Security
- Threat categories reviewed: **TM-SANDBOX** (container sandbox), **TM-AGENT-019** (internal network probing).
- Findings and resolutions:
  - Insecure default Docker control plane (plaintext unauthenticated TCP) → fixed: secure unix-socket default + fail-closed resolution; documented as TM-SANDBOX-011.
  - Runtime defaults to plain `runc` (no user-ns isolation) → documented as an accepted, operator-owned deployment decision (TM-SANDBOX-001); intentionally not changed because CI uses runc.
  - No egress/metadata/private-IP filtering for sandbox containers (SSRF/metadata reachable) → documented accurately as ACCEPTED, network-layer operator responsibility (TM-SANDBOX-003, TM-AGENT-019). No egress subsystem built (out of scope).

## Follow-ups
- Unix-socket transport support for the Docker client (would let the secure default work directly rather than fail closed). Rationale: requires a hyper unix connector; out of scope here.
- In-product egress filtering (block RFC1918 + 169.254.169.254) and wiring the parsed `network_mode`. Rationale: a filtering subsystem is a larger feature than this hardening fix.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal API unchanged; default-only behavior change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)