### PR TITLE
fix(llm-tests): skip on Anthropic 400 credit-balance exhaustion

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -207,6 +207,22 @@ pub fn is_quota_exhausted(err: &str) -> bool {
         return true;
     }
 
+    // Explicit credit/balance exhaustion that never uses the word "quota".
+    // Anthropic returns this as a 400 `invalid_request_error`, not a 429:
+    //   "Your credit balance is too low to access the Anthropic API. Please go
+    //    to Plans & Billing to upgrade or purchase credits."
+    // Require the billing/credit signal to be paired with an exhaustion phrase
+    // so ordinary billing-related prose isn't swallowed.
+    let exhaustion_phrase = e.contains("too low")
+        || e.contains("run out")
+        || e.contains("ran out")
+        || e.contains("out of credit")
+        || e.contains("purchase credit")
+        || e.contains("depleted");
+    if billing_signal && exhaustion_phrase {
+        return true;
+    }
+
     // HTTP 429 only counts when paired with an explicit quota/billing signal,
     // so plain rate limiting (which should be retried/flagged, not skipped)
     // still fails even if the provider says a rate limit was "exceeded".
@@ -274,6 +290,12 @@ mod quota_detector_tests {
         assert!(is_quota_exhausted(
             "You have exceeded your current quota for this month"
         ));
+        // Anthropic real-world 400 credit-balance exhaustion (no "quota" word,
+        // not a 429). This is the exact message returned when the account is
+        // out of credits and must skip rather than fail the matrix.
+        assert!(is_quota_exhausted(
+            "LLM error: Anthropic API error (400 Bad Request): {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.\"}}"
+        ));
         // Anthropic / Gemini style billing/credit exhaustion.
         assert!(is_quota_exhausted(
             "Your account has run out of credit; quota exhausted"
@@ -308,6 +330,10 @@ mod quota_detector_tests {
             "HTTP 429 Too Many Requests: requests per minute exceeded"
         ));
         assert!(!is_quota_exhausted("rate_limit_exceeded"));
+        // Billing-related prose without an exhaustion phrase must NOT be
+        // swallowed (e.g. a declined card or a generic billing notice).
+        assert!(!is_quota_exhausted("Please update your billing details"));
+        assert!(!is_quota_exhausted("Your credit card was declined"));
         // Auth/permission failures must never be swallowed as quota.
         assert!(!is_quota_exhausted("401 Unauthorized: invalid api key"));
         assert!(!is_quota_exhausted("403 Forbidden"));


### PR DESCRIPTION
## What

Make the live LLM matrix's quota-exhaustion detector (`is_quota_exhausted` in `crates/llm-tests/tests/llm_test_matrix/mod.rs`) recognize Anthropic's credit-balance exhaustion so the case **skips** instead of panicking.

## Why

`main` CI has been red on every post-merge push since ~05:21 UTC 2026-06-24. The only failing job is **Integration Tests (PostgreSQL)** → the push-gated `Run LLM integration tests` step. Four `case_1_anthropic_*` cases panic with:

```
Turn should succeed: Some("LLM error: Anthropic API error (400 Bad Request):
{...\"message\":\"Your credit balance is too low to access the Anthropic API.
Please go to Plans & Billing to upgrade or purchase credits.\"}")
```

The matrix is **designed** to skip a provider that is merely out of credits (a live billing condition, not a code regression — see the comment on the CI step and `skip_if_quota!`). But Anthropic returns credit exhaustion as a **400 `invalid_request_error`** whose message carries a `credit`/`billing` signal but **no `quota` word** and is **not a 429** — so the old detector returned `false`, the case panicked, and main went red.

> Note: this only fixes the test-skip logic. The underlying account is genuinely out of Anthropic credits; topping it up is a separate, operator-side action. This change ensures the billing condition no longer turns main red, matching the documented fail-closed-but-skip-on-billing contract.

## How

- Add a credit/balance-exhaustion branch: a billing signal (`credit`/`billing`) paired with an exhaustion phrase (`too low`, `run out`, `ran out`, `out of credit`, `purchase credit`, `depleted`) now counts as quota exhaustion. Auth/permission failures are still rejected earlier and never swallowed.
- Regression tests: the exact Anthropic 400 body asserts `true`; new negative guards (`"Please update your billing details"`, `"Your credit card was declined"`) assert `false` so ordinary billing prose isn't swallowed.

## Testing

`cargo test -p everruns-llm-tests --test agent_run_basic quota_detector` → 2 passed. `cargo fmt --check` clean.

## Risk

Low. Test-helper-only change in the `llm-tests` test crate; no product code touched.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [ ] Security review performed against relevant threat model categories (N/A — test-only)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FprnEcwVVkC44Sw4eAuGKN)_