### PR TITLE
fix(llm-tests): skip model-not-available live case when out of credits

### DIFF
--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -187,6 +187,12 @@ async fn test_model_not_available_returns_user_friendly_error(
 
     let result = runner.run_turn("Hello").await.unwrap();
 
+    // If the provider account is out of credits/quota, the live API returns a
+    // billing error before it ever validates the model name, so the
+    // "model not available" path can't be exercised — skip rather than fail
+    // (same billing-condition handling as the other live cases).
+    skip_if_quota!(result, model_name);
+
     // The turn should complete (not crash) but with failure
     assert!(!result.success, "Turn should fail for nonexistent model");
     let error = result.error.as_deref().unwrap_or("");


### PR DESCRIPTION
## What
Follow-up to #2452. Add a `skip_if_quota!` guard to `test_model_not_available_returns_user_friendly_error` so it skips (instead of failing) when the provider account is out of credits/quota.

## Why
After #2452 merged, the post-merge `main` CI run (commit `0e31125`) was **still red** on the push-gated LLM step — but only one case now: `test_model_not_available_returns_user_friendly_error::case_1_anthropic_nonexistent`.

Unlike the happy-path cases, that test *expects* a failed turn and asserts `error.contains("Model not available")`, so it never called `skip_if_quota!`. With the Anthropic account out of credits, the live API returns the **400 credit-balance** error *before* it validates the model name, so the assertion failed:

```
panicked at crates/llm-tests/tests/agent_run_basic.rs:194:
... "Your credit balance is too low ... purchase credits"
```

#2452 fixed the 3 happy-path cases (they now skip); this fixes the 4th.

## How
Insert `skip_if_quota!(result, model_name)` immediately after the turn and before the assertions: a billing/quota failure skips (consistent with the other live cases), while a genuine model-not-available error still runs the assertions. Verified all six live cases across `agent_run_basic` and `agent_run_with_thinking` are now quota-guarded.

## Testing
`cargo fmt --check` clean; test binary compiles (`--no-run`). The live step only runs on push (skipped on this PR).

## Risk
Low — test-only; adds a skip guard, no product code.

## Checklist
- [x] Tests added or updated (skip guard)
- [x] Backward compatibility considered
- [ ] Security review (N/A — test-only)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FprnEcwVVkC44Sw4eAuGKN)_