### PR TITLE
fix(ci): quarantine decommissioned ARD live registry tests

### DIFF
--- a/.github/workflows/ard-integration.yml
+++ b/.github/workflows/ard-integration.yml
@@ -55,10 +55,21 @@ jobs:
   # push/workflow_dispatch so an optional Doppler-provided token is never
   # available in a fork-PR context. The weekly `integration-live-sweep.yml`
   # backstop catches shared-crate regressions that slip past this gate.
+  #
+  # QUARANTINED (EVE-659): the public reference registry
+  # (https://agenticresourcediscovery.org/api/v1) was decommissioned — it is
+  # now a docs-only site (405/404 on the API; registry/api subdomains no longer
+  # resolve), so these fail-closed live tests can never pass. The job is gated
+  # off (`if: false`) rather than allowed to silently skip/pass, per the
+  # fail-closed contract in specs/integrations.md. The wiremock-backed unit +
+  # integration tests in the `unit-test` job above still cover the ARD client.
+  # To re-enable: restore the trigger condition below and repoint
+  # ARD_LIVE_REGISTRY_URL to a reachable reference registry.
   live-test:
     name: ARD Live Registry Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: false
     timeout-minutes: 10
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -30,7 +30,6 @@ jobs:
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
       DENO_SANDBOX_REGION: ${{ matrix.deno_sandbox_region || '' }}
-      ARD_LIVE_REGISTRY_URL: ${{ matrix.ard_registry_url || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,9 +50,16 @@ jobs:
             required_secret: SPRITES_API_TOKEN
           - name: Brave Search API Tests
             command: cargo test -p everruns-integrations-brave-search --features integration
-          - name: ARD Live Registry Tests
-            command: cargo test -p everruns-integrations-ard --features ard-live-tests --test live_api_test
-            ard_registry_url: https://agenticresourcediscovery.org/api/v1
+          # ARD Live Registry Tests are quarantined: the public reference
+          # registry (https://agenticresourcediscovery.org/api/v1) was
+          # decommissioned (now docs-only; 405/404 on the API, registry/api
+          # subdomains no longer resolve), so the fail-closed live tests can
+          # never pass. Per the fail-closed contract we remove the job rather
+          # than let it silently skip/pass. The wiremock-backed unit +
+          # integration tests (`cargo test -p everruns-integrations-ard`) still
+          # cover the ARD client. Re-add this entry (or repoint
+          # ARD_LIVE_REGISTRY_URL) once a reachable reference registry exists.
+          # See EVE-659.
 
     steps:
       - uses: actions/checkout@v5

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -67,7 +67,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Sprites | [`integrations/sprites/SPEC.md`](../integrations/sprites/SPEC.md) | Persistent Firecracker microVMs via Sprites (Fly.io). Persistent filesystem, checkpoints, HTTP services. |
 | Cursor | [`integrations/cursor/SPEC.md`](../integrations/cursor/SPEC.md) | Cursor Cloud Agents API for launching and managing asynchronous coding agents on GitHub repositories. |
 | Docker | `integrations/docker/` | Container-based agent execution. Experimental (Dev only). No spec yet. |
-| ARD | [`integrations/ard/SPEC.md`](../integrations/ard/SPEC.md) | Client-side Agentic Resource Discovery (`resource_discovery`): discover and attach external MCP servers / A2A agents from ARD registries at runtime. Experimental (Dev only). |
+| ARD | [`integrations/ard/SPEC.md`](../integrations/ard/SPEC.md) | Client-side Agentic Resource Discovery (`resource_discovery`): discover and attach external MCP servers / A2A agents from ARD registries at runtime. Experimental (Dev only). **Live registry CI tests are quarantined (EVE-659):** the public reference registry was decommissioned, so the fail-closed live job is removed from the weekly sweep and gated off in `ard-integration.yml` rather than allowed to silently pass; the wiremock-backed unit/integration tests still run. Re-enable once a reachable reference registry exists. |
 
 ## Messaging Integrations (`crates/server/`)
 


### PR DESCRIPTION
## What
Quarantine the **ARD Live Registry Tests** from CI: remove the entry from the weekly `integration-live-sweep.yml` matrix and gate off the `ard-integration.yml` `live-test` job (`if: false`). Documented in `specs/integrations.md`.

Refs EVE-659. **Makes the nightly (Integration Live Sweep) green again.**

## Why
The weekly sweep has been red since the 2026-06-22 run — only the ARD job fails. Its public reference registry `https://agenticresourcediscovery.org/api/v1` was **decommissioned** (verified in EVE-659): the API now returns 405/404 (docs-only mkdocs site), and the `registry.`/`api.` subdomains no longer resolve. The live tests are fail-closed, so they can never pass, and no code in this repo can revive a dead third-party endpoint.

Per the fail-closed contract (`specs/integrations.md`: *"CI live jobs must never silently pass"*), the correct move is to **remove** the dead job — not let it silently skip/pass. The wiremock-backed unit + integration tests (`cargo test -p everruns-integrations-ard`, the `unit-test` job) still cover the ARD client; only the live-registry coverage is paused.

## Decision note
This is the maintainer-decision item flagged in EVE-659. Of the three options — (a) repoint to a new registry URL, (b) quarantine, (c) self-host a reference registry — only **(b)** is actionable without an external URL or new infra. **If you have a replacement registry URL, prefer (a):** restore the matrix entry / job trigger and repoint `ARD_LIVE_REGISTRY_URL`; the quarantine is written to be reversed by a one-line restore (the original `if:` condition is preserved as a comment).

## How
- `integration-live-sweep.yml`: drop the `ARD Live Registry Tests` matrix entry and the now-unused `ARD_LIVE_REGISTRY_URL` env, with a comment explaining the quarantine + re-enable steps.
- `ard-integration.yml`: gate the `live-test` job with `if: false` (original condition retained as a comment); `unit-test` job unchanged.
- `specs/integrations.md`: note the quarantine under the ARD row.

## Risk
Low. CI-config + spec only; no product code. Reduces ARD coverage to the mocked unit/integration tests until a registry is available (documented).

## Checklist
- [x] Backward compatibility considered (reversible by one-line restore)
- [x] Security review (N/A — CI config)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FprnEcwVVkC44Sw4eAuGKN)_