### PR TITLE
feat(voice): per-connection realtime provider binding

### DIFF
--- a/apps/ui/src/lib/api/voice.ts
+++ b/apps/ui/src/lib/api/voice.ts
@@ -7,6 +7,13 @@ export interface VoiceCallRequest {
   voice?: string;
   reasoning_effort?: string;
   instructions?: string;
+  /**
+   * Optional realtime provider binding: the prefixed public id of the provider
+   * connection to route this voice connection through. Lets an org with more
+   * than one realtime-capable provider choose which one serves the session.
+   * Omit to use the org default (or single) realtime provider.
+   */
+  provider_id?: string;
 }
 
 export interface VoiceCallResponse {

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -12,7 +12,8 @@ use crate::domains::messages::{CreateMessage, MessageService};
 use crate::domains::sessions::{CreateSession, GetOrCreateChatSession, SessionService};
 use crate::event_delivery::EventDelivery;
 use crate::services::{
-    EventService, ProviderResolverService, provider_resolver::ResolvedProviderCredentials,
+    EventService, ProviderResolverService,
+    provider_resolver::{ResolvedProviderCredentials, ResolvedServiceProvider},
 };
 use crate::storage::{DbLeasedResourceStore, DbSessionResourceRegistry, StorageBackend};
 use axum::{
@@ -190,6 +191,15 @@ pub struct VoiceSessionOptions {
     #[serde(default)]
     #[schema(example = "Always confirm before placing an order.")]
     pub instructions: Option<String>,
+    /// Realtime provider binding: the prefixed public id of the provider
+    /// connection to route this voice connection through (e.g. `prov_…`). Lets
+    /// an org with more than one realtime-capable provider pick which one serves
+    /// the connection. When omitted, the server resolves the org's default (or
+    /// single) realtime provider. The bound provider's driver MUST declare the
+    /// realtime service, otherwise the request is rejected with 400.
+    #[serde(default)]
+    #[schema(example = "prov_01h…")]
+    pub provider_id: Option<String>,
 }
 
 /// Request body for voice client secret.
@@ -324,8 +334,10 @@ pub async fn create_client_secret(
     ensure_voice_enabled(&org)?;
     let session_id = parse_session_id(&session_id)?;
     authorize_session(&state, &org, session_id).await?;
+    let binding = req.options.provider_id.clone();
     let normalized = normalize_options(req.options)?;
-    let credentials = resolve_realtime_credentials(&state, org.org_id).await?;
+    let resolved = resolve_realtime_credentials(&state, org.org_id, binding.as_deref()).await?;
+    let credentials = resolved.credentials;
     let voice_connection_id = new_voice_connection_id();
     let lease = upsert_voice_resource(VoiceResourceUpsert {
         state: &state,
@@ -333,6 +345,7 @@ pub async fn create_client_secret(
         org: &org,
         voice_connection_id: &voice_connection_id,
         provider_call_id: None,
+        provider_id: &resolved.provider_id,
         options: &normalized,
         transport: "client_secret",
         status: "pending_client",
@@ -416,14 +429,17 @@ pub async fn attach_call(
             ErrorResponse::new("Invalid voice connection").into_response(StatusCode::BAD_REQUEST)
         );
     }
+    let binding = req.options.provider_id.clone();
     let normalized = normalize_options(req.options)?;
-    let credentials = resolve_realtime_credentials(&state, org.org_id).await?;
+    let resolved = resolve_realtime_credentials(&state, org.org_id, binding.as_deref()).await?;
+    let credentials = resolved.credentials;
     let lease = upsert_voice_resource(VoiceResourceUpsert {
         state: &state,
         session_id,
         org: &org,
         voice_connection_id: &voice_connection_id,
         provider_call_id: Some(&req.provider_call_id),
+        provider_id: &resolved.provider_id,
         options: &normalized,
         transport: "webrtc",
         status: "active",
@@ -570,8 +586,10 @@ async fn bootstrap_call(
     if req.sdp.trim().is_empty() {
         return Err(ErrorResponse::new("Missing SDP").into_response(StatusCode::BAD_REQUEST));
     }
+    let binding = req.options.provider_id.clone();
     let normalized = normalize_options(req.options)?;
-    let credentials = resolve_realtime_credentials(state, org.org_id).await?;
+    let resolved = resolve_realtime_credentials(state, org.org_id, binding.as_deref()).await?;
+    let credentials = resolved.credentials;
     let voice_connection_id = new_voice_connection_id();
     let form = multipart::Form::new()
         .part(
@@ -615,6 +633,7 @@ async fn bootstrap_call(
         org,
         voice_connection_id: &voice_connection_id,
         provider_call_id: provider_call_id.as_deref(),
+        provider_id: &resolved.provider_id,
         options: &normalized,
         transport: "webrtc",
         status: "active",
@@ -769,20 +788,49 @@ async fn authorize_session(
 }
 
 /// Resolve the realtime-voice provider connection for an org via service-bound
-/// resolution (specs/providers.md): the active provider whose driver declares
+/// resolution (specs/providers.md): the provider whose driver declares
 /// `ServiceKind::Realtime`, fail-closed. Replaces the previous "first active
 /// provider matching the `openai` type string" behavior — only realtime-capable
 /// drivers are eligible now.
+///
+/// `binding` is an optional client-supplied realtime provider public id. When
+/// present it pins resolution to that provider (resolver tier 1); a binding that
+/// is unknown or whose driver does not declare the realtime service is a request
+/// error surfaced as 400, not an upstream `502`.
 async fn resolve_realtime_credentials(
     state: &AppState,
     org_id: i64,
-) -> Result<ResolvedProviderCredentials, (StatusCode, Json<ErrorResponse>)> {
+    binding: Option<&str>,
+) -> Result<ResolvedServiceProvider, (StatusCode, Json<ErrorResponse>)> {
     state
         .provider_resolver
-        .resolve_service(org_id, ServiceKind::Realtime, None)
+        .resolve_service(org_id, ServiceKind::Realtime, binding)
         .await
-        .map(|resolved| resolved.credentials)
-        .map_err(provider_error)
+        .map_err(|error| map_realtime_resolution_error(binding, error))
+}
+
+/// Map a realtime provider resolution failure onto an HTTP error.
+///
+/// When the caller pinned a `binding`, the failure is about their request
+/// (unknown provider id, driver that does not declare the realtime service, or
+/// missing credentials), so return a `400` with the resolver's reason — a
+/// multi-provider caller needs to know which selection to fix. With no binding
+/// the failure is server-side configuration (no realtime provider available),
+/// surfaced as the generic `502` like any other provider problem.
+fn map_realtime_resolution_error(
+    binding: Option<&str>,
+    error: anyhow::Error,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match binding {
+        Some(provider_id) => {
+            tracing::debug!(%provider_id, error = %error, "voice realtime provider binding rejected");
+            ErrorResponse::new(format!(
+                "Realtime provider '{provider_id}' is not available for voice: {error}"
+            ))
+            .into_response(StatusCode::BAD_REQUEST)
+        }
+        None => provider_error(error),
+    }
 }
 
 fn parse_session_id(session_id: &str) -> Result<SessionId, (StatusCode, Json<ErrorResponse>)> {
@@ -858,6 +906,10 @@ struct VoiceResourceUpsert<'a> {
     org: &'a ResolvedOrg,
     voice_connection_id: &'a str,
     provider_call_id: Option<&'a str>,
+    /// Public id of the realtime provider connection resolved for this voice
+    /// connection (the binding when one was supplied, otherwise the
+    /// auto-selected provider). Persisted for audit / multi-provider visibility.
+    provider_id: &'a str,
     options: &'a NormalizedVoiceOptions,
     transport: &'a str,
     status: &'a str,
@@ -872,6 +924,7 @@ async fn upsert_voice_resource(
         "voice": req.options.voice,
         "reasoning_effort": req.options.reasoning_effort,
         "transport": req.transport,
+        "provider_id": req.provider_id,
     });
     if let Some(provider_call_id) = req.provider_call_id {
         metadata["provider_call_id"] = json!(provider_call_id);
@@ -1434,6 +1487,65 @@ async fn execute_realtime_tool(_session_id: SessionId, call: ToolCall) -> Realti
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn voice_session_options_accept_provider_binding() {
+        // The realtime provider binding rides on the shared options struct that
+        // is flattened into every create/attach voice request body.
+        let opts: VoiceSessionOptions =
+            serde_json::from_value(json!({ "provider_id": "prov_realtime_1" }))
+                .expect("provider_id is an accepted option");
+        assert_eq!(opts.provider_id.as_deref(), Some("prov_realtime_1"));
+
+        // Omitting it is valid and resolves to the org default later.
+        let empty: VoiceSessionOptions = serde_json::from_value(json!({})).expect("empty options");
+        assert_eq!(empty.provider_id, None);
+    }
+
+    #[test]
+    fn provider_binding_is_not_forwarded_to_the_realtime_payload() {
+        // The binding is a routing decision, not a realtime-session knob, so it
+        // must not leak into the provider session payload.
+        let normalized = normalize_options(VoiceSessionOptions {
+            model: None,
+            voice: None,
+            reasoning_effort: None,
+            instructions: None,
+            provider_id: Some("prov_realtime_1".to_string()),
+        })
+        .expect("default options normalize");
+        let payload = realtime_session_payload(&normalized);
+        assert_eq!(payload.get("provider_id"), None);
+        assert_eq!(payload.get("provider"), None);
+    }
+
+    #[test]
+    fn bad_provider_binding_maps_to_bad_request() {
+        // A client-chosen provider that cannot serve realtime is the caller's
+        // mistake — surface 400 with the resolver's reason, not an opaque 502.
+        let (status, body) = map_realtime_resolution_error(
+            Some("prov_realtime_1"),
+            anyhow::anyhow!("provider prov_realtime_1 does not provide the realtime service"),
+        );
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let detail = body.0.detail.expect("detail set");
+        assert!(detail.contains("prov_realtime_1"), "names the provider");
+        assert!(
+            detail.contains("does not provide the realtime service"),
+            "surfaces the resolver reason: {detail}"
+        );
+    }
+
+    #[test]
+    fn missing_realtime_provider_without_binding_maps_to_bad_gateway() {
+        // No binding => server-side configuration gap, reported like any other
+        // provider failure (generic 502, no internal detail leaked).
+        let (status, _body) = map_realtime_resolution_error(
+            None,
+            anyhow::anyhow!("no provider configured for the realtime service"),
+        );
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+    }
 
     #[test]
     fn parses_call_id_from_location() {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -34514,6 +34514,14 @@
             "description": "Provider-side realtime model identifier. When omitted the server picks the agent's configured default.",
             "example": "gpt-realtime"
           },
+          "provider_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Realtime provider binding: the prefixed public id of the provider\nconnection to route this voice connection through (e.g. `prov_…`). Lets\nan org with more than one realtime-capable provider pick which one serves\nthe connection. When omitted, the server resolves the org's default (or\nsingle) realtime provider. The bound provider's driver MUST declare the\nrealtime service, otherwise the request is rejected with 400.",
+            "example": "prov_01h…"
+          },
           "reasoning_effort": {
             "type": [
               "string",

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -165,14 +165,14 @@ resolve_service(org, ServiceKind, binding) -> (ProviderConnection, service clien
 
 Selection: explicit `provider_id` on the consumer's binding (e.g. the voice connection's `provider_id` field) wins; otherwise an org-level default provider per service; otherwise the single active provider whose driver declares the service. "First active provider matching a type string" — the old voice behavior — is removed. Resolution failures surface structured "no provider configured for {service}" errors, fail-closed.
 
-All three tiers are implemented. The org-default-per-service tier reads an org-settings map (`organization_settings.default_provider_per_service`, `ServiceKind` → provider id) set via `PATCH /v1/orgs/{org}` (`default_provider_per_service`). It is consulted only when no explicit binding is supplied, and it is fail-closed: a configured default that is missing, inactive, or whose driver does not declare the service errors rather than falling through to the active-provider scan. An unset default for a service falls through to that scan as before. Voice realtime currently calls `resolve_service(org, Realtime, None)` — a per-connection provider binding is not plumbed, so it relies on the org default (or the single realtime-capable provider); the binding parameter exists for when that selection lands.
+All three tiers are implemented. The org-default-per-service tier reads an org-settings map (`organization_settings.default_provider_per_service`, `ServiceKind` → provider id) set via `PATCH /v1/orgs/{org}` (`default_provider_per_service`). It is consulted only when no explicit binding is supplied, and it is fail-closed: a configured default that is missing, inactive, or whose driver does not declare the service errors rather than falling through to the active-provider scan. An unset default for a service falls through to that scan as before. Voice realtime plumbs the per-connection binding: the create/attach request bodies carry an optional `provider_id` (the realtime provider connection's public id), passed straight through as `resolve_service(org, Realtime, provider_id)`. When omitted it falls back to the org default (or the single realtime-capable provider); an unknown binding or one whose driver does not declare the realtime service is rejected with `400` rather than the generic provider `502`. The resolved provider id is persisted on the voice connection's leased-resource metadata.
 
 Consumers and their paths:
 
 | Consumer | Path |
 |---|---|
 | Agent chat turns | Model-bound resolution (above) |
-| Voice realtime | `resolve_service(org, Realtime, None)` today (single realtime-capable provider); passes `voice_connection.provider_id` once per-connection provider selection is plumbed |
+| Voice realtime | `resolve_service(org, Realtime, voice_connection.provider_id)` — optional per-connection `provider_id` binding on the create/attach bodies; omitted falls back to the org default or the single realtime-capable provider; an unknown/non-realtime binding is a `400` |
 | Knowledge-base embeddings (future) | `resolve_service` with an embedding model selection |
 | Model sync | Per-provider, via the driver's `list_models` with the provider's connection |
 | Utility LLM | **Not a provider consumer.** Stays system-owned and env-configured by design (`specs/utility-llm.md`) |


### PR DESCRIPTION
## What
Plumb an optional `provider_id` realtime-provider binding through the voice create/attach request bodies, so an org with more than one realtime-capable provider can choose which one serves a given connection. Resolution becomes `resolve_service(org, Realtime, provider_id)` instead of always passing `None`.

Closes EVE-570 (deferred follow-up from phase 4 of the providers refactor, `specs/providers.md`).

## Why
Voice realtime resolved its provider via `resolve_service(org, Realtime, None)` — it picked the single active realtime-capable provider. The resolver's `binding` tier already existed and was honored, but voice never supplied one, so multi-realtime-provider orgs had no way to select a provider per session.

## How
- Add optional `provider_id` to the shared `VoiceSessionOptions` (flattened into `VoiceClientSecretRequest` / `VoiceCallRequest` / `VoiceAttachRequest`). It is a routing decision, not a realtime-session knob, so it is **not** forwarded into the provider session payload.
- Each resolution site (`create_client_secret`, `attach_call`, `bootstrap_call`) extracts the binding and passes it to `resolve_realtime_credentials(state, org, binding)`.
- `resolve_realtime_credentials` now returns the full `ResolvedServiceProvider`; the resolved provider id is persisted on the voice connection's leased-resource metadata for audit / multi-provider visibility.
- Error mapping (`map_realtime_resolution_error`): a **client-supplied** binding that fails to resolve (unknown id, driver lacks the realtime service, missing credentials) is a `400` with the resolver's reason. With **no** binding, a resolution failure remains the generic `502` (server-side config gap) — unchanged behavior.
- `specs/providers.md`: updated the consumer table + resolution paragraph. UI voice client type (`apps/ui/src/lib/api/voice.ts`) gains the `provider_id?` field.

## Risk
- Low
- Additive optional field; the no-binding path is unchanged (still resolves the org default / single realtime provider). Only new behavior is an explicit binding being honored and bad bindings returning `400` instead of `502`.

## Security
- Threat categories reviewed: TM-API / TM-TENANT. The binding is a provider **public id** resolved through the existing org-scoped `resolve_service` (provider list is `list_providers(org_id)`), so a caller cannot bind to another org's provider — an id not in the caller's org resolves to "not found" → `400`. No credentials or cross-org data are exposed; the 400 detail only echoes the caller's own provider id and a config-level reason.
- Findings and resolutions: none.

## Follow-ups
- **UI picker**: surface a realtime-provider selector in the chat composer when an org has more than one realtime-capable provider configured, wiring the selection into the voice start calls. Deferred from this PR — it is a larger UX change and the UI cannot be type-checked/built in this environment; the client API type already accepts `provider_id` so the picker is purely additive. (Low-priority issue; backend contract is complete and tested.)

## Checklist
- [x] Tests added or updated (`bad_provider_binding_maps_to_bad_request`, `missing_realtime_provider_without_binding_maps_to_bad_gateway`, `voice_session_options_accept_provider_binding`, `provider_binding_is_not_forwarded_to_the_realtime_payload`; resolver binding tiers already covered in `provider_resolver.rs`)
- [x] Backward compatibility considered (additive optional field; no-binding path unchanged)
- [x] Security review performed against relevant threat model categories (TM-API / TM-TENANT)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013TJj7DxGSpWh5vsjqXqwqd)_