### PR TITLE
perf(llm): accumulate streamed tool-call args in place (EVE-636)

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -825,18 +825,20 @@ impl ChatDriver for AnthropicChatDriver {
                                 {
                                     match data.delta {
                                         AnthropicDelta::TextDelta { text } => {
-                                            *output_tokens.lock().unwrap() += 1;
+                                            // EVE-636: do not count deltas as tokens here —
+                                            // deltas != tokens, and this took a mutex on every
+                                            // token. Authoritative `output_tokens` is set from
+                                            // the terminal `message_delta` usage event below.
                                             return Ok(LlmStreamEvent::TextDelta(text));
                                         }
                                         AnthropicDelta::InputJsonDelta { partial_json } => {
-                                            // Accumulate tool input JSON
+                                            // EVE-636: accumulate tool-input JSON in place via
+                                            // push_str (amortized O(total)) instead of
+                                            // re-copying + re-boxing into a Value per delta
+                                            // (O(n^2)). Parsed once at content_block_stop.
                                             let mut current = current_tool_call.lock().unwrap();
                                             if let Some(ref mut tc) = *current {
-                                                let current_args =
-                                                    tc.arguments.as_str().unwrap_or("");
-                                                let combined =
-                                                    format!("{}{}", current_args, partial_json);
-                                                tc.arguments = json!(combined);
+                                                append_tool_input_delta(tc, &partial_json);
                                             }
                                             return Ok(LlmStreamEvent::TextDelta(String::new()));
                                         }
@@ -871,11 +873,8 @@ impl ChatDriver for AnthropicChatDriver {
                                 // Finalize current tool call if any
                                 let mut current = current_tool_call.lock().unwrap();
                                 if let Some(mut tc) = current.take() {
-                                    // Parse the accumulated JSON string
-                                    if let Some(args_str) = tc.arguments.as_str() {
-                                        tc.arguments =
-                                            serde_json::from_str(args_str).unwrap_or(json!({}));
-                                    }
+                                    // EVE-636: parse the accumulated JSON string exactly once.
+                                    finalize_tool_arguments(&mut tc);
                                     accumulated_tool_calls.lock().unwrap().push(tc);
                                 }
                                 // Check if this is a thinking block with signature
@@ -1079,6 +1078,30 @@ pub fn register_driver(registry: &mut DriverRegistry) {
             Box::new(driver) as BoxedChatDriver
         })
     });
+}
+
+// ============================================================================
+// Streaming tool-call accumulation (EVE-636)
+// ============================================================================
+
+/// Appends a streamed tool-input JSON fragment onto the accumulating arguments
+/// in place. During streaming `ToolCall::arguments` is kept as a
+/// `Value::String`, so `push_str` grows it in amortized O(total) — avoiding the
+/// O(n^2) re-copy + re-box (`format!` + `json!`) that the per-delta path used.
+/// The string is parsed once at `content_block_stop` via
+/// [`finalize_tool_arguments`].
+fn append_tool_input_delta(tool_call: &mut ToolCall, fragment: &str) {
+    if let serde_json::Value::String(s) = &mut tool_call.arguments {
+        s.push_str(fragment);
+    }
+}
+
+/// Parses the accumulated tool-input JSON string into a structured value once a
+/// tool-use content block completes. Empty/invalid JSON falls back to `{}`.
+fn finalize_tool_arguments(tool_call: &mut ToolCall) {
+    if let Some(args_str) = tool_call.arguments.as_str() {
+        tool_call.arguments = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+    }
 }
 
 // ============================================================================
@@ -1849,6 +1872,43 @@ mod tests {
     fn supports_parallel_tool_calls_is_true() {
         let driver = AnthropicChatDriver::new("test-key");
         assert!(driver.supports_parallel_tool_calls("claude-opus-4-8"));
+    }
+
+    /// EVE-636: streamed tool-call arguments accumulate as a raw string across
+    /// many small deltas (parsed zero times during streaming) and are parsed
+    /// exactly once at finalize into the structured value.
+    #[test]
+    fn test_tool_input_accumulates_linearly_and_parses_once() {
+        let payload = r#"{"path":"src/main.rs","contents":"fn main() { println!(\"hello, world — a deliberately long argument payload to exceed one hundred streamed characters\"); }","count":1234567}"#;
+        assert!(
+            payload.chars().count() > 100,
+            "test needs >100 fragments to exercise the accumulation path"
+        );
+
+        let mut tc = ToolCall {
+            id: "tool_1".to_string(),
+            name: "write_file".to_string(),
+            arguments: json!(""),
+        };
+
+        // One character per delta => well over 100 deltas.
+        let mut expected = String::new();
+        for ch in payload.chars() {
+            let frag = ch.to_string();
+            append_tool_input_delta(&mut tc, &frag);
+            expected.push_str(&frag);
+        }
+
+        // Still a Value::String holding the exact concatenation (no per-delta
+        // parse/re-box happened).
+        assert_eq!(tc.arguments.as_str(), Some(expected.as_str()));
+
+        // Parsed exactly once at finalize.
+        finalize_tool_arguments(&mut tc);
+        assert_eq!(
+            tc.arguments,
+            serde_json::from_str::<serde_json::Value>(payload).unwrap()
+        );
     }
 
     // These tests verify that empty text blocks are filtered out to avoid

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -1060,9 +1060,15 @@ fn process_stream_choice(
                     accumulated_tool_calls[idx].name = name.clone();
                 }
                 if let Some(args) = &function.arguments {
-                    let current = accumulated_tool_calls[idx].arguments.as_str().unwrap_or("");
-                    let combined = format!("{}{}", current, args);
-                    accumulated_tool_calls[idx].arguments = json!(combined);
+                    // EVE-636: accumulate fragments in place via push_str
+                    // (amortized O(total)) instead of re-copying + re-boxing into
+                    // a Value per delta (O(n^2)). `arguments` is kept as a
+                    // Value::String here and parsed once at finish via
+                    // finalize_tool_calls.
+                    if let serde_json::Value::String(s) = &mut accumulated_tool_calls[idx].arguments
+                    {
+                        s.push_str(args);
+                    }
                 }
             }
         }
@@ -1667,6 +1673,69 @@ mod tests {
         );
         assert!(matches!(e, LlmStreamEvent::TextDelta(s) if s == "hello"));
         assert_eq!(total_tokens, 1);
+    }
+
+    /// EVE-636: streamed tool-call arguments must concatenate exactly across
+    /// many small chunks (accumulated as a raw string, parsed zero times
+    /// mid-stream) and be parsed exactly once at the `tool_calls` finish chunk.
+    #[test]
+    fn test_tool_call_arguments_accumulate_across_many_chunks() {
+        let mut total_tokens = 0u32;
+        let mut acc: Vec<ToolCall> = Vec::new();
+        let mut finish_reason: Option<String> = None;
+
+        // Open the call (id + name, empty initial arguments).
+        process_stream_choice(
+            &choice(
+                r#"{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"write_file","arguments":""}}]},"finish_reason":null}"#,
+            ),
+            &mut total_tokens,
+            &mut acc,
+            &mut finish_reason,
+        );
+
+        let payload = r#"{"path":"a.rs","contents":"a fairly long contents value streamed one character at a time to exceed one hundred chunks","n":987654321}"#;
+        assert!(payload.chars().count() > 100);
+
+        // Stream the arguments one character per chunk.
+        let mut expected = String::new();
+        for ch in payload.chars() {
+            let frag = ch.to_string();
+            let chunk = json!({
+                "delta": {"tool_calls": [{"index": 0, "function": {"arguments": frag}}]},
+                "finish_reason": null
+            })
+            .to_string();
+            process_stream_choice(
+                &choice(&chunk),
+                &mut total_tokens,
+                &mut acc,
+                &mut finish_reason,
+            );
+            expected.push_str(&frag);
+        }
+
+        // Mid-stream: accumulated as a raw string, not yet parsed.
+        assert_eq!(acc[0].arguments.as_str(), Some(expected.as_str()));
+
+        // Finish chunk: parsed exactly once into the structured value.
+        let e = process_stream_choice(
+            &choice(r#"{"delta":{},"finish_reason":"tool_calls"}"#),
+            &mut total_tokens,
+            &mut acc,
+            &mut finish_reason,
+        );
+        match e {
+            LlmStreamEvent::ToolCalls(calls) => {
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].id, "call_1");
+                assert_eq!(
+                    calls[0].arguments,
+                    serde_json::from_str::<serde_json::Value>(payload).unwrap()
+                );
+            }
+            other => panic!("expected ToolCalls, got {:?}", other),
+        }
     }
 
     /// OpenAI's native path sends `delta: {}` (no content key) in the finish


### PR DESCRIPTION
## What
Fix O(n²) accumulation of streamed tool-call arguments in the Anthropic and OpenAI-compatible drivers.

Both drivers accumulated streamed tool-call arguments by re-copying the entire accumulated string and re-boxing it into a `serde_json::Value` on **every** delta:
```rust
let combined = format!("{}{}", current_args, partial_json);
tc.arguments = json!(combined);
```
For arguments streamed as N chunks of total size S this is O(N·S) copying — quadratic for large structured tool arguments (code, JSON blobs).

The in-progress `arguments` is already a `Value::String`, so this PR grows it in place with `push_str` (amortized O(total)) and parses to a structured `Value` exactly once at `content_block_stop` (Anthropic) / the `tool_calls` finish chunk (OpenAI). This mirrors the already-correct pattern in `openresponses_protocol.rs`.

Also drops the per-delta `output_tokens` mutex increment in the Anthropic stream: it took a lock on every text token and miscounted (deltas ≠ tokens). Authoritative `output_tokens` already comes from the terminal `message_delta` usage event (it overwrote the per-delta value anyway), so this is behavior-preserving for the reported count.

## Why
Closes EVE-636. Quadratic per-delta churn on the streaming hot path; large tool-call arguments paid it worst.

## How
- `crates/anthropic/src/driver.rs`: `InputJsonDelta` now appends via `append_tool_input_delta` (in-place `push_str` on the `Value::String`); `content_block_stop` parses once via `finalize_tool_arguments`. Removed the `*output_tokens += 1` per-`TextDelta` increment.
- `crates/core/src/openai_protocol.rs`: `process_stream_choice` appends fragments in place instead of `format!` + `json!`; still parsed once at finish via `finalize_tool_calls`.

## Validation
- New unit tests in both crates stream a tool call across **>100 single-char deltas** and assert the accumulated string equals the exact concatenation (parsed zero times mid-stream), then parses once at finish.
- `cargo test -p everruns-anthropic` (47 passed) and `cargo test -p everruns-core --lib openai_protocol` (40 passed) green.
- `cargo fmt --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean on both crates.
- Smoke test: the affected flow is streaming tool-call argument assembly, which the new deterministic tests reproduce chunk-by-chunk from the provider wire shapes. A full live smoke test of the agent loop requires provider credentials and a running stack and would add no signal beyond these tests for a behavior-preserving internal perf refactor; `just` is unavailable in this environment.

## Risk
Low. Behavior-preserving: same final parsed arguments, same token accounting (authoritative source unchanged). Pure hot-path allocation fix.

## Security
- Threat categories reviewed: **TM-LLM** (prompt/stream handling). No new trust boundary, input source, or parsing semantics — the same `serde_json::from_str(...).unwrap_or({})` finalization is preserved; only the intermediate accumulation strategy changed. No credentials, logging, or data-exposure surface touched.
- Findings: none.

## Follow-ups
- The streamed-state `Arc<Mutex<…>>` churn in the per-delta closures (`anthropic/src/driver.rs`, `openai_protocol.rs`) is unchanged — moving it into a stateful generator is a larger, riskier rewrite (the `.then` closure is `FnMut`); deferred, tracked under EVE-636's "where practical" note.
- The OpenAI `total_tokens += 1` per-delta counter is intentionally **kept** as a fallback estimate for gateways that omit a terminal `usage` chunk (removing it would report `completion_tokens: 0` for those providers); the authoritative `usage.completion_tokens` still overwrites it when present.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal; behavior-preserving)
- [x] Security review performed (TM-LLM)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPWywcD96sHibL1ATFWq4C)_