### PR TITLE
perf(llm): reuse provider HTTP clients across reasoning steps (EVE-635)

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -77,7 +77,7 @@ impl AnthropicChatDriver {
     /// Create a new provider with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: driver_helpers::shared_streaming_http_client(),
             api_key: api_key.into(),
             api_url: DEFAULT_API_URL.to_string(),
             uses_custom_url: false,
@@ -88,7 +88,7 @@ impl AnthropicChatDriver {
     /// Create a new provider with a custom API URL
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: driver_helpers::shared_streaming_http_client(),
             api_key: api_key.into(),
             api_url: api_url.into(),
             uses_custom_url: true,

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -43,30 +43,38 @@ use crate::credential::BedrockCredential;
 /// Credentials come from the driver's declared typed credential fields.
 #[derive(Clone, Debug)]
 pub struct BedrockChatDriver {
-    credential: BedrockCredential,
+    /// AWS Bedrock client built once at construction. `aws_sdk_bedrockruntime::Client`
+    /// is cheap to clone and reuses its connection pool and credentials provider,
+    /// so we build it here instead of rebuilding the whole SDK client (credential
+    /// chain + pool) on every `chat_completion_stream` call (EVE-635).
+    client: Client,
 }
 
 impl BedrockChatDriver {
     pub fn from_config(config: &DriverConfig) -> Result<Self> {
         let credential = BedrockCredential::from_driver_config(config)?;
-        Ok(Self { credential })
+        Ok(Self {
+            client: build_client(&credential),
+        })
     }
+}
 
-    fn create_client(&self) -> Client {
-        let creds = Credentials::new(
-            self.credential.access_key_id.clone(),
-            self.credential.secret_access_key.clone(),
-            self.credential.session_token.clone(),
-            None,
-            "everruns-bedrock",
-        );
-        let config = BedrockConfigBuilder::new()
-            .behavior_version(BehaviorVersion::latest())
-            .credentials_provider(creds)
-            .region(Region::new(self.credential.region.clone()))
-            .build();
-        Client::from_conf(config)
-    }
+/// Build the AWS Bedrock runtime client from typed credentials. Called once per
+/// driver construction, not per request.
+fn build_client(credential: &BedrockCredential) -> Client {
+    let creds = Credentials::new(
+        credential.access_key_id.clone(),
+        credential.secret_access_key.clone(),
+        credential.session_token.clone(),
+        None,
+        "everruns-bedrock",
+    );
+    let config = BedrockConfigBuilder::new()
+        .behavior_version(BehaviorVersion::latest())
+        .credentials_provider(creds)
+        .region(Region::new(credential.region.clone()))
+        .build();
+    Client::from_conf(config)
 }
 
 /// Register the Bedrock driver with the given registry.
@@ -123,7 +131,7 @@ impl ChatDriver for BedrockChatDriver {
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        let client = self.create_client();
+        let client = self.client.clone();
         let model_id = config.model.clone();
 
         let (system_blocks, bedrock_messages) = build_messages(&messages)?;

--- a/crates/core/src/driver_helpers.rs
+++ b/crates/core/src/driver_helpers.rs
@@ -6,9 +6,70 @@
 // See specs/llm-drivers.md for driver requirements.
 
 use reqwest::StatusCode;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 /// Placeholder text for audio content in providers that don't support audio input.
 pub const AUDIO_CONTENT_PLACEHOLDER: &str = "[Audio content not supported]";
+
+// ============================================================================
+// Shared HTTP clients (EVE-635)
+// ============================================================================
+
+/// Connect/TLS handshake timeout applied to every provider HTTP client.
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Per-read inactivity timeout for streaming chat clients. This bounds a
+/// silently stalled connection (no bytes for this long) without capping the
+/// total time a long, actively-streaming response may take — an overall
+/// `.timeout()` would do the latter and kill legitimate long streams. Set well
+/// above the agent loop's own stall timeout (EVE-531, ~120s) so it only acts as
+/// a transport-level backstop.
+const HTTP_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(300);
+/// Overall request timeout for non-streaming reads (embeddings, vector store)
+/// so a hung response body cannot block a request indefinitely.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+/// Idle pooled-connection lifetime, so reused HTTP keep-alive/HTTP-2
+/// connections are eventually recycled.
+const HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Process-wide HTTP client shared by all streaming chat drivers.
+///
+/// `reqwest::Client` is internally reference-counted and built to be cloned and
+/// shared; it carries no per-request credentials (auth headers are attached per
+/// request), so one pool is safe to reuse across providers, credentials, and
+/// reasoning steps. Sharing it is what lets TCP/TLS handshakes and HTTP/2
+/// connections be reused across agent turns even though the driver structs are
+/// rebuilt on every step (EVE-635).
+pub fn shared_streaming_http_client() -> reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .connect_timeout(HTTP_CONNECT_TIMEOUT)
+                .read_timeout(HTTP_STREAM_READ_TIMEOUT)
+                .pool_idle_timeout(HTTP_POOL_IDLE_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new())
+        })
+        .clone()
+}
+
+/// Process-wide HTTP client shared by non-streaming request/response drivers
+/// (embeddings, vector store). Uses an overall request timeout because these
+/// reads are bounded and must not hang forever.
+pub fn shared_request_http_client() -> reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .connect_timeout(HTTP_CONNECT_TIMEOUT)
+                .timeout(HTTP_REQUEST_TIMEOUT)
+                .pool_idle_timeout(HTTP_POOL_IDLE_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new())
+        })
+        .clone()
+}
 
 // ============================================================================
 // Data URL Parsing

--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -14,6 +14,7 @@
 // Design: exponential backoff with 25% jitter, respecting provider retry-after hints.
 // Defaults match official SDKs: 2 retries, 1s initial, 60s max, 2x multiplier.
 
+use rand::Rng;
 use std::time::Duration;
 
 /// Maximum retry-after value to honor (seconds).
@@ -87,9 +88,10 @@ impl LlmRetryConfig {
         // This gives range [0.75, 1.0] * base
         let jitter = if self.jitter_factor > 0.0 {
             let jitter_range = capped_backoff * self.jitter_factor;
-            // Simple deterministic jitter based on attempt number
-            // In production, use rand crate for true randomness
-            let jitter_offset = (attempt as f64 * 0.37).fract() * 2.0 - 1.0; // -1 to 1
+            // EVE-635: real RNG so concurrent clients hitting the same attempt
+            // number (e.g. a shared 429/503) do not retry in lockstep
+            // (thundering herd). Range [-1, 1).
+            let jitter_offset = rand::rng().random::<f64>() * 2.0 - 1.0;
             jitter_range * jitter_offset
         } else {
             0.0
@@ -457,6 +459,35 @@ mod tests {
         assert_eq!(config.calculate_backoff(2), Duration::from_secs(30));
         // attempt 3: 80s -> capped to 30s
         assert_eq!(config.calculate_backoff(3), Duration::from_secs(30));
+    }
+
+    /// EVE-635: with jitter enabled the backoff must use a real RNG, so repeated
+    /// computations for the same attempt number diverge (no thundering herd).
+    #[test]
+    fn test_backoff_jitter_is_randomized() {
+        let config = LlmRetryConfig {
+            initial_backoff: Duration::from_secs(10),
+            max_backoff: Duration::from_secs(60),
+            backoff_multiplier: 2.0,
+            jitter_factor: 0.25,
+            ..Default::default()
+        };
+        let samples: std::collections::HashSet<u128> = (0..20)
+            .map(|_| config.calculate_backoff(1).as_nanos())
+            .collect();
+        assert!(
+            samples.len() > 1,
+            "jittered backoff should vary across calls, got {} distinct value(s)",
+            samples.len()
+        );
+        // Jitter stays within ±25% of the 20s base for attempt 1.
+        for _ in 0..50 {
+            let secs = config.calculate_backoff(1).as_secs_f64();
+            assert!(
+                (15.0..=25.0).contains(&secs),
+                "backoff {secs}s out of range"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -212,7 +212,7 @@ impl OpenAIProtocolChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: crate::driver_helpers::shared_streaming_http_client(),
             api_key: api_key.into(),
             api_url: DEFAULT_API_URL.to_string(),
             retry_config: LlmRetryConfig::default(),
@@ -223,7 +223,7 @@ impl OpenAIProtocolChatDriver {
     /// Create a new driver with a custom API URL (for OpenAI-compatible APIs)
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: crate::driver_helpers::shared_streaming_http_client(),
             api_key: api_key.into(),
             api_url: api_url.into(),
             retry_config: LlmRetryConfig::default(),

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -50,7 +50,7 @@ impl GeminiChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: everruns_core::driver_helpers::shared_streaming_http_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
             uses_custom_url: false,
@@ -61,7 +61,7 @@ impl GeminiChatDriver {
     /// Create a new driver with a custom base URL
     pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: everruns_core::driver_helpers::shared_streaming_http_client(),
             api_key: api_key.into(),
             base_url: base_url.into(),
             uses_custom_url: true,

--- a/crates/openai/src/embeddings.rs
+++ b/crates/openai/src/embeddings.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use everruns_core::driver_helpers::shared_request_http_client;
+use everruns_core::llm_retry::{LlmRetryConfig, is_transient_error};
 use everruns_core::{EmbedRequest, EmbedResponse, EmbeddingsDriver, EmbeddingsDriverError};
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +16,7 @@ impl OpenAIEmbeddingsDriver {
         Self {
             api_key: api_key.into(),
             base_url: "https://api.openai.com/v1".to_string(),
-            client: reqwest::Client::new(),
+            client: shared_request_http_client(),
         }
     }
 
@@ -22,7 +24,7 @@ impl OpenAIEmbeddingsDriver {
         Self {
             api_key: api_key.into(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
-            client: reqwest::Client::new(),
+            client: shared_request_http_client(),
         }
     }
 }
@@ -60,31 +62,60 @@ impl EmbeddingsDriver for OpenAIEmbeddingsDriver {
             model: request.model,
             encoding_format: "float",
         };
-        let response = self
-            .client
-            .post(&url)
-            .bearer_auth(&self.api_key)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| EmbeddingsDriverError::Transport(e.to_string()))?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            return Err(EmbeddingsDriverError::Provider(format!(
-                "HTTP {status}: {text}"
-            )));
+        // EVE-635: retry transient failures (network errors, 429/5xx) with the
+        // shared exponential-backoff policy. Non-transient errors (4xx other
+        // than 429, parse failures) fail fast.
+        let retry = LlmRetryConfig::default();
+        let mut attempt: u32 = 0;
+        loop {
+            let send_result = self
+                .client
+                .post(&url)
+                .bearer_auth(&self.api_key)
+                .json(&body)
+                .send()
+                .await;
+
+            let transient_err: EmbeddingsDriverError = match send_result {
+                Ok(response) => {
+                    let status = response.status();
+                    if status.is_success() {
+                        let api_resp: EmbeddingsApiResponse = response
+                            .json()
+                            .await
+                            .map_err(|e| EmbeddingsDriverError::Transport(e.to_string()))?;
+                        // Sort by index to ensure output order matches input order.
+                        let mut data = api_resp.data;
+                        data.sort_by_key(|e| e.index);
+                        return Ok(EmbedResponse {
+                            embeddings: data.into_iter().map(|e| e.embedding).collect(),
+                            usage_tokens: Some(api_resp.usage.total_tokens),
+                        });
+                    }
+                    let text = response.text().await.unwrap_or_default();
+                    let err = EmbeddingsDriverError::Provider(format!("HTTP {status}: {text}"));
+                    // Only transient HTTP statuses are worth retrying.
+                    if !is_transient_error(status) {
+                        return Err(err);
+                    }
+                    err
+                }
+                // Network/transport errors are transient.
+                Err(e) => EmbeddingsDriverError::Transport(e.to_string()),
+            };
+
+            if attempt >= retry.max_retries {
+                return Err(transient_err);
+            }
+            let backoff = retry.calculate_backoff(attempt);
+            tracing::warn!(
+                attempt,
+                backoff_secs = backoff.as_secs_f64(),
+                error = %transient_err,
+                "embeddings request transient failure; retrying"
+            );
+            tokio::time::sleep(backoff).await;
+            attempt += 1;
         }
-        let api_resp: EmbeddingsApiResponse = response
-            .json()
-            .await
-            .map_err(|e| EmbeddingsDriverError::Transport(e.to_string()))?;
-        // Sort by index to ensure output order matches input order.
-        let mut data = api_resp.data;
-        data.sort_by_key(|e| e.index);
-        Ok(EmbedResponse {
-            embeddings: data.into_iter().map(|e| e.embedding).collect(),
-            usage_tokens: Some(api_resp.usage.total_tokens),
-        })
     }
 }

--- a/crates/server/src/domains/knowledge_indexes/source_sync.rs
+++ b/crates/server/src/domains/knowledge_indexes/source_sync.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
+use futures::StreamExt;
+
 use everruns_core::driver_registry::{DriverRegistry, EmbedRequest};
 use everruns_core::traits::UserConnectionResolver;
 use everruns_core::typed_id::{KnowledgeIndexChunkId, KnowledgeIndexDocumentId};
@@ -44,6 +46,9 @@ const CHUNK_OVERLAP_CHARS: usize = 150;
 /// Embedding batch size: how many chunks are sent to the embeddings driver per
 /// request.
 const EMBED_BATCH_SIZE: usize = 64;
+/// Max embedding batches in flight at once (EVE-635). Bounds fan-out so a large
+/// document does not open an unbounded number of concurrent provider requests.
+const EMBED_BATCH_CONCURRENCY: usize = 4;
 
 #[derive(Debug, Clone)]
 pub struct KnowledgeIndexSyncConfig {
@@ -261,7 +266,11 @@ impl KnowledgeIndexSyncService {
             index,
         )
         .await?;
-        let driver = embedder.driver;
+        // EVE-635: share the driver across concurrently in-flight embedding
+        // batches (bounded fan-out below). `BoxedEmbeddingsDriver` is not Clone,
+        // so wrap it once in an Arc.
+        let driver = Arc::new(embedder.driver);
+        let model_id = embedder.model_id.clone();
 
         let mut documents = Vec::with_capacity(docs.len());
         let mut records = Vec::new();
@@ -271,21 +280,41 @@ impl KnowledgeIndexSyncService {
             let pieces = chunk_text(&doc.text, CHUNK_SIZE_CHARS, CHUNK_OVERLAP_CHARS);
             let mut chunk_rows = Vec::with_capacity(pieces.len());
 
-            // Embed in batches to bound request size.
-            let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(pieces.len());
-            for batch in pieces.chunks(EMBED_BATCH_SIZE) {
-                let response = driver
-                    .embed(EmbedRequest {
-                        texts: batch.iter().map(|p| p.text.clone()).collect(),
-                        model: embedder.model_id.clone(),
-                    })
-                    .await
-                    .map_err(|e| anyhow!("embedding request failed: {e}"))?;
-                if response.embeddings.len() != batch.len() {
-                    bail!("embeddings provider returned a mismatched batch size");
-                }
-                embeddings.extend(response.embeddings);
+            // Embed in batches to bound request size. EVE-635: run batches with
+            // bounded concurrency rather than strictly one-at-a-time, then
+            // reassemble in batch order so embeddings still line up with chunks.
+            let batch_inputs: Vec<(usize, Vec<String>)> = pieces
+                .chunks(EMBED_BATCH_SIZE)
+                .enumerate()
+                .map(|(i, batch)| (i, batch.iter().map(|p| p.text.clone()).collect()))
+                .collect();
+            let mut batch_results: Vec<Option<Vec<Vec<f32>>>> = vec![None; batch_inputs.len()];
+
+            let mut embed_stream =
+                futures::stream::iter(batch_inputs.into_iter().map(|(i, texts)| {
+                    let driver = Arc::clone(&driver);
+                    let model = model_id.clone();
+                    async move {
+                        let expected = texts.len();
+                        let response = driver
+                            .embed(EmbedRequest { texts, model })
+                            .await
+                            .map_err(|e| anyhow!("embedding request failed: {e}"))?;
+                        if response.embeddings.len() != expected {
+                            bail!("embeddings provider returned a mismatched batch size");
+                        }
+                        Ok::<(usize, Vec<Vec<f32>>), anyhow::Error>((i, response.embeddings))
+                    }
+                }))
+                .buffer_unordered(EMBED_BATCH_CONCURRENCY);
+
+            while let Some(result) = embed_stream.next().await {
+                let (i, batch_embeddings) = result?;
+                batch_results[i] = Some(batch_embeddings);
             }
+
+            // Flatten batches back into a single per-chunk order.
+            let embeddings: Vec<Vec<f32>> = batch_results.into_iter().flatten().flatten().collect();
 
             let document_public_id = KnowledgeIndexDocumentId::new().to_string();
             for (ordinal, (piece, embedding)) in pieces.into_iter().zip(embeddings).enumerate() {

--- a/crates/turbopuffer/src/lib.rs
+++ b/crates/turbopuffer/src/lib.rs
@@ -43,7 +43,9 @@ impl TurbopufferVectorStore {
     /// (any trailing slash is trimmed); `api_key` authenticates every request.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            // EVE-635: shared client with connect + overall request timeouts so
+            // a hung vector-store read cannot block indefinitely.
+            http: everruns_core::driver_helpers::shared_request_http_client(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key: api_key.into(),
         }


### PR DESCRIPTION
## What
LLM drivers (and their `reqwest::Client` connection pools) were rebuilt on **every** reasoning step: `create_chat_driver` runs the provider factory per turn, and each factory called `Client::new()`, so every agent turn paid a fresh TCP+TLS handshake and never reused HTTP/2 connections. The per-struct `client` field was effectively dead.

This PR makes the HTTP client/driver reusable and hardens provider HTTP hygiene.

## How
- **Shared streaming client** (`crates/core/src/driver_helpers.rs`): `shared_streaming_http_client()` returns a process-wide `OnceLock<reqwest::Client>`. Anthropic, Gemini, and the OpenAI-protocol driver now take their client from it. `reqwest::Client` is internally `Arc` and carries no per-request credentials (auth is per-request), so one pool is safe to share across providers/credentials and is what lets connections be reused across turns even though driver structs are rebuilt each step. Mirrors the existing `voice.rs` `OnceLock` pattern.
- **Timeouts**: the streaming client sets `connect_timeout` + `read_timeout` (per-read inactivity, set to 300s — well above the agent loop's own ~120s stall timeout) + `pool_idle_timeout`. Crucially **not** an overall `.timeout()`, which would cap and kill legitimately long streams. The non-streaming `shared_request_http_client()` (embeddings, turbopuffer) uses `connect_timeout` + an overall request timeout so bounded reads can't hang forever.
- **Bedrock** (`crates/bedrock/src/driver.rs`): builds the AWS SDK `Client` once in `from_config` and stores it, instead of rebuilding the whole credential chain + pool per `chat_completion_stream` call.
- **Retry jitter** (`crates/core/src/llm_retry.rs`): backoff jitter now uses a real RNG (`rand`) instead of a pure function of the attempt number, so concurrent clients hitting the same attempt don't retry in lockstep (thundering herd).
- **Embeddings retry** (`crates/openai/src/embeddings.rs`): transient failures (network, 429/5xx via `is_transient_error`) are retried with the shared `LlmRetryConfig` backoff; non-transient errors fail fast.
- **Embedding fan-out** (`crates/server/.../knowledge_indexes/source_sync.rs`): batches now run with bounded concurrency (`buffer_unordered(4)`) instead of strictly one-at-a-time, reassembled in batch order so embeddings still line up with their chunks.

## Why
Closes EVE-635. Eliminates per-turn TCP/TLS handshakes, bounds hung connections, and removes lockstep retry behavior.

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings` clean on all touched crates (core, anthropic, gemini, bedrock, openai, turbopuffer, server).
- `cargo test` green: anthropic (47), gemini, bedrock (11), openai (25), turbopuffer (38), core `llm_retry` (incl. new jitter-divergence test) + `openai_protocol`.
- `./scripts/lib/pre-push.sh` green (fmt, clippy, lockfile, migration ordering, author).
- New `test_backoff_jitter_is_randomized` asserts repeated same-attempt backoffs diverge and stay within ±25%.

## Smoke test
The streaming-client/timeout/jitter changes are behavior-preserving and covered by the provider unit tests. The embeddings-retry and knowledge-index fan-out paths require a live embeddings provider + Postgres + a GitHub source (and `just`, unavailable here) to exercise end-to-end; the fan-out preserves output order by reassembling batches by index, and the PostgreSQL integration job in CI exercises the knowledge-index sync pipeline. No behavioral contract changed for either path.

## Risk
Medium. Touches the LLM HTTP hot path and the knowledge-index embedding path across several crates. Mitigations: shared client is credential-free and per-host-pooled; streaming uses `read_timeout` (not an overall cap) so long streams are unaffected; fan-out is order-preserving and bounded; embeddings retry is additive (success path unchanged).

## Security
- Threat categories reviewed: **TM-LLM** (provider HTTP/credentials), **TM-DOS** (timeouts + bounded fan-out). The shared client holds no credentials (auth headers attached per request), so sharing it across orgs/credentials does not cross a tenant boundary. New timeouts and bounded concurrency reduce resource-exhaustion exposure. `app_endpoint_auth.rs`'s intentional per-request DNS-pinned client is left as-is (out of scope, anti-TOCTOU).
- Findings: none.

## Follow-ups
No follow-ups. All EVE-635 exit criteria are addressed in this PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal; behavior-preserving)
- [x] Security review performed (TM-LLM, TM-DOS)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPWywcD96sHibL1ATFWq4C)_