### PR TITLE
fix(security): bump ws to >=8.21.0 (jsdom DoS advisory, dev/test dep)

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -77,7 +77,8 @@
       "js-yaml": "4.2.0",
       "postcss": "8.5.14",
       "prismjs": "1.30.0",
-      "uuid": "11.1.1"
+      "uuid": "11.1.1",
+      "ws": "^8.21.0"
     },
     "onlyBuiltDependencies": [
       "@tailwindcss/oxide",

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   postcss: 8.5.14
   prismjs: 1.30.0
   uuid: 11.1.1
+  ws: ^8.21.0
 
 importers:
 
@@ -4258,8 +4259,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7489,7 +7490,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.1
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -8999,7 +9000,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## What
`pnpm audit` flagged **GHSA-96hv-2xvq-fx4p** — `ws` memory-exhaustion DoS from tiny fragments/data chunks, affecting `>=8.0.0 <8.21.0`. The UI lockfile pinned `ws@8.20.1`.

Pin `ws` to `^8.21.0` via the existing `pnpm.overrides` block and regenerate the lockfile (`ws 8.20.1 → 8.21.0`).

## Why
Surfaced while processing security/dependency vulnerabilities (the GitHub Dependabot alerts API is not reachable from this environment, so this was found via `pnpm audit`). `ws` reaches the tree **only through the test toolchain** (`jest-environment-jsdom > jsdom > ws`) — `pnpm audit --prod` is clean, so it is **not** in the production bundle — but the dev/test surface shouldn't carry a known-vulnerable transitive dep.

## Validation
- `pnpm audit` (full graph): **No known vulnerabilities found** after the bump (was 1 high before).
- Diff is minimal: one override line + a 9-line lockfile change; `ws@8.21.0` is the only `ws` version resolved.
- UI build/lint/test + Playwright smoke run in CI (UI can't be built in this environment — no `node_modules`).

## Risk
Very low. `8.20.1 → 8.21.0` is a semver-patch bump of a test-only transitive dependency; the production bundle is unaffected.

## Security
- Closes a known advisory (GHSA-96hv-2xvq-fx4p / DoS). No code changes, dev-dependency only — no runtime trust boundary touched.

## Follow-ups
No follow-ups. (Rust `cargo audit` could not be run here — the RustSec advisory DB fetch from github.com is blocked by egress policy; the one known Rust advisory, RUSTSEC-2023-0071, is already documented as not-compiled-in in `.cargo/audit.toml`.)

## Checklist
- [x] Backward compatibility considered (patch bump, dev-only)
- [x] Security review performed (dependency advisory)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPWywcD96sHibL1ATFWq4C)_