### PR TITLE
fix(llm): retry transient connection send errors across providers

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -35,6 +35,7 @@ use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
 use everruns_core::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
+    is_transient_send_error, send_error_message,
 };
 use everruns_core::tool_types::{DeferrablePolicy, ToolCall, ToolDefinition};
 
@@ -619,11 +620,37 @@ impl ChatDriver for AnthropicChatDriver {
                 request_builder = request_builder.header("anthropic-beta", beta);
             }
 
-            let response = request_builder
-                .json(&request)
-                .send()
-                .await
-                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            let response = match request_builder.json(&request).send().await {
+                Ok(response) => response,
+                Err(e) => {
+                    // A send failure never produced an HTTP response, so it
+                    // bypasses the status-based retry below. Connection-level
+                    // errors (incl. a stale pooled keep-alive connection,
+                    // EVE-635) are transient — retry them with backoff, matching
+                    // SDK `APIConnectionError` behavior.
+                    if is_transient_send_error(&e)
+                        && retry_metadata.attempts < self.retry_config.max_retries
+                    {
+                        let wait_duration =
+                            self.retry_config.calculate_backoff(retry_metadata.attempts);
+                        tracing::warn!(
+                            error = %e,
+                            attempt = retry_metadata.attempts + 1,
+                            max_retries = self.retry_config.max_retries,
+                            wait_secs = wait_duration.as_secs_f64(),
+                            "AnthropicDriver: transient connection error sending request, retrying"
+                        );
+                        retry_metadata.record_retry(wait_duration, None);
+                        last_error = Some(format!("Failed to send request: {e}"));
+                        tokio::time::sleep(wait_duration).await;
+                        continue;
+                    }
+                    return Err(AgentLoopError::llm(send_error_message(
+                        &e,
+                        retry_metadata.attempts,
+                    )));
+                }
+            };
 
             let status = response.status();
 

--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -377,6 +377,35 @@ pub fn is_transient_error(status: reqwest::StatusCode) -> bool {
     false
 }
 
+/// Check if a `reqwest` error raised while *sending* a request is a transient
+/// connection-level failure that is safe to retry.
+///
+/// These are errors where the request never produced an HTTP response: a
+/// connect/TLS failure, a connect timeout, or a generic send failure on a
+/// (possibly stale) pooled keep-alive connection — surfaced by reqwest as
+/// `error sending request for url ...`. The official Anthropic/OpenAI SDKs
+/// retry exactly these as `APIConnectionError`. Because the server produced no
+/// response, the request had no effect, so retrying is safe.
+///
+/// This matters since EVE-635 introduced a process-wide shared connection pool:
+/// a keep-alive connection the peer has already closed is only discovered when
+/// the next request tries to reuse it, and that send fails here rather than
+/// returning an HTTP status — so it must be retried alongside the 429/5xx path
+/// (see `is_transient_error`).
+pub fn is_transient_send_error(err: &reqwest::Error) -> bool {
+    err.is_connect() || err.is_timeout() || err.is_request()
+}
+
+/// Build the user-facing message for a request that failed to send, noting how
+/// many retries were exhausted so it mirrors the HTTP-status error path.
+pub fn send_error_message(err: &reqwest::Error, attempts: u32) -> String {
+    if attempts > 0 {
+        format!("Failed to send request: {err} (after {attempts} retries)")
+    } else {
+        format!("Failed to send request: {err}")
+    }
+}
+
 /// Check if an in-band provider error message looks transient and safe to retry.
 ///
 /// This complements HTTP-status-based retry detection for streaming APIs that can
@@ -583,6 +612,29 @@ mod tests {
         assert!(!is_transient_error(reqwest::StatusCode::FORBIDDEN)); // 403
         assert!(!is_transient_error(reqwest::StatusCode::NOT_FOUND)); // 404
         assert!(!is_transient_error(reqwest::StatusCode::NOT_IMPLEMENTED)); // 501
+    }
+
+    /// A real send that cannot reach the server (connection refused on a closed
+    /// port) must be classified as a transient connection error — this is the
+    /// "error sending request for url" case that the retry loop now retries.
+    #[tokio::test]
+    async fn test_is_transient_send_error_on_connection_refused() {
+        // Bind then immediately drop a listener to obtain a port that is
+        // guaranteed to be closed, so the connect attempt is refused.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let err = reqwest::Client::new()
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("request to a closed port should fail");
+
+        assert!(
+            is_transient_send_error(&err),
+            "connection-refused send error should be transient: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -30,6 +30,7 @@ use crate::driver_registry::{
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
+    is_transient_send_error, send_error_message,
 };
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::user_facing_error::is_provider_quota_message;
@@ -438,12 +439,42 @@ impl ChatDriver for OpenAIProtocolChatDriver {
                 None => apply_openai_api_auth(request_builder, &self.api_url, &self.api_key),
             };
 
-            let response = request_builder
+            let response = match request_builder
                 .header("Content-Type", "application/json")
                 .json(&request)
                 .send()
                 .await
-                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    // A send failure never produced an HTTP response, so it
+                    // bypasses the status-based retry below. Connection-level
+                    // errors (incl. a stale pooled keep-alive connection,
+                    // EVE-635) are transient — retry them with backoff, matching
+                    // SDK `APIConnectionError` behavior.
+                    if is_transient_send_error(&e)
+                        && retry_metadata.attempts < self.retry_config.max_retries
+                    {
+                        let wait_duration =
+                            self.retry_config.calculate_backoff(retry_metadata.attempts);
+                        tracing::warn!(
+                            error = %e,
+                            attempt = retry_metadata.attempts + 1,
+                            max_retries = self.retry_config.max_retries,
+                            wait_secs = wait_duration.as_secs_f64(),
+                            "OpenAIProtocolDriver: transient connection error sending request, retrying"
+                        );
+                        retry_metadata.record_retry(wait_duration, None);
+                        last_error = Some(format!("Failed to send request: {e}"));
+                        tokio::time::sleep(wait_duration).await;
+                        continue;
+                    }
+                    return Err(AgentLoopError::llm(send_error_message(
+                        &e,
+                        retry_metadata.attempts,
+                    )));
+                }
+            };
 
             let status = response.status();
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -39,6 +39,7 @@ use crate::driver_registry::{
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
+    is_transient_send_error, send_error_message,
 };
 use crate::openai_protocol::{
     AuthHeaderProvider, is_openai_model_not_found, is_openai_request_too_large,
@@ -505,7 +506,7 @@ impl OpenResponsesProtocolChatDriver {
             // Auth is resolved per attempt so refreshable providers can rotate
             // tokens across retries (same seam as the streaming path).
             let (auth_name, auth_value) = self.resolve_auth_header(&compact_url).await?;
-            let response = self
+            let response = match self
                 .client
                 .post(&compact_url)
                 .header(auth_name, auth_value)
@@ -513,9 +514,41 @@ impl OpenResponsesProtocolChatDriver {
                 .json(&request)
                 .send()
                 .await
-                .map_err(|e| {
-                    AgentLoopError::llm(format!("Failed to send compact request: {}", e))
-                })?;
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    // A send failure never produced an HTTP response, so it
+                    // bypasses the status-based retry below. Connection-level
+                    // errors (incl. a stale pooled keep-alive connection,
+                    // EVE-635) are transient — retry them with backoff, matching
+                    // SDK `APIConnectionError` behavior.
+                    if is_transient_send_error(&e)
+                        && retry_metadata.attempts < self.retry_config.max_retries
+                    {
+                        let wait_duration =
+                            self.retry_config.calculate_backoff(retry_metadata.attempts);
+                        tracing::warn!(
+                            error = %e,
+                            attempt = retry_metadata.attempts + 1,
+                            max_retries = self.retry_config.max_retries,
+                            wait_secs = wait_duration.as_secs_f64(),
+                            "OpenResponsesDriver: compact transient connection error sending request, retrying"
+                        );
+                        retry_metadata.record_retry(wait_duration, None);
+                        last_error = Some(format!("Failed to send compact request: {e}"));
+                        tokio::time::sleep(wait_duration).await;
+                        continue;
+                    }
+                    let suffix = if retry_metadata.attempts > 0 {
+                        format!(" (after {} retries)", retry_metadata.attempts)
+                    } else {
+                        String::new()
+                    };
+                    return Err(AgentLoopError::llm(format!(
+                        "Failed to send compact request: {e}{suffix}"
+                    )));
+                }
+            };
 
             let status = response.status();
 
@@ -989,7 +1022,7 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             let (auth_name, auth_value) = self.resolve_auth_header(&self.api_url).await?;
             headers.insert(auth_name, auth_value);
 
-            let response = self
+            let response = match self
                 .client
                 .post(&self.api_url)
                 .headers(headers)
@@ -997,7 +1030,37 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                 .json(&request_body)
                 .send()
                 .await
-                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    // A send failure never produced an HTTP response, so it
+                    // bypasses the status-based retry below. Connection-level
+                    // errors (incl. a stale pooled keep-alive connection,
+                    // EVE-635) are transient — retry them with backoff, matching
+                    // SDK `APIConnectionError` behavior.
+                    if is_transient_send_error(&e)
+                        && retry_metadata.attempts < self.retry_config.max_retries
+                    {
+                        let wait_duration =
+                            self.retry_config.calculate_backoff(retry_metadata.attempts);
+                        tracing::warn!(
+                            error = %e,
+                            attempt = retry_metadata.attempts + 1,
+                            max_retries = self.retry_config.max_retries,
+                            wait_secs = wait_duration.as_secs_f64(),
+                            "OpenResponsesProtocolDriver: transient connection error sending request, retrying"
+                        );
+                        retry_metadata.record_retry(wait_duration, None);
+                        last_error = Some(format!("Failed to send request: {e}"));
+                        tokio::time::sleep(wait_duration).await;
+                        continue;
+                    }
+                    return Err(AgentLoopError::llm(send_error_message(
+                        &e,
+                        retry_metadata.attempts,
+                    )));
+                }
+            };
 
             let status = response.status();
 

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -28,7 +28,9 @@ use everruns_core::driver_registry::{
 };
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
-use everruns_core::llm_retry::{LlmRetryConfig, RetryMetadata, is_transient_error};
+use everruns_core::llm_retry::{
+    LlmRetryConfig, RetryMetadata, is_transient_error, is_transient_send_error, send_error_message,
+};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -340,7 +342,7 @@ impl ChatDriver for GeminiChatDriver {
         let url = self.stream_url(&config.model);
 
         let response = loop {
-            let response = self
+            let response = match self
                 .client
                 .post(&url)
                 .header("Content-Type", "application/json")
@@ -348,7 +350,37 @@ impl ChatDriver for GeminiChatDriver {
                 .json(&request)
                 .send()
                 .await
-                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    // A send failure never produced an HTTP response, so it
+                    // bypasses the status-based retry below. Connection-level
+                    // errors (incl. a stale pooled keep-alive connection,
+                    // EVE-635) are transient — retry them with backoff, matching
+                    // SDK `APIConnectionError` behavior.
+                    if is_transient_send_error(&e)
+                        && retry_metadata.attempts < self.retry_config.max_retries
+                    {
+                        let wait_duration =
+                            self.retry_config.calculate_backoff(retry_metadata.attempts);
+                        tracing::warn!(
+                            error = %e,
+                            attempt = retry_metadata.attempts + 1,
+                            max_retries = self.retry_config.max_retries,
+                            wait_secs = wait_duration.as_secs_f64(),
+                            "GeminiDriver: transient connection error sending request, retrying"
+                        );
+                        retry_metadata.record_retry(wait_duration, None);
+                        last_error = Some(format!("Failed to send request: {e}"));
+                        tokio::time::sleep(wait_duration).await;
+                        continue;
+                    }
+                    return Err(AgentLoopError::llm(send_error_message(
+                        &e,
+                        retry_metadata.attempts,
+                    )));
+                }
+            };
 
             let status = response.status();
 


### PR DESCRIPTION
## What
Retry connection-level request *send* failures in the LLM streaming chat drivers (anthropic, openai_protocol, gemini, openresponses streaming + compact), instead of failing the turn immediately. Adds `is_transient_send_error` and a shared `send_error_message` to `llm_retry`.

## Why
CI on `main` was intermittently red on the push-triggered LLM integration tests (`crates/llm-tests/tests/agent_run_with_thinking.rs`), failing with:

```
Turn should succeed: Some("LLM error: Failed to send request:
error sending request for url (https://api.anthropic.com/v1/messages)")
```

This is a connection-level send error — the request never produced an HTTP response. The drivers did `.send().await.map_err(...)?`, so such errors returned immediately and **bypassed the retry loop**, which only handled HTTP status errors (429/5xx).

The failure became observable after **EVE-635** (#2462) introduced a process-wide shared keep-alive connection pool: a pooled connection the peer has already closed is only discovered on the next reuse, where the send fails with "error sending request" rather than returning a status. The official Anthropic/OpenAI SDKs retry exactly this case as `APIConnectionError`.

## How
- `is_transient_send_error(&reqwest::Error)` classifies connect/timeout/request errors as transient.
- Each streaming driver's retry loop now matches on the `.send()` result: a transient send error is retried with the existing exponential backoff (bounded by `max_retries`), and otherwise surfaced via the shared `send_error_message` (which notes retries exhausted, mirroring the status-error path).
- A failed send produced no response, so the request had no effect and is safe to retry.

## Risk
- Low. The success path is unchanged; this only adds an error branch to existing retry loops. Retries remain bounded by `LlmRetryConfig::max_retries` (default 2), so no unbounded behavior.

> Note on CI: the flaking LLM integration tests run **only on `push` to `main`** (gated `if: github.event_name == 'push'`), so they do **not** run on this PR. PR CI green confirms compile/clippy/unit coverage; final confirmation of the fix is the post-merge `main` push run. The new connection path is covered by a unit test that classifies a real connection-refused send as transient.

## Security
- Threat categories reviewed: **TM-LLM**. The change is confined to transient-error retry logic in the provider HTTP drivers.
- Findings and resolutions: None. No new inputs or endpoints; no new dependencies; retries stay bounded (no DoS). The logged `reqwest::Error` Display includes the request URL but not auth headers/API keys (keys are sent as headers, not in the URL), so no secret exposure.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01146Ld7ieQvairPM6bbXEmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01146Ld7ieQvairPM6bbXEmA)_