### PR TITLE
perf(server): read-through cache for org feature-flag lookups (EVE-637)

### DIFF
--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -20,6 +20,7 @@ pub mod leased_resource_store;
 pub mod memory;
 pub mod message_store;
 pub mod models;
+pub mod org_feature_flags_cache;
 pub mod partial_stream;
 pub mod password;
 pub mod provider_store;

--- a/crates/server/src/storage/org_feature_flags_cache.rs
+++ b/crates/server/src/storage/org_feature_flags_cache.rs
@@ -1,0 +1,222 @@
+//! In-process read-through cache for per-organization feature-flag opt-ins (EVE-637).
+//!
+//! Org feature flags are read on essentially every org-scoped request (via
+//! `ResolvedOrg::with_effective_feature_flags`) but change rarely. Before this
+//! cache the Postgres backend ran a `SELECT ... FROM org_feature_flags` on every
+//! such request. This wraps that read in a bounded, short-TTL moka cache so a hit
+//! performs zero database round-trips.
+//!
+//! Freshness: the cache lives on the Postgres `Database`, so the read path and the
+//! `replace_org_feature_flags` write path share one instance — a flag update on the
+//! same instance invalidates the entry immediately. The short TTL is the backstop
+//! for the multi-instance case: instance A's PATCH does not reach instance B's
+//! in-process cache, so B can serve a stale value for at most `TTL`. This bounded
+//! staleness is acceptable for feature flags (they gate features, not access) and
+//! matches the EVE-637 design intent.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::time::Duration;
+
+use moka::future::Cache;
+
+/// TTL for cached org feature-flag entries. Bounds cross-instance staleness; the
+/// owning instance invalidates immediately on update.
+const ORG_FEATURE_FLAGS_CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Max distinct orgs held in the cache. Bounds memory across many orgs.
+const ORG_FEATURE_FLAGS_CACHE_MAX_CAPACITY: u64 = 10_000;
+
+/// Read-through cache of `org_id -> {flag_name -> enabled}`.
+///
+/// Cloning shares the underlying store (moka is `Arc`-backed), so all clones of a
+/// `Database` observe the same cache and invalidations.
+#[derive(Clone)]
+pub struct OrgFeatureFlagsCache {
+    cache: Cache<i64, HashMap<String, bool>>,
+}
+
+impl OrgFeatureFlagsCache {
+    pub fn new() -> Self {
+        Self::with_ttl(ORG_FEATURE_FLAGS_CACHE_TTL)
+    }
+
+    fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            cache: Cache::builder()
+                .max_capacity(ORG_FEATURE_FLAGS_CACHE_MAX_CAPACITY)
+                .time_to_live(ttl)
+                .build(),
+        }
+    }
+
+    /// Return the cached flags for `org_id`, or invoke `loader` to fetch them and
+    /// populate the cache. On a hit, `loader` is not called (zero DB round-trips).
+    pub async fn get_or_load<F, Fut>(
+        &self,
+        org_id: i64,
+        loader: F,
+    ) -> anyhow::Result<HashMap<String, bool>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = anyhow::Result<HashMap<String, bool>>>,
+    {
+        if let Some(flags) = self.cache.get(&org_id).await {
+            return Ok(flags);
+        }
+        let flags = loader().await?;
+        self.cache.insert(org_id, flags.clone()).await;
+        Ok(flags)
+    }
+
+    /// Drop the cached entry for `org_id`. Called after a write so the next read
+    /// reflects the new state immediately on this instance.
+    pub async fn invalidate(&self, org_id: i64) {
+        self.cache.invalidate(&org_id).await;
+    }
+
+    #[cfg(test)]
+    async fn entry_count(&self) -> u64 {
+        self.cache.run_pending_tasks().await;
+        self.cache.entry_count()
+    }
+}
+
+impl Default for OrgFeatureFlagsCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn flags(pairs: &[(&str, bool)]) -> HashMap<String, bool> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    #[tokio::test]
+    async fn hit_does_not_invoke_loader() {
+        let cache = OrgFeatureFlagsCache::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let load = |calls: Arc<AtomicUsize>, value: HashMap<String, bool>| {
+            move || {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(value)
+                }
+            }
+        };
+
+        let first = cache
+            .get_or_load(1, load(calls.clone(), flags(&[("public_chat", true)])))
+            .await
+            .unwrap();
+        assert_eq!(first, flags(&[("public_chat", true)]));
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "miss loads once");
+
+        // Second read with a loader that would return a *different* value: a hit
+        // must serve the cached value and must not invoke the loader.
+        let second = cache
+            .get_or_load(1, load(calls.clone(), flags(&[("public_chat", false)])))
+            .await
+            .unwrap();
+        assert_eq!(second, flags(&[("public_chat", true)]), "served from cache");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "hit performs zero loads");
+    }
+
+    #[tokio::test]
+    async fn invalidate_forces_reload() {
+        let cache = OrgFeatureFlagsCache::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let load = |calls: Arc<AtomicUsize>, value: HashMap<String, bool>| {
+            move || {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(value)
+                }
+            }
+        };
+
+        cache
+            .get_or_load(7, load(calls.clone(), flags(&[("a", true)])))
+            .await
+            .unwrap();
+        cache.invalidate(7).await;
+
+        let after = cache
+            .get_or_load(7, load(calls.clone(), flags(&[("a", false)])))
+            .await
+            .unwrap();
+        assert_eq!(after, flags(&[("a", false)]), "reload after invalidation");
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "invalidation re-loads");
+    }
+
+    #[tokio::test]
+    async fn keys_are_independent() {
+        let cache = OrgFeatureFlagsCache::new();
+        let load = |value: HashMap<String, bool>| move || async move { Ok(value) };
+
+        cache
+            .get_or_load(1, load(flags(&[("a", true)])))
+            .await
+            .unwrap();
+        cache
+            .get_or_load(2, load(flags(&[("b", true)])))
+            .await
+            .unwrap();
+        cache.invalidate(1).await;
+
+        // org 2 still cached: loader returning a different value is ignored.
+        let org2 = cache
+            .get_or_load(2, load(flags(&[("b", false)])))
+            .await
+            .unwrap();
+        assert_eq!(org2, flags(&[("b", true)]), "unrelated key untouched");
+    }
+
+    #[tokio::test]
+    async fn ttl_expiry_reloads() {
+        let cache = OrgFeatureFlagsCache::with_ttl(Duration::from_millis(50));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let load = |calls: Arc<AtomicUsize>| {
+            move || {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(HashMap::new())
+                }
+            }
+        };
+
+        cache.get_or_load(1, load(calls.clone())).await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        cache.get_or_load(1, load(calls.clone())).await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "expired entry re-loads");
+    }
+
+    #[tokio::test]
+    async fn entry_count_tracks_inserts() {
+        let cache = OrgFeatureFlagsCache::new();
+        let load = |value: HashMap<String, bool>| move || async move { Ok(value) };
+        cache
+            .get_or_load(1, load(flags(&[("a", true)])))
+            .await
+            .unwrap();
+        cache
+            .get_or_load(2, load(flags(&[("a", true)])))
+            .await
+            .unwrap();
+        assert_eq!(cache.entry_count().await, 2);
+        cache.invalidate(1).await;
+        assert_eq!(cache.entry_count().await, 1);
+    }
+}

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -157,6 +157,10 @@ pub struct Database {
     /// a pointer (specs/object-storage.md). `None` keeps bytes inline in
     /// PostgreSQL (default behavior).
     blob_store: Option<crate::storage::blob_store::SharedBlobStore>,
+    /// Read-through cache for per-org feature-flag opt-ins (EVE-637). Shared
+    /// across clones; the read and `replace_org_feature_flags` write paths use
+    /// this same instance so a local update invalidates immediately.
+    org_feature_flags_cache: crate::storage::org_feature_flags_cache::OrgFeatureFlagsCache,
 }
 
 impl Database {
@@ -164,6 +168,7 @@ impl Database {
         Self {
             pool,
             blob_store: None,
+            org_feature_flags_cache: Default::default(),
         }
     }
 
@@ -238,6 +243,7 @@ impl Database {
         Ok(Self {
             pool,
             blob_store: None,
+            org_feature_flags_cache: Default::default(),
         })
     }
 

--- a/crates/server/src/storage/repositories/org_feature_flags.rs
+++ b/crates/server/src/storage/repositories/org_feature_flags.rs
@@ -6,14 +6,22 @@ use std::collections::HashMap;
 
 impl Database {
     pub async fn list_org_feature_flags(&self, org_id: i64) -> Result<HashMap<String, bool>> {
-        let rows = sqlx::query_as::<_, (String, bool)>(
-            "SELECT flag_name, enabled FROM org_feature_flags WHERE org_id = $1",
-        )
-        .bind(org_id)
-        .fetch_all(&self.pool)
-        .await?;
+        // Read-through cache (EVE-637): this read happens on essentially every
+        // org-scoped request; a hit avoids the SELECT entirely. The write path
+        // (`replace_org_feature_flags`) invalidates the same instance.
+        let pool = self.pool.clone();
+        self.org_feature_flags_cache
+            .get_or_load(org_id, move || async move {
+                let rows = sqlx::query_as::<_, (String, bool)>(
+                    "SELECT flag_name, enabled FROM org_feature_flags WHERE org_id = $1",
+                )
+                .bind(org_id)
+                .fetch_all(&pool)
+                .await?;
 
-        Ok(rows.into_iter().collect())
+                Ok(rows.into_iter().collect())
+            })
+            .await
     }
 
     pub async fn replace_org_feature_flags(
@@ -48,6 +56,10 @@ impl Database {
         }
 
         tx.commit().await?;
+        // Invalidate the read-through cache so the next read reflects the write
+        // on this instance immediately (cross-instance staleness is bounded by
+        // the cache TTL). See `storage::org_feature_flags_cache`.
+        self.org_feature_flags_cache.invalidate(org_id).await;
         Ok(())
     }
 }


### PR DESCRIPTION
## What
Add a bounded, short-TTL (30s) in-process **read-through cache** for per-org feature-flag opt-ins, co-located on the Postgres `Database`. A cache hit performs **zero** DB round-trips.

This is the **org-feature-flag half of EVE-637**. The JWT identity-cache half is intentionally deferred — see Follow-ups.

## Why
Org feature flags are read on essentially every org-scoped request (via `ResolvedOrg::with_effective_feature_flags` → `resolve_org_feature_flags` → `db.list_org_feature_flags`), but they change rarely. On the Postgres backend that was a `SELECT … FROM org_feature_flags` per request — one of the per-request latency contributors called out in EVE-637.

## How
- New `storage::org_feature_flags_cache::OrgFeatureFlagsCache` — a thin moka wrapper (`org_id -> {flag -> enabled}`), `time_to_live = 30s`, `max_capacity = 10_000`. `get_or_load(org_id, loader)` returns the cached map or invokes the loader once and populates; `invalidate(org_id)` drops the entry.
- The cache lives on the Postgres `Database` struct (moka is `Arc`-backed, so it's shared across clones). `list_org_feature_flags` now reads through it; `replace_org_feature_flags` invalidates the same instance after commit. Because read + write share one instance, **invalidation can't be missed** — no plumbing through `AppState`/middleware/handlers.
- The in-memory dev backend is unchanged (its `list_org_feature_flags` is already a map read).
- Multi-instance freshness: the owning instance invalidates immediately on update; another instance can serve a stale value for at most the TTL. Documented in the module; this bounded staleness is the design EVE-637 proposes (30–60s) and is acceptable for feature flags (they gate features, not access).

## Risk
- **Low.** Internal caching layer on two storage methods; returned values are identical to the uncached path. Worst case is a flag toggle taking ≤30s to propagate to *other* instances; the updating instance is immediate. No public API, schema, or auth-path change.

## Security
- Threat categories reviewed: **TM-AUTHZ / TM-TENANT** (feature flags are org-scoped and can gate org-effective behavior). The cache key is `org_id`, so there is no cross-org bleed; values are per-org maps. Flags are not an access-control boundary, and changes are immediate on the writing instance + bounded by a 30s TTL elsewhere.
- This PR deliberately does **not** touch the auth identity path. The existing PAT auth cache is write-only by design (read-through was previously removed for a TOCTOU window on token revocation / membership / role changes); reintroducing read-through auth caching is the deferred half below and warrants dedicated security review.
- Findings and resolutions: none outstanding.

## Follow-ups
- **JWT identity-cache half of EVE-637 (deferred).** Caching `(user, organizations)` on the JWT hot path reverses a deliberate auth hardening — `crates/server/src/auth/builtin.rs` keeps the PAT cache write-only and always re-validates against the DB (enforced by `validate_api_key_rejects_after_key_deleted_from_db` / `…reflects_fresh_user_state_on_revalidation`). Doing it safely requires wiring invalidation into every user/membership/role/token mutation site and proving each revocation path; that is a security-sensitive change that should land on its own with human review rather than be bundled here. EVE-637 stays open for it.

## Checklist
- [x] Tests added or updated (5 unit tests: hit performs zero loads, invalidation forces reload, key isolation, TTL expiry, bounded entry count)
- [x] Backward compatibility considered (additive; identical values; dev/in-memory path unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Validation: `cargo test -p everruns-server storage::org_feature_flags_cache` (5 passed), `cargo fmt --check` clean, `cargo clippy -p everruns-server --all-features --lib` clean. The real Postgres read/invalidate path is exercised by the postgres-integration CI job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xw1cMbnkenzBJM22ewwdwE)_