### PR TITLE
feat(core): mount-based workspace path resolver (EVE-660)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,10 @@ jobs:
           # Do not pass --all-features here: it would enable `turbopuffer-live-tests`,
           # which fails closed without TURBOPUFFER_API_KEY. Live tests run separately.
           cargo test -p everruns-turbopuffer --lib
-          cargo test -p everruns-runtime --test in_process_runtime_test --test runtime_host_test -- --test-threads=1
+          # `--lib` runs the runtime backend unit tests (RealDiskFileStore,
+          # in-memory store); the named integration tests cover the runtime host
+          # paths and the EVE-660 mount-resolver conformance across a worktree switch.
+          cargo test -p everruns-runtime --lib --test in_process_runtime_test --test runtime_host_test --test workspace_paths_conformance_test -- --test-threads=1
           # Doctests are excluded by the target-filtered runs above (--test/--lib
           # skip the Doc-tests target), so run them explicitly to guard the
           # crate-level embedding example in crates/runtime/src/lib.rs.
@@ -388,6 +391,8 @@ jobs:
           # exercises the end-to-end routing contract + runnable example.
           cargo test -p everruns-runtime --features lua --test lua_code_mode_test -- --test-threads=1
           cargo run -p everruns-runtime --features lua --example lua_code_mode_agent
+          # Runnable demonstration of the EVE-660 mount resolver (/workspace mount + cwd).
+          cargo run -p everruns-runtime --example mount_fs_workspace
           cargo test -p everruns-cli --test auth_integration_test --test chat_integration_test --test files_integration_test -- --test-threads=1
           # Do not pass --all-features to integration crates: it enables their *-live-tests
           # features, which fail closed without real credentials. Live tests run in their

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,17 +379,12 @@ jobs:
           # Do not pass --all-features here: it would enable `turbopuffer-live-tests`,
           # which fails closed without TURBOPUFFER_API_KEY. Live tests run separately.
           cargo test -p everruns-turbopuffer --lib
-          # `--lib` runs the runtime backend unit tests (RealDiskFileStore,
-          # in-memory store); the named integration tests cover the runtime host
-          # paths and the EVE-660 mount-resolver conformance across a worktree switch.
-          cargo test -p everruns-runtime --lib --test in_process_runtime_test --test runtime_host_test --test workspace_paths_conformance_test -- --test-threads=1
-          # Doctests are excluded by the target-filtered runs above (--test/--lib
-          # skip the Doc-tests target), so run them explicitly to guard the
-          # crate-level embedding example in crates/runtime/src/lib.rs.
-          cargo test -p everruns-runtime --doc
-          # Lua code-mode capability: compiles the mlua engine (`lua` feature) and
-          # exercises the end-to-end routing contract + runnable example.
-          cargo test -p everruns-runtime --features lua --test lua_code_mode_test -- --test-threads=1
+          # Run the whole runtime crate (lib unit tests incl. RealDiskFileStore /
+          # in-memory store, ALL integration tests incl. the EVE-660 mount-resolver
+          # conformance, and doctests). No per-test enumeration: new test files are
+          # picked up automatically rather than silently skipped. `--features lua`
+          # so the lua code-mode integration test compiles and runs in the same pass.
+          cargo test -p everruns-runtime --features lua -- --test-threads=1
           cargo run -p everruns-runtime --features lua --example lua_code_mode_agent
           # Runnable demonstration of the EVE-660 mount resolver (/workspace mount + cwd).
           cargo run -p everruns-runtime --example mount_fs_workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,11 @@ jobs:
           # doctests), not just --lib, so integration tests aren't silently skipped.
           # Both are pure (llmsim-based, no credentials or network).
           cargo test -p everruns-core -p everruns-local --all-features
+          # mcp: whole crate (lib + http_transport + stdio_transport + doctests).
+          # Was not tested in CI at all. --all-features enables the `stdio` transport
+          # (off in hosted builds) so its transport test runs here. All in-process,
+          # no network/credentials.
+          cargo test -p everruns-mcp --all-features
           # Do not pass --all-features here: it would enable `turbopuffer-live-tests`,
           # which fails closed without TURBOPUFFER_API_KEY. Live tests run separately.
           cargo test -p everruns-turbopuffer --lib
@@ -428,8 +433,10 @@ jobs:
         with:
           shared-key: "test"
 
-      - name: Run worker library tests
-        run: cargo test -p everruns-worker --lib -- --test-threads=1
+      - name: Run worker tests
+        # Whole crate (lib + integration), not just --lib: the network_reliability
+        # integration test is pure (no network/credentials) and was being skipped.
+        run: cargo test -p everruns-worker --all-features -- --test-threads=1
 
   shell-test:
     name: Shell Tests (Repo Scripts)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,13 @@ jobs:
 
       - name: Run pure unit tests
         run: |
-          cargo test -p everruns-anthropic -p everruns-openai -p everruns-gemini -p everruns-internal-protocol -p everruns-core --lib --all-features
+          # Provider crates: --lib only. Their integration tests are live (network)
+          # and run in dedicated credentialed jobs, so the default suite stays --lib.
+          cargo test -p everruns-anthropic -p everruns-openai -p everruns-gemini -p everruns-internal-protocol --lib --all-features
+          # Core and the local embedder: run the WHOLE suite (lib + integration +
+          # doctests), not just --lib, so integration tests aren't silently skipped.
+          # Both are pure (llmsim-based, no credentials or network).
+          cargo test -p everruns-core -p everruns-local --all-features
           # Do not pass --all-features here: it would enable `turbopuffer-live-tests`,
           # which fails closed without TURBOPUFFER_API_KEY. Live tests run separately.
           cargo test -p everruns-turbopuffer --lib

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -1526,6 +1526,12 @@ where
                 ));
             }
         }
+        // Resolve model paths through the mount resolver (EVE-660): `/workspace`
+        // is a mount + cwd, not a per-store prefix. Applied over the
+        // workspace-keyed store so resolution sits above re-keying.
+        if let Some(store) = tool_context.file_store.take() {
+            tool_context.file_store = Some(crate::mount_fs::MountFs::wrap(store));
+        }
         if let Some(ref store) = self.sqldb_store {
             tool_context.sqldb_store = Some(store.clone());
         }

--- a/crates/core/src/capabilities/bashkit_shell.rs
+++ b/crates/core/src/capabilities/bashkit_shell.rs
@@ -71,6 +71,29 @@ fn execution_limits() -> ExecutionLimits {
         .parser_timeout(std::time::Duration::from_secs(5))
 }
 
+/// Resolve the shell working directory and `WORKSPACE` env value through the
+/// unified workspace path model (EVE-660).
+///
+/// Both reflect the file store's display root, so the in-VFS shell and the file
+/// tools speak one namespace: a model that learns a path from `read_file` can
+/// pass it straight to `cat`. Returns an error message when an explicit
+/// `working_dir` cannot be parsed. The tuple is `(cwd, workspace_env)`.
+fn resolve_shell_workspace(
+    context: &ToolContext,
+    working_dir_arg: Option<&str>,
+) -> std::result::Result<(String, String), String> {
+    let paths = context.workspace_paths();
+    let display_root = paths.display_root();
+    let cwd = match working_dir_arg {
+        Some(arg) => paths
+            .parse_input(arg)
+            .map(|rel| paths.to_display(&rel))
+            .map_err(|e| format!("invalid working_dir '{arg}': {e}"))?,
+        None => display_root.clone(),
+    };
+    Ok((cwd, display_root))
+}
+
 /// Configured bashkit tool instance with everruns settings.
 static BASHKIT_TOOL: LazyLock<BashkitTool> = LazyLock::new(|| {
     BashkitTool::builder()
@@ -276,10 +299,13 @@ impl Tool for BashTool {
             }
         };
 
-        let working_dir = arguments
-            .get("working_dir")
-            .and_then(|v| v.as_str())
-            .unwrap_or("/workspace");
+        let (working_dir, workspace_env) = match resolve_shell_workspace(
+            context,
+            arguments.get("working_dir").and_then(|v| v.as_str()),
+        ) {
+            Ok(resolved) => resolved,
+            Err(msg) => return ToolExecutionResult::tool_error(msg),
+        };
 
         let timeout_ms = arguments
             .get("timeout_ms")
@@ -317,13 +343,13 @@ impl Tool for BashTool {
         // is available without changing any existing limits or boundaries.
         let builder = Bash::builder()
             .fs(session_fs)
-            .cwd(working_dir)
+            .cwd(working_dir.as_str())
             .username("everruns")
             .hostname("everruns")
             .env("HOME", "/home/agent")
             .env("SHELL", "/bin/bash")
             .env("PATH", "/usr/local/bin:/usr/bin:/bin")
-            .env("WORKSPACE", "/workspace")
+            .env("WORKSPACE", workspace_env.as_str())
             .env("LANG", locale)
             .limits(execution_limits())
             .max_memory(10 * 1024 * 1024) // 10 MB — prevent OOM from untrusted input
@@ -503,10 +529,11 @@ impl BackgroundExecutableTool for BashTool {
             }
         };
 
-        let working_dir = arguments
-            .get("working_dir")
-            .and_then(|v| v.as_str())
-            .unwrap_or("/workspace");
+        let (working_dir, workspace_env) = resolve_shell_workspace(
+            &context,
+            arguments.get("working_dir").and_then(|v| v.as_str()),
+        )
+        .map_err(ToolExecutionResult::tool_error)?;
 
         let timeout_ms = arguments
             .get("timeout_ms")
@@ -537,13 +564,13 @@ impl BackgroundExecutableTool for BashTool {
 
         let builder = Bash::builder()
             .fs(session_fs)
-            .cwd(working_dir)
+            .cwd(working_dir.as_str())
             .username("everruns")
             .hostname("everruns")
             .env("HOME", "/home/agent")
             .env("SHELL", "/bin/bash")
             .env("PATH", "/usr/local/bin:/usr/bin:/bin")
-            .env("WORKSPACE", "/workspace")
+            .env("WORKSPACE", workspace_env.as_str())
             .env("LANG", locale)
             .limits(execution_limits())
             .max_memory(10 * 1024 * 1024)
@@ -793,38 +820,18 @@ impl SessionFileSystemAdapter {
         Self { session_id, store }
     }
 
-    /// Workspace mount point in the virtual filesystem
-    const WORKSPACE_PREFIX: &'static str = "/workspace";
-
-    /// Convert bash path to session file store path.
-    /// Paths under /workspace are mapped to session store.
-    /// Returns None for paths outside /workspace.
-    fn to_session_path(path: &Path) -> Option<String> {
-        let path_str = path.to_string_lossy();
-
-        // Normalize to absolute path
-        let abs_path = if path_str.starts_with('/') {
-            path_str.to_string()
-        } else {
-            format!("/{}", path_str)
-        };
-
-        // Check if path is under /workspace
-        if abs_path == Self::WORKSPACE_PREFIX {
-            // Root of workspace maps to root of session store
-            Some("/".to_string())
-        } else if let Some(stripped) = abs_path.strip_prefix(Self::WORKSPACE_PREFIX) {
-            // /workspace/foo -> /foo
-            if stripped.starts_with('/') {
-                Some(stripped.to_string())
-            } else {
-                // /workspacefoo is not valid
-                None
-            }
-        } else {
-            // Path is outside /workspace
-            None
-        }
+    /// Convert a bash VFS path to a canonical session file store path.
+    ///
+    /// Delegates to the store's unified [`WorkspacePaths`] (EVE-660): paths
+    /// inside the workspace mount — the `/workspace` alias *or* host-absolute
+    /// paths under the root — map to a session path; anything outside the mount
+    /// returns `None`. The adapter no longer hard-codes `/workspace` stripping,
+    /// so the shell and the file tools share one namespace.
+    fn to_session_path(&self, path: &Path) -> Option<String> {
+        self.store
+            .workspace_paths()
+            .parse_mounted(&path.to_string_lossy())
+            .map(|rel| rel.to_session_path())
     }
 }
 
@@ -834,7 +841,7 @@ impl FileSystemExt for SessionFileSystemAdapter {}
 #[async_trait]
 impl FileSystem for SessionFileSystemAdapter {
     async fn read_file(&self, path: &Path) -> bashkit::Result<Vec<u8>> {
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("Path not in workspace: {}", path.display()),
@@ -856,7 +863,7 @@ impl FileSystem for SessionFileSystemAdapter {
     }
 
     async fn write_file(&self, path: &Path, content: &[u8]) -> bashkit::Result<()> {
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 format!("Cannot write outside workspace: {}", path.display()),
@@ -873,7 +880,7 @@ impl FileSystem for SessionFileSystemAdapter {
     }
 
     async fn append_file(&self, path: &Path, content: &[u8]) -> bashkit::Result<()> {
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 format!("Cannot write outside workspace: {}", path.display()),
@@ -904,7 +911,7 @@ impl FileSystem for SessionFileSystemAdapter {
     }
 
     async fn mkdir(&self, path: &Path, _recursive: bool) -> bashkit::Result<()> {
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 format!(
@@ -922,7 +929,7 @@ impl FileSystem for SessionFileSystemAdapter {
     }
 
     async fn remove(&self, path: &Path, recursive: bool) -> bashkit::Result<()> {
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 format!("Cannot delete outside workspace: {}", path.display()),
@@ -949,7 +956,7 @@ impl FileSystem for SessionFileSystemAdapter {
             });
         }
 
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("Path not in workspace: {}", path.display()),
@@ -1006,7 +1013,7 @@ impl FileSystem for SessionFileSystemAdapter {
     }
 
     async fn read_dir(&self, path: &Path) -> bashkit::Result<Vec<DirEntry>> {
-        let session_path = Self::to_session_path(path).ok_or_else(|| {
+        let session_path = self.to_session_path(path).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("Path not in workspace: {}", path.display()),
@@ -1050,7 +1057,7 @@ impl FileSystem for SessionFileSystemAdapter {
             return Ok(true);
         }
 
-        let session_path = match Self::to_session_path(path) {
+        let session_path = match self.to_session_path(path) {
             Some(p) => p,
             None => return Ok(false), // Paths outside workspace don't exist
         };
@@ -1074,7 +1081,7 @@ impl FileSystem for SessionFileSystemAdapter {
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> bashkit::Result<()> {
-        let from_session = Self::to_session_path(from).ok_or_else(|| {
+        let from_session = self.to_session_path(from).ok_or_else(|| {
             bashkit::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("Source not in workspace: {}", from.display()),
@@ -1134,7 +1141,7 @@ impl FileSystem for SessionFileSystemAdapter {
 impl SearchCapable for SessionFileSystemAdapter {
     fn search_provider(&self, path: &Path) -> Option<Box<dyn SearchProvider>> {
         // Only provide indexed search for paths inside /workspace
-        Self::to_session_path(path)?;
+        self.to_session_path(path)?;
         Some(Box::new(SessionSearchProvider {
             session_id: self.session_id,
             store: self.store.clone(),
@@ -1165,11 +1172,14 @@ impl SearchProvider for SessionSearchProvider {
             query.pattern.clone()
         };
 
-        // Convert root path from bash VFS path to session store path.
-        // search_provider already guards against paths outside /workspace,
-        // so to_session_path should always succeed here.
-        let session_root =
-            SessionFileSystemAdapter::to_session_path(Path::new(&root)).ok_or_else(|| {
+        // Convert root path from bash VFS path to session store path through
+        // the unified workspace path model (EVE-660). search_provider already
+        // guards against paths outside the workspace mount, so this succeeds.
+        let workspace_paths = self.store.workspace_paths();
+        let session_root = workspace_paths
+            .parse_mounted(&root)
+            .map(|rel| rel.to_session_path())
+            .ok_or_else(|| {
                 bashkit::Error::Io(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!("Path not in workspace: {}", root),
@@ -1210,8 +1220,13 @@ impl SearchProvider for SessionSearchProvider {
             .into_iter()
             .take(max_results.unwrap_or(usize::MAX))
             .map(|m| {
-                // Convert session store path back to bash VFS path
-                let vfs_path = format!("{}{}", SessionFileSystemAdapter::WORKSPACE_PREFIX, m.path);
+                // Convert session store path back to the bash VFS display path
+                // (the `/workspace` alias or host-absolute root) so matches read
+                // back in the same namespace the shell resolves against.
+                let vfs_path = workspace_paths
+                    .parse_input(&m.path)
+                    .map(|rel| workspace_paths.to_display(&rel))
+                    .unwrap_or_else(|_| m.path.clone());
                 BashkitSearchMatch {
                     path: PathBuf::from(vfs_path),
                     line_number: m.line_number,
@@ -1532,54 +1547,56 @@ mod tests {
     // Path translation tests
     // ========================================================================
 
+    // The adapter now delegates path translation to the store's unified
+    // `WorkspacePaths` (EVE-660). Over a VFS store the mount is `/workspace`, so
+    // these assert the same containment semantics as before.
+    fn vfs_adapter() -> SessionFileSystemAdapter {
+        SessionFileSystemAdapter::new(SessionId::new(), Arc::new(MockFileStore::new()))
+    }
+
     #[test]
     fn test_to_session_path_workspace_root() {
-        let result = SessionFileSystemAdapter::to_session_path(Path::new("/workspace"));
+        let result = vfs_adapter().to_session_path(Path::new("/workspace"));
         assert_eq!(result, Some("/".to_string()));
     }
 
     #[test]
     fn test_to_session_path_workspace_file() {
-        let result = SessionFileSystemAdapter::to_session_path(Path::new("/workspace/file.txt"));
+        let result = vfs_adapter().to_session_path(Path::new("/workspace/file.txt"));
         assert_eq!(result, Some("/file.txt".to_string()));
     }
 
     #[test]
     fn test_to_session_path_workspace_nested() {
-        let result =
-            SessionFileSystemAdapter::to_session_path(Path::new("/workspace/dir/subdir/file.txt"));
+        let result = vfs_adapter().to_session_path(Path::new("/workspace/dir/subdir/file.txt"));
         assert_eq!(result, Some("/dir/subdir/file.txt".to_string()));
     }
 
     #[test]
     fn test_to_session_path_outside_workspace() {
-        let result = SessionFileSystemAdapter::to_session_path(Path::new("/tmp/file.txt"));
+        let result = vfs_adapter().to_session_path(Path::new("/tmp/file.txt"));
         assert_eq!(result, None);
     }
 
     #[test]
     fn test_to_session_path_home_outside_workspace() {
-        let result = SessionFileSystemAdapter::to_session_path(Path::new("/home/agent/file.txt"));
+        let result = vfs_adapter().to_session_path(Path::new("/home/agent/file.txt"));
         assert_eq!(result, None);
     }
 
     #[test]
     fn test_to_session_path_workspacefoo_invalid() {
         // /workspacefoo is NOT under /workspace
-        let result = SessionFileSystemAdapter::to_session_path(Path::new("/workspacefoo"));
+        let result = vfs_adapter().to_session_path(Path::new("/workspacefoo"));
         assert_eq!(result, None);
     }
 
     #[test]
     fn test_to_session_path_relative_path() {
-        // Relative path gets normalized to absolute
-        let result = SessionFileSystemAdapter::to_session_path(Path::new("workspace/file.txt"));
-        // /workspace/file.txt would be valid, but "workspace/file.txt" -> "/workspace/file.txt"
-        // Wait, that's not right. Let me check the logic again.
-        // normalize adds "/" prefix: "workspace/file.txt" -> "/workspace/file.txt"
-        // Then it checks if it starts with "/workspace" - yes it does
-        // So this should return Some("/file.txt")
-        assert_eq!(result, Some("/file.txt".to_string()));
+        // A relative path maps into the workspace mount. `workspace/file.txt`
+        // is a path to a `workspace` subdirectory, not the `/workspace` alias.
+        let result = vfs_adapter().to_session_path(Path::new("workspace/file.txt"));
+        assert_eq!(result, Some("/workspace/file.txt".to_string()));
     }
 
     // ========================================================================

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -144,28 +144,15 @@ fn effective_read_defaults(
     }
 }
 
-/// Normalize a file path by stripping the /workspace prefix.
-/// This ensures both file_system and bashkit_shell capabilities use the same
-/// path format in the session file store.
+/// Normalize a file-tool path input to a canonical leading-slash session path.
 ///
-/// Examples:
+/// Delegates to the single workspace path normalizer (EVE-660) so capabilities
+/// no longer hand-roll `/workspace` stripping. Examples:
 /// - `/workspace/foo.txt` -> `/foo.txt`
 /// - `/workspace` -> `/`
 /// - `/foo.txt` -> `/foo.txt` (already normalized)
 fn normalize_path(path: &str) -> String {
-    if path == WORKSPACE_PREFIX {
-        "/".to_string()
-    } else if let Some(stripped) = path.strip_prefix(WORKSPACE_PREFIX) {
-        if stripped.starts_with('/') {
-            stripped.to_string()
-        } else {
-            // path like "/workspacefoo" - not a valid workspace path
-            path.to_string()
-        }
-    } else {
-        // Path doesn't start with /workspace - use as-is
-        path.to_string()
-    }
+    crate::workspace_paths::to_session_path(path)
 }
 
 fn fs_display_path(file_store: &dyn SessionFileSystem, path: &str) -> String {
@@ -565,7 +552,7 @@ impl Tool for ReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read a file from the session workspace (/workspace). Returns text content directly. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image so you can see it visually. This is NOT for reading files in cloud sandboxes — use the sandbox-specific read tool instead."
+        "Read a file from the session workspace. Returns text content directly. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image so you can see it visually. This is NOT for reading files in cloud sandboxes — use the sandbox-specific read tool instead."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -574,7 +561,7 @@ impl Tool for ReadFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute path to the file (e.g., '/workspace/docs/readme.txt')"
+                    "description": "Workspace-relative path to the file (e.g., 'docs/readme.txt'). A leading '/' or '/workspace/' prefix is also accepted."
                 },
                 "offset": {
                     "type": "integer",
@@ -881,7 +868,7 @@ impl Tool for WriteFileTool {
     }
 
     fn description(&self) -> &str {
-        "Create or update a file in the session workspace (/workspace). Parent directories are created automatically. This is NOT for writing files in cloud sandboxes — use sandbox-specific write tools (e.g. daytona_write_file, e2b_write_file) instead."
+        "Create or update a file in the session workspace. Parent directories are created automatically. This is NOT for writing files in cloud sandboxes — use sandbox-specific write tools (e.g. daytona_write_file, e2b_write_file) instead."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -890,7 +877,7 @@ impl Tool for WriteFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute path for the file (e.g., '/workspace/docs/notes.txt')"
+                    "description": "Workspace-relative path for the file (e.g., 'docs/notes.txt'). A leading '/' or '/workspace/' prefix is also accepted."
                 },
                 "content": {
                     "type": "string",
@@ -1028,7 +1015,7 @@ impl Tool for EditFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Absolute path to the existing text file (e.g., '/workspace/src/main.rs')"
+                    "description": "Workspace-relative path to the existing text file (e.g., 'src/main.rs'). A leading '/' or '/workspace/' prefix is also accepted."
                 },
                 "expected_hash": {
                     "type": "string",
@@ -1285,7 +1272,7 @@ impl Tool for ListDirectoryTool {
                 "path": {
                     "type": "string",
                     "default": "/workspace",
-                    "description": "Directory path to list (default: '/workspace')"
+                    "description": "Workspace-relative directory path to list (e.g., 'src'). Defaults to the workspace root; a leading '/' or '/workspace/' prefix is also accepted."
                 },
                 "offset": {
                     "type": "integer",
@@ -1460,7 +1447,7 @@ impl Tool for GrepFilesTool {
                 },
                 "path_pattern": {
                     "type": "string",
-                    "description": "Optional path pattern to filter files (e.g., '*.txt', '/workspace/docs/*')"
+                    "description": "Optional path pattern to filter files (e.g., '*.txt', 'docs/*')"
                 },
                 "offset": {
                     "type": "integer",

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -394,6 +394,17 @@ impl SystemPromptContext {
         self.model = Some(model.into());
         self
     }
+
+    /// The unified workspace path model for this context (EVE-660), derived from
+    /// the attached file store. Capabilities use this for path display/parsing
+    /// instead of hand-rolling `/workspace` handling. Falls back to the VFS
+    /// model when no file store is wired.
+    pub fn workspace_paths(&self) -> crate::workspace_paths::WorkspacePaths {
+        self.file_store
+            .as_ref()
+            .map(|store| store.workspace_paths())
+            .unwrap_or_default()
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -116,6 +116,7 @@ pub mod skill;
 pub mod system_allowlist;
 pub mod vector_store;
 pub mod workspace;
+pub mod workspace_paths;
 
 // Multi-platform channel abstractions (thread context, delivery, routing)
 pub mod channel;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -98,6 +98,7 @@ pub mod memory;
 pub mod model;
 pub mod model_profiles;
 pub mod model_router;
+pub mod mount_fs;
 pub mod network_access;
 pub mod observer;
 pub mod organization;
@@ -205,6 +206,7 @@ pub use message_filter::{
     MessageFilterProvider, MessageQuery, PrependTransform,
 };
 pub use message_retriever::{InputMessage, MessageRetriever};
+pub use mount_fs::{MountFs, WORKSPACE_MOUNT};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use runtime_context::{
     AssembledTurnContext, ResolvedRuntimeCapabilities, assemble_turn_context, inspect_turn_context,

--- a/crates/core/src/mount_fs.rs
+++ b/crates/core/src/mount_fs.rs
@@ -1,0 +1,520 @@
+// Mount-based virtual filesystem resolver (EVE-660).
+//
+// `MountFs` is the single resolution seam for the agent's filesystem. It owns:
+//
+//   * a **mount table** — named mount points, each backed by a
+//     `SessionFileSystem`, with a per-mount root in the backend's keyspace, and
+//   * a **current working directory** — relative paths resolve against it.
+//
+// Resolution is uniform and POSIX-shaped: normalize the input against cwd,
+// collapse `.`/`..`, then dispatch to the longest matching mount. `/workspace`
+// is just a mount point (and the default cwd), not a magic prefix re-implemented
+// in every store. Adding `/outputs`, `/.agents/skills`, or volume mounts backed
+// by *different* stores later is `with_mount(...)` — the resolver does not change.
+//
+// Today there is a single workspace backend, so the table holds the root mount
+// (`/` → backend, for legacy backend-native paths like `/AGENTS.md`,
+// `/outputs/…`) and the `/workspace` view of the same backend. Both resolve to
+// the same files; `/workspace` wins by longest-prefix so `/workspace/foo`
+// ≡ `/foo`.
+//
+// See `specs/file-store.md` for the contract and the migration plan.
+
+use async_trait::async_trait;
+use std::sync::{Arc, RwLock};
+
+use crate::error::Result;
+use crate::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
+use crate::traits::SessionFileSystem;
+use crate::typed_id::SessionId;
+use crate::workspace_paths::WorkspacePaths;
+
+/// The conventional mount point and default cwd for the workspace. Models
+/// trained on cloud-agent layouts address files here; it is a real mount, not a
+/// strip-prefix.
+pub const WORKSPACE_MOUNT: &str = "/workspace";
+
+/// A single entry in the mount table.
+#[derive(Clone)]
+struct Mount {
+    /// Virtual mount point: normalized, absolute, no trailing slash (`/` for
+    /// root).
+    mount_point: String,
+    /// Backend serving this mount.
+    backend: Arc<dyn SessionFileSystem>,
+    /// Path inside the backend's own keyspace that `mount_point` maps to.
+    backend_root: String,
+}
+
+/// Mount-based resolver. Implements `SessionFileSystem`, so it drops into
+/// `ToolContext` / `SystemPromptContext` wherever the file store is wired.
+pub struct MountFs {
+    /// Sorted by mount-point length descending so the first match is the
+    /// longest (most specific) mount.
+    mounts: Vec<Mount>,
+    /// The workspace backend — used for grep, display, and host mapping.
+    primary: Arc<dyn SessionFileSystem>,
+    /// Current working directory (a normalized virtual path). Relative inputs
+    /// resolve against it. Defaults to [`WORKSPACE_MOUNT`].
+    cwd: Arc<RwLock<String>>,
+}
+
+impl MountFs {
+    /// Build a resolver over a single workspace backend.
+    ///
+    /// The backend is mounted at both `/` (its native keyspace, for legacy
+    /// absolute paths) and `/workspace` (the model-facing view). cwd defaults to
+    /// `/workspace`.
+    pub fn new(workspace: Arc<dyn SessionFileSystem>) -> Self {
+        let mounts = vec![
+            Mount {
+                mount_point: "/".to_string(),
+                backend: workspace.clone(),
+                backend_root: "/".to_string(),
+            },
+            Mount {
+                mount_point: WORKSPACE_MOUNT.to_string(),
+                backend: workspace.clone(),
+                backend_root: "/".to_string(),
+            },
+        ];
+        let mut fs = Self {
+            mounts,
+            primary: workspace,
+            cwd: Arc::new(RwLock::new(WORKSPACE_MOUNT.to_string())),
+        };
+        fs.sort_mounts();
+        fs
+    }
+
+    /// Build a resolver and return it as a trait object.
+    pub fn wrap(workspace: Arc<dyn SessionFileSystem>) -> Arc<dyn SessionFileSystem> {
+        Arc::new(Self::new(workspace))
+    }
+
+    /// Register an additional mount (e.g. a read-only skills source or a named
+    /// volume) backed by a different store. Longest-prefix wins at resolution.
+    pub fn with_mount(
+        mut self,
+        mount_point: impl Into<String>,
+        backend: Arc<dyn SessionFileSystem>,
+        backend_root: impl Into<String>,
+    ) -> Self {
+        self.mounts.push(Mount {
+            mount_point: normalize_virtual(&mount_point.into(), "/"),
+            backend,
+            backend_root: normalize_virtual(&backend_root.into(), "/"),
+        });
+        self.sort_mounts();
+        self
+    }
+
+    /// The current working directory (normalized virtual path).
+    pub fn cwd(&self) -> String {
+        self.cwd.read().expect("MountFs cwd lock poisoned").clone()
+    }
+
+    /// Repoint the current working directory. Relative paths resolve against it.
+    pub fn set_cwd(&self, cwd: impl AsRef<str>) {
+        let normalized = normalize_virtual(cwd.as_ref(), "/");
+        *self.cwd.write().expect("MountFs cwd lock poisoned") = normalized;
+    }
+
+    fn sort_mounts(&mut self) {
+        // Longest mount point first, so resolution picks the most specific mount.
+        self.mounts
+            .sort_by_key(|m| std::cmp::Reverse(m.mount_point.len()));
+    }
+
+    /// Resolve any input path to `(backend, backend_path)`.
+    ///
+    /// Relative inputs are joined to cwd; `.`/`..` are collapsed (clamped at
+    /// root); the longest matching mount is selected and the remainder is mapped
+    /// into that backend's keyspace.
+    fn resolve(&self, input: &str) -> (Arc<dyn SessionFileSystem>, String) {
+        let virtual_path = normalize_virtual(input, &self.cwd());
+        for mount in &self.mounts {
+            if let Some(rest) = mount_suffix(&mount.mount_point, &virtual_path) {
+                return (
+                    mount.backend.clone(),
+                    join_backend_path(&mount.backend_root, &rest),
+                );
+            }
+        }
+        // The root mount matches every absolute path, so this is unreachable in
+        // practice; fall back to the primary backend with the literal path.
+        (self.primary.clone(), virtual_path)
+    }
+}
+
+/// Normalize an input into an absolute virtual path: join cwd if relative, then
+/// collapse `.`/`..` segments (a leading `..` is clamped at root).
+fn normalize_virtual(input: &str, cwd: &str) -> String {
+    let combined = if input.starts_with('/') {
+        input.to_string()
+    } else {
+        format!("{}/{}", cwd.trim_end_matches('/'), input)
+    };
+    let mut stack: Vec<&str> = Vec::new();
+    for segment in combined.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                stack.pop();
+            }
+            other => stack.push(other),
+        }
+    }
+    if stack.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", stack.join("/"))
+    }
+}
+
+/// If `virtual_path` is at or under `mount_point`, return the suffix as a
+/// `/`-rooted remainder (`/` for an exact match). Segment-aware: `/workspacefoo`
+/// is not under `/workspace`.
+fn mount_suffix(mount_point: &str, virtual_path: &str) -> Option<String> {
+    if mount_point == "/" {
+        // The root mount owns the whole path.
+        return Some(virtual_path.to_string());
+    }
+    if virtual_path == mount_point {
+        return Some("/".to_string());
+    }
+    virtual_path
+        .strip_prefix(mount_point)
+        .filter(|rest| rest.starts_with('/'))
+        .map(|rest| rest.to_string())
+}
+
+/// Join a backend root with a `/`-rooted remainder into a backend keyspace path.
+fn join_backend_path(backend_root: &str, rest: &str) -> String {
+    if backend_root == "/" {
+        return rest.to_string();
+    }
+    if rest == "/" {
+        return backend_root.to_string();
+    }
+    format!("{backend_root}{rest}")
+}
+
+#[async_trait]
+impl SessionFileSystem for MountFs {
+    fn workspace_paths(&self) -> WorkspacePaths {
+        // Present the workspace mount's view: host mapping (if the backend is
+        // host-rooted) preserved, display forced to the `/workspace` mount so
+        // the model sees one namespace regardless of backend.
+        self.primary
+            .workspace_paths()
+            .with_display_prefix(WORKSPACE_MOUNT)
+    }
+
+    fn display_root(&self) -> String {
+        WORKSPACE_MOUNT.to_string()
+    }
+
+    fn display_path(&self, path: &str) -> String {
+        // `path` is a backend keyspace path (e.g. `/foo`); render it under the
+        // workspace mount.
+        if path == "/" || path.is_empty() {
+            return WORKSPACE_MOUNT.to_string();
+        }
+        if let Some(rest) = path.strip_prefix('/') {
+            format!("{WORKSPACE_MOUNT}/{rest}")
+        } else {
+            format!("{WORKSPACE_MOUNT}/{path}")
+        }
+    }
+
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        let (backend, backend_path) = self.resolve(path);
+        backend.read_file(session_id, &backend_path).await
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        let (backend, backend_path) = self.resolve(path);
+        backend
+            .write_file(session_id, &backend_path, content, encoding)
+            .await
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let (backend, backend_path) = self.resolve(path);
+        backend
+            .write_file_if_content_matches(
+                session_id,
+                &backend_path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
+            .await
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
+        let (backend, backend_path) = self.resolve(path);
+        backend
+            .delete_file(session_id, &backend_path, recursive)
+            .await
+    }
+
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
+        let (backend, backend_path) = self.resolve(path);
+        backend.list_directory(session_id, &backend_path).await
+    }
+
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
+        let (backend, backend_path) = self.resolve(path);
+        backend.stat_file(session_id, &backend_path).await
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        match path_pattern {
+            Some(pp) => {
+                let (backend, backend_path) = self.resolve(pp);
+                backend
+                    .grep_files(session_id, pattern, Some(&backend_path))
+                    .await
+            }
+            None => self.primary.grep_files(session_id, pattern, None).await,
+        }
+    }
+
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
+        let (backend, backend_path) = self.resolve(path);
+        backend.create_directory(session_id, &backend_path).await
+    }
+
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        let (backend, backend_path) = self.resolve(&file.path);
+        let seeded = InitialFile {
+            path: backend_path,
+            content: file.content.clone(),
+            encoding: file.encoding.clone(),
+            is_readonly: file.is_readonly,
+        };
+        backend.seed_initial_file(session_id, &seeded).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace_paths::WorkspacePaths;
+
+    fn sid() -> SessionId {
+        SessionId::from_seed(1)
+    }
+
+    // A minimal `/`-rooted in-memory backend for resolver tests (kept local to
+    // avoid a dependency on everruns-runtime).
+    #[derive(Default)]
+    struct FlatStore {
+        files: std::sync::Mutex<std::collections::HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl SessionFileSystem for FlatStore {
+        async fn read_file(&self, sid: SessionId, path: &str) -> Result<Option<SessionFile>> {
+            let files = self.files.lock().unwrap();
+            Ok(files.get(path).map(|content| SessionFile {
+                id: uuid::Uuid::nil(),
+                session_id: sid.uuid(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                content: Some(content.clone()),
+                encoding: "text".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: content.len() as i64,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }))
+        }
+        async fn write_file(
+            &self,
+            sid: SessionId,
+            path: &str,
+            content: &str,
+            encoding: &str,
+        ) -> Result<SessionFile> {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), content.to_string());
+            Ok(SessionFile {
+                id: uuid::Uuid::nil(),
+                session_id: sid.uuid(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                content: Some(content.to_string()),
+                encoding: encoding.to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: content.len() as i64,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+        async fn delete_file(&self, _: SessionId, path: &str, _: bool) -> Result<bool> {
+            Ok(self.files.lock().unwrap().remove(path).is_some())
+        }
+        async fn list_directory(&self, _: SessionId, _: &str) -> Result<Vec<FileInfo>> {
+            Ok(vec![])
+        }
+        async fn stat_file(&self, _: SessionId, _: &str) -> Result<Option<FileStat>> {
+            Ok(None)
+        }
+        async fn grep_files(
+            &self,
+            _: SessionId,
+            _: &str,
+            _: Option<&str>,
+        ) -> Result<Vec<GrepMatch>> {
+            Ok(vec![])
+        }
+        async fn create_directory(&self, sid: SessionId, path: &str) -> Result<FileInfo> {
+            Ok(FileInfo {
+                id: uuid::Uuid::nil(),
+                session_id: sid.uuid(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                path: path.to_string(),
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+    }
+
+    #[test]
+    fn normalize_resolves_relative_against_cwd() {
+        assert_eq!(
+            normalize_virtual("foo/bar", "/workspace"),
+            "/workspace/foo/bar"
+        );
+        assert_eq!(normalize_virtual("/foo", "/workspace"), "/foo");
+        assert_eq!(normalize_virtual("a/../b", "/workspace"), "/workspace/b");
+        assert_eq!(normalize_virtual("../../x", "/workspace"), "/x");
+        assert_eq!(normalize_virtual(".", "/workspace"), "/workspace");
+        assert_eq!(normalize_virtual("/", "/workspace"), "/");
+    }
+
+    #[tokio::test]
+    async fn workspace_and_root_address_the_same_file() {
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(backend);
+
+        // Write via the /workspace view; read back via the backend-native path.
+        fs.write_file(sid(), "/workspace/src/lib.rs", "X", "text")
+            .await
+            .unwrap();
+        let via_root = fs.read_file(sid(), "/src/lib.rs").await.unwrap().unwrap();
+        assert_eq!(via_root.content.as_deref(), Some("X"));
+        // The backend keyed it at /src/lib.rs (no /workspace in the keyspace).
+        assert_eq!(via_root.path, "/src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn relative_paths_resolve_against_cwd() {
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(backend);
+        assert_eq!(fs.cwd(), "/workspace");
+
+        fs.write_file(sid(), "notes.md", "hi", "text")
+            .await
+            .unwrap();
+        // cwd is /workspace, so the relative write landed at backend /notes.md.
+        let read = fs.read_file(sid(), "/notes.md").await.unwrap().unwrap();
+        assert_eq!(read.content.as_deref(), Some("hi"));
+    }
+
+    #[tokio::test]
+    async fn legacy_subtree_paths_pass_through_root_mount() {
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(backend);
+        // Internal callers write /outputs/... and /AGENTS.md directly.
+        fs.write_file(sid(), "/outputs/call.stdout", "out", "text")
+            .await
+            .unwrap();
+        let read = fs
+            .read_file(sid(), "/workspace/outputs/call.stdout")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(read.content.as_deref(), Some("out"));
+    }
+
+    #[test]
+    fn display_is_the_workspace_view() {
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(backend);
+        assert_eq!(fs.display_root(), "/workspace");
+        assert_eq!(fs.display_path("/src/lib.rs"), "/workspace/src/lib.rs");
+        assert_eq!(fs.display_path("/"), "/workspace");
+        // And it agrees with the workspace_paths view.
+        let wp = fs.workspace_paths();
+        assert_eq!(wp.display_root(), "/workspace");
+    }
+
+    #[tokio::test]
+    async fn additional_mount_routes_to_its_backend() {
+        let workspace: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let volume: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(workspace).with_mount("/data", volume.clone(), "/");
+
+        fs.write_file(sid(), "/data/report.csv", "1,2,3", "text")
+            .await
+            .unwrap();
+        // It went to the volume backend at /report.csv, not the workspace.
+        let from_volume = volume
+            .read_file(sid(), "/report.csv")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(from_volume.content.as_deref(), Some("1,2,3"));
+    }
+
+    #[test]
+    fn workspace_paths_keeps_host_mapping() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // A host-rooted WorkspacePaths backend would expose to_host; here we
+        // assert the resolver forces the /workspace display while delegating.
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(backend);
+        let wp = fs.workspace_paths();
+        // VFS backend has no host root.
+        assert!(wp.host_root().is_none());
+        // Sanity: a standalone host WorkspacePaths still maps (unrelated to fs).
+        let host = WorkspacePaths::host(dir.path()).unwrap();
+        assert!(host.host_root().is_some());
+    }
+}

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -214,9 +214,15 @@ async fn assemble_turn_context_with_mode(
     let resolved_locale = extract_locale_override(&messages).or_else(|| session.locale.clone());
     // Pin system-prompt file reads (AGENTS.md, skills, …) to the session's
     // workspace so an attached shared workspace's instructions are used. For the
-    // default 1:1 session this is a transparent pass-through.
-    let file_store = file_store
-        .map(|fs| crate::traits::WorkspaceScopedFileSystem::wrap(fs, session.workspace_id));
+    // default 1:1 session this is a transparent pass-through. Then resolve model
+    // paths through the mount resolver (EVE-660): `/workspace` is a mount + cwd,
+    // not a per-store prefix.
+    let file_store = file_store.map(|fs| {
+        crate::mount_fs::MountFs::wrap(crate::traits::WorkspaceScopedFileSystem::wrap(
+            fs,
+            session.workspace_id,
+        ))
+    });
     // The resolved model is known here, so model-adaptive capabilities (e.g.
     // `auto_tool_search`) can pick the right mechanism during collection in
     // `build_runtime_agent` below.

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -18,15 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
 
-fn workspace_display_path(path: &str) -> String {
-    if path == "/" {
-        "/workspace".to_string()
-    } else if path.starts_with('/') {
-        format!("/workspace{path}")
-    } else {
-        format!("/workspace/{path}")
-    }
-}
+use crate::workspace_paths::WorkspacePaths;
 
 /// Build a map of tool names to definitions for efficient lookup
 fn build_tool_map(tool_defs: &[ToolDefinition]) -> HashMap<&str, &ToolDefinition> {
@@ -436,18 +428,33 @@ impl ToolExecutor for std::sync::Arc<dyn ToolExecutor> {
 /// - Project files onto real disk or object storage
 #[async_trait]
 pub trait SessionFileSystem: Send + Sync {
+    /// The workspace path model for this filesystem (EVE-660).
+    ///
+    /// This is the single addressing seam: parsing of model/tool input,
+    /// host mapping, and display formatting all go through it. The default is
+    /// the in-memory/DB VFS model (`/workspace` display, no host root);
+    /// host-backed stores override it to expose their root. Capabilities MUST
+    /// use this rather than implementing their own `/workspace` stripping.
+    fn workspace_paths(&self) -> WorkspacePaths {
+        WorkspacePaths::vfs()
+    }
+
     /// Human-facing root path for this filesystem.
     ///
     /// `/workspace` remains the stable agent namespace, but embedded runtimes
     /// backed by a host directory can expose the real root here so shared
     /// capabilities can avoid misleading users about where files live.
     fn display_root(&self) -> String {
-        "/workspace".to_string()
+        self.workspace_paths().display_root()
     }
 
     /// Convert a canonical session path into a human-facing path.
     fn display_path(&self, path: &str) -> String {
-        workspace_display_path(path)
+        let paths = self.workspace_paths();
+        match paths.parse_input(path) {
+            Ok(rel) => paths.to_display(&rel),
+            Err(_) => path.to_string(),
+        }
     }
 
     /// Read a file by path
@@ -619,6 +626,10 @@ impl SessionFileSystem for WorkspaceScopedFileSystem {
         self.inner.seed_initial_file(self.key, file).await
     }
 
+    fn workspace_paths(&self) -> WorkspacePaths {
+        self.inner.workspace_paths()
+    }
+
     fn display_root(&self) -> String {
         self.inner.display_root()
     }
@@ -630,6 +641,10 @@ impl SessionFileSystem for WorkspaceScopedFileSystem {
 
 #[async_trait]
 impl<T: SessionFileSystem + ?Sized> SessionFileSystem for std::sync::Arc<T> {
+    fn workspace_paths(&self) -> WorkspacePaths {
+        (**self).workspace_paths()
+    }
+
     fn display_root(&self) -> String {
         (**self).display_root()
     }
@@ -1458,6 +1473,20 @@ impl ToolContext {
     /// addresses the workspace's files rather than its own session-id keyspace.
     pub fn workspace_fs_key(&self) -> SessionId {
         SessionId::from_uuid(self.workspace_id.uuid())
+    }
+
+    /// The unified workspace path model for this execution (EVE-660).
+    ///
+    /// Derived from the attached file store so there is a single source of
+    /// truth. Capabilities that accept `path` arguments — including host-path
+    /// tools like the shell — MUST resolve them through this rather than
+    /// re-implementing `/workspace` stripping or containment checks. Falls back
+    /// to the VFS model when no file store is wired.
+    pub fn workspace_paths(&self) -> crate::workspace_paths::WorkspacePaths {
+        self.file_store
+            .as_ref()
+            .map(|store| store.workspace_paths())
+            .unwrap_or_default()
     }
 
     /// Override the attached workspace (default is the 1:1 session-derived id).

--- a/crates/core/src/workspace_paths.rs
+++ b/crates/core/src/workspace_paths.rs
@@ -1,0 +1,652 @@
+// Unified workspace path model (EVE-660).
+//
+// Everruns historically carried two incompatible path namespaces for the same
+// workspace: a VFS/tool namespace that taught models `/workspace/...`, and a
+// host namespace used by bash, spawn cwd, and embedder capabilities. Every
+// host-path consumer independently re-implemented `/workspace` stripping,
+// containment checks, and worktree-root updates. `WorkspacePaths` is the single
+// addressing seam that all of them share.
+//
+// Design intent and the migration plan live in `specs/file-store.md`.
+//
+// Key invariants:
+//   * The canonical, in-memory representation is workspace-*relative* (`RelPath`):
+//     normalized, no `..`, no leading slash, no host prefix.
+//   * The on-the-wire form used by `SessionFileSystem` / the DB store stays the
+//     legacy leading-slash session path (`/src/lib.rs`); `RelPath::to_session_path`
+//     produces it so existing storage backends need no change.
+//   * `/workspace` is a *display alias* over the workspace root, not a second
+//     namespace. `to_display` is the only place a prefix is added.
+
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use crate::error::{AgentLoopError, Result};
+
+/// The default display prefix shown to models and UIs for the workspace root.
+///
+/// `/workspace` is a common cloud-agent convention (DevContainers, Codespaces).
+/// It is purely a *view* over the workspace root — see [`WorkspacePaths`].
+pub const DEFAULT_DISPLAY_PREFIX: &str = "/workspace";
+
+/// A canonical workspace-relative path.
+///
+/// Always normalized: forward-slash separated, no leading slash, no `.`/`..`
+/// segments, no host prefix. The workspace root is the empty path.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct RelPath(String);
+
+impl RelPath {
+    /// The workspace root.
+    pub fn root() -> Self {
+        Self(String::new())
+    }
+
+    /// True when this path addresses the workspace root.
+    pub fn is_root(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The relative form: `src/lib.rs` (empty string for the root).
+    pub fn as_relative(&self) -> &str {
+        &self.0
+    }
+
+    /// The legacy leading-slash session/VFS path: `/src/lib.rs` (`/` for root).
+    ///
+    /// This is the form `SessionFileSystem` methods and the DB-backed store key
+    /// on, so callers bridging to those layers serialize through here.
+    pub fn to_session_path(&self) -> String {
+        if self.0.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", self.0)
+        }
+    }
+}
+
+/// The single workspace path parser/formatter shared by every backend.
+///
+/// A `WorkspacePaths` optionally binds a host filesystem root (set for
+/// real-disk stores and host shells; absent for the pure in-memory / DB VFS)
+/// and carries a display prefix used to render model-facing paths. Clones share
+/// the same host-root handle, so a worktree switch via [`set_host_root`] is seen
+/// by every consumer that cloned from the same instance — the file store, the
+/// shell, and host-path capabilities all agree on the current root.
+///
+/// [`set_host_root`]: WorkspacePaths::set_host_root
+#[derive(Clone, Debug)]
+pub struct WorkspacePaths {
+    /// Host filesystem root, shared so worktree switches propagate to clones.
+    /// `None` for the in-memory / DB VFS which has no host mapping.
+    host_root: Option<Arc<RwLock<PathBuf>>>,
+    /// Literal display prefix. `None` means "derive from the host root" (the
+    /// real-disk default, which displays host-absolute paths). `Some("")`
+    /// displays bare relative paths.
+    display_prefix: Option<Arc<str>>,
+}
+
+impl Default for WorkspacePaths {
+    fn default() -> Self {
+        Self::vfs()
+    }
+}
+
+impl WorkspacePaths {
+    /// A VFS path model with no host root and the default `/workspace` display
+    /// prefix. This is what the in-memory and DB-backed stores use.
+    pub fn vfs() -> Self {
+        Self {
+            host_root: None,
+            display_prefix: Some(Arc::from(DEFAULT_DISPLAY_PREFIX)),
+        }
+    }
+
+    /// A host-rooted path model bound to `root`.
+    ///
+    /// The root is canonicalized once (resolving symlinks). Returns an error if
+    /// it does not exist or is not a directory. The display prefix defaults to
+    /// "derive from host root", preserving real-disk's host-absolute display.
+    pub fn host(root: impl Into<PathBuf>) -> Result<Self> {
+        let canonical = canonicalize_root(root.into())?;
+        Ok(Self {
+            host_root: Some(Arc::new(RwLock::new(canonical))),
+            display_prefix: None,
+        })
+    }
+
+    /// Override the model-facing display prefix.
+    ///
+    /// Pass `/workspace` to show the cloud-agent alias even for a host-rooted
+    /// workspace, or `""` to show bare relative paths.
+    pub fn with_display_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.display_prefix = Some(Arc::from(prefix.into().as_str()));
+        self
+    }
+
+    /// The current host root, if this workspace is host-bound.
+    pub fn host_root(&self) -> Option<PathBuf> {
+        self.host_root.as_ref().map(|handle| {
+            handle
+                .read()
+                .expect("workspace host root lock poisoned")
+                .clone()
+        })
+    }
+
+    /// Repoint the host root — used when an embedder switches worktrees.
+    ///
+    /// Canonicalizes and validates the new root, then updates the shared handle
+    /// so every clone (file store, shell, capabilities) sees the switch.
+    /// Returns an error for a VFS workspace that has no host root.
+    pub fn set_host_root(&self, root: impl Into<PathBuf>) -> Result<()> {
+        let handle = self.host_root.as_ref().ok_or_else(|| {
+            AgentLoopError::config("cannot set host root on a VFS workspace (no host filesystem)")
+        })?;
+        let canonical = canonicalize_root(root.into())?;
+        *handle.write().expect("workspace host root lock poisoned") = canonical;
+        Ok(())
+    }
+
+    /// Parse any accepted model/tool path input into a canonical [`RelPath`].
+    ///
+    /// Accepts (all addressing the same canonical path):
+    ///   * relative: `src/foo`
+    ///   * absolute session: `/src/foo`
+    ///   * display-alias: `/workspace/src/foo`, `/workspace`
+    ///   * host-absolute under the root (when host-bound): `/host/root/src/foo`
+    ///
+    /// Rejects `..` traversal anywhere and paths that escape the root. Bare
+    /// `workspace/...` (no leading slash) is intentionally *not* treated as the
+    /// alias, so a real top-level `workspace/` directory stays reachable.
+    pub fn parse_input(&self, input: &str) -> Result<RelPath> {
+        let trimmed = input.trim();
+
+        // Host-absolute paths under the root are aliases for the same canonical
+        // path (e.g. an editor or model that echoes the real checkout path).
+        if let Some(root) = self.host_root() {
+            let candidate = Path::new(trimmed);
+            if candidate.is_absolute()
+                && let Ok(relative) = candidate.strip_prefix(&root)
+            {
+                return rel_from_path(relative);
+            }
+        }
+
+        let stripped = strip_alias_prefix(trimmed, self.display_prefix.as_deref());
+        rel_from_str(stripped)
+    }
+
+    /// Canonical path → host filesystem path (for bash cwd, `std::fs`, spawn).
+    ///
+    /// Errors on a VFS workspace, or if the result would escape the root.
+    pub fn to_host(&self, path: &RelPath) -> Result<PathBuf> {
+        let root = self.require_host_root()?;
+        if path.is_root() {
+            return Ok(root);
+        }
+        let candidate = root.join(path.as_relative());
+        if !candidate.starts_with(&root) {
+            return Err(AgentLoopError::tool(format!(
+                "path escapes workspace root: {}",
+                path.as_relative()
+            )));
+        }
+        Ok(candidate)
+    }
+
+    /// Host path under the root → canonical, if contained.
+    pub fn from_host(&self, host: &Path) -> Result<RelPath> {
+        let root = self.require_host_root()?;
+        let relative = host.strip_prefix(&root).map_err(|_| {
+            AgentLoopError::tool(format!(
+                "path is outside workspace root: {}",
+                host.display()
+            ))
+        })?;
+        rel_from_path(relative)
+    }
+
+    /// Parse an absolute path produced by a shell (bashkit resolves every path
+    /// against cwd before handing it to the filesystem), returning `None` when
+    /// it falls *outside* the workspace mount rather than leniently
+    /// reinterpreting it as workspace-relative.
+    ///
+    /// This preserves the "the shell can only touch the workspace" containment
+    /// while recognizing every accepted spelling of an in-mount path: the
+    /// `/workspace` alias, the configured display prefix, and — crucially for
+    /// real-disk stores — host-absolute paths under the root. The latter is
+    /// what lets a model use the same path with `read_file` and with `cat`.
+    pub fn parse_mounted(&self, input: &str) -> Option<RelPath> {
+        let trimmed = input.trim();
+
+        // The `/workspace` alias / configured display prefix is always in-mount.
+        let stripped = strip_alias_prefix(trimmed, self.display_prefix.as_deref());
+        if !std::ptr::eq(stripped, trimmed) {
+            return rel_from_str(stripped).ok();
+        }
+
+        match self.host_root() {
+            Some(root) => {
+                let candidate = Path::new(trimmed);
+                if candidate.is_absolute() {
+                    // Only host-absolute paths under the root are in the mount.
+                    candidate
+                        .strip_prefix(&root)
+                        .ok()
+                        .and_then(|rel| rel_from_path(rel).ok())
+                } else {
+                    rel_from_str(trimmed).ok()
+                }
+            }
+            None => {
+                // VFS: an absolute path that didn't match the alias is outside
+                // the mount; relative paths map into it.
+                if trimmed.starts_with('/') {
+                    None
+                } else {
+                    rel_from_str(trimmed).ok()
+                }
+            }
+        }
+    }
+
+    /// Canonical path → model-facing display string.
+    pub fn to_display(&self, path: &RelPath) -> String {
+        let root = self.display_root();
+        if path.is_root() {
+            return root;
+        }
+        // Empty prefix => bare relative display.
+        if root.is_empty() {
+            return path.as_relative().to_string();
+        }
+        if root.ends_with('/') {
+            format!("{root}{}", path.as_relative())
+        } else {
+            format!("{root}/{}", path.as_relative())
+        }
+    }
+
+    /// The human-facing root label (display prefix, host root, or `/workspace`).
+    pub fn display_root(&self) -> String {
+        match &self.display_prefix {
+            Some(prefix) => prefix.to_string(),
+            None => match self.host_root() {
+                Some(root) => root.display().to_string(),
+                None => DEFAULT_DISPLAY_PREFIX.to_string(),
+            },
+        }
+    }
+
+    /// A validated working directory for spawning a host process.
+    ///
+    /// Fails clearly when the workspace directory is missing (e.g. a removed
+    /// worktree) instead of surfacing an opaque `No such file or directory`
+    /// from the spawn itself.
+    pub fn spawn_cwd(&self) -> Result<PathBuf> {
+        let root = self.require_host_root()?;
+        if !root.is_dir() {
+            return Err(AgentLoopError::tool(format!(
+                "workspace directory does not exist: {}",
+                root.display()
+            )));
+        }
+        Ok(root)
+    }
+
+    fn require_host_root(&self) -> Result<PathBuf> {
+        self.host_root().ok_or_else(|| {
+            AgentLoopError::tool("workspace has no host filesystem root".to_string())
+        })
+    }
+}
+
+/// Strip the `/workspace` alias from a leading-slash session path, lenient about
+/// `..` (the underlying store's `resolve` is the traversal defense for host
+/// stores; the flat VFS does not need one). This is the single normalizer the
+/// in-memory store and `file_system` capability share.
+///
+/// Examples: `/workspace` → `/`, `/workspace/a.txt` → `/a.txt`,
+/// `/workspacefoo` → `/workspacefoo`, `a.txt` → `/a.txt`.
+pub fn to_session_path(input: &str) -> String {
+    let stripped = strip_workspace_alias(input);
+    if stripped.is_empty() || stripped == "/" {
+        return "/".to_string();
+    }
+    let mut normalized = if stripped.starts_with('/') {
+        stripped.to_string()
+    } else {
+        format!("/{stripped}")
+    };
+    while normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+    normalized
+}
+
+/// Strip the canonical `/workspace` alias only (exact match or `/workspace/`
+/// prefix). Returns the remainder, which may or may not have a leading slash.
+fn strip_workspace_alias(s: &str) -> &str {
+    if s == DEFAULT_DISPLAY_PREFIX {
+        return "";
+    }
+    if let Some(rest) = s.strip_prefix(&format!("{DEFAULT_DISPLAY_PREFIX}/")) {
+        return rest;
+    }
+    s
+}
+
+/// Strip the canonical `/workspace` alias and, if configured and absolute, the
+/// instance's display prefix too. Returns the remainder for segment parsing.
+fn strip_alias_prefix<'a>(s: &'a str, display_prefix: Option<&str>) -> &'a str {
+    let after_workspace = strip_workspace_alias(s);
+    if !std::ptr::eq(after_workspace, s) {
+        return after_workspace;
+    }
+    if let Some(prefix) = display_prefix
+        && prefix.starts_with('/')
+        && prefix != DEFAULT_DISPLAY_PREFIX
+    {
+        if s == prefix {
+            return "";
+        }
+        if let Some(rest) = s.strip_prefix(&format!("{prefix}/")) {
+            return rest;
+        }
+    }
+    s
+}
+
+/// Normalize a slash-separated string into a [`RelPath`], rejecting traversal.
+fn rel_from_str(s: &str) -> Result<RelPath> {
+    let mut segments = Vec::new();
+    for part in s.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                return Err(AgentLoopError::tool(format!(
+                    "path traversal rejected: {s}"
+                )));
+            }
+            segment => segments.push(segment),
+        }
+    }
+    Ok(RelPath(segments.join("/")))
+}
+
+/// Normalize a host-relative `Path` into a [`RelPath`], rejecting traversal and
+/// non-UTF-8 components. `CurDir` (`.`) segments are skipped so host aliases
+/// like `<root>/./src/lib.rs` resolve cleanly.
+fn rel_from_path(relative: &Path) -> Result<RelPath> {
+    let mut segments = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(seg) => {
+                let segment = seg.to_str().ok_or_else(|| {
+                    AgentLoopError::tool(format!(
+                        "non-UTF-8 path component: {}",
+                        relative.display()
+                    ))
+                })?;
+                segments.push(segment.to_string());
+            }
+            Component::ParentDir => {
+                return Err(AgentLoopError::tool(format!(
+                    "path traversal rejected: {}",
+                    relative.display()
+                )));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(AgentLoopError::tool(format!(
+                    "absolute path component rejected: {}",
+                    relative.display()
+                )));
+            }
+        }
+    }
+    Ok(RelPath(segments.join("/")))
+}
+
+fn canonicalize_root(root: PathBuf) -> Result<PathBuf> {
+    if !root.exists() {
+        return Err(AgentLoopError::config(format!(
+            "workspace directory does not exist: {}",
+            root.display()
+        )));
+    }
+    let canonical = std::fs::canonicalize(&root).map_err(|e| {
+        AgentLoopError::config(format!(
+            "failed to canonicalize workspace root {}: {e}",
+            root.display()
+        ))
+    })?;
+    if !canonical.is_dir() {
+        return Err(AgentLoopError::config(format!(
+            "workspace root is not a directory: {}",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn vfs_parses_alias_forms_to_same_canonical() {
+        let wp = WorkspacePaths::vfs();
+        for input in [
+            "src/lib.rs",
+            "/src/lib.rs",
+            "/workspace/src/lib.rs",
+            "  /workspace/src/lib.rs  ",
+        ] {
+            let rel = wp.parse_input(input).expect("parse");
+            assert_eq!(rel.as_relative(), "src/lib.rs", "input: {input:?}");
+            assert_eq!(rel.to_session_path(), "/src/lib.rs", "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn workspace_root_aliases_normalize_to_root() {
+        let wp = WorkspacePaths::vfs();
+        for input in ["/workspace", "/", "", "."] {
+            let rel = wp.parse_input(input).expect("parse");
+            assert!(rel.is_root(), "input: {input:?}");
+            assert_eq!(rel.to_session_path(), "/");
+        }
+    }
+
+    #[test]
+    fn bare_workspace_dir_is_not_aliased() {
+        let wp = WorkspacePaths::vfs();
+        // A real top-level `workspace/` directory must stay reachable.
+        let rel = wp.parse_input("workspace/notes.md").expect("parse");
+        assert_eq!(rel.as_relative(), "workspace/notes.md");
+        // `/workspacefoo` is not the `/workspace` segment.
+        let rel = wp.parse_input("/workspacefoo").expect("parse");
+        assert_eq!(rel.as_relative(), "workspacefoo");
+    }
+
+    #[test]
+    fn traversal_is_rejected() {
+        let wp = WorkspacePaths::vfs();
+        for input in ["../outside", "/workspace/../etc/passwd", "a/../../b"] {
+            let err = wp.parse_input(input).expect_err("must reject");
+            assert!(format!("{err}").contains("traversal"), "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn host_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(dir.path()).expect("host");
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+
+        let rel = wp.parse_input("/workspace/src/lib.rs").expect("parse");
+        let host = wp.to_host(&rel).expect("to_host");
+        assert_eq!(host, root.join("src/lib.rs"));
+
+        let back = wp.from_host(&host).expect("from_host");
+        assert_eq!(back, rel);
+        assert_eq!(back.to_session_path(), "/src/lib.rs");
+    }
+
+    #[test]
+    fn host_absolute_input_is_an_alias() {
+        let dir = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(dir.path()).expect("host");
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+
+        let via_host = wp
+            .parse_input(&root.join("src/lib.rs").display().to_string())
+            .expect("parse host abs");
+        let via_workspace = wp
+            .parse_input("/workspace/src/lib.rs")
+            .expect("parse alias");
+        assert_eq!(via_host, via_workspace);
+
+        // `.` segments in host aliases resolve cleanly.
+        let via_curdir = wp
+            .parse_input(&root.join("./src/lib.rs").display().to_string())
+            .expect("parse curdir");
+        assert_eq!(via_curdir, via_workspace);
+    }
+
+    #[test]
+    fn host_display_is_host_absolute_by_default() {
+        let dir = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(dir.path()).expect("host");
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+
+        assert_eq!(wp.display_root(), root.display().to_string());
+        let rel = wp.parse_input("/src/lib.rs").unwrap();
+        assert_eq!(
+            wp.to_display(&rel),
+            root.join("src/lib.rs").display().to_string()
+        );
+    }
+
+    #[test]
+    fn configurable_display_prefix() {
+        let dir = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(dir.path())
+            .unwrap()
+            .with_display_prefix("/workspace");
+        let rel = wp.parse_input("/src/lib.rs").unwrap();
+        assert_eq!(wp.to_display(&rel), "/workspace/src/lib.rs");
+
+        let relative = WorkspacePaths::host(dir.path())
+            .unwrap()
+            .with_display_prefix("");
+        assert_eq!(relative.to_display(&rel), "src/lib.rs");
+        assert_eq!(relative.to_display(&RelPath::root()), "");
+    }
+
+    #[test]
+    fn missing_root_spawn_error_is_clear() {
+        let dir = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(dir.path()).expect("host");
+        // Healthy root spawns fine.
+        assert_eq!(
+            wp.spawn_cwd().unwrap(),
+            std::fs::canonicalize(dir.path()).unwrap()
+        );
+
+        // Removing the directory (e.g. `git worktree remove`) yields a clear
+        // error rather than an opaque spawn failure. The canonical root handle
+        // still points at the now-deleted path.
+        drop(dir);
+        let err = wp.spawn_cwd().expect_err("missing root must fail clearly");
+        assert!(
+            format!("{err}").contains("workspace directory does not exist"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn set_host_root_propagates_to_clones() {
+        let first = TempDir::new().unwrap();
+        let second = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(first.path()).expect("host");
+        let clone = wp.clone();
+
+        wp.set_host_root(second.path()).expect("switch root");
+
+        let expected = std::fs::canonicalize(second.path()).unwrap();
+        assert_eq!(clone.host_root().unwrap(), expected);
+        let rel = clone.parse_input("/a.txt").unwrap();
+        assert_eq!(clone.to_host(&rel).unwrap(), expected.join("a.txt"));
+    }
+
+    #[test]
+    fn vfs_has_no_host_mapping() {
+        let wp = WorkspacePaths::vfs();
+        assert!(wp.host_root().is_none());
+        let rel = wp.parse_input("/a.txt").unwrap();
+        assert!(wp.to_host(&rel).is_err());
+        assert!(wp.spawn_cwd().is_err());
+        assert!(wp.set_host_root("/tmp").is_err());
+    }
+
+    #[test]
+    fn parse_mounted_vfs_contains_only_workspace() {
+        let wp = WorkspacePaths::vfs();
+        assert_eq!(
+            wp.parse_mounted("/workspace/src/lib.rs")
+                .unwrap()
+                .to_session_path(),
+            "/src/lib.rs"
+        );
+        assert_eq!(
+            wp.parse_mounted("/workspace").unwrap().to_session_path(),
+            "/"
+        );
+        // Absolute paths outside the alias are outside the mount.
+        assert!(wp.parse_mounted("/tmp/file.txt").is_none());
+        assert!(wp.parse_mounted("/home/agent/x").is_none());
+        assert!(wp.parse_mounted("/workspacefoo").is_none());
+    }
+
+    #[test]
+    fn parse_mounted_host_accepts_host_absolute_and_alias() {
+        let dir = TempDir::new().unwrap();
+        let wp = WorkspacePaths::host(dir.path()).unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+
+        // Host-absolute under the root is in-mount (the real-disk fix).
+        assert_eq!(
+            wp.parse_mounted(&root.join("src/lib.rs").display().to_string())
+                .unwrap()
+                .to_session_path(),
+            "/src/lib.rs"
+        );
+        // The `/workspace` alias still works even on a host store.
+        assert_eq!(
+            wp.parse_mounted("/workspace/src/lib.rs")
+                .unwrap()
+                .to_session_path(),
+            "/src/lib.rs"
+        );
+        // Host-absolute outside the root is rejected.
+        assert!(wp.parse_mounted("/etc/passwd").is_none());
+    }
+
+    #[test]
+    fn free_to_session_path_matches_legacy_normalizer() {
+        assert_eq!(to_session_path("/workspace"), "/");
+        assert_eq!(to_session_path("/workspace/test.txt"), "/test.txt");
+        assert_eq!(
+            to_session_path("/workspace/foo/bar/test.txt"),
+            "/foo/bar/test.txt"
+        );
+        assert_eq!(to_session_path("/test.txt"), "/test.txt");
+        assert_eq!(to_session_path("/workspacefoo"), "/workspacefoo");
+        assert_eq!(to_session_path("foo.txt"), "/foo.txt");
+        assert_eq!(to_session_path("/sub/dir/"), "/sub/dir");
+    }
+}

--- a/crates/runtime/examples/mount_fs_workspace.rs
+++ b/crates/runtime/examples/mount_fs_workspace.rs
@@ -1,0 +1,89 @@
+// Mount-based workspace filesystem (EVE-660).
+//
+// Demonstrates `MountFs`: the agent sees ONE namespace where `/workspace` is a
+// mount point and the default current working directory — not a magic prefix
+// re-implemented in every store. The same resolver works over the in-memory VFS
+// and over a real host directory, and a worktree switch repoints every surface
+// at once while the model-facing `/workspace` stays stable.
+//
+// Run it:
+//   cargo run -p everruns-runtime --example mount_fs_workspace
+//
+// See `specs/file-store.md` for the contract.
+
+use everruns_core::{MountFs, SessionFileSystem, SessionId};
+use everruns_runtime::{InMemorySessionFileStore, RealDiskFileStore};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let session = SessionId::new();
+
+    // ---------------------------------------------------------------------
+    // 1. One namespace + cwd, over the in-memory VFS.
+    // ---------------------------------------------------------------------
+    let backend: Arc<dyn SessionFileSystem> = Arc::new(InMemorySessionFileStore::new());
+    let fs = MountFs::wrap(backend);
+
+    // Write the file using the `/workspace` mount view.
+    fs.write_file(session, "/workspace/src/lib.rs", "fn main() {}", "text")
+        .await?;
+
+    // The same file is reachable three ways — all resolve to one backend key:
+    //   * the /workspace mount view
+    //   * the backend-native absolute path
+    //   * a path relative to the cwd (which defaults to /workspace)
+    for input in ["/workspace/src/lib.rs", "/src/lib.rs", "src/lib.rs"] {
+        let file = fs.read_file(session, input).await?.expect("file exists");
+        assert_eq!(file.content.as_deref(), Some("fn main() {}"));
+        // The store keys it at /src/lib.rs; `/workspace` is never in the keyspace.
+        assert_eq!(file.path, "/src/lib.rs");
+        println!("read {input:<24} -> backend key {} ✓", file.path);
+    }
+
+    // Display renders the stable /workspace view for the model.
+    assert_eq!(fs.display_root(), "/workspace");
+    assert_eq!(fs.display_path("/src/lib.rs"), "/workspace/src/lib.rs");
+    println!(
+        "display_root = {}, display_path(/src/lib.rs) = {}",
+        fs.display_root(),
+        fs.display_path("/src/lib.rs")
+    );
+
+    // ---------------------------------------------------------------------
+    // 2. The same resolver over a real host directory, across a worktree switch.
+    // ---------------------------------------------------------------------
+    let worktree_a = tempfile::tempdir()?;
+    let worktree_b = tempfile::tempdir()?;
+
+    let disk = Arc::new(RealDiskFileStore::new(worktree_a.path())?);
+    let host_fs = MountFs::wrap(disk.clone());
+
+    host_fs
+        .write_file(session, "/workspace/notes.md", "from worktree A", "text")
+        .await?;
+    let on_disk_a = std::fs::read_to_string(disk.root().join("notes.md"))?;
+    println!("\nworktree A root: {}", disk.root().display());
+    println!("  /workspace/notes.md -> on disk: {on_disk_a:?}");
+    assert_eq!(on_disk_a, "from worktree A");
+
+    // The embedder switches worktrees: repoint the host root once.
+    disk.set_host_root(worktree_b.path())?;
+    host_fs
+        .write_file(session, "/workspace/notes.md", "from worktree B", "text")
+        .await?;
+    let on_disk_b = std::fs::read_to_string(disk.root().join("notes.md"))?;
+    println!("worktree B root: {}", disk.root().display());
+    println!("  /workspace/notes.md -> on disk: {on_disk_b:?}");
+    assert_eq!(on_disk_b, "from worktree B");
+
+    // The model-facing namespace never changed, even though the disk root did.
+    assert_eq!(host_fs.display_root(), "/workspace");
+    println!(
+        "\nmodel-facing root stayed `{}` across the switch ✓",
+        host_fs.display_root()
+    );
+
+    println!("\nmount_fs_workspace example OK");
+    Ok(())
+}

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -410,10 +410,13 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         session_id,
         locale: locale.or(session.locale.clone()),
         // Pin system-prompt file reads to the session's workspace (the default
-        // 1:1 case is a transparent pass-through).
-        file_store: Some(everruns_core::WorkspaceScopedFileSystem::wrap(
-            adapter.file_store(),
-            session.workspace_id,
+        // 1:1 case is a transparent pass-through), then resolve through the
+        // mount resolver (EVE-660): `/workspace` is a mount + cwd.
+        file_store: Some(everruns_core::MountFs::wrap(
+            everruns_core::WorkspaceScopedFileSystem::wrap(
+                adapter.file_store(),
+                session.workspace_id,
+            ),
         )),
         model: None,
     };

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -542,23 +542,9 @@ async fn list_storage(
 }
 
 fn normalize_path(path: &str) -> String {
-    if path == "/" || path.is_empty() {
-        return "/".to_string();
-    }
-    let mut normalized = if let Some(stripped) = path.strip_prefix("/workspace/") {
-        format!("/{}", stripped)
-    } else if path == "/workspace" {
-        "/".to_string()
-    } else if path.starts_with('/') {
-        path.to_string()
-    } else {
-        format!("/{}", path)
-    };
-
-    while normalized.len() > 1 && normalized.ends_with('/') {
-        normalized.pop();
-    }
-    normalized
+    // Single workspace path normalizer (EVE-660): the in-memory VFS shares the
+    // same `/workspace`-alias handling as every other backend.
+    everruns_core::workspace_paths::to_session_path(path)
 }
 
 fn root_directory(session_id: SessionId) -> SessionFile {

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -17,6 +17,7 @@ use everruns_core::traits::{
     SessionFileSystem, SessionFileSystemFactory, SessionFileSystemFactoryContext,
 };
 use everruns_core::typed_id::SessionId;
+use everruns_core::workspace_paths::WorkspacePaths;
 use ignore::WalkBuilder;
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
@@ -39,7 +40,11 @@ use uuid::Uuid;
 /// other host processes can still modify the file directly.
 #[derive(Debug, Clone)]
 pub struct RealDiskFileStore {
-    root: PathBuf,
+    /// The unified workspace path model (EVE-660). Owns the host root and all
+    /// parsing/host-mapping/display logic; the store no longer hand-rolls
+    /// `/workspace` stripping or containment checks. The root is shared so an
+    /// embedder's worktree switch via `set_host_root` is seen everywhere.
+    paths: WorkspacePaths,
     readonly: Arc<RwLock<HashSet<String>>>,
 }
 
@@ -75,27 +80,8 @@ impl RealDiskFileStore {
     /// The root is canonicalized once at construction time. Any operation
     /// whose canonical-form path would escape the root is rejected.
     pub fn new(root: impl Into<PathBuf>) -> Result<Self> {
-        let root = root.into();
-        if !root.exists() {
-            return Err(AgentLoopError::config(format!(
-                "RealDiskFileStore root does not exist: {}",
-                root.display()
-            )));
-        }
-        let canonical = std::fs::canonicalize(&root).map_err(|e| {
-            AgentLoopError::config(format!(
-                "failed to canonicalize RealDiskFileStore root {}: {e}",
-                root.display()
-            ))
-        })?;
-        if !canonical.is_dir() {
-            return Err(AgentLoopError::config(format!(
-                "RealDiskFileStore root is not a directory: {}",
-                canonical.display()
-            )));
-        }
         Ok(Self {
-            root: canonical,
+            paths: WorkspacePaths::host(root)?,
             readonly: Arc::new(RwLock::new(HashSet::new())),
         })
     }
@@ -113,61 +99,31 @@ impl RealDiskFileStore {
         }
     }
 
-    /// Borrow the canonicalized workspace root.
-    pub fn root(&self) -> &Path {
-        &self.root
+    /// The current canonicalized workspace root.
+    pub fn root(&self) -> PathBuf {
+        self.paths
+            .host_root()
+            .expect("RealDiskFileStore is always host-rooted")
     }
 
-    fn normalize_path(&self, path: &str) -> String {
-        let input = Path::new(path);
-        if input.is_absolute()
-            && let Ok(relative) = input.strip_prefix(&self.root)
-            && let Ok(path) = capability_path_from_relative(relative)
-        {
-            return path;
-        }
-        normalize_path(path)
+    /// Repoint the workspace root, e.g. when an embedder switches worktrees.
+    ///
+    /// The shared path model means every consumer that took its
+    /// [`WorkspacePaths`] from this store (file tools, shell cwd, host-path
+    /// capabilities) immediately addresses the new root. See EVE-660.
+    pub fn set_host_root(&self, root: impl Into<PathBuf>) -> Result<()> {
+        self.paths.set_host_root(root)
     }
 
     /// Resolve a capability-facing path to an absolute host path.
     ///
-    /// Returns an error if the input contains a `..` segment or if joining
-    /// produces a path outside the root. Symlink containment is checked by
-    /// `reject_symlink_path` at each filesystem access so missing write
-    /// targets can still be created safely.
+    /// All parsing (alias stripping, traversal rejection, host-absolute alias
+    /// handling, containment) is delegated to [`WorkspacePaths`]. Symlink
+    /// containment is checked by `reject_symlink_path` at each filesystem access
+    /// so missing write targets can still be created safely.
     fn resolve(&self, path: &str) -> Result<PathBuf> {
-        let normalized = self.normalize_path(path);
-        if normalized == "/" {
-            return Ok(self.root.clone());
-        }
-        // Drop the leading `/` so `Path::join` treats it as relative.
-        let relative = normalized.trim_start_matches('/');
-        let candidate = Path::new(relative);
-
-        for component in candidate.components() {
-            match component {
-                Component::Normal(_) => {}
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    return Err(AgentLoopError::tool(format!(
-                        "path traversal rejected: {path}"
-                    )));
-                }
-                Component::RootDir | Component::Prefix(_) => {
-                    return Err(AgentLoopError::tool(format!(
-                        "absolute path component rejected: {path}"
-                    )));
-                }
-            }
-        }
-
-        let absolute = self.root.join(candidate);
-        if !absolute.starts_with(&self.root) {
-            return Err(AgentLoopError::tool(format!(
-                "path escapes workspace root: {path}"
-            )));
-        }
-        Ok(absolute)
+        let rel = self.paths.parse_input(path)?;
+        self.paths.to_host(&rel)
     }
 
     /// Reject symlinks anywhere in the resolved path before performing real
@@ -177,14 +133,15 @@ impl RealDiskFileStore {
     /// are allowed so callers can create new files/directories after all
     /// existing ancestors have been checked.
     async fn reject_symlink_path(&self, absolute: &Path) -> Result<()> {
-        let relative = absolute.strip_prefix(&self.root).map_err(|_| {
+        let root = self.root();
+        let relative = absolute.strip_prefix(&root).map_err(|_| {
             AgentLoopError::tool(format!(
                 "path is outside workspace root: {}",
                 absolute.display()
             ))
         })?;
 
-        let mut current = self.root.clone();
+        let mut current = root.clone();
         for component in relative.components() {
             match component {
                 Component::Normal(segment) => current.push(segment),
@@ -216,66 +173,17 @@ impl RealDiskFileStore {
         Ok(())
     }
 
+    /// Map an absolute host path under the root back to its canonical
+    /// leading-slash session path (e.g. `/src/lib.rs`).
     fn relative_capability_path(&self, absolute: &Path) -> Result<String> {
-        let rel = absolute.strip_prefix(&self.root).map_err(|_| {
-            AgentLoopError::tool(format!(
-                "path is outside workspace root: {}",
-                absolute.display()
-            ))
-        })?;
-        capability_path_from_relative(rel)
+        Ok(self.paths.from_host(absolute)?.to_session_path())
     }
-}
-
-fn capability_path_from_relative(relative: &Path) -> Result<String> {
-    if relative.as_os_str().is_empty() {
-        return Ok("/".to_string());
-    }
-    let mut segments = Vec::new();
-    for component in relative.components() {
-        match component {
-            Component::CurDir => {}
-            Component::Normal(s) => {
-                let segment = s.to_str().ok_or_else(|| {
-                    AgentLoopError::tool(format!(
-                        "non-UTF-8 path component: {}",
-                        relative.display()
-                    ))
-                })?;
-                segments.push(segment);
-            }
-            _ => {
-                return Err(AgentLoopError::tool(format!(
-                    "unexpected path component in {}",
-                    relative.display()
-                )));
-            }
-        }
-    }
-    if segments.is_empty() {
-        Ok("/".to_string())
-    } else {
-        Ok(format!("/{}", segments.join("/")))
-    }
-}
-
-fn display_join(root: &Path, path: &str) -> String {
-    if path == "/" {
-        return root.display().to_string();
-    }
-    root.join(path.trim_start_matches('/'))
-        .display()
-        .to_string()
 }
 
 #[async_trait]
 impl SessionFileSystem for RealDiskFileStore {
-    fn display_root(&self) -> String {
-        self.root.display().to_string()
-    }
-
-    fn display_path(&self, path: &str) -> String {
-        display_join(&self.root, &self.normalize_path(path))
+    fn workspace_paths(&self) -> WorkspacePaths {
+        self.paths.clone()
     }
 
     async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
@@ -421,7 +329,7 @@ impl SessionFileSystem for RealDiskFileStore {
     ) -> Result<bool> {
         let absolute = self.resolve(path)?;
         self.reject_symlink_path(&absolute).await?;
-        if absolute == self.root {
+        if absolute == self.root() {
             return Err(AgentLoopError::tool(
                 "cannot delete workspace root".to_string(),
             ));
@@ -575,13 +483,12 @@ impl SessionFileSystem for RealDiskFileStore {
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
-        let root = self.root.clone();
+        let root = self.root();
         let pattern = pattern.to_string();
-        let path_pattern = path_pattern.map(|path| {
-            self.normalize_path(path)
-                .trim_start_matches('/')
-                .to_string()
-        });
+        let path_pattern = match path_pattern {
+            Some(path) => Some(self.paths.parse_input(path)?.as_relative().to_string()),
+            None => None,
+        };
 
         // `ignore::WalkBuilder` is sync; reading file content per match is
         // sync too. Push the whole walk onto `spawn_blocking` so we don't
@@ -693,25 +600,6 @@ impl SessionFileSystem for RealDiskFileStore {
             updated_at,
         })
     }
-}
-
-fn normalize_path(path: &str) -> String {
-    if path.is_empty() || path == "/" {
-        return "/".to_string();
-    }
-    let mut normalized = if let Some(stripped) = path.strip_prefix("/workspace/") {
-        format!("/{}", stripped)
-    } else if path == "/workspace" {
-        "/".to_string()
-    } else if path.starts_with('/') {
-        path.to_string()
-    } else {
-        format!("/{}", path)
-    };
-    while normalized.len() > 1 && normalized.ends_with('/') {
-        normalized.pop();
-    }
-    normalized
 }
 
 fn path_id(canonical_path: &str) -> Uuid {

--- a/crates/runtime/tests/workspace_paths_conformance_test.rs
+++ b/crates/runtime/tests/workspace_paths_conformance_test.rs
@@ -1,22 +1,25 @@
-// EVE-660 conformance: every workspace surface shares one namespace and one
-// root, including across a worktree switch.
+// EVE-660 conformance: one mount-resolved namespace, one root, across a
+// worktree switch.
 //
-// Acceptance criterion: `read_file`, `grep_files`, a host-path scanner
-// capability, and the bash cwd must all agree on the same root before and after
-// `set_host_root` repoints the workspace (the worktree-switch scenario).
+// The agent's filesystem is `MountFs` over the workspace backend: `/workspace`
+// is a mount + the default cwd, not a per-store prefix. This proves that
+// `read_file`, `grep_files`, a host-path scanner capability, the bash cwd, and
+// cwd-relative resolution all agree on the same root — and that repointing the
+// host root (the worktree-switch scenario) moves every surface together while
+// the model-facing namespace stays a stable `/workspace`.
 
 use everruns_core::capabilities::BashTool;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
-use everruns_core::{SessionFileSystem, SessionId};
+use everruns_core::{MountFs, SessionFileSystem, SessionId};
 use everruns_runtime::RealDiskFileStore;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
 
 /// Read a path the way a host-path capability (e.g. `repo_map`, `ast_grep`)
-/// would: resolve through the shared `WorkspacePaths` to a host path, then scan
-/// the real file. No local `/workspace` stripping.
+/// would: resolve through the workspace path model to a host path, then scan the
+/// real file. No local `/workspace` stripping.
 fn host_scanner_read(ctx: &ToolContext, input: &str) -> std::io::Result<String> {
     let paths = ctx.workspace_paths();
     let rel = paths
@@ -47,18 +50,20 @@ async fn all_surfaces_agree_on_root_across_worktree_switch() {
 
     // --- Worktree A ---
     let worktree_a = TempDir::new().unwrap();
-    let store = Arc::new(RealDiskFileStore::new(worktree_a.path()).unwrap());
+    // The host-backed store, behind the mount resolver (as the runtime wires it).
+    let backend = Arc::new(RealDiskFileStore::new(worktree_a.path()).unwrap());
+    let store: Arc<dyn SessionFileSystem> = MountFs::wrap(backend.clone());
     let ctx = ToolContext::with_file_store(session, store.clone());
 
-    let root_a = store.root();
+    let root_a = backend.root();
 
-    // The model addresses files with the workspace alias; the store maps it.
+    // Model addresses files at /workspace; the resolver maps to the backend.
     store
         .write_file(session, "/workspace/marker.txt", "ALPHA", "text")
         .await
         .unwrap();
 
-    // read_file agrees.
+    // read_file agrees — both the /workspace view and the backend-native path.
     let read = store
         .read_file(session, "/workspace/marker.txt")
         .await
@@ -67,27 +72,34 @@ async fn all_surfaces_agree_on_root_across_worktree_switch() {
     assert_eq!(read.content.as_deref(), Some("ALPHA"));
     assert_eq!(read.path, "/marker.txt");
 
+    // cwd-relative resolution agrees: cwd defaults to /workspace.
+    let relative = store
+        .read_file(session, "marker.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(relative.content.as_deref(), Some("ALPHA"));
+
     // grep_files agrees.
     let hits = store.grep_files(session, "ALPHA", None).await.unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].path, "/marker.txt");
 
     // Host-path scanner agrees — and reads from worktree A on disk.
-    assert_eq!(host_scanner_read(&ctx, "/marker.txt").unwrap(), "ALPHA");
     assert_eq!(
-        ctx.workspace_paths()
-            .to_host(&ctx.workspace_paths().parse_input("/").unwrap())
-            .unwrap(),
-        root_a
+        host_scanner_read(&ctx, "/workspace/marker.txt").unwrap(),
+        "ALPHA"
     );
 
-    // Bash cwd agrees: pwd reports worktree A's root.
-    assert_eq!(bash_pwd(&ctx).await, root_a.display().to_string());
+    // The model-facing namespace is a stable /workspace, even on real disk.
+    assert_eq!(store.display_root(), "/workspace");
+    assert_eq!(store.display_path("/marker.txt"), "/workspace/marker.txt");
+    assert_eq!(bash_pwd(&ctx).await, "/workspace");
 
-    // --- Switch to Worktree B (e.g. the embedder moved worktrees) ---
+    // --- Switch to Worktree B (the embedder moved worktrees) ---
     let worktree_b = TempDir::new().unwrap();
-    store.set_host_root(worktree_b.path()).unwrap();
-    let root_b = store.root();
+    backend.set_host_root(worktree_b.path()).unwrap();
+    let root_b = backend.root();
     assert_ne!(root_a, root_b);
 
     // A file that exists only in B.
@@ -96,7 +108,7 @@ async fn all_surfaces_agree_on_root_across_worktree_switch() {
         .await
         .unwrap();
 
-    // Every surface now agrees on worktree B — using the *same* context.
+    // Every surface now resolves to worktree B — using the *same* context.
     let read_b = store
         .read_file(session, "/workspace/marker.txt")
         .await
@@ -108,16 +120,20 @@ async fn all_surfaces_agree_on_root_across_worktree_switch() {
     assert_eq!(hits_b.len(), 1);
     assert_eq!(hits_b[0].path, "/marker.txt");
 
-    assert_eq!(host_scanner_read(&ctx, "/marker.txt").unwrap(), "BETA");
+    assert_eq!(
+        host_scanner_read(&ctx, "/workspace/marker.txt").unwrap(),
+        "BETA"
+    );
 
-    // The old root no longer holds the file the scanner now resolves.
-    let host_b = ctx
-        .workspace_paths()
-        .to_host(&ctx.workspace_paths().parse_input("/marker.txt").unwrap())
+    // The scanner's host path is under the new root, not the old one.
+    let paths = ctx.workspace_paths();
+    let host_b = paths
+        .to_host(&paths.parse_input("/marker.txt").unwrap())
         .unwrap();
     assert!(host_b.starts_with(&root_b));
     assert!(!host_b.starts_with(&root_a));
 
-    // Bash cwd followed the switch too.
-    assert_eq!(bash_pwd(&ctx).await, root_b.display().to_string());
+    // The model-facing namespace is unchanged: still /workspace.
+    assert_eq!(store.display_root(), "/workspace");
+    assert_eq!(bash_pwd(&ctx).await, "/workspace");
 }

--- a/crates/runtime/tests/workspace_paths_conformance_test.rs
+++ b/crates/runtime/tests/workspace_paths_conformance_test.rs
@@ -1,0 +1,123 @@
+// EVE-660 conformance: every workspace surface shares one namespace and one
+// root, including across a worktree switch.
+//
+// Acceptance criterion: `read_file`, `grep_files`, a host-path scanner
+// capability, and the bash cwd must all agree on the same root before and after
+// `set_host_root` repoints the workspace (the worktree-switch scenario).
+
+use everruns_core::capabilities::BashTool;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use everruns_core::{SessionFileSystem, SessionId};
+use everruns_runtime::RealDiskFileStore;
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+/// Read a path the way a host-path capability (e.g. `repo_map`, `ast_grep`)
+/// would: resolve through the shared `WorkspacePaths` to a host path, then scan
+/// the real file. No local `/workspace` stripping.
+fn host_scanner_read(ctx: &ToolContext, input: &str) -> std::io::Result<String> {
+    let paths = ctx.workspace_paths();
+    let rel = paths
+        .parse_input(input)
+        .expect("scanner: parse workspace path");
+    let host = paths.to_host(&rel).expect("scanner: map to host");
+    std::fs::read_to_string(host)
+}
+
+/// Run `pwd` through the bash tool and return the reported working directory.
+async fn bash_pwd(ctx: &ToolContext) -> String {
+    match BashTool
+        .execute_with_context(json!({ "commands": "pwd" }), ctx)
+        .await
+    {
+        ToolExecutionResult::Success(output) => output["stdout"]
+            .as_str()
+            .expect("pwd stdout is a string")
+            .trim()
+            .to_string(),
+        other => panic!("bash pwd did not succeed: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn all_surfaces_agree_on_root_across_worktree_switch() {
+    let session = SessionId::from_seed(660);
+
+    // --- Worktree A ---
+    let worktree_a = TempDir::new().unwrap();
+    let store = Arc::new(RealDiskFileStore::new(worktree_a.path()).unwrap());
+    let ctx = ToolContext::with_file_store(session, store.clone());
+
+    let root_a = store.root();
+
+    // The model addresses files with the workspace alias; the store maps it.
+    store
+        .write_file(session, "/workspace/marker.txt", "ALPHA", "text")
+        .await
+        .unwrap();
+
+    // read_file agrees.
+    let read = store
+        .read_file(session, "/workspace/marker.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(read.content.as_deref(), Some("ALPHA"));
+    assert_eq!(read.path, "/marker.txt");
+
+    // grep_files agrees.
+    let hits = store.grep_files(session, "ALPHA", None).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].path, "/marker.txt");
+
+    // Host-path scanner agrees — and reads from worktree A on disk.
+    assert_eq!(host_scanner_read(&ctx, "/marker.txt").unwrap(), "ALPHA");
+    assert_eq!(
+        ctx.workspace_paths()
+            .to_host(&ctx.workspace_paths().parse_input("/").unwrap())
+            .unwrap(),
+        root_a
+    );
+
+    // Bash cwd agrees: pwd reports worktree A's root.
+    assert_eq!(bash_pwd(&ctx).await, root_a.display().to_string());
+
+    // --- Switch to Worktree B (e.g. the embedder moved worktrees) ---
+    let worktree_b = TempDir::new().unwrap();
+    store.set_host_root(worktree_b.path()).unwrap();
+    let root_b = store.root();
+    assert_ne!(root_a, root_b);
+
+    // A file that exists only in B.
+    store
+        .write_file(session, "/marker.txt", "BETA", "text")
+        .await
+        .unwrap();
+
+    // Every surface now agrees on worktree B — using the *same* context.
+    let read_b = store
+        .read_file(session, "/workspace/marker.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(read_b.content.as_deref(), Some("BETA"));
+
+    let hits_b = store.grep_files(session, "BETA", None).await.unwrap();
+    assert_eq!(hits_b.len(), 1);
+    assert_eq!(hits_b[0].path, "/marker.txt");
+
+    assert_eq!(host_scanner_read(&ctx, "/marker.txt").unwrap(), "BETA");
+
+    // The old root no longer holds the file the scanner now resolves.
+    let host_b = ctx
+        .workspace_paths()
+        .to_host(&ctx.workspace_paths().parse_input("/marker.txt").unwrap())
+        .unwrap();
+    assert!(host_b.starts_with(&root_b));
+    assert!(!host_b.starts_with(&root_a));
+
+    // Bash cwd followed the switch too.
+    assert_eq!(bash_pwd(&ctx).await, root_b.display().to_string());
+}

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -64,45 +64,70 @@ supports `read_file`, `write_file`, `write_file_if_content_matches` (CAS),
 `delete_file`, `list_directory`, `stat_file`, `grep_files`,
 `create_directory`, and `seed_initial_file`.
 
+### Unified Workspace Path Model (EVE-660)
+
+There is **one** workspace path language, owned by
+`everruns_core::workspace_paths::WorkspacePaths`. It is the single seam that
+parses model/tool input, maps to the host filesystem, and formats display
+strings. Every backend (in-memory VFS, DB store, `RealDiskFileStore`) and every
+host consumer (the shell, host-path capabilities) goes through it instead of
+re-implementing `/workspace` stripping.
+
+- **Canonical form is workspace-relative.** The in-memory representation is
+  `RelPath` — normalized, no `..`, no leading slash, no host prefix
+  (`src/lib.rs`, `Cargo.toml`). The workspace root is the empty path.
+- **The wire form stays leading-slash.** `RelPath::to_session_path()` produces
+  the legacy `/src/lib.rs` form that `SessionFileSystem` methods and the DB
+  store key on, so storage backends need no change.
+- **`/workspace` is a display alias, not a namespace.** It is one accepted
+  spelling on input and the default display prefix on output — never a second
+  addressing scheme.
+
+`WorkspacePaths` binds an optional host root (set for real-disk stores and
+shells; absent for the pure VFS) shared behind a handle, so an embedder's
+worktree switch via `set_host_root` propagates to every consumer that took its
+`WorkspacePaths` from the same store. `spawn_cwd()` validates the root exists and
+fails clearly (`workspace directory does not exist: …`) rather than letting a
+spawn surface an opaque `No such file or directory`.
+
 ### Path Namespace
 
-Session filesystem paths are **absolute, forward-slash, leading-slash**
-strings.
+`parse_input` accepts every spelling below and normalizes to the same canonical
+path. The store's wire form is **absolute, forward-slash, leading-slash**.
 
-| Input | Canonical form |
-|-------|----------------|
-| `"/foo/bar.txt"` | `/foo/bar.txt` |
-| `"/workspace/foo/bar.txt"` | `/foo/bar.txt` |
-| `"/workspace"` | `/` |
-| `""` or `"/"` | `/` |
-| `"foo.txt"` (no leading slash) | `/foo.txt` |
+| Input | Canonical (`RelPath`) | Wire form |
+|-------|-----------------------|-----------|
+| `"src/bar.txt"` | `src/bar.txt` | `/src/bar.txt` |
+| `"/src/bar.txt"` | `src/bar.txt` | `/src/bar.txt` |
+| `"/workspace/src/bar.txt"` | `src/bar.txt` | `/src/bar.txt` |
+| host-absolute under root | `src/bar.txt` | `/src/bar.txt` |
+| `"/workspace"`, `""`, `"/"` | (root) | `/` |
 
-Implementations MUST:
+Implementations MUST route path handling through `WorkspacePaths` and MUST NOT
+hand-roll prefix logic. The shared parser guarantees:
 
-- Treat the optional leading `/workspace` segment as equivalent to the root.
-  The `/workspace` prefix exists because agents reason about a `/workspace`
-  mount point (see `specs/workspace.md`), but the store itself
-  works in a flat per-session namespace.
-- Strip trailing slashes (except for `/`).
-- Reject path traversal: any path that, after normalization, would escape
-  the store root MUST return an error. `..` segments anywhere in the path
-  are treated as a traversal attempt regardless of input shape (absolute,
-  relative, or `/workspace`-prefixed).
-- Never interpret backslashes as separators or environment variables as
-  expansions. Paths are opaque strings of slash-separated segments.
+- The optional leading `/workspace` segment is equivalent to the root. Bare
+  `workspace/...` (no leading slash) is **not** the alias, so a real top-level
+  `workspace/` directory stays reachable.
+- Trailing slashes are stripped (except for `/`).
+- Path traversal is rejected: `..` anywhere returns an error regardless of input
+  shape, and host mapping re-checks containment under the root.
+- Backslashes are not separators and environment variables are not expanded.
+  Paths are opaque slash-separated segments.
 
 ### Display Paths
 
-`/workspace` is the canonical tool namespace, but it is not always the most
-accurate user-facing label. `SessionFileSystem` implementations may expose a
-display root and display paths for capability results and prompt guidance.
+`WorkspacePaths::to_display` is the single formatter. The display prefix is
+configurable, not magical:
 
-Default in-memory and storage-backed implementations display `/workspace`,
-matching the server workspace model. `RealDiskFileStore` displays its
-canonical host root and accepts host-absolute paths under that root as aliases
-for the same canonical session paths. This lets embedders show paths like
-`/Users/alex/project/src/lib.rs` while preserving `/workspace/src/lib.rs` as a
-valid compatibility input.
+- Default in-memory and storage-backed implementations display `/workspace`,
+  matching the server workspace model.
+- `RealDiskFileStore` displays its canonical host root by default and accepts
+  host-absolute paths under that root as aliases for the same canonical paths.
+  This lets embedders show `/Users/alex/project/src/lib.rs` while preserving
+  `/workspace/src/lib.rs` as a valid compatibility input. An embedder may set
+  the prefix to `/workspace` (to show the cloud alias) or to empty (bare
+  relative paths) without changing the addressing.
 
 ### Encoding
 
@@ -245,6 +270,15 @@ upstream.
 > a host process (e.g. the bash tool spawns a shell, which inherits the
 > host filesystem regardless of which `SessionFileSystem` is plugged in).
 
+> Capabilities that accept `path` arguments MUST resolve them through
+> `ToolContext.workspace_paths()` / `SystemPromptContext.workspace_paths()`
+> (which derive from the file store) — or through the store's own
+> `SessionFileSystem::workspace_paths()`. They MUST NOT implement their own
+> `/workspace` stripping, alias handling, or containment checks. This includes
+> host-process tools: the shell resolves its working directory and translates
+> command paths through the same `WorkspacePaths`, so it shares one namespace
+> with the file tools.
+
 This rule keeps all existing and future capabilities aligned with the
 pluggable seam. A capability that follows the rule works against the
 in-memory VFS, the database-backed server store, and the real-disk store
@@ -375,7 +409,10 @@ When the mount-overlay resolver lands, the migration path is:
 
 ## Source Index
 
+- `crates/core/src/workspace_paths.rs` — `WorkspacePaths`, `RelPath` (the
+  unified path model, EVE-660)
 - `crates/core/src/traits.rs` — `SessionFileSystem` trait
+  (`workspace_paths()`), `ToolContext::workspace_paths()`
 - `crates/core/src/session_file.rs` — `SessionFile`, `FileInfo`,
   `FileStat`, `GrepMatch`, `InitialFile`
 - `crates/runtime/src/backends.rs` — `RuntimeBackends`

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -66,12 +66,30 @@ supports `read_file`, `write_file`, `write_file_if_content_matches` (CAS),
 
 ### Unified Workspace Path Model (EVE-660)
 
-There is **one** workspace path language, owned by
-`everruns_core::workspace_paths::WorkspacePaths`. It is the single seam that
-parses model/tool input, maps to the host filesystem, and formats display
-strings. Every backend (in-memory VFS, DB store, `RealDiskFileStore`) and every
-host consumer (the shell, host-path capabilities) goes through it instead of
-re-implementing `/workspace` stripping.
+The agent sees **one** filesystem, resolved by
+`everruns_core::mount_fs::MountFs` — a `SessionFileSystem` decorator the runtime
+wires around the workspace backend wherever a file store enters a `ToolContext`
+or `SystemPromptContext`. `MountFs` owns:
+
+- a **mount table** — named mount points, each backed by a `SessionFileSystem`,
+  with a per-mount root in that backend's keyspace, dispatched by longest-prefix
+  match; and
+- a **current working directory** (default `/workspace`) — relative paths
+  resolve against it, `.`/`..` collapse POSIX-style.
+
+`/workspace` is therefore a **mount point and the default cwd**, not a magic
+prefix re-implemented in every store. Today there is a single workspace backend,
+so the table holds the root mount (`/` → backend, for legacy backend-native
+paths such as `/AGENTS.md`, `/outputs/…`, `/.agents/skills/…`) and the
+`/workspace` view of the same backend; `/workspace` wins by longest-prefix, so
+`/workspace/foo` ≡ `/foo`. Splitting `/outputs`, `/.agents/skills`, or volumes
+onto *different* backends later is `MountFs::with_mount(...)` — the resolver does
+not change. The model-facing namespace is a stable `/workspace` even for a
+host-rooted backend; host-absolute display is opt-in rendering, not addressing.
+
+Underneath, the workspace backend normalizes paths and maps to the host
+filesystem through `everruns_core::workspace_paths::WorkspacePaths`. It is the
+single normalizer/host-mapper the stores share, below the resolver.
 
 - **Canonical form is workspace-relative.** The in-memory representation is
   `RelPath` — normalized, no `..`, no leading slash, no host prefix
@@ -409,8 +427,9 @@ When the mount-overlay resolver lands, the migration path is:
 
 ## Source Index
 
+- `crates/core/src/mount_fs.rs` — `MountFs` (the mount + cwd resolver, EVE-660)
 - `crates/core/src/workspace_paths.rs` — `WorkspacePaths`, `RelPath` (the
-  unified path model, EVE-660)
+  backend normalizer / host-mapper under the resolver, EVE-660)
 - `crates/core/src/traits.rs` — `SessionFileSystem` trait
   (`workspace_paths()`), `ToolContext::workspace_paths()`
 - `crates/core/src/session_file.rs` — `SessionFile`, `FileInfo`,

--- a/specs/workspace.md
+++ b/specs/workspace.md
@@ -179,8 +179,12 @@ multi-session sharing story for API clients.
 ### Decision 5: Workspace Mount Point
 **Chosen:** Workspace files exposed to agents at `/workspace`
 **Rationale:** `/workspace` is a common convention (VS Code DevContainers,
-GitHub Codespaces). All capabilities normalize paths by stripping/adding
-the `/workspace` prefix when interfacing with the workspace file store.
+GitHub Codespaces). It is a **display alias** over the workspace root, not a
+separate namespace: the canonical path model is workspace-relative
+(`everruns_core::workspace_paths::WorkspacePaths`, EVE-660). Capabilities do not
+strip/add `/workspace` themselves — they route every path through
+`WorkspacePaths`, which parses all accepted spellings and formats display paths.
+See `specs/file-store.md`.
 
 ### Decision 6: Per-Workspace Storage Quotas
 **Chosen:** Enforce byte-level quotas at the application layer in both


### PR DESCRIPTION
## What
Unify the workspace path model so the agent sees **one** filesystem namespace across the in-memory/DB VFS, real disk, the shell, and host-path capabilities. Plus a CI hardening pass that stops several crates' tests from being silently skipped.

- New `everruns_core::mount_fs::MountFs` — a `SessionFileSystem` resolver with a **mount table** (named mount points → backends, longest-prefix dispatch) and a **current working directory** (default `/workspace`). Relative paths resolve against cwd; `.`/`..` collapse POSIX-style. `/workspace` is a mount point + cwd, not a magic prefix re-derived in every store.
- New `everruns_core::workspace_paths::{WorkspacePaths, RelPath}` — the single backend normalizer / host-mapper *under* the resolver (host-root binding with a shared handle for worktree switches, host round-trip, traversal rejection).
- `MountFs` is wired around the workspace backend at the three context-construction chokepoints (`assemble_turn_context`, `ActAtom`, server host), so it is the production filesystem for tool and prompt execution.
- The four hand-rolled `/workspace` normalizers (`traits.rs`, `file_system`, `real_disk`, `in_memory`) now route through the shared type; the bash capability resolves its cwd, `WORKSPACE` env, and command paths through it (fixes host-absolute paths being rejected by bashkit over real disk).
- File-tool schemas prefer workspace-relative examples (`src/foo.rs`); `/workspace` documented as a display alias. `specs/file-store.md` + `specs/workspace.md` updated.

## Why
Everruns exposed **two incompatible path namespaces** for the same workspace: a VFS/tool namespace teaching models `/workspace/...`, and a host namespace used by bash, spawn cwd, and embedder capabilities. Each host-path consumer independently re-implemented alias stripping, containment checks, and worktree-root updates — fragile, duplicated, and the cause of repeated production pain in yolop and eval runs (e.g. `repo_map`/`ast_grep` wasting a turn on `path not found: /workspace`, opaque spawn failures on removed worktrees). EVE-660 asks for a single, first-class workspace-rooted path model.

## How
- Canonical in-memory form is workspace-relative (`RelPath`); the on-the-wire form stays the legacy leading-slash session path (`/src/lib.rs`), so the DB store, git, and the control-plane FS API need no change.
- `MountFs` mounts the single workspace backend at `/` (legacy backend-native paths like `/AGENTS.md`, `/outputs/…`, `/.agents/skills/…`) and at `/workspace` (the model view); both resolve to the same files, `/workspace` wins by longest-prefix. `with_mount(...)` is ready to split `/outputs`/skills/volumes onto distinct backends later without changing the resolver.
- The model-facing namespace is a stable `/workspace` even over a host-rooted backend; host-absolute display becomes opt-in rendering, not addressing.
- A worktree switch is `set_host_root` on the shared root handle: read_file, grep, the host scanner, and the shell all repoint together while `/workspace` stays stable.

## CI: stop silently skipping tests
Surfacing the EVE-660 mount-resolver test exposed a broader pattern — several crates' CI steps hand-enumerated a subset of test files by name (`--test foo --test bar`) or ran `--lib` only, so integration tests (and whole crates) never ran and new test files would be silently dropped. De-enumerated / expanded to full suites for the crates that are pure (no network/credentials), all verified green locally:

| Crate | Before | After |
|---|---|---|
| runtime | 2 of 6 test files enumerated | whole crate (lib + integration + doctests + examples) |
| core | `--lib` only (7 integration files + doctests skipped) | whole suite |
| local | not tested in CI at all | whole suite (covers `RealDiskFileStore`) |
| worker | `--lib` only (`network_reliability_test` skipped) | whole crate |
| mcp | not tested in CI at all | whole suite (http + stdio transports) |

The Postgres-gated `server` crate has the same hand-enumeration (~17 of 38 integration files never run) but needs its own triage; tracked as **EVE-664**.

## Risk
- **Medium.** Touches the filesystem resolution path used by every file tool, the shell, and prompt-time reads (AGENTS.md/skills). Mitigated by: the change is additive (resolver wraps the existing backend), backends keep their existing keyspaces, the control-plane FS HTTP API is out of `MountFs`'s path and unchanged, and the full core + runtime suites plus a dedicated cross-surface conformance test pass.
- Behavior change: bashkit no longer rejects non-`/workspace` absolute paths — they resolve into the workspace mount (still contained by the backend root + symlink rejection), rather than erroring.
- CI changes are test-only (no production code), and run more tests than before — strictly additive coverage.

## Security
- **Threat categories reviewed: TM-FS** (file paths, sandbox boundaries). No TM-AUTH/AUTHZ/API/SQL/TENANT surface touched (no endpoints, queries, auth, or org-scoping changes).
- **Findings / resolutions:**
  - *Path traversal:* `MountFs::normalize_virtual` collapses `..` and clamps at root **before** dispatch; the real-disk backend independently rejects `..` and symlinks and verifies containment under the canonical root. Defense-in-depth preserved — e.g. `/workspace/../../etc/passwd` normalizes to `/etc/passwd`, maps to `/etc/passwd` (contained), never the host `/etc/passwd`. Covered by `workspace_paths` traversal tests and `real_disk` symlink/traversal tests.
  - *Sandbox boundary (bash):* the root mount means bash paths resolve into the workspace backend instead of erroring on non-`/workspace` paths; this grants no escape — access stays contained under the backend root with symlink rejection, and bash could already reach the same files via `/workspace/...`.
  - *Worktree switch:* `set_host_root` canonicalizes and validates the new root (errors if missing/not-a-dir); `spawn_cwd` fails clearly (`workspace directory does not exist: …`) instead of an opaque spawn error.
  - No new dependencies. No unbounded inputs introduced.

## Follow-ups
- **EVE-664: de-enumerate the `server` integration tests** (~17 of 38 never run; Postgres-gated, needs per-test triage incl. `session_workspace_attach_test` / `workspace_files_integration_test` which may exercise this PR's path model).
- **Drop residual store-level `/workspace` tolerance.** `RealDiskFileStore` / in-memory still defensively normalize `/workspace`; behind `MountFs` it's dead weight. Left in to avoid churning ~150 bare-store unit tests in this PR. Safe to defer — it's redundant, not incorrect.
- **Fold the bashkit adapter into `MountFs` resolution and delete `WorkspacePaths::parse_mounted`.** The adapter still pre-normalizes before calling the store; routing it fully through the resolver removes the `parse_input`/`parse_mounted` split. Deferred to keep bashkit test churn out of this PR.
- **Persistent cwd** (a `cd` surviving across tool calls) is intentionally **not** implemented — bashkit handles cwd within a call, and cross-call cwd is new session state nobody needs yet. `MountFs::set_cwd` exists for when it does.
- **Split `/outputs` and `/.agents/skills` onto distinct backends** when a separate source (remote/read-only skills, named volumes) actually exists — `with_mount(...)` is the seam.

## Checklist
- [x] Tests added or updated (14 `workspace_paths` + 7 `mount_fs` unit tests; runtime conformance test across a worktree switch; updated file_system/bashkit tests; CI now runs the full core/runtime/local/worker/mcp suites)
- [x] Backward compatibility considered (wire form + DB/git/control-plane FS API unchanged; backends keep keyspaces)
- [x] Security review performed against relevant threat model categories (TM-FS)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Closes EVE-660.