### PR TITLE
feat(ui): unify Agents and Harnesses pages on a five-zone page layout

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -222,7 +222,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
     await renderWithSuspense({ agentId: "agent-1" });
 
     // Agent name should be visible
-    expect(screen.getByText("Test Agent")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Test Agent" })).toBeInTheDocument();
     // Sessions section header should be visible
     expect(screen.getByText("Sessions")).toBeInTheDocument();
   });
@@ -245,7 +245,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
     await renderWithSuspense({ agentId: "agent-1" });
 
     // Agent name should be visible
-    expect(screen.getByText("Test Agent")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Test Agent" })).toBeInTheDocument();
   });
 
   it("does not display model badge when model data is not loaded", async () => {
@@ -293,7 +293,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
 
     // Default model should be displayed in configuration section
     expect(screen.getByText("Default Model")).toBeInTheDocument();
-    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getAllByText("GPT-4o").length).toBeGreaterThan(0);
   });
 
   it("handles empty sessions list", async () => {
@@ -338,7 +338,7 @@ describe("AgentDetailPage - Default Model Display in Configuration", () => {
 
     // Check that default model section is visible
     expect(screen.getByText("Default Model")).toBeInTheDocument();
-    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getAllByText("GPT-4o").length).toBeGreaterThan(0);
     // Provider icon should be rendered
     expect(screen.getByTestId("provider-icon-openai")).toBeInTheDocument();
   });
@@ -353,7 +353,7 @@ describe("AgentDetailPage - Default Model Display in Configuration", () => {
     await renderWithSuspense({ agentId: "agent-1" });
 
     expect(screen.getByText("Default Model")).toBeInTheDocument();
-    expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+    expect(screen.getAllByText("Claude 3.5 Sonnet").length).toBeGreaterThan(0);
     expect(screen.getByTestId("provider-icon-anthropic")).toBeInTheDocument();
   });
 

--- a/apps/ui/src/__tests__/agent-edit-page.test.tsx
+++ b/apps/ui/src/__tests__/agent-edit-page.test.tsx
@@ -137,7 +137,8 @@ describe("EditAgentPage", () => {
   it("renders the form when tags is null", async () => {
     await renderWithSuspense({ agentId: "agent_123" });
 
-    expect(screen.getByRole("heading", { name: "Edit Agent" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Test Agent" })).toBeInTheDocument();
+    expect(screen.getByText("Editing")).toBeInTheDocument();
     expect(screen.getByLabelText("Tags")).toHaveValue("");
     expect(screen.getByDisplayValue("test-agent")).toBeInTheDocument();
   });
@@ -148,7 +149,7 @@ describe("EditAgentPage", () => {
 
     await renderWithSuspense({ agentId: "agent_123" });
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /Save Changes/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Save changes/ }));
     });
 
     expect(mutateAsync).toHaveBeenCalledTimes(1);
@@ -167,7 +168,7 @@ describe("EditAgentPage", () => {
       target: { value: "internal.corp" },
     });
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /Save Changes/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Save changes/ }));
     });
 
     expect(mutateAsync).toHaveBeenCalledTimes(1);
@@ -190,7 +191,7 @@ describe("EditAgentPage", () => {
 
     fireEvent.change(screen.getByLabelText("Allowed hosts"), { target: { value: "" } });
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /Save Changes/ }));
+      fireEvent.click(screen.getByRole("button", { name: /Save changes/ }));
     });
 
     expect(mutateAsync).toHaveBeenCalledTimes(1);

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -2,7 +2,6 @@
 
 import { use, useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import {
   useAgent,
   useUpdateAgent,
@@ -15,13 +14,25 @@ import {
 import { usePolicies } from "@/hooks/use-policies";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 import {
   Dialog,
   DialogContent,
@@ -38,7 +49,7 @@ import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { NetworkAccessEditor, normalizeNetworkAccess } from "@/components/network-access-editor";
 import { ModelPicker } from "@/components/models/model-picker";
-import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
+import { Trash2, Eye, Edit2, Check, X, Loader2, Boxes, Pencil } from "lucide-react";
 import {
   agentFormSchema,
   getFieldErrors,
@@ -242,331 +253,349 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   const agentDisplayName = getDisplayName(agent);
 
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href={`/agents/${agentId}`}
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Agent
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Agents", href: "/agents" },
+          { label: agentDisplayName, href: `/agents/${agentId}` },
+          { label: "Edit" },
+        ]}
+      />
 
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Edit Agent</h1>
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList>
-            <TabsTrigger value="edit">
-              <Edit2 className="w-4 h-4 mr-2" />
-              Edit
-            </TabsTrigger>
-            <TabsTrigger value="preview">
-              <Eye className="w-4 h-4 mr-2" />
-              Preview
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </div>
+      <PageMasthead
+        icon={<Boxes />}
+        title={agentDisplayName}
+        badges={
+          <Badge variant="accent">
+            <Pencil className="size-3" />
+            Editing
+          </Badge>
+        }
+        description="Changes apply to new sessions only. Running sessions keep the current definition."
+        meta={
+          <>
+            <span>
+              Identity <span className="font-mono text-primary">{agent.name}</span>
+            </span>
+            <span>
+              Last edited{" "}
+              <span className="text-foreground">
+                {new Date(agent.updated_at).toLocaleDateString()}
+              </span>
+            </span>
+          </>
+        }
+        actions={
+          <>
+            <Button type="submit" form="agent-edit-form" disabled={isSaving || isReadOnly}>
+              <Check className="size-4" />
+              {isReadOnly ? "Read-only" : isSaving ? "Saving..." : "Save changes"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Discard
+            </Button>
+          </>
+        }
+      />
 
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        {/* Edit Tab Content */}
-        <TabsContent value="edit">
-          <form onSubmit={handleSubmit}>
-            <div className="grid gap-6 lg:grid-cols-3">
-              {/* Main form */}
-              <div className="lg:col-span-2 space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Agent Details</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-6">
-                    <div className="space-y-2">
-                      <Label htmlFor="name">Name</Label>
-                      <Input
-                        id="name"
-                        placeholder="customer-support"
-                        value={formData.name}
-                        onChange={(e) => handleFormChange("name", e.target.value)}
-                        aria-invalid={!!fieldErrors.name}
-                        disabled={isSaving || isReadOnly}
-                        required
-                      />
-                      {fieldErrors.name && (
-                        <p className="text-xs text-destructive">{fieldErrors.name}</p>
-                      )}
-                      {nameChanged && formData.name.length >= 2 && (
-                        <div className="flex items-center gap-1.5 text-xs">
-                          {nameAvailability.isChecking ? (
-                            <>
-                              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                              <span className="text-muted-foreground">Checking availability…</span>
-                            </>
-                          ) : nameAvailability.available === true ? (
-                            <>
-                              <Check className="w-3 h-3 text-green-600" />
-                              <span className="text-green-600">Name is available</span>
-                            </>
-                          ) : nameAvailability.available === false ? (
-                            <>
-                              <X className="w-3 h-3 text-destructive" />
-                              <span className="text-destructive">
-                                Name is already taken or invalid
-                              </span>
-                            </>
-                          ) : null}
-                        </div>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        Unique identifier used in URLs and API. Lowercase letters, numbers, and
-                        hyphens.
-                      </p>
-                    </div>
+      <PageControlStrip>
+        <SectionTabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          items={[
+            { value: "edit", label: "Edit", icon: <Edit2 className="size-4" /> },
+            { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
+          ]}
+        />
+      </PageControlStrip>
 
-                    <div className="space-y-2">
-                      <Label htmlFor="display_name">Display Name</Label>
-                      <Input
-                        id="display_name"
-                        placeholder={formData.name ? undefined : "Customer Support Agent"}
-                        value={formData.display_name}
-                        onChange={(e) => handleFormChange("display_name", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Optional human-readable label shown in the UI. Defaults to name if empty.
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="description">Description</Label>
-                      <Textarea
-                        id="description"
-                        placeholder="Describe what this agent does..."
-                        value={formData.description}
-                        onChange={(e) => handleFormChange("description", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                        rows={2}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="tags">Tags</Label>
-                      <Input
-                        id="tags"
-                        placeholder="tag1, tag2, tag3"
-                        value={formData.tags}
-                        onChange={(e) => handleFormChange("tags", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="model">Model (optional)</Label>
-                      <ModelPicker
-                        value={formData.default_model_id || ""}
-                        onChange={(value) => handleFormChange("default_model_id", value)}
-                        disabled={isSaving || isReadOnly}
-                        placeholder="Use default model"
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Select a specific model or leave empty to use the default
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="system_prompt">System Prompt</Label>
-                      <PromptEditor
-                        id="system_prompt"
-                        placeholder="You are a helpful assistant..."
-                        value={formData.system_prompt}
-                        onChange={(value) => handleFormChange("system_prompt", value)}
-                        disabled={isSaving || isReadOnly}
-                        required
-                      />
-                      {fieldErrors.system_prompt && (
-                        <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        Instructions for the AI model (supports Markdown)
-                      </p>
-                    </div>
-
-                    <InitialFilesEditor
-                      value={selectedInitialFiles}
-                      onChange={setLocalInitialFiles}
-                      disabled={isSaving || isReadOnly}
-                      description="Files copied into each new session for this agent."
-                    />
-
-                    <NetworkAccessEditor
-                      value={initialNetworkAccess}
-                      onChange={setLocalNetworkAccess}
-                      disabled={isSaving || isReadOnly}
-                      description="Control which hosts this agent's sessions can reach via network-capable tools. Narrows the harness policy; sessions can narrow it further."
-                    />
-                  </CardContent>
-                </Card>
-
-                {/* Danger Zone */}
-                <Card className="border-destructive/50">
-                  <CardHeader>
-                    <CardTitle className="text-destructive">Danger Zone</CardTitle>
-                    <CardDescription>Irreversible actions that affect this agent</CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">
-                          {agent.status === "archived" ? "Delete this agent" : "Archive this agent"}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {agent.status === "archived"
-                            ? "Permanently delete this archived agent. Existing references will render as deleted tombstones."
-                            : "Archive this agent. It will stay visible when archived items are shown, become read-only, and stop being assignable."}
-                        </p>
-                      </div>
-                      {agent.status === "archived" ? (
-                        canDangerousDelete && (
-                          <Button
-                            type="button"
-                            variant="destructive"
-                            onClick={() => setShowDeleteDialog(true)}
-                            disabled={destroyAgent.isPending}
-                          >
-                            <Trash2 className="w-4 h-4 mr-2" />
-                            {destroyAgent.isPending ? "Deleting..." : "Delete Agent"}
-                          </Button>
-                        )
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={handleArchive}
-                          disabled={deleteAgent.isPending}
-                        >
-                          {deleteAgent.isPending ? "Archiving..." : "Archive Agent"}
-                        </Button>
-                      )}
-                    </div>
-                    {deleteError && (
-                      <EntityDeleteErrorNotice
-                        entityKind="agent"
-                        action={deleteAction}
-                        message={deleteError.message}
-                        className="mt-4"
-                      />
-                    )}
-                  </CardContent>
-                </Card>
-              </div>
-
-              {/* Capabilities sidebar */}
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Capabilities</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <CapabilitySelector
-                      capabilities={allCapabilities || []}
-                      selected={selectedCapabilities}
-                      onChange={handleCapabilitiesChange}
-                      disabled={isSaving || isReadOnly}
-                    />
-                  </CardContent>
-                </Card>
-
-                {/* Save button */}
-                <div className="flex gap-4">
-                  <Button type="submit" disabled={isSaving || isReadOnly} className="flex-1">
-                    <Save className="w-4 h-4 mr-2" />
-                    {isReadOnly
-                      ? "Archived Agents Are Read-Only"
-                      : isSaving
-                        ? "Saving..."
-                        : "Save Changes"}
-                  </Button>
-                  <Button type="button" variant="outline" onClick={() => router.back()}>
-                    Cancel
-                  </Button>
-                </div>
-
-                {updateAgent.error && (
-                  <p className="text-sm text-destructive">Error: {updateAgent.error.message}</p>
-                )}
-              </div>
-            </div>
-          </form>
-        </TabsContent>
-
-        {/* Preview Tab Content */}
-        <TabsContent value="preview">
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2">
-              <AgentPreview
-                systemPrompt={formData.system_prompt}
-                capabilities={selectedCapabilities}
-                initialFiles={selectedInitialFiles}
-                tools={agent.tools ?? []}
-                onApplyFix={(start, end, replacement) =>
-                  handleFormChange(
-                    "system_prompt",
-                    applyByteSpanReplacement(formData.system_prompt, start, end, replacement),
-                  )
-                }
-              />
-              <div className="mt-6">
-                <AgentHealthCheck agentId={agent.id} />
-              </div>
-            </div>
-
-            {/* Summary sidebar */}
-            <div className="space-y-6">
+      {activeTab === "edit" && (
+        <form id="agent-edit-form" onSubmit={handleSubmit}>
+          <PageColumns>
+            {/* Main form */}
+            <PageMain>
               <Card>
                 <CardHeader>
-                  <CardTitle>Agent Summary</CardTitle>
-                  <CardDescription>Current configuration</CardDescription>
+                  <CardTitle>Agent Details</CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <p className="text-sm font-medium">Name</p>
-                    <p className="text-sm text-muted-foreground font-mono">
-                      {formData.name || "(not set)"}
+                <CardContent className="space-y-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Name</Label>
+                    <Input
+                      id="name"
+                      placeholder="customer-support"
+                      value={formData.name}
+                      onChange={(e) => handleFormChange("name", e.target.value)}
+                      aria-invalid={!!fieldErrors.name}
+                      disabled={isSaving || isReadOnly}
+                      required
+                    />
+                    {fieldErrors.name && (
+                      <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                    )}
+                    {nameChanged && formData.name.length >= 2 && (
+                      <div className="flex items-center gap-1.5 text-xs">
+                        {nameAvailability.isChecking ? (
+                          <>
+                            <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                            <span className="text-muted-foreground">Checking availability…</span>
+                          </>
+                        ) : nameAvailability.available === true ? (
+                          <>
+                            <Check className="w-3 h-3 text-green-600" />
+                            <span className="text-green-600">Name is available</span>
+                          </>
+                        ) : nameAvailability.available === false ? (
+                          <>
+                            <X className="w-3 h-3 text-destructive" />
+                            <span className="text-destructive">
+                              Name is already taken or invalid
+                            </span>
+                          </>
+                        ) : null}
+                      </div>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Unique identifier used in URLs and API. Lowercase letters, numbers, and
+                      hyphens.
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Display Name</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formData.display_name || "(not set)"}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="display_name">Display Name</Label>
+                    <Input
+                      id="display_name"
+                      placeholder={formData.name ? undefined : "Customer Support Agent"}
+                      value={formData.display_name}
+                      onChange={(e) => handleFormChange("display_name", e.target.value)}
+                      disabled={isSaving || isReadOnly}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Optional human-readable label shown in the UI. Defaults to name if empty.
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Description</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formData.description || "(not set)"}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                      id="description"
+                      placeholder="Describe what this agent does..."
+                      value={formData.description}
+                      onChange={(e) => handleFormChange("description", e.target.value)}
+                      disabled={isSaving || isReadOnly}
+                      rows={2}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="tags">Tags</Label>
+                    <Input
+                      id="tags"
+                      placeholder="tag1, tag2, tag3"
+                      value={formData.tags}
+                      onChange={(e) => handleFormChange("tags", e.target.value)}
+                      disabled={isSaving || isReadOnly}
+                    />
+                    <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="model">Model (optional)</Label>
+                    <ModelPicker
+                      value={formData.default_model_id || ""}
+                      onChange={(value) => handleFormChange("default_model_id", value)}
+                      disabled={isSaving || isReadOnly}
+                      placeholder="Use default model"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Select a specific model or leave empty to use the default
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Capabilities</p>
-                    <p className="text-sm text-muted-foreground">
-                      {selectedCapabilities.length} capabilit
-                      {selectedCapabilities.length !== 1 ? "ies" : "y"} enabled
+
+                  <div className="space-y-2">
+                    <Label htmlFor="system_prompt">System Prompt</Label>
+                    <PromptEditor
+                      id="system_prompt"
+                      placeholder="You are a helpful assistant..."
+                      value={formData.system_prompt}
+                      onChange={(value) => handleFormChange("system_prompt", value)}
+                      disabled={isSaving || isReadOnly}
+                      required
+                    />
+                    {fieldErrors.system_prompt && (
+                      <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Instructions for the AI model (supports Markdown)
                     </p>
                   </div>
+
+                  <InitialFilesEditor
+                    value={selectedInitialFiles}
+                    onChange={setLocalInitialFiles}
+                    disabled={isSaving || isReadOnly}
+                    description="Files copied into each new session for this agent."
+                  />
+
+                  <NetworkAccessEditor
+                    value={initialNetworkAccess}
+                    onChange={setLocalNetworkAccess}
+                    disabled={isSaving || isReadOnly}
+                    description="Control which hosts this agent's sessions can reach via network-capable tools. Narrows the harness policy; sessions can narrow it further."
+                  />
                 </CardContent>
               </Card>
 
-              <Card className="border-dashed">
-                <CardContent className="pt-6">
-                  <p className="text-sm text-muted-foreground text-center">
-                    This preview shows what the final agent will look like after applying all
-                    capabilities. Switch to the Edit tab to make changes.
-                  </p>
+              {/* Danger Zone */}
+              <Card className="border-destructive/50">
+                <CardHeader>
+                  <CardTitle className="text-destructive">Danger Zone</CardTitle>
+                  <CardDescription>Irreversible actions that affect this agent</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">
+                        {agent.status === "archived" ? "Delete this agent" : "Archive this agent"}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {agent.status === "archived"
+                          ? "Permanently delete this archived agent. Existing references will render as deleted tombstones."
+                          : "Archive this agent. It will stay visible when archived items are shown, become read-only, and stop being assignable."}
+                      </p>
+                    </div>
+                    {agent.status === "archived" ? (
+                      canDangerousDelete && (
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          onClick={() => setShowDeleteDialog(true)}
+                          disabled={destroyAgent.isPending}
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          {destroyAgent.isPending ? "Deleting..." : "Delete Agent"}
+                        </Button>
+                      )
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleArchive}
+                        disabled={deleteAgent.isPending}
+                      >
+                        {deleteAgent.isPending ? "Archiving..." : "Archive Agent"}
+                      </Button>
+                    )}
+                  </div>
+                  {deleteError && (
+                    <EntityDeleteErrorNotice
+                      entityKind="agent"
+                      action={deleteAction}
+                      message={deleteError.message}
+                      className="mt-4"
+                    />
+                  )}
                 </CardContent>
               </Card>
+            </PageMain>
+
+            {/* Capabilities sidebar */}
+            <PageRail>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Capabilities</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CapabilitySelector
+                    capabilities={allCapabilities || []}
+                    selected={selectedCapabilities}
+                    onChange={handleCapabilitiesChange}
+                    disabled={isSaving || isReadOnly}
+                  />
+                </CardContent>
+              </Card>
+
+              {updateAgent.error && (
+                <p className="text-sm text-destructive">Error: {updateAgent.error.message}</p>
+              )}
+            </PageRail>
+          </PageColumns>
+        </form>
+      )}
+
+      {/* Preview Tab Content */}
+      {activeTab === "preview" && (
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <AgentPreview
+              systemPrompt={formData.system_prompt}
+              capabilities={selectedCapabilities}
+              initialFiles={selectedInitialFiles}
+              tools={agent.tools ?? []}
+              onApplyFix={(start, end, replacement) =>
+                handleFormChange(
+                  "system_prompt",
+                  applyByteSpanReplacement(formData.system_prompt, start, end, replacement),
+                )
+              }
+            />
+            <div className="mt-6">
+              <AgentHealthCheck agentId={agent.id} />
             </div>
           </div>
-        </TabsContent>
-      </Tabs>
+
+          {/* Summary sidebar */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Agent Summary</CardTitle>
+                <CardDescription>Current configuration</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <p className="text-sm font-medium">Name</p>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    {formData.name || "(not set)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Display Name</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formData.display_name || "(not set)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Description</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formData.description || "(not set)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Capabilities</p>
+                  <p className="text-sm text-muted-foreground">
+                    {selectedCapabilities.length} capabilit
+                    {selectedCapabilities.length !== 1 ? "ies" : "y"} enabled
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-dashed">
+              <CardContent className="pt-6">
+                <p className="text-sm text-muted-foreground text-center">
+                  This preview shows what the final agent will look like after applying all
+                  capabilities. Switch to the Edit tab to make changes.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      )}
+
+      <PageFooter>
+        <BackLink href={`/agents/${agentId}`}>Back to {agentDisplayName}</BackLink>
+      </PageFooter>
+
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent>
           <DialogHeader>
@@ -594,6 +623,6 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -24,12 +24,10 @@ import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { SessionCard } from "@/components/session/session-card";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { AgentVersionHistory } from "@/components/agents/agent-version-history";
 import { IntegrationGuide } from "@/components/integration/integration-guide";
 import {
-  ArrowLeft,
   Plus,
   Pencil,
   Download,
@@ -41,9 +39,23 @@ import {
   GitBranch,
   Rocket,
   Terminal,
+  Boxes,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+  type SectionTabItem,
+} from "@/components/layout";
 import type { Capability, ModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -171,312 +183,321 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
     );
   }
 
-  return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/agents"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Agents
-      </Link>
+  const defaultModelName = defaultModel?.display_name ?? defaultModel?.id;
 
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(agent.status)}>{getDisplayName(agent)}</span>
+  const tabItems: SectionTabItem[] = [
+    { value: "overview", label: "Overview", icon: <LayoutDashboard className="size-4" /> },
+    { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
+    { value: "integrate", label: "Integrate", icon: <Terminal className="size-4" /> },
+    { value: "stats", label: "Stats", icon: <BarChart3 className="size-4" /> },
+    ...(agentVersionsEnabled
+      ? [{ value: "versions", label: "Versions", icon: <GitBranch className="size-4" /> }]
+      : []),
+  ];
+
+  return (
+    <PageContainer>
+      <PageBreadcrumb
+        items={[{ label: "Agents", href: "/agents" }, { label: getDisplayName(agent) }]}
+      />
+
+      <PageMasthead
+        icon={<Boxes />}
+        title={
+          <span className={getEntityNameClassName(agent.status)}>{getDisplayName(agent)}</span>
+        }
+        badges={
+          <>
             <CopyButton value={agent.id} />
             <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
-          </h1>
-          <p className="text-sm text-muted-foreground font-mono mt-1">{agent.name}</p>
-        </div>
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>
-            <Copy className="w-4 h-4 mr-2" />
-            {copyAgent.isPending ? "Copying..." : "Copy"}
-          </Button>
-          <Button variant="outline" onClick={handleExport} disabled={exportAgent.isPending}>
-            <Download className="w-4 h-4 mr-2" />
-            {exportAgent.isPending ? "Exporting..." : "Export"}
-          </Button>
-          {agent.status === "active" && (
-            <Link href={`/agents/${agentId}/edit`}>
-              <Button variant="outline">
-                <Pencil className="w-4 h-4 mr-2" />
-                Edit
-              </Button>
-            </Link>
-          )}
-          {agent.status === "active" && (
-            <Link href={{ pathname: "/apps/new", query: { agent_id: agentId } }}>
-              <Button variant="outline">
-                <Rocket className="w-4 h-4 mr-2" />
-                Create app
-              </Button>
-            </Link>
-          )}
-          <Button
-            variant="accent"
-            onClick={handleNewSession}
-            disabled={createSession.isPending || agent.status !== "active"}
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            {createSession.isPending ? "Creating..." : "New Session"}
-          </Button>
-        </div>
-      </div>
+          </>
+        }
+        description={agent.description || undefined}
+        meta={
+          <>
+            <span>
+              Identity <span className="font-mono text-primary">{agent.name}</span>
+            </span>
+            {defaultModelName && (
+              <span>
+                Model <span className="text-primary">{defaultModelName}</span>
+              </span>
+            )}
+            <span>
+              Created{" "}
+              <span className="text-foreground">
+                {new Date(agent.created_at).toLocaleDateString()}
+              </span>
+            </span>
+            <span>
+              <span className="text-foreground">{agentSessionCount}</span>{" "}
+              {pluralize(agentSessionCount, "session")}
+            </span>
+          </>
+        }
+        actions={
+          <>
+            <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>
+              <Copy className="size-4" />
+              {copyAgent.isPending ? "Copying..." : "Copy"}
+            </Button>
+            <Button variant="outline" onClick={handleExport} disabled={exportAgent.isPending}>
+              <Download className="size-4" />
+              {exportAgent.isPending ? "Exporting..." : "Export"}
+            </Button>
+            {agent.status === "active" && (
+              <Link href={`/agents/${agentId}/edit`}>
+                <Button variant="outline">
+                  <Pencil className="size-4" />
+                  Edit
+                </Button>
+              </Link>
+            )}
+            {agent.status === "active" && (
+              <Link href={{ pathname: "/apps/new", query: { agent_id: agentId } }}>
+                <Button variant="outline">
+                  <Rocket className="size-4" />
+                  Create app
+                </Button>
+              </Link>
+            )}
+            <Button
+              variant="accent"
+              onClick={handleNewSession}
+              disabled={createSession.isPending || agent.status !== "active"}
+            >
+              <Plus className="size-4" />
+              {createSession.isPending ? "Creating..." : "New session"}
+            </Button>
+          </>
+        }
+      />
 
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="mb-6">
-          <TabsTrigger value="overview">
-            <LayoutDashboard className="w-4 h-4 mr-2" />
-            Overview
-          </TabsTrigger>
-          <TabsTrigger value="preview">
-            <Eye className="w-4 h-4 mr-2" />
-            Preview
-          </TabsTrigger>
-          <TabsTrigger value="integrate">
-            <Terminal className="w-4 h-4 mr-2" />
-            Integrate
-          </TabsTrigger>
-          <TabsTrigger value="stats">
-            <BarChart3 className="w-4 h-4 mr-2" />
-            Stats
-          </TabsTrigger>
-          {agentVersionsEnabled && (
-            <TabsTrigger value="versions">
-              <GitBranch className="w-4 h-4 mr-2" />
-              Versions
-            </TabsTrigger>
-          )}
-        </TabsList>
+      <PageControlStrip>
+        <SectionTabs value={activeTab} onValueChange={setActiveTab} items={tabItems} />
+      </PageControlStrip>
 
-        <TabsContent value="overview">
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2 space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>System Prompt</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <MarkdownDisplay content={agent.system_prompt} />
-                </CardContent>
-              </Card>
+      {activeTab === "overview" && (
+        <PageColumns>
+          <PageMain>
+            <Card>
+              <CardHeader>
+                <CardTitle>System Prompt</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <MarkdownDisplay content={agent.system_prompt} />
+              </CardContent>
+            </Card>
 
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between">
-                  <CardTitle>Sessions</CardTitle>
-                  {hasMoreSessions && (
-                    <Link
-                      href={`/agents/${agentId}/sessions`}
-                      className="text-sm text-muted-foreground hover:text-foreground"
-                    >
-                      View all {totalSessions} sessions →
-                    </Link>
-                  )}
-                </CardHeader>
-                <CardContent>
-                  {sessionsLoading ? (
-                    <div className="space-y-2">
-                      <Skeleton className="h-12 w-full" />
-                      <Skeleton className="h-12 w-full" />
-                    </div>
-                  ) : sessions.length === 0 ? (
-                    <p className="text-center py-8 text-muted-foreground">
-                      No sessions yet. Start a new session to begin chatting.
-                    </p>
-                  ) : (
-                    <div className="space-y-2">
-                      {sessions.map((session) => (
-                        <SessionCard
-                          key={session.id}
-                          session={session}
-                          model={session.model_id ? modelMap.get(session.model_id) : undefined}
-                        />
-                      ))}
-                      {hasMoreSessions && (
-                        <Link
-                          href={`/agents/${agentId}/sessions`}
-                          className="flex items-center justify-center p-3 border border-dashed hover:bg-muted transition-colors text-muted-foreground"
-                        >
-                          View all {totalSessions} sessions
-                        </Link>
-                      )}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-
-            <div className="space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Capabilities</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {agentCapabilities.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      No capabilities enabled.{" "}
-                      <Link
-                        href={`/agents/${agentId}/edit`}
-                        className="text-primary hover:underline"
-                      >
-                        Add some
-                      </Link>
-                    </p>
-                  ) : (
-                    <div className="space-y-2">
-                      {agentCapabilities.map((capConfig) => {
-                        const cap = getCapabilityInfo(capConfig.ref);
-                        if (!cap) return null;
-                        const IconComponent = getCapabilityIcon(cap.icon);
-
-                        return (
-                          <div
-                            key={capConfig.ref}
-                            className="flex items-center gap-2 p-2 border bg-muted/50"
-                          >
-                            <IconComponent className="w-4 h-4" />
-                            <div className="flex-1">
-                              <p className="text-sm font-medium">
-                                {localizedCapabilityName(cap, locale)}
-                              </p>
-                              <p className="text-xs text-muted-foreground">
-                                {localizedCapabilityDescription(cap, locale)}
-                              </p>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle>Configuration</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {defaultModel && (
-                    <div>
-                      <p className="text-sm font-medium mb-2">Default Model</p>
-                      <div className="flex items-center gap-2">
-                        <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
-                        <span className="text-sm">{defaultModel.display_name}</span>
-                      </div>
-                    </div>
-                  )}
-
-                  {agent.description && (
-                    <div>
-                      <p className="text-sm font-medium">Description</p>
-                      <div className="text-sm text-muted-foreground">
-                        <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
-                      </div>
-                    </div>
-                  )}
-
-                  {agentTags.length > 0 && (
-                    <div>
-                      <p className="text-sm font-medium mb-2">Tags</p>
-                      <div className="flex flex-wrap gap-1">
-                        {agentTags.map((tag) => (
-                          <Badge key={tag} variant="outline">
-                            {tag}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  <div>
-                    <p className="text-sm font-medium mb-2">Usage</p>
-                    <div className="grid grid-cols-2 gap-2">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Sessions</CardTitle>
+                {hasMoreSessions && (
+                  <Link
+                    href={`/agents/${agentId}/sessions`}
+                    className="text-sm text-muted-foreground hover:text-foreground"
+                  >
+                    View all {totalSessions} sessions →
+                  </Link>
+                )}
+              </CardHeader>
+              <CardContent>
+                {sessionsLoading ? (
+                  <div className="space-y-2">
+                    <Skeleton className="h-12 w-full" />
+                    <Skeleton className="h-12 w-full" />
+                  </div>
+                ) : sessions.length === 0 ? (
+                  <p className="text-center py-8 text-muted-foreground">
+                    No sessions yet. Start a new session to begin chatting.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {sessions.map((session) => (
+                      <SessionCard
+                        key={session.id}
+                        session={session}
+                        model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                      />
+                    ))}
+                    {hasMoreSessions && (
                       <Link
                         href={`/agents/${agentId}/sessions`}
-                        className="border bg-muted/50 p-2 hover:bg-muted"
+                        className="flex items-center justify-center p-3 border border-dashed hover:bg-muted transition-colors text-muted-foreground"
                       >
-                        <p className="text-sm font-medium">{agentSessionCount}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {pluralize(agentSessionCount, "session")}
-                        </p>
+                        View all {totalSessions} sessions
                       </Link>
-                      <div className="border bg-muted/50 p-2">
-                        <p className="text-sm font-medium">{agentAppCount}</p>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </PageMain>
+
+          <PageRail>
+            <Card>
+              <CardHeader>
+                <CardTitle>Capabilities</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {agentCapabilities.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No capabilities enabled.{" "}
+                    <Link href={`/agents/${agentId}/edit`} className="text-primary hover:underline">
+                      Add some
+                    </Link>
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {agentCapabilities.map((capConfig) => {
+                      const cap = getCapabilityInfo(capConfig.ref);
+                      if (!cap) return null;
+                      const IconComponent = getCapabilityIcon(cap.icon);
+
+                      return (
+                        <div
+                          key={capConfig.ref}
+                          className="flex items-center gap-2 p-2 border bg-muted/50"
+                        >
+                          <IconComponent className="w-4 h-4" />
+                          <div className="flex-1">
+                            <p className="text-sm font-medium">
+                              {localizedCapabilityName(cap, locale)}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {localizedCapabilityDescription(cap, locale)}
+                            </p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Configuration</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {defaultModel && (
+                  <div>
+                    <p className="text-sm font-medium mb-2">Default Model</p>
+                    <div className="flex items-center gap-2">
+                      <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
+                      <span className="text-sm">{defaultModel.display_name}</span>
+                    </div>
+                  </div>
+                )}
+
+                {agent.description && (
+                  <div>
+                    <p className="text-sm font-medium">Description</p>
+                    <div className="text-sm text-muted-foreground">
+                      <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
+                    </div>
+                  </div>
+                )}
+
+                {agentTags.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium mb-2">Tags</p>
+                    <div className="flex flex-wrap gap-1">
+                      {agentTags.map((tag) => (
+                        <Badge key={tag} variant="outline">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div>
+                  <p className="text-sm font-medium mb-2">Usage</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <Link
+                      href={`/agents/${agentId}/sessions`}
+                      className="border bg-muted/50 p-2 hover:bg-muted"
+                    >
+                      <p className="text-sm font-medium">{agentSessionCount}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {pluralize(agentSessionCount, "session")}
+                      </p>
+                    </Link>
+                    <div className="border bg-muted/50 p-2">
+                      <p className="text-sm font-medium">{agentAppCount}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {pluralize(agentAppCount, "app")}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {agent.usage && (
+                  <div>
+                    <p className="text-sm font-medium mb-2">Token Usage</p>
+                    <div className="flex items-center gap-2 p-2 border bg-muted/50">
+                      <Zap className="w-4 h-4 text-yellow-500" />
+                      <div className="flex-1">
+                        <p className="text-sm font-medium">
+                          {formatTokens(totalTokens(agent.usage))} total
+                        </p>
                         <p className="text-xs text-muted-foreground">
-                          {pluralize(agentAppCount, "app")}
+                          {formatTokens(agent.usage.input_tokens)} input /{" "}
+                          {formatTokens(agent.usage.output_tokens)} output
+                          {agent.usage.cache_read_tokens &&
+                            ` / ${formatTokens(agent.usage.cache_read_tokens)} cached`}
                         </p>
                       </div>
                     </div>
                   </div>
+                )}
 
-                  {agent.usage && (
-                    <div>
-                      <p className="text-sm font-medium mb-2">Token Usage</p>
-                      <div className="flex items-center gap-2 p-2 border bg-muted/50">
-                        <Zap className="w-4 h-4 text-yellow-500" />
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">
-                            {formatTokens(totalTokens(agent.usage))} total
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {formatTokens(agent.usage.input_tokens)} input /{" "}
-                            {formatTokens(agent.usage.output_tokens)} output
-                            {agent.usage.cache_read_tokens &&
-                              ` / ${formatTokens(agent.usage.cache_read_tokens)} cached`}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  )}
+                <div>
+                  <p className="text-sm font-medium">Created</p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(agent.created_at).toLocaleString()}
+                  </p>
+                </div>
 
-                  <div>
-                    <p className="text-sm font-medium">Created</p>
-                    <p className="text-sm text-muted-foreground">
-                      {new Date(agent.created_at).toLocaleString()}
-                    </p>
-                  </div>
+                <div>
+                  <p className="text-sm font-medium">Updated</p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(agent.updated_at).toLocaleString()}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </PageRail>
+        </PageColumns>
+      )}
 
-                  <div>
-                    <p className="text-sm font-medium">Updated</p>
-                    <p className="text-sm text-muted-foreground">
-                      {new Date(agent.updated_at).toLocaleString()}
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </TabsContent>
+      {activeTab === "preview" && (
+        <AgentPreview
+          systemPrompt={agent.system_prompt}
+          capabilities={agentCapabilities.map((cap) => ({
+            ref: cap.ref,
+            config: cap.config,
+          }))}
+          initialFiles={agent.initial_files}
+          tools={agent.tools ?? []}
+        />
+      )}
 
-        <TabsContent value="preview">
-          <AgentPreview
-            systemPrompt={agent.system_prompt}
-            capabilities={agentCapabilities.map((cap) => ({
-              ref: cap.ref,
-              config: cap.config,
-            }))}
-            initialFiles={agent.initial_files}
-            tools={agent.tools ?? []}
-          />
-        </TabsContent>
+      {activeTab === "integrate" && (
+        <IntegrationGuide kind="agent" id={agent.id} name={getDisplayName(agent)} />
+      )}
 
-        <TabsContent value="integrate">
-          <IntegrationGuide kind="agent" id={agent.id} name={getDisplayName(agent)} />
-        </TabsContent>
+      {activeTab === "stats" && (
+        <ResourceStatsPanel stats={stats} isLoading={statsLoading} error={statsError} />
+      )}
 
-        <TabsContent value="stats">
-          <ResourceStatsPanel stats={stats} isLoading={statsLoading} error={statsError} />
-        </TabsContent>
+      {agentVersionsEnabled && activeTab === "versions" && <AgentVersionHistory agent={agent} />}
 
-        {agentVersionsEnabled && (
-          <TabsContent value="versions">
-            <AgentVersionHistory agent={agent} />
-          </TabsContent>
-        )}
-      </Tabs>
-    </div>
+      <PageFooter>
+        <BackLink href="/agents">Back to Agents</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/agents/all/agents-all-page-client.tsx
+++ b/apps/ui/src/app/(main)/agents/all/agents-all-page-client.tsx
@@ -4,10 +4,19 @@ import { useState } from "react";
 import { useAgents, useCapabilities } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Plus, ArrowLeft } from "lucide-react";
+import { Plus, Boxes } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { AgentCard } from "@/components/agents";
 import { ArchiveFilter } from "@/components/archive-filter";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 
 export default function AgentsAllPageClient() {
   const [showArchived, setShowArchived] = useState(false);
@@ -15,57 +24,64 @@ export default function AgentsAllPageClient() {
   const { data: allCapabilities } = useCapabilities();
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-3">
-          <Link href="/agents">
-            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back to agents">
-              <ArrowLeft className="w-4 h-4" />
-            </Button>
-          </Link>
-          <h1 className="text-2xl font-bold">All Agents</h1>
-        </div>
-        <div className="flex items-center gap-2">
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
-          <Link href="/agents/new">
-            <Button variant="accent">
-              <Plus className="w-4 h-4 mr-2" />
-              New Agent
-            </Button>
-          </Link>
-        </div>
-      </div>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Agents", href: "/agents" }, { label: "All agents" }]} />
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={agents}
-        errorMessagePrefix="Failed to load agents"
-        emptyState={
-          <div className="text-center py-12">
-            <p className="text-muted-foreground mb-4">No agents yet</p>
+      <PageMasthead
+        icon={<Boxes />}
+        title="All agents"
+        description="Every agent definition in this organization."
+        actions={
+          <>
+            <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
             <Link href="/agents/new">
-              <Button>
-                <Plus className="w-4 h-4 mr-2" />
-                Create your first agent
+              <Button variant="accent">
+                <Plus className="size-4" />
+                New agent
               </Button>
             </Link>
-          </div>
+          </>
         }
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((agent, index) => (
-              <AgentCard
-                key={agent.id ?? `agent-${index}`}
-                agent={agent}
-                allCapabilities={allCapabilities}
-                showEditButton
-              />
-            ))}
-          </div>
-        )}
-      </QueryStateWrapper>
-    </div>
+      />
+
+      <PageColumns className="lg:grid-cols-1">
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={agents}
+            errorMessagePrefix="Failed to load agents"
+            emptyState={
+              <div className="border border-dashed py-12 text-center">
+                <p className="mb-4 text-muted-foreground">No agents yet</p>
+                <Link href="/agents/new">
+                  <Button>
+                    <Plus className="size-4" />
+                    Create your first agent
+                  </Button>
+                </Link>
+              </div>
+            }
+          >
+            {(items) => (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {items.map((agent, index) => (
+                  <AgentCard
+                    key={agent.id ?? `agent-${index}`}
+                    agent={agent}
+                    allCapabilities={allCapabilities}
+                    showEditButton
+                  />
+                ))}
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+      </PageColumns>
+
+      <PageFooter>
+        <BackLink href="/agents">Back to Agents</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback, useMemo } from "react";
 import {
   useAgents,
   useAgentExamples,
@@ -12,16 +12,41 @@ import {
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Plus, Upload, ArrowRight } from "lucide-react";
+import { SearchInput } from "@/components/ui/search-input";
+import { Badge } from "@/components/ui/badge";
+import { Plus, Upload, ArrowRight, Boxes, LayoutGrid, List as ListIcon } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { AgentCard, ExampleCard } from "@/components/agents";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+import { localizedCapabilityName } from "@/lib/capability-localization";
+import { useLocale } from "@/providers/locale-provider";
+import { isArchivedStatus } from "@/lib/entity-lifecycle";
+import { normalizeTags } from "@/lib/tags";
+import { pluralize } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
+import type { Agent } from "@/lib/api/types";
 
-const PREVIEW_LIMIT = 6;
+const EXAMPLE_PREVIEW_LIMIT = 6;
+type StatusTab = "all" | "active" | "archived";
 
 export default function AgentsPage() {
   usePageTitle("Agents");
+  const { locale } = useLocale();
   const router = useRouter();
-  const { data: agents, isLoading, error } = useAgents({ includeArchived: false });
+  // Fetch the full set (including archived) so the facet rail can show accurate counts.
+  const { data: agents, isLoading, error } = useAgents({ includeArchived: true });
   const { data: allCapabilities } = useCapabilities();
   const { data: examples, isLoading: examplesLoading, error: examplesError } = useAgentExamples();
   const importAgent = useImportAgent();
@@ -29,6 +54,10 @@ export default function AgentsPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [importingName, setImportingName] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
+  const [view, setView] = useState<"grid" | "list">("grid");
 
   const handleImportClick = useCallback(() => {
     fileInputRef.current?.click();
@@ -72,103 +101,280 @@ export default function AgentsPage() {
     [importExample, router],
   );
 
-  const previewAgents = agents?.slice(0, PREVIEW_LIMIT);
-  const previewExamples = examples?.slice(0, PREVIEW_LIMIT);
-  const hasMoreAgents = (agents?.length ?? 0) > PREVIEW_LIMIT;
-  const hasMoreExamples = (examples?.length ?? 0) > PREVIEW_LIMIT;
+  const counts = useMemo(() => {
+    const list = agents ?? [];
+    const archived = list.filter((a) => isArchivedStatus(a.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [agents]);
+
+  // Capability usage counts across all agents, for the rail facet.
+  const capabilityFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const agent of agents ?? []) {
+      for (const cap of agent.capabilities ?? []) {
+        tally.set(cap.ref, (tally.get(cap.ref) ?? 0) + 1);
+      }
+    }
+    return [...tally.entries()]
+      .map(([ref, count]) => ({
+        ref,
+        count,
+        name: (() => {
+          const cap = allCapabilities?.find((c) => c.id === ref);
+          return cap ? localizedCapabilityName(cap, locale) : ref;
+        })(),
+        icon: getCapabilityIcon(allCapabilities?.find((c) => c.id === ref)?.icon),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 6);
+  }, [agents, allCapabilities, locale]);
+
+  const tagFacets = useMemo(() => {
+    const tags = new Set<string>();
+    for (const agent of agents ?? []) {
+      for (const tag of normalizeTags(agent.tags)) tags.add(tag);
+    }
+    return [...tags].slice(0, 12);
+  }, [agents]);
+
+  const filteredAgents = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (agents ?? []).filter((agent: Agent) => {
+      if (statusTab === "active" && isArchivedStatus(agent.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(agent.status)) return false;
+      if (!query) return true;
+      const haystack = [agent.display_name, agent.name, agent.description]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [agents, search, statusTab]);
+
+  const previewExamples = examples?.slice(0, EXAMPLE_PREVIEW_LIMIT);
+  const hasMoreExamples = (examples?.length ?? 0) > EXAMPLE_PREVIEW_LIMIT;
+
+  const statusItems = [
+    { value: "all" as const, label: `All` },
+    { value: "active" as const, label: `Active` },
+    { value: "archived" as const, label: `Archived` },
+  ];
 
   return (
-    <div className="container mx-auto p-6 space-y-10">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Agents</h1>
-        <div className="flex items-center gap-2">
-          <input
-            type="file"
-            ref={fileInputRef}
-            onChange={handleFileChange}
-            accept=".md,.yaml,.yml,.json"
-            className="hidden"
-            aria-label="Import agent file"
-          />
-          <Button variant="outline" onClick={handleImportClick} disabled={importAgent.isPending}>
-            <Upload className="w-4 h-4 mr-2" />
-            {importAgent.isPending ? "Importing..." : "Import"}
-          </Button>
-          <Link href="/agents/new">
-            <Button variant="accent">
-              <Plus className="w-4 h-4 mr-2" />
-              New Agent
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Agents" }]} />
+
+      <PageMasthead
+        icon={<Boxes />}
+        title="Agents"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
+        }
+        description="Reusable agent definitions — instructions, capabilities, and model."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
+          <>
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              accept=".md,.yaml,.yml,.json"
+              className="hidden"
+              aria-label="Import agent file"
+            />
+            <Button variant="outline" onClick={handleImportClick} disabled={importAgent.isPending}>
+              <Upload className="size-4" />
+              {importAgent.isPending ? "Importing..." : "Import"}
             </Button>
-          </Link>
-        </div>
-      </div>
+            <Link href="/agents/new">
+              <Button variant="accent">
+                <Plus className="size-4" />
+                New agent
+              </Button>
+            </Link>
+          </>
+        }
+      />
 
       {importError && (
-        <div className="p-4 bg-red-50 border border-red-200 text-red-600 text-sm">
+        <div className="border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
           {importError}
         </div>
       )}
 
-      {/* My Agents Section */}
-      <section>
-        <QueryStateWrapper
-          isLoading={isLoading}
-          error={error}
-          data={previewAgents}
-          errorMessagePrefix="Failed to load agents"
-          emptyState={
-            <div className="text-center py-12">
-              <p className="text-muted-foreground mb-4">No agents yet</p>
-              <div className="flex items-center justify-center gap-2">
-                <Link href="/agents/new">
-                  <Button>
-                    <Plus className="w-4 h-4 mr-2" />
-                    Create your first agent
-                  </Button>
-                </Link>
-                <Link href="/agents/all">
-                  <Button variant="outline">
-                    View all agents
-                    <ArrowRight className="w-4 h-4 ml-2" />
-                  </Button>
-                </Link>
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search agents…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          containerClassName="w-64"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+        <div className="flex border">
+          <button
+            type="button"
+            aria-label="Grid view"
+            aria-pressed={view === "grid"}
+            onClick={() => setView("grid")}
+            className={cn(
+              "inline-flex size-8 items-center justify-center border-r",
+              view === "grid"
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/50",
+            )}
+          >
+            <LayoutGrid className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="List view"
+            aria-pressed={view === "list"}
+            onClick={() => setView("list")}
+            className={cn(
+              "inline-flex size-8 items-center justify-center",
+              view === "list"
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/50",
+            )}
+          >
+            <ListIcon className="size-4" />
+          </button>
+        </div>
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredAgents}
+            errorMessagePrefix="Failed to load agents"
+            emptyState={
+              <div className="border border-dashed py-12 text-center">
+                <p className="mb-4 text-muted-foreground">
+                  {search || statusTab !== "active"
+                    ? "No agents match your filters."
+                    : "No agents yet"}
+                </p>
+                {!search && statusTab === "active" && (
+                  <Link href="/agents/new">
+                    <Button>
+                      <Plus className="size-4" />
+                      Create your first agent
+                    </Button>
+                  </Link>
+                )}
               </div>
-            </div>
-          }
-        >
-          {(items) => (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {items.map((agent, index) => (
-                <AgentCard
-                  key={agent.id ?? `agent-${index}`}
-                  agent={agent}
-                  allCapabilities={allCapabilities}
-                  showEditButton
-                />
+            }
+          >
+            {(items) => (
+              <div className={cn("grid gap-4", view === "grid" ? "md:grid-cols-2" : "grid-cols-1")}>
+                {items.map((agent, index) => (
+                  <AgentCard
+                    key={agent.id ?? `agent-${index}`}
+                    agent={agent}
+                    allCapabilities={allCapabilities}
+                    showEditButton
+                  />
+                ))}
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
               ))}
             </div>
+          </RailSection>
+
+          {capabilityFacets.length > 0 && (
+            <RailSection label="Capability">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {capabilityFacets.map((facet) => {
+                  const Icon = facet.icon;
+                  return (
+                    <div key={facet.ref} className="flex items-center justify-between">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Icon className="size-3.5" />
+                        {facet.name}
+                      </span>
+                      <span>{facet.count}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </RailSection>
           )}
-        </QueryStateWrapper>
-        {hasMoreAgents && (
-          <div className="flex justify-end mt-4">
-            <Link href="/agents/all">
-              <Button variant="outline">
-                All agents
-                <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
+
+          {tagFacets.length > 0 && (
+            <RailSection label="Tags">
+              <div className="flex flex-wrap gap-1.5">
+                {tagFacets.map((tag) => (
+                  <span key={tag} className="border bg-muted px-2 py-0.5 text-xs">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredAgents.length} of {counts.all} {pluralize(counts.all, "agent")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
         )}
-      </section>
+      </PageFooter>
 
-      {/* Divider */}
-      <hr className="border-border" />
-
-      {/* Example Agents Section */}
-      <section>
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-semibold">Example agents</h2>
+      {/* Example agents — a secondary discovery section below the primary frame. */}
+      <section className="mt-4">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold tracking-tight">Example agents</h2>
+          {hasMoreExamples && (
+            <Link
+              href="/agents/examples"
+              className="inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
+            >
+              All examples
+              <ArrowRight className="size-3.5" />
+            </Link>
+          )}
         </div>
         <QueryStateWrapper
           isLoading={examplesLoading}
@@ -176,7 +382,7 @@ export default function AgentsPage() {
           data={previewExamples}
           errorMessagePrefix="Failed to load examples"
           emptyState={
-            <div className="text-center py-12">
+            <div className="py-8 text-center">
               <p className="text-muted-foreground">No examples available</p>
             </div>
           }
@@ -195,17 +401,7 @@ export default function AgentsPage() {
             </div>
           )}
         </QueryStateWrapper>
-        {hasMoreExamples && (
-          <div className="flex justify-end mt-4">
-            <Link href="/agents/examples">
-              <Button variant="outline">
-                All examples
-                <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
-        )}
       </section>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -2,7 +2,6 @@
 
 import { use, useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import {
   useHarness,
   useHarnesses,
@@ -16,13 +15,25 @@ import {
 import { usePolicies } from "@/hooks/use-policies";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 import {
   Dialog,
   DialogContent,
@@ -39,7 +50,7 @@ import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { NetworkAccessEditor, normalizeNetworkAccess } from "@/components/network-access-editor";
 import { ModelPicker } from "@/components/models/model-picker";
-import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
+import { Trash2, Eye, Edit2, Check, X, Loader2, Shield, Pencil } from "lucide-react";
 import {
   getFieldErrors,
   harnessFormSchema,
@@ -249,347 +260,367 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
     );
   }
 
+  const harnessDisplayName = getDisplayName(harness);
+
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href={`/harnesses/${harnessId}`}
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Harness
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Harnesses", href: "/harnesses" },
+          { label: harnessDisplayName, href: `/harnesses/${harnessId}` },
+          { label: "Edit" },
+        ]}
+      />
 
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Edit Harness</h1>
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList>
-            <TabsTrigger value="edit">
-              <Edit2 className="w-4 h-4 mr-2" />
-              Edit
-            </TabsTrigger>
-            <TabsTrigger value="preview">
-              <Eye className="w-4 h-4 mr-2" />
-              Preview
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </div>
+      <PageMasthead
+        icon={<Shield />}
+        title={harnessDisplayName}
+        badges={
+          <Badge variant="accent">
+            <Pencil className="size-3" />
+            Editing
+          </Badge>
+        }
+        description="Changes apply to new sessions only. Running sessions keep the current definition."
+        meta={
+          <>
+            <span>
+              Identity <span className="font-mono text-primary">{harness.name}</span>
+            </span>
+            <span>
+              Last edited{" "}
+              <span className="text-foreground">
+                {new Date(harness.updated_at).toLocaleDateString()}
+              </span>
+            </span>
+          </>
+        }
+        actions={
+          <>
+            <Button type="submit" form="harness-edit-form" disabled={isSaving || isReadOnly}>
+              <Check className="size-4" />
+              {isReadOnly ? "Read-only" : isSaving ? "Saving..." : "Save changes"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Discard
+            </Button>
+          </>
+        }
+      />
 
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        {/* Edit Tab Content */}
-        <TabsContent value="edit">
-          <form onSubmit={handleSubmit}>
-            <div className="grid gap-6 lg:grid-cols-3">
-              {/* Main form */}
-              <div className="lg:col-span-2 space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Harness Details</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-6">
-                    <div className="space-y-2">
-                      <Label htmlFor="name">Name</Label>
-                      <Input
-                        id="name"
-                        placeholder="my-harness"
-                        value={formData.name}
-                        onChange={(e) => handleFormChange("name", e.target.value)}
-                        aria-invalid={!!fieldErrors.name}
-                        disabled={isSaving || isReadOnly}
-                        required
-                      />
-                      {fieldErrors.name && (
-                        <p className="text-xs text-destructive">{fieldErrors.name}</p>
-                      )}
-                      {nameChanged && formData.name.length >= 2 && (
-                        <div className="flex items-center gap-1.5 text-xs">
-                          {nameAvailability.isChecking ? (
-                            <>
-                              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                              <span className="text-muted-foreground">Checking availability…</span>
-                            </>
-                          ) : nameAvailability.available === true ? (
-                            <>
-                              <Check className="w-3 h-3 text-green-600" />
-                              <span className="text-green-600">Name is available</span>
-                            </>
-                          ) : nameAvailability.available === false ? (
-                            <>
-                              <X className="w-3 h-3 text-destructive" />
-                              <span className="text-destructive">
-                                Name is already taken or invalid
-                              </span>
-                            </>
-                          ) : null}
-                        </div>
-                      )}
-                    </div>
+      <PageControlStrip>
+        <SectionTabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          items={[
+            { value: "edit", label: "Edit", icon: <Edit2 className="size-4" /> },
+            { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
+          ]}
+        />
+      </PageControlStrip>
 
-                    <div className="space-y-2">
-                      <Label htmlFor="display_name">Display Name</Label>
-                      <Input
-                        id="display_name"
-                        placeholder={formData.name ? undefined : "My Harness"}
-                        value={formData.display_name}
-                        onChange={(e) => handleFormChange("display_name", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Optional human-readable label shown in the UI. Defaults to name if empty.
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="description">Description</Label>
-                      <Textarea
-                        id="description"
-                        placeholder="Describe what this harness does..."
-                        value={formData.description}
-                        onChange={(e) => handleFormChange("description", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                        rows={2}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="parent-harness">Parent Harness</Label>
-                      <HarnessSelect
-                        value={formData.parent_harness_id}
-                        onValueChange={(value) => handleFormChange("parent_harness_id", value)}
-                        placeholder="No parent harness"
-                        includeNoneOption
-                        noneLabel="No parent harness"
-                        excludeIds={[harnessId]}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Inherit prompt, capabilities, initial files, and model fallback from a
-                        parent harness.
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="tags">Tags</Label>
-                      <Input
-                        id="tags"
-                        placeholder="tag1, tag2, tag3"
-                        value={formData.tags}
-                        onChange={(e) => handleFormChange("tags", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="model">Model (optional)</Label>
-                      <ModelPicker
-                        value={formData.default_model_id || ""}
-                        onChange={(value) => handleFormChange("default_model_id", value)}
-                        disabled={isSaving || isReadOnly}
-                        placeholder="Use default model"
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Select a specific model or leave empty to use the default
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="system_prompt">System Prompt (optional)</Label>
-                      <PromptEditor
-                        id="system_prompt"
-                        placeholder="You are a helpful assistant..."
-                        value={formData.system_prompt}
-                        onChange={(value) => handleFormChange("system_prompt", value)}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      {fieldErrors.system_prompt && (
-                        <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        Base instructions for the AI model (supports Markdown). Leave empty to
-                        contribute no base prompt — the parent harness, agent, session, and
-                        capabilities still apply.
-                      </p>
-                    </div>
-
-                    <InitialFilesEditor
-                      value={selectedInitialFiles}
-                      onChange={setLocalInitialFiles}
-                      disabled={isSaving || isReadOnly}
-                      description="Files copied into each new session created from this harness."
-                    />
-
-                    <NetworkAccessEditor
-                      value={initialNetworkAccess}
-                      onChange={setLocalNetworkAccess}
-                      disabled={isSaving || isReadOnly}
-                      description="Baseline network policy for every agent and session on this harness. Agents and sessions can only narrow it, never widen it."
-                    />
-                  </CardContent>
-                </Card>
-
-                {/* Danger Zone */}
-                <Card className="border-destructive/50">
-                  <CardHeader>
-                    <CardTitle className="text-destructive">Danger Zone</CardTitle>
-                    <CardDescription>Irreversible actions that affect this harness</CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">
-                          {harness.status === "archived"
-                            ? "Delete this harness"
-                            : "Archive this harness"}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {harness.status === "archived"
-                            ? "Permanently delete this archived harness. Existing references will render as deleted tombstones."
-                            : "Archive this harness. It will stay visible when archived items are shown, become read-only, and stop being assignable."}
-                        </p>
-                      </div>
-                      {harness.status === "archived" ? (
-                        canDangerousDelete && (
-                          <Button
-                            type="button"
-                            variant="destructive"
-                            onClick={() => setShowDeleteDialog(true)}
-                            disabled={destroyHarness.isPending}
-                          >
-                            <Trash2 className="w-4 h-4 mr-2" />
-                            {destroyHarness.isPending ? "Deleting..." : "Delete Harness"}
-                          </Button>
-                        )
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={handleArchive}
-                          disabled={deleteHarness.isPending}
-                        >
-                          {deleteHarness.isPending ? "Archiving..." : "Archive Harness"}
-                        </Button>
-                      )}
-                    </div>
-                    {deleteError && (
-                      <EntityDeleteErrorNotice
-                        entityKind="harness"
-                        action={deleteAction}
-                        message={deleteError.message}
-                        className="mt-4"
-                      />
-                    )}
-                  </CardContent>
-                </Card>
-              </div>
-
-              {/* Capabilities sidebar */}
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Capabilities</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <CapabilitySelector
-                      capabilities={allCapabilities || []}
-                      selected={selectedCapabilities}
-                      onChange={handleCapabilitiesChange}
-                      disabled={isSaving || isReadOnly}
-                    />
-                  </CardContent>
-                </Card>
-
-                {/* Save button */}
-                <div className="flex gap-4">
-                  <Button type="submit" disabled={isSaving || isReadOnly} className="flex-1">
-                    <Save className="w-4 h-4 mr-2" />
-                    {isReadOnly
-                      ? "Archived Harnesses Are Read-Only"
-                      : isSaving
-                        ? "Saving..."
-                        : "Save Changes"}
-                  </Button>
-                  <Button type="button" variant="outline" onClick={() => router.back()}>
-                    Cancel
-                  </Button>
-                </div>
-
-                {updateHarness.error && (
-                  <p className="text-sm text-destructive">Error: {updateHarness.error.message}</p>
-                )}
-              </div>
-            </div>
-          </form>
-        </TabsContent>
-
-        {/* Preview Tab Content */}
-        <TabsContent value="preview">
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2">
-              <HarnessPreview
-                systemPrompt={formData.system_prompt}
-                capabilities={selectedCapabilities}
-                initialFiles={selectedInitialFiles}
-                parentHarnessId={formData.parent_harness_id || undefined}
-              />
-            </div>
-
-            {/* Summary sidebar */}
-            <div className="space-y-6">
+      {activeTab === "edit" && (
+        <form id="harness-edit-form" onSubmit={handleSubmit}>
+          <PageColumns>
+            {/* Main form */}
+            <PageMain>
               <Card>
                 <CardHeader>
-                  <CardTitle>Harness Summary</CardTitle>
-                  <CardDescription>Current configuration</CardDescription>
+                  <CardTitle>Harness Details</CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <p className="text-sm font-medium">Name</p>
-                    <p className="text-sm text-muted-foreground font-mono">
-                      {formData.name || "(not set)"}
+                <CardContent className="space-y-6">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Name</Label>
+                    <Input
+                      id="name"
+                      placeholder="my-harness"
+                      value={formData.name}
+                      onChange={(e) => handleFormChange("name", e.target.value)}
+                      aria-invalid={!!fieldErrors.name}
+                      disabled={isSaving || isReadOnly}
+                      required
+                    />
+                    {fieldErrors.name && (
+                      <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                    )}
+                    {nameChanged && formData.name.length >= 2 && (
+                      <div className="flex items-center gap-1.5 text-xs">
+                        {nameAvailability.isChecking ? (
+                          <>
+                            <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                            <span className="text-muted-foreground">Checking availability…</span>
+                          </>
+                        ) : nameAvailability.available === true ? (
+                          <>
+                            <Check className="w-3 h-3 text-green-600" />
+                            <span className="text-green-600">Name is available</span>
+                          </>
+                        ) : nameAvailability.available === false ? (
+                          <>
+                            <X className="w-3 h-3 text-destructive" />
+                            <span className="text-destructive">
+                              Name is already taken or invalid
+                            </span>
+                          </>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="display_name">Display Name</Label>
+                    <Input
+                      id="display_name"
+                      placeholder={formData.name ? undefined : "My Harness"}
+                      value={formData.display_name}
+                      onChange={(e) => handleFormChange("display_name", e.target.value)}
+                      disabled={isSaving || isReadOnly}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Optional human-readable label shown in the UI. Defaults to name if empty.
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Display Name</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formData.display_name || "(not set)"}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                      id="description"
+                      placeholder="Describe what this harness does..."
+                      value={formData.description}
+                      onChange={(e) => handleFormChange("description", e.target.value)}
+                      disabled={isSaving || isReadOnly}
+                      rows={2}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="parent-harness">Parent Harness</Label>
+                    <HarnessSelect
+                      value={formData.parent_harness_id}
+                      onValueChange={(value) => handleFormChange("parent_harness_id", value)}
+                      placeholder="No parent harness"
+                      includeNoneOption
+                      noneLabel="No parent harness"
+                      excludeIds={[harnessId]}
+                      disabled={isSaving || isReadOnly}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Inherit prompt, capabilities, initial files, and model fallback from a parent
+                      harness.
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Description</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formData.description || "(not set)"}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="tags">Tags</Label>
+                    <Input
+                      id="tags"
+                      placeholder="tag1, tag2, tag3"
+                      value={formData.tags}
+                      onChange={(e) => handleFormChange("tags", e.target.value)}
+                      disabled={isSaving || isReadOnly}
+                    />
+                    <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="model">Model (optional)</Label>
+                    <ModelPicker
+                      value={formData.default_model_id || ""}
+                      onChange={(value) => handleFormChange("default_model_id", value)}
+                      disabled={isSaving || isReadOnly}
+                      placeholder="Use default model"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Select a specific model or leave empty to use the default
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Parent Harness</p>
-                    <p className="text-sm text-muted-foreground">
-                      {getDisplayName(selectedParentHarness) ||
-                        formData.parent_harness_id ||
-                        "(none)"}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="system_prompt">System Prompt (optional)</Label>
+                    <PromptEditor
+                      id="system_prompt"
+                      placeholder="You are a helpful assistant..."
+                      value={formData.system_prompt}
+                      onChange={(value) => handleFormChange("system_prompt", value)}
+                      disabled={isSaving || isReadOnly}
+                    />
+                    {fieldErrors.system_prompt && (
+                      <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Base instructions for the AI model (supports Markdown). Leave empty to
+                      contribute no base prompt — the parent harness, agent, session, and
+                      capabilities still apply.
                     </p>
                   </div>
-                  <div>
-                    <p className="text-sm font-medium">Capabilities</p>
-                    <p className="text-sm text-muted-foreground">
-                      {selectedCapabilities.length} capabilit
-                      {selectedCapabilities.length !== 1 ? "ies" : "y"} enabled
-                    </p>
-                  </div>
+
+                  <InitialFilesEditor
+                    value={selectedInitialFiles}
+                    onChange={setLocalInitialFiles}
+                    disabled={isSaving || isReadOnly}
+                    description="Files copied into each new session created from this harness."
+                  />
+
+                  <NetworkAccessEditor
+                    value={initialNetworkAccess}
+                    onChange={setLocalNetworkAccess}
+                    disabled={isSaving || isReadOnly}
+                    description="Baseline network policy for every agent and session on this harness. Agents and sessions can only narrow it, never widen it."
+                  />
                 </CardContent>
               </Card>
 
-              <Card className="border-dashed">
-                <CardContent className="pt-6">
-                  <p className="text-sm text-muted-foreground text-center">
-                    This preview shows what the final harness will look like after applying all
-                    capabilities. Switch to the Edit tab to make changes.
-                  </p>
+              {/* Danger Zone */}
+              <Card className="border-destructive/50">
+                <CardHeader>
+                  <CardTitle className="text-destructive">Danger Zone</CardTitle>
+                  <CardDescription>Irreversible actions that affect this harness</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">
+                        {harness.status === "archived"
+                          ? "Delete this harness"
+                          : "Archive this harness"}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {harness.status === "archived"
+                          ? "Permanently delete this archived harness. Existing references will render as deleted tombstones."
+                          : "Archive this harness. It will stay visible when archived items are shown, become read-only, and stop being assignable."}
+                      </p>
+                    </div>
+                    {harness.status === "archived" ? (
+                      canDangerousDelete && (
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          onClick={() => setShowDeleteDialog(true)}
+                          disabled={destroyHarness.isPending}
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          {destroyHarness.isPending ? "Deleting..." : "Delete Harness"}
+                        </Button>
+                      )
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleArchive}
+                        disabled={deleteHarness.isPending}
+                      >
+                        {deleteHarness.isPending ? "Archiving..." : "Archive Harness"}
+                      </Button>
+                    )}
+                  </div>
+                  {deleteError && (
+                    <EntityDeleteErrorNotice
+                      entityKind="harness"
+                      action={deleteAction}
+                      message={deleteError.message}
+                      className="mt-4"
+                    />
+                  )}
                 </CardContent>
               </Card>
-            </div>
+            </PageMain>
+
+            {/* Capabilities sidebar */}
+            <PageRail>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Capabilities</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CapabilitySelector
+                    capabilities={allCapabilities || []}
+                    selected={selectedCapabilities}
+                    onChange={handleCapabilitiesChange}
+                    disabled={isSaving || isReadOnly}
+                  />
+                </CardContent>
+              </Card>
+
+              {updateHarness.error && (
+                <p className="text-sm text-destructive">Error: {updateHarness.error.message}</p>
+              )}
+            </PageRail>
+          </PageColumns>
+        </form>
+      )}
+
+      {/* Preview Tab Content */}
+      {activeTab === "preview" && (
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <HarnessPreview
+              systemPrompt={formData.system_prompt}
+              capabilities={selectedCapabilities}
+              initialFiles={selectedInitialFiles}
+              parentHarnessId={formData.parent_harness_id || undefined}
+            />
           </div>
-        </TabsContent>
-      </Tabs>
+
+          {/* Summary sidebar */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Harness Summary</CardTitle>
+                <CardDescription>Current configuration</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <p className="text-sm font-medium">Name</p>
+                  <p className="text-sm text-muted-foreground font-mono">
+                    {formData.name || "(not set)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Display Name</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formData.display_name || "(not set)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Description</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formData.description || "(not set)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Parent Harness</p>
+                  <p className="text-sm text-muted-foreground">
+                    {getDisplayName(selectedParentHarness) ||
+                      formData.parent_harness_id ||
+                      "(none)"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Capabilities</p>
+                  <p className="text-sm text-muted-foreground">
+                    {selectedCapabilities.length} capabilit
+                    {selectedCapabilities.length !== 1 ? "ies" : "y"} enabled
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-dashed">
+              <CardContent className="pt-6">
+                <p className="text-sm text-muted-foreground text-center">
+                  This preview shows what the final harness will look like after applying all
+                  capabilities. Switch to the Edit tab to make changes.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      )}
+
+      <PageFooter>
+        <BackLink href={`/harnesses/${harnessId}`}>Back to {harnessDisplayName}</BackLink>
+      </PageFooter>
+
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent>
           <DialogHeader>
@@ -621,6 +652,6 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -21,12 +21,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/providers/provider-icon";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { IntegrationGuide } from "@/components/integration/integration-guide";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import {
-  ArrowLeft,
   Pencil,
   Copy,
   Trash2,
@@ -35,9 +33,23 @@ import {
   BarChart3,
   Rocket,
   Terminal,
+  Shield,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+  type SectionTabItem,
+} from "@/components/layout";
 import type { Capability, ModelWithProvider } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -131,270 +143,289 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
     );
   }
 
-  return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/harnesses"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Harnesses
-      </Link>
+  const defaultModelName = defaultModel?.display_name ?? defaultModel?.id;
+  const harnessSessionCountLabel = harness.session_count ?? 0;
 
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(harness.status)}>
-              {getDisplayName(harness)}
-            </span>
+  const tabItems: SectionTabItem[] = [
+    { value: "overview", label: "Overview", icon: <LayoutDashboard className="size-4" /> },
+    { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
+    { value: "integrate", label: "Integrate", icon: <Terminal className="size-4" /> },
+    { value: "stats", label: "Stats", icon: <BarChart3 className="size-4" /> },
+  ];
+
+  return (
+    <PageContainer>
+      <PageBreadcrumb
+        items={[{ label: "Harnesses", href: "/harnesses" }, { label: getDisplayName(harness) }]}
+      />
+
+      <PageMasthead
+        icon={<Shield />}
+        title={
+          <span className={getEntityNameClassName(harness.status)}>{getDisplayName(harness)}</span>
+        }
+        badges={
+          <>
             <CopyButton value={harness.id} />
             {harness.is_built_in && <Badge variant="outline">Built-in</Badge>}
             <Badge variant={getEntityStatusBadgeVariant(harness.status)}>{harness.status}</Badge>
-          </h1>
-        </div>
-        <div className="flex gap-2">
-          {harness.status === "active" && (
-            <Link href={{ pathname: "/apps/new", query: { harness_id: harnessId } }}>
-              <Button variant="accent">
-                <Rocket className="w-4 h-4 mr-2" />
-                Create app
-              </Button>
-            </Link>
-          )}
-          <Button variant="outline" onClick={handleCopy} disabled={copyHarness.isPending}>
-            <Copy className="w-4 h-4 mr-2" />
-            {copyHarness.isPending ? "Copying..." : "Copy"}
-          </Button>
-          {!harness.is_built_in && (
-            <>
-              {harness.status === "active" && (
-                <Link href={`/harnesses/${harnessId}/edit`}>
-                  <Button variant="outline">
-                    <Pencil className="w-4 h-4 mr-2" />
-                    Edit
-                  </Button>
-                </Link>
-              )}
-              <Button
-                variant="outline"
-                onClick={handleDelete}
-                disabled={deleteHarness.isPending || harness.status !== "active"}
-              >
-                <Trash2 className="w-4 h-4 mr-2" />
-                {deleteHarness.isPending ? "Archiving..." : "Archive"}
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
+          </>
+        }
+        description={harness.description || undefined}
+        meta={
+          <>
+            <span>
+              Identity <span className="font-mono text-primary">{harness.name}</span>
+            </span>
+            {defaultModelName && (
+              <span>
+                Model <span className="text-primary">{defaultModelName}</span>
+              </span>
+            )}
+            <span>
+              Created{" "}
+              <span className="text-foreground">
+                {new Date(harness.created_at).toLocaleDateString()}
+              </span>
+            </span>
+            <span>
+              <span className="text-foreground">{harnessSessionCountLabel}</span>{" "}
+              {pluralize(harnessSessionCountLabel, "session")}
+            </span>
+          </>
+        }
+        actions={
+          <>
+            {harness.status === "active" && (
+              <Link href={{ pathname: "/apps/new", query: { harness_id: harnessId } }}>
+                <Button variant="accent">
+                  <Rocket className="size-4" />
+                  Create app
+                </Button>
+              </Link>
+            )}
+            <Button variant="outline" onClick={handleCopy} disabled={copyHarness.isPending}>
+              <Copy className="size-4" />
+              {copyHarness.isPending ? "Copying..." : "Copy"}
+            </Button>
+            {!harness.is_built_in && (
+              <>
+                {harness.status === "active" && (
+                  <Link href={`/harnesses/${harnessId}/edit`}>
+                    <Button variant="outline">
+                      <Pencil className="size-4" />
+                      Edit
+                    </Button>
+                  </Link>
+                )}
+                <Button
+                  variant="outline"
+                  onClick={handleDelete}
+                  disabled={deleteHarness.isPending || harness.status !== "active"}
+                >
+                  <Trash2 className="size-4" />
+                  {deleteHarness.isPending ? "Archiving..." : "Archive"}
+                </Button>
+              </>
+            )}
+          </>
+        }
+      />
+
       {deleteError && (
         <EntityDeleteErrorNotice
           entityKind="harness"
           action="archive"
           message={deleteError.message}
-          className="mb-4"
         />
       )}
 
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="mb-6">
-          <TabsTrigger value="overview">
-            <LayoutDashboard className="w-4 h-4 mr-2" />
-            Overview
-          </TabsTrigger>
-          <TabsTrigger value="preview">
-            <Eye className="w-4 h-4 mr-2" />
-            Preview
-          </TabsTrigger>
-          <TabsTrigger value="integrate">
-            <Terminal className="w-4 h-4 mr-2" />
-            Integrate
-          </TabsTrigger>
-          <TabsTrigger value="stats">
-            <BarChart3 className="w-4 h-4 mr-2" />
-            Stats
-          </TabsTrigger>
-        </TabsList>
+      <PageControlStrip>
+        <SectionTabs value={activeTab} onValueChange={setActiveTab} items={tabItems} />
+      </PageControlStrip>
 
-        <TabsContent value="overview">
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2 space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>System Prompt</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {harness.system_prompt?.trim() ? (
-                    <MarkdownDisplay content={harness.system_prompt} />
-                  ) : (
-                    <p className="text-sm text-muted-foreground">
-                      This harness contributes no base prompt. The effective prompt comes from the
-                      parent harness, agent, session, and capabilities.
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
+      {activeTab === "overview" && (
+        <PageColumns>
+          <PageMain>
+            <Card>
+              <CardHeader>
+                <CardTitle>System Prompt</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {harness.system_prompt?.trim() ? (
+                  <MarkdownDisplay content={harness.system_prompt} />
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    This harness contributes no base prompt. The effective prompt comes from the
+                    parent harness, agent, session, and capabilities.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </PageMain>
 
-            <div className="space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Capabilities</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {harnessCapabilities.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      {harness.parent_harness_id
-                        ? "No local capabilities configured on this harness. Preview shows inherited capabilities."
-                        : "No capabilities enabled. "}
-                      {!harness.parent_harness_id && (
-                        <Link
-                          href={`/harnesses/${harnessId}/edit`}
-                          className="text-primary hover:underline"
+          <PageRail>
+            <Card>
+              <CardHeader>
+                <CardTitle>Capabilities</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {harnessCapabilities.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {harness.parent_harness_id
+                      ? "No local capabilities configured on this harness. Preview shows inherited capabilities."
+                      : "No capabilities enabled. "}
+                    {!harness.parent_harness_id && (
+                      <Link
+                        href={`/harnesses/${harnessId}/edit`}
+                        className="text-primary hover:underline"
+                      >
+                        Add some
+                      </Link>
+                    )}
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {harnessCapabilities.map((capConfig) => {
+                      const cap = getCapabilityInfo(capConfig.ref);
+                      if (!cap) return null;
+                      const IconComponent = getCapabilityIcon(cap.icon);
+
+                      return (
+                        <div
+                          key={capConfig.ref}
+                          className="flex items-center gap-2 p-2 border bg-muted/50"
                         >
-                          Add some
-                        </Link>
-                      )}
-                    </p>
-                  ) : (
-                    <div className="space-y-2">
-                      {harnessCapabilities.map((capConfig) => {
-                        const cap = getCapabilityInfo(capConfig.ref);
-                        if (!cap) return null;
-                        const IconComponent = getCapabilityIcon(cap.icon);
-
-                        return (
-                          <div
-                            key={capConfig.ref}
-                            className="flex items-center gap-2 p-2 border bg-muted/50"
-                          >
-                            <IconComponent className="w-4 h-4" />
-                            <div className="flex-1">
-                              <p className="text-sm font-medium">
-                                {localizedCapabilityName(cap, locale)}
-                              </p>
-                              <p className="text-xs text-muted-foreground">
-                                {localizedCapabilityDescription(cap, locale)}
-                              </p>
-                            </div>
+                          <IconComponent className="w-4 h-4" />
+                          <div className="flex-1">
+                            <p className="text-sm font-medium">
+                              {localizedCapabilityName(cap, locale)}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {localizedCapabilityDescription(cap, locale)}
+                            </p>
                           </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
 
-              <Card>
-                <CardHeader>
-                  <CardTitle>Configuration</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {defaultModel && (
-                    <div>
-                      <p className="text-sm font-medium mb-2">Default Model</p>
-                      <div className="flex items-center gap-2">
-                        <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
-                        <span className="text-sm">{defaultModel.display_name}</span>
-                      </div>
-                    </div>
-                  )}
-
-                  {harness.parent_harness_id && (
-                    <div>
-                      <p className="text-sm font-medium">Inherits From</p>
-                      {parentHarness ? (
-                        <Link
-                          href={`/harnesses/${parentHarness.id}`}
-                          className="text-sm text-primary hover:underline"
-                        >
-                          {getDisplayName(parentHarness)}
-                        </Link>
-                      ) : (
-                        <p className="text-sm text-muted-foreground">{harness.parent_harness_id}</p>
-                      )}
-                    </div>
-                  )}
-
-                  {harness.description && (
-                    <div>
-                      <p className="text-sm font-medium">Description</p>
-                      <div className="text-sm text-muted-foreground">
-                        <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
-                      </div>
-                    </div>
-                  )}
-
-                  {harnessTags.length > 0 && (
-                    <div>
-                      <p className="text-sm font-medium mb-2">Tags</p>
-                      <div className="flex flex-wrap gap-1">
-                        {harnessTags.map((tag) => (
-                          <Badge key={tag} variant="outline">
-                            {tag}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
+            <Card>
+              <CardHeader>
+                <CardTitle>Configuration</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {defaultModel && (
                   <div>
-                    <p className="text-sm font-medium mb-2">Usage</p>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div className="border bg-muted/50 p-2">
-                        <p className="text-sm font-medium">{harnessSessionCount}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {pluralize(harnessSessionCount, "session")}
-                        </p>
-                      </div>
-                      <div className="border bg-muted/50 p-2">
-                        <p className="text-sm font-medium">{harnessAppCount}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {pluralize(harnessAppCount, "app")}
-                        </p>
-                      </div>
+                    <p className="text-sm font-medium mb-2">Default Model</p>
+                    <div className="flex items-center gap-2">
+                      <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
+                      <span className="text-sm">{defaultModel.display_name}</span>
                     </div>
                   </div>
+                )}
 
+                {harness.parent_harness_id && (
                   <div>
-                    <p className="text-sm font-medium">Created</p>
-                    <p className="text-sm text-muted-foreground">
-                      {new Date(harness.created_at).toLocaleString()}
-                    </p>
+                    <p className="text-sm font-medium">Inherits From</p>
+                    {parentHarness ? (
+                      <Link
+                        href={`/harnesses/${parentHarness.id}`}
+                        className="text-sm text-primary hover:underline"
+                      >
+                        {getDisplayName(parentHarness)}
+                      </Link>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">{harness.parent_harness_id}</p>
+                    )}
                   </div>
+                )}
 
+                {harness.description && (
                   <div>
-                    <p className="text-sm font-medium">Updated</p>
-                    <p className="text-sm text-muted-foreground">
-                      {new Date(harness.updated_at).toLocaleString()}
-                    </p>
+                    <p className="text-sm font-medium">Description</p>
+                    <div className="text-sm text-muted-foreground">
+                      <InlineStreamdownMessage>{harness.description}</InlineStreamdownMessage>
+                    </div>
                   </div>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </TabsContent>
+                )}
 
-        <TabsContent value="preview">
-          <HarnessPreview
-            systemPrompt={harness.system_prompt}
-            parentHarnessId={harness.parent_harness_id || undefined}
-            capabilities={harnessCapabilities.map((cap) => ({
-              ref: cap.ref,
-              config: cap.config,
-            }))}
-            initialFiles={harness.initial_files}
-          />
-        </TabsContent>
+                {harnessTags.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium mb-2">Tags</p>
+                    <div className="flex flex-wrap gap-1">
+                      {harnessTags.map((tag) => (
+                        <Badge key={tag} variant="outline">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
 
-        <TabsContent value="integrate">
-          <IntegrationGuide kind="harness" id={harness.id} name={getDisplayName(harness)} />
-        </TabsContent>
+                <div>
+                  <p className="text-sm font-medium mb-2">Usage</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="border bg-muted/50 p-2">
+                      <p className="text-sm font-medium">{harnessSessionCount}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {pluralize(harnessSessionCount, "session")}
+                      </p>
+                    </div>
+                    <div className="border bg-muted/50 p-2">
+                      <p className="text-sm font-medium">{harnessAppCount}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {pluralize(harnessAppCount, "app")}
+                      </p>
+                    </div>
+                  </div>
+                </div>
 
-        <TabsContent value="stats">
-          <ResourceStatsPanel stats={stats} isLoading={statsLoading} error={statsError} />
-        </TabsContent>
-      </Tabs>
-    </div>
+                <div>
+                  <p className="text-sm font-medium">Created</p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(harness.created_at).toLocaleString()}
+                  </p>
+                </div>
+
+                <div>
+                  <p className="text-sm font-medium">Updated</p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(harness.updated_at).toLocaleString()}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </PageRail>
+        </PageColumns>
+      )}
+
+      {activeTab === "preview" && (
+        <HarnessPreview
+          systemPrompt={harness.system_prompt}
+          parentHarnessId={harness.parent_harness_id || undefined}
+          capabilities={harnessCapabilities.map((cap) => ({
+            ref: cap.ref,
+            config: cap.config,
+          }))}
+          initialFiles={harness.initial_files}
+        />
+      )}
+
+      {activeTab === "integrate" && (
+        <IntegrationGuide kind="harness" id={harness.id} name={getDisplayName(harness)} />
+      )}
+
+      {activeTab === "stats" && (
+        <ResourceStatsPanel stats={stats} isLoading={statsLoading} error={statsError} />
+      )}
+
+      <PageFooter>
+        <BackLink href="/harnesses">Back to Harnesses</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
+++ b/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, useMemo } from "react";
 import {
   useCapabilities,
   useHarnessExamples,
@@ -10,21 +10,46 @@ import {
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { ArrowRight, Plus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { SearchInput } from "@/components/ui/search-input";
+import { ArrowRight, Plus, Shield, LayoutGrid, List as ListIcon } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { HarnessCard, HarnessExampleCard } from "@/components/harnesses";
-import { ArchiveFilter } from "@/components/archive-filter";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+import { localizedCapabilityName } from "@/lib/capability-localization";
+import { useLocale } from "@/providers/locale-provider";
+import { isArchivedStatus } from "@/lib/entity-lifecycle";
+import { normalizeTags } from "@/lib/tags";
+import { pluralize } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
 
-const PREVIEW_LIMIT = 6;
+const EXAMPLE_PREVIEW_LIMIT = 6;
+type StatusTab = "all" | "active" | "archived";
 
 export default function HarnessesPageClient() {
   const router = useRouter();
-  const [showArchived, setShowArchived] = useState(false);
-  const { data: harnesses, isLoading, error } = useHarnesses({ includeArchived: showArchived });
+  const { locale } = useLocale();
+  const { data: harnesses, isLoading, error } = useHarnesses({ includeArchived: true });
   const { data: allCapabilities } = useCapabilities();
   const { data: examples, isLoading: examplesLoading, error: examplesError } = useHarnessExamples();
   const importExample = useImportHarnessExample();
   const [importingName, setImportingName] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
+  const [view, setView] = useState<"grid" | "list">("grid");
 
   const handleImport = useCallback(
     async (name: string) => {
@@ -41,62 +66,260 @@ export default function HarnessesPageClient() {
     [importExample, router],
   );
 
-  const previewExamples = examples?.slice(0, PREVIEW_LIMIT);
-  const hasMoreExamples = (examples?.length ?? 0) > PREVIEW_LIMIT;
+  const counts = useMemo(() => {
+    const list = harnesses ?? [];
+    const archived = list.filter((h) => isArchivedStatus(h.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [harnesses]);
+
+  const capabilityFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const harness of harnesses ?? []) {
+      for (const cap of harness.capabilities ?? []) {
+        tally.set(cap.ref, (tally.get(cap.ref) ?? 0) + 1);
+      }
+    }
+    return [...tally.entries()]
+      .map(([ref, count]) => ({
+        ref,
+        count,
+        name: (() => {
+          const cap = allCapabilities?.find((c) => c.id === ref);
+          return cap ? localizedCapabilityName(cap, locale) : ref;
+        })(),
+        icon: getCapabilityIcon(allCapabilities?.find((c) => c.id === ref)?.icon),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 6);
+  }, [harnesses, allCapabilities, locale]);
+
+  const tagFacets = useMemo(() => {
+    const tags = new Set<string>();
+    for (const harness of harnesses ?? []) {
+      for (const tag of normalizeTags(harness.tags)) tags.add(tag);
+    }
+    return [...tags].slice(0, 12);
+  }, [harnesses]);
+
+  const filteredHarnesses = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (harnesses ?? []).filter((harness) => {
+      if (statusTab === "active" && isArchivedStatus(harness.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(harness.status)) return false;
+      if (!query) return true;
+      const haystack = [harness.display_name, harness.name, harness.description]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [harnesses, search, statusTab]);
+
+  const previewExamples = examples?.slice(0, EXAMPLE_PREVIEW_LIMIT);
+  const hasMoreExamples = (examples?.length ?? 0) > EXAMPLE_PREVIEW_LIMIT;
+
+  const statusItems = [
+    { value: "all" as const, label: "All" },
+    { value: "active" as const, label: "Active" },
+    { value: "archived" as const, label: "Archived" },
+  ];
 
   return (
-    <div className="container mx-auto p-6 space-y-10">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Harnesses</h1>
-        <div className="flex items-center gap-2">
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Harnesses" }]} />
+
+      <PageMasthead
+        icon={<Shield />}
+        title="Harnesses"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
+        }
+        description="Shared runtime configuration — base prompt, capabilities, and policies sessions inherit."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
           <Link href="/harnesses/new">
             <Button variant="accent">
-              <Plus className="w-4 h-4 mr-2" />
-              New Harness
+              <Plus className="size-4" />
+              New harness
             </Button>
           </Link>
-        </div>
-      </div>
+        }
+      />
 
-      <section>
-        <QueryStateWrapper
-          isLoading={isLoading}
-          error={error}
-          data={harnesses}
-          errorMessagePrefix="Failed to load harnesses"
-          emptyState={
-            <div className="text-center py-12">
-              <p className="text-muted-foreground mb-4">No harnesses yet</p>
-              <Link href="/harnesses/new">
-                <Button>
-                  <Plus className="w-4 h-4 mr-2" />
-                  Create your first harness
-                </Button>
-              </Link>
-            </div>
-          }
-        >
-          {(items) => (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {items.map((harness) => (
-                <HarnessCard
-                  key={harness.id}
-                  harness={harness}
-                  allCapabilities={allCapabilities}
-                  showEditButton
-                />
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search harnesses…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          containerClassName="w-64"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+        <div className="flex border">
+          <button
+            type="button"
+            aria-label="Grid view"
+            aria-pressed={view === "grid"}
+            onClick={() => setView("grid")}
+            className={cn(
+              "inline-flex size-8 items-center justify-center border-r",
+              view === "grid"
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/50",
+            )}
+          >
+            <LayoutGrid className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="List view"
+            aria-pressed={view === "list"}
+            onClick={() => setView("list")}
+            className={cn(
+              "inline-flex size-8 items-center justify-center",
+              view === "list"
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/50",
+            )}
+          >
+            <ListIcon className="size-4" />
+          </button>
+        </div>
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredHarnesses}
+            errorMessagePrefix="Failed to load harnesses"
+            emptyState={
+              <div className="border border-dashed py-12 text-center">
+                <p className="mb-4 text-muted-foreground">
+                  {search || statusTab !== "active"
+                    ? "No harnesses match your filters."
+                    : "No harnesses yet"}
+                </p>
+                {!search && statusTab === "active" && (
+                  <Link href="/harnesses/new">
+                    <Button>
+                      <Plus className="size-4" />
+                      Create your first harness
+                    </Button>
+                  </Link>
+                )}
+              </div>
+            }
+          >
+            {(items) => (
+              <div className={cn("grid gap-4", view === "grid" ? "md:grid-cols-2" : "grid-cols-1")}>
+                {items.map((harness) => (
+                  <HarnessCard
+                    key={harness.id}
+                    harness={harness}
+                    allCapabilities={allCapabilities}
+                    showEditButton
+                  />
+                ))}
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
               ))}
             </div>
+          </RailSection>
+
+          {capabilityFacets.length > 0 && (
+            <RailSection label="Capability">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {capabilityFacets.map((facet) => {
+                  const Icon = facet.icon;
+                  return (
+                    <div key={facet.ref} className="flex items-center justify-between">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Icon className="size-3.5" />
+                        {facet.name}
+                      </span>
+                      <span>{facet.count}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </RailSection>
           )}
-        </QueryStateWrapper>
-      </section>
 
-      <hr className="border-border" />
+          {tagFacets.length > 0 && (
+            <RailSection label="Tags">
+              <div className="flex flex-wrap gap-1.5">
+                {tagFacets.map((tag) => (
+                  <span key={tag} className="border bg-muted px-2 py-0.5 text-xs">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
 
-      <section>
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-semibold">Example harnesses</h2>
+      <PageFooter>
+        <span>
+          Showing {filteredHarnesses.length} of {counts.all}{" "}
+          {pluralize(counts.all, "harness", "harnesses")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
+        )}
+      </PageFooter>
+
+      {/* Example harnesses — a secondary discovery section below the primary frame. */}
+      <section className="mt-4">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold tracking-tight">Example harnesses</h2>
+          {hasMoreExamples && (
+            <Link
+              href="/harnesses/examples"
+              className="inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
+            >
+              All examples
+              <ArrowRight className="size-3.5" />
+            </Link>
+          )}
         </div>
         <QueryStateWrapper
           isLoading={examplesLoading}
@@ -104,7 +327,7 @@ export default function HarnessesPageClient() {
           data={previewExamples}
           errorMessagePrefix="Failed to load examples"
           emptyState={
-            <div className="text-center py-12">
+            <div className="py-8 text-center">
               <p className="text-muted-foreground">No examples available</p>
             </div>
           }
@@ -123,17 +346,7 @@ export default function HarnessesPageClient() {
             </div>
           )}
         </QueryStateWrapper>
-        {hasMoreExamples && (
-          <div className="flex justify-end mt-4">
-            <Link href="/harnesses/examples">
-              <Button variant="outline">
-                All examples
-                <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
-        )}
       </section>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -5,7 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Pencil } from "lucide-react";
+import { Pencil, Boxes } from "lucide-react";
+import { IconTile } from "@/components/layout/page-layout";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -48,6 +49,7 @@ export function AgentCard({
 
   return (
     <EntityCard
+      icon={<IconTile size="md" icon={<Boxes />} />}
       title={getDisplayName(agent)}
       href={`/agents/${agent.id}`}
       titleClassName={getEntityNameClassName(agent.status)}

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -5,7 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Pencil } from "lucide-react";
+import { Pencil, Shield } from "lucide-react";
+import { IconTile } from "@/components/layout/page-layout";
 import type { Harness, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -46,6 +47,7 @@ export function HarnessCard({
 
   return (
     <EntityCard
+      icon={<IconTile size="md" icon={<Shield />} />}
       title={getDisplayName(harness)}
       href={`/harnesses/${harness.id}`}
       titleClassName={getEntityNameClassName(harness.status)}

--- a/apps/ui/src/components/layout/index.ts
+++ b/apps/ui/src/components/layout/index.ts
@@ -10,3 +10,20 @@ export {
 } from "./sidebar";
 export { MainLayout } from "./main-layout";
 export { PageShell, PageHeader, PageBody } from "./page-shell";
+export {
+  PageContainer,
+  PageBreadcrumb,
+  IconTile,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  StatCard,
+  StatGrid,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+  BackLink,
+} from "./page-layout";
+export type { BreadcrumbItem, SectionTabItem } from "./page-layout";

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -1,0 +1,366 @@
+// Unified page layout — the single five-zone skeleton every standard page is built on.
+//
+// Zones (numbered ①–⑤ in the design source):
+//   1. Breadcrumb     — PageBreadcrumb: the context line (root → name → mode).
+//   2. Header         — PageMasthead: icon tile · title · status badge · meta, then a
+//                       right-aligned action cluster (primary verb first).
+//   3. Control strip   — the shape-shifter: filters on list, stats on view, section nav
+//                       on edit. Same slot, always. Compose with PageControlStrip plus
+//                       SectionTabs / StatGrid as needed.
+//   4. Body            — PageColumns: a primary column (PageMain) plus a fixed right rail
+//                       (PageRail) for context.
+//   5. Footer          — PageFooter: a quiet back link / count line that closes the page.
+//
+// Only the contents of each zone change per page; position and mechanics stay identical.
+// These primitives are presentational and prop-driven so any page can adopt the language.
+
+import { Fragment, type ReactNode } from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/* ─────────────────────────────── Container ─────────────────────────────── */
+
+interface PageContainerProps {
+  children: ReactNode;
+  /** Opt into full-bleed width for dense tool pages. Defaults to a centered container. */
+  fullWidth?: boolean;
+  className?: string;
+}
+
+/**
+ * Outer page wrapper. Provides padding and the consistent vertical rhythm between
+ * the five zones so callers never hand-roll spacing.
+ */
+export function PageContainer({ children, fullWidth = false, className }: PageContainerProps) {
+  return (
+    <div
+      className={cn(
+        fullWidth ? "w-full" : "container mx-auto",
+        "flex flex-col gap-6 p-6",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* ────────────────────────────── 1 · Breadcrumb ─────────────────────────── */
+
+export interface BreadcrumbItem {
+  label: ReactNode;
+  href?: string;
+}
+
+/**
+ * Zone ① — the context line. Renders `Root → name → mode`; the final item reads as
+ * the current location and is never linked.
+ */
+export function PageBreadcrumb({
+  items,
+  className,
+}: {
+  items: BreadcrumbItem[];
+  className?: string;
+}) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn(
+        "flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground",
+        className,
+      )}
+    >
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <Fragment key={index}>
+            {index > 0 && (
+              <span aria-hidden className="text-muted-foreground/50">
+                /
+              </span>
+            )}
+            {item.href && !isLast ? (
+              <Link href={item.href} className="transition-colors hover:text-foreground">
+                {item.label}
+              </Link>
+            ) : (
+              <span className={isLast ? "text-foreground" : undefined}>{item.label}</span>
+            )}
+          </Fragment>
+        );
+      })}
+    </nav>
+  );
+}
+
+/* ──────────────────────────────── Icon tile ────────────────────────────── */
+
+/**
+ * The gold-tinted square that leads the header (and entity cards). `lg` is the
+ * masthead size; `md` matches inline card rows.
+ */
+export function IconTile({
+  icon,
+  size = "lg",
+  className,
+}: {
+  icon: ReactNode;
+  size?: "md" | "lg";
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex flex-none items-center justify-center border bg-accent/20 text-foreground",
+        size === "lg" ? "size-11 [&_svg]:size-[22px]" : "size-8 [&_svg]:size-4",
+        className,
+      )}
+    >
+      {icon}
+    </span>
+  );
+}
+
+/* ──────────────────────────────── 2 · Header ───────────────────────────── */
+
+interface PageMastheadProps {
+  /** Leading icon, wrapped in an IconTile automatically. */
+  icon?: ReactNode;
+  title: ReactNode;
+  /** Status badges / counts shown inline after the title. */
+  badges?: ReactNode;
+  /** One-line description under the title. */
+  description?: ReactNode;
+  /** Meta run — small key/value spans rendered below the description. */
+  meta?: ReactNode;
+  /** Right-aligned action cluster, primary verb first. */
+  actions?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Zone ② — header anatomy shared by every page: gold icon tile · title · status
+ * badge · meta run, then a right-aligned action cluster.
+ */
+export function PageMasthead({
+  icon,
+  title,
+  badges,
+  description,
+  meta,
+  actions,
+  className,
+}: PageMastheadProps) {
+  return (
+    <div className={cn("flex items-start justify-between gap-4 border-b pb-4", className)}>
+      <div className="flex min-w-0 items-start gap-4">
+        {icon && <IconTile icon={icon} />}
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+            {badges}
+          </div>
+          {description && <p className="mt-1.5 text-sm text-muted-foreground">{description}</p>}
+          {meta && (
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-[13px] text-muted-foreground">
+              {meta}
+            </div>
+          )}
+        </div>
+      </div>
+      {actions && <div className="flex flex-none items-center gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+/* ─────────────────────────────── 3 · Control strip ─────────────────────── */
+
+/**
+ * Zone ③ — the shape-shifter slot. A thin wrapper so the zone keeps its position
+ * regardless of what it holds (filters, stats, or section nav).
+ */
+export function PageControlStrip({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={className}>{children}</div>;
+}
+
+export interface SectionTabItem {
+  value: string;
+  label: ReactNode;
+  icon?: ReactNode;
+}
+
+/**
+ * Underline section navigation used for the list status filter and the edit
+ * section nav. Controlled — pair with local state and conditional panels.
+ */
+export function SectionTabs({
+  value,
+  onValueChange,
+  items,
+  className,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  items: SectionTabItem[];
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex items-center border-b", className)} role="tablist">
+      {items.map((item) => {
+        const isActive = item.value === value;
+        return (
+          <button
+            key={item.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onValueChange(item.value)}
+            className={cn(
+              "-mb-px inline-flex items-center gap-2 border-b-2 px-3.5 py-2 text-[13px] font-medium transition-colors",
+              isActive
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {item.icon}
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * A single metric tile for the view control strip. Pass `value` for the big
+ * number, `hint` for the caption, or `children` for custom content (e.g. a chart).
+ */
+export function StatCard({
+  label,
+  value,
+  hint,
+  children,
+  className,
+}: {
+  label: ReactNode;
+  value?: ReactNode;
+  hint?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-1.5 border bg-card p-4", className)}>
+      <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </span>
+      {value !== undefined && (
+        <span className="text-2xl font-semibold tracking-tight text-foreground">{value}</span>
+      )}
+      {children}
+      {hint && <span className="text-[13px] text-muted-foreground">{hint}</span>}
+    </div>
+  );
+}
+
+/** Responsive grid for {@link StatCard}s. Defaults to four columns on wide screens. */
+export function StatGrid({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("grid grid-cols-2 gap-3 lg:grid-cols-4", className)}>{children}</div>;
+}
+
+/* ──────────────────────────────── 4 · Body ─────────────────────────────── */
+
+/**
+ * Zone ④ — the two-column body: a flexible primary column plus a fixed-width
+ * right rail. On narrow screens the rail stacks below.
+ */
+export function PageColumns({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={cn("grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]", className)}>
+      {children}
+    </div>
+  );
+}
+
+/** The primary column inside {@link PageColumns}. */
+export function PageMain({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("flex min-w-0 flex-col gap-4", className)}>{children}</div>;
+}
+
+/** The fixed right rail inside {@link PageColumns}. */
+export function PageRail({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("flex flex-col gap-4", className)}>{children}</div>;
+}
+
+/**
+ * A rail facet card: small mono uppercase label over content. For richer titled
+ * panels (e.g. "Recent sessions") use the standard Card component instead.
+ */
+export function RailSection({
+  label,
+  children,
+  className,
+}: {
+  label: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("border bg-card p-4", className)}>
+      <div className="mb-2.5 font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/* ──────────────────────────────── 5 · Footer ───────────────────────────── */
+
+/**
+ * Zone ⑤ — the closing line. A quiet bordered strip; pass a {@link BackLink} and
+ * an optional count/secondary link.
+ */
+export function PageFooter({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-4 border-t pt-3.5 text-[13px] text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Back link with a leading arrow, sized for the footer. */
+export function BackLink({
+  href,
+  children,
+  className,
+}: {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "inline-flex items-center gap-2 text-[13px] text-muted-foreground transition-colors hover:text-foreground",
+        className,
+      )}
+    >
+      <ArrowLeft className="size-4" />
+      {children}
+    </Link>
+  );
+}

--- a/apps/ui/src/components/ui/badge.tsx
+++ b/apps/ui/src/components/ui/badge.tsx
@@ -16,6 +16,8 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline: "text-foreground [a&]:hover:bg-muted [a&]:hover:text-foreground",
         accent: "bg-accent/15 text-accent-foreground border-accent/30",
+        success:
+          "border-emerald-600/30 bg-emerald-600/12 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/15 dark:text-emerald-400",
       },
     },
     defaultVariants: {

--- a/apps/ui/src/lib/entity-lifecycle.ts
+++ b/apps/ui/src/lib/entity-lifecycle.ts
@@ -36,7 +36,7 @@ export function getEntityStatusBadgeVariant(
   switch (status) {
     case "active":
     case "published":
-      return "default";
+      return "success";
     case "deleted":
       return "destructive";
     case "archived":


### PR DESCRIPTION
## What
Introduces a reusable five-zone page layout and rebuilds the Agents and Harnesses **list / view / edit** pages on it, so they share one visual language matching the "one language for every page" design source.

New primitives in `components/layout/page-layout.tsx` (exported from `@/components/layout`):
- `PageContainer`, `PageBreadcrumb` (①), `PageMasthead` + `IconTile` (②), `PageControlStrip` / `SectionTabs` / `StatCard` / `StatGrid` (③), `PageColumns` / `PageMain` / `PageRail` / `RailSection` (④), `PageFooter` / `BackLink` (⑤).

Applied to: `/agents` (+ `/agents/all`), `/agents/[id]`, `/agents/[id]/edit`, `/harnesses`, `/harnesses/[id]`, `/harnesses/[id]/edit`.

Also two design-system touch-ups to match the source:
- New `success` Badge variant (emerald); `getEntityStatusBadgeVariant` maps `active`/`published` → `success`, so active entities read green and archived stays grey app-wide.
- Leading gold `IconTile` added to `AgentCard` (Boxes) and `HarnessCard` (Shield).

## Why
List, view, and edit each invented their own layout. This unifies them onto one breadcrumb → header → control-strip → two-column-body → footer skeleton. The primitives are prop-driven and presentational so the next pages can adopt the same language without re-deriving spacing/anatomy.

## How
- List pages: search + status `SectionTabs` + grid/list toggle in the control strip; card grid + facet rail (live Status / Capability / Tags counts) in the body; "Showing N of M" footer. Example agents/harnesses kept as a secondary section.
- View pages: existing tabs (Overview/Preview/Integrate/Stats/Versions) move into the control strip; overview content split across primary + rail columns; all prior functionality preserved.
- Edit pages: "Editing" badge; Save/Discard promoted into the masthead (the Save button sits outside the form and submits via `form="…-edit-form"`); Edit/Preview as section nav; danger-zone dialog and all save logic unchanged.

## Risk
- Low. UI-only, presentational. No backend, API, schema, or migration changes. The `success` badge / status-variant mapping is global but additive (active was navy `default`, now green `success`); archived/other statuses unchanged.

## Security
- Threat categories reviewed: **TM-WEB** (frontend rendering only). No TM-AUTH/AUTHZ/API/SQL/TENANT surface touched.
- Findings: none. No `dangerouslySetInnerHTML` introduced; all text rendered as escaped React children (descriptions still go through the existing `InlineStreamdownMessage`). Client-side search uses string `includes` (no injection). No new dependencies. No data/secret exposure, no auth/permission logic touched.

## Validation
- `pnpm typecheck`, `pnpm lint` (oxlint), `pnpm format:check`, `pnpm build`, and the full `pnpm test` suite (1043 tests) pass locally; CI green (UI Build/Lint/Test, UI Playwright Smoke, CodeQL).
- `scripts/lib/check-migration-ordering.sh`: sequential (no migrations touched).
- Smoke-tested on a live `just start-dev` stack (auth=none, seeded example agents/harnesses): list renders with green active badges + card icon tiles; search filters; status facets + grid/list toggle work; view renders with tab nav; **edit Save (the out-of-form `form=` submit) persisted a field change and navigated back to the view page**; harnesses list renders.

## Follow-ups
- `specs/brand.md` describes the Figma component-library page as having "5 badge variants"; code now has a 6th (`success`, green) sourced from the design mockup. The Figma library could add the green/active badge to match — left to the design source rather than editing the doc to misdescribe the Figma file.
- Per-card icon tiles were added to Agents/Harnesses cards; other entity cards (skills, apps, MCP) still use the icon-less variant. Adopting the unified layout + card icons across the remaining sections is the planned next step.

## Checklist
- [x] Tests added or updated — updated `agent-edit-page` / `agent-detail-model` suites for the new heading/labels and the breadcrumb+meta duplication.
- [x] Backward compatibility considered — internal UI only; status-badge color change is additive.
- [x] Security review performed against relevant threat model categories (TM-WEB).
- [x] Final CI ran checks affected by this PR — UI Build/Lint/Test, UI Playwright Smoke, CodeQL all green; non-affected jobs correctly skipped by Detect Changes.
- [x] All review comments addressed — no review comments posted (no unresolved threads).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Actfh4H4uA3fHMXM39XKH)_