### PR TITLE
feat(ui): unify building-block entity pages on the five-zone layout

### DIFF
--- a/apps/ui/src/__tests__/knowledge-index-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-index-detail-page.test.tsx
@@ -105,16 +105,17 @@ describe("KnowledgeIndexDetailPage", () => {
     await renderWithSuspense();
 
     expect(screen.getByRole("heading", { level: 1, name: "Product Docs" })).toBeInTheDocument();
-    expect(screen.getByText("Synced product documentation")).toBeInTheDocument();
+    expect(screen.getAllByText("Synced product documentation").length).toBeGreaterThan(0);
     expect(screen.getByText("everruns/everruns")).toBeInTheDocument();
-    expect(screen.getByText("model_001")).toBeInTheDocument();
+    expect(screen.getAllByText("model_001").length).toBeGreaterThan(0);
     expect(screen.getByText("Readme")).toBeInTheDocument();
     expect(screen.getByText(/docs\/readme\.md/)).toBeInTheDocument();
-    expect(screen.getByText("4")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Knowledge Indexes/i })).toHaveAttribute(
-      "href",
-      "/knowledge-indexes",
-    );
+    expect(screen.getAllByText("4").length).toBeGreaterThan(0);
+    expect(
+      screen
+        .getAllByRole("link", { name: /Knowledge Indexes/i })
+        .some((l) => l.getAttribute("href") === "/knowledge-indexes"),
+    ).toBe(true);
   });
 
   it("triggers a manual sync", async () => {

--- a/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
@@ -167,7 +167,7 @@ describe("KnowledgeIndexesPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Product Docs")).toBeInTheDocument();
     expect(screen.getByText("Synced product documentation")).toBeInTheDocument();
-    expect(screen.getByText("synced")).toBeInTheDocument();
+    expect(screen.getAllByText("synced").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open/i })).toHaveAttribute(
       "href",
       "/knowledge-indexes/kidx_019dfb261a407c6085dcdd602402c3f7",
@@ -180,7 +180,7 @@ describe("KnowledgeIndexesPage", () => {
       target: { value: "docs" },
     });
     expect(mockUseKnowledgeIndexes).toHaveBeenLastCalledWith({
-      includeArchived: false,
+      includeArchived: true,
       search: "docs",
     });
   });
@@ -190,7 +190,7 @@ describe("KnowledgeIndexesPage", () => {
     mockUseCreateKnowledgeIndex.mockReturnValue({ mutateAsync, isPending: false });
     render(<KnowledgeIndexesPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "New Index" }));
+    fireEvent.click(screen.getByRole("button", { name: "New index" }));
     const dialog = screen.getByRole("dialog");
     fireEvent.change(within(dialog).getByLabelText("Name"), { target: { value: "API Docs" } });
     fireEvent.change(within(dialog).getByLabelText("Embedding model"), {
@@ -225,7 +225,7 @@ describe("KnowledgeIndexesPage", () => {
     mockUseCreateKnowledgeIndex.mockReturnValue({ mutateAsync, isPending: false });
     render(<KnowledgeIndexesPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "New Index" }));
+    fireEvent.click(screen.getByRole("button", { name: "New index" }));
     const dialog = screen.getByRole("dialog");
     fireEvent.change(within(dialog).getByLabelText("Name"), { target: { value: "No Model" } });
     fireEvent.click(within(dialog).getByRole("button", { name: "Create Index" }));
@@ -252,6 +252,6 @@ describe("KnowledgeIndexesPage", () => {
   it("renders the empty state", () => {
     mockUseKnowledgeIndexes.mockReturnValue({ data: [], isLoading: false, error: null });
     render(<KnowledgeIndexesPage />);
-    expect(screen.getByText("No knowledge indexes")).toBeInTheDocument();
+    expect(screen.getByText(/No knowledge indexes/)).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/memory-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/memory-detail-page.test.tsx
@@ -79,7 +79,11 @@ describe("MemoryDetailPage", () => {
 
     expect(screen.getByRole("heading", { level: 1, name: "Research" })).toBeInTheDocument();
     expect(screen.getByText("Shared research files")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Memory/i })).toHaveAttribute("href", "/memory");
+    expect(
+      screen
+        .getAllByRole("link", { name: /Memory/i })
+        .some((l) => l.getAttribute("href") === "/memory"),
+    ).toBe(true);
   });
 
   it("updates memory metadata", async () => {

--- a/apps/ui/src/__tests__/models-page.test.tsx
+++ b/apps/ui/src/__tests__/models-page.test.tsx
@@ -141,7 +141,7 @@ describe("ModelsPage", () => {
   it("renders Models section header", () => {
     render(<ModelsPage />, { wrapper });
 
-    expect(screen.getByText("Models")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Models" })).toBeInTheDocument();
     expect(
       screen.getByText("Manage the models available from your configured providers."),
     ).toBeInTheDocument();

--- a/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { use, useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Save, Trash2 } from "lucide-react";
+import { Check, Pencil, Trash2, UserRound } from "lucide-react";
 import {
   useAgentIdentity,
   useDeleteAgentIdentity,
@@ -30,7 +29,21 @@ import {
 } from "@/components/ui/dialog";
 import { Combobox } from "@/components/ui/combobox";
 import { PromptEditor } from "@/components/ui/prompt-editor";
-import { getEntityStatusBadgeVariant, isReadOnlyStatus } from "@/lib/entity-lifecycle";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
+import {
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+  isReadOnlyStatus,
+} from "@/lib/entity-lifecycle";
 import { LOCALE_OPTIONS, TIMEZONE_OPTIONS } from "@/lib/locale-data";
 import { IdentityConnections } from "@/components/agent-identity/identity-connections";
 
@@ -139,27 +152,64 @@ export default function AgentIdentityDetailPage({
   }
 
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/agent-identities"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Agent Identities
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Agent Identities", href: "/agent-identities" },
+          { label: identity.name },
+        ]}
+      />
 
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold">{identity.name}</h1>
-          <CopyButton value={identity.id} />
-          <Badge variant={getEntityStatusBadgeVariant(identity.status)}>{identity.status}</Badge>
-        </div>
-      </div>
+      <PageMasthead
+        icon={<UserRound />}
+        title={<span className={getEntityNameClassName(identity.status)}>{identity.name}</span>}
+        badges={
+          <>
+            <CopyButton value={identity.id} />
+            <Badge variant={getEntityStatusBadgeVariant(identity.status)}>{identity.status}</Badge>
+            {!isReadOnly && (
+              <Badge variant="accent">
+                <Pencil className="size-3" />
+                Editing
+              </Badge>
+            )}
+          </>
+        }
+        description={identity.description || undefined}
+        meta={
+          <>
+            <span>
+              Locale <span className="text-primary">{identity.locale || "—"}</span>
+            </span>
+            <span>
+              Timezone <span className="text-primary">{identity.timezone || "—"}</span>
+            </span>
+            <span>
+              Created{" "}
+              <span className="text-foreground">
+                {new Date(identity.created_at).toLocaleDateString()}
+              </span>
+            </span>
+          </>
+        }
+        actions={
+          <>
+            <Button type="submit" form="identity-edit-form" disabled={isSaving || isReadOnly}>
+              <Check className="size-4" />
+              {isReadOnly ? "Read-only" : isSaving ? "Saving..." : "Save changes"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Discard
+            </Button>
+          </>
+        }
+      />
 
-      <form onSubmit={handleSubmit}>
-        <div className="grid gap-6 lg:grid-cols-3">
+      <form id="identity-edit-form" onSubmit={handleSubmit}>
+        <PageColumns>
           {/* Main form */}
-          <div className="lg:col-span-2 space-y-6">
+          <PageMain>
             <Card>
               <CardHeader>
                 <CardTitle>Identity Details</CardTitle>
@@ -287,20 +337,10 @@ export default function AgentIdentityDetailPage({
                 )}
               </CardContent>
             </Card>
-          </div>
+          </PageMain>
 
-          {/* Sidebar */}
-          <div className="space-y-6">
-            <div className="flex gap-4">
-              <Button type="submit" disabled={isSaving || isReadOnly} className="flex-1">
-                <Save className="w-4 h-4 mr-2" />
-                {isReadOnly ? "Read-Only" : isSaving ? "Saving..." : "Save Changes"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
-                Cancel
-              </Button>
-            </div>
-
+          {/* Summary sidebar */}
+          <PageRail>
             {updateIdentity.error && (
               <p className="text-sm text-destructive">Error: {updateIdentity.error.message}</p>
             )}
@@ -338,9 +378,13 @@ export default function AgentIdentityDetailPage({
                 </div>
               </CardContent>
             </Card>
-          </div>
-        </div>
+          </PageRail>
+        </PageColumns>
       </form>
+
+      <PageFooter>
+        <BackLink href="/agent-identities">Back to Agent Identities</BackLink>
+      </PageFooter>
 
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent>
@@ -373,6 +417,6 @@ export default function AgentIdentityDetailPage({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/agent-identities/new/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/new/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { ArrowLeft } from "lucide-react";
+import { Check, UserRound } from "lucide-react";
 import { useCreateAgentIdentity } from "@/hooks/use-agent-identities";
 import { usePageTitle } from "@/hooks";
 import { Button } from "@/components/ui/button";
@@ -12,6 +11,16 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Combobox } from "@/components/ui/combobox";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 import { agentIdentityFormSchema, getFieldErrors, type FieldErrors } from "@/lib/form-validation";
 import { LOCALE_OPTIONS, TIMEZONE_OPTIONS } from "@/lib/locale-data";
 
@@ -47,96 +56,133 @@ export default function NewAgentIdentityPage() {
     router.push(`/agent-identities/${identity.id}`);
   }
 
+  const isSaving = createIdentity.isPending;
+
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/agent-identities"
-        className="mb-6 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft className="mr-2 h-4 w-4" />
-        Back to Agent Identities
-      </Link>
-      <Card>
-        <CardHeader>
-          <CardTitle>Create Agent Identity</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label>Name</Label>
-              <Input
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  setFieldErrors((prev) => ({ ...prev, name: undefined }));
-                }}
-                aria-invalid={!!fieldErrors.name}
-                required
-              />
-              {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
-            </div>
-            <div className="space-y-2">
-              <Label>Description</Label>
-              <Textarea
-                value={description}
-                onChange={(e) => {
-                  setDescription(e.target.value);
-                  setFieldErrors((prev) => ({ ...prev, description: undefined }));
-                }}
-                aria-invalid={!!fieldErrors.description}
-                placeholder="Describe this identity..."
-                rows={3}
-              />
-              {fieldErrors.description && (
-                <p className="text-xs text-destructive">{fieldErrors.description}</p>
-              )}
-              <p className="text-xs text-muted-foreground">Supports Markdown</p>
-            </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <Label>Locale</Label>
-                <Combobox
-                  options={LOCALE_OPTIONS}
-                  value={locale}
-                  onValueChange={(value) => {
-                    setLocale(value);
-                    setFieldErrors((prev) => ({ ...prev, locale: undefined }));
-                  }}
-                  placeholder="Select locale..."
-                  searchPlaceholder="Search locales..."
-                />
-                {fieldErrors.locale && (
-                  <p className="text-xs text-destructive">{fieldErrors.locale}</p>
-                )}
-              </div>
-              <div className="space-y-2">
-                <Label>Timezone</Label>
-                <Combobox
-                  options={TIMEZONE_OPTIONS}
-                  value={timezone}
-                  onValueChange={(value) => {
-                    setTimezone(value);
-                    setFieldErrors((prev) => ({ ...prev, timezone: undefined }));
-                  }}
-                  placeholder="Select timezone..."
-                  searchPlaceholder="Search timezones..."
-                />
-                {fieldErrors.timezone && (
-                  <p className="text-xs text-destructive">{fieldErrors.timezone}</p>
-                )}
-              </div>
-            </div>
-            <div className="flex gap-3">
-              <Button type="submit" disabled={createIdentity.isPending || !name}>
-                {createIdentity.isPending ? "Creating..." : "Create Identity"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
-                Cancel
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Agent Identities", href: "/agent-identities" },
+          { label: "New identity" },
+        ]}
+      />
+
+      <PageMasthead
+        icon={<UserRound />}
+        title="New identity"
+        description="Identities give agents a locale, timezone, and connections to run sessions as."
+        actions={
+          <>
+            <Button type="submit" form="identity-edit-form" disabled={isSaving || !name}>
+              <Check className="size-4" />
+              {isSaving ? "Creating..." : "Create identity"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Discard
+            </Button>
+          </>
+        }
+      />
+
+      <form id="identity-edit-form" onSubmit={handleSubmit}>
+        <PageColumns>
+          <PageMain>
+            <Card>
+              <CardHeader>
+                <CardTitle>Identity Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    value={name}
+                    onChange={(e) => {
+                      setName(e.target.value);
+                      setFieldErrors((prev) => ({ ...prev, name: undefined }));
+                    }}
+                    aria-invalid={!!fieldErrors.name}
+                    required
+                  />
+                  {fieldErrors.name && (
+                    <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    value={description}
+                    onChange={(e) => {
+                      setDescription(e.target.value);
+                      setFieldErrors((prev) => ({ ...prev, description: undefined }));
+                    }}
+                    aria-invalid={!!fieldErrors.description}
+                    placeholder="Describe this identity..."
+                    rows={3}
+                  />
+                  {fieldErrors.description && (
+                    <p className="text-xs text-destructive">{fieldErrors.description}</p>
+                  )}
+                  <p className="text-xs text-muted-foreground">Supports Markdown</p>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>Locale</Label>
+                    <Combobox
+                      options={LOCALE_OPTIONS}
+                      value={locale}
+                      onValueChange={(value) => {
+                        setLocale(value);
+                        setFieldErrors((prev) => ({ ...prev, locale: undefined }));
+                      }}
+                      placeholder="Select locale..."
+                      searchPlaceholder="Search locales..."
+                    />
+                    {fieldErrors.locale && (
+                      <p className="text-xs text-destructive">{fieldErrors.locale}</p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Timezone</Label>
+                    <Combobox
+                      options={TIMEZONE_OPTIONS}
+                      value={timezone}
+                      onValueChange={(value) => {
+                        setTimezone(value);
+                        setFieldErrors((prev) => ({ ...prev, timezone: undefined }));
+                      }}
+                      placeholder="Select timezone..."
+                      searchPlaceholder="Search timezones..."
+                    />
+                    {fieldErrors.timezone && (
+                      <p className="text-xs text-destructive">{fieldErrors.timezone}</p>
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </PageMain>
+
+          <PageRail>
+            <Card className="border-dashed">
+              <CardContent className="pt-6">
+                <p className="text-sm text-muted-foreground">
+                  An identity bundles a locale, timezone, and connections. After creating it, assign
+                  connections so agents can run sessions as this identity.
+                </p>
+              </CardContent>
+            </Card>
+          </PageRail>
+        </PageColumns>
+      </form>
+
+      <PageFooter>
+        <BackLink href="/agent-identities">Back to Agent Identities</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/agent-identities/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/page.tsx
@@ -1,97 +1,281 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Plus, UserRound } from "lucide-react";
-import { ArchiveFilter } from "@/components/archive-filter";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
+import { SearchInput } from "@/components/ui/search-input";
 import { Badge } from "@/components/ui/badge";
 import { CopyButton } from "@/components/ui/copy-button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useAgentIdentities } from "@/hooks/use-agent-identities";
 import { usePageTitle } from "@/hooks";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  IconTile,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
+import {
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+  isArchivedStatus,
+} from "@/lib/entity-lifecycle";
+import { pluralize } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
+import type { AgentIdentity } from "@/lib/api/types";
+
+type StatusTab = "all" | "active" | "archived";
 
 export default function AgentIdentitiesPage() {
   usePageTitle("Agent Identities");
-  const [showArchived, setShowArchived] = useState(false);
-  const {
-    data: identities,
-    isLoading,
-    error,
-  } = useAgentIdentities({ includeArchived: showArchived });
+  // Fetch the full set (including archived) so the facet rail can show accurate counts.
+  const { data: identities, isLoading, error } = useAgentIdentities({ includeArchived: true });
 
-  if (error) {
-    return (
-      <div className="container mx-auto p-6 text-red-500">
-        Error loading identities: {error.message}
-      </div>
-    );
-  }
+  const [search, setSearch] = useState("");
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
+
+  const counts = useMemo(() => {
+    const list = identities ?? [];
+    const archived = list.filter((i) => isArchivedStatus(i.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [identities]);
+
+  const localeFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const identity of identities ?? []) {
+      if (identity.locale) tally.set(identity.locale, (tally.get(identity.locale) ?? 0) + 1);
+    }
+    return [...tally.entries()]
+      .map(([locale, count]) => ({ locale, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 8);
+  }, [identities]);
+
+  const timezoneFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const identity of identities ?? []) {
+      if (identity.timezone) tally.set(identity.timezone, (tally.get(identity.timezone) ?? 0) + 1);
+    }
+    return [...tally.entries()]
+      .map(([timezone, count]) => ({ timezone, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 8);
+  }, [identities]);
+
+  const filteredIdentities = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (identities ?? []).filter((identity: AgentIdentity) => {
+      if (statusTab === "active" && isArchivedStatus(identity.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(identity.status)) return false;
+      if (!query) return true;
+      const haystack = [identity.name, identity.description, identity.locale, identity.timezone]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [identities, search, statusTab]);
+
+  const statusItems = [
+    { value: "all" as const, label: "All" },
+    { value: "active" as const, label: "Active" },
+    { value: "archived" as const, label: "Archived" },
+  ];
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Agent Identities</h1>
-        <div className="flex items-center gap-2">
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Agent Identities" }]} />
+
+      <PageMasthead
+        icon={<UserRound />}
+        title="Agent Identities"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
+        }
+        description="Identities give agents a locale, timezone, and connections to run sessions as."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
           <Link href="/agent-identities/new">
             <Button variant="accent">
-              <Plus className="mr-2 h-4 w-4" />
-              New Identity
+              <Plus className="size-4" />
+              New identity
             </Button>
           </Link>
-        </div>
-      </div>
+        }
+      />
 
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(3)].map((_, i) => (
-            <Card key={i}>
-              <CardHeader>
-                <Skeleton className="h-6 w-1/2" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full" />
-              </CardContent>
-            </Card>
-          ))}
+      {error && (
+        <div className="border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          Error loading identities: {error.message}
         </div>
-      ) : identities && identities.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {identities.map((identity) => (
-            <Link key={identity.id} href={`/agent-identities/${identity.id}`}>
-              <Card className="cursor-pointer hover:border-accent/50 transition-colors">
-                <CardHeader>
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2">
-                      <UserRound className="h-5 w-5 text-muted-foreground" />
-                      <h3
-                        className={`text-lg font-semibold ${getEntityNameClassName(identity.status)}`}
-                      >
-                        {identity.name}
-                      </h3>
-                      <CopyButton value={identity.id} />
+      )}
+
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search identities…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          containerClassName="w-64"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          {isLoading ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              {[...Array(4)].map((_, i) => (
+                <div key={i} className="border bg-card p-4">
+                  <Skeleton className="mb-3 h-6 w-1/2" />
+                  <Skeleton className="h-4 w-full" />
+                </div>
+              ))}
+            </div>
+          ) : filteredIdentities.length === 0 ? (
+            <div className="border border-dashed py-12 text-center">
+              <p className="mb-4 text-muted-foreground">
+                {search || statusTab !== "active"
+                  ? "No identities match your filters."
+                  : "No agent identities yet."}
+              </p>
+              {!search && statusTab === "active" && (
+                <Link href="/agent-identities/new">
+                  <Button>
+                    <Plus className="size-4" />
+                    Create your first identity
+                  </Button>
+                </Link>
+              )}
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {filteredIdentities.map((identity) => (
+                <Link
+                  key={identity.id}
+                  href={`/agent-identities/${identity.id}`}
+                  className="group flex flex-col gap-3 border bg-card p-4 transition-colors hover:border-accent/50"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <IconTile size="md" icon={<UserRound />} />
+                      <div className="min-w-0">
+                        <h3
+                          className={cn(
+                            "truncate text-base font-semibold",
+                            getEntityNameClassName(identity.status),
+                          )}
+                        >
+                          {identity.name}
+                        </h3>
+                        <div className="mt-0.5 flex items-center gap-1.5">
+                          <span className="font-mono text-xs text-muted-foreground">
+                            {identity.id}
+                          </span>
+                          <CopyButton value={identity.id} />
+                        </div>
+                      </div>
                     </div>
                     <Badge variant={getEntityStatusBadgeVariant(identity.status)}>
                       {identity.status}
                     </Badge>
                   </div>
-                </CardHeader>
-                <CardContent className="space-y-2 text-sm text-muted-foreground">
-                  {identity.description && <p>{identity.description}</p>}
-                  <p>
+                  {identity.description && (
+                    <p className="line-clamp-2 text-sm text-muted-foreground">
+                      {identity.description}
+                    </p>
+                  )}
+                  <p className="text-[13px] text-muted-foreground">
                     {identity.locale || "No locale"} · {identity.timezone || "No timezone"}
                   </p>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
-        </div>
-      ) : (
-        <div className="py-12 text-center text-muted-foreground">No agent identities yet.</div>
-      )}
-    </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {localeFacets.length > 0 && (
+            <RailSection label="Locale">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {localeFacets.map((facet) => (
+                  <div key={facet.locale} className="flex items-center justify-between">
+                    <span>{facet.locale}</span>
+                    <span>{facet.count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+
+          {timezoneFacets.length > 0 && (
+            <RailSection label="Timezone">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {timezoneFacets.map((facet) => (
+                  <div key={facet.timezone} className="flex items-center justify-between">
+                    <span className="truncate">{facet.timezone}</span>
+                    <span>{facet.count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredIdentities.length} of {counts.all}{" "}
+          {pluralize(counts.all, "identity", "identities")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
+        )}
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/apps/[appId]/channels/[channelId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/channels/[channelId]/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { use, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Play, Trash2 } from "lucide-react";
+import { Check, Pencil, Play, Radio, Trash2 } from "lucide-react";
 import { useApp } from "@/hooks/use-apps";
 import { usePolicies } from "@/hooks/use-policies";
 import { deleteChannel, triggerChannel, updateChannel } from "@/lib/api/apps";
@@ -12,7 +11,6 @@ import { queryKeys } from "@/lib/query-keys";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { CronLabel } from "@/components/apps/cron-label";
 import { MiniTimeline } from "@/components/apps/mini-timeline";
@@ -23,6 +21,19 @@ import {
   isChannelFormValid,
   type ChannelFormState,
 } from "@/components/apps/channel-form";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+  type SectionTabItem,
+} from "@/components/layout";
 import type { ScheduleChannelConfig } from "@/lib/api/types";
 import { getChannelTypeDisplayName } from "@/lib/app-channels";
 import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
@@ -142,166 +153,178 @@ export default function EditChannelPage({
     );
   }
 
-  return (
-    <div className="min-h-[calc(100vh-3rem)]">
-      <div className="border-b bg-background">
-        <div className="container mx-auto px-6 py-4">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link href="/apps" className="hover:text-foreground">
-              Apps
-            </Link>
-            <span>/</span>
-            <Link href={`/apps/${app.id}`} className="hover:text-foreground">
-              {app.name}
-            </Link>
-            <span>/</span>
-            <span>{channelTitle(formState)}</span>
-          </div>
-          <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-            <div className="flex items-start gap-4">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={() => router.push(`/apps/${app.id}`)}
-              >
-                <ArrowLeft className="size-4" />
-              </Button>
-              <div>
-                <div className="flex items-center gap-2">
-                  <h1 className="text-2xl font-semibold">{channelTitle(formState)}</h1>
-                  <Badge variant={formState.enabled ? "default" : "secondary"}>
-                    {formState.enabled ? "active" : "paused"}
-                  </Badge>
-                </div>
-                <p className="mt-1 text-muted-foreground">{subline}</p>
-              </div>
-            </div>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => toggleChannel.mutate(!formState.enabled)}
-                disabled={!canManage || toggleChannel.isPending}
-              >
-                {formState.enabled ? "Pause" : "Enable"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => runNow.mutate()}
-                disabled={!canRunNow || runNow.isPending}
-              >
-                <Play className="size-4" />
-                Run now
-              </Button>
-            </div>
-          </div>
-        </div>
-      </div>
+  const tabItems: SectionTabItem[] = [
+    ...(formState.kind === "schedule" ? [{ value: "schedule", label: "Schedule" }] : []),
+    { value: "invocation", label: "Invocation" },
+    { value: "session", label: "Session" },
+    { value: "runs", label: "Runs" },
+  ];
 
-      <div className="container mx-auto grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <Card>
-          <CardContent className="py-4">
-            <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList>
-                {formState.kind === "schedule" && (
-                  <TabsTrigger value="schedule">Schedule</TabsTrigger>
-                )}
-                <TabsTrigger value="invocation">Invocation</TabsTrigger>
-                <TabsTrigger value="session">Session</TabsTrigger>
-                <TabsTrigger value="runs">Runs</TabsTrigger>
-              </TabsList>
-              {formState.kind === "schedule" && (
-                <TabsContent value="schedule" className="mt-6">
+  return (
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Apps", href: "/apps" },
+          { label: app.name, href: `/apps/${app.id}` },
+          { label: channelTitle(formState) },
+        ]}
+      />
+
+      <PageMasthead
+        icon={<Radio />}
+        title={channelTitle(formState)}
+        badges={
+          <>
+            <Badge variant="accent">
+              <Pencil className="size-3" />
+              Editing
+            </Badge>
+            <Badge variant={formState.enabled ? "default" : "secondary"}>
+              {formState.enabled ? "active" : "paused"}
+            </Badge>
+          </>
+        }
+        description={subline}
+        actions={
+          <>
+            <Button
+              type="submit"
+              form="channel-edit-form"
+              disabled={!canManage || !isChannelFormValid(formState) || saveChannel.isPending}
+            >
+              <Check className="size-4" />
+              {saveChannel.isPending ? "Saving..." : "Save"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => toggleChannel.mutate(!formState.enabled)}
+              disabled={!canManage || toggleChannel.isPending}
+            >
+              {formState.enabled ? "Pause" : "Enable"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => runNow.mutate()}
+              disabled={!canRunNow || runNow.isPending}
+            >
+              <Play className="size-4" />
+              Run now
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.push(`/apps/${app.id}`)}>
+              Discard
+            </Button>
+          </>
+        }
+      />
+
+      <PageControlStrip>
+        <SectionTabs value={activeTab} onValueChange={setActiveTab} items={tabItems} />
+      </PageControlStrip>
+
+      <form
+        id="channel-edit-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          saveChannel.mutate();
+        }}
+      >
+        <PageColumns>
+          <PageMain>
+            <Card>
+              <CardContent className="py-4">
+                {activeTab === "schedule" && formState.kind === "schedule" && (
                   <ChannelForm
                     state={formState}
                     onChange={setFormState}
                     mode="edit"
                     section="schedule"
                   />
-                </TabsContent>
-              )}
-              <TabsContent value="invocation" className="mt-6">
-                <ChannelForm
-                  state={formState}
-                  onChange={setFormState}
-                  mode="edit"
-                  section="invocation"
-                />
-              </TabsContent>
-              <TabsContent value="session" className="mt-6">
-                <ChannelForm
-                  state={formState}
-                  onChange={setFormState}
-                  mode="edit"
-                  section="session"
-                />
-              </TabsContent>
-              <TabsContent value="runs" className="mt-6">
-                <ChannelForm state={formState} onChange={setFormState} mode="edit" section="runs" />
-              </TabsContent>
-            </Tabs>
-          </CardContent>
-        </Card>
+                )}
+                {activeTab === "invocation" && (
+                  <ChannelForm
+                    state={formState}
+                    onChange={setFormState}
+                    mode="edit"
+                    section="invocation"
+                  />
+                )}
+                {activeTab === "session" && (
+                  <ChannelForm
+                    state={formState}
+                    onChange={setFormState}
+                    mode="edit"
+                    section="session"
+                  />
+                )}
+                {activeTab === "runs" && (
+                  <ChannelForm
+                    state={formState}
+                    onChange={setFormState}
+                    mode="edit"
+                    section="runs"
+                  />
+                )}
+              </CardContent>
+            </Card>
+          </PageMain>
 
-        <Card className="h-fit">
-          <CardHeader>
-            <CardTitle>24h stats</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <div className="border p-3">
-                <p className="text-xs uppercase text-muted-foreground">Runs</p>
-                <p className="mt-1 text-xl font-semibold">0</p>
-              </div>
-              <div className="border p-3">
-                <p className="text-xs uppercase text-muted-foreground">Errors</p>
-                <p className="mt-1 text-xl font-semibold">0</p>
-              </div>
-              <div className="border p-3">
-                <p className="text-xs uppercase text-muted-foreground">p95</p>
-                <p className="mt-1 text-xl font-semibold">--</p>
-              </div>
-              <div className="border p-3">
-                <p className="text-xs uppercase text-muted-foreground">Success</p>
-                <p className="mt-1 text-xl font-semibold">--</p>
-              </div>
-            </div>
-            <MiniTimeline />
-            <div className="text-sm text-muted-foreground">
-              <p>Created {new Date(channel.created_at).toLocaleString()}</p>
-              <p>Updated {new Date(channel.updated_at).toLocaleString()}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+          <PageRail>
+            <Card className="h-fit">
+              <CardHeader>
+                <CardTitle>24h stats</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-3 text-sm">
+                  <div className="border p-3">
+                    <p className="text-xs uppercase text-muted-foreground">Runs</p>
+                    <p className="mt-1 text-xl font-semibold">0</p>
+                  </div>
+                  <div className="border p-3">
+                    <p className="text-xs uppercase text-muted-foreground">Errors</p>
+                    <p className="mt-1 text-xl font-semibold">0</p>
+                  </div>
+                  <div className="border p-3">
+                    <p className="text-xs uppercase text-muted-foreground">p95</p>
+                    <p className="mt-1 text-xl font-semibold">--</p>
+                  </div>
+                  <div className="border p-3">
+                    <p className="text-xs uppercase text-muted-foreground">Success</p>
+                    <p className="mt-1 text-xl font-semibold">--</p>
+                  </div>
+                </div>
+                <MiniTimeline />
+                <div className="text-sm text-muted-foreground">
+                  <p>Created {new Date(channel.created_at).toLocaleString()}</p>
+                  <p>Updated {new Date(channel.updated_at).toLocaleString()}</p>
+                </div>
+              </CardContent>
+            </Card>
 
-      <div className="sticky bottom-0 border-t bg-background/95 px-6 py-3 backdrop-blur">
-        <div className="container mx-auto flex items-center justify-between gap-2">
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={() => removeChannel.mutate()}
-            disabled={!canManage || removeChannel.isPending}
-          >
-            <Trash2 className="size-4" />
-            Delete
-          </Button>
-          <div className="flex gap-2">
-            <Button type="button" variant="outline" onClick={() => router.push(`/apps/${app.id}`)}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              disabled={!canManage || !isChannelFormValid(formState) || saveChannel.isPending}
-              onClick={() => saveChannel.mutate()}
-            >
-              {saveChannel.isPending ? "Saving..." : "Save"}
-            </Button>
-          </div>
-        </div>
-      </div>
-    </div>
+            <Card className="h-fit border-destructive/50">
+              <CardHeader>
+                <CardTitle className="text-destructive">Danger zone</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => removeChannel.mutate()}
+                  disabled={!canManage || removeChannel.isPending}
+                >
+                  <Trash2 className="size-4" />
+                  Delete channel
+                </Button>
+              </CardContent>
+            </Card>
+          </PageRail>
+        </PageColumns>
+      </form>
+
+      <PageFooter>
+        <BackLink href={`/apps/${app.id}`}>Back to {app.name}</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/apps/[appId]/channels/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/channels/new/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft } from "lucide-react";
+import { Check, Radio } from "lucide-react";
 import { useApp } from "@/hooks/use-apps";
 import { usePolicies } from "@/hooks/use-policies";
 import { addChannel } from "@/lib/api/apps";
@@ -21,6 +20,16 @@ import {
   getDefaultChannelFormState,
   isChannelFormValid,
 } from "@/components/apps/channel-form";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
 export default function NewChannelPage({ params }: { params: Promise<{ appId: string }> }) {
@@ -67,85 +76,79 @@ export default function NewChannelPage({ params }: { params: Promise<{ appId: st
   }
 
   return (
-    <div className="min-h-[calc(100vh-3rem)]">
-      <div className="border-b bg-background">
-        <div className="container mx-auto px-6 py-4">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link href="/apps" className="hover:text-foreground">
-              Apps
-            </Link>
-            <span>/</span>
-            <Link href={`/apps/${app.id}`} className="hover:text-foreground">
-              {app.name}
-            </Link>
-            <span>/</span>
-            <span>Add channel</span>
-          </div>
-          <div className="mt-4 flex items-start gap-4">
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Apps", href: "/apps" },
+          { label: app.name, href: `/apps/${app.id}` },
+          { label: "New channel" },
+        ]}
+      />
+
+      <PageMasthead
+        icon={<Radio />}
+        title="New channel"
+        badges={<Badge variant="outline">{app.status}</Badge>}
+        description="Invoke this app on a schedule, via webhook, through AG-UI, or from Slack."
+        actions={
+          <>
             <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => router.push(`/apps/${app.id}`)}
+              type="submit"
+              form="channel-edit-form"
+              disabled={!canManage || !isChannelFormValid(formState) || createChannel.isPending}
             >
-              <ArrowLeft className="size-4" />
+              <Check className="size-4" />
+              {createChannel.isPending ? "Saving..." : "Save channel"}
             </Button>
-            <div>
-              <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-semibold">Add channel</h1>
-                <Badge variant="outline">{app.status}</Badge>
-              </div>
-              <p className="mt-1 text-muted-foreground">
-                Invoke this app on a schedule, via webhook, through AG-UI, or from Slack.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+            <Button type="button" variant="outline" onClick={() => router.push(`/apps/${app.id}`)}>
+              Discard
+            </Button>
+          </>
+        }
+      />
 
-      <div className="container mx-auto grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>1. Channel type</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ChannelTypePicker
-                value={formState.kind}
-                onChange={(kind) => setFormState(getDefaultChannelFormState(kind))}
-              />
-            </CardContent>
-          </Card>
+      <form
+        id="channel-edit-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          createChannel.mutate();
+        }}
+      >
+        <PageColumns>
+          <PageMain>
+            <Card>
+              <CardHeader>
+                <CardTitle>1. Channel type</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ChannelTypePicker
+                  value={formState.kind}
+                  onChange={(kind) => setFormState(getDefaultChannelFormState(kind))}
+                />
+              </CardContent>
+            </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>
-                2. Configure {formState.kind === "ag_ui" ? "AG-UI" : formState.kind}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ChannelForm state={formState} onChange={setFormState} mode="new" />
-            </CardContent>
-          </Card>
-        </div>
+            <Card>
+              <CardHeader>
+                <CardTitle>
+                  2. Configure {formState.kind === "ag_ui" ? "AG-UI" : formState.kind}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ChannelForm state={formState} onChange={setFormState} mode="new" />
+              </CardContent>
+            </Card>
+          </PageMain>
 
-        <ChannelFormSummary app={app} state={formState} />
-      </div>
+          <PageRail>
+            <ChannelFormSummary app={app} state={formState} />
+          </PageRail>
+        </PageColumns>
+      </form>
 
-      <div className="sticky bottom-0 border-t bg-background/95 px-6 py-3 backdrop-blur">
-        <div className="container mx-auto flex justify-end gap-2">
-          <Button type="button" variant="outline" onClick={() => router.push(`/apps/${app.id}`)}>
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={!canManage || !isChannelFormValid(formState) || createChannel.isPending}
-            onClick={() => createChannel.mutate()}
-          >
-            {createChannel.isPending ? "Saving..." : "Save channel"}
-          </Button>
-        </div>
-      </div>
-    </div>
+      <PageFooter>
+        <BackLink href={`/apps/${app.id}`}>Back to {app.name}</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -19,8 +19,19 @@ import {
 import { AgentSelect } from "@/components/agent/agent-select";
 import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import { HarnessSelect } from "@/components/harness/harness-select";
-import Link from "next/link";
-import { ArrowLeft, RefreshCw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
+import { Check, Plus, RefreshCw } from "lucide-react";
 import type {
   AgUiToolVisibility,
   ChannelType,
@@ -153,378 +164,430 @@ export default function NewAppPage() {
   };
 
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/apps"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Apps
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Apps", href: "/apps" }, { label: "New app" }]} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Create New App</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Support Bot"
-                required
-              />
-            </div>
+      <PageMasthead
+        icon={<Plus />}
+        title="New app"
+        badges={<Badge variant="accent">Draft</Badge>}
+        description="Deploy an agent to a channel — Slack, AG-UI, webhook, or schedule."
+        actions={
+          <>
+            <Button
+              type="submit"
+              form="app-edit-form"
+              disabled={createApp.isPending || !name || !harnessId || !isChannelConfigValid}
+            >
+              <Check className="size-4" />
+              {createApp.isPending ? "Creating..." : "Create App"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Discard
+            </Button>
+          </>
+        }
+      />
 
-            <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
-              <Input
-                id="description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Customer support bot for #help channel"
-              />
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="harness">Harness</Label>
-                <HarnessSelect value={harnessId} onValueChange={setHarnessId} />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="agent">Agent (optional)</Label>
-                <AgentSelect
-                  value={agentId}
-                  onValueChange={setAgentId}
-                  includeNoneOption
-                  noneLabel="Choose later"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="agent_identity">Agent identity</Label>
-                <AgentIdentitySelect value={agentIdentityId} onValueChange={setAgentIdentityId} />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="channel_type">Channel (optional)</Label>
-              <Select value={channelType || "__none__"} onValueChange={handleChannelTypeChange}>
-                <SelectTrigger id="channel_type">
-                  <SelectValue placeholder="Choose later" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">Choose later</SelectItem>
-                  <SelectItem value="slack">{getChannelTypeDisplayName("slack")}</SelectItem>
-                  <SelectItem value="ag_ui">{getChannelTypeDisplayName("ag_ui")}</SelectItem>
-                  <SelectItem value="schedule">{getChannelTypeDisplayName("schedule")}</SelectItem>
-                  <SelectItem value="webhook">{getChannelTypeDisplayName("webhook")}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {channelType === "slack" && (
-              <div className="space-y-4 rounded-md border p-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="slack_signing_secret">Signing Secret</Label>
-                    <Input
-                      id="slack_signing_secret"
-                      type="password"
-                      value={slackSigningSecret}
-                      onChange={(e) => setSlackSigningSecret(e.target.value)}
-                      placeholder="Slack signing secret"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="slack_bot_token">Bot Token</Label>
-                    <Input
-                      id="slack_bot_token"
-                      type="password"
-                      value={slackBotToken}
-                      onChange={(e) => setSlackBotToken(e.target.value)}
-                      placeholder="xoxb-..."
-                    />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="slack_team_id">Workspace ID (optional)</Label>
-                    <Input
-                      id="slack_team_id"
-                      value={slackTeamId}
-                      onChange={(e) => setSlackTeamId(e.target.value)}
-                      placeholder="T0123456789"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="slack_channel_id">Channel ID (optional)</Label>
-                    <Input
-                      id="slack_channel_id"
-                      value={slackChannelId}
-                      onChange={(e) => setSlackChannelId(e.target.value)}
-                      placeholder="C0123456789"
-                    />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="slack_session_strategy">Session Strategy</Label>
-                    <Select
-                      value={slackSessionStrategy}
-                      onValueChange={(value) => setSlackSessionStrategy(value as SessionStrategy)}
-                    >
-                      <SelectTrigger id="slack_session_strategy">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="per_thread">
-                          {getSessionStrategyDisplayName("per_thread")}
-                        </SelectItem>
-                        <SelectItem value="per_channel">
-                          {getSessionStrategyDisplayName("per_channel")}
-                        </SelectItem>
-                        <SelectItem value="per_user">
-                          {getSessionStrategyDisplayName("per_user")}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="slack_reply_mode">Reply Mode</Label>
-                    <Select
-                      value={slackReplyMode}
-                      onValueChange={(value) => setSlackReplyMode(value as SlackReplyMode)}
-                    >
-                      <SelectTrigger id="slack_reply_mode">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all_messages">
-                          {getSlackReplyModeDisplayName("all_messages")}
-                        </SelectItem>
-                        <SelectItem value="report_progress_only">
-                          {getSlackReplyModeDisplayName("report_progress_only")}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {channelType === "ag_ui" && (
-              <div className="space-y-4 rounded-md border p-4">
+      <form id="app-edit-form" onSubmit={handleSubmit}>
+        <PageColumns>
+          <PageMain>
+            <Card>
+              <CardHeader>
+                <CardTitle>App details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
                 <div className="space-y-2">
-                  <Label htmlFor="ag_ui_token">Endpoint Token</Label>
-                  <div className="flex gap-2">
-                    <Input
-                      id="ag_ui_token"
-                      value={agUiToken}
-                      onChange={(e) => setAgUiToken(e.target.value)}
-                      className="font-mono"
-                      placeholder="Generated bearer token"
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setAgUiToken(generateChannelToken())}
-                      aria-label="Regenerate AG-UI token"
-                    >
-                      <RefreshCw className="h-4 w-4" />
-                    </Button>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    AG-UI clients must send this as `Authorization: Bearer &lt;token&gt;` or
-                    `X-Everruns-AG-UI-Token`.
-                  </p>
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Support Bot"
+                    required
+                  />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="ag_ui_tool_visibility">Tool Activity</Label>
-                  <Select
-                    value={agUiToolVisibility}
-                    onValueChange={(value) => setAgUiToolVisibility(value as AgUiToolVisibility)}
-                  >
-                    <SelectTrigger id="ag_ui_tool_visibility">
-                      <SelectValue />
+                  <Label htmlFor="description">Description</Label>
+                  <Input
+                    id="description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Customer support bot for #help channel"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="harness">Harness</Label>
+                    <HarnessSelect value={harnessId} onValueChange={setHarnessId} />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="agent">Agent (optional)</Label>
+                    <AgentSelect
+                      value={agentId}
+                      onValueChange={setAgentId}
+                      includeNoneOption
+                      noneLabel="Choose later"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="agent_identity">Agent identity</Label>
+                    <AgentIdentitySelect
+                      value={agentIdentityId}
+                      onValueChange={setAgentIdentityId}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="channel_type">Channel (optional)</Label>
+                  <Select value={channelType || "__none__"} onValueChange={handleChannelTypeChange}>
+                    <SelectTrigger id="channel_type">
+                      <SelectValue placeholder="Choose later" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="none">
-                        {getAgUiToolVisibilityDisplayName("none")}
+                      <SelectItem value="__none__">Choose later</SelectItem>
+                      <SelectItem value="slack">{getChannelTypeDisplayName("slack")}</SelectItem>
+                      <SelectItem value="ag_ui">{getChannelTypeDisplayName("ag_ui")}</SelectItem>
+                      <SelectItem value="schedule">
+                        {getChannelTypeDisplayName("schedule")}
                       </SelectItem>
-                      <SelectItem value="generic">
-                        {getAgUiToolVisibilityDisplayName("generic")}
-                      </SelectItem>
-                      <SelectItem value="narrated">
-                        {getAgUiToolVisibilityDisplayName("narrated")}
+                      <SelectItem value="webhook">
+                        {getChannelTypeDisplayName("webhook")}
                       </SelectItem>
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Tool names, arguments, and results are never sent to public AG-UI clients.
-                  </p>
                 </div>
 
-                {agUiToolVisibility === "generic" && (
-                  <div className="space-y-2">
-                    <Label htmlFor="ag_ui_generic_tool_text">Generic Activity Text</Label>
-                    <Input
-                      id="ag_ui_generic_tool_text"
-                      value={agUiGenericToolText}
-                      onChange={(e) => setAgUiGenericToolText(e.target.value)}
-                      maxLength={120}
-                      placeholder={DEFAULT_AG_UI_GENERIC_TOOL_TEXT}
-                    />
+                {channelType === "slack" && (
+                  <div className="space-y-4 rounded-md border p-4">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="slack_signing_secret">Signing Secret</Label>
+                        <Input
+                          id="slack_signing_secret"
+                          type="password"
+                          value={slackSigningSecret}
+                          onChange={(e) => setSlackSigningSecret(e.target.value)}
+                          placeholder="Slack signing secret"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="slack_bot_token">Bot Token</Label>
+                        <Input
+                          id="slack_bot_token"
+                          type="password"
+                          value={slackBotToken}
+                          onChange={(e) => setSlackBotToken(e.target.value)}
+                          placeholder="xoxb-..."
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="slack_team_id">Workspace ID (optional)</Label>
+                        <Input
+                          id="slack_team_id"
+                          value={slackTeamId}
+                          onChange={(e) => setSlackTeamId(e.target.value)}
+                          placeholder="T0123456789"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="slack_channel_id">Channel ID (optional)</Label>
+                        <Input
+                          id="slack_channel_id"
+                          value={slackChannelId}
+                          onChange={(e) => setSlackChannelId(e.target.value)}
+                          placeholder="C0123456789"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="slack_session_strategy">Session Strategy</Label>
+                        <Select
+                          value={slackSessionStrategy}
+                          onValueChange={(value) =>
+                            setSlackSessionStrategy(value as SessionStrategy)
+                          }
+                        >
+                          <SelectTrigger id="slack_session_strategy">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="per_thread">
+                              {getSessionStrategyDisplayName("per_thread")}
+                            </SelectItem>
+                            <SelectItem value="per_channel">
+                              {getSessionStrategyDisplayName("per_channel")}
+                            </SelectItem>
+                            <SelectItem value="per_user">
+                              {getSessionStrategyDisplayName("per_user")}
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="slack_reply_mode">Reply Mode</Label>
+                        <Select
+                          value={slackReplyMode}
+                          onValueChange={(value) => setSlackReplyMode(value as SlackReplyMode)}
+                        >
+                          <SelectTrigger id="slack_reply_mode">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all_messages">
+                              {getSlackReplyModeDisplayName("all_messages")}
+                            </SelectItem>
+                            <SelectItem value="report_progress_only">
+                              {getSlackReplyModeDisplayName("report_progress_only")}
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
                   </div>
                 )}
-              </div>
-            )}
 
-            {channelType === "schedule" && (
-              <div className="space-y-4 rounded-md border p-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="schedule_cron_expression">Cron Expression</Label>
-                    <Input
-                      id="schedule_cron_expression"
-                      value={scheduleCronExpression}
-                      onChange={(e) => setScheduleCronExpression(e.target.value)}
-                      placeholder="0 */5 * * * * *"
-                    />
-                    {scheduleCronExpression &&
-                      isSupportedCronExpression(scheduleCronExpression) &&
-                      (getCronIntervalSeconds(scheduleCronExpression) ?? 0) <
-                        CRON_MIN_INTERVAL_SECONDS && (
-                        <p className="text-xs text-destructive">
-                          Minimum interval is {Math.floor(CRON_MIN_INTERVAL_SECONDS / 60)} minutes.
-                        </p>
-                      )}
+                {channelType === "ag_ui" && (
+                  <div className="space-y-4 rounded-md border p-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="ag_ui_token">Endpoint Token</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="ag_ui_token"
+                          value={agUiToken}
+                          onChange={(e) => setAgUiToken(e.target.value)}
+                          className="font-mono"
+                          placeholder="Generated bearer token"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setAgUiToken(generateChannelToken())}
+                          aria-label="Regenerate AG-UI token"
+                        >
+                          <RefreshCw className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        AG-UI clients must send this as `Authorization: Bearer &lt;token&gt;` or
+                        `X-Everruns-AG-UI-Token`.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="ag_ui_tool_visibility">Tool Activity</Label>
+                      <Select
+                        value={agUiToolVisibility}
+                        onValueChange={(value) =>
+                          setAgUiToolVisibility(value as AgUiToolVisibility)
+                        }
+                      >
+                        <SelectTrigger id="ag_ui_tool_visibility">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">
+                            {getAgUiToolVisibilityDisplayName("none")}
+                          </SelectItem>
+                          <SelectItem value="generic">
+                            {getAgUiToolVisibilityDisplayName("generic")}
+                          </SelectItem>
+                          <SelectItem value="narrated">
+                            {getAgUiToolVisibilityDisplayName("narrated")}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <p className="text-xs text-muted-foreground">
+                        Tool names, arguments, and results are never sent to public AG-UI clients.
+                      </p>
+                    </div>
+
+                    {agUiToolVisibility === "generic" && (
+                      <div className="space-y-2">
+                        <Label htmlFor="ag_ui_generic_tool_text">Generic Activity Text</Label>
+                        <Input
+                          id="ag_ui_generic_tool_text"
+                          value={agUiGenericToolText}
+                          onChange={(e) => setAgUiGenericToolText(e.target.value)}
+                          maxLength={120}
+                          placeholder={DEFAULT_AG_UI_GENERIC_TOOL_TEXT}
+                        />
+                      </div>
+                    )}
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="schedule_timezone">Timezone</Label>
-                    <Input
-                      id="schedule_timezone"
-                      value={scheduleTimezone}
-                      onChange={(e) => setScheduleTimezone(e.target.value)}
-                      placeholder="UTC"
-                    />
+                )}
+
+                {channelType === "schedule" && (
+                  <div className="space-y-4 rounded-md border p-4">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="schedule_cron_expression">Cron Expression</Label>
+                        <Input
+                          id="schedule_cron_expression"
+                          value={scheduleCronExpression}
+                          onChange={(e) => setScheduleCronExpression(e.target.value)}
+                          placeholder="0 */5 * * * * *"
+                        />
+                        {scheduleCronExpression &&
+                          isSupportedCronExpression(scheduleCronExpression) &&
+                          (getCronIntervalSeconds(scheduleCronExpression) ?? 0) <
+                            CRON_MIN_INTERVAL_SECONDS && (
+                            <p className="text-xs text-destructive">
+                              Minimum interval is {Math.floor(CRON_MIN_INTERVAL_SECONDS / 60)}{" "}
+                              minutes.
+                            </p>
+                          )}
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="schedule_timezone">Timezone</Label>
+                        <Input
+                          id="schedule_timezone"
+                          value={scheduleTimezone}
+                          onChange={(e) => setScheduleTimezone(e.target.value)}
+                          placeholder="UTC"
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="schedule_session_mode">Invocation Session Mode</Label>
+                      <Select
+                        value={invocationSessionMode}
+                        onValueChange={(value) =>
+                          setInvocationSessionMode(value as InvocationSessionMode)
+                        }
+                      >
+                        <SelectTrigger id="schedule_session_mode">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="shared_session">
+                            {getInvocationSessionModeDisplayName("shared_session")}
+                          </SelectItem>
+                          <SelectItem value="session_per_invocation">
+                            {getInvocationSessionModeDisplayName("session_per_invocation")}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="schedule_message">Invocation Message</Label>
+                      <Textarea
+                        id="schedule_message"
+                        value={channelMessage}
+                        onChange={(e) => setChannelMessage(e.target.value)}
+                        placeholder="Run repository checks for {{app.name}}"
+                      />
+                    </div>
                   </div>
+                )}
+
+                {channelType === "webhook" && (
+                  <div className="space-y-4 rounded-md border p-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="webhook_token">Webhook Token</Label>
+                      <Input
+                        id="webhook_token"
+                        type="password"
+                        value={webhookToken}
+                        onChange={(e) => setWebhookToken(e.target.value)}
+                        placeholder="shared-secret"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="webhook_session_mode">Invocation Session Mode</Label>
+                      <Select
+                        value={invocationSessionMode}
+                        onValueChange={(value) =>
+                          setInvocationSessionMode(value as InvocationSessionMode)
+                        }
+                      >
+                        <SelectTrigger id="webhook_session_mode">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="shared_session">
+                            {getInvocationSessionModeDisplayName("shared_session")}
+                          </SelectItem>
+                          <SelectItem value="session_per_invocation">
+                            {getInvocationSessionModeDisplayName("session_per_invocation")}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="webhook_message">Invocation Message</Label>
+                      <Textarea
+                        id="webhook_message"
+                        value={channelMessage}
+                        onChange={(e) => setChannelMessage(e.target.value)}
+                        placeholder="Process webhook payload for {{payload.repo.name}}"
+                      />
+                    </div>
+                  </div>
+                )}
+
+                <p className="text-sm text-muted-foreground">
+                  {channelType === "slack"
+                    ? "Slack needs credentials up front. You can still refine webhook setup and manifest details on the app detail page."
+                    : channelType === "ag_ui"
+                      ? "After creating the app, publish it and point your AG-UI client at the channel endpoint on the detail page."
+                      : channelType === "schedule"
+                        ? "This creates an app-level scheduled invocation channel. It activates only when the app is published."
+                        : channelType === "webhook"
+                          ? "This creates an authenticated app webhook channel. The detail page will show the endpoint URL to call."
+                          : `Create the draft now, then assign an agent or add ${getChannelTypeDisplayName("slack")}, ${getChannelTypeDisplayName("ag_ui")}, ${getChannelTypeDisplayName("schedule")}, or ${getChannelTypeDisplayName("webhook")} later from the detail page.`}
+                </p>
+
+                {createApp.error && (
+                  <p className="text-sm text-destructive">Error: {createApp.error.message}</p>
+                )}
+              </CardContent>
+            </Card>
+          </PageMain>
+
+          <PageRail>
+            <RailSection label="Summary">
+              <div className="flex flex-col gap-3 text-sm">
+                <div>
+                  <p className="font-medium">Name</p>
+                  <p className="text-muted-foreground">{name || "(not set)"}</p>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="schedule_session_mode">Invocation Session Mode</Label>
-                  <Select
-                    value={invocationSessionMode}
-                    onValueChange={(value) =>
-                      setInvocationSessionMode(value as InvocationSessionMode)
-                    }
-                  >
-                    <SelectTrigger id="schedule_session_mode">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="shared_session">
-                        {getInvocationSessionModeDisplayName("shared_session")}
-                      </SelectItem>
-                      <SelectItem value="session_per_invocation">
-                        {getInvocationSessionModeDisplayName("session_per_invocation")}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
+                <div>
+                  <p className="font-medium">Channel</p>
+                  <p className="text-muted-foreground">
+                    {channelType ? getChannelTypeDisplayName(channelType) : "Choose later"}
+                  </p>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="schedule_message">Invocation Message</Label>
-                  <Textarea
-                    id="schedule_message"
-                    value={channelMessage}
-                    onChange={(e) => setChannelMessage(e.target.value)}
-                    placeholder="Run repository checks for {{app.name}}"
-                  />
+                <div>
+                  <p className="font-medium">Agent</p>
+                  <p className="text-muted-foreground">{agentId ? "Assigned" : "Choose later"}</p>
                 </div>
               </div>
-            )}
+            </RailSection>
 
-            {channelType === "webhook" && (
-              <div className="space-y-4 rounded-md border p-4">
-                <div className="space-y-2">
-                  <Label htmlFor="webhook_token">Webhook Token</Label>
-                  <Input
-                    id="webhook_token"
-                    type="password"
-                    value={webhookToken}
-                    onChange={(e) => setWebhookToken(e.target.value)}
-                    placeholder="shared-secret"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="webhook_session_mode">Invocation Session Mode</Label>
-                  <Select
-                    value={invocationSessionMode}
-                    onValueChange={(value) =>
-                      setInvocationSessionMode(value as InvocationSessionMode)
-                    }
-                  >
-                    <SelectTrigger id="webhook_session_mode">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="shared_session">
-                        {getInvocationSessionModeDisplayName("shared_session")}
-                      </SelectItem>
-                      <SelectItem value="session_per_invocation">
-                        {getInvocationSessionModeDisplayName("session_per_invocation")}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="webhook_message">Invocation Message</Label>
-                  <Textarea
-                    id="webhook_message"
-                    value={channelMessage}
-                    onChange={(e) => setChannelMessage(e.target.value)}
-                    placeholder="Process webhook payload for {{payload.repo.name}}"
-                  />
-                </div>
-              </div>
-            )}
+            <RailSection label="About">
+              <p className="text-sm text-muted-foreground">
+                Apps deploy your agents to channels like Slack and AG-UI. Create the draft first,
+                then refine channel setup on the detail page.
+              </p>
+            </RailSection>
+          </PageRail>
+        </PageColumns>
+      </form>
 
-            <p className="text-sm text-muted-foreground">
-              {channelType === "slack"
-                ? "Slack needs credentials up front. You can still refine webhook setup and manifest details on the app detail page."
-                : channelType === "ag_ui"
-                  ? "After creating the app, publish it and point your AG-UI client at the channel endpoint on the detail page."
-                  : channelType === "schedule"
-                    ? "This creates an app-level scheduled invocation channel. It activates only when the app is published."
-                    : channelType === "webhook"
-                      ? "This creates an authenticated app webhook channel. The detail page will show the endpoint URL to call."
-                      : `Create the draft now, then assign an agent or add ${getChannelTypeDisplayName("slack")}, ${getChannelTypeDisplayName("ag_ui")}, ${getChannelTypeDisplayName("schedule")}, or ${getChannelTypeDisplayName("webhook")} later from the detail page.`}
-            </p>
-
-            <div className="flex gap-4">
-              <Button
-                type="submit"
-                disabled={createApp.isPending || !name || !harnessId || !isChannelConfigValid}
-              >
-                {createApp.isPending ? "Creating..." : "Create App"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
-                Cancel
-              </Button>
-            </div>
-
-            {createApp.error && (
-              <p className="text-sm text-destructive">Error: {createApp.error.message}</p>
-            )}
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+      <PageFooter>
+        <BackLink href="/apps">Back to Apps</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -1,57 +1,212 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useApps, usePublishApp, useUnpublishApp } from "@/hooks/use-apps";
 import { usePageTitle } from "@/hooks";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { SearchInput } from "@/components/ui/search-input";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Plus, Rocket, Globe, GlobeLock, Copy, Clock3 } from "lucide-react";
-import { ArchiveFilter } from "@/components/archive-filter";
-import { CopyButton } from "@/components/ui/copy-button";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+  IconTile,
+} from "@/components/layout";
 import Link from "next/link";
-import type { App, AppChannel, ScheduleChannelConfig } from "@/lib/api/types";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import type { App, AppChannel, ChannelType, ScheduleChannelConfig } from "@/lib/api/types";
+import {
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+  isArchivedStatus,
+} from "@/lib/entity-lifecycle";
 import { getChannelTypeDisplayName } from "@/lib/app-channels";
+import { pluralize } from "@/lib/formatting";
+
+type StatusTab = "all" | "active" | "archived";
 
 export default function AppsPage() {
   usePageTitle("Apps");
-  const [showArchived, setShowArchived] = useState(false);
-  const { data: apps, isLoading, error } = useApps({ includeArchived: showArchived });
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
+  const [search, setSearch] = useState("");
+  // Fetch the full set (including archived) so the facet rail can show accurate counts.
+  const { data: apps, isLoading, error } = useApps({ includeArchived: true });
+
+  const counts = useMemo(() => {
+    const list = apps ?? [];
+    const archived = list.filter((a) => isArchivedStatus(a.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [apps]);
+
+  const channelFacets = useMemo(() => {
+    const tally = new Map<ChannelType, number>();
+    for (const app of apps ?? []) {
+      for (const channel of app.channels) {
+        tally.set(channel.channel_type, (tally.get(channel.channel_type) ?? 0) + 1);
+      }
+    }
+    return [...tally.entries()]
+      .map(([type, count]) => ({ type, count, name: getChannelTypeDisplayName(type) }))
+      .sort((a, b) => b.count - a.count);
+  }, [apps]);
+
+  const filteredApps = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (apps ?? []).filter((app) => {
+      if (statusTab === "active" && isArchivedStatus(app.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(app.status)) return false;
+      if (!query) return true;
+      const haystack = [app.name, app.description].filter(Boolean).join(" ").toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [apps, search, statusTab]);
+
+  const statusItems = [
+    { value: "all" as const, label: "All" },
+    { value: "active" as const, label: "Active" },
+    { value: "archived" as const, label: "Archived" },
+  ];
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold flex items-center gap-3">Apps</h1>
-        <div className="flex items-center gap-2">
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Apps" }]} />
+
+      <PageMasthead
+        icon={<Rocket />}
+        title="Apps"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
+        }
+        description="Deploy agents to channels — Slack, AG-UI, webhooks, and schedules."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
           <Link href="/apps/new">
             <Button variant="accent">
-              <Plus className="w-4 h-4 mr-2" />
-              New App
+              <Plus className="size-4" />
+              New app
             </Button>
           </Link>
-        </div>
-      </div>
+        }
+      />
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={apps}
-        errorMessagePrefix="Failed to load apps"
-        skeletonCount={3}
-        emptyState={<EmptyState />}
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((app) => (
-              <AppCard key={app.id} app={app} />
-            ))}
-          </div>
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search apps…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          containerClassName="w-64"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredApps}
+            errorMessagePrefix="Failed to load apps"
+            skeletonCount={3}
+            emptyState={
+              <div className="border border-dashed py-12 text-center">
+                <p className="mb-4 text-muted-foreground">
+                  {search || statusTab !== "active"
+                    ? "No apps match your filters."
+                    : "Apps deploy your agents to channels like Slack and AG-UI. Create an app to connect an agent to the interface you need, or trigger it from schedules and authenticated webhooks."}
+                </p>
+                {!search && statusTab === "active" && (
+                  <Link href="/apps/new">
+                    <Button variant="accent">
+                      <Plus className="size-4" />
+                      Create your first app
+                    </Button>
+                  </Link>
+                )}
+              </div>
+            }
+          >
+            {(items) => (
+              <div className="grid gap-4 md:grid-cols-2">
+                {items.map((app) => (
+                  <AppCard key={app.id} app={app} />
+                ))}
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={
+                    statusTab === item.value
+                      ? "flex items-center justify-between text-foreground transition-colors hover:text-foreground"
+                      : "flex items-center justify-between text-muted-foreground transition-colors hover:text-foreground"
+                  }
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {channelFacets.length > 0 && (
+            <RailSection label="Channels">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {channelFacets.map((facet) => (
+                  <div key={facet.type} className="flex items-center justify-between">
+                    <span>{facet.name}</span>
+                    <span>{facet.count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredApps.length} of {counts.all} {pluralize(counts.all, "app")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
         )}
-      </QueryStateWrapper>
-    </div>
+      </PageFooter>
+    </PageContainer>
   );
 }
 
@@ -64,107 +219,96 @@ function AppCard({ app }: { app: App }) {
   const primaryAccess = getPrimaryChannelAccess(app.id, primaryChannel);
 
   return (
-    <Link href={`/apps/${app.id}`}>
-      <Card className="cursor-pointer hover:border-accent/50 transition-colors">
-        <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Rocket className="w-5 h-5 text-muted-foreground" />
-              <h3 className={`font-semibold text-lg ${getEntityNameClassName(app.status)}`}>
-                {app.name}
-              </h3>
-              <CopyButton value={app.id} />
-            </div>
-            <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {app.description && <p className="text-sm text-muted-foreground">{app.description}</p>}
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {app.channels.map((channel) => (
-              <Badge key={channel.id} variant="outline" className="text-xs">
-                {getChannelTypeDisplayName(channel.channel_type)}
-              </Badge>
-            ))}
-            {app.channels.length === 0 && <span>No channels</span>}
-          </div>
-
-          {isPublished && primaryAccess && (
-            <div className="flex items-center gap-1 text-xs text-muted-foreground bg-muted p-2 rounded">
-              {primaryAccess.kind === "schedule" ? (
-                <Clock3 className="w-3 h-3 shrink-0" />
-              ) : (
-                <Globe className="w-3 h-3 shrink-0" />
-              )}
-              <span className="truncate font-mono">{primaryAccess.value}</span>
-              {primaryAccess.copyable && (
-                <button
-                  className="shrink-0 ml-1 hover:text-foreground"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    navigator.clipboard.writeText(primaryAccess.value);
-                  }}
+    <EntityCard
+      icon={<IconTile size="md" icon={<Rocket />} />}
+      title={app.name}
+      href={`/apps/${app.id}`}
+      titleClassName={getEntityNameClassName(app.status)}
+      copyValue={app.id}
+      headerActions={<Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>}
+      footer={
+        <EntityCardFooter
+          meta={
+            <>
+              {app.channels.length === 0
+                ? "No channels"
+                : `${app.channels.length} ${pluralize(app.channels.length, "channel")}`}
+            </>
+          }
+          actions={
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions -- group container only suppresses click propagation; nested actions own interactivity
+            <div
+              role="group"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              {isPublished ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => unpublishApp.mutate(app.id)}
+                  disabled={unpublishApp.isPending || isArchived}
                 >
-                  <Copy className="w-3 h-3" />
-                </button>
+                  <GlobeLock className="mr-1 size-3" />
+                  Unpublish
+                </Button>
+              ) : (
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={() => publishApp.mutate(app.id)}
+                  disabled={publishApp.isPending || isArchived}
+                >
+                  <Globe className="mr-1 size-3" />
+                  Publish
+                </Button>
               )}
             </div>
+          }
+        />
+      }
+    >
+      {app.description ? (
+        <p className="mb-3 line-clamp-2 text-sm text-muted-foreground">{app.description}</p>
+      ) : (
+        <p className="mb-3 text-sm italic text-muted-foreground">No description provided</p>
+      )}
+
+      {app.channels.length > 0 && (
+        <div className="mb-3 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+          {app.channels.map((channel) => (
+            <Badge key={channel.id} variant="outline" className="text-xs">
+              {getChannelTypeDisplayName(channel.channel_type)}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {isPublished && primaryAccess && (
+        <div className="mb-3 flex items-center gap-1 rounded bg-muted p-2 text-xs text-muted-foreground">
+          {primaryAccess.kind === "schedule" ? (
+            <Clock3 className="size-3 shrink-0" />
+          ) : (
+            <Globe className="size-3 shrink-0" />
           )}
-
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions -- group container only suppresses click propagation; nested actions own interactivity */}
-          <div
-            className="flex gap-2 pt-2"
-            role="group"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
-            {isPublished ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => unpublishApp.mutate(app.id)}
-                disabled={unpublishApp.isPending || isArchived}
-              >
-                <GlobeLock className="w-3 h-3 mr-1" />
-                Unpublish
-              </Button>
-            ) : (
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() => publishApp.mutate(app.id)}
-                disabled={publishApp.isPending || isArchived}
-              >
-                <Globe className="w-3 h-3 mr-1" />
-                Publish
-              </Button>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-    </Link>
-  );
-}
-
-function EmptyState() {
-  return (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <Rocket className="w-12 h-12 text-muted-foreground mb-4" />
-      <h3 className="text-lg font-semibold mb-2">No Apps Yet</h3>
-      <p className="text-muted-foreground mb-4 max-w-md">
-        Apps deploy your agents to channels like Slack and AG-UI. Create an app to connect an agent
-        to the interface you need, or trigger it from schedules and authenticated webhooks.
-      </p>
-      <Link href="/apps/new">
-        <Button variant="accent">
-          <Plus className="w-4 h-4 mr-2" />
-          Create Your First App
-        </Button>
-      </Link>
-    </div>
+          <span className="truncate font-mono">{primaryAccess.value}</span>
+          {primaryAccess.copyable && (
+            <button
+              className="ml-1 shrink-0 hover:text-foreground"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                navigator.clipboard.writeText(primaryAccess.value);
+              }}
+            >
+              <Copy className="size-3" />
+            </button>
+          )}
+        </div>
+      )}
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -10,7 +10,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import {
-  ArrowLeft,
   CircleOff,
   Wrench,
   FileText,
@@ -30,6 +29,16 @@ import {
 import { useLocale } from "@/providers/locale-provider";
 import { getCapabilityStatusBadgeVariant } from "@/lib/status-utils";
 import { formatCountLabel } from "@/lib/formatting";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 
 const DOCS_BASE_URL = "https://dev.everruns.com/capabilities";
 
@@ -129,55 +138,60 @@ export default function CapabilityDetailPage({
   const toolDefinitions = capability.tool_definitions || [];
 
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/capabilities"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Capabilities
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Capabilities", href: "/capabilities" },
+          { label: localizedCapabilityName(capability, locale) },
+        ]}
+      />
 
-      <div className="flex items-start justify-between mb-6 gap-4 flex-wrap">
-        <div className="flex items-center gap-4 min-w-0">
-          <div className="p-3 bg-muted shrink-0">
-            <IconComponent className="w-6 h-6" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="text-2xl font-bold flex items-center gap-3 flex-wrap">
-              {localizedCapabilityName(capability, locale)}
-              <CopyButton value={capability.id} />
-              <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
-                {getStatusLabel(capability.status)}
-              </Badge>
-            </h1>
-            <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
-              <span className="inline-flex items-center gap-1">
-                <Bot className="h-3.5 w-3.5" />
-                {formatCountLabel(capability.agent_count ?? 0, "agent")}
+      <PageMasthead
+        icon={<IconComponent />}
+        title={localizedCapabilityName(capability, locale)}
+        badges={
+          <>
+            <CopyButton value={capability.id} />
+            <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
+              {getStatusLabel(capability.status)}
+            </Badge>
+          </>
+        }
+        meta={
+          <>
+            <span className="inline-flex items-center gap-1">
+              <Bot className="h-3.5 w-3.5" />
+              {formatCountLabel(capability.agent_count ?? 0, "agent")}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Layers className="h-3.5 w-3.5" />
+              {formatCountLabel(capability.harness_count ?? 0, "harness", "harnesses")}
+            </span>
+            {capability.category && (
+              <span>
+                Category <span className="text-foreground">{capability.category}</span>
               </span>
-              <span className="inline-flex items-center gap-1">
-                <Layers className="h-3.5 w-3.5" />
-                {formatCountLabel(capability.harness_count ?? 0, "harness", "harnesses")}
-              </span>
-            </div>
-          </div>
-        </div>
-        {capability.docs_slug && (
-          <a
-            href={`${DOCS_BASE_URL}/${capability.docs_slug}/`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
-          >
-            View documentation
-            <ExternalLink className="w-3.5 h-3.5" />
-          </a>
-        )}
-      </div>
+            )}
+          </>
+        }
+        actions={
+          capability.docs_slug && (
+            <a
+              href={`${DOCS_BASE_URL}/${capability.docs_slug}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              View documentation
+              <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+          )
+        }
+      />
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2 space-y-6">
+      <PageColumns>
+        <PageMain>
           {/* Description Card */}
           <Card>
             <CardHeader>
@@ -230,10 +244,10 @@ export default function CapabilityDetailPage({
               </p>
             </Card>
           )}
-        </div>
+        </PageMain>
 
         {/* Sidebar */}
-        <div className="space-y-6">
+        <PageRail>
           <Card>
             <CardHeader>
               <CardTitle className="text-base">Details</CardTitle>
@@ -320,8 +334,12 @@ export default function CapabilityDetailPage({
               </div>
             </CardContent>
           </Card>
-        </div>
-      </div>
-    </div>
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <BackLink href="/capabilities">Back to Capabilities</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
-import { CircleOff, Bot, Layers, X, Plus, Pencil } from "lucide-react";
+import { CircleOff, Bot, Layers, Plus, Pencil, Puzzle } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, CapabilityStatus, DeclarativeCapability } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -24,10 +24,24 @@ import {
 import { useLocale } from "@/providers/locale-provider";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { getCapabilityStatusBadgeVariant } from "@/lib/status-utils";
-import { formatCountLabel } from "@/lib/formatting";
+import { formatCountLabel, pluralize } from "@/lib/formatting";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  IconTile,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
 import { cn } from "@/lib/utils";
 
 const UNCATEGORIZED = "Uncategorized";
+type StatusTab = "all" | CapabilityStatus;
 
 function getStatusLabel(status: CapabilityStatus): string {
   switch (status) {
@@ -38,17 +52,6 @@ function getStatusLabel(status: CapabilityStatus): string {
     case "deprecated":
       return "Deprecated";
   }
-}
-
-function NewDeclarativeButton() {
-  return (
-    <Link href="/capabilities/declarative/new">
-      <Button type="button" size="sm">
-        <Plus className="mr-1.5 h-4 w-4" />
-        New Declarative
-      </Button>
-    </Link>
-  );
 }
 
 function DeclarativeCapabilityRow({ capability }: { capability: DeclarativeCapability }) {
@@ -114,9 +117,7 @@ function CapabilityCard({ capability }: { capability: Capability }) {
       <Card className="h-full cursor-pointer bg-background transition-colors hover:bg-card">
         <CardHeader className="flex flex-row items-start justify-between space-y-0">
           <div className="flex items-center gap-3 min-w-0">
-            <div className="border bg-muted p-2 shrink-0">
-              <IconComponent className="icon-sharp h-5 w-5" />
-            </div>
+            <IconTile size="md" icon={<IconComponent />} />
             <div className="flex items-center gap-2 min-w-0">
               <CardTitle className="text-lg truncate">
                 {localizedCapabilityName(capability, locale)}
@@ -182,64 +183,13 @@ function matchesDeclarative(capability: DeclarativeCapability, query: string): b
   );
 }
 
-function CategoryFilter({
-  categories,
-  selected,
-  counts,
-  onSelect,
-}: {
-  categories: string[];
-  selected: string | null;
-  counts: Record<string, number>;
-  onSelect: (category: string | null) => void;
-}) {
-  if (categories.length === 0) return null;
-
-  return (
-    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
-      <button
-        type="button"
-        onClick={() => onSelect(null)}
-        aria-pressed={selected === null}
-        className={cn(
-          "inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors",
-          selected === null
-            ? "bg-primary text-primary-foreground border-primary"
-            : "bg-background hover:bg-muted",
-        )}
-      >
-        All
-        <span className="text-[10px] opacity-70">
-          {Object.values(counts).reduce((a, b) => a + b, 0)}
-        </span>
-      </button>
-      {categories.map((category) => (
-        <button
-          key={category}
-          type="button"
-          onClick={() => onSelect(category === selected ? null : category)}
-          aria-pressed={selected === category}
-          className={cn(
-            "inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors",
-            selected === category
-              ? "bg-primary text-primary-foreground border-primary"
-              : "bg-background hover:bg-muted",
-          )}
-        >
-          {category}
-          <span className="text-[10px] opacity-70">{counts[category] ?? 0}</span>
-        </button>
-      ))}
-    </div>
-  );
-}
-
 export default function CapabilitiesPage() {
   usePageTitle("Capabilities");
   const { data: capabilities, isLoading, error } = useCapabilities();
   const { data: declarativeCapabilities } = useDeclarativeCapabilities();
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [statusTab, setStatusTab] = useState<StatusTab>("all");
 
   const { categories, categoryCounts } = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -255,16 +205,27 @@ export default function CapabilitiesPage() {
     return { categories: cats, categoryCounts: counts };
   }, [capabilities]);
 
+  const statusCounts = useMemo(() => {
+    const list = capabilities ?? [];
+    return {
+      all: list.length,
+      available: list.filter((c) => c.status === "available").length,
+      coming_soon: list.filter((c) => c.status === "coming_soon").length,
+      deprecated: list.filter((c) => c.status === "deprecated").length,
+    } satisfies Record<StatusTab, number>;
+  }, [capabilities]);
+
   const filtered = useMemo(() => {
     return (capabilities ?? []).filter((cap) => {
       if (!matches(cap, searchQuery)) return false;
+      if (statusTab !== "all" && cap.status !== statusTab) return false;
       if (selectedCategory) {
         const key = cap.category || UNCATEGORIZED;
         if (key !== selectedCategory) return false;
       }
       return true;
     });
-  }, [capabilities, searchQuery, selectedCategory]);
+  }, [capabilities, searchQuery, selectedCategory, statusTab]);
 
   const filteredDeclarative = useMemo(
     () =>
@@ -288,139 +249,226 @@ export default function CapabilitiesPage() {
     });
   }, [filtered]);
 
-  if (error) {
-    return (
-      <div className="container mx-auto p-6">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-bold">Capabilities</h1>
-        </div>
-        <div className="text-red-500">Error loading capabilities: {error.message}</div>
-      </div>
-    );
-  }
-
   const totalCount = capabilities?.length ?? 0;
   const filteredCount = filtered.length;
-  const isFiltering = searchQuery.length > 0 || selectedCategory !== null;
+  const isFiltering = searchQuery.length > 0 || selectedCategory !== null || statusTab !== "all";
+
+  const statusItems = [
+    { value: "all" as const, label: "All" },
+    { value: "available" as const, label: "Available" },
+    { value: "coming_soon" as const, label: "Coming Soon" },
+    { value: "deprecated" as const, label: "Deprecated" },
+  ];
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Capabilities</h1>
-          <span className="text-sm text-muted-foreground">
-            {isFiltering
-              ? `${filteredCount} of ${totalCount}`
-              : formatCountLabel(totalCount, "capability", "capabilities")}
-          </span>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Capabilities" }]} />
+
+      <PageMasthead
+        icon={<Puzzle />}
+        title="Capabilities"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {totalCount}
+          </Badge>
+        }
+        description="Building blocks — system prompt additions and tools agents and harnesses can use."
+        meta={
+          <>
+            <span>{statusCounts.available} available</span>
+            <span>{statusCounts.coming_soon} coming soon</span>
+            <span>{statusCounts.deprecated} deprecated</span>
+          </>
+        }
+        actions={
+          <Link href="/capabilities/declarative/new">
+            <Button variant="accent">
+              <Plus className="size-4" />
+              New Declarative
+            </Button>
+          </Link>
+        }
+      />
+
+      {error && (
+        <div className="border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          Error loading capabilities: {error.message}
         </div>
-        <NewDeclarativeButton />
-      </div>
-
-      {filteredDeclarative.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Declarative Capabilities</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {filteredDeclarative.map((capability) => (
-              <DeclarativeCapabilityRow key={capability.id} capability={capability} />
-            ))}
-          </CardContent>
-        </Card>
       )}
 
-      {/* Search */}
-      <SearchInput
-        containerClassName="max-w-xl"
-        className="pr-9"
-        placeholder="Search by name, description, ID, or category..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-      >
-        {searchQuery && (
-          <button
-            type="button"
-            onClick={() => setSearchQuery("")}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
-            aria-label="Clear search"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
-      </SearchInput>
-
-      {/* Category filter */}
-      {!isLoading && (
-        <CategoryFilter
-          categories={categories}
-          selected={selectedCategory}
-          counts={categoryCounts}
-          onSelect={setSelectedCategory}
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search by name, description, ID, or category…"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          containerClassName="w-72"
         />
-      )}
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
 
-      {/* Loading skeleton */}
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(6)].map((_, i) => (
-            <Card key={i}>
+      <PageColumns>
+        <PageMain>
+          {filteredDeclarative.length > 0 && (
+            <Card>
               <CardHeader>
-                <Skeleton className="h-6 w-3/4" />
+                <CardTitle className="text-base">Declarative Capabilities</CardTitle>
               </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full mb-2" />
-                <Skeleton className="h-4 w-2/3" />
+              <CardContent className="space-y-2">
+                {filteredDeclarative.map((capability) => (
+                  <DeclarativeCapabilityRow key={capability.id} capability={capability} />
+                ))}
               </CardContent>
             </Card>
-          ))}
-        </div>
-      ) : totalCount === 0 ? (
-        <Card className="p-8 text-center">
-          <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-          <h3 className="text-lg font-medium mb-2">No capabilities available</h3>
-          <p className="text-muted-foreground">
-            Capabilities will appear here once they are configured.
-          </p>
-        </Card>
-      ) : filteredCount === 0 ? (
-        <Card className="p-8 text-center">
-          <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-          <h3 className="text-lg font-medium mb-2">No matches</h3>
-          <p className="text-muted-foreground mb-4">
-            No capabilities match the current search and filters.
-          </p>
-          <Button
-            variant="outline"
+          )}
+
+          {isLoading ? (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {[...Array(6)].map((_, i) => (
+                <Card key={i}>
+                  <CardHeader>
+                    <Skeleton className="h-6 w-3/4" />
+                  </CardHeader>
+                  <CardContent>
+                    <Skeleton className="h-4 w-full mb-2" />
+                    <Skeleton className="h-4 w-2/3" />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : totalCount === 0 ? (
+            <Card className="p-8 text-center">
+              <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No capabilities available</h3>
+              <p className="text-muted-foreground">
+                Capabilities will appear here once they are configured.
+              </p>
+            </Card>
+          ) : filteredCount === 0 ? (
+            <Card className="p-8 text-center">
+              <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No matches</h3>
+              <p className="text-muted-foreground mb-4">
+                No capabilities match the current search and filters.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setSearchQuery("");
+                  setSelectedCategory(null);
+                  setStatusTab("all");
+                }}
+              >
+                Clear filters
+              </Button>
+            </Card>
+          ) : (
+            <div className="space-y-8">
+              {grouped.map(([category, caps]) => (
+                <section key={category}>
+                  <div className="flex items-center justify-between mb-3">
+                    <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                      {category}
+                    </h2>
+                    <span className="text-xs text-muted-foreground">
+                      {formatCountLabel(caps.length, "capability", "capabilities")}
+                    </span>
+                  </div>
+                  <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    {caps.map((capability) => (
+                      <CapabilityCard key={capability.id} capability={capability} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{statusCounts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {categories.length > 0 && (
+            <RailSection label="Category">
+              <div className="flex flex-col gap-1.5 text-[13px]">
+                <button
+                  type="button"
+                  onClick={() => setSelectedCategory(null)}
+                  aria-pressed={selectedCategory === null}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    selectedCategory === null ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>All</span>
+                  <span className="text-muted-foreground">
+                    {Object.values(categoryCounts).reduce((a, b) => a + b, 0)}
+                  </span>
+                </button>
+                {categories.map((category) => (
+                  <button
+                    key={category}
+                    type="button"
+                    onClick={() =>
+                      setSelectedCategory(category === selectedCategory ? null : category)
+                    }
+                    aria-pressed={selectedCategory === category}
+                    className={cn(
+                      "flex items-center justify-between transition-colors hover:text-foreground",
+                      selectedCategory === category ? "text-foreground" : "text-muted-foreground",
+                    )}
+                  >
+                    <span>{category}</span>
+                    <span className="text-muted-foreground">{categoryCounts[category] ?? 0}</span>
+                  </button>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          {isFiltering
+            ? `Showing ${filteredCount} of ${totalCount} ${pluralize(totalCount, "capability", "capabilities")}`
+            : `Showing ${formatCountLabel(totalCount, "capability", "capabilities")}`}
+        </span>
+        {isFiltering && (
+          <button
+            type="button"
             onClick={() => {
               setSearchQuery("");
               setSelectedCategory(null);
+              setStatusTab("all");
             }}
+            className="text-primary transition-colors hover:underline"
           >
-            Clear filters
-          </Button>
-        </Card>
-      ) : (
-        <div className="space-y-8">
-          {grouped.map(([category, caps]) => (
-            <section key={category}>
-              <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                  {category}
-                </h2>
-                <span className="text-xs text-muted-foreground">
-                  {formatCountLabel(caps.length, "capability", "capabilities")}
-                </span>
-              </div>
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {caps.map((capability) => (
-                  <CapabilityCard key={capability.id} capability={capability} />
-                ))}
-              </div>
-            </section>
-          ))}
-        </div>
-      )}
-    </div>
+            Clear filters →
+          </button>
+        )}
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -327,7 +327,7 @@ export default function CapabilitiesPage() {
           )}
 
           {isLoading ? (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-4 md:grid-cols-2">
               {[...Array(6)].map((_, i) => (
                 <Card key={i}>
                   <CardHeader>
@@ -378,7 +378,7 @@ export default function CapabilitiesPage() {
                       {formatCountLabel(caps.length, "capability", "capabilities")}
                     </span>
                   </div>
-                  <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  <div className="grid gap-4 md:grid-cols-2">
                     {caps.map((capability) => (
                       <CapabilityCard key={capability.id} capability={capability} />
                     ))}

--- a/apps/ui/src/app/(main)/knowledge-indexes/[indexId]/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/[indexId]/page.tsx
@@ -1,16 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import { use, useState } from "react";
-import {
-  AlertCircle,
-  Archive,
-  ArrowLeft,
-  GitBranch,
-  Library,
-  Pencil,
-  RefreshCw,
-} from "lucide-react";
+import { use, useMemo, useState } from "react";
+import { AlertCircle, Archive, GitBranch, Library, Pencil, RefreshCw } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { ArchiveKnowledgeIndexDialog } from "@/components/knowledge-indexes/archive-knowledge-index-dialog";
@@ -21,6 +12,28 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  StatCard,
+  StatGrid,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
+import {
   useArchiveKnowledgeIndex,
   useKnowledgeIndex,
   useKnowledgeIndexDocuments,
@@ -28,7 +41,11 @@ import {
   useSyncKnowledgeIndex,
   useUpdateKnowledgeIndex,
 } from "@/hooks";
-import type { KnowledgeIndex, UpdateKnowledgeIndexRequest } from "@/lib/api/types";
+import type {
+  KnowledgeIndex,
+  KnowledgeIndexDocument,
+  UpdateKnowledgeIndexRequest,
+} from "@/lib/api/types";
 import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
@@ -51,10 +68,20 @@ export default function KnowledgeIndexDetailPage({
   const [editOpen, setEditOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const { data: index, isLoading, error } = useKnowledgeIndex(indexId);
+  const {
+    data: documents,
+    isLoading: documentsLoading,
+    error: documentsError,
+  } = useKnowledgeIndexDocuments(indexId);
   const updateIndex = useUpdateKnowledgeIndex();
   const syncIndex = useSyncKnowledgeIndex();
   const archiveIndex = useArchiveKnowledgeIndex();
   usePageTitle(index ? index.name : null, "Knowledge Indexes");
+
+  const totalChunks = useMemo(
+    () => (documents ?? []).reduce((sum, doc) => sum + (doc.chunk_count ?? 0), 0),
+    [documents],
+  );
 
   if (isLoading) {
     return <DetailSkeleton />;
@@ -78,176 +105,222 @@ export default function KnowledgeIndexDetailPage({
   const gitUrl = sourceField(index, "url");
   const branch = sourceField(index, "branch");
   const rootFolder = sourceField(index, "root_folder");
+  const documentCount = documents?.length ?? 0;
 
   return (
-    <div className="container mx-auto space-y-6 p-6">
-      <div className="flex items-center justify-between">
-        <Link href="/knowledge-indexes">
-          <Button variant="outline">
-            <ArrowLeft className="h-4 w-4" />
-            Knowledge Indexes
-          </Button>
-        </Link>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => setEditOpen(true)} disabled={isReadOnly}>
-            <Pencil className="h-4 w-4" />
-            Edit
-          </Button>
-          {!isReadOnly && (
-            <Button variant="outline" onClick={() => setArchiveOpen(true)}>
-              <Archive className="h-4 w-4" />
-              Archive
-            </Button>
-          )}
-          {canSync && (
-            <Button
-              variant="accent"
-              onClick={() => syncIndex.mutate(index.id)}
-              disabled={
-                syncIndex.isPending ||
-                index.sync_status === "pending" ||
-                index.sync_status === "syncing"
-              }
-            >
-              <RefreshCw className="h-4 w-4" />
-              Sync now
-            </Button>
-          )}
-        </div>
-      </div>
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Knowledge Indexes", href: "/knowledge-indexes" },
+          { label: index.name },
+        ]}
+      />
 
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center bg-primary/10">
-            <Library className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className={`truncate text-2xl font-bold ${getEntityNameClassName(index.status)}`}>
-              {index.name}
-            </h1>
-            <div className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
-              <span className="truncate font-mono">{index.id}</span>
-              <CopyButton value={index.id} />
-            </div>
-          </div>
-        </div>
-        <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Overview</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <p className="text-muted-foreground">{index.description || "No description"}</p>
-            <div>
-              <div className="font-medium">Embedding model</div>
-              <div className="font-mono text-muted-foreground">{index.embedding_model_id}</div>
-            </div>
-            {typeof index.vector_dim === "number" && (
-              <div>
-                <div className="font-medium">Vector dimension</div>
-                <div className="text-muted-foreground">{index.vector_dim}</div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Source</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <div>
-              <div className="font-medium">Type</div>
-              <div className="flex items-center gap-1.5 text-muted-foreground">
+      <PageMasthead
+        icon={<Library />}
+        title={<span className={getEntityNameClassName(index.status)}>{index.name}</span>}
+        badges={
+          <>
+            <CopyButton value={index.id} />
+            <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
+            <Badge variant={syncStatusBadgeVariant(index.sync_status)}>{index.sync_status}</Badge>
+          </>
+        }
+        description={index.description || undefined}
+        meta={
+          <>
+            <span>
+              Embedding <span className="font-mono text-primary">{index.embedding_model_id}</span>
+            </span>
+            <span>
+              Source{" "}
+              <span className="inline-flex items-center gap-1 text-primary">
                 {index.source_type === "github" ? (
-                  <Github className="h-4 w-4" />
+                  <Github className="size-3.5" />
                 ) : (
-                  <GitBranch className="h-4 w-4" />
+                  <GitBranch className="size-3.5" />
                 )}
-                <span>{index.source_type}</span>
-              </div>
-            </div>
-            {repository && (
-              <div>
-                <div className="font-medium">Repository</div>
-                <div className="font-mono text-muted-foreground">{repository}</div>
-              </div>
-            )}
-            {gitUrl && (
-              <div>
-                <div className="font-medium">Git URL</div>
-                <div className="break-all font-mono text-muted-foreground">{gitUrl}</div>
-              </div>
-            )}
-            {branch && (
-              <div>
-                <div className="font-medium">Branch</div>
-                <div className="text-muted-foreground">{branch}</div>
-              </div>
-            )}
-            {rootFolder && (
-              <div>
-                <div className="font-medium">Root Folder</div>
-                <div className="font-mono text-muted-foreground">{rootFolder}</div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Sync status</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3 text-sm">
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-            <div>
-              <div className="font-medium">Status</div>
-              <Badge variant={syncStatusBadgeVariant(index.sync_status)}>{index.sync_status}</Badge>
-            </div>
-            <div>
-              <div className="font-medium">Last synced</div>
-              <div className="text-muted-foreground">
+                {index.source_type}
+              </span>
+            </span>
+            <span>
+              Last synced{" "}
+              <span className="text-foreground">
                 {index.last_synced_at ? formatRelativeTime(index.last_synced_at) : "Never"}
-              </div>
-            </div>
-            <div>
-              <div className="font-medium">Created</div>
-              <div className="text-muted-foreground">{formatDate(index.created_at)}</div>
-            </div>
-            <div>
-              <div className="font-medium">Updated</div>
-              <div className="text-muted-foreground">{formatRelativeTime(index.updated_at)}</div>
-            </div>
-          </div>
-          {index.last_sync_error && (
-            <div className="flex gap-2 text-destructive">
-              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{index.last_sync_error}</span>
-            </div>
-          )}
-          {canSync && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => syncIndex.mutate(index.id)}
-              disabled={
-                syncIndex.isPending ||
-                index.sync_status === "pending" ||
-                index.sync_status === "syncing"
-              }
-            >
-              <RefreshCw className="h-4 w-4" />
-              Sync now
+              </span>
+            </span>
+          </>
+        }
+        actions={
+          <>
+            <Button variant="outline" onClick={() => setEditOpen(true)} disabled={isReadOnly}>
+              <Pencil className="size-4" />
+              Edit
             </Button>
-          )}
-        </CardContent>
-      </Card>
+            {!isReadOnly && (
+              <Button variant="outline" onClick={() => setArchiveOpen(true)}>
+                <Archive className="size-4" />
+                Archive
+              </Button>
+            )}
+            {canSync && (
+              <Button
+                variant="accent"
+                onClick={() => syncIndex.mutate(index.id)}
+                disabled={
+                  syncIndex.isPending ||
+                  index.sync_status === "pending" ||
+                  index.sync_status === "syncing"
+                }
+              >
+                <RefreshCw className="size-4" />
+                Sync now
+              </Button>
+            )}
+          </>
+        }
+      />
 
-      <DocumentsCard indexId={index.id} />
+      <PageControlStrip>
+        <StatGrid className="lg:grid-cols-3">
+          <StatCard
+            label="Documents"
+            value={documentsLoading ? "—" : documentCount}
+            hint="indexed"
+          />
+          <StatCard label="Chunks" value={documentsLoading ? "—" : totalChunks} hint="embedded" />
+          <StatCard
+            label="Vector dim"
+            value={typeof index.vector_dim === "number" ? index.vector_dim : "—"}
+          />
+        </StatGrid>
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <Card>
+            <CardHeader>
+              <CardTitle>Overview</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <p className="text-muted-foreground">{index.description || "No description"}</p>
+              <div>
+                <div className="font-medium">Embedding model</div>
+                <div className="font-mono text-muted-foreground">{index.embedding_model_id}</div>
+              </div>
+              {typeof index.vector_dim === "number" && (
+                <div>
+                  <div className="font-medium">Vector dimension</div>
+                  <div className="text-muted-foreground">{index.vector_dim}</div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <DocumentsCard
+            documents={documents}
+            isLoading={documentsLoading}
+            error={documentsError}
+          />
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Source">
+            <div className="space-y-3 text-sm">
+              <div>
+                <div className="font-medium">Type</div>
+                <div className="flex items-center gap-1.5 text-muted-foreground">
+                  {index.source_type === "github" ? (
+                    <Github className="size-4" />
+                  ) : (
+                    <GitBranch className="size-4" />
+                  )}
+                  <span>{index.source_type}</span>
+                </div>
+              </div>
+              {repository && (
+                <div>
+                  <div className="font-medium">Repository</div>
+                  <div className="font-mono text-muted-foreground">{repository}</div>
+                </div>
+              )}
+              {gitUrl && (
+                <div>
+                  <div className="font-medium">Git URL</div>
+                  <div className="break-all font-mono text-muted-foreground">{gitUrl}</div>
+                </div>
+              )}
+              {branch && (
+                <div>
+                  <div className="font-medium">Branch</div>
+                  <div className="text-muted-foreground">{branch}</div>
+                </div>
+              )}
+              {rootFolder && (
+                <div>
+                  <div className="font-medium">Root Folder</div>
+                  <div className="font-mono text-muted-foreground">{rootFolder}</div>
+                </div>
+              )}
+            </div>
+          </RailSection>
+
+          <RailSection label="Sync status">
+            <div className="space-y-3 text-sm">
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+                <div>
+                  <div className="font-medium">Status</div>
+                  <Badge variant={syncStatusBadgeVariant(index.sync_status)}>
+                    {index.sync_status}
+                  </Badge>
+                </div>
+                <div>
+                  <div className="font-medium">Last synced</div>
+                  <div className="text-muted-foreground">
+                    {index.last_synced_at ? formatRelativeTime(index.last_synced_at) : "Never"}
+                  </div>
+                </div>
+                <div>
+                  <div className="font-medium">Created</div>
+                  <div className="text-muted-foreground">{formatDate(index.created_at)}</div>
+                </div>
+                <div>
+                  <div className="font-medium">Updated</div>
+                  <div className="text-muted-foreground">
+                    {formatRelativeTime(index.updated_at)}
+                  </div>
+                </div>
+              </div>
+              {index.last_sync_error && (
+                <div className="flex gap-2 text-destructive">
+                  <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                  <span>{index.last_sync_error}</span>
+                </div>
+              )}
+              {canSync && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => syncIndex.mutate(index.id)}
+                  disabled={
+                    syncIndex.isPending ||
+                    index.sync_status === "pending" ||
+                    index.sync_status === "syncing"
+                  }
+                >
+                  <RefreshCw className="size-4" />
+                  Sync now
+                </Button>
+              )}
+            </div>
+          </RailSection>
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <BackLink href="/knowledge-indexes">Back to Knowledge Indexes</BackLink>
+      </PageFooter>
 
       <KnowledgeIndexFormDialog
         mode="edit"
@@ -269,13 +342,19 @@ export default function KnowledgeIndexDetailPage({
         onOpenChange={setArchiveOpen}
         onArchive={() => archiveIndex.mutateAsync(index.id)}
       />
-    </div>
+    </PageContainer>
   );
 }
 
-function DocumentsCard({ indexId }: { indexId: string }) {
-  const { data: documents, isLoading, error } = useKnowledgeIndexDocuments(indexId);
-
+function DocumentsCard({
+  documents,
+  isLoading,
+  error,
+}: {
+  documents: KnowledgeIndexDocument[] | undefined;
+  isLoading: boolean;
+  error: unknown;
+}) {
   return (
     <Card>
       <CardHeader>
@@ -283,42 +362,40 @@ function DocumentsCard({ indexId }: { indexId: string }) {
       </CardHeader>
       <CardContent>
         {isLoading && <Skeleton className="h-24 w-full" />}
-        {error && <p className="text-sm text-destructive">Failed to load documents.</p>}
+        {!!error && <p className="text-sm text-destructive">Failed to load documents.</p>}
         {!isLoading && !error && (documents?.length ?? 0) === 0 && (
           <p className="text-sm text-muted-foreground">
             No documents indexed yet. Run a sync to populate this index.
           </p>
         )}
         {!isLoading && !error && (documents?.length ?? 0) > 0 && (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-xs text-muted-foreground">
-                  <th className="py-2 pr-4 font-medium">Document</th>
-                  <th className="py-2 pr-4 font-medium">Chunks</th>
-                  <th className="py-2 font-medium">Last seen</th>
-                </tr>
-              </thead>
-              <tbody>
-                {documents!.map((doc) => (
-                  <tr key={doc.id} className="border-b last:border-0">
-                    <td className="py-2 pr-4">
-                      <div className="font-medium">{doc.title || doc.source_uri}</div>
-                      {doc.title && (
-                        <div className="break-all font-mono text-xs text-muted-foreground">
-                          {doc.source_uri}
-                        </div>
-                      )}
-                    </td>
-                    <td className="py-2 pr-4 text-muted-foreground">{doc.chunk_count}</td>
-                    <td className="py-2 text-muted-foreground">
-                      {doc.last_seen_at ? formatRelativeTime(doc.last_seen_at) : "—"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Document</TableHead>
+                <TableHead>Chunks</TableHead>
+                <TableHead>Last seen</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {documents!.map((doc) => (
+                <TableRow key={doc.id}>
+                  <TableCell>
+                    <div className="font-medium">{doc.title || doc.source_uri}</div>
+                    {doc.title && (
+                      <div className="break-all font-mono text-xs text-muted-foreground">
+                        {doc.source_uri}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{doc.chunk_count}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {doc.last_seen_at ? formatRelativeTime(doc.last_seen_at) : "—"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         )}
       </CardContent>
     </Card>

--- a/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   AlertCircle,
   Archive,
@@ -13,15 +13,33 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
-import { ArchiveFilter } from "@/components/archive-filter";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ArchiveKnowledgeIndexDialog } from "@/components/knowledge-indexes/archive-knowledge-index-dialog";
 import { KnowledgeIndexFormDialog } from "@/components/knowledge-indexes/knowledge-index-form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
 import { SearchInput } from "@/components/ui/search-input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
 import {
   useArchiveKnowledgeIndex,
   useCreateKnowledgeIndex,
@@ -38,71 +56,239 @@ import type {
 import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
+  isArchivedStatus,
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
-import { formatRelativeTime } from "@/lib/formatting";
+import { formatRelativeTime, pluralize } from "@/lib/formatting";
 import { syncStatusBadgeVariant } from "@/lib/knowledge-index-sync";
+import { cn } from "@/lib/utils";
+
+type StatusTab = "all" | "active" | "archived";
+
+const statusItems = [
+  { value: "all" as const, label: "All" },
+  { value: "active" as const, label: "Active" },
+  { value: "archived" as const, label: "Archived" },
+];
 
 export default function KnowledgeIndexesPage() {
   usePageTitle("Knowledge Indexes");
-  const [showArchived, setShowArchived] = useState(false);
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<KnowledgeIndex | null>(null);
   const [archivingIndex, setArchivingIndex] = useState<KnowledgeIndex | null>(null);
+  // Fetch the full set (including archived) so the facet rail can show accurate counts;
+  // the active/archived/all split is applied client-side from the same response.
   const {
     data: indexes,
     isLoading,
     error,
-  } = useKnowledgeIndexes({ includeArchived: showArchived, search });
+  } = useKnowledgeIndexes({ includeArchived: true, search });
   const createIndex = useCreateKnowledgeIndex();
   const updateIndex = useUpdateKnowledgeIndex();
   const syncIndex = useSyncKnowledgeIndex();
   const archiveIndex = useArchiveKnowledgeIndex();
 
-  return (
-    <div className="container mx-auto p-6">
-      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <h1 className="flex items-center gap-3 text-2xl font-bold">Knowledge Indexes</h1>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <SearchInput
-            containerClassName="sm:w-64"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search knowledge indexes"
-            aria-label="Search knowledge indexes"
-          />
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
-          <Button variant="accent" onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4" />
-            New Index
-          </Button>
-        </div>
-      </div>
+  const counts = useMemo(() => {
+    const list = indexes ?? [];
+    const archived = list.filter((i) => isArchivedStatus(i.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [indexes]);
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={indexes}
-        errorMessagePrefix="Failed to load knowledge indexes"
-        skeletonCount={6}
-        emptyState={<EmptyState hasSearch={!!search.trim()} onCreate={() => setCreateOpen(true)} />}
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {items.map((index) => (
-              <KnowledgeIndexCard
-                key={index.id}
-                index={index}
-                onEdit={setEditingIndex}
-                onArchive={setArchivingIndex}
-                onSync={(candidate) => syncIndex.mutate(candidate.id)}
-                isSyncing={syncIndex.isPending}
-              />
-            ))}
-          </div>
+  const sourceFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const index of indexes ?? []) {
+      tally.set(index.source_type, (tally.get(index.source_type) ?? 0) + 1);
+    }
+    return [...tally.entries()].sort((a, b) => b[1] - a[1]);
+  }, [indexes]);
+
+  const syncFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const index of indexes ?? []) {
+      tally.set(index.sync_status, (tally.get(index.sync_status) ?? 0) + 1);
+    }
+    return [...tally.entries()].sort((a, b) => b[1] - a[1]);
+  }, [indexes]);
+
+  const filteredIndexes = useMemo(() => {
+    return (indexes ?? []).filter((index) => {
+      if (statusTab === "active" && isArchivedStatus(index.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(index.status)) return false;
+      return true;
+    });
+  }, [indexes, statusTab]);
+
+  return (
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Knowledge Indexes" }]} />
+
+      <PageMasthead
+        icon={<Library />}
+        title="Knowledge Indexes"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
+        }
+        description="Synced document collections that power retrieval — sources, embeddings, and sync state."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
+          <Button variant="accent" onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            New index
+          </Button>
+        }
+      />
+
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search knowledge indexes…"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          aria-label="Search knowledge indexes"
+          containerClassName="w-64"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredIndexes}
+            errorMessagePrefix="Failed to load knowledge indexes"
+            skeletonCount={6}
+            emptyState={
+              <div className="border border-dashed py-12 text-center">
+                <Library className="mx-auto mb-4 size-10 text-muted-foreground" />
+                <p className="mb-4 text-muted-foreground">
+                  {search.trim() || statusTab !== "active"
+                    ? "No knowledge indexes match your filters."
+                    : "No knowledge indexes yet"}
+                </p>
+                {!search.trim() && statusTab === "active" && (
+                  <Button variant="accent" onClick={() => setCreateOpen(true)}>
+                    <Plus className="size-4" />
+                    New index
+                  </Button>
+                )}
+              </div>
+            }
+          >
+            {(items) => (
+              <div className="border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Source</TableHead>
+                      <TableHead>Sync</TableHead>
+                      <TableHead>Last synced</TableHead>
+                      <TableHead>Updated</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((index) => (
+                      <KnowledgeIndexRow
+                        key={index.id}
+                        index={index}
+                        onEdit={setEditingIndex}
+                        onArchive={setArchivingIndex}
+                        onSync={(candidate) => syncIndex.mutate(candidate.id)}
+                        isSyncing={syncIndex.isPending}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {sourceFacets.length > 0 && (
+            <RailSection label="Source">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {sourceFacets.map(([source, count]) => (
+                  <div key={source} className="flex items-center justify-between">
+                    <span className="inline-flex items-center gap-1.5">
+                      {source === "github" ? (
+                        <Github className="size-3.5" />
+                      ) : (
+                        <GitBranch className="size-3.5" />
+                      )}
+                      {source}
+                    </span>
+                    <span>{count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+
+          {syncFacets.length > 0 && (
+            <RailSection label="Sync status">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {syncFacets.map(([syncStatus, count]) => (
+                  <div key={syncStatus} className="flex items-center justify-between">
+                    <span>{syncStatus}</span>
+                    <span>{count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredIndexes.length} of {counts.all}{" "}
+          {pluralize(counts.all, "index", "indexes")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
         )}
-      </QueryStateWrapper>
+      </PageFooter>
 
       <KnowledgeIndexFormDialog
         mode="create"
@@ -133,11 +319,11 @@ export default function KnowledgeIndexesPage() {
         onOpenChange={(open) => !open && setArchivingIndex(null)}
         onArchive={() => archiveIndex.mutateAsync(archivingIndex!.id)}
       />
-    </div>
+    </PageContainer>
   );
 }
 
-function KnowledgeIndexCard({
+function KnowledgeIndexRow({
   index,
   onEdit,
   onArchive,
@@ -154,59 +340,53 @@ function KnowledgeIndexCard({
   const canSync = index.status === "active";
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center bg-primary/10">
-            <Library className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <CardTitle className={`truncate text-lg ${getEntityNameClassName(index.status)}`}>
-              {index.name}
-            </CardTitle>
-            <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span className="truncate font-mono">{index.id}</span>
-              <CopyButton value={index.id} />
-            </div>
-          </div>
+    <TableRow>
+      <TableCell>
+        <div className="flex items-start gap-2">
+          <Link
+            href={`/knowledge-indexes/${index.id}`}
+            className={cn("font-medium hover:underline", getEntityNameClassName(index.status))}
+          >
+            {index.name}
+          </Link>
+          <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
         </div>
-        <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="min-h-10 text-sm text-muted-foreground">
-          {index.description || "No description"}
-        </p>
-        <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
-          <div>
-            <div className="font-medium text-foreground">Source</div>
-            <div className="flex items-center gap-1">
-              {index.source_type === "github" ? (
-                <Github className="h-3.5 w-3.5" />
-              ) : (
-                <GitBranch className="h-3.5 w-3.5" />
-              )}
-              <span>{index.source_type}</span>
-            </div>
+        {index.description && (
+          <div className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+            {index.description}
           </div>
-          <div>
-            <div className="font-medium text-foreground">Sync</div>
-            <Badge variant={syncStatusBadgeVariant(index.sync_status)}>{index.sync_status}</Badge>
-          </div>
-          <div>
-            <div className="font-medium text-foreground">Last synced</div>
-            <div>{index.last_synced_at ? formatRelativeTime(index.last_synced_at) : "Never"}</div>
-          </div>
-          <div>
-            <div className="font-medium text-foreground">Updated</div>
-            <div>{formatRelativeTime(index.updated_at)}</div>
-          </div>
+        )}
+        <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="truncate font-mono">{index.id}</span>
+          <CopyButton value={index.id} />
         </div>
         {index.last_sync_error && (
-          <div className="flex gap-2 text-xs text-destructive">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <div className="mt-1 flex gap-1.5 text-xs text-destructive">
+            <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
             <span className="line-clamp-2">{index.last_sync_error}</span>
           </div>
         )}
+      </TableCell>
+      <TableCell>
+        <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+          {index.source_type === "github" ? (
+            <Github className="size-3.5" />
+          ) : (
+            <GitBranch className="size-3.5" />
+          )}
+          {index.source_type}
+        </span>
+      </TableCell>
+      <TableCell>
+        <Badge variant={syncStatusBadgeVariant(index.sync_status)}>{index.sync_status}</Badge>
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {index.last_synced_at ? formatRelativeTime(index.last_synced_at) : "Never"}
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {formatRelativeTime(index.updated_at)}
+      </TableCell>
+      <TableCell>
         <div className="flex items-center justify-end gap-2">
           {canSync && (
             <Button
@@ -217,45 +397,28 @@ function KnowledgeIndexCard({
                 isSyncing || index.sync_status === "pending" || index.sync_status === "syncing"
               }
             >
-              <RefreshCw className="h-4 w-4" />
+              <RefreshCw className="size-4" />
               Sync
             </Button>
           )}
           <Link href={`/knowledge-indexes/${index.id}`}>
             <Button variant="outline" size="sm">
-              <FolderOpen className="h-4 w-4" />
+              <FolderOpen className="size-4" />
               Open
             </Button>
           </Link>
           <Button variant="outline" size="sm" onClick={() => onEdit(index)} disabled={isReadOnly}>
-            <Pencil className="h-4 w-4" />
+            <Pencil className="size-4" />
             Edit
           </Button>
           {!isReadOnly && (
             <Button variant="outline" size="sm" onClick={() => onArchive(index)}>
-              <Archive className="h-4 w-4" />
+              <Archive className="size-4" />
               Archive
             </Button>
           )}
         </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function EmptyState({ hasSearch, onCreate }: { hasSearch: boolean; onCreate: () => void }) {
-  return (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <Library className="mb-4 h-12 w-12 text-muted-foreground" />
-      <h3 className="mb-2 text-lg font-semibold">
-        {hasSearch ? "No knowledge indexes found" : "No knowledge indexes"}
-      </h3>
-      {!hasSearch && (
-        <Button variant="accent" onClick={onCreate}>
-          <Plus className="h-4 w-4" />
-          New Index
-        </Button>
-      )}
-    </div>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -1,14 +1,23 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { SearchInput } from "@/components/ui/search-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import {
   Select,
   SelectContent,
@@ -32,7 +41,7 @@ import {
 } from "@/hooks/use-mcp-servers";
 import { usePolicies } from "@/hooks/use-policies";
 import { usePageTitle } from "@/hooks";
-import { Plus, Plug, Trash2, Key, Globe, X, Settings2 } from "lucide-react";
+import { Plus, Plug, Trash2, Key, X } from "lucide-react";
 import type { McpServer, CreateMcpServerRequest, McpServerAuthMode } from "@/lib/api/types";
 import {
   apiKeySecretSchema,
@@ -40,10 +49,37 @@ import {
   mcpServerFormSchema,
   type FieldErrors,
 } from "@/lib/form-validation";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
-import { ArchiveFilter } from "@/components/archive-filter";
+import {
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+  isArchivedStatus,
+} from "@/lib/entity-lifecycle";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  IconTile,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
+import { capabilityIconMap } from "@/lib/capability-icons";
+import { pluralize } from "@/lib/formatting";
 
-function McpServerCard({
+const McpIcon = capabilityIconMap.mcp;
+
+function authLabel(server: McpServer): string {
+  if (server.auth_mode === "oauth") return "OAuth";
+  if (server.auth_mode === "api_key")
+    return server.api_key_set ? "API key configured" : "API key missing";
+  return "None";
+}
+
+function McpServerRow({
   server,
   canDestroy,
   onDelete,
@@ -63,54 +99,34 @@ function McpServerCard({
   const headerCount = Object.keys(server.headers ?? {}).length;
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+    <TableRow>
+      <TableCell className="py-2.5">
         <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
-            <Plug className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <CardTitle className={`text-lg ${getEntityNameClassName(server.status)}`}>
+          <IconTile size="md" icon={<McpIcon />} />
+          <div className="min-w-0">
+            <div className={`font-medium ${getEntityNameClassName(server.status)}`}>
               {server.name}
-            </CardTitle>
-            <CardDescription className="text-sm">
-              {server.description || "No description"}
-            </CardDescription>
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              {server.description || server.url}
+            </div>
           </div>
         </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant="secondary" className="font-mono">
+          {server.transport_type.toUpperCase()}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-muted-foreground">{authLabel(server)}</TableCell>
+      <TableCell className="text-muted-foreground">
+        {headerCount > 0 ? `${headerCount} ${pluralize(headerCount, "header")}` : "—"}
+      </TableCell>
+      <TableCell>
         <Badge variant={getEntityStatusBadgeVariant(server.status)}>{server.status}</Badge>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2 text-sm">
-          <div className="flex items-center gap-2">
-            <Globe className="h-4 w-4 text-muted-foreground" />
-            <span className="text-muted-foreground truncate">{server.url}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Key className="h-4 w-4 text-muted-foreground" />
-            <span className="text-muted-foreground">
-              Auth:{" "}
-              {server.auth_mode === "oauth"
-                ? "OAuth"
-                : server.auth_mode === "api_key"
-                  ? server.api_key_set
-                    ? "API key configured"
-                    : "API key missing"
-                  : "None"}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs">
-              {server.transport_type.toUpperCase()}
-            </Badge>
-            {headerCount > 0 && (
-              <Badge variant="outline" className="text-xs">
-                {headerCount} custom header{headerCount !== 1 ? "s" : ""}
-              </Badge>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center justify-end gap-2 mt-4">
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center justify-end gap-2">
           {server.auth_mode === "api_key" && (
             <Button variant="outline" size="sm" onClick={() => onSetApiKey(server)}>
               <Key className="h-4 w-4 mr-1" />
@@ -119,7 +135,6 @@ function McpServerCard({
           )}
           {!isArchived && !isDeleted && (
             <Button variant="outline" size="sm" onClick={() => onManageHeaders(server)}>
-              <Settings2 className="h-4 w-4 mr-1" />
               Headers
             </Button>
           )}
@@ -135,8 +150,8 @@ function McpServerCard({
             </Button>
           )}
         </div>
-      </CardContent>
-    </Card>
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -652,35 +667,49 @@ function ArchiveConfirmDialog({
   );
 }
 
-function McpServerCardSkeleton() {
+function McpServerRowSkeleton() {
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+    <TableRow>
+      <TableCell className="py-2.5">
         <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9" />
+          <Skeleton className="h-8 w-8" />
           <div className="space-y-2">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-40" />
           </div>
         </div>
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-14" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-10" />
+      </TableCell>
+      <TableCell>
         <Skeleton className="h-5 w-16" />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className="h-4 w-full mb-4" />
-        <Skeleton className="h-8 w-24 ml-auto" />
-      </CardContent>
-    </Card>
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-8 w-24" />
+      </TableCell>
+    </TableRow>
   );
 }
 
+type StatusTab = "all" | "active" | "archived";
+
 export default function McpServersPage() {
   usePageTitle("MCP Servers");
-  const [showArchived, setShowArchived] = useState(false);
-  const { data: servers, isLoading, error } = useMcpServers({ includeArchived: showArchived });
+  // Always load archived so the facet rail and tab counts stay accurate; filter client-side.
+  const { data: servers, isLoading, error } = useMcpServers({ includeArchived: true });
   const destroyServer = useDestroyMcpServer();
   const { can: canPolicies } = usePolicies("mcp-servers");
   const canDestroy = canPolicies("mcp_server.dangerous");
 
+  const [search, setSearch] = useState("");
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
   const [addServerOpen, setAddServerOpen] = useState(false);
   const [apiKeyServer, setApiKeyServer] = useState<McpServer | null>(null);
   const [headersServer, setHeadersServer] = useState<McpServer | null>(null);
@@ -693,67 +722,204 @@ export default function McpServersPage() {
     setPendingDeleteServer(null);
   };
 
+  const counts = useMemo(() => {
+    const list = servers ?? [];
+    const archived = list.filter((s) => isArchivedStatus(s.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [servers]);
+
+  // Transport facet counts computed from loaded data.
+  const transportFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const server of servers ?? []) {
+      const key = server.transport_type.toUpperCase();
+      tally.set(key, (tally.get(key) ?? 0) + 1);
+    }
+    return [...tally.entries()].map(([transport, count]) => ({ transport, count }));
+  }, [servers]);
+
+  const filteredServers = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (servers ?? []).filter((server) => {
+      if (statusTab === "active" && isArchivedStatus(server.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(server.status)) return false;
+      if (!query) return true;
+      const haystack = [server.name, server.description, server.url]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [servers, search, statusTab]);
+
+  const statusItems = [
+    { value: "all" as const, label: "All" },
+    { value: "active" as const, label: "Active" },
+    { value: "archived" as const, label: "Archived" },
+  ];
+
   return (
-    <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">MCP Servers</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Configure Model Context Protocol (MCP) servers to extend agent capabilities with
-            external tools and resources.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "MCP servers" }]} />
+
+      <PageMasthead
+        icon={<McpIcon />}
+        title="MCP Servers"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
+        }
+        description="Model Context Protocol servers that extend agents with external tools and resources."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
           <Button variant="accent" onClick={() => setAddServerOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
+            <Plus className="size-4" />
             Add Server
           </Button>
-        </div>
-      </div>
+        }
+      />
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={servers}
-        errorMessagePrefix="Failed to load MCP servers"
-        loadingSkeleton={
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {[...Array(3)].map((_, i) => (
-              <McpServerCardSkeleton key={i} />
-            ))}
-          </div>
-        }
-        emptyState={
-          <Card className="p-8 text-center">
-            <Plug className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-            <h2 className="mb-2 text-lg font-medium">No MCP servers configured</h2>
-            <p className="mb-4 text-muted-foreground">
-              Add an MCP server to extend your agents with external tools and resources.
-            </p>
-            <Button variant="accent" onClick={() => setAddServerOpen(true)}>
-              <Plus className="mr-2 h-4 w-4" />
-              Add Server
-            </Button>
-          </Card>
-        }
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((server) => (
-              <McpServerCard
-                key={server.id}
-                server={server}
-                canDestroy={canDestroy}
-                onDelete={setPendingDeleteServer}
-                onArchive={setPendingArchiveServer}
-                onSetApiKey={setApiKeyServer}
-                onManageHeaders={setHeadersServer}
-              />
-            ))}
-          </div>
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search servers…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          containerClassName="w-64"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredServers}
+            errorMessagePrefix="Failed to load MCP servers"
+            loadingSkeleton={
+              <Table>
+                <TableBody>
+                  {[...Array(3)].map((_, i) => (
+                    <McpServerRowSkeleton key={i} />
+                  ))}
+                </TableBody>
+              </Table>
+            }
+            emptyState={
+              <Card className="p-8 text-center">
+                <Plug className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+                <h2 className="mb-2 text-lg font-medium">
+                  {search || statusTab !== "active"
+                    ? "No MCP servers match your filters"
+                    : "No MCP servers configured"}
+                </h2>
+                {!search && statusTab === "active" && (
+                  <>
+                    <p className="mb-4 text-muted-foreground">
+                      Add an MCP server to extend your agents with external tools and resources.
+                    </p>
+                    <Button variant="accent" onClick={() => setAddServerOpen(true)}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add Server
+                    </Button>
+                  </>
+                )}
+              </Card>
+            }
+          >
+            {(items) => (
+              <div className="border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Server</TableHead>
+                      <TableHead>Transport</TableHead>
+                      <TableHead>Auth</TableHead>
+                      <TableHead>Headers</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((server) => (
+                      <McpServerRow
+                        key={server.id}
+                        server={server}
+                        canDestroy={canDestroy}
+                        onDelete={setPendingDeleteServer}
+                        onArchive={setPendingArchiveServer}
+                        onSetApiKey={setApiKeyServer}
+                        onManageHeaders={setHeadersServer}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={
+                    statusTab === item.value
+                      ? "flex items-center justify-between text-foreground transition-colors"
+                      : "flex items-center justify-between text-muted-foreground transition-colors hover:text-foreground"
+                  }
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {transportFacets.length > 0 && (
+            <RailSection label="Transport">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {transportFacets.map((facet) => (
+                  <div key={facet.transport} className="flex items-center justify-between">
+                    <span>{facet.transport}</span>
+                    <span>{facet.count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredServers.length} of {counts.all} {pluralize(counts.all, "server")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
         )}
-      </QueryStateWrapper>
+      </PageFooter>
 
       {/* Dialogs */}
       <AddMcpServerDialog open={addServerOpen} onOpenChange={setAddServerOpen} />
@@ -799,6 +965,6 @@ export default function McpServersPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -72,13 +72,6 @@ import { pluralize } from "@/lib/formatting";
 
 const McpIcon = capabilityIconMap.mcp;
 
-function authLabel(server: McpServer): string {
-  if (server.auth_mode === "oauth") return "OAuth";
-  if (server.auth_mode === "api_key")
-    return server.api_key_set ? "API key configured" : "API key missing";
-  return "None";
-}
-
 function McpServerRow({
   server,
   canDestroy,
@@ -96,7 +89,6 @@ function McpServerRow({
 }) {
   const isArchived = server.status === "archived";
   const isDeleted = server.status === "deleted";
-  const headerCount = Object.keys(server.headers ?? {}).length;
 
   return (
     <TableRow>
@@ -107,7 +99,7 @@ function McpServerRow({
             <div className={`font-medium ${getEntityNameClassName(server.status)}`}>
               {server.name}
             </div>
-            <div className="truncate text-xs text-muted-foreground">
+            <div className="max-w-[42ch] truncate text-xs text-muted-foreground">
               {server.description || server.url}
             </div>
           </div>
@@ -117,10 +109,6 @@ function McpServerRow({
         <Badge variant="secondary" className="font-mono">
           {server.transport_type.toUpperCase()}
         </Badge>
-      </TableCell>
-      <TableCell className="text-muted-foreground">{authLabel(server)}</TableCell>
-      <TableCell className="text-muted-foreground">
-        {headerCount > 0 ? `${headerCount} ${pluralize(headerCount, "header")}` : "—"}
       </TableCell>
       <TableCell>
         <Badge variant={getEntityStatusBadgeVariant(server.status)}>{server.status}</Badge>
@@ -683,12 +671,6 @@ function McpServerRowSkeleton() {
         <Skeleton className="h-5 w-14" />
       </TableCell>
       <TableCell>
-        <Skeleton className="h-4 w-24" />
-      </TableCell>
-      <TableCell>
-        <Skeleton className="h-4 w-10" />
-      </TableCell>
-      <TableCell>
         <Skeleton className="h-5 w-16" />
       </TableCell>
       <TableCell>
@@ -845,8 +827,6 @@ export default function McpServersPage() {
                     <TableRow>
                       <TableHead>Server</TableHead>
                       <TableHead>Transport</TableHead>
-                      <TableHead>Auth</TableHead>
-                      <TableHead>Headers</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead className="text-right">Actions</TableHead>
                     </TableRow>

--- a/apps/ui/src/app/(main)/memory/[memoryId]/page.tsx
+++ b/apps/ui/src/app/(main)/memory/[memoryId]/page.tsx
@@ -1,16 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { use, useState } from "react";
-import {
-  AlertCircle,
-  Archive,
-  ArrowLeft,
-  GitBranch,
-  HardDrive,
-  Pencil,
-  RefreshCw,
-} from "lucide-react";
+import { AlertCircle, Archive, Brain, GitBranch, HardDrive, Pencil, RefreshCw } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { ArchiveMemoryDialog } from "@/components/memory/archive-memory-dialog";
@@ -20,6 +11,16 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 import { useArchiveMemory, usePageTitle, useSyncMemory, useUpdateMemory, useMemory } from "@/hooks";
 import type { UpdateMemoryRequest, Memory } from "@/lib/api/types";
 import {
@@ -59,145 +60,156 @@ export default function MemoryDetailPage({ params }: { params: Promise<{ memoryI
   const canSync = memory.source_type !== "manual" && memory.status === "active";
 
   return (
-    <div className="container mx-auto space-y-6 p-6">
-      <div className="flex items-center justify-between">
-        <Link href="/memory">
-          <Button variant="outline">
-            <ArrowLeft className="h-4 w-4" />
-            Memory
-          </Button>
-        </Link>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => setEditOpen(true)} disabled={isReadOnly}>
-            <Pencil className="h-4 w-4" />
-            Edit
-          </Button>
-          {!isReadOnly && (
-            <Button variant="outline" onClick={() => setArchiveOpen(true)}>
-              <Archive className="h-4 w-4" />
-              Archive
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Memory", href: "/memory" },
+          { label: memory.name },
+        ]}
+      />
+
+      <PageMasthead
+        icon={<Brain />}
+        title={<span className={getEntityNameClassName(memory.status)}>{memory.name}</span>}
+        badges={
+          <>
+            <CopyButton value={memory.id} />
+            <Badge variant={getEntityStatusBadgeVariant(memory.status)}>{memory.status}</Badge>
+            {memory.is_readonly && <Badge variant="secondary">Read-only</Badge>}
+          </>
+        }
+        meta={
+          <>
+            <span className="font-mono">{memory.id}</span>
+            <span>
+              Source <span className="text-foreground">{sourceLabel(memory)}</span>
+            </span>
+          </>
+        }
+        actions={
+          <>
+            <Button variant="outline" onClick={() => setEditOpen(true)} disabled={isReadOnly}>
+              <Pencil className="h-4 w-4" />
+              Edit
             </Button>
-          )}
-          {canSync && (
-            <Button
-              variant="outline"
-              onClick={() => syncMemory.mutate(memory.id)}
-              disabled={
-                syncMemory.isPending ||
-                memory.sync_status === "pending" ||
-                memory.sync_status === "syncing"
-              }
-            >
-              <RefreshCw className="h-4 w-4" />
-              Sync
-            </Button>
-          )}
-        </div>
-      </div>
-
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center bg-primary/10">
-            <HardDrive className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className={`truncate text-2xl font-bold ${getEntityNameClassName(memory.status)}`}>
-              {memory.name}
-            </h1>
-            <div className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
-              <span className="truncate font-mono">{memory.id}</span>
-              <CopyButton value={memory.id} />
-            </div>
-          </div>
-        </div>
-        <Badge variant={getEntityStatusBadgeVariant(memory.status)}>{memory.status}</Badge>
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Overview</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              {memory.description || "No description"}
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Source</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <div>
-              <div className="font-medium">Provider</div>
-              <div className="flex items-center gap-1.5 text-muted-foreground">
-                {memory.source.provider === "github" ? (
-                  <Github className="h-4 w-4" />
-                ) : memory.source.provider === "git" ? (
-                  <GitBranch className="h-4 w-4" />
-                ) : (
-                  <HardDrive className="h-4 w-4" />
-                )}
-                <span>{sourceLabel(memory)}</span>
-              </div>
-            </div>
-            {memory.source.provider !== "manual" && (
-              <>
-                <div>
-                  <div className="font-medium">Branch</div>
-                  <div className="text-muted-foreground">{memory.source.branch}</div>
-                </div>
-                {memory.source.root_folder && (
-                  <div>
-                    <div className="font-medium">Root Folder</div>
-                    <div className="font-mono text-muted-foreground">
-                      {memory.source.root_folder}
-                    </div>
-                  </div>
-                )}
-                <div>
-                  <div className="font-medium">Resync</div>
-                  <div className="text-muted-foreground">{formatSyncInterval(memory)}</div>
-                </div>
-              </>
+            {!isReadOnly && (
+              <Button variant="outline" onClick={() => setArchiveOpen(true)}>
+                <Archive className="h-4 w-4" />
+                Archive
+              </Button>
             )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Activity</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <div>
-              <div className="font-medium">Created</div>
-              <div className="text-muted-foreground">{formatDate(memory.created_at)}</div>
-            </div>
-            <div>
-              <div className="font-medium">Updated</div>
-              <div className="text-muted-foreground">{formatRelativeTime(memory.updated_at)}</div>
-            </div>
-            <div>
-              <div className="font-medium">Sync</div>
-              <div className="text-muted-foreground">{formatSyncStatus(memory)}</div>
-            </div>
-            {memory.last_sync_error && (
-              <div className="flex gap-2 text-destructive">
-                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                <span>{memory.last_sync_error}</span>
-              </div>
+            {canSync && (
+              <Button
+                variant="outline"
+                onClick={() => syncMemory.mutate(memory.id)}
+                disabled={
+                  syncMemory.isPending ||
+                  memory.sync_status === "pending" ||
+                  memory.sync_status === "syncing"
+                }
+              >
+                <RefreshCw className="h-4 w-4" />
+                Sync
+              </Button>
             )}
-            {memory.archived_at && (
+          </>
+        }
+      />
+
+      <PageColumns>
+        <PageMain>
+          <Card>
+            <CardHeader>
+              <CardTitle>Overview</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                {memory.description || "No description"}
+              </p>
+            </CardContent>
+          </Card>
+        </PageMain>
+
+        <PageRail>
+          <Card>
+            <CardHeader>
+              <CardTitle>Source</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
               <div>
-                <div className="font-medium">Archived</div>
-                <div className="text-muted-foreground">{formatDate(memory.archived_at)}</div>
+                <div className="font-medium">Provider</div>
+                <div className="flex items-center gap-1.5 text-muted-foreground">
+                  {memory.source.provider === "github" ? (
+                    <Github className="h-4 w-4" />
+                  ) : memory.source.provider === "git" ? (
+                    <GitBranch className="h-4 w-4" />
+                  ) : (
+                    <HardDrive className="h-4 w-4" />
+                  )}
+                  <span>{sourceLabel(memory)}</span>
+                </div>
               </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+              {memory.source.provider !== "manual" && (
+                <>
+                  <div>
+                    <div className="font-medium">Branch</div>
+                    <div className="text-muted-foreground">{memory.source.branch}</div>
+                  </div>
+                  {memory.source.root_folder && (
+                    <div>
+                      <div className="font-medium">Root Folder</div>
+                      <div className="font-mono text-muted-foreground">
+                        {memory.source.root_folder}
+                      </div>
+                    </div>
+                  )}
+                  <div>
+                    <div className="font-medium">Resync</div>
+                    <div className="text-muted-foreground">{formatSyncInterval(memory)}</div>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Activity</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                <div className="font-medium">Created</div>
+                <div className="text-muted-foreground">{formatDate(memory.created_at)}</div>
+              </div>
+              <div>
+                <div className="font-medium">Updated</div>
+                <div className="text-muted-foreground">{formatRelativeTime(memory.updated_at)}</div>
+              </div>
+              <div>
+                <div className="font-medium">Sync</div>
+                <div className="text-muted-foreground">{formatSyncStatus(memory)}</div>
+              </div>
+              {memory.last_sync_error && (
+                <div className="flex gap-2 text-destructive">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{memory.last_sync_error}</span>
+                </div>
+              )}
+              {memory.archived_at && (
+                <div>
+                  <div className="font-medium">Archived</div>
+                  <div className="text-muted-foreground">{formatDate(memory.archived_at)}</div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <BackLink href="/memory">Back to Memory</BackLink>
+      </PageFooter>
 
       <MemoryFormDialog
         mode="edit"
@@ -219,7 +231,7 @@ export default function MemoryDetailPage({ params }: { params: Promise<{ memoryI
         onOpenChange={setArchiveOpen}
         onArchive={() => archiveMemory.mutateAsync(memory.id)}
       />
-    </div>
+    </PageContainer>
   );
 }
 
@@ -264,19 +276,19 @@ function formatSyncInterval(memory: Memory) {
 
 function MemoryDetailSkeleton() {
   return (
-    <div className="container mx-auto space-y-6 p-6">
-      <Skeleton className="h-8 w-28" />
-      <div className="flex items-start gap-3">
-        <Skeleton className="h-10 w-10" />
+    <PageContainer>
+      <Skeleton className="h-4 w-48" />
+      <div className="flex items-start gap-4 border-b pb-4">
+        <Skeleton className="size-11" />
         <div className="space-y-2">
           <Skeleton className="h-8 w-64" />
           <Skeleton className="h-4 w-80" />
         </div>
       </div>
-      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+      <PageColumns>
         <Skeleton className="h-40" />
         <Skeleton className="h-40" />
-      </div>
-    </div>
+      </PageColumns>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/memory/page.tsx
+++ b/apps/ui/src/app/(main)/memory/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   AlertCircle,
   Archive,
+  Brain,
   FolderOpen,
   GitBranch,
   HardDrive,
@@ -13,15 +14,26 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
-import { ArchiveFilter } from "@/components/archive-filter";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ArchiveMemoryDialog } from "@/components/memory/archive-memory-dialog";
 import { MemoryFormDialog } from "@/components/memory/memory-form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { SearchInput } from "@/components/ui/search-input";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+  IconTile,
+} from "@/components/layout";
 import {
   useArchiveMemory,
   useCreateMemory,
@@ -34,66 +46,180 @@ import type { CreateMemoryRequest, UpdateMemoryRequest, Memory } from "@/lib/api
 import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
+  isArchivedStatus,
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
-import { formatRelativeTime } from "@/lib/formatting";
+import { formatRelativeTime, pluralize } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
+
+type StatusTab = "active" | "archived";
 
 export default function MemoryPage() {
   usePageTitle("Memory");
-  const [showArchived, setShowArchived] = useState(false);
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [editingMemory, setEditingMemory] = useState<Memory | null>(null);
   const [archivingMemory, setArchivingMemory] = useState<Memory | null>(null);
+  const showArchived = statusTab === "archived";
   const { data: memory, isLoading, error } = useMemories({ includeArchived: showArchived, search });
   const createMemory = useCreateMemory();
   const updateMemory = useUpdateMemory();
   const syncMemory = useSyncMemory();
   const archiveMemory = useArchiveMemory();
 
+  const list = useMemo(() => memory ?? [], [memory]);
+
+  // When showing archived, the API includes both active and archived; narrow to
+  // the selected tab so the count and grid stay consistent with the filter.
+  const filteredMemory = useMemo(() => {
+    if (!showArchived) return list;
+    return list.filter((m) => isArchivedStatus(m.status));
+  }, [list, showArchived]);
+
+  const counts = useMemo(() => {
+    const archived = list.filter((m) => isArchivedStatus(m.status)).length;
+    return { active: list.length - archived, archived };
+  }, [list]);
+
+  // Source-type usage counts for the rail facet.
+  const sourceFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const m of filteredMemory) {
+      tally.set(m.source_type, (tally.get(m.source_type) ?? 0) + 1);
+    }
+    return [...tally.entries()].sort((a, b) => b[1] - a[1]);
+  }, [filteredMemory]);
+
+  const statusItems = [
+    { value: "active" as const, label: "Active" },
+    { value: "archived" as const, label: "Archived" },
+  ];
+
   return (
-    <div className="container mx-auto p-6">
-      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <h1 className="flex items-center gap-3 text-2xl font-bold">Memory</h1>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <SearchInput
-            containerClassName="sm:w-64"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search memory"
-            aria-label="Search memory"
-          />
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Memory" }]} />
+
+      <PageMasthead
+        icon={<Brain />}
+        title="Memory"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {filteredMemory.length}
+          </Badge>
+        }
+        description="Knowledge stores that agents can read — manual notes or synced from Git."
+        actions={
           <Button variant="accent" onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4" />
+            <Plus className="size-4" />
             New Memory
           </Button>
-        </div>
-      </div>
+        }
+      />
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={memory}
-        errorMessagePrefix="Failed to load memory"
-        skeletonCount={6}
-        emptyState={<EmptyState hasSearch={!!search.trim()} onCreate={() => setCreateOpen(true)} />}
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {items.map((memory) => (
-              <MemoryCard
-                key={memory.id}
-                memory={memory}
-                onEdit={setEditingMemory}
-                onArchive={setArchivingMemory}
-                onSync={(candidate) => syncMemory.mutate(candidate.id)}
-                isSyncing={syncMemory.isPending}
-              />
-            ))}
-          </div>
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          containerClassName="w-64"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search memory"
+          aria-label="Search memory"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredMemory}
+            errorMessagePrefix="Failed to load memory"
+            skeletonCount={6}
+            emptyState={
+              <EmptyState hasSearch={!!search.trim()} onCreate={() => setCreateOpen(true)} />
+            }
+          >
+            {(items) => (
+              <div className="grid gap-4 xl:grid-cols-2">
+                {items.map((memory) => (
+                  <MemoryCard
+                    key={memory.id}
+                    memory={memory}
+                    onEdit={setEditingMemory}
+                    onArchive={setArchivingMemory}
+                    onSync={(candidate) => syncMemory.mutate(candidate.id)}
+                    isSyncing={syncMemory.isPending}
+                  />
+                ))}
+              </div>
+            )}
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {sourceFacets.length > 0 && (
+            <RailSection label="Source">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {sourceFacets.map(([source, count]) => (
+                  <div key={source} className="flex items-center justify-between">
+                    <span className="inline-flex items-center gap-1.5">
+                      {source === "github" ? (
+                        <Github className="size-3.5" />
+                      ) : source === "git" ? (
+                        <GitBranch className="size-3.5" />
+                      ) : (
+                        <HardDrive className="size-3.5" />
+                      )}
+                      {source === "manual" ? "Manual" : source}
+                    </span>
+                    <span>{count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredMemory.length} {pluralize(filteredMemory.length, "memory", "memories")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
         )}
-      </QueryStateWrapper>
+      </PageFooter>
 
       <MemoryFormDialog
         mode="create"
@@ -124,7 +250,7 @@ export default function MemoryPage() {
         onOpenChange={(open) => !open && setArchivingMemory(null)}
         onArchive={() => archiveMemory.mutateAsync(archivingMemory!.id)}
       />
-    </div>
+    </PageContainer>
   );
 }
 
@@ -145,97 +271,101 @@ function MemoryCard({
   const canSync = memory.source_type !== "manual" && memory.status === "active";
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center bg-primary/10">
-            <HardDrive className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <CardTitle className={`truncate text-lg ${getEntityNameClassName(memory.status)}`}>
-              {memory.name}
-            </CardTitle>
-            <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span className="truncate font-mono">{memory.id}</span>
-              <CopyButton value={memory.id} />
-            </div>
-          </div>
-        </div>
-        <div className="flex shrink-0 flex-col items-end gap-1">
+    <EntityCard
+      icon={<IconTile size="md" icon={<Brain />} />}
+      title={memory.name}
+      href={`/memory/${memory.id}`}
+      titleClassName={getEntityNameClassName(memory.status)}
+      copyValue={memory.id}
+      headerActions={
+        <div className="flex flex-col items-end gap-1">
           <Badge variant={getEntityStatusBadgeVariant(memory.status)}>{memory.status}</Badge>
           {memory.is_readonly && <Badge variant="secondary">Read-only</Badge>}
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="min-h-10 text-sm text-muted-foreground">
-          {memory.description || "No description"}
-        </p>
-        <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
-          <div>
-            <div className="font-medium text-foreground">Source</div>
-            <div className="flex items-center gap-1">
-              {memory.source_type === "github" ? (
-                <Github className="h-3.5 w-3.5" />
-              ) : memory.source_type === "git" ? (
-                <GitBranch className="h-3.5 w-3.5" />
-              ) : (
-                <HardDrive className="h-3.5 w-3.5" />
+      }
+      footer={
+        <EntityCardFooter
+          className="mt-4"
+          actions={
+            <div className="flex items-center gap-2">
+              {canSync && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onSync(memory)}
+                  disabled={
+                    isSyncing ||
+                    memory.sync_status === "pending" ||
+                    memory.sync_status === "syncing"
+                  }
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Sync
+                </Button>
               )}
-              <span>{memory.source_type === "manual" ? "Manual" : memory.source_type}</span>
+              <Link href={`/memory/${memory.id}`}>
+                <Button variant="outline" size="sm">
+                  <FolderOpen className="h-4 w-4" />
+                  Open
+                </Button>
+              </Link>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onEdit(memory)}
+                disabled={isReadOnly}
+              >
+                <Pencil className="h-4 w-4" />
+                Edit
+              </Button>
+              {!isReadOnly && (
+                <Button variant="outline" size="sm" onClick={() => onArchive(memory)}>
+                  <Archive className="h-4 w-4" />
+                  Archive
+                </Button>
+              )}
             </div>
-          </div>
-          <div>
-            <div className="font-medium text-foreground">Sync</div>
-            <div>{formatSyncStatus(memory)}</div>
-          </div>
-          <div>
-            <div className="font-medium text-foreground">Created</div>
-            <div>{formatRelativeTime(memory.created_at)}</div>
-          </div>
-          <div>
-            <div className="font-medium text-foreground">Updated</div>
-            <div>{formatRelativeTime(memory.updated_at)}</div>
+          }
+        />
+      }
+    >
+      <p className="mb-3 min-h-10 text-sm text-muted-foreground">
+        {memory.description || "No description"}
+      </p>
+      <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
+        <div>
+          <div className="font-medium text-foreground">Source</div>
+          <div className="flex items-center gap-1">
+            {memory.source_type === "github" ? (
+              <Github className="h-3.5 w-3.5" />
+            ) : memory.source_type === "git" ? (
+              <GitBranch className="h-3.5 w-3.5" />
+            ) : (
+              <HardDrive className="h-3.5 w-3.5" />
+            )}
+            <span>{memory.source_type === "manual" ? "Manual" : memory.source_type}</span>
           </div>
         </div>
-        {memory.last_sync_error && (
-          <div className="flex gap-2 text-xs text-destructive">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span className="line-clamp-2">{memory.last_sync_error}</span>
-          </div>
-        )}
-        <div className="flex items-center justify-end gap-2">
-          {canSync && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onSync(memory)}
-              disabled={
-                isSyncing || memory.sync_status === "pending" || memory.sync_status === "syncing"
-              }
-            >
-              <RefreshCw className="h-4 w-4" />
-              Sync
-            </Button>
-          )}
-          <Link href={`/memory/${memory.id}`}>
-            <Button variant="outline" size="sm">
-              <FolderOpen className="h-4 w-4" />
-              Open
-            </Button>
-          </Link>
-          <Button variant="outline" size="sm" onClick={() => onEdit(memory)} disabled={isReadOnly}>
-            <Pencil className="h-4 w-4" />
-            Edit
-          </Button>
-          {!isReadOnly && (
-            <Button variant="outline" size="sm" onClick={() => onArchive(memory)}>
-              <Archive className="h-4 w-4" />
-              Archive
-            </Button>
-          )}
+        <div>
+          <div className="font-medium text-foreground">Sync</div>
+          <div>{formatSyncStatus(memory)}</div>
         </div>
-      </CardContent>
-    </Card>
+        <div>
+          <div className="font-medium text-foreground">Created</div>
+          <div>{formatRelativeTime(memory.created_at)}</div>
+        </div>
+        <div>
+          <div className="font-medium text-foreground">Updated</div>
+          <div>{formatRelativeTime(memory.updated_at)}</div>
+        </div>
+      </div>
+      {memory.last_sync_error && (
+        <div className="mt-4 flex gap-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span className="line-clamp-2">{memory.last_sync_error}</span>
+        </div>
+      )}
+    </EntityCard>
   );
 }
 
@@ -271,8 +401,8 @@ function formatSyncInterval(memory: Memory) {
 
 function EmptyState({ hasSearch, onCreate }: { hasSearch: boolean; onCreate: () => void }) {
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <HardDrive className="mb-4 h-12 w-12 text-muted-foreground" />
+    <div className="flex flex-col items-center justify-center border border-dashed py-12 text-center">
+      <Brain className="mb-4 h-12 w-12 text-muted-foreground" />
       <h3 className="mb-2 text-lg font-semibold">{hasSearch ? "No memory found" : "No memory"}</h3>
       {!hasSearch && (
         <Button variant="accent" onClick={onCreate}>

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -6,8 +6,10 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Cpu, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import { SearchInput } from "@/components/ui/search-input";
 import {
   Select,
   SelectContent,
@@ -16,7 +18,17 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { PageShell, PageHeader, PageBody } from "@/components/layout";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
 import { AddModelDialog } from "@/components/models/add-model-dialog";
 import { ModelRow } from "@/components/models/model-row";
 import { ProviderIcon } from "@/components/providers/provider-icon";
@@ -25,6 +37,8 @@ import { useOrganization, useUpdateOrganization } from "@/hooks/use-organization
 import { usePageTitle } from "@/hooks";
 import { updateModel } from "@/lib/api/providers";
 import { queryKeys } from "@/lib/query-keys";
+import { pluralize } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
 import type { ModelWithProvider } from "@/lib/api/types";
 
 // Order models by release date desc (newest first), then by created_at desc.
@@ -49,6 +63,7 @@ export default function ModelsPage() {
   const deleteModel = useDeleteModel();
   const [addModelOpen, setAddModelOpen] = useState(false);
   const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
   const selectedProviderId = searchParams.get("provider");
   const selectedProvider = useMemo(
     () =>
@@ -57,13 +72,24 @@ export default function ModelsPage() {
         : undefined,
     [providers, selectedProviderId],
   );
-  const filteredModels = useMemo(
+  const providerFilteredModels = useMemo(
     () =>
       selectedProviderId
         ? models.filter((model) => model.provider_id === selectedProviderId)
         : models,
     [models, selectedProviderId],
   );
+  const filteredModels = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return providerFilteredModels;
+    return providerFilteredModels.filter((model) => {
+      const haystack = [model.display_name, model.model_id, model.provider_name]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [providerFilteredModels, search]);
 
   const { enabledModels, availableModels } = useMemo(() => {
     const enabled = filteredModels.filter((m) => m.enabled).sort(compareByRecency);
@@ -78,6 +104,21 @@ export default function ModelsPage() {
     ? (allEnabledModels.find((model) => model.id === org.default_model_id)?.display_name ??
       "Unknown model")
     : undefined;
+
+  // Provider usage counts across all models, for the rail facet.
+  const providerFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const model of models) {
+      tally.set(model.provider_id, (tally.get(model.provider_id) ?? 0) + 1);
+    }
+    return [...tally.entries()]
+      .map(([id, count]) => ({
+        id,
+        count,
+        name: providers.find((p) => p.id === id)?.name ?? id,
+      }))
+      .sort((a, b) => b.count - a.count);
+  }, [models, providers]);
 
   const handleDeleteModel = async (id: string) => {
     if (confirm("Are you sure you want to delete this model?")) {
@@ -109,37 +150,59 @@ export default function ModelsPage() {
   };
 
   return (
-    <PageShell>
-      <PageHeader
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Models" }]} />
+
+      <PageMasthead
+        icon={<Cpu />}
         title="Models"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {providerFilteredModels.length}
+          </Badge>
+        }
         description={
           selectedProvider
             ? `Manage the models available from ${selectedProvider.name}.`
             : "Manage the models available from your configured providers."
         }
+        meta={
+          <>
+            <span>{enabledModels.length} enabled</span>
+            <span>{availableModels.length} available</span>
+          </>
+        }
         actions={
           <>
-            {selectedProviderId && (
-              <Link href="/models">
-                <Button variant="outline">Clear filter</Button>
-              </Link>
-            )}
-            <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
-              <Plus className="h-4 w-4 mr-2" />
+            <Button
+              variant="accent"
+              onClick={() => setAddModelOpen(true)}
+              disabled={providers.length === 0}
+            >
+              <Plus className="size-4" />
               Add Model
             </Button>
           </>
         }
       />
 
-      <PageBody>
-        <section>
-          {modelsError && (
-            <div className="bg-destructive/10 text-destructive p-4 mb-4">
-              Failed to load models: {modelsError.message}
-            </div>
-          )}
+      {modelsError && (
+        <div className="border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          Failed to load models: {modelsError.message}
+        </div>
+      )}
 
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder="Search models…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          containerClassName="w-64"
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
           {modelsLoading ? (
             <div className="space-y-2">
               {[...Array(3)].map((_, index) => (
@@ -150,16 +213,22 @@ export default function ModelsPage() {
             <Card className="p-8 text-center">
               <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
               <h3 className="text-lg font-medium mb-2">
-                {selectedProvider ? "No models for this provider" : "No models configured"}
+                {search
+                  ? "No models match your search"
+                  : selectedProvider
+                    ? "No models for this provider"
+                    : "No models configured"}
               </h3>
               <p className="text-muted-foreground mb-4">
-                {selectedProvider
-                  ? "Sync or add models for this provider to use them with agents."
-                  : providers.length === 0
-                    ? "Add a provider first, then add models to it."
-                    : "Add models to your providers to use them with agents."}
+                {search
+                  ? "Try a different search term."
+                  : selectedProvider
+                    ? "Sync or add models for this provider to use them with agents."
+                    : providers.length === 0
+                      ? "Add a provider first, then add models to it."
+                      : "Add models to your providers to use them with agents."}
               </p>
-              {providers.length > 0 && (
+              {!search && providers.length > 0 && (
                 <Button onClick={() => setAddModelOpen(true)}>
                   <Plus className="h-4 w-4 mr-2" />
                   Add Model
@@ -221,59 +290,95 @@ export default function ModelsPage() {
               )}
             </div>
           )}
-        </section>
 
-        {allEnabledModels.length > 0 && (
-          <section>
-            <div className="mb-4">
-              <h2 className="text-xl font-semibold">Organization Settings</h2>
-              <p className="text-sm text-muted-foreground">
-                Configure the default model for your organization. This is used when no model is
-                specified at the agent or session level.
-              </p>
-            </div>
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-4">
-                  <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
-                    Default Model
-                  </Label>
-                  <Select
-                    value={org?.default_model_id ?? "none"}
-                    onValueChange={(value) => handleSetDefaultModel(value === "none" ? "" : value)}
-                    disabled={updateOrg.isPending}
+          {allEnabledModels.length > 0 && (
+            <section className="mt-4">
+              <div className="mb-4">
+                <h2 className="text-xl font-semibold">Organization Settings</h2>
+                <p className="text-sm text-muted-foreground">
+                  Configure the default model for your organization. This is used when no model is
+                  specified at the agent or session level.
+                </p>
+              </div>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-4">
+                    <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
+                      Default Model
+                    </Label>
+                    <Select
+                      value={org?.default_model_id ?? "none"}
+                      onValueChange={(value) =>
+                        handleSetDefaultModel(value === "none" ? "" : value)
+                      }
+                      disabled={updateOrg.isPending}
+                    >
+                      <SelectTrigger className="w-full max-w-md" id="default-model">
+                        <SelectValue placeholder="No default model">
+                          {selectedDefaultModelName}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">No default model</SelectItem>
+                        {allEnabledModels.map((model) => (
+                          <SelectItem key={model.id} value={model.id}>
+                            <div className="flex items-center gap-2">
+                              <ProviderIcon
+                                providerType={model.provider_type}
+                                size="sm"
+                                showBackground={false}
+                              />
+                              <span>
+                                {model.display_name} ({model.provider_name})
+                              </span>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+          )}
+        </PageMain>
+
+        <PageRail>
+          {providerFacets.length > 0 && (
+            <RailSection label="Provider">
+              <div className="flex flex-col gap-1.5 text-[13px]">
+                {providerFacets.map((facet) => (
+                  <Link
+                    key={facet.id}
+                    href={`/models?provider=${facet.id}`}
+                    className={cn(
+                      "flex items-center justify-between transition-colors hover:text-foreground",
+                      selectedProviderId === facet.id ? "text-foreground" : "text-muted-foreground",
+                    )}
                   >
-                    <SelectTrigger className="w-full max-w-md" id="default-model">
-                      <SelectValue placeholder="No default model">
-                        {selectedDefaultModelName}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">No default model</SelectItem>
-                      {allEnabledModels.map((model) => (
-                        <SelectItem key={model.id} value={model.id}>
-                          <div className="flex items-center gap-2">
-                            <ProviderIcon
-                              providerType={model.provider_type}
-                              size="sm"
-                              showBackground={false}
-                            />
-                            <span>
-                              {model.display_name} ({model.provider_name})
-                            </span>
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </CardContent>
-            </Card>
-          </section>
+                    <span>{facet.name}</span>
+                    <span className="text-muted-foreground">{facet.count}</span>
+                  </Link>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredModels.length} of {providerFilteredModels.length}{" "}
+          {pluralize(providerFilteredModels.length, "model")}
+        </span>
+        {selectedProviderId && (
+          <Link href="/models" className="text-primary transition-colors hover:underline">
+            Clear filter →
+          </Link>
         )}
-      </PageBody>
+      </PageFooter>
 
       <AddModelDialog providers={providers} open={addModelOpen} onOpenChange={setAddModelOpen} />
-    </PageShell>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/plugins/page.tsx
+++ b/apps/ui/src/app/(main)/plugins/page.tsx
@@ -9,8 +9,16 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CopyButton } from "@/components/ui/copy-button";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageMain,
+  PageFooter,
+} from "@/components/layout";
 import {
   Dialog,
   DialogContent,
@@ -35,6 +43,7 @@ import {
 import { usePageTitle } from "@/hooks";
 import {
   Plus,
+  Puzzle,
   Package,
   Store,
   RefreshCw,
@@ -44,6 +53,7 @@ import {
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
+import { pluralize } from "@/lib/formatting";
 import type {
   Marketplace,
   MarketplaceCatalogEntry,
@@ -650,35 +660,54 @@ export default function PluginsPage() {
     null,
   );
 
+  const installedCount = plugins?.length ?? 0;
+  const marketplaceCount = marketplaces?.length ?? 0;
+
+  const sectionItems = [
+    { value: "installed" as const, label: "Installed Plugins" },
+    { value: "marketplaces" as const, label: "Marketplaces" },
+  ];
+
   return (
-    <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Plugins</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Install plugins from marketplaces to extend agents with skills, commands, and MCP
-            servers packaged in the standard plugin format.
-          </p>
-        </div>
-        {activeTab === "marketplaces" && (
-          <Button onClick={() => setAddMarketplaceOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Add Marketplace
-          </Button>
-        )}
-      </div>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Plugins" }]} />
 
-      <Tabs
-        value={activeTab}
-        onValueChange={(v) => setActiveTab(v as "installed" | "marketplaces")}
-      >
-        <TabsList>
-          <TabsTrigger value="installed">Installed Plugins</TabsTrigger>
-          <TabsTrigger value="marketplaces">Marketplaces</TabsTrigger>
-        </TabsList>
+      <PageMasthead
+        icon={<Puzzle />}
+        title="Plugins"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {installedCount}
+          </Badge>
+        }
+        description="Install plugins from marketplaces to extend agents with skills, commands, and MCP servers packaged in the standard plugin format."
+        meta={
+          <>
+            <span>{installedCount} installed</span>
+            <span>{marketplaceCount} marketplaces</span>
+          </>
+        }
+        actions={
+          activeTab === "marketplaces" && (
+            <Button variant="accent" onClick={() => setAddMarketplaceOpen(true)}>
+              <Plus className="size-4" />
+              Add Marketplace
+            </Button>
+          )
+        }
+      />
 
+      <PageControlStrip>
+        <SectionTabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as "installed" | "marketplaces")}
+          items={sectionItems}
+        />
+      </PageControlStrip>
+
+      <PageMain>
         {/* ---- Installed Plugins tab ---- */}
-        <TabsContent value="installed">
+        {activeTab === "installed" && (
           <QueryStateWrapper
             isLoading={pluginsLoading}
             error={pluginsError}
@@ -717,10 +746,10 @@ export default function PluginsPage() {
               </div>
             )}
           </QueryStateWrapper>
-        </TabsContent>
+        )}
 
         {/* ---- Marketplaces tab ---- */}
-        <TabsContent value="marketplaces">
+        {activeTab === "marketplaces" && (
           <QueryStateWrapper
             isLoading={marketplacesLoading}
             error={marketplacesError}
@@ -760,8 +789,20 @@ export default function PluginsPage() {
               </div>
             )}
           </QueryStateWrapper>
-        </TabsContent>
-      </Tabs>
+        )}
+      </PageMain>
+
+      <PageFooter>
+        {activeTab === "installed" ? (
+          <span>
+            Showing {installedCount} {pluralize(installedCount, "plugin")}
+          </span>
+        ) : (
+          <span>
+            Showing {marketplaceCount} {pluralize(marketplaceCount, "marketplace")}
+          </span>
+        )}
+      </PageFooter>
 
       {/* Marketplace dialogs */}
       <AddMarketplaceDialog open={addMarketplaceOpen} onOpenChange={setAddMarketplaceOpen} />
@@ -782,6 +823,6 @@ export default function PluginsPage() {
         open={pendingUninstallPlugin !== null}
         onOpenChange={(open) => !open && setPendingUninstallPlugin(null)}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/skills/[skillId]/page.tsx
+++ b/apps/ui/src/app/(main)/skills/[skillId]/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { use } from "react";
-import Link from "next/link";
-import { ArrowLeft, Archive, FileText } from "lucide-react";
+import { Archive, FileText } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { SkillDetailView } from "@/components/skills/skill-detail-view";
+import { SkillUsageRow } from "@/components/skills/skill-usage-row";
 import { usePageTitle } from "@/hooks";
 import { useSkill, useSkillContent, useSkillsUsage } from "@/hooks/use-skills";
 import {
@@ -14,6 +15,17 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 
 export default function SkillDetailPage({ params }: { params: Promise<{ skillId: string }> }) {
   const { skillId } = use(params);
@@ -49,40 +61,105 @@ export default function SkillDetailPage({ params }: { params: Promise<{ skillId:
     );
   }
 
+  const skillUsage = usage?.[skill.id];
+
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/skills"
-        className="mb-6 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft className="mr-2 h-4 w-4" />
-        Back to Skills
-      </Link>
-
-      <header className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="min-w-0">
-          <h1 className="flex min-w-0 flex-wrap items-center gap-2 text-2xl font-bold">
-            {skill.source_type === "archive" ? (
-              <Archive className="h-6 w-6 shrink-0 text-primary" />
-            ) : (
-              <FileText className="h-6 w-6 shrink-0 text-primary" />
-            )}
-            <span className={getEntityNameClassName(skill.status)}>{getDisplayName(skill)}</span>
-            <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
-          </h1>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
-            {skill.description}
-          </p>
-        </div>
-      </header>
-
-      <SkillDetailView
-        skill={skill}
-        usage={usage?.[skill.id]}
-        content={content}
-        contentLoading={contentLoading}
-        contentError={contentError}
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Skills", href: "/skills" },
+          { label: getDisplayName(skill) },
+        ]}
       />
-    </div>
+
+      <PageMasthead
+        icon={skill.source_type === "archive" ? <Archive /> : <FileText />}
+        title={
+          <span className={getEntityNameClassName(skill.status)}>{getDisplayName(skill)}</span>
+        }
+        badges={
+          <>
+            <CopyButton value={skill.id} />
+            <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
+            <Badge variant="secondary" className="text-xs">
+              {skill.source_type}
+            </Badge>
+          </>
+        }
+        description={skill.description || undefined}
+        meta={
+          <>
+            <span>
+              Version <span className="text-primary">v{skill.version}</span>
+            </span>
+            {skill.license && (
+              <span>
+                License <span className="text-foreground">{skill.license}</span>
+              </span>
+            )}
+            <span>
+              Created{" "}
+              <span className="text-foreground">
+                {new Date(skill.created_at).toLocaleDateString()}
+              </span>
+            </span>
+          </>
+        }
+      />
+
+      <PageColumns>
+        <PageMain>
+          <SkillDetailView
+            skill={skill}
+            usage={skillUsage}
+            content={content}
+            contentLoading={contentLoading}
+            contentError={contentError}
+          />
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Used by">
+            <SkillUsageRow usage={skillUsage} />
+          </RailSection>
+
+          <RailSection label="Details">
+            <dl className="flex flex-col gap-2 text-[13px]">
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Source</dt>
+                <dd className="text-foreground">{skill.source_type}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Version</dt>
+                <dd className="text-foreground">v{skill.version}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">License</dt>
+                <dd className="text-foreground">{skill.license ?? "-"}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Compatibility</dt>
+                <dd className="text-foreground">{skill.compatibility ?? "-"}</dd>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-muted-foreground">Allowed tools</dt>
+                <dd className="break-words text-foreground">{skill.allowed_tools ?? "-"}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Updated</dt>
+                <dd className="text-foreground">
+                  {new Date(skill.updated_at).toLocaleDateString()}
+                </dd>
+              </div>
+            </dl>
+          </RailSection>
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <BackLink href="/skills">Back to Skills</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -2,8 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
+import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
@@ -29,11 +28,32 @@ import {
 import { usePolicies } from "@/hooks/use-policies";
 import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box } from "lucide-react";
 import type { Skill, SkillUsage } from "@/lib/api/types";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
-import { ArchiveFilter } from "@/components/archive-filter";
+import {
+  getDisplayName,
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+  isArchivedStatus,
+} from "@/lib/entity-lifecycle";
+import { pluralize } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  IconTile,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  RailSection,
+  PageFooter,
+} from "@/components/layout";
 import { SkillUsageRow } from "@/components/skills/skill-usage-row";
 
-function SkillCard({
+type StatusTab = "all" | "active" | "archived";
+
+function SkillRow({
   skill,
   usage,
   canDestroy,
@@ -50,60 +70,52 @@ function SkillCard({
 
   return (
     <EntityCard
+      variant="row"
       icon={
-        <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
-          {skill.source_type === "archive" ? (
-            <Archive className="h-5 w-5 text-primary" />
-          ) : (
-            <FileText className="h-5 w-5 text-primary" />
-          )}
-        </div>
+        <IconTile size="md" icon={skill.source_type === "archive" ? <Archive /> : <FileText />} />
       }
-      title={skill.name}
+      title={getDisplayName(skill)}
       href={`/skills/${skill.id}`}
       titleClassName={getEntityNameClassName(skill.status)}
-      subtitle={<span className="text-sm text-muted-foreground">{skill.description}</span>}
-      headerActions={
-        <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
-      }
-      footer={
-        <EntityCardFooter
-          className="mt-4"
-          actions={
-            <div className="flex items-center gap-2">
-              {!isArchived && !isDeleted && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => updateSkill.mutate({ status: "archived" })}
-                  disabled={updateSkill.isPending}
-                >
-                  <Archive className="h-4 w-4 mr-1" />
-                  {updateSkill.isPending ? "Archiving..." : "Archive"}
-                </Button>
-              )}
-              {isArchived && canDestroy && (
-                <Button variant="destructive" size="sm" onClick={() => onDelete(skill)}>
-                  <Trash2 className="h-4 w-4 mr-1" />
-                  Delete
-                </Button>
-              )}
-            </div>
-          }
-        />
-      }
-    >
-      <div className="space-y-2 text-sm">
-        <div className="flex items-center gap-2">
+      inlineBadges={
+        <>
+          <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
           <Badge variant="secondary" className="text-xs">
             {skill.source_type}
           </Badge>
-          <span className="text-muted-foreground">v{skill.version}</span>
-        </div>
-        {skill.license && <div className="text-muted-foreground">License: {skill.license}</div>}
-        {skill.allowed_tools && (
-          <div className="text-muted-foreground">Tools: {skill.allowed_tools}</div>
+          <span className="text-xs text-muted-foreground">v{skill.version}</span>
+        </>
+      }
+      headerActions={
+        <>
+          {!isArchived && !isDeleted && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => updateSkill.mutate({ status: "archived" })}
+              disabled={updateSkill.isPending}
+            >
+              <Archive className="h-4 w-4 mr-1" />
+              {updateSkill.isPending ? "Archiving..." : "Archive"}
+            </Button>
+          )}
+          {isArchived && canDestroy && (
+            <Button variant="destructive" size="sm" onClick={() => onDelete(skill)}>
+              <Trash2 className="h-4 w-4 mr-1" />
+              Delete
+            </Button>
+          )}
+        </>
+      }
+    >
+      <div className="mt-1 space-y-1.5 text-sm">
+        {skill.description && (
+          <p className="line-clamp-2 text-muted-foreground">{skill.description}</p>
         )}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {skill.license && <span>License: {skill.license}</span>}
+          {skill.allowed_tools && <span>Tools: {skill.allowed_tools}</span>}
+        </div>
         <SkillUsageRow usage={usage} />
       </div>
     </EntityCard>
@@ -224,31 +236,27 @@ function UploadSkillDialog({
   );
 }
 
-function SkillCardSkeleton() {
+function SkillRowSkeleton() {
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9" />
-          <div className="space-y-2">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-4 w-48" />
-          </div>
+    <div className="flex items-start justify-between border p-3">
+      <div className="flex flex-1 items-start gap-3">
+        <Skeleton className="h-8 w-8" />
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-64" />
         </div>
-        <Skeleton className="h-5 w-16" />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className="h-4 w-full mb-4" />
-        <Skeleton className="h-8 w-24 ml-auto" />
-      </CardContent>
-    </Card>
+      </div>
+      <Skeleton className="h-8 w-24" />
+    </div>
   );
 }
 
 export default function SkillsPageClient() {
-  const [showArchived, setShowArchived] = useState(false);
+  const [statusTab, setStatusTab] = useState<StatusTab>("active");
   const [search, setSearch] = useState("");
-  const { data: skills, isLoading, error } = useSkills({ includeArchived: showArchived });
+  // Active tab fetches active-only (matching the SSR seed); other tabs include archived.
+  const includeArchived = statusTab !== "active";
+  const { data: skills, isLoading, error } = useSkills({ includeArchived });
   const { data: usage } = useSkillsUsage();
   const destroySkillMutation = useDestroySkill();
   const { can: canPolicies } = usePolicies("skills");
@@ -258,17 +266,34 @@ export default function SkillsPageClient() {
   const [uploadSkillOpen, setUploadSkillOpen] = useState(false);
   const [pendingDeleteSkill, setPendingDeleteSkill] = useState<Skill | null>(null);
 
+  const counts = useMemo(() => {
+    const list = skills ?? [];
+    const archived = list.filter((s) => isArchivedStatus(s.status)).length;
+    return { all: list.length, active: list.length - archived, archived };
+  }, [skills]);
+
   const filteredSkills = useMemo(() => {
-    if (!skills) return skills;
     const query = search.trim().toLowerCase();
-    if (!query) return skills;
-    return skills.filter(
-      (s) =>
+    return (skills ?? []).filter((s) => {
+      if (statusTab === "active" && isArchivedStatus(s.status)) return false;
+      if (statusTab === "archived" && !isArchivedStatus(s.status)) return false;
+      if (!query) return true;
+      return (
         s.name.toLowerCase().includes(query) ||
         s.description.toLowerCase().includes(query) ||
-        (s.allowed_tools?.toLowerCase().includes(query) ?? false),
-    );
-  }, [skills, search]);
+        (s.allowed_tools?.toLowerCase().includes(query) ?? false)
+      );
+    });
+  }, [skills, search, statusTab]);
+
+  // Source-type usage counts across the fetched skills, for the rail facet.
+  const sourceFacets = useMemo(() => {
+    const tally = new Map<string, number>();
+    for (const skill of skills ?? []) {
+      tally.set(skill.source_type, (tally.get(skill.source_type) ?? 0) + 1);
+    }
+    return [...tally.entries()].sort((a, b) => b[1] - a[1]);
+  }, [skills]);
 
   const handleDeleteSkill = async () => {
     if (!pendingDeleteSkill) return;
@@ -276,77 +301,170 @@ export default function SkillsPageClient() {
     setPendingDeleteSkill(null);
   };
 
-  return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6 gap-2 flex-wrap">
-        <h1 className="text-2xl font-bold">Skills</h1>
-        <div className="flex items-center gap-2 flex-wrap">
-          <SearchInput
-            containerClassName="w-64"
-            placeholder="Search skills..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            aria-label="Search skills"
-          />
-          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
-          <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
-            <Upload className="h-4 w-4 mr-2" />
-            Upload ZIP
-          </Button>
-          <Button variant="accent" onClick={() => setAddSkillOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Skill
-          </Button>
-        </div>
-      </div>
+  const statusItems = [
+    { value: "all" as const, label: "All" },
+    { value: "active" as const, label: "Active" },
+    { value: "archived" as const, label: "Archived" },
+  ];
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={filteredSkills}
-        errorMessagePrefix="Failed to load skills"
-        loadingSkeleton={
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {[...Array(6)].map((_, i) => (
-              <SkillCardSkeleton key={i} />
-            ))}
-          </div>
+  return (
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Skills" }]} />
+
+      <PageMasthead
+        icon={<BookOpen />}
+        title="Skills"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {counts.all}
+          </Badge>
         }
-        emptyState={
-          <div className="text-center py-12">
-            <BookOpen className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <p className="text-muted-foreground mb-4">
-              {search.trim() ? "No skills match your search" : "No skills yet"}
-            </p>
-            {!search.trim() && (
-              <div className="flex justify-center gap-2">
-                <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
-                  <Upload className="h-4 w-4 mr-2" />
-                  Upload ZIP
-                </Button>
-                <Button onClick={() => setAddSkillOpen(true)}>
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add Skill
-                </Button>
+        description="Reusable Agent Skills — SKILL.md instructions and optional bundled files."
+        meta={
+          <>
+            <span>{counts.active} active</span>
+            <span>{counts.archived} archived</span>
+          </>
+        }
+        actions={
+          <>
+            <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
+              <Upload className="size-4" />
+              Upload ZIP
+            </Button>
+            <Button variant="accent" onClick={() => setAddSkillOpen(true)}>
+              <Plus className="size-4" />
+              Add Skill
+            </Button>
+          </>
+        }
+      />
+
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          containerClassName="w-64"
+          placeholder="Search skills…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search skills"
+        />
+        <div className="flex-1" />
+        <SectionTabs
+          value={statusTab}
+          onValueChange={(v) => setStatusTab(v as StatusTab)}
+          items={statusItems}
+        />
+      </PageControlStrip>
+
+      <PageColumns>
+        <PageMain>
+          <QueryStateWrapper
+            isLoading={isLoading}
+            error={error}
+            data={filteredSkills}
+            errorMessagePrefix="Failed to load skills"
+            loadingSkeleton={
+              <div className="flex flex-col gap-3">
+                {[...Array(6)].map((_, i) => (
+                  <SkillRowSkeleton key={i} />
+                ))}
+              </div>
+            }
+            emptyState={
+              <div className="border border-dashed py-12 text-center">
+                <BookOpen className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+                <p className="mb-4 text-muted-foreground">
+                  {search.trim() || statusTab !== "active"
+                    ? "No skills match your filters."
+                    : "No skills yet"}
+                </p>
+                {!search.trim() && statusTab === "active" && (
+                  <div className="flex justify-center gap-2">
+                    <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
+                      <Upload className="h-4 w-4 mr-2" />
+                      Upload ZIP
+                    </Button>
+                    <Button onClick={() => setAddSkillOpen(true)}>
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Skill
+                    </Button>
+                  </div>
+                )}
+              </div>
+            }
+          >
+            {(items) => (
+              <div className="flex flex-col gap-3">
+                {items.map((skill) => (
+                  <SkillRow
+                    key={skill.id}
+                    skill={skill}
+                    usage={usage?.[skill.id]}
+                    canDestroy={canDestroy}
+                    onDelete={setPendingDeleteSkill}
+                  />
+                ))}
               </div>
             )}
-          </div>
-        }
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((skill) => (
-              <SkillCard
-                key={skill.id}
-                skill={skill}
-                usage={usage?.[skill.id]}
-                canDestroy={canDestroy}
-                onDelete={setPendingDeleteSkill}
-              />
-            ))}
-          </div>
+          </QueryStateWrapper>
+        </PageMain>
+
+        <PageRail>
+          <RailSection label="Status">
+            <div className="flex flex-col gap-1.5 text-[13px]">
+              {statusItems.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => setStatusTab(item.value)}
+                  className={cn(
+                    "flex items-center justify-between transition-colors hover:text-foreground",
+                    statusTab === item.value ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-muted-foreground">{counts[item.value]}</span>
+                </button>
+              ))}
+            </div>
+          </RailSection>
+
+          {sourceFacets.length > 0 && (
+            <RailSection label="Source">
+              <div className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
+                {sourceFacets.map(([source, count]) => (
+                  <div key={source} className="flex items-center justify-between">
+                    <span className="inline-flex items-center gap-1.5">
+                      {source === "archive" ? (
+                        <Archive className="size-3.5" />
+                      ) : (
+                        <FileText className="size-3.5" />
+                      )}
+                      {source}
+                    </span>
+                    <span>{count}</span>
+                  </div>
+                ))}
+              </div>
+            </RailSection>
+          )}
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <span>
+          Showing {filteredSkills.length} of {counts.all} {pluralize(counts.all, "skill")}
+        </span>
+        {counts.archived > 0 && statusTab !== "archived" && (
+          <button
+            type="button"
+            onClick={() => setStatusTab("archived")}
+            className="text-primary transition-colors hover:underline"
+          >
+            View archived →
+          </button>
         )}
-      </QueryStateWrapper>
+      </PageFooter>
 
       <AddSkillDialog open={addSkillOpen} onOpenChange={setAddSkillOpen} />
       <UploadSkillDialog open={uploadSkillOpen} onOpenChange={setUploadSkillOpen} />
@@ -378,6 +496,6 @@ export default function SkillsPageClient() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/components/apps/app-detail.tsx
+++ b/apps/ui/src/components/apps/app-detail.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Archive, ArrowLeft, GlobeLock, Play, Plus, Rocket } from "lucide-react";
+import { Archive, GlobeLock, Play, Plus, Rocket } from "lucide-react";
 import { useAgents, usePageTitle } from "@/hooks";
 import { useHarnesses } from "@/hooks/use-harnesses";
 import { usePolicies } from "@/hooks/use-policies";
@@ -13,17 +13,34 @@ import { queryKeys } from "@/lib/query-keys";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { ChannelRow } from "@/components/apps/channel-row";
 import { LiveActivityRail } from "@/components/apps/live-activity-rail";
-import { StatStrip, type StatStripStats } from "@/components/apps/stat-strip";
+import { MiniTimeline } from "@/components/apps/mini-timeline";
+import { type StatStripStats } from "@/components/apps/stat-strip";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  StatCard,
+  StatGrid,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+} from "@/components/layout";
 import type { App, AppChannel } from "@/lib/api/types";
 import {
   getDisplayName,
+  getEntityNameClassName,
   getEntityStatusBadgeVariant,
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
+import { pluralize } from "@/lib/formatting";
 
 function buildStats(app: App): StatStripStats {
   const enabled = app.channels.filter((channel) => channel.enabled).length;
@@ -106,162 +123,177 @@ export function AppDetail({ appId }: { appId: string }) {
     );
   }
 
+  const enabledChannels = app.channels.filter((channel) => channel.enabled).length;
+
   return (
-    <div className="container mx-auto space-y-6 p-6">
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Link href="/apps" className="hover:text-foreground">
-          Apps
-        </Link>
-        <span>/</span>
-        <span>{app.name}</span>
-      </div>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Apps", href: "/apps" }, { label: app.name }]} />
 
-      <div className="flex flex-col gap-4 border-b pb-5 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex min-w-0 gap-4">
-          <span className="flex size-11 shrink-0 items-center justify-center border bg-accent/20">
-            <Rocket className="size-5" />
-          </span>
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="text-2xl font-semibold">{app.name}</h1>
-              <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
-            </div>
-            {app.description && <p className="mt-1 text-muted-foreground">{app.description}</p>}
-            <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-sm text-muted-foreground">
-              <span>
-                Agent{" "}
-                {app.agent_id ? (
-                  <Link
-                    href={`/agents/${app.agent_id}`}
-                    className="text-foreground hover:underline"
-                  >
-                    {agent?.name ?? app.agent_id}
-                  </Link>
-                ) : (
-                  "unassigned"
-                )}
-              </span>
-              <span>
-                Harness{" "}
-                <Link
-                  href={`/harnesses/${app.harness_id}`}
-                  className="text-foreground hover:underline"
-                >
-                  {harness?.name ?? app.harness_id}
+      <PageMasthead
+        icon={<Rocket />}
+        title={<span className={getEntityNameClassName(app.status)}>{app.name}</span>}
+        badges={
+          <>
+            <CopyButton value={app.id} />
+            <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
+          </>
+        }
+        description={app.description || undefined}
+        meta={
+          <>
+            <span>
+              Agent{" "}
+              {app.agent_id ? (
+                <Link href={`/agents/${app.agent_id}`} className="text-foreground hover:underline">
+                  {agent?.name ?? app.agent_id}
                 </Link>
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Button
-            variant="outline"
-            onClick={() => runnableChannel && triggerMutation.mutate(runnableChannel.id)}
-            disabled={!runnableChannel || triggerMutation.isPending || !canManage}
-          >
-            <Play className="size-4" />
-            Test run
-          </Button>
-          {app.status === "published" ? (
+              ) : (
+                <span className="text-foreground">unassigned</span>
+              )}
+            </span>
+            <span>
+              Harness{" "}
+              <Link
+                href={`/harnesses/${app.harness_id}`}
+                className="text-foreground hover:underline"
+              >
+                {harness?.name ?? app.harness_id}
+              </Link>
+            </span>
+          </>
+        }
+        actions={
+          <>
             <Button
               variant="outline"
-              onClick={() => unpublishApp.mutate(app.id)}
-              disabled={unpublishApp.isPending || !canDangerous}
+              onClick={() => runnableChannel && triggerMutation.mutate(runnableChannel.id)}
+              disabled={!runnableChannel || triggerMutation.isPending || !canManage}
             >
-              <GlobeLock className="size-4" />
-              Unpublish
+              <Play className="size-4" />
+              Test run
             </Button>
-          ) : (
-            <Button
-              onClick={() => publishApp.mutate(app.id)}
-              disabled={publishApp.isPending || !canDangerous}
-            >
-              Publish
-            </Button>
-          )}
-          <Button
-            variant="outline"
-            onClick={() => deleteAppMutation.mutate(app.id)}
-            disabled={deleteAppMutation.isPending || !canDangerous}
-          >
-            <Archive className="size-4" />
-            Archive
-          </Button>
-        </div>
-      </div>
-
-      {stats && <StatStrip stats={stats} />}
-
-      <div className="grid gap-6 2xl:grid-cols-[minmax(0,1fr)_360px]">
-        <section className="space-y-3">
-          <div className="flex items-end justify-between gap-4">
-            <div>
-              <h2 className="text-lg font-semibold">Channels</h2>
-              <p className="text-sm text-muted-foreground">
-                {app.channels.length} channels ·{" "}
-                {app.channels.filter((channel) => channel.enabled).length} enabled
-              </p>
-            </div>
-            {canManage && (
-              <Link
-                href={`/apps/${app.id}/channels/new`}
-                className={buttonVariants({ variant: "outline", size: "sm" })}
+            {app.status === "published" ? (
+              <Button
+                variant="outline"
+                onClick={() => unpublishApp.mutate(app.id)}
+                disabled={unpublishApp.isPending || !canDangerous}
               >
-                <Plus className="size-4" />
-                Add channel
-              </Link>
+                <GlobeLock className="size-4" />
+                Unpublish
+              </Button>
+            ) : (
+              <Button
+                variant="accent"
+                onClick={() => publishApp.mutate(app.id)}
+                disabled={publishApp.isPending || !canDangerous}
+              >
+                Publish
+              </Button>
             )}
-          </div>
+            <Button
+              variant="outline"
+              onClick={() => deleteAppMutation.mutate(app.id)}
+              disabled={deleteAppMutation.isPending || !canDangerous}
+            >
+              <Archive className="size-4" />
+              Archive
+            </Button>
+          </>
+        }
+      />
 
-          {app.channels.length === 0 ? (
-            <Card>
-              <CardContent className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
-                <p className="text-sm text-muted-foreground">Add a channel to expose this app.</p>
-                {canManage && (
-                  <Link
-                    href={`/apps/${app.id}/channels/new`}
-                    className={buttonVariants({ size: "sm" })}
-                  >
-                    <Plus className="size-4" />
-                    Add channel
-                  </Link>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="space-y-2">
-              {app.channels.map((channel) => (
-                <ChannelRow
-                  key={channel.id}
-                  channel={channel}
-                  app={app}
-                  expanded={expandedChannelId === channel.id}
-                  onToggle={() =>
-                    setExpandedChannelId((current) => (current === channel.id ? null : channel.id))
-                  }
-                  onRunNow={
-                    canManage && !triggerMutation.isPending
-                      ? () => triggerMutation.mutate(channel.id)
-                      : undefined
-                  }
-                  configureHref={`/apps/${app.id}/channels/${channel.id}`}
-                />
-              ))}
+      {stats && (
+        <PageControlStrip>
+          <StatGrid>
+            <StatCard label="Health" value={stats.health} hint={stats.healthSub} />
+            <StatCard
+              label="Invocations · 24h"
+              value={String(stats.invocations24h)}
+              hint={stats.invocationSub}
+            />
+            <StatCard
+              label="Success rate"
+              value={stats.successRate === null ? "No runs" : `${stats.successRate.toFixed(1)}%`}
+              hint={stats.successSub}
+            />
+            <StatCard label="Activity" hint="Last 24 hours">
+              <MiniTimeline runs={stats.timeline} />
+            </StatCard>
+          </StatGrid>
+        </PageControlStrip>
+      )}
+
+      <PageColumns>
+        <PageMain>
+          <section className="flex flex-col gap-3">
+            <div className="flex items-end justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold tracking-tight">Channels</h2>
+                <p className="text-sm text-muted-foreground">
+                  {app.channels.length} {pluralize(app.channels.length, "channel")} ·{" "}
+                  {enabledChannels} enabled
+                </p>
+              </div>
+              {canManage && (
+                <Link
+                  href={`/apps/${app.id}/channels/new`}
+                  className={buttonVariants({ variant: "outline", size: "sm" })}
+                >
+                  <Plus className="size-4" />
+                  Add channel
+                </Link>
+              )}
             </div>
-          )}
-        </section>
 
-        <LiveActivityRail appId={app.id} />
-      </div>
+            {app.channels.length === 0 ? (
+              <Card>
+                <CardContent className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+                  <p className="text-sm text-muted-foreground">Add a channel to expose this app.</p>
+                  {canManage && (
+                    <Link
+                      href={`/apps/${app.id}/channels/new`}
+                      className={buttonVariants({ size: "sm" })}
+                    >
+                      <Plus className="size-4" />
+                      Add channel
+                    </Link>
+                  )}
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {app.channels.map((channel) => (
+                  <ChannelRow
+                    key={channel.id}
+                    channel={channel}
+                    app={app}
+                    expanded={expandedChannelId === channel.id}
+                    onToggle={() =>
+                      setExpandedChannelId((current) =>
+                        current === channel.id ? null : channel.id,
+                      )
+                    }
+                    onRunNow={
+                      canManage && !triggerMutation.isPending
+                        ? () => triggerMutation.mutate(channel.id)
+                        : undefined
+                    }
+                    configureHref={`/apps/${app.id}/channels/${channel.id}`}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </PageMain>
 
-      <Link
-        href="/apps"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft className="mr-2 size-4" />
-        Back to Apps
-      </Link>
-    </div>
+        <PageRail>
+          <LiveActivityRail appId={app.id} />
+        </PageRail>
+      </PageColumns>
+
+      <PageFooter>
+        <BackLink href="/apps">Back to Apps</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/components/capabilities/declarative-capability-form.tsx
+++ b/apps/ui/src/components/capabilities/declarative-capability-form.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,8 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ArrowLeft } from "lucide-react";
+import { Pencil, Plus, Puzzle, Settings, Wrench, BookOpen, FileText } from "lucide-react";
 import type { DeclarativeCapabilityDefinition } from "@/lib/api/types";
 import { useCreateDeclarativeCapability, useUpdateDeclarativeCapability } from "@/hooks";
 import { McpServersEditor } from "./mcp-servers-editor";
@@ -28,11 +26,26 @@ import {
   formStateToDefinition,
   type DeclarativeFormState,
 } from "./declarative-form-types";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  SectionTabs,
+  PageColumns,
+  PageMain,
+  PageRail,
+  PageFooter,
+  BackLink,
+  type SectionTabItem,
+} from "@/components/layout";
+
+const FORM_ID = "capability-edit-form";
 
 function TabCount({ count }: { count: number }) {
   if (count === 0) return null;
   return (
-    <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-[10px]">
+    <Badge variant="secondary" className="ml-0.5 h-4 px-1.5 text-[10px]">
       {count}
     </Badge>
   );
@@ -80,155 +93,244 @@ export function DeclarativeCapabilityForm({
     }
   };
 
-  return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/capabilities"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Capabilities
-      </Link>
+  const tabItems: SectionTabItem[] = [
+    { value: "general", label: "General", icon: <Settings className="size-4" /> },
+    {
+      value: "mcp",
+      label: (
+        <>
+          MCP Servers
+          <TabCount count={state.mcpServers.length} />
+        </>
+      ),
+      icon: <Wrench className="size-4" />,
+    },
+    {
+      value: "skills",
+      label: (
+        <>
+          Skills
+          <TabCount count={state.skills.length} />
+        </>
+      ),
+      icon: <BookOpen className="size-4" />,
+    },
+    {
+      value: "files",
+      label: (
+        <>
+          Files
+          <TabCount count={state.files.length} />
+        </>
+      ),
+      icon: <FileText className="size-4" />,
+    },
+  ];
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="flex items-start justify-between gap-4 flex-wrap">
-          <h1 className="text-2xl font-bold">
-            {mode === "create" ? "New Declarative Capability" : "Edit Declarative Capability"}
-          </h1>
-          <div className="flex items-center gap-2">
-            <Button type="button" variant="outline" onClick={() => router.push("/capabilities")}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isPending || !canSubmit}>
+  const title =
+    mode === "create" ? "New capability" : state.displayName || state.name || "Capability";
+
+  return (
+    <PageContainer>
+      <PageBreadcrumb
+        items={[
+          { label: "Building blocks" },
+          { label: "Capabilities", href: "/capabilities" },
+          { label: mode === "create" ? "New Declarative" : "Edit" },
+        ]}
+      />
+
+      <PageMasthead
+        icon={<Puzzle />}
+        title={title}
+        badges={
+          <Badge variant="accent">
+            {mode === "create" ? (
+              <>
+                <Plus className="size-3" />
+                New
+              </>
+            ) : (
+              <>
+                <Pencil className="size-3" />
+                Editing
+              </>
+            )}
+          </Badge>
+        }
+        description="Declarative capabilities bundle MCP servers, skills, and files into a reusable building block."
+        meta={
+          mode === "edit" ? (
+            <span>
+              Referenced as <span className="font-mono text-primary">declarative:{state.name}</span>
+            </span>
+          ) : undefined
+        }
+        actions={
+          <>
+            <Button type="submit" form={FORM_ID} disabled={isPending || !canSubmit}>
+              <Pencil className="size-4" />
               {isPending ? "Saving..." : mode === "create" ? "Create" : "Save changes"}
             </Button>
-          </div>
-        </div>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Discard
+            </Button>
+          </>
+        }
+      />
 
-        <Tabs value={tab} onValueChange={setTab}>
-          <TabsList>
-            <TabsTrigger value="general">General</TabsTrigger>
-            <TabsTrigger value="mcp">
-              MCP Servers
-              <TabCount count={state.mcpServers.length} />
-            </TabsTrigger>
-            <TabsTrigger value="skills">
-              Skills
-              <TabCount count={state.skills.length} />
-            </TabsTrigger>
-            <TabsTrigger value="files">
-              Files
-              <TabCount count={state.files.length} />
-            </TabsTrigger>
-          </TabsList>
+      <PageControlStrip>
+        <SectionTabs value={tab} onValueChange={setTab} items={tabItems} />
+      </PageControlStrip>
 
-          <TabsContent value="general">
-            <Card>
-              <CardContent className="space-y-4 pt-6">
-                <div className="grid gap-2">
-                  <Label htmlFor="declarative-name">Unique name</Label>
-                  <Input
-                    id="declarative-name"
-                    placeholder="research_pack"
-                    value={state.name}
-                    onChange={(e) => set("name", e.target.value.toLowerCase())}
-                    disabled={mode === "edit"}
-                    required
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Lowercase letters, digits, <code>_</code> and <code>-</code>. Referenced as{" "}
-                    <code>declarative:{state.name || "name"}</code>.
-                    {mode === "edit" && " The name cannot be changed after creation."}
-                  </p>
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="declarative-display-name">Display name</Label>
-                  <Input
-                    id="declarative-display-name"
-                    placeholder="Research Pack"
-                    value={state.displayName}
-                    onChange={(e) => set("displayName", e.target.value)}
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="declarative-description">Description</Label>
-                  <Input
-                    id="declarative-description"
-                    value={state.description}
-                    onChange={(e) => set("description", e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="declarative-prompt">System prompt addition</Label>
-                  <Textarea
-                    id="declarative-prompt"
-                    value={state.systemPrompt}
-                    onChange={(e) => set("systemPrompt", e.target.value)}
-                    rows={8}
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="declarative-risk">Risk level</Label>
-                  <Select
-                    value={state.riskLevel}
-                    onValueChange={(value) =>
-                      set("riskLevel", value as DeclarativeFormState["riskLevel"])
-                    }
-                  >
-                    <SelectTrigger id="declarative-risk" className="w-48">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="low">Low</SelectItem>
-                      <SelectItem value="medium">Medium</SelectItem>
-                      <SelectItem value="high">High (admin only)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
+      <form id={FORM_ID} onSubmit={handleSubmit}>
+        <PageColumns>
+          <PageMain>
+            {tab === "general" && (
+              <Card>
+                <CardContent className="space-y-4 pt-6">
+                  <div className="grid gap-2">
+                    <Label htmlFor="declarative-name">Unique name</Label>
+                    <Input
+                      id="declarative-name"
+                      placeholder="research_pack"
+                      value={state.name}
+                      onChange={(e) => set("name", e.target.value.toLowerCase())}
+                      disabled={mode === "edit"}
+                      required
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Lowercase letters, digits, <code>_</code> and <code>-</code>. Referenced as{" "}
+                      <code>declarative:{state.name || "name"}</code>.
+                      {mode === "edit" && " The name cannot be changed after creation."}
+                    </p>
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="declarative-display-name">Display name</Label>
+                    <Input
+                      id="declarative-display-name"
+                      placeholder="Research Pack"
+                      value={state.displayName}
+                      onChange={(e) => set("displayName", e.target.value)}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="declarative-description">Description</Label>
+                    <Input
+                      id="declarative-description"
+                      value={state.description}
+                      onChange={(e) => set("description", e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="declarative-prompt">System prompt addition</Label>
+                    <Textarea
+                      id="declarative-prompt"
+                      value={state.systemPrompt}
+                      onChange={(e) => set("systemPrompt", e.target.value)}
+                      rows={8}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="declarative-risk">Risk level</Label>
+                    <Select
+                      value={state.riskLevel}
+                      onValueChange={(value) =>
+                        set("riskLevel", value as DeclarativeFormState["riskLevel"])
+                      }
+                    >
+                      <SelectTrigger id="declarative-risk" className="w-48">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="low">Low</SelectItem>
+                        <SelectItem value="medium">Medium</SelectItem>
+                        <SelectItem value="high">High (admin only)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
 
-          <TabsContent value="mcp">
+            {tab === "mcp" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">MCP Servers</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <McpServersEditor
+                    servers={state.mcpServers}
+                    onChange={(servers) => set("mcpServers", servers)}
+                  />
+                </CardContent>
+              </Card>
+            )}
+
+            {tab === "skills" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Skills</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <SkillsEditor
+                    skills={state.skills}
+                    onChange={(skills) => set("skills", skills)}
+                  />
+                </CardContent>
+              </Card>
+            )}
+
+            {tab === "files" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Files</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <FilesEditor files={state.files} onChange={(files) => set("files", files)} />
+                </CardContent>
+              </Card>
+            )}
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </PageMain>
+
+          <PageRail>
             <Card>
               <CardHeader>
-                <CardTitle className="text-base">MCP Servers</CardTitle>
+                <CardTitle className="text-base">Summary</CardTitle>
               </CardHeader>
-              <CardContent>
-                <McpServersEditor
-                  servers={state.mcpServers}
-                  onChange={(servers) => set("mcpServers", servers)}
-                />
+              <CardContent className="space-y-3 text-sm">
+                <div>
+                  <p className="font-medium">Name</p>
+                  <p className="text-muted-foreground font-mono">{state.name || "(not set)"}</p>
+                </div>
+                <div>
+                  <p className="font-medium">Display name</p>
+                  <p className="text-muted-foreground">{state.displayName || "(not set)"}</p>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">MCP servers</span>
+                  <span className="text-muted-foreground">{state.mcpServers.length}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">Skills</span>
+                  <span className="text-muted-foreground">{state.skills.length}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">Files</span>
+                  <span className="text-muted-foreground">{state.files.length}</span>
+                </div>
               </CardContent>
             </Card>
-          </TabsContent>
-
-          <TabsContent value="skills">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Skills</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <SkillsEditor skills={state.skills} onChange={(skills) => set("skills", skills)} />
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="files">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Files</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <FilesEditor files={state.files} onChange={(files) => set("files", files)} />
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
-
-        {error && <p className="text-sm text-destructive">{error}</p>}
+          </PageRail>
+        </PageColumns>
       </form>
-    </div>
+
+      <PageFooter>
+        <BackLink href="/capabilities">Back to Capabilities</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## What
Extends the merged five-zone page layout (#2476) to the remaining building-block entities: **MCP servers, Capabilities, Skills, Knowledge indexes, Models, Agent Identities, Plugins, Apps, Memory** — list, view, and edit/new where those routes exist.

Per the "four more entities" design source, list density flexes per entity while the spine stays fixed:
- **Tables**: MCP servers, Knowledge indexes
- **Rows**: Skills
- **Cards**: Capabilities, Agent Identities, Apps, Memory, Models, Plugins

Each list gains a leading icon tile, search, status section-nav, a facet rail, and a "Showing N of M" footer. Detail/view pages move tabs and stat strips into the control strip and split content across the primary column + context rail. Edit/new forms promote Save/Discard into the masthead (submitting via `form="…-edit-form"`) and use section-nav where the form has logical sections.

## Why
Continues unifying the app onto one breadcrumb → header → control-strip → two-column-body → footer skeleton so every building-block entity reads as one product. Composes the already-merged primitives — no new layout infrastructure.

## How
- Built per-entity on the merged `@/components/layout` primitives, mirroring the Agents/Harnesses template.
- Status section-nav (All/Active/Archived etc.) replaces the old archive-filter dropdowns; lists fetch the full set and split client-side so facet counts are accurate (matching the Agents pattern).
- Entity icons match the sidebar (Server/Puzzle/BookOpen/Library/Cpu/UserRound/Rocket/Brain).
- All existing hooks, mutations, dialogs, wizards (apps/channels), danger zones, and permission gating preserved — this is a layout refactor.

## Risk
- Low–medium. UI-only, presentational; no backend/API/schema/migration changes. Broad file count (24) but each page composes the same vetted primitives. Default list view now hides archived by default (consistent with Agents).

## Security
- Threat categories reviewed: **TM-WEB** only. No TM-AUTH/AUTHZ/API/SQL/TENANT surface touched.
- Findings: none. Grepped the diff — no `dangerouslySetInnerHTML`, `eval`, `innerHTML`, or `new Function`; all server data rendered as escaped React children. No new dependencies. No auth/permission logic changed.

## Validation
- `pnpm typecheck`, `pnpm lint` (oxlint), `pnpm format:check`, `pnpm build`, and the full `pnpm test` suite (**1043 tests**) pass locally; CI green (UI Build/Lint/Test, UI Playwright Smoke, CodeQL).
- Updated 4 component test suites for the new headings/labels (`New index`), table description sub-lines, and breadcrumb+meta/stat duplication — no behavioral assertions weakened beyond exact-match → presence/role.
- **Live smoke** on a `just start-dev` stack (auth=none, seeded data): all 9 list routes render (table/rows/cards densities), Capabilities/MCP/Apps/Models populate or show empty states, the Capability **view** and Agent-Identity **new** form render with correct breadcrumb/masthead/columns/footer. No redirects or crashes.

## Follow-ups
- MCP servers table: the row Actions cell (multiple text buttons) can still cause slight horizontal scroll on narrow primary columns; converting those to icon buttons would fully eliminate it.
- `skills/[skillId]` keeps `SkillDetailView`'s internal body tabs rather than hoisting them into the control strip (that component is shared and out of this PR's scope).
- The remaining non-entity surfaces (Dashboard, Sessions, Settings, Durable, Reports, Evals) are intentionally out of scope for this batch, as agreed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — internal UI only
- [x] Security review performed against relevant threat model categories (TM-WEB)
- [x] Final CI ran checks affected by this PR — UI Build/Lint/Test, UI Playwright Smoke, CodeQL green; non-affected jobs skipped by Detect Changes
- [x] All review comments addressed — no review comments posted

---
_Generated by [Claude Code](https://claude.ai/code/session_011Actfh4H4uA3fHMXM39XKH)_