### PR TITLE
feat(ui): align Sessions, Dashboard, and Settings with the page language

### DIFF
--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -179,12 +179,12 @@ describe("SettingsLayout", () => {
     const personalLabel = screen.getByText("Personal");
 
     expect(orgLabel).toHaveClass("uppercase");
-    expect(orgLabel).toHaveClass("tracking-wider");
-    expect(orgLabel).toHaveClass("text-xs");
-    expect(orgLabel).toHaveClass("font-semibold");
+    expect(orgLabel).toHaveClass("tracking-[0.08em]");
+    expect(orgLabel).toHaveClass("text-[11px]");
+    expect(orgLabel).toHaveClass("font-mono");
 
     expect(personalLabel).toHaveClass("uppercase");
-    expect(personalLabel).toHaveClass("tracking-wider");
+    expect(personalLabel).toHaveClass("tracking-[0.08em]");
   });
 
   it("applies inactive styles to non-active items", () => {

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -28,8 +28,9 @@ import {
 import { AgentSelect } from "@/components/agent/agent-select";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { Plus, LayoutDashboard } from "lucide-react";
 import { useOrganization } from "@/hooks/use-organizations";
+import { PageContainer, PageMasthead } from "@/components/layout";
 
 export default function DashboardPage() {
   usePageTitle("Dashboard");
@@ -71,24 +72,38 @@ export default function DashboardPage() {
     }
   };
 
+  const dashboardMasthead = (
+    <PageMasthead
+      icon={<LayoutDashboard />}
+      title="Dashboard"
+      description="Your agents, recent sessions, and activity at a glance."
+      actions={
+        <Button
+          variant="accent"
+          onClick={handleOpenNewSessionDialog}
+          disabled={agents.length === 0}
+        >
+          <Plus className="size-4" />
+          New session
+        </Button>
+      }
+    />
+  );
+
   if (agentsLoading || sessionsLoading) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-bold">Dashboard</h1>
+      <PageContainer>
+        {dashboardMasthead}
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Skeleton key={i} className="h-32" />
+          ))}
         </div>
-        <div className="space-y-6">
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {[...Array(4)].map((_, i) => (
-              <Skeleton key={i} className="h-32" />
-            ))}
-          </div>
-          <div className="grid gap-6 md:grid-cols-2">
-            <Skeleton className="h-96" />
-            <Skeleton className="h-96" />
-          </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <Skeleton className="h-96" />
+          <Skeleton className="h-96" />
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -96,12 +111,10 @@ export default function DashboardPage() {
 
   return (
     <>
-      <div className="container mx-auto p-6">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-bold">Dashboard</h1>
-        </div>
+      <PageContainer>
+        {dashboardMasthead}
         <StatsCards agents={agents} sessionStats={sessionStats} />
-        <div className="grid gap-6 md:grid-cols-2 mt-6">
+        <div className="grid gap-6 md:grid-cols-2">
           <AgentListWidget agents={agents} allCapabilities={allCapabilities} />
 
           <Card>
@@ -129,10 +142,8 @@ export default function DashboardPage() {
           </Card>
         </div>
 
-        <div className="mt-6">
-          <RecentSessions sessions={sessions} agents={agentsForReferences} models={models} />
-        </div>
-      </div>
+        <RecentSessions sessions={sessions} agents={agentsForReferences} models={models} />
+      </PageContainer>
 
       {/* New Session Dialog */}
       <Dialog open={newSessionDialogOpen} onOpenChange={setNewSessionDialogOpen}>

--- a/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
+++ b/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Dialog,
@@ -28,11 +28,21 @@ import { HarnessSelect } from "@/components/harness/harness-select";
 import { AgentFilterMenu } from "@/components/agent/agent-filter-menu";
 import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import { Label } from "@/components/ui/label";
-import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
+import { Plus, ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
 import { exportSessionJsonl } from "@/lib/api/sessions";
 import type { ModelWithProvider, Agent } from "@/lib/api/types";
 import { getDisplayName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
+import {
+  PageContainer,
+  PageBreadcrumb,
+  PageMasthead,
+  PageControlStrip,
+  PageColumns,
+  PageMain,
+  PageFooter,
+} from "@/components/layout";
+import { pluralize } from "@/lib/formatting";
 
 const PAGE_SIZE = 20;
 
@@ -136,31 +146,49 @@ export default function SessionsPageClient() {
     });
   };
 
-  return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Sessions</h1>
-        <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={!harnesses?.length}>
-          <Plus className="w-4 h-4 mr-2" />
-          New Session
-        </Button>
-      </div>
+  const filterLabel = selectedAgentId
+    ? getDisplayName(agentMap.get(selectedAgentId)) || "Agent"
+    : "All agents";
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0">
-          <div>
-            <CardTitle>
-              {selectedAgentId
-                ? getDisplayName(agentMap.get(selectedAgentId)) || "Agent"
-                : "All Agents"}
-            </CardTitle>
-            <p className="text-sm text-muted-foreground mt-1">
-              {totalSessions} session{totalSessions !== 1 ? "s" : ""}
-            </p>
-          </div>
-          <AgentFilterMenu value={selectedAgentId} onValueChange={handleAgentFilterChange} />
-        </CardHeader>
-        <CardContent>
+  return (
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Sessions" }]} />
+
+      <PageMasthead
+        icon={<MessageSquare />}
+        title="Sessions"
+        badges={
+          <Badge variant="outline" className="font-mono">
+            {totalSessions}
+          </Badge>
+        }
+        description="Conversations and background runs across your agents."
+        meta={
+          <span>
+            Showing <span className="text-foreground">{filterLabel}</span>
+          </span>
+        }
+        actions={
+          <Button
+            variant="accent"
+            onClick={handleOpenNewSessionDialog}
+            disabled={!harnesses?.length}
+          >
+            <Plus className="size-4" />
+            New session
+          </Button>
+        }
+      />
+
+      <PageControlStrip className="flex items-center justify-between gap-3">
+        <span className="text-[13px] text-muted-foreground">
+          {totalSessions} {pluralize(totalSessions, "session")}
+        </span>
+        <AgentFilterMenu value={selectedAgentId} onValueChange={handleAgentFilterChange} />
+      </PageControlStrip>
+
+      <PageColumns className="lg:grid-cols-1">
+        <PageMain>
           {sessionsLoading || agentsLoading ? (
             <div className="space-y-2">
               {Array.from({ length: 5 }).map((_, i) => (
@@ -168,9 +196,9 @@ export default function SessionsPageClient() {
               ))}
             </div>
           ) : sessions.length === 0 ? (
-            <p className="text-center py-8 text-muted-foreground">
+            <div className="border border-dashed py-12 text-center text-muted-foreground">
               No sessions yet. Start a new session to begin chatting.
-            </p>
+            </div>
           ) : (
             <div className="space-y-2">
               {sessions.map((session) => {
@@ -197,40 +225,36 @@ export default function SessionsPageClient() {
               })}
             </div>
           )}
+        </PageMain>
+      </PageColumns>
 
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4 pt-4 border-t">
-              <p className="text-sm text-muted-foreground">
-                Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalSessions)} of{" "}
-                {totalSessions} sessions
-              </p>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handlePreviousPage}
-                  disabled={page === 0}
-                >
-                  <ChevronLeft className="h-4 w-4 mr-1" />
-                  Previous
-                </Button>
-                <span className="text-sm text-muted-foreground">
-                  Page {page + 1} of {totalPages}
-                </span>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleNextPage}
-                  disabled={page >= totalPages - 1}
-                >
-                  Next
-                  <ChevronRight className="h-4 w-4 ml-1" />
-                </Button>
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <PageFooter>
+        <span>
+          Showing {totalSessions === 0 ? 0 : offset + 1}-
+          {Math.min(offset + PAGE_SIZE, totalSessions)} of {totalSessions}{" "}
+          {pluralize(totalSessions, "session")}
+        </span>
+        {totalPages > 1 && (
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handlePreviousPage} disabled={page === 0}>
+              <ChevronLeft className="h-4 w-4" />
+              Previous
+            </Button>
+            <span>
+              Page {page + 1} of {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleNextPage}
+              disabled={page >= totalPages - 1}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </PageFooter>
 
       <Dialog open={newSessionDialogOpen} onOpenChange={setNewSessionDialogOpen}>
         <DialogContent>
@@ -280,6 +304,6 @@ export default function SessionsPageClient() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { IconTile } from "@/components/layout/page-layout";
 import {
   Server,
   Key,
@@ -12,6 +13,7 @@ import {
   User,
   WalletCards,
   FlaskConical,
+  Settings as SettingsIcon,
 } from "lucide-react";
 
 interface NavItem {
@@ -96,8 +98,14 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b px-6 py-4">
-        <h1 className="text-2xl font-bold">Settings</h1>
+      <div className="flex items-center gap-4 border-b px-6 py-4">
+        <IconTile icon={<SettingsIcon />} />
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Settings</h1>
+          <p className="text-sm text-muted-foreground">
+            Organization defaults, providers, members, and your personal preferences.
+          </p>
+        </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
         {/* Settings Sidebar */}
@@ -105,7 +113,7 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
           <div className="space-y-6">
             {settingsSections.map((section) => (
               <div key={section.label}>
-                <div className="px-3 pb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+                <div className="px-3 pb-2 font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
                   {section.label}
                 </div>
                 <div className="grid gap-1 sm:grid-cols-2 lg:block lg:space-y-1">

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -25,6 +25,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { IconTile } from "@/components/layout/page-layout";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useUpdateSession } from "@/hooks/use-sessions";
 import {
@@ -385,35 +386,38 @@ export function SessionHeader({
       </Link>
 
       <div className="flex items-center justify-between gap-4">
-        <div className="group/title min-w-0">
-          <EditableSessionTitle
-            sessionId={sessionId}
-            title={session.title}
-            fallback={`Session ${shortenId(session.id)}`}
-            editable={allowTitleEditing}
-          />
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            {agentReferenceLabel &&
-              (agent && agentId ? (
-                <Link
-                  href={`/agents/${agentId}`}
-                  className="inline-flex items-center gap-1 hover:text-foreground"
-                >
-                  <Bot className="icon-sharp h-3 w-3" />
-                  <span className={getEntityReferenceClassName(agentReferenceStatus)}>
-                    {agentReferenceLabel}
+        <div className="flex min-w-0 items-start gap-3">
+          <IconTile size="md" icon={<MessageSquare />} className="mt-0.5" />
+          <div className="group/title min-w-0">
+            <EditableSessionTitle
+              sessionId={sessionId}
+              title={session.title}
+              fallback={`Session ${shortenId(session.id)}`}
+              editable={allowTitleEditing}
+            />
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              {agentReferenceLabel &&
+                (agent && agentId ? (
+                  <Link
+                    href={`/agents/${agentId}`}
+                    className="inline-flex items-center gap-1 hover:text-foreground"
+                  >
+                    <Bot className="icon-sharp h-3 w-3" />
+                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
+                      {agentReferenceLabel}
+                    </span>
+                  </Link>
+                ) : (
+                  <span className="inline-flex items-center gap-1">
+                    <Bot className="icon-sharp h-3 w-3" />
+                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
+                      {agentReferenceLabel}
+                    </span>
                   </span>
-                </Link>
-              ) : (
-                <span className="inline-flex items-center gap-1">
-                  <Bot className="icon-sharp h-3 w-3" />
-                  <span className={getEntityReferenceClassName(agentReferenceStatus)}>
-                    {agentReferenceLabel}
-                  </span>
-                </span>
-              ))}
-            <span>•</span>
-            <span>{secondaryMetaText}</span>
+                ))}
+              <span>•</span>
+              <span>{secondaryMetaText}</span>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## What
Brings the three remaining high-traffic surfaces into the shared page language (#2476, #2477):
- **Sessions list** — rebuilt on the five-zone primitives: breadcrumb · masthead (MessageSquare tile, session count, "New session") · agent-filter control strip · session-card body · pagination footer.
- **Dashboard** — wrapped in `PageContainer` + `PageMasthead` (LayoutDashboard tile, "New session"); stats cards and widgets unchanged.
- **Settings** — the persistent left-nav shell is refreshed in place: gold icon tile + masthead-style header with a subtitle, and nav section labels aligned to the mono-uppercase facet style. The nav structure (and every subpage) is untouched.
- **Session detail header** — the shared `SessionHeader` gains a leading gold icon tile so its anatomy matches the masthead, without disturbing the full-bleed chat surface or its tab/Advanced nav.

## Why
These are the surfaces users hit most. A full five-zone rebuild fits the Sessions list and Dashboard cleanly; Settings and the session detail are bespoke shells, so they get a lighter, in-place alignment (the user explicitly asked to "refresh to make styling close," not to restructure them).

## How
- Sessions list: composed the merged `@/components/layout` primitives, preserving the agent filter, pin/export, pagination, and the New-Session dialog.
- Dashboard: masthead extracted so both the loading and loaded states share it; widgets and dialog unchanged.
- Settings: only the layout header/nav-label styling changed.
- Session header: one IconTile added to the existing title block — all badges, status, usage, trace link, and navigation untouched.

## Risk
- Low. UI-only, presentational; no backend/API/schema/migration changes. `SessionHeader` is shared (also used by the dev page and tests), so the change was kept to a non-structural icon addition and verified against the session-layout/navigation suites.

## Security
- Threat categories reviewed: **TM-WEB** only. No TM-AUTH/AUTHZ/API/SQL/TENANT surface touched.
- Findings: none. Diff grepped — no `dangerouslySetInnerHTML`, `eval`, `innerHTML`, or `new Function`. No new dependencies. No auth/permission logic changed.

## Validation
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build`, and the full `pnpm test` suite (**1043 tests**) pass locally; CI green (UI Build/Lint/Test, UI Playwright Smoke, CodeQL).
- Updated `settings-layout` test assertions for the refreshed nav-label classes (styling-only).
- **Live smoke** on a `just start-dev` stack (auth=none, seeded agent + session): Sessions list renders with masthead/count/filter/footer; Dashboard renders stats + widgets with the masthead; Settings shows the refreshed header + nav and the org form; the session detail header leads with the icon tile and the chat surface is intact.

## Follow-ups
- Settings subpages keep their own internal section headers; a deeper pass could give each a consistent breadcrumb, but that's beyond this styling refresh.
- Remaining non-entity surfaces still untouched: Durable, Reports, Evals, Chat, Onboarding, Orgs.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered — internal UI only
- [x] Security review performed against relevant threat model categories (TM-WEB)
- [x] Final CI ran checks affected by this PR — UI Build/Lint/Test, UI Playwright Smoke, CodeQL green; non-affected jobs skipped by Detect Changes
- [x] All review comments addressed — no review comments posted

---
_Generated by [Claude Code](https://claude.ai/code/session_011Actfh4H4uA3fHMXM39XKH)_