### PR TITLE
fix(auth): bind MCP OAuth consent to session, not a second cookie

### DIFF
--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -22,6 +22,27 @@ pub const ACCESS_TOKEN_TYPE: &str = "access";
 /// closes the OAuth confused-deputy / missing-audience gap (TM-MCP-006).
 pub const MCP_ACCESS_TOKEN_TYPE: &str = "mcp_access";
 
+/// `token_type` claim value for the short-lived MCP OAuth consent (anti-CSRF)
+/// token embedded in the `/oauth/authorize` confirmation form.
+///
+/// The browser-facing consent step must guarantee that the POST which mints an
+/// authorization code was driven by a form this server rendered for the
+/// signed-in user — not auto-submitted by a malicious page. That was previously
+/// enforced with a freshly-set `SameSite=Lax` cookie that had to round-trip
+/// from the rendered form back to the POST. In real MCP-client browser contexts
+/// (popup / embedded webview / partitioned third-party storage) that second
+/// cookie is not reliably stored, while the pre-existing session cookie still
+/// rides along — so the POST authenticated the user yet failed with "Missing
+/// CSRF cookie". Binding the anti-CSRF token to the session instead (a signed
+/// token whose `sub` must equal the POSTing user) removes the dependency on
+/// that second cookie while keeping the CSRF guarantee: an attacker cannot mint
+/// a token for the victim without the server secret.
+pub const OAUTH_CONSENT_TOKEN_TYPE: &str = "mcp_oauth_consent";
+
+/// Lifetime of the MCP OAuth consent token (30 minutes) — i.e. how long a
+/// rendered `/oauth/authorize` confirmation page stays submittable.
+const OAUTH_CONSENT_TOKEN_LIFETIME_SECS: i64 = 30 * 60;
+
 /// Generate a random identifier string (32 hex characters)
 fn generate_random_id() -> String {
     let mut rng = rand::rng();
@@ -67,6 +88,21 @@ pub struct RefreshTokenClaims {
     pub iat: i64,
     /// Unique token ID (for revocation)
     pub jti: String,
+}
+
+/// Claims for the short-lived MCP OAuth consent (anti-CSRF) token embedded in
+/// the `/oauth/authorize` confirmation form. See [`OAUTH_CONSENT_TOKEN_TYPE`].
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OAuthConsentClaims {
+    /// Subject (user ID) the consent form was rendered for. The POST handler
+    /// must confirm this equals the authenticated session user.
+    pub sub: String,
+    /// Token type — always [`OAUTH_CONSENT_TOKEN_TYPE`].
+    pub token_type: String,
+    /// Expiration time (Unix timestamp).
+    pub exp: i64,
+    /// Issued at (Unix timestamp).
+    pub iat: i64,
 }
 
 /// Token pair returned after successful authentication
@@ -248,6 +284,49 @@ impl JwtService {
             Some(aud) if aud == expected_resource => Ok(token_data.claims),
             _ => anyhow::bail!("MCP access token audience mismatch"),
         }
+    }
+
+    /// Generate a short-lived signed consent token binding the
+    /// `/oauth/authorize` confirmation form to `user_id`.
+    ///
+    /// Embedded as a hidden form field and re-validated on POST against the
+    /// authenticated session user (anti-CSRF). Replaces the previous
+    /// freshly-set cookie that did not reliably round-trip from real MCP-client
+    /// browser contexts — see [`OAUTH_CONSENT_TOKEN_TYPE`].
+    pub fn generate_oauth_consent_token(&self, user_id: Uuid) -> Result<String> {
+        let now = Utc::now();
+        let exp = now + Duration::seconds(OAUTH_CONSENT_TOKEN_LIFETIME_SECS);
+
+        let claims = OAuthConsentClaims {
+            sub: user_id.to_string(),
+            token_type: OAUTH_CONSENT_TOKEN_TYPE.to_string(),
+            exp: exp.timestamp(),
+            iat: now.timestamp(),
+        };
+
+        encode(&Header::default(), &claims, &self.encoding_key)
+            .context("Failed to encode OAuth consent token")
+    }
+
+    /// Validate and decode an OAuth consent token minted by
+    /// [`generate_oauth_consent_token`].
+    ///
+    /// Checks the signature, expiry, and token type. The caller MUST additionally
+    /// confirm the returned `sub` matches the authenticated session user — the
+    /// signature alone only proves this server issued the token, not for whom.
+    pub fn validate_oauth_consent_token(&self, token: &str) -> Result<OAuthConsentClaims> {
+        let mut validation = Validation::default();
+        validation.validate_exp = true;
+        validation.validate_aud = false;
+
+        let token_data = decode::<OAuthConsentClaims>(token, &self.decoding_key, &validation)
+            .context("Invalid OAuth consent token")?;
+
+        if token_data.claims.token_type != OAUTH_CONSENT_TOKEN_TYPE {
+            anyhow::bail!("Invalid token type for OAuth consent");
+        }
+
+        Ok(token_data.claims)
     }
 
     /// Validate and decode a refresh token
@@ -455,6 +534,47 @@ mod tests {
                 .validate_mcp_access_token(&token, "https://evil.example.com/mcp")
                 .is_err(),
             "MCP token must be bound to its audience"
+        );
+    }
+
+    #[test]
+    fn test_oauth_consent_token_roundtrips_and_binds_user() {
+        let service = JwtService::new(test_config());
+        let user_id = Uuid::from_u128(0x1234_5678);
+
+        let token = service.generate_oauth_consent_token(user_id).unwrap();
+        let claims = service.validate_oauth_consent_token(&token).unwrap();
+
+        assert_eq!(claims.sub, user_id.to_string());
+        assert_eq!(claims.token_type, OAUTH_CONSENT_TOKEN_TYPE);
+    }
+
+    #[test]
+    fn test_oauth_consent_token_rejects_other_token_types() {
+        // A regular access token must not be accepted as a consent token, and a
+        // consent token must not be accepted on the general access path.
+        let service = JwtService::new(test_config());
+        let access = service
+            .generate_access_token(Uuid::nil(), "u@example.com", "U", &["user".to_string()])
+            .unwrap();
+        assert!(service.validate_oauth_consent_token(&access).is_err());
+
+        let consent = service.generate_oauth_consent_token(Uuid::nil()).unwrap();
+        assert!(service.validate_access_token(&consent).is_err());
+    }
+
+    #[test]
+    fn test_oauth_consent_token_rejected_under_wrong_secret() {
+        let issuer = JwtService::new(test_config());
+        let token = issuer.generate_oauth_consent_token(Uuid::nil()).unwrap();
+
+        let attacker = JwtService::new(JwtConfig {
+            secret: "a-totally-different-secret".to_string(),
+            ..test_config()
+        });
+        assert!(
+            attacker.validate_oauth_consent_token(&token).is_err(),
+            "consent token must not validate under a different signing secret"
         );
     }
 

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -29,10 +29,7 @@ use axum::{
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
 };
-use axum_extra::extract::{
-    CookieJar,
-    cookie::{Cookie, SameSite},
-};
+use axum_extra::extract::CookieJar;
 use chrono::{Duration, Utc};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -45,7 +42,6 @@ const AUTH_CODE_TTL_SECS: i64 = 300;
 
 /// MCP refresh token lifetime (30 days)
 const MCP_REFRESH_TOKEN_LIFETIME_SECS: i64 = 30 * 24 * 3600;
-const OAUTH_AUTHORIZE_CSRF_COOKIE: &str = "mcp_oauth_authorize_csrf";
 
 /// Generate a random hex string (32 bytes = 64 hex chars)
 fn generate_random_hex() -> String {
@@ -512,14 +508,19 @@ async fn oauth_authorize(
         return Err(AuthError::unauthorized("Invalid redirect_uri"));
     }
 
-    let csrf_token = generate_random_hex();
-    let csrf_cookie = Cookie::build((OAUTH_AUTHORIZE_CSRF_COOKIE, csrf_token.clone()))
-        .path("/")
-        .http_only(true)
-        .secure(true)
-        .same_site(SameSite::Lax)
-        .build();
-    let jar = jar.add(csrf_cookie);
+    // Anti-CSRF: bind the confirmation form to this session with a short-lived
+    // signed consent token instead of a separate cookie. The session cookie
+    // that authenticates the POST reliably round-trips from real MCP-client
+    // browser contexts; a freshly-set second cookie does not always (popup /
+    // embedded webview / partitioned storage), which surfaced as a spurious
+    // "Missing CSRF cookie" 401 on confirm. See `generate_oauth_consent_token`.
+    let csrf_token = state
+        .jwt_service
+        .generate_oauth_consent_token(user.id)
+        .map_err(|e| {
+            tracing::error!("Failed to mint OAuth consent token: {}", e);
+            AuthError::unauthorized("Failed to start authorization")
+        })?;
 
     let confirm_page =
         render_authorize_confirm_page(&query, &client.client_name, &user, &csrf_token);
@@ -534,7 +535,7 @@ async fn oauth_authorize(
         ip,
         serde_json::json!({"client_id": query.client_id}),
     );
-    Ok((jar, Html(confirm_page)).into_response())
+    Ok(Html(confirm_page).into_response())
 }
 
 async fn oauth_authorize_confirm(
@@ -548,11 +549,19 @@ async fn oauth_authorize_confirm(
         .await
         .ok_or_else(|| AuthError::unauthorized("Authentication required"))?;
 
-    let csrf_cookie = jar
-        .get(OAUTH_AUTHORIZE_CSRF_COOKIE)
-        .ok_or_else(|| AuthError::unauthorized("Missing CSRF cookie"))?;
-    if csrf_cookie.value() != form.csrf_token {
-        return Err(AuthError::unauthorized("Invalid CSRF token"));
+    // Anti-CSRF: the consent token must be one this server signed (proves it
+    // originated from our rendered confirm page) and must be bound to the same
+    // user the session authenticates as. Both checks are required: the
+    // signature alone proves issuance, the `sub` match prevents replaying a
+    // token minted for a different session. See `generate_oauth_consent_token`.
+    let consent = state
+        .jwt_service
+        .validate_oauth_consent_token(&form.csrf_token)
+        .map_err(|_| AuthError::unauthorized("Invalid or expired authorization request"))?;
+    if !constant_time_eq(consent.sub.as_bytes(), user.id.to_string().as_bytes()) {
+        return Err(AuthError::unauthorized(
+            "Authorization request user mismatch",
+        ));
     }
 
     if form.response_type != "code" {
@@ -578,8 +587,7 @@ async fn oauth_authorize_confirm(
     validate_authorize_client(&state, &query).await?;
     let redirect_url = issue_authorization_code(&state, &query, &user, ip).await?;
 
-    let jar = jar.remove(Cookie::build(OAUTH_AUTHORIZE_CSRF_COOKIE).path("/"));
-    Ok((jar, Redirect::to(&redirect_url)).into_response())
+    Ok(Redirect::to(&redirect_url).into_response())
 }
 
 async fn validate_authorize_client(

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -3169,6 +3169,119 @@ async fn test_oauth_register_and_metadata() {
         .assert_status(StatusCode::NOT_FOUND);
 }
 
+/// Build a `/oauth/authorize` query string for `client_id` with fixed,
+/// well-formed PKCE/state values (PKCE is only verified at the token step).
+fn authorize_query_string(client_id: &str) -> String {
+    format!(
+        "/oauth/authorize?client_id={client_id}\
+         &redirect_uri=http://localhost:9999/callback\
+         &response_type=code\
+         &code_challenge=abc123challenge\
+         &code_challenge_method=S256\
+         &state=xyz-state\
+         &scope=mcp"
+    )
+}
+
+/// Pull the hidden `csrf_token` (the signed consent token) out of the rendered
+/// confirmation page.
+fn extract_csrf_token(html: &str) -> String {
+    let needle = r#"name="csrf_token" value=""#;
+    let start = html
+        .find(needle)
+        .expect("confirm page must embed a csrf_token field")
+        + needle.len();
+    let end = html[start..].find('"').expect("csrf_token must be closed");
+    html[start..start + end].to_string()
+}
+
+/// The browser-facing consent step must NOT depend on a second cookie set by
+/// the GET round-tripping to the POST: in real MCP-client browser contexts that
+/// cookie is not reliably stored even though the session cookie is, which
+/// surfaced as a spurious "Missing CSRF cookie" 401. This drives the full
+/// GET -> POST confirm flow without threading any cookie and asserts an
+/// authorization code is issued. (In test/`AuthMode::None` the session is the
+/// anonymous user, so the consent token's `sub` binding still applies.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_authorize_confirm_needs_no_csrf_cookie() {
+    let server = TestServer::in_memory().await;
+    let (client_id, _) = register_oauth_client(&server).await;
+
+    // GET the confirmation page. No cookie is set/threaded by the test client.
+    let page = server.get(&authorize_query_string(&client_id)).await;
+    assert_eq!(page.status(), StatusCode::OK);
+    let csrf_token = extract_csrf_token(&page.text());
+
+    // POST the consent form back with the embedded token but no cookies.
+    let body = format!(
+        "client_id={client_id}\
+         &redirect_uri=http://localhost:9999/callback\
+         &response_type=code\
+         &code_challenge=abc123challenge\
+         &code_challenge_method=S256\
+         &state=xyz-state\
+         &scope=mcp\
+         &csrf_token={csrf_token}"
+    );
+    let resp = server
+        .request_raw(
+            Method::POST,
+            "/oauth/authorize",
+            vec![("content-type", "application/x-www-form-urlencoded")],
+            body.into_bytes(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::SEE_OTHER,
+        "confirm must redirect to the client callback with a code"
+    );
+    let location = resp
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        location.starts_with("http://localhost:9999/callback?"),
+        "unexpected redirect target: {location}"
+    );
+    assert!(location.contains("code="), "redirect must carry a code");
+    assert!(
+        location.contains("state=xyz-state"),
+        "state must round-trip"
+    );
+}
+
+/// A forged/garbage consent token must be rejected — the anti-CSRF guarantee
+/// must survive moving from a cookie to a signed session-bound token.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_authorize_confirm_rejects_invalid_consent_token() {
+    let server = TestServer::in_memory().await;
+    let (client_id, _) = register_oauth_client(&server).await;
+
+    let body = format!(
+        "client_id={client_id}\
+         &redirect_uri=http://localhost:9999/callback\
+         &response_type=code\
+         &code_challenge=abc123challenge\
+         &code_challenge_method=S256\
+         &state=xyz-state\
+         &scope=mcp\
+         &csrf_token=not-a-valid-token"
+    );
+    let resp = server
+        .request_raw(
+            Method::POST,
+            "/oauth/authorize",
+            vec![("content-type", "application/x-www-form-urlencoded")],
+            body.into_bytes(),
+        )
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
 /// TM-DOS: the unauthenticated dynamic client registration endpoint must be
 /// per-IP rate limited so it cannot be used to create unbounded `oauth_clients`
 /// rows. The in-memory register limit is 5/min; the 6th request from the same


### PR DESCRIPTION
## What
Replace the per-request CSRF **cookie** on the `/oauth/authorize` confirmation step with a short-lived, signed **consent token** that is bound to the session user and embedded in the confirm form.

## Why
After authorizing an MCP client, the consent POST returned `401 {"detail":"Missing CSRF cookie"}`.

The GET that renders the confirm page set a fresh `SameSite=Lax; Secure; HttpOnly` CSRF cookie that had to round-trip to the POST. The error (`Missing CSRF cookie` rather than `Authentication required`) proves the **session** cookie *was* sent on the POST while the just-set CSRF cookie was **not**. That asymmetry is exactly what happens in real MCP-client browser contexts (popup / embedded webview / partitioned third-party storage): the pre-existing first-party session cookie keeps riding along, but a freshly `Set-Cookie` in that context is not reliably stored. Result: the user is authenticated but consent fails.

## How
- `auth/jwt.rs`: add a `mcp_oauth_consent` token type — `generate_oauth_consent_token(user_id)` (HS256, 30-min TTL, `sub = user id`) and `validate_oauth_consent_token`.
- `auth/mcp_oauth.rs`: the GET mints the consent token and embeds it in the form's hidden `csrf_token` field (no cookie set); the POST validates signature/expiry/type and checks (constant-time) that `sub` equals the authenticated session user, then issues the code. Removed the cookie set/remove machinery and the now-unused `Cookie`/`SameSite` imports.

This keeps the anti-CSRF guarantee while removing the fragile second cookie: it relies only on the session cookie, which already authenticates the very same POST and reliably round-trips.

## Risk
- Low.
- Surface is the MCP OAuth consent step only. The token grant, PKCE, client/redirect validation, and all other auth paths are unchanged. Worst case would be the consent step rejecting a valid submission — covered by new tests and a runtime smoke test.

## Security
- Threat categories reviewed: **TM-AUTH** (token mint/validate), **TM-WEB** (CSRF / cookie handling).
- Findings and resolutions:
  - **Forgery:** consent token is HS256-signed with the server JWT secret; an attacker cannot mint one. Verified by `test_oauth_consent_token_rejected_under_wrong_secret`.
  - **Replay across sessions:** token is bound to `sub` and compared constant-time against the session user; a token minted for another session is rejected (`Authorization request user mismatch`).
  - **Token confusion:** `token_type` discriminates consent tokens from `access`/`mcp_access`/`refresh`; `validate_access_token` rejects consent tokens and vice-versa. Verified by `test_oauth_consent_token_rejects_other_token_types`.
  - **Cross-site CSRF:** unchanged and still defended — the `SameSite=Lax` session cookie is not sent on cross-site POSTs, so a forged consent POST fails the session check before reaching consent validation. Removing the second cookie does not weaken this.
  - The token is rendered through the existing `escape_html` path; JWTs contain no HTML-special characters.
- No new endpoints, inputs, or dependencies. No `THREAT[...]` comments were affected; the design rationale is documented inline at the new token type.

## Follow-ups
- Optional defense-in-depth: bind `client_id` into the consent token so a token minted while viewing client A cannot be submitted with client B's params. Safe to defer — this is not a regression (the previous cookie was not client-bound either) and the cross-site session-cookie guard already blocks the forged-POST path; the POST also re-validates `client_id`/`redirect_uri` against the DB.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (no persisted state or wire contract changed; in-flight confirm pages from the old build would 401 on submit and simply re-render — acceptable for a fix)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `auth::jwt::tests` — 13 pass, incl. 3 new consent-token tests.
- `mcp_endpoint_test`: `test_oauth_authorize_confirm_needs_no_csrf_cookie` (full GET→POST, no cookie threaded → 303 with `code`+`state`) and `test_oauth_authorize_confirm_rejects_invalid_consent_token` (→ 401).
- `cargo fmt --check` clean; `cargo clippy --tests --all-features -D warnings` clean.
- Runtime smoke test against a dev server: GET set **no** cookies and embedded a JWT; POST with the token and no cookies → `303` redirect with a valid `code`; POST with a bogus token → `401`.

https://claude.ai/code/session_017q8R6syQRDhQgMB33eK3Ek

---
_Generated by [Claude Code](https://claude.ai/code/session_017q8R6syQRDhQgMB33eK3Ek)_