### PR TITLE
fix(mcp): drop org from MCP OAuth consent page

### DIFF
--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -691,16 +691,6 @@ fn render_authorize_confirm_page(
     user: &AuthUser,
     csrf_token: &str,
 ) -> String {
-    let org = user.organizations.first();
-    let org_name = org
-        .map(|org| org.name.as_str())
-        .unwrap_or("Default Organization");
-    let org_public_id = org
-        .map(|org| org.public_id.as_str())
-        .unwrap_or(everruns_core::DEFAULT_ORG_PUBLIC_ID);
-    let org_role = org
-        .map(|org| org.role.to_string())
-        .unwrap_or_else(|| "owner".to_string());
     let normalized_scope = normalize_scope(&query.scope);
     let cancel_url = build_oauth_redirect_url(
         &query.redirect_uri,
@@ -900,10 +890,6 @@ button {
           <span class="field-value">{user_name} &lt;{user_email}&gt;</span>
         </div>
         <div class="field">
-          <span class="field-label">Organization</span>
-          <span class="field-value">{org_name} ({org_public_id}, {org_role})</span>
-        </div>
-        <div class="field">
           <span class="field-label">Redirect URI</span>
           <span class="field-value">{redirect_uri}</span>
         </div>
@@ -917,11 +903,11 @@ button {
       <ul class="grant-list">
         <li>
           <span class="grant-title">Use Everruns MCP</span>
-          <span class="grant-copy">Call MCP tools and read MCP resources exposed for this organization.</span>
+          <span class="grant-copy">Call MCP tools and read MCP resources across the organizations you can access.</span>
         </li>
         <li>
           <span class="grant-title">Act as your signed-in user</span>
-          <span class="grant-copy">Requests are authorized as {user_name} with your current {org_role} role in {org_name}.</span>
+          <span class="grant-copy">Requests are authorized as {user_name} using your access to each organization you are a member of.</span>
         </li>
         <li>
           <span class="grant-title">Keep a connection token</span>
@@ -954,9 +940,6 @@ button {
         client_id = escape_html(&query.client_id),
         user_name = escape_html(&user.name),
         user_email = escape_html(&user.email),
-        org_name = escape_html(org_name),
-        org_public_id = escape_html(org_public_id),
-        org_role = escape_html(&org_role),
         redirect_uri = escape_html(&query.redirect_uri),
         scope_chips = scope_chips,
         response_type = escape_html(&query.response_type),
@@ -1546,7 +1529,10 @@ mod tests {
         assert!(html.contains("Authorize this MCP client?"));
         assert!(html.contains("<strong>Cursor</strong>"));
         assert!(html.contains("Ava Root &lt;ava@example.com&gt;"));
-        assert!(html.contains("User Personal (org_test, admin)"));
+        // The consent page is intentionally org-free: MCP OAuth tokens are
+        // user-scoped and resolve org per request, so showing a single org
+        // here would be misleading.
+        assert!(!html.contains("Organization"));
         assert!(html.contains("Call MCP tools and read MCP resources"));
         assert!(html.contains("access token and refresh token"));
         assert!(html.contains(r#"<span class="scope">mcp</span>"#));
@@ -1566,7 +1552,6 @@ mod tests {
         let mut user = auth_user_for_render();
         user.name = "Ava \"Root\" <Ops>".to_string();
         user.email = "ava+ops@example.com".to_string();
-        user.organizations[0].name = "Org <One>".to_string();
 
         let html = render_authorize_confirm_page(
             &query,
@@ -1579,7 +1564,6 @@ mod tests {
         assert!(html.contains("Cursor &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"));
         assert!(html.contains("client_&lt;id&gt;"));
         assert!(html.contains("Ava &quot;Root&quot; &lt;Ops&gt;"));
-        assert!(html.contains("Org &lt;One&gt;"));
         assert!(html.contains("custom&lt;scope&gt;"));
         assert!(html.contains("csrf&amp;token"));
         assert!(html.contains("next=%3Cbad%3E&amp;ok=1&amp;error=access_denied&amp;state=a%26b"));

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -208,10 +208,12 @@ Authorization endpoint. Redirects to login when no session cookie is present.
 
 The confirmation page is rendered by the backend because `/oauth/*` routes are
 root-level OAuth endpoints, not frontend application routes. It shows the
-registered client name and client ID, signed-in user, selected organization,
-redirect URI, requested scope, and the concrete MCP access being granted.
-Canceling redirects back to the registered redirect URI with
-`error=access_denied` and the original `state`.
+registered client name and client ID, signed-in user, redirect URI, requested
+scope, and the concrete MCP access being granted. It deliberately shows no
+organization: MCP OAuth tokens are user-scoped (the access token carries no
+`org_id`) and resolve org per request, so naming a single org on the consent
+page would misrepresent the grant. Canceling redirects back to the registered
+redirect URI with `error=access_denied` and the original `state`.
 
 Authorization codes: random 32-byte hex, 5-minute TTL, one-time use, stored with PKCE challenge.
 


### PR DESCRIPTION
## What
Remove the "Organization" field (and its `org_name`/`org_public_id`/`org_role` bindings) from the MCP OAuth consent page, and reword the grant copy that previously framed access as scoped to a single org.

## Why
MCP OAuth access tokens are **user-scoped**: the issued JWT carries no `org_id`, and org is resolved per request (default = first org, overridable per tool call via `organization_id`, always re-checked against live DB membership). The consent page was displaying `user.organizations.first()` purely cosmetically, which misrepresented the grant as org-scoped when the resulting token can reach any org the user is a member of. This was misleading to anyone authorizing an MCP client.

## How
- Drop the org field from `render_authorize_confirm_page` and the three `org_*` template bindings that fed it (`crates/server/src/auth/mcp_oauth.rs`).
- Reword two grant-list lines to describe cross-org, user-scoped access instead of "this organization" / "your {role} role in {org}".
- Update unit tests: assert the page contains no "Organization", drop the org-escaping assertion.
- Update `specs/mcp.md`: the confirmation-page description no longer lists "selected organization" and now documents why it deliberately shows none.

No change to the authorization-code / refresh-token `org_id` persistence (audit-only, untouched) or to any auth/authz logic.

## Risk
- Low
- Pure presentational removal on a backend-rendered HTML page. Worst case is cosmetic. No token issuance, validation, or org-resolution logic changed.

## Security
- Threat categories reviewed: **TM-AUTH** (MCP OAuth consent/authorize flow), **TM-WEB** (server-rendered HTML).
- Findings and resolutions:
  - Injection/XSS: removed fields were `escape_html`-wrapped output; removing them introduces no new sink. All remaining dynamic values stay escaped. No new finding.
  - Auth/authz: `issue_authorization_code` org binding and JWT issuance are unchanged — no bypass surface added.
  - Data exposure: net reduction — the consent page no longer renders org public ID and role.
  - No new dependencies, no resource concerns. No threat-model entry change needed (no new threat surface; existing mitigations untouched).

## Follow-ups
- The `org_id` columns on `oauth_authorization_codes` / `oauth_refresh_tokens` are stored but never enforced (audit-only). Cleaning them up is a separate, larger change requiring a migration and is intentionally out of scope here. Deferred — safe because the columns are not on the access path and removing them has no behavioral effect on token use.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01MHne753A8CKDpy4zwQ8oBv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHne753A8CKDpy4zwQ8oBv)_