### PR TITLE
fix(examples): repair weekend-concierge-host compile against core API drift

### DIFF
--- a/examples/weekend-concierge-host/src/lib.rs
+++ b/examples/weekend-concierge-host/src/lib.rs
@@ -7,8 +7,8 @@ use everruns_core::session_file::InitialFile;
 use everruns_core::tool_types::{ToolCall, ToolHints};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverId, Harness, HarnessStatus,
-    Message, PlatformDefinition, ResolvedModel, Session, SessionStatus,
+    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverId, Harness,
+    HarnessStatus, Message, PlatformDefinition, ResolvedModel, Session, SessionStatus,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -212,8 +212,9 @@ fn harness(harness_id: everruns_core::HarnessId) -> Harness {
         name: "weekend-concierge".into(),
         display_name: Some("Weekend Concierge".into()),
         description: Some("A hosted in-process concierge for planning fun local outings.".into()),
-        system_prompt: "You are a concise local concierge. Use host tools when venue facts matter."
-            .into(),
+        system_prompt: Some(
+            "You are a concise local concierge. Use host tools when venue facts matter.".into(),
+        ),
         parent_harness_id: None,
         default_model_id: None,
         tags: vec!["example".into(), "embedded".into()],
@@ -226,6 +227,7 @@ fn harness(harness_id: everruns_core::HarnessId) -> Harness {
             is_readonly: true,
         }],
         network_access: None,
+        parallel_tool_calls: None,
         embedder_metadata: Default::default(),
         is_built_in: false,
         status: HarnessStatus::Active,
@@ -250,12 +252,17 @@ fn agent(
             "Keep the recommendation practical: one primary pick, one backup, one reason each."
                 .into(),
         default_model_id: default_model,
+        default_version_id: None,
+        forked_from_agent_id: None,
+        forked_from_version_id: None,
+        root_agent_id: None,
         tags: vec!["example".into()],
         capabilities: vec![],
         mcp_servers: Default::default(),
         initial_files: vec![],
         network_access: None,
         max_iterations: Some(6),
+        parallel_tool_calls: None,
         tools: vec![],
         status: AgentStatus::Active,
         created_at: Utc::now(),
@@ -277,7 +284,12 @@ fn session(
         organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
         harness_id,
         agent_id: Some(agent_id),
+        agent_version_id: None,
         agent_identity_id: None,
+        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+        resolved_owner_user_id: None,
+        owner: None,
+        effective_owner: None,
         title: Some("Friday Team Outing".into()),
         locale: Some("en-US".into()),
         preview: None,
@@ -292,6 +304,7 @@ fn session(
         hints: None,
         network_access: None,
         max_iterations: None,
+        parallel_tool_calls: None,
         status: SessionStatus::Started,
         created_at: Utc::now(),
         updated_at: Utc::now(),


### PR DESCRIPTION
## What
Fix the `examples/weekend-concierge-host` standalone example so it compiles against the current `everruns-core` API. Resolves **EVE-663**.

## Why
The example is in the workspace `exclude` list (it has its own `[workspace]`/`Cargo.lock`), so no CI job builds it and it silently drifted out of sync with core's `Agent`/`Harness`/`Session` shapes. The public OSS repo was shipping a non-compiling example.

## How
Construct the current struct shapes in `src/lib.rs`:
- **Agent**: add `default_version_id`, `forked_from_agent_id`, `forked_from_version_id`, `root_agent_id`, `parallel_tool_calls`
- **Harness**: add `parallel_tool_calls`; `system_prompt` is now `Option<String>` (wrap in `Some(...)`)
- **Session**: add `agent_version_id`, `owner_principal_id` (`PrincipalId::from_seed(1)`, the canonical example/test seed), `resolved_owner_user_id`, `owner`, `effective_owner`, `parallel_tool_calls`

Validated locally: `cargo check` and `cargo test` pass (2/2); applied `cargo fmt` (the excluded example was never fmt-gated, so a pre-existing import block was reflowed).

## Risk
- **Low**
- Example-only code outside the workspace; no library/runtime/server code changed. Cannot affect production or other crates.

## Security
- Threat categories reviewed: **No security-relevant code changes** — this is example/demo code (struct field initialization for a docs example), with no auth, API, tool-execution, or data-handling surface.
- Findings and resolutions: none.

## Follow-ups
- **CI guard for excluded examples (deferred → EVE-666).** Root-cause prevention is a CI/sweep job that `cargo check`s standalone examples so they cannot silently break again. Deferred because a per-PR full compile of an out-of-workspace example (separate `Cargo.lock`/dep tree) adds non-trivial CI time, so the right home is likely a periodic/weekly sweep rather than the per-PR path — tracked in EVE-666.

## Checklist
- [x] Tests added or updated — existing example tests pass; the compile itself is the regression guard
- [x] Backward compatibility considered — example-only, no public API change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — required checks green; the example is intentionally outside the workspace so CI skips Rust jobs (the reason for EVE-666); validated locally instead
- [x] All review comments addressed (code change or written reasoning) — none posted