### PR TITLE
test(ci): wire previously-unrun server integration tests + enumeration guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,22 @@ jobs:
       - name: Check existing migrations are immutable
         run: bash scripts/lib/check-migration-immutability.sh
 
+  # Guards against the silent-skip bug class: CI enumerates server integration
+  # tests by name, so a new crates/server/tests/*.rs file is never run until
+  # someone adds a `--test` line. This check fails if any server test file is
+  # neither wired into a CI job nor explicitly allowlisted (EVE-664).
+  server-test-enumeration:
+    name: Server Test Enumeration
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check every server test file is run by CI or allowlisted
+        run: bash scripts/lib/check-server-test-enumeration.sh
+
   clippy:
     name: Clippy Lints
     runs-on: ubuntu-latest
@@ -683,6 +699,30 @@ jobs:
             --test org_lifecycle_test \
             --test schedule_integration_test \
             --test session_git_integration_test \
+            -- --test-threads=1
+
+      # Previously-unrun server integration tests, now wired in (EVE-664). These
+      # files existed under crates/server/tests/ but were never named in any CI
+      # step, so ~17 files silently never ran. These pass on a fresh migrated DB;
+      # the still-failing ones are allowlisted in
+      # scripts/lib/check-server-test-enumeration.sh with tracking issues
+      # (EVE-667, EVE-668). The Server Test Enumeration job enforces that every
+      # server test file is either run here or explicitly allowlisted.
+      - name: Run previously-unenumerated domain integration tests
+        run: |
+          cargo test -p everruns-server \
+            --test app_api_integration_test \
+            --test command_policy_enforcement_test \
+            --test fcp_integration_test \
+            --test guardrails_integration_test \
+            --test migration_history_test \
+            --test org_invitations_test \
+            --test plugins_integration_test \
+            --test plugins_remote_test \
+            --test session_workspace_attach_test \
+            --test strict_client_tools \
+            --test subagent_spawn_handles_test \
+            --test workspace_files_integration_test \
             -- --test-threads=1
 
       - name: Run durable integration tests

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -20,8 +20,8 @@
 use std::sync::Arc;
 
 use everruns_core::{
-    Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, OrgRole, Permission,
-    PermissionResolver,
+    Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, FeatureFlags,
+    OrgRole, Permission, PermissionResolver,
 };
 use everruns_server::api::evals::CreateEvalRunRequest;
 use everruns_server::domains::agents::health_check::commands::TriggerAgentHealthCheck;
@@ -434,10 +434,16 @@ async fn agent_health_check_requires_session_permission() {
 async fn eval_manage_without_session_permission_still_allows_list() {
     // A caller with only OrgAgentsManage can still list evals — the EVAL_VIEW
     // policy only requires OrgAgentsManage. Only run creation needs more.
+    // Evals are feature-gated (require_evals_enabled), so enable the flag here;
+    // this test asserts policy behavior, not the gate.
     let ctx = make_ctx(
         caller_with_role(OrgRole::Owner),
         Arc::new(AgentsOnlyResolver),
-    );
+    )
+    .with_feature_flags(FeatureFlags {
+        evals: true,
+        ..Default::default()
+    });
     ListEvals {
         search: None,
         include_archived: false,

--- a/scripts/lib/check-server-test-enumeration.sh
+++ b/scripts/lib/check-server-test-enumeration.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Check that every server integration test file in crates/server/tests/ is
+# either run by CI (referenced as `--test <name>` in .github/workflows/ci.yml)
+# or explicitly listed in the ALLOWLIST below as intentionally not run.
+#
+# Why: CI hand-enumerates server integration tests by name. Without this guard
+# a *new* test file under crates/server/tests/ is silently skipped until
+# someone remembers to add a `--test` line — a real bug class (EVE-664). This
+# makes the enumeration self-enforcing: add a test file and CI fails until you
+# either wire it into a job or justify the exclusion here.
+#
+# Used by: scripts/lib/pre-push.sh, the `server-test-enumeration` CI job.
+#
+# Exits 0 on success, 1 on violation. Never silently skips.
+#
+# Usage: bash scripts/lib/check-server-test-enumeration.sh
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TESTS_DIR="$PROJECT_ROOT/crates/server/tests"
+CI_FILE="$PROJECT_ROOT/.github/workflows/ci.yml"
+
+# Test files that are NOT a runnable integration-test target on their own, or
+# are intentionally excluded from CI. Each entry MUST carry a one-line reason.
+# Files failing against a fresh migrated DB are parked here (explicit skip, not
+# silent) with a tracking issue, until their failures are fixed and they are
+# wired into a CI server-test step.
+declare -A ALLOWLIST=(
+  [test_harness]="shared TestServer helper module, not a standalone test target"
+  [mcp_endpoint_test]="8 MCP tool/contract tests fail on a fresh DB — see EVE-668"
+  [skills_integration_test]="12 tests fail on fixed-name collisions (isolation) — see EVE-668"
+  [openapi_coverage_test]="13 plugin handlers missing from ApiDoc — see EVE-667"
+  [openapi_descriptions_test]="doc/example coverage below MIN_*_PCT floors — see EVE-668"
+  [reporting_integration_test]="backfill test omits NOT NULL owner_principal_id — see EVE-668"
+)
+
+if [ ! -d "$TESTS_DIR" ]; then
+  echo "error: server tests directory not found: $TESTS_DIR"
+  exit 1
+fi
+if [ ! -f "$CI_FILE" ]; then
+  echo "error: CI workflow not found: $CI_FILE"
+  exit 1
+fi
+
+shopt -s nullglob
+test_files=("$TESTS_DIR"/*.rs)
+shopt -u nullglob
+
+if [ "${#test_files[@]}" -eq 0 ]; then
+  echo "error: no test files found under $TESTS_DIR (expected many)"
+  exit 1
+fi
+
+ci_contents="$(cat "$CI_FILE")"
+missing=()
+
+for path in "${test_files[@]}"; do
+  name="$(basename "$path" .rs)"
+  if [ -n "${ALLOWLIST[$name]+x}" ]; then
+    continue
+  fi
+  # A test is "run" when CI invokes it as `--test <name>` for everruns-server.
+  if printf '%s' "$ci_contents" | grep -qE -- "--test[[:space:]]+${name}([[:space:]]|\$)"; then
+    continue
+  fi
+  missing+=("$name")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "❌ server integration test files not run by CI and not allowlisted:"
+  for name in "${missing[@]}"; do
+    echo "   - crates/server/tests/${name}.rs"
+  done
+  echo ""
+  echo "Fix one of:"
+  echo "  1. Add '--test ${missing[0]}' to a server test step in .github/workflows/ci.yml, or"
+  echo "  2. If the file is a shared helper or intentionally excluded, add it to"
+  echo "     ALLOWLIST in scripts/lib/check-server-test-enumeration.sh with a reason."
+  exit 1
+fi
+
+echo "✅ all ${#test_files[@]} server test files are run by CI or allowlisted"

--- a/scripts/lib/pre-push.sh
+++ b/scripts/lib/pre-push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Pre-push checks: fast local validation to catch CI failures early (~30s).
-# Runs formatting, linting, lockfile, migration, docs index, and attribution checks.
+# Runs formatting, linting, lockfile, migration, test-enumeration, docs index, and attribution checks.
 # Usage: just pre-push (or: bash scripts/lib/pre-push.sh)
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
@@ -13,7 +13,7 @@ echo "🔒 Running pre-push checks..."
 echo ""
 
 # 1. Rust formatting
-echo "1/9 Rust formatting"
+echo "1/10 Rust formatting"
 if cargo fmt --check 2>/dev/null; then
   pass "cargo fmt"
 else
@@ -21,7 +21,7 @@ else
 fi
 
 # 2. Clippy
-echo "2/9 Rust linting"
+echo "2/10 Rust linting"
 if cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
   pass "clippy"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # 3. Cargo.lock freshness
-echo "3/9 Cargo.lock freshness"
+echo "3/10 Cargo.lock freshness"
 if cargo fetch --locked 2>/dev/null; then
   pass "Cargo.lock up to date"
 else
@@ -37,7 +37,7 @@ else
 fi
 
 # 4. UI formatting (skip if node_modules missing)
-echo "4/9 UI formatting"
+echo "4/10 UI formatting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run format:check 2>/dev/null); then
     pass "UI format"
@@ -49,7 +49,7 @@ else
 fi
 
 # 5. UI linting (skip if node_modules missing)
-echo "5/9 UI linting"
+echo "5/10 UI linting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run lint 2>/dev/null); then
     pass "UI lint"
@@ -61,7 +61,7 @@ else
 fi
 
 # 6. Migration ordering check
-echo "6/9 Migration ordering"
+echo "6/10 Migration ordering"
 if MIGRATION_ORDERING_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-migration-ordering.sh" 2>&1
 )"; then
@@ -72,7 +72,7 @@ else
 fi
 
 # 7. Migration immutability check
-echo "7/9 Migration immutability"
+echo "7/10 Migration immutability"
 if MIGRATION_IMMUTABILITY_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-migration-immutability.sh" 2>&1
 )"; then
@@ -82,8 +82,19 @@ else
   fail "migration immutability check failed"
 fi
 
-# 8. Specs index coverage
-echo "8/9 Specs index coverage"
+# 8. Server integration test enumeration
+echo "8/10 Server test enumeration"
+if SERVER_TEST_ENUM_OUTPUT="$(
+  bash "$PROJECT_ROOT/scripts/lib/check-server-test-enumeration.sh" 2>&1
+)"; then
+  pass "$SERVER_TEST_ENUM_OUTPUT"
+else
+  printf '%s\n' "$SERVER_TEST_ENUM_OUTPUT" | sed 's/^/   /'
+  fail "server test enumeration check failed"
+fi
+
+# 9. Specs index coverage
+echo "9/10 Specs index coverage"
 if SPECS_INDEX_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/test-specs-index.sh" 2>&1
 )"; then
@@ -93,8 +104,8 @@ else
   fail "specs index coverage check failed"
 fi
 
-# 9. Commit author attribution check
-echo "9/9 Commit author attribution"
+# 10. Commit author attribution check
+echo "10/10 Commit author attribution"
 if ! resolve_commit_git_identity; then
   fail "commit identity invalid — fix git config or set GIT_USER_NAME/GIT_USER_EMAIL to a real user"
 elif OFFENDING_COMMIT="$(find_agent_like_outgoing_commit)"; then


### PR DESCRIPTION
## What
Stop the silent-skip of server integration tests and wire the runnable ones into CI. Resolves **EVE-664**.

CI hand-enumerates server integration tests by name (`cargo test -p everruns-server --test <name> …`), so of **38** files under `crates/server/tests/`, ~17 were never run and any *new* file is silently skipped until someone remembers to add a `--test` line.

## How
- **New guard** `scripts/lib/check-server-test-enumeration.sh`: fails if any `crates/server/tests/*.rs` file is neither run by CI (named as `--test <name>`) nor explicitly allowlisted. Wired into a new **`Server Test Enumeration`** CI job and into `scripts/lib/pre-push.sh`. This makes the enumeration self-enforcing — a new test file fails CI until it is wired in or justified.
- **Enable 12 previously-unrun files** that pass on a fresh migrated DB, in a new CI server-test step: `app_api`, `command_policy_enforcement`, `fcp`, `guardrails`, `migration_history`, `org_invitations`, `plugins_integration`, `plugins_remote`, `session_workspace_attach`, `strict_client_tools`, `subagent_spawn_handles`, `workspace_files`.
- **Fix one stale test** — `command_policy_enforcement_test::eval_manage_without_session_permission_still_allows_list`: it predates the `require_evals_enabled` feature gate, so it tripped the gate before reaching the `EVAL_VIEW` policy it means to assert. Enable the `evals` flag in the test ctx (14/14 now).
- **Allowlist 5 files** that still genuinely fail on a fresh DB, each with a tracking issue so the skip is **explicit, not silent**:
  - `openapi_coverage_test` → **EVE-667** (13 plugin/marketplace handlers missing from `ApiDoc`)
  - `mcp_endpoint_test`, `skills_integration_test`, `openapi_descriptions_test`, `reporting_integration_test` → **EVE-668**

## Validation
Ran against a **freshly migrated PostgreSQL** (`sqlx migrate run`), single-threaded, replicating the CI job: all existing CI server tests (`api` 115, `repository` 30, + 15 domain files) **plus** the 12 newly-enabled files pass on one shared DB — no cross-file collisions. `command_policy_enforcement_test` = 14/14. Guard script verified to flag exactly the unrun files before this change and to pass after. `ci.yml` YAML validated; scripts pass `bash -n`.

## Risk
- **Low–medium.** CI-only + test-only changes; no production/library code touched. The added CI step increases the PostgreSQL job's runtime (the new files are fast; `fcp` ~35s is the slowest). If a newly-enabled file proves flaky in CI, it can be moved to the guard allowlist with an issue.

## Security
- Threat categories reviewed: **No security-relevant code changes.** Changes are CI workflow, a shell guard, `pre-push.sh`, and a test-only feature-flag toggle. No auth/API/tool-execution/data-handling surface. (The newly-enabled `command_policy_enforcement_test` and `guardrails` tests *increase* security-policy coverage in CI.)

## Follow-ups
- **EVE-667** — register the 13 plugin/marketplace handlers in `openapi.rs`, then remove `openapi_coverage_test` from the allowlist.
- **EVE-668** — fix `mcp_endpoint` (8 tool/contract fails), `skills` (12 fixed-name isolation fails), `openapi_descriptions` (coverage floors), `reporting` (`owner_principal_id` NOT NULL drift), then wire each in and remove from the allowlist.

## Checklist
- [x] Tests added or updated — 12 test files newly run in CI; 1 stale test fixed; enumeration guard added
- [x] Backward compatibility considered — CI/test-only, no API change
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)