### PR TITLE
feat(mcp): conform MCP endpoint to 2026-07-28 stateless spec

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -16,7 +16,13 @@
 //   extractors accept personal access tokens and resource-bound MCP OAuth tokens
 //   (validate_mcp_token), plus anonymous in no-auth mode — never a regular
 //   session/access JWT or cookie. Org context resolves the same as session auth.
-// - No MCP session state — stateless request/response per JSON-RPC call
+// - No MCP session state — stateless request/response per JSON-RPC call.
+//   This already satisfies the MCP 2026-07-28 stateless model (no
+//   `Mcp-Session-Id`, no sticky sessions); any request can hit any instance.
+// - Protocol versions: 2026-07-28, 2025-06-18, 2025-03-26 (fallback). 2026
+//   dropped the `initialize` handshake — client info rides in per-request
+//   `_meta` and routing rides in `Mcp-Method`/`Mcp-Name` headers — but we keep
+//   `initialize` for older clients since it creates no server state either way.
 // - Multi-org: org-scoped tools accept optional `organization_id` to override the default org
 
 mod cards;
@@ -127,9 +133,26 @@ impl JsonRpcResponse {
 const MCP_SERVER_NAME: &str = "everruns";
 const MCP_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MCP_PROTOCOL_VERSION_FALLBACK: &str = "2025-03-26";
-const MCP_PROTOCOL_VERSION_LATEST: &str = "2025-06-18";
-const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
-    &[MCP_PROTOCOL_VERSION_LATEST, MCP_PROTOCOL_VERSION_FALLBACK];
+const MCP_PROTOCOL_VERSION_2025_06: &str = "2025-06-18";
+const MCP_PROTOCOL_VERSION_LATEST: &str = "2026-07-28";
+// Newest first — negotiation and the "supported" error message both rely on
+// this ordering reading high-to-low.
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[
+    MCP_PROTOCOL_VERSION_LATEST,
+    MCP_PROTOCOL_VERSION_2025_06,
+    MCP_PROTOCOL_VERSION_FALLBACK,
+];
+
+/// The richer tool shape introduced in MCP 2025-06-18 — `title`,
+/// `outputSchema`, `structuredContent`, and entity-card tools — applies to
+/// that version and every later one (2026-07-28 is a superset). Only the
+/// 2025-03-26 fallback omits it.
+pub(crate) fn supports_rich_tool_shape(protocol_version: &str) -> bool {
+    matches!(
+        protocol_version,
+        MCP_PROTOCOL_VERSION_2025_06 | MCP_PROTOCOL_VERSION_LATEST
+    )
+}
 
 const ORG_ID_DESCRIPTION: &str = "Optional organization ID (format: org_{32-hex}). MCP has no current-organization switch; pass this on each org-scoped call to override the default organization. Use list_organizations to see available orgs.";
 
@@ -152,11 +175,27 @@ fn find_tool_definition(
 }
 
 fn negotiate_protocol_version(requested: Option<&str>) -> &'static str {
-    match requested {
-        Some(MCP_PROTOCOL_VERSION_FALLBACK) => MCP_PROTOCOL_VERSION_FALLBACK,
-        Some(version) if version < MCP_PROTOCOL_VERSION_LATEST => MCP_PROTOCOL_VERSION_FALLBACK,
-        Some(_) => MCP_PROTOCOL_VERSION_LATEST,
-        None => MCP_PROTOCOL_VERSION_FALLBACK,
+    let Some(requested) = requested else {
+        return MCP_PROTOCOL_VERSION_FALLBACK;
+    };
+    // Echo a version we support exactly.
+    if let Some(version) = SUPPORTED_PROTOCOL_VERSIONS
+        .iter()
+        .copied()
+        .find(|&v| v == requested)
+    {
+        return version;
+    }
+    // Unknown version: offer the newest version we support that is not newer
+    // than what the client asked for. The date-string ordering is
+    // lexicographic-safe (YYYY-MM-DD). A client ahead of us gets our latest
+    // and decides whether to proceed.
+    if requested > MCP_PROTOCOL_VERSION_LATEST {
+        MCP_PROTOCOL_VERSION_LATEST
+    } else if requested > MCP_PROTOCOL_VERSION_2025_06 {
+        MCP_PROTOCOL_VERSION_2025_06
+    } else {
+        MCP_PROTOCOL_VERSION_FALLBACK
     }
 }
 
@@ -167,16 +206,75 @@ fn protocol_version_from_headers(headers: &HeaderMap) -> Result<&'static str, St
             let version = value
                 .to_str()
                 .map_err(|_| "Invalid MCP-Protocol-Version header".to_string())?;
-            match version {
-                MCP_PROTOCOL_VERSION_FALLBACK => Ok(MCP_PROTOCOL_VERSION_FALLBACK),
-                MCP_PROTOCOL_VERSION_LATEST => Ok(MCP_PROTOCOL_VERSION_LATEST),
-                _ => Err(format!(
-                    "Unsupported MCP-Protocol-Version: {version}. Supported: {}",
-                    SUPPORTED_PROTOCOL_VERSIONS.join(", ")
-                )),
-            }
+            SUPPORTED_PROTOCOL_VERSIONS
+                .iter()
+                .copied()
+                .find(|&v| v == version)
+                .ok_or_else(|| {
+                    format!(
+                        "Unsupported MCP-Protocol-Version: {version}. Supported: {}",
+                        SUPPORTED_PROTOCOL_VERSIONS.join(", ")
+                    )
+                })
         }
     }
+}
+
+/// MCP 2026-07-28 removed the `initialize`/`initialized` handshake (SEP-2575):
+/// protocol version, client info, and capabilities now ride on every request.
+/// Client info arrives in `params._meta["io.modelcontextprotocol/clientInfo"]`.
+/// The endpoint is stateless and stores nothing — we surface it for telemetry
+/// only. Returns `(name, version)`, defaulting either field to `"unknown"`.
+fn client_info_from_params(params: &Value) -> Option<(String, String)> {
+    let info = params
+        .get("_meta")
+        .and_then(|meta| meta.get("io.modelcontextprotocol/clientInfo"))?;
+    let name = info
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let version = info
+        .get("version")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    Some((name, version))
+}
+
+/// MCP 2026-07-28 Streamable HTTP adds the `Mcp-Method` and `Mcp-Name` request
+/// headers (SEP) so load balancers, gateways, and rate-limiters can route on
+/// the operation without parsing the JSON-RPC body. They are optional and the
+/// body stays authoritative, but when a client sends them they MUST agree with
+/// the body — a disagreement is a request-smuggling signal, so we reject it.
+fn validate_routing_headers(headers: &HeaderMap, req: &JsonRpcRequest) -> Result<(), String> {
+    if let Some(value) = headers.get("Mcp-Method") {
+        let header_method = value
+            .to_str()
+            .map_err(|_| "Invalid Mcp-Method header".to_string())?;
+        if header_method != req.method {
+            return Err(format!(
+                "Mcp-Method header ({header_method}) does not match request method ({})",
+                req.method
+            ));
+        }
+    }
+    if let Some(value) = headers.get("Mcp-Name") {
+        let header_name = value
+            .to_str()
+            .map_err(|_| "Invalid Mcp-Name header".to_string())?;
+        // `Mcp-Name` identifies the specific tool/resource/prompt. We can only
+        // cross-check it on `tools/call`, where the body carries `params.name`.
+        if req.method == "tools/call"
+            && let Some(body_name) = req.params.get("name").and_then(Value::as_str)
+            && body_name != header_name
+        {
+            return Err(format!(
+                "Mcp-Name header ({header_name}) does not match tool name ({body_name})"
+            ));
+        }
+    }
+    Ok(())
 }
 
 // ============================================================================
@@ -461,6 +559,27 @@ async fn handle_mcp(
             "Invalid Request: jsonrpc must be \"2.0\"",
         ))
         .into_response();
+    }
+
+    // MCP 2026-07-28 routing headers: optional, but must agree with the body.
+    if let Err(msg) = validate_routing_headers(&headers, &req) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(JsonRpcResponse::error(req.id, -32600, msg)),
+        )
+            .into_response();
+    }
+
+    // MCP 2026-07-28 carries client info in `_meta` on every request instead of
+    // a once-per-connection `initialize`. Surface it for telemetry; we store
+    // nothing.
+    if let Some((name, version)) = client_info_from_params(&req.params) {
+        tracing::debug!(
+            mcp.client.name = %name,
+            mcp.client.version = %version,
+            mcp.method = %req.method,
+            "MCP request client info"
+        );
     }
 
     let response = match req.method.as_str() {
@@ -828,13 +947,12 @@ async fn handle_tools_call(
 
     match result {
         Ok(content) => {
-            let structured_content = if _protocol_version == MCP_PROTOCOL_VERSION_LATEST
-                && tool_def.has_output_schema()
-            {
-                serde_json::from_str::<Value>(&content).ok()
-            } else {
-                None
-            };
+            let structured_content =
+                if supports_rich_tool_shape(_protocol_version) && tool_def.has_output_schema() {
+                    serde_json::from_str::<Value>(&content).ok()
+                } else {
+                    None
+                };
 
             let mut result = json!({
                 "content": [{ "type": "text", "text": content }]
@@ -1874,5 +1992,184 @@ mod resources_read_policy_tests {
             matches!(err, CommandError { kind: CommandErrorKind::Forbidden(ref msg), .. } if msg.contains("agent.view")),
             "expected Forbidden(agent.view), got {err:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod protocol_version_tests {
+    use super::*;
+
+    #[test]
+    fn negotiate_echoes_each_supported_version() {
+        assert_eq!(
+            negotiate_protocol_version(Some(MCP_PROTOCOL_VERSION_LATEST)),
+            MCP_PROTOCOL_VERSION_LATEST
+        );
+        assert_eq!(
+            negotiate_protocol_version(Some(MCP_PROTOCOL_VERSION_2025_06)),
+            MCP_PROTOCOL_VERSION_2025_06
+        );
+        assert_eq!(
+            negotiate_protocol_version(Some(MCP_PROTOCOL_VERSION_FALLBACK)),
+            MCP_PROTOCOL_VERSION_FALLBACK
+        );
+    }
+
+    #[test]
+    fn negotiate_missing_version_falls_back() {
+        assert_eq!(
+            negotiate_protocol_version(None),
+            MCP_PROTOCOL_VERSION_FALLBACK
+        );
+    }
+
+    #[test]
+    fn negotiate_future_version_offers_latest() {
+        // A client newer than us gets our latest and decides what to do.
+        assert_eq!(
+            negotiate_protocol_version(Some("2099-01-01")),
+            MCP_PROTOCOL_VERSION_LATEST
+        );
+    }
+
+    #[test]
+    fn negotiate_in_between_version_picks_highest_supported_below() {
+        // Between 2025-06-18 and 2026-07-28 → 2025-06-18.
+        assert_eq!(
+            negotiate_protocol_version(Some("2025-12-01")),
+            MCP_PROTOCOL_VERSION_2025_06
+        );
+        // Below the floor → fallback.
+        assert_eq!(
+            negotiate_protocol_version(Some("2024-01-01")),
+            MCP_PROTOCOL_VERSION_FALLBACK
+        );
+    }
+
+    #[test]
+    fn header_accepts_supported_versions() {
+        for version in SUPPORTED_PROTOCOL_VERSIONS {
+            let mut headers = HeaderMap::new();
+            headers.insert("MCP-Protocol-Version", version.parse().unwrap());
+            assert_eq!(protocol_version_from_headers(&headers), Ok(*version));
+        }
+    }
+
+    #[test]
+    fn header_missing_falls_back() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            protocol_version_from_headers(&headers),
+            Ok(MCP_PROTOCOL_VERSION_FALLBACK)
+        );
+    }
+
+    #[test]
+    fn header_unsupported_version_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("MCP-Protocol-Version", "2099-01-01".parse().unwrap());
+        let err = protocol_version_from_headers(&headers).expect_err("must reject");
+        assert!(err.contains("Unsupported"));
+        assert!(err.contains(MCP_PROTOCOL_VERSION_LATEST));
+    }
+
+    #[test]
+    fn rich_tool_shape_gated_by_version() {
+        assert!(supports_rich_tool_shape(MCP_PROTOCOL_VERSION_LATEST));
+        assert!(supports_rich_tool_shape(MCP_PROTOCOL_VERSION_2025_06));
+        assert!(!supports_rich_tool_shape(MCP_PROTOCOL_VERSION_FALLBACK));
+    }
+
+    #[test]
+    fn card_tools_present_for_2026_absent_for_fallback() {
+        let names = |version| {
+            tool_definitions(version)
+                .into_iter()
+                .map(|t| t.name)
+                .collect::<Vec<_>>()
+        };
+        assert!(names(MCP_PROTOCOL_VERSION_LATEST).contains(&"agent_get_card".to_string()));
+        assert!(names(MCP_PROTOCOL_VERSION_2025_06).contains(&"agent_get_card".to_string()));
+        assert!(!names(MCP_PROTOCOL_VERSION_FALLBACK).contains(&"agent_get_card".to_string()));
+    }
+
+    #[test]
+    fn client_info_parsed_from_meta() {
+        let params = json!({
+            "_meta": {
+                "io.modelcontextprotocol/clientInfo": { "name": "my-app", "version": "1.2.3" }
+            }
+        });
+        assert_eq!(
+            client_info_from_params(&params),
+            Some(("my-app".to_string(), "1.2.3".to_string()))
+        );
+    }
+
+    #[test]
+    fn client_info_defaults_missing_fields() {
+        let params = json!({
+            "_meta": { "io.modelcontextprotocol/clientInfo": {} }
+        });
+        assert_eq!(
+            client_info_from_params(&params),
+            Some(("unknown".to_string(), "unknown".to_string()))
+        );
+    }
+
+    #[test]
+    fn client_info_absent_returns_none() {
+        assert_eq!(client_info_from_params(&json!({})), None);
+    }
+
+    fn req(method: &str, params: Value) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(json!(1)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[test]
+    fn routing_headers_absent_is_ok() {
+        let headers = HeaderMap::new();
+        assert!(validate_routing_headers(&headers, &req("tools/list", json!({}))).is_ok());
+    }
+
+    #[test]
+    fn routing_headers_matching_is_ok() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Mcp-Method", "tools/call".parse().unwrap());
+        headers.insert("Mcp-Name", "agent_run".parse().unwrap());
+        let request = req("tools/call", json!({ "name": "agent_run" }));
+        assert!(validate_routing_headers(&headers, &request).is_ok());
+    }
+
+    #[test]
+    fn routing_header_method_mismatch_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Mcp-Method", "tools/list".parse().unwrap());
+        let err = validate_routing_headers(&headers, &req("tools/call", json!({})))
+            .expect_err("mismatch must reject");
+        assert!(err.contains("Mcp-Method"));
+    }
+
+    #[test]
+    fn routing_header_name_mismatch_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Mcp-Name", "discover".parse().unwrap());
+        let request = req("tools/call", json!({ "name": "agent_run" }));
+        let err =
+            validate_routing_headers(&headers, &request).expect_err("name mismatch must reject");
+        assert!(err.contains("Mcp-Name"));
+    }
+
+    #[test]
+    fn routing_header_name_ignored_for_non_tools_call() {
+        // `Mcp-Name` only cross-checks against `tools/call` bodies.
+        let mut headers = HeaderMap::new();
+        headers.insert("Mcp-Name", "anything".parse().unwrap());
+        assert!(validate_routing_headers(&headers, &req("tools/list", json!({}))).is_ok());
     }
 }

--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -11,7 +11,7 @@ use everruns_core::McpToolAnnotations;
 use serde::Serialize;
 use serde_json::{Value, json};
 
-const MCP_PROTOCOL_VERSION_LATEST: &str = "2025-06-18";
+use super::supports_rich_tool_shape;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -55,9 +55,10 @@ pub fn tool_definitions(
         execute_tool(protocol_version, org_id_description),
     ];
     // Entity cards (specs/mcp-cards.md) require `text/html` embedded
-    // resources and tool annotations introduced in MCP 2025-06-18. Older
-    // clients negotiate the fallback protocol and don't see card tools.
-    if protocol_version == MCP_PROTOCOL_VERSION_LATEST {
+    // resources and tool annotations introduced in MCP 2025-06-18 (and carried
+    // forward in 2026-07-28). Older clients negotiate the fallback protocol and
+    // don't see card tools.
+    if supports_rich_tool_shape(protocol_version) {
         tools.push(agent_get_card_tool(protocol_version, org_id_description));
     }
     tools
@@ -514,7 +515,7 @@ fn tool(
     annotations: Option<McpToolAnnotations>,
     timeout_ms: u64,
 ) -> McpEndpointToolDefinition {
-    let supports_2025_06 = protocol_version == MCP_PROTOCOL_VERSION_LATEST;
+    let supports_2025_06 = supports_rich_tool_shape(protocol_version);
     McpEndpointToolDefinition {
         name: name.to_string(),
         title: supports_2025_06.then(|| title.to_string()),

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -20,11 +20,22 @@ Everruns also acts as an **MCP client** (connecting to remote MCP servers). That
 
 JSON-RPC 2.0 over Streamable HTTP (`POST /mcp` with JSON-RPC body).
 
-Everruns supports MCP protocol versions `2025-06-18` and `2025-03-26`.
+Everruns supports MCP protocol versions `2026-07-28`, `2025-06-18`, and `2025-03-26`.
 
-- `initialize` negotiates `protocolVersion` from the request body. When the client omits a version, Everruns falls back to `2025-03-26`.
+- `initialize` negotiates `protocolVersion` from the request body. When the client omits a version, Everruns falls back to `2025-03-26`. An exactly-supported version is echoed back; an unrecognized version negotiates down to the newest supported version that is not newer than the request (a client ahead of Everruns receives `2026-07-28`).
 - All non-`initialize` requests may send `MCP-Protocol-Version`. When omitted, Everruns falls back to `2025-03-26`.
-- Requests that send an unsupported `MCP-Protocol-Version` are rejected with HTTP `400 Bad Request` and a JSON-RPC error payload.
+- Requests that send an unsupported `MCP-Protocol-Version` header are rejected with HTTP `400 Bad Request` and a JSON-RPC error payload.
+
+### Statelessness (MCP 2026-07-28)
+
+The endpoint is stateless request/response per JSON-RPC call — no `Mcp-Session-Id`, no sticky sessions, no server-side per-connection state. This already satisfies the `2026-07-28` stateless model: any request can hit any instance, with PostgreSQL as the shared source of truth. Adopting `2026-07-28` was protocol conformance, not re-architecture. Concretely:
+
+- **`initialize` is optional.** `2026-07-28` removed the `initialize`/`initialized` handshake (SEP-2575). Everruns still accepts `initialize` for older clients because it creates no server state either way, and never requires a prior `initialize` for any method.
+- **Client info rides in `_meta`.** Per-request client identity is read from `params._meta["io.modelcontextprotocol/clientInfo"]` (`{name, version}`) and used for telemetry only; nothing is stored.
+- **Routing headers.** `2026-07-28` Streamable HTTP adds optional `Mcp-Method` and `Mcp-Name` request headers so gateways/load-balancers/rate-limiters can route on the operation without parsing the body. They are optional and the body stays authoritative; when present they must agree with the body (`Mcp-Method` vs the JSON-RPC `method`, and `Mcp-Name` vs `params.name` on `tools/call`), otherwise the request is rejected `400 Bad Request`. See [`specs/production-deployment.md`](production-deployment.md#mcp-endpoint-scaling) for the proxy contract.
+- **The richer tool shape** (`title`, `outputSchema`, `structuredContent`, entity-card tools) introduced in `2025-06-18` applies to `2025-06-18` and every later version, including `2026-07-28`; only the `2025-03-26` fallback omits it.
+
+The Tasks extension (server-directed long-running `tools/call` driven by `tasks/get`/`tasks/update`/`tasks/cancel`) is tracked separately as optional interop alignment for the existing `agent_run` → `session_get_status` poll pattern (Linear EVE-669); it is not yet implemented.
 
 ### Supported Methods
 

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -123,6 +123,15 @@ See [`specs/correlation-ids.md`](./correlation-ids.md) for the `X-Request-ID` co
 - OAuth discovery metadata stays at root: `/.well-known/oauth-authorization-server`
 - If the UI is deployed separately, it still must target the same public `/api` base and root-level `/oauth/*`, `/mcp`
 
+### MCP Endpoint Scaling
+
+`/mcp` is stateless request/response per JSON-RPC call (see [`specs/mcp.md`](./mcp.md)). It satisfies the MCP `2026-07-28` stateless model out of the box:
+
+- **No sticky sessions, no shared session store.** There is no `Mcp-Session-Id` and no server-side per-connection state, so any MCP request can route to any backend instance. Plain round-robin behind any load balancer is sufficient; horizontal scaling is "add instances."
+- **All state is in PostgreSQL** (sessions, OAuth clients/tokens, MCP server configs). Instances share one source of truth, so there are no read-after-write affinity requirements at the proxy.
+- **Routing headers are honored, not required.** When clients send the `2026-07-28` `Mcp-Method` / `Mcp-Name` headers, gateways/load-balancers/rate-limiters may route and throttle on them without parsing the JSON-RPC body. The body stays authoritative; the server rejects a header that disagrees with the body. Proxies that forward these headers unchanged enable body-free routing but are not mandatory.
+- **SSE buffering.** `tools/call` responses may carry SSE-framed results from remote MCP servers; keep proxy buffering disabled on the `/mcp` route as for `/api/*`.
+
 Canonical references:
 - [`specs/apis.md`](./apis.md)
 - [`specs/mcp.md`](./mcp.md)


### PR DESCRIPTION
## What
Adopt the protocol-level changes from the MCP `2026-07-28` ("stateless") spec on the `/mcp` endpoint:

- Add `2026-07-28` to the supported protocol versions and rework negotiation to pick the highest supported version not newer than the client request (a client ahead of us gets our latest; unknown in-between versions step down).
- Gate the richer `2025-06-18` tool shape (`title`, `outputSchema`, `structuredContent`, entity-card tools) behind a shared `supports_rich_tool_shape` predicate so it applies to `2026-07-28` too.
- Read per-request client info from `_meta["io.modelcontextprotocol/clientInfo"]` for telemetry; keep `initialize` optional (it creates no server state) for older clients.
- Honor the optional `Mcp-Method` / `Mcp-Name` routing headers, rejecting a header that disagrees with the JSON-RPC body (`400 Bad Request`).
- Document statelessness/scaling in `specs/mcp.md` and the reverse-proxy contract in `specs/production-deployment.md`.

## Why
The `2026-07-28` spec makes statelessness a protocol-level property: it removes the `initialize` handshake (SEP-2575) and `Mcp-Session-Id` (SEP-2567), moves client info into per-request `_meta`, and adds `Mcp-Method`/`Mcp-Name` so gateways route without parsing the body. Everruns' `/mcp` was **already stateless** (no `Mcp-Session-Id`, no sticky sessions, PostgreSQL as source of truth, per-call `organization_id`), so this is wire conformance, not re-architecture — it lets `2026-07-28` clients and infra treat the endpoint as first-class.

## How
All changes are in `crates/server/src/api/mcp_endpoint/`:

- `mod.rs`: version constants + `supports_rich_tool_shape`, rewritten `negotiate_protocol_version` / `protocol_version_from_headers`, new `client_info_from_params` and `validate_routing_headers`, wired into `handle_mcp` after the JSON-RPC validity check (so it runs **after** auth extraction).
- `tool_registry.rs`: card-tool and rich-shape gating now use the shared predicate instead of an `== LATEST` check.
- Specs updated to match.

## Risk
- **Low.** Additive, backward-compatible across protocol versions: `2025-03-26` and `2025-06-18` clients see identical behavior (verified by tests). New routing-header validation only triggers when a client *sends* the optional headers, and only rejects on a body/header mismatch. No auth, schema, or migration changes.

## Security
- **Threat categories reviewed:** `TM-TOOL` (MCP endpoint), `TM-API` (request/header/`_meta` parsing), `TM-AUTH`/`TM-AUTHZ` (confirmed untouched).
- **Findings and resolutions:**
  - Auth ordering preserved — the new `_meta`/routing-header logic runs in `handle_mcp` *after* the `McpAuthUser`/`McpResolvedOrg` extractors; the `THREAT[TM-MCP-006]` separate-auth-path and `THREAT[TM-MCP-001]` org-override mitigations are unchanged.
  - Header/`_meta` parsing is fail-safe: `HeaderValue::to_str` errors return a `400` (no panics), parsing is O(1) and bounded (no DoS surface).
  - `validate_routing_headers` is a **hardening**: rejecting a `Mcp-Method`/`Mcp-Name` that disagrees with the body closes a request-smuggling gap where a gateway routes on the header but the server executes a different body operation.
  - Client info from `_meta` is emitted only as structured `tracing::debug!` fields (not format-interpolated, no log injection); values are short client identifiers, no secrets, nothing persisted.
  - No new dependencies; no SQL/FS/bash/prompt surface touched.
  - No new threat introduced and no existing mitigation materially changed, so no `specs/threat-model.md` update is warranted.

## Follow-ups
- **[EVE-669](https://linear.app/everruns/issue/EVE-669/align-mcp-async-tools-with-2026-tasks-extension-vocabulary)** — optional alignment of the async tools (`agent_run` → `session_get_status` poll) with the `2026-07-28` Tasks extension (`tasks/get`/`update`/`cancel`). Deferred: it is interop/naming work, not new capability (Everruns already implements the pattern via Postgres-backed sessions), and the exact `tasks/*` schema must be confirmed against the official spec before coding.

## Checklist
- [x] Tests added or updated (16 new unit tests: negotiation, header validation, `_meta` parsing, routing-header agreement, version-gated tool shape)
- [x] Backward compatibility considered (`2025-*` clients unchanged, verified by tests)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_014c9jWG42bjSSxaP5jLub2v)_