### PR TITLE
docs(ui): adopt DESIGN.md for the Slate design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'
 - To find relevant specs, use `rg -n "<topic>" specs` and read the linked specs before changing behavior.
 - Specs capture why/what, not exhaustive how. Do not duplicate fields, enum variants, SQL DDL, or exact API shapes already readable from source.
 - Public product documentation lives in `docs/`. Internal proposals, durable design intent, and temporary investigations do not belong there.
+- UI design system (Slate): `apps/ui/src/app/design-system.css` is the runtime source of truth; `apps/ui/DESIGN.md` is its agent-readable companion in the [DESIGN.md format](https://github.com/google-labs-code/design.md). When changing design tokens, update both together and run `pnpm run design:lint` in `apps/ui`. See `specs/brand.md`.
 
 ### Local dev and tests
 

--- a/apps/ui/DESIGN.md
+++ b/apps/ui/DESIGN.md
@@ -1,0 +1,219 @@
+---
+version: alpha
+name: Slate
+description: Everruns design system — sharp-cornered, grayscale-dominant, navy primary with a single gold accent.
+colors:
+  # Mirrors the light-mode CSS custom properties in src/app/design-system.css,
+  # which is the runtime single source of truth. Values use hsl() to match those
+  # variables exactly; dark-mode equivalents are documented in the Colors prose.
+  background: "hsl(0 0% 98%)"
+  foreground: "hsl(0 0% 10%)"
+  card: "hsl(0 0% 100%)"
+  card-foreground: "hsl(0 0% 10%)"
+  popover: "hsl(0 0% 100%)"
+  popover-foreground: "hsl(0 0% 10%)"
+  primary: "hsl(220 62% 13%)"
+  primary-foreground: "hsl(0 0% 98%)"
+  secondary: "hsl(0 0% 96%)"
+  secondary-foreground: "hsl(0 0% 10%)"
+  muted: "hsl(0 0% 96%)"
+  muted-foreground: "hsl(0 0% 45%)"
+  accent: "hsl(43 60% 53%)"
+  accent-foreground: "hsl(43 60% 30%)"
+  destructive: "hsl(0 84% 60%)"
+  destructive-foreground: "hsl(0 0% 98%)"
+  border: "hsl(0 0% 88%)"
+  input: "hsl(0 0% 85%)"
+  ring: "hsl(43 60% 53%)"
+typography:
+  # Font families come from CSS variables: --font-sans (Geist Sans),
+  # --font-mono (Geist Mono), and --font-caveat (Caveat, used only for the
+  # hand-drawn experimental badge). Body copy carries -0.01em global tracking.
+  headline-lg:
+    fontFamily: Geist Sans
+    fontSize: 1.875rem
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: -0.02em
+  headline-md:
+    fontFamily: Geist Sans
+    fontSize: 1.5rem
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: -0.015em
+  title:
+    fontFamily: Geist Sans
+    fontSize: 1.125rem
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: -0.01em
+  body-lg:
+    fontFamily: Geist Sans
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: -0.01em
+  body-md:
+    fontFamily: Geist Sans
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: -0.01em
+  label-md:
+    fontFamily: Geist Sans
+    fontSize: 0.75rem
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: 0em
+  code:
+    fontFamily: Geist Mono
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.6
+  accent-script:
+    fontFamily: Caveat
+    fontSize: 1.05rem
+    fontWeight: 600
+    lineHeight: 1
+rounded:
+  # Sharp corners are a defining brand trait: every radius is 0.
+  none: 0px
+  sm: 0px
+  md: 0px
+  lg: 0px
+spacing:
+  # 4px base scale (Tailwind defaults are used in practice); the branded dot
+  # grid background repeats on a 24px cell.
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 32px
+  2xl: 48px
+  dot-grid: 24px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.primary-foreground}"
+    rounded: "{rounded.none}"
+    typography: "{typography.label-md}"
+    padding: "0.5rem 1rem"
+  button-primary-hover:
+    backgroundColor: "hsl(220 62% 18%)"
+  button-secondary:
+    backgroundColor: "{colors.secondary}"
+    textColor: "{colors.secondary-foreground}"
+    rounded: "{rounded.none}"
+    typography: "{typography.label-md}"
+    padding: "0.5rem 1rem"
+  input:
+    backgroundColor: "{colors.card}"
+    textColor: "{colors.foreground}"
+    rounded: "{rounded.none}"
+    padding: "0.5rem 0.75rem"
+  card:
+    backgroundColor: "{colors.card}"
+    textColor: "{colors.card-foreground}"
+    rounded: "{rounded.none}"
+    padding: "1rem"
+---
+
+# Slate Design System
+
+Slate is the Everruns design system. The normative token values live in the YAML
+front matter above and in `src/app/design-system.css` (the runtime source of
+truth); the prose below explains how to apply them.
+
+## Overview
+
+Slate feels like precision instrumentation: sober, dense, and engineered. The
+product manages and monitors AI agents, so the UI favors legibility and calm
+over decoration. The personality is **architectural** — sharp corners, a
+grayscale foundation, and a single gold accent reserved for moments that matter.
+When a rule is not spelled out, prefer the restrained, professional, slightly
+utilitarian choice over the playful or ornamental one.
+
+## Colors
+
+The palette is grayscale-dominant, anchored by a deep navy primary and a single
+gold accent. Descriptive brand names map to systematic tokens as follows:
+
+- **Navy (`primary`, light `hsl(220 62% 13%)` ≈ `#0A1636`):** The brand color,
+  used for primary buttons, key actions, and the loading-wave ramp. In dark mode
+  `primary` inverts to near-white (`hsl(0 0% 95%)`) so actions stay prominent.
+- **Gold (`accent` / `ring`, `hsl(43 60% 53%)` ≈ `#D4A43A`):** The sole accent,
+  reserved for active states, focus rings, highlights, and the dark-mode dot
+  grid. Use it sparingly — never as a large text surface.
+- **Ink (`foreground`, `hsl(0 0% 10%)`):** Core text on light surfaces.
+- **Surfaces (`background` `hsl(0 0% 98%)`, `card` white):** A near-white page
+  with pure-white cards. Dark mode shifts to a navy-tinted charcoal
+  (`background hsl(220 15% 8%)`, `card hsl(220 15% 10%)`).
+- **Muted (`muted` / `muted-foreground`):** Quiet grays for secondary text,
+  metadata, and disabled states.
+- **Destructive (`hsl(0 84% 60%)`):** Errors and irreversible actions only.
+
+Every token has a light and dark value in `design-system.css`; the tokens above
+capture the light theme as the canonical reference.
+
+## Typography
+
+Two families carry the system: **Geist Sans** for everything structural and
+**Geist Mono** for code, logs, and telemetry. **Caveat** appears in exactly one
+place — the hand-drawn "experimental" page badge — and should not be reused.
+
+- **Headlines (`headline-lg`, `headline-md`):** Geist Sans Semi-Bold with tight
+  negative tracking for an engineered, condensed feel.
+- **Body (`body-lg`, `body-md`):** Geist Sans Regular. Dense SaaS surfaces lean
+  on `body-md` (14px); long-form reading uses `body-lg` (16px). Global letter
+  spacing is `-0.01em`.
+- **Labels (`label-md`):** Compact Geist Sans Medium for buttons, chips, and
+  metadata.
+- **Code (`code`):** Geist Mono for inline code and code blocks.
+
+## Layout
+
+Layouts use a 4px base spacing scale (`xs`–`2xl`) consistent with the Tailwind
+defaults already in use. Content sits on a near-white page textured by a branded
+**dot grid** — navy dots at 8% opacity in light mode, gold dots at 10% in dark
+mode — repeating on a 24px cell (`spacing.dot-grid`). Group related items into
+white cards with generous internal padding to separate them from the textured
+background.
+
+## Elevation & Depth
+
+Slate is intentionally **flat**. Hierarchy comes from tonal layering and
+borders, not shadows: a near-white background, pure-white cards, and 1px borders
+(`colors.border`). Focus and active emphasis is signaled with the gold `ring`
+rather than elevation. Subtle motion (row-enter, tool-pulse, loading-wave, and a
+progress sheen) conveys state changes in place.
+
+## Shapes
+
+The shape language is **uncompromisingly sharp**: every corner radius is `0px`
+(`--radius` and all `--radius-*` tokens). Icons reinforce this with squared
+line caps and mitered joins (`.icon-sharp`). The single deliberate exception is
+the hand-drawn experimental badge, whose organic border is a one-off accent.
+
+## Components
+
+- **Buttons:** `button-primary` is navy with near-white label text and sharp
+  corners; it darkens on hover (`button-primary-hover`). `button-secondary` uses
+  the light gray `secondary` surface for lower-emphasis actions. Both use the
+  `label-md` token.
+- **Inputs:** White surface, `input` border color, sharp corners, comfortable
+  padding; focus draws the gold `ring`.
+- **Cards:** White surface on the textured background, 1px border, no radius,
+  no shadow.
+
+## Do's and Don'ts
+
+- **Do** keep every corner sharp — never introduce a non-zero radius outside the
+  experimental badge.
+- **Do** reserve gold (`accent`) for active states, focus rings, and highlights;
+  use navy (`primary`) for the single most important action per screen.
+- **Don't** place dark text on a gold surface or use gold for body text — its
+  contrast is too low for WCAG AA.
+- **Don't** add drop shadows; convey hierarchy with tone and borders instead.
+- **Do** edit `src/app/design-system.css` and this file together — they must
+  stay in sync.
+- **Don't** reuse the Caveat font outside the experimental badge.

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -16,6 +16,17 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Design system
+
+The Slate design system is documented in [`DESIGN.md`](./DESIGN.md), an agent- and
+human-readable file in the [DESIGN.md format](https://github.com/google-labs-code/design.md).
+Its tokens mirror `src/app/design-system.css`, which remains the runtime source
+of truth — edit both together. Validate the file with:
+
+```bash
+pnpm run design:lint
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -20,6 +20,7 @@
     "format": "oxfmt --write ./src",
     "format:check": "oxfmt --check ./src",
     "typecheck": "tsc --noEmit",
+    "design:lint": "npx --yes @google/design.md@latest lint DESIGN.md",
     "test": "jest",
     "test:watch": "jest --watch",
     "e2e": "playwright test",

--- a/apps/ui/src/app/design-system.css
+++ b/apps/ui/src/app/design-system.css
@@ -8,6 +8,10 @@
  * This file is the single source of truth for the Everruns design system.
  * Downstream consumers (e.g. SaaS UI) should import this file instead of
  * duplicating CSS variables, theme tokens, utilities, and animations.
+ *
+ * The design intent and tokens are also documented in ../../DESIGN.md
+ * (DESIGN.md format). Keep that file in sync when changing tokens here;
+ * validate with `pnpm run design:lint`.
  */
 
 @layer base {

--- a/specs/brand.md
+++ b/specs/brand.md
@@ -140,6 +140,25 @@ surrounding canvas — never re-derive ring coordinates by bounding box.
 
 The "Slate" design system defines the visual language for the Everruns UI application.
 
+#### Sources of truth and DESIGN.md
+
+The Slate design system has two co-located, machine-readable sources of truth in
+the UI app:
+
+- `apps/ui/src/app/design-system.css` — the **runtime** source of truth: CSS
+  custom properties, theme tokens, utilities, and animations consumed at build
+  time. Downstream apps import this file rather than duplicating it.
+- `apps/ui/DESIGN.md` — the **agent- and human-readable** source of truth in the
+  [DESIGN.md format](https://github.com/google-labs-code/design.md) (YAML token
+  front matter + design-rationale prose). Its tokens mirror the light-mode values
+  in `design-system.css`.
+
+These two files MUST stay in sync: when changing a token in `design-system.css`,
+update `DESIGN.md` in the same change (and vice versa). Validate `DESIGN.md`
+structurally and against WCAG contrast with `pnpm run design:lint` (in
+`apps/ui`), which runs `@google/design.md lint`. This spec captures intent only;
+do not duplicate the full token tables here — read them from those two files.
+
 #### Corners & Radius
 
 **Sharp corners (0px)** throughout for a clean, developer-focused aesthetic.


### PR DESCRIPTION
## What
Adopt the [DESIGN.md format](https://github.com/google-labs-code/design.md) for the Everruns "Slate" design system.

- Add `apps/ui/DESIGN.md` — an agent- and human-readable description of Slate in the DESIGN.md format (YAML token front matter + design-rationale prose). Tokens mirror the light-mode values in `apps/ui/src/app/design-system.css`.
- Add a `design:lint` script to `apps/ui/package.json` (`npx @google/design.md lint DESIGN.md`) to validate the file structurally and against WCAG contrast.
- Cross-link `DESIGN.md` and `design-system.css`; document both in `apps/ui/README.md`.
- Record the adoption and the two-sources-of-truth sync rule in `specs/brand.md`, with a matching pointer in `AGENTS.md`.

## Why
The design system previously had a runtime source of truth (`design-system.css`) but no structured, machine-readable description that coding agents and tools could consume to apply the brand consistently. DESIGN.md is an open format purpose-built for that, and gives us a linter that enforces structure and contrast.

## How
Derived `DESIGN.md` directly from the existing `design-system.css` (not invented): colors use `hsl()` matching the CSS custom properties exactly; typography reflects the Geist Sans/Mono + Caveat families and the global `-0.01em` tracking; sharp `0px` corners and the 24px dot grid are captured as tokens. `design-system.css` remains the runtime source of truth; `DESIGN.md` is its companion, and the two must be edited together.

## Risk
- **Low.** Docs plus one local-only dev script and a comment in `design-system.css`. No runtime, build, or CI behavior changes.

## Security
- Threat categories reviewed: dependency/supply-chain. No TM-AUTH/AUTHZ/API/TENANT/FS/SQL/WEB surface is touched — the change is documentation plus a developer-invoked lint script.
- Findings and resolutions: the `design:lint` script invokes `@google/design.md` via `npx` on demand. It is intentionally **not** added to the lockfile and never runs in build, CI, or production — only when a developer opts in locally. Version is left at `@latest` because the tool is alpha and fast-moving; the blast radius is a local, opt-in lint run. No secrets, inputs, or trust boundaries are involved.

## Follow-ups
- Wire `design:lint` into CI / `just pre-push` — deferred: it needs network access at runtime and the check is advisory; out of scope for this doc adoption.
- `DESIGN.md` captures the light theme as the canonical token set; dark-mode values are described in prose. The format models one canonical palette, so this is intentional, not a gap.
- `design:lint` reports 11 `orphaned-token` warnings (0 errors). Intentional: the file mirrors the full semantic palette from the CSS, not only tokens consumed by the documented component atoms.

## Checklist
- [x] Tests added or updated — N/A (docs/config only); validated with `pnpm run design:lint` (0 errors)
- [x] Backward compatibility considered — additive only; no existing behavior changed
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmZx8EpCh2ktdMdYRp1GRo)_