### PR TITLE
fix(storage): delete replaced workspace file blobs

### DIFF
--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -305,6 +305,13 @@ impl Database {
             .await?;
 
             let mut tx = self.pool.begin().await?;
+            let previous_key: Option<String> = sqlx::query_as::<_, (String,)>(
+                "SELECT blob_key FROM workspace_file_blobs WHERE file_id = $1",
+            )
+            .bind(file_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(|(key,)| key);
             sqlx::query(
                 r#"
                 INSERT INTO workspace_file_blobs (file_id, blob_key, content_sha256, size_bytes)
@@ -339,6 +346,17 @@ impl Database {
             .fetch_optional(&mut *tx)
             .await?;
             tx.commit().await?;
+
+            // Once PostgreSQL points at the new immutable revision, delete the
+            // superseded object immediately so repeated same-size updates cannot
+            // amplify physical object-store usage until the delayed GC runs.
+            if previous_key
+                .as_deref()
+                .is_some_and(|old_key| old_key != key.as_str())
+                && let Some(previous_key) = previous_key
+            {
+                blob.delete(&previous_key).await?;
+            }
 
             if let Some(row) = row.as_mut() {
                 row.content = Some(content.clone());
@@ -432,6 +450,14 @@ impl Database {
                 return Ok(None);
             }
 
+            let previous_key: Option<String> = sqlx::query_as::<_, (String,)>(
+                "SELECT blob_key FROM workspace_file_blobs WHERE file_id = $1",
+            )
+            .bind(existing.id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(|(key,)| key);
+
             let size_bytes = new_content.len() as i64;
             let sha = content_sha256(&new_content);
             let key = workspace_file_key(session_id, existing.id, &sha);
@@ -476,6 +502,17 @@ impl Database {
             .fetch_optional(&mut *tx)
             .await?;
             tx.commit().await?;
+
+            // CAS updates also replace the sidecar pointer. Remove the old
+            // immutable revision after commit to bound physical storage growth
+            // without reintroducing in-place overwrites.
+            if previous_key
+                .as_deref()
+                .is_some_and(|old_key| old_key != key.as_str())
+                && let Some(previous_key) = previous_key
+            {
+                blob.delete(&previous_key).await?;
+            }
 
             if let Some(row) = row.as_mut() {
                 row.content = Some(new_content);

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -353,8 +353,8 @@ async fn offloaded_file_update_writes_immutable_blob_revision_and_hash() {
     let blob = blob_store_under_test();
     assert_eq!(
         blob.get(&old_key).await.expect("old blob get").as_deref(),
-        Some(original_body.as_slice()),
-        "the previous revision must not be overwritten in place"
+        None,
+        "the previous revision should be deleted after the sidecar moves"
     );
     assert_eq!(
         blob.get(&new_key).await.expect("new blob get").as_deref(),
@@ -412,6 +412,10 @@ async fn offloaded_file_cas_matches_and_rejects() {
         .expect("present");
     assert_eq!(fetched.content.as_deref(), Some(original.as_slice()));
 
+    let (old_cas_key, _) = file_sidecar(&pool, workspace_id, "/cas.txt")
+        .await
+        .expect("sidecar exists before CAS");
+
     // Correct expected content applies the write.
     let new_body = b"second revision".to_vec();
     let applied = backend
@@ -432,10 +436,20 @@ async fn offloaded_file_cas_matches_and_rejects() {
         raw_file_content(&pool, workspace_id, "/cas.txt").await,
         None
     );
-    let (_, sha) = file_sidecar(&pool, workspace_id, "/cas.txt")
+    let (new_cas_key, sha) = file_sidecar(&pool, workspace_id, "/cas.txt")
         .await
         .expect("sidecar exists");
     assert_eq!(sha, content_sha256(&new_body));
+    assert_ne!(new_cas_key, old_cas_key);
+    let blob = blob_store_under_test();
+    assert_eq!(
+        blob.get(&old_cas_key)
+            .await
+            .expect("old CAS blob get")
+            .as_deref(),
+        None,
+        "CAS should delete the previous revision after the sidecar moves"
+    );
 
     backend.delete_session(TEST_ORG_ID, session_id).await.ok();
 }


### PR DESCRIPTION
### Motivation

- Immutable blob keys were added to avoid object-store overwrite races, but updates moved the sidecar pointer without deleting the previously referenced object, enabling storage-amplification DoS when an authenticated writer repeatedly updates the same file with same-sized content.

### Description

- Capture the currently-referenced `blob_key` from `workspace_file_blobs` before updating the sidecar and, after the PostgreSQL transaction commits, delete the previous object when it differs from the new immutable key, applied to both normal offload updates and CAS update paths (`crates/server/src/storage/repositories/session_files.rs`).
- Update the offload integration expectations to assert superseded immutable revisions are removed after the sidecar moves and add CAS coverage that the prior revision is deleted (`crates/server/tests/blob_offload_integration_test.rs`).
- The change preserves the immutability and integrity guarantees (new revisions are still written under revision-specific keys) while bounding physical object-store growth for replaced revisions.

### Testing

- Ran `cargo fmt --check`, which passed.
- Verified formatting and whitespace checks and updated integration tests compile-format checks (`cargo fmt --check` on edited test files passed).
- Attempted a focused integration binary build with `cargo test -p everruns-server --test blob_offload_integration_test --no-run`, and ran an incremental `cargo check -p everruns-server --lib`, but both runs hit environment/time limits in this workspace (build started successfully and dependency resolution progressed, but the full compile was stopped due to resource/time constraints).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60df27c0832b9177a0e8dd145de4)