### PR TITLE
fix(schedules): make schedule cap creation atomic

### DIFF
--- a/crates/core/src/capabilities/session_schedule.rs
+++ b/crates/core/src/capabilities/session_schedule.rs
@@ -159,26 +159,8 @@ impl Tool for CreateScheduleTool {
             return ToolExecutionResult::tool_error("Schedule store not available in this context");
         };
 
-        // Enforce per-session cap, per-org cap, and minimum recurring cron
-        // interval (shared with spawn_background's scheduled path).
-        match crate::session_schedule::enforce_create_limits(
-            store.as_ref(),
-            context.session_id,
-            cron_expression.as_deref(),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(crate::session_schedule::ScheduleLimitError::Store(e)) => {
-                return ToolExecutionResult::internal_error(e);
-            }
-            Err(crate::session_schedule::ScheduleLimitError::Rejected(msg)) => {
-                return ToolExecutionResult::tool_error(msg);
-            }
-        }
-
         match store
-            .create_schedule(
+            .create_schedule_enforcing_limits(
                 context.session_id,
                 description,
                 cron_expression,
@@ -198,7 +180,12 @@ impl Tool for CreateScheduleTool {
                 "enabled": schedule.enabled,
                 "created": true,
             })),
-            Err(e) => ToolExecutionResult::internal_error(e),
+            Err(crate::session_schedule::ScheduleLimitError::Store(e)) => {
+                ToolExecutionResult::internal_error(e)
+            }
+            Err(crate::session_schedule::ScheduleLimitError::Rejected(msg)) => {
+                ToolExecutionResult::tool_error(msg)
+            }
         }
     }
 }

--- a/crates/core/src/session_schedule.rs
+++ b/crates/core/src/session_schedule.rs
@@ -118,8 +118,8 @@ pub enum ScheduleLimitError {
 /// interval gate). Each fire dispatches a real worker turn, so these bound
 /// operator compute on open-signup deployments (see `specs/threat-model.md`
 /// TM-SCHED-001).
-pub async fn enforce_create_limits(
-    store: &dyn crate::traits::SessionScheduleStore,
+pub async fn validate_schedule_create_limits<T: crate::traits::SessionScheduleStore + ?Sized>(
+    store: &T,
     session_id: SessionId,
     cron_expression: Option<&str>,
 ) -> std::result::Result<(), ScheduleLimitError> {

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1138,24 +1138,6 @@ impl Tool for SpawnBackgroundTool {
                 );
             };
 
-            // Enforce per-session cap, per-org cap, and minimum recurring cron
-            // interval (shared with the create_schedule tool).
-            match crate::session_schedule::enforce_create_limits(
-                schedule_store.as_ref(),
-                context.session_id,
-                schedule_request.cron_expression.as_deref(),
-            )
-            .await
-            {
-                Ok(()) => {}
-                Err(crate::session_schedule::ScheduleLimitError::Store(err)) => {
-                    return ToolExecutionResult::internal_error(err);
-                }
-                Err(crate::session_schedule::ScheduleLimitError::Rejected(msg)) => {
-                    return ToolExecutionResult::tool_error(msg);
-                }
-            }
-
             let description = build_background_schedule_description(
                 tool_name,
                 &tool_args,
@@ -1164,7 +1146,7 @@ impl Tool for SpawnBackgroundTool {
             );
 
             return match schedule_store
-                .create_schedule(
+                .create_schedule_enforcing_limits(
                     context.session_id,
                     description,
                     schedule_request.cron_expression.clone(),
@@ -1233,7 +1215,12 @@ impl Tool for SpawnBackgroundTool {
                         "task_id": monitor_task_id,
                     }))
                 }
-                Err(err) => ToolExecutionResult::internal_error(err),
+                Err(crate::session_schedule::ScheduleLimitError::Store(err)) => {
+                    ToolExecutionResult::internal_error(err)
+                }
+                Err(crate::session_schedule::ScheduleLimitError::Rejected(msg)) => {
+                    ToolExecutionResult::tool_error(msg)
+                }
             };
         }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -919,6 +919,59 @@ pub trait SessionScheduleStore: Send + Sync {
         timezone: String,
     ) -> Result<SessionSchedule>;
 
+    /// Create a new schedule after enforcing create-time limits in the same
+    /// store operation. Backends with shared mutable state must override this
+    /// to make the check-and-create sequence atomic.
+    async fn create_schedule_enforcing_limits(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+        timezone: String,
+    ) -> std::result::Result<SessionSchedule, crate::session_schedule::ScheduleLimitError> {
+        let per_session = self
+            .count_active_schedules(session_id)
+            .await
+            .map_err(crate::session_schedule::ScheduleLimitError::Store)?;
+        if per_session >= crate::session_schedule::MAX_ACTIVE_SCHEDULES_PER_SESSION {
+            return Err(crate::session_schedule::ScheduleLimitError::Rejected(
+                format!(
+                    "Maximum {} active schedules per session. Cancel an existing schedule first.",
+                    crate::session_schedule::MAX_ACTIVE_SCHEDULES_PER_SESSION
+                ),
+            ));
+        }
+
+        let max_per_org = crate::session_schedule::max_active_schedules_per_org();
+        let per_org = self
+            .count_active_org_schedules()
+            .await
+            .map_err(crate::session_schedule::ScheduleLimitError::Store)?;
+        if i64::from(per_org) >= max_per_org {
+            return Err(crate::session_schedule::ScheduleLimitError::Rejected(
+                format!(
+                    "Maximum {max_per_org} active schedules per org reached. Cancel an existing schedule first."
+                ),
+            ));
+        }
+
+        if let Some(cron) = cron_expression.as_deref() {
+            crate::session_schedule::validate_cron_min_interval(cron)
+                .map_err(crate::session_schedule::ScheduleLimitError::Rejected)?;
+        }
+
+        self.create_schedule(
+            session_id,
+            description,
+            cron_expression,
+            scheduled_at,
+            timezone,
+        )
+        .await
+        .map_err(crate::session_schedule::ScheduleLimitError::Store)
+    }
+
     /// Cancel (disable) a schedule.
     async fn cancel_schedule(
         &self,

--- a/crates/local/src/schedule_store.rs
+++ b/crates/local/src/schedule_store.rs
@@ -14,7 +14,10 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::session_schedule::SessionSchedule;
+use everruns_core::session_schedule::{
+    MAX_ACTIVE_SCHEDULES_PER_SESSION, ScheduleLimitError, SessionSchedule,
+    max_active_schedules_per_org, validate_cron_min_interval,
+};
 use everruns_core::traits::SessionScheduleStore;
 use everruns_core::typed_id::{PrincipalId, ScheduleId, SessionId};
 use rusqlite::OptionalExtension;
@@ -220,6 +223,83 @@ impl SessionScheduleStore for LocalScheduleStore {
             Value::Object(Default::default()),
         )
         .await
+    }
+
+    async fn create_schedule_enforcing_limits(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<DateTime<Utc>>,
+        timezone: String,
+    ) -> std::result::Result<SessionSchedule, ScheduleLimitError> {
+        if let Some(cron) = cron_expression.as_deref() {
+            validate_cron_min_interval(cron).map_err(ScheduleLimitError::Rejected)?;
+        }
+
+        let schedule = self.build_schedule(
+            session_id,
+            description,
+            cron_expression,
+            scheduled_at,
+            timezone,
+        );
+        let snapshot = serde_json::to_string(&schedule)
+            .map_err(|e| ScheduleLimitError::Store(AgentLoopError::from(LocalError::from(e))))?;
+        let metadata_json = serde_json::to_string(&Value::Object(Default::default()))
+            .map_err(|e| ScheduleLimitError::Store(AgentLoopError::from(LocalError::from(e))))?;
+        let id = schedule.id.to_string();
+        let session = session_id.to_string();
+        let enabled = schedule.enabled as i64;
+        let org_id = self.org_id;
+        let max_per_org = max_active_schedules_per_org();
+
+        let inserted = self
+            .db
+            .with_conn(|conn| {
+                let active_session_count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM local_schedules
+                     WHERE org_id = ?1 AND session_id = ?2 AND enabled = 1",
+                    rusqlite::params![org_id, session],
+                    |row| row.get(0),
+                )?;
+                let active_org_count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM local_schedules
+                     WHERE org_id = ?1 AND enabled = 1",
+                    rusqlite::params![org_id],
+                    |row| row.get(0),
+                )?;
+                if active_session_count >= i64::from(MAX_ACTIVE_SCHEDULES_PER_SESSION) {
+                    return Ok(false);
+                }
+                if active_org_count >= max_per_org {
+                    return Ok(false);
+                }
+                conn.execute(
+                    "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    rusqlite::params![id, org_id, session, enabled, snapshot, metadata_json],
+                )?;
+                Ok(true)
+            })
+            .map_err(|e| ScheduleLimitError::Store(AgentLoopError::from(e)))?;
+
+        if inserted {
+            Ok(schedule)
+        } else if self
+            .count_active_schedules(session_id)
+            .await
+            .map_err(ScheduleLimitError::Store)?
+            >= MAX_ACTIVE_SCHEDULES_PER_SESSION
+        {
+            Err(ScheduleLimitError::Rejected(format!(
+                "Maximum {MAX_ACTIVE_SCHEDULES_PER_SESSION} active schedules per session. Cancel an existing schedule first."
+            )))
+        } else {
+            Err(ScheduleLimitError::Rejected(format!(
+                "Maximum {max_per_org} active schedules per org reached. Cancel an existing schedule first."
+            )))
+        }
     }
 
     async fn cancel_schedule(

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3067,7 +3067,7 @@ impl WorkerService for WorkerServiceImpl {
             .map(everruns_internal_protocol::proto_timestamp_to_datetime);
 
         let schedule = store
-            .create_schedule(
+            .create_schedule_enforcing_limits(
                 session_id.into(),
                 req.description,
                 req.cron_expression,
@@ -3075,9 +3075,14 @@ impl WorkerService for WorkerServiceImpl {
                 req.timezone,
             )
             .await
-            .map_err(|e| {
-                tracing::error!("Failed to create schedule: {}", e);
-                Status::internal(format!("Failed to create schedule: {}", e))
+            .map_err(|e| match e {
+                everruns_core::session_schedule::ScheduleLimitError::Rejected(msg) => {
+                    Status::resource_exhausted(msg)
+                }
+                everruns_core::session_schedule::ScheduleLimitError::Store(err) => {
+                    tracing::error!("Failed to create schedule: {}", err);
+                    Status::internal(format!("Failed to create schedule: {}", err))
+                }
             })?;
 
         Ok(Response::new(CreateSessionScheduleResponse {

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3043,6 +3043,21 @@ impl StorageBackend {
         dispatch!(self, delete_session_schedule, org_id, schedule_id)
     }
 
+    pub async fn create_session_schedule_with_limits(
+        &self,
+        input: CreateSessionScheduleRow,
+        max_per_session: u32,
+        max_per_org: i64,
+    ) -> Result<Option<SessionScheduleRow>> {
+        dispatch!(
+            self,
+            create_session_schedule_with_limits,
+            input,
+            max_per_session,
+            max_per_org
+        )
+    }
+
     pub async fn count_active_session_schedules(&self, session_id: SessionId) -> Result<u32> {
         dispatch!(self, count_active_session_schedules, session_id)
     }

--- a/crates/server/src/storage/memory/schedules.rs
+++ b/crates/server/src/storage/memory/schedules.rs
@@ -41,6 +41,51 @@ impl InMemoryDatabase {
         Ok(row)
     }
 
+    pub async fn create_session_schedule_with_limits(
+        &self,
+        input: CreateSessionScheduleRow,
+        max_per_session: u32,
+        max_per_org: i64,
+    ) -> Result<Option<SessionScheduleRow>> {
+        let mut schedules = self.session_schedules.write();
+        let active_session_count = schedules
+            .values()
+            .filter(|r| r.session_id == input.session_id && r.enabled)
+            .count();
+        let active_org_count = schedules
+            .values()
+            .filter(|r| r.org_id == input.org_id && r.enabled)
+            .count();
+        if active_session_count >= max_per_session as usize
+            || active_org_count >= max_per_org as usize
+        {
+            return Ok(None);
+        }
+
+        let now = Self::now();
+        let id = ScheduleId::new();
+        let public_id = id.to_string();
+        let row = SessionScheduleRow {
+            id,
+            public_id,
+            org_id: input.org_id,
+            session_id: input.session_id,
+            owner_principal_id: input.owner_principal_id,
+            resolved_owner_user_id: input.resolved_owner_user_id,
+            description: input.description,
+            cron_expression: input.cron_expression,
+            scheduled_at: input.scheduled_at,
+            timezone: input.timezone,
+            enabled: true,
+            next_trigger_at: input.next_trigger_at,
+            last_triggered_at: None,
+            trigger_count: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        schedules.insert(id, row.clone());
+        Ok(Some(row))
+    }
     pub async fn get_session_schedule(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/schedules.rs
+++ b/crates/server/src/storage/repositories/schedules.rs
@@ -42,6 +42,65 @@ impl Database {
         Ok(row)
     }
 
+    pub async fn create_session_schedule_with_limits(
+        &self,
+        input: CreateSessionScheduleRow,
+        max_per_session: u32,
+        max_per_org: i64,
+    ) -> Result<Option<SessionScheduleRow>> {
+        let mut tx = self.pool.begin().await?;
+        // Serialize quota checks and insertion per org so concurrent creators
+        // cannot all observe the same below-cap count before inserting.
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(input.org_id)
+            .execute(&mut *tx)
+            .await?;
+
+        let active_session_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM session_schedules WHERE session_id = $1 AND enabled = true",
+        )
+        .bind(input.session_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let active_org_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM session_schedules WHERE org_id = $1 AND enabled = true",
+        )
+        .bind(input.org_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if active_session_count.0 >= i64::from(max_per_session) || active_org_count.0 >= max_per_org
+        {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        let id = ScheduleId::new();
+        let public_id = id.to_string();
+        let row = sqlx::query_as::<_, SessionScheduleRow>(
+            r#"
+            INSERT INTO session_schedules (id, public_id, org_id, session_id, owner_principal_id, resolved_owner_user_id, description, cron_expression, scheduled_at, timezone, next_trigger_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(&public_id)
+        .bind(input.org_id)
+        .bind(input.session_id)
+        .bind(input.owner_principal_id)
+        .bind(input.resolved_owner_user_id)
+        .bind(&input.description)
+        .bind(&input.cron_expression)
+        .bind(input.scheduled_at)
+        .bind(&input.timezone)
+        .bind(input.next_trigger_at)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(Some(row))
+    }
     pub async fn get_session_schedule(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/session_schedule_store.rs
+++ b/crates/server/src/storage/session_schedule_store.rs
@@ -7,7 +7,11 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::{
     AgentLoopError, Result, ScheduleId, SessionId, StoreResultExt,
-    session_schedule::SessionSchedule, traits::SessionScheduleStore,
+    session_schedule::{
+        MAX_ACTIVE_SCHEDULES_PER_SESSION, ScheduleLimitError, SessionSchedule,
+        max_active_schedules_per_org, validate_schedule_create_limits,
+    },
+    traits::SessionScheduleStore,
 };
 
 use super::backend::StorageBackend;
@@ -92,6 +96,62 @@ impl SessionScheduleStore for DbSessionScheduleStore {
             .store_err()?;
 
         Ok(row_to_domain(&row))
+    }
+
+    async fn create_schedule_enforcing_limits(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<DateTime<Utc>>,
+        timezone: String,
+    ) -> std::result::Result<SessionSchedule, ScheduleLimitError> {
+        if let Some(cron) = cron_expression.as_deref() {
+            everruns_core::session_schedule::validate_cron_min_interval(cron)
+                .map_err(ScheduleLimitError::Rejected)?;
+        }
+
+        let next_trigger =
+            compute_next_trigger(cron_expression.as_deref(), scheduled_at, &timezone)
+                .map_err(|e| ScheduleLimitError::Store(AgentLoopError::tool(e.to_string())))?;
+        let session = self
+            .db
+            .get_session(self.org_id, session_id)
+            .await
+            .store_err()
+            .map_err(ScheduleLimitError::Store)?
+            .ok_or_else(|| ScheduleLimitError::Store(AgentLoopError::tool("Session not found")))?;
+
+        let max_per_org = max_active_schedules_per_org();
+        let row = self
+            .db
+            .create_session_schedule_with_limits(
+                CreateSessionScheduleRow {
+                    org_id: self.org_id,
+                    session_id,
+                    owner_principal_id: session.owner_principal_id,
+                    resolved_owner_user_id: session.resolved_owner_user_id,
+                    description,
+                    cron_expression,
+                    scheduled_at,
+                    timezone,
+                    next_trigger_at: next_trigger,
+                },
+                MAX_ACTIVE_SCHEDULES_PER_SESSION,
+                max_per_org,
+            )
+            .await
+            .store_err()
+            .map_err(ScheduleLimitError::Store)?;
+
+        match row {
+            Some(row) => Ok(row_to_domain(&row)),
+            None => validate_schedule_create_limits(self, session_id, None).await.and_then(|()| {
+                Err(ScheduleLimitError::Rejected(format!(
+                    "Maximum {max_per_org} active schedules per org reached. Cancel an existing schedule first."
+                )))
+            }),
+        }
     }
 
     async fn cancel_schedule(

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -2611,6 +2611,52 @@ impl everruns_core::traits::SessionScheduleStore for GrpcOrgAdapter {
         proto_schedule_to_schema(proto_schedule)
     }
 
+    async fn create_schedule_enforcing_limits(
+        &self,
+        session_id: everruns_core::SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+        timezone: String,
+    ) -> std::result::Result<
+        everruns_core::session_schedule::SessionSchedule,
+        everruns_core::session_schedule::ScheduleLimitError,
+    > {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::CreateSessionScheduleRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            description,
+            cron_expression,
+            scheduled_at: scheduled_at.map(everruns_internal_protocol::datetime_to_proto_timestamp),
+            timezone,
+            org_id: self.org_id,
+        };
+        let response = client
+            .create_session_schedule(request)
+            .await
+            .map_err(|status| {
+                if matches!(
+                    status.code(),
+                    tonic::Code::ResourceExhausted | tonic::Code::InvalidArgument
+                ) {
+                    everruns_core::session_schedule::ScheduleLimitError::Rejected(
+                        status.message().to_string(),
+                    )
+                } else {
+                    everruns_core::session_schedule::ScheduleLimitError::Store(
+                        grpc_status_to_error(status),
+                    )
+                }
+            })?;
+        let proto_schedule = response.into_inner().schedule.ok_or_else(|| {
+            everruns_core::session_schedule::ScheduleLimitError::Store(grpc_missing_field(
+                "No schedule in response",
+            ))
+        })?;
+        proto_schedule_to_schema(proto_schedule)
+            .map_err(everruns_core::session_schedule::ScheduleLimitError::Store)
+    }
+
     async fn cancel_schedule(
         &self,
         session_id: everruns_core::SessionId,


### PR DESCRIPTION
### Motivation
- Close a race where the org-wide active-session-schedule cap could be bypassed by concurrent creators observing a stale count then inserting schedules. 
- Ensure the per-session and per-org quota, and the cron-interval gate, are enforced atomically across all agent-facing creation paths (tools, spawn_background, gRPC) and across storage backends.

### Description
- Added `SessionScheduleStore::create_schedule_enforcing_limits` and routed both the `create_schedule` tool and `spawn_background` scheduled path to call this store-level operation so validation + insert can be atomic. 
- Implemented an atomic PostgreSQL path `create_session_schedule_with_limits` that uses a transaction-scoped `pg_advisory_xact_lock(org_id)` and performs quota `COUNT(*)` checks and the `INSERT` inside one transaction. 
- Implemented equivalent atomic behavior for the in-memory and local SQLite stores by performing the count+insert inside their existing write/connection critical sections. 
- Updated the server gRPC handler and gRPC store adapter so remote workers hit the server-side atomic path and quota rejections are mapped to domain/tool-friendly errors.

### Testing
- Ran `cargo fmt --check` and formatting checks passed. 
- Ran `cargo check -p everruns-core -p everruns-server -p everruns-local -p everruns-worker` and the build check succeeded. 
- Ran focused unit tests `cargo test -p everruns-core capabilities::session_schedule` and all tests passed (9 passed, 0 failed). 
- Verified the change compiles and the new store-level paths cover DB, in-memory, and local SQLite backends.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60df2eb4832bb77cf4cecaeaa9d4)