### PR TITLE
fix(local): secure local profile storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,8 +2816,10 @@ version = "0.17.1"
 dependencies = [
  "async-trait",
  "chrono",
+ "dirs",
  "everruns-core",
  "everruns-runtime",
+ "libc",
  "parking_lot",
  "rusqlite",
  "serde_json",

--- a/crates/local/Cargo.toml
+++ b/crates/local/Cargo.toml
@@ -17,6 +17,10 @@ categories = ["development-tools", "database"]
 # SQLite
 rusqlite = { version = "0.39", features = ["bundled"] }
 
+# Filesystem locations / ownership checks
+dirs.workspace = true
+libc = "0.2"
+
 # Everruns crates
 # NOTE: core defaults are intentionally NOT disabled here. everruns-local pulls
 # in everruns-runtime (and via it everruns-mcp), which depend on core with full

--- a/crates/local/src/db.rs
+++ b/crates/local/src/db.rs
@@ -6,6 +6,8 @@
 // correct. Connections are opened with WAL so a freshly-spawned process can
 // reopen the same file (restart-survivability) without losing committed data.
 
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -25,7 +27,9 @@ pub struct SqliteDb {
 impl SqliteDb {
     /// Open (creating if needed) a file-backed database at `path`.
     pub fn open(path: impl AsRef<Path>) -> LocalResult<Self> {
-        let conn = Connection::open(path.as_ref())?;
+        let path = path.as_ref();
+        ensure_private_db_file(path)?;
+        let conn = Connection::open(path)?;
         Self::from_connection(conn)
     }
 
@@ -52,5 +56,81 @@ impl SqliteDb {
     ) -> LocalResult<T> {
         let guard = self.conn.lock();
         f(&guard).map_err(LocalError::from)
+    }
+}
+
+#[cfg(unix)]
+fn ensure_private_db_file(path: &Path) -> std::io::Result<()> {
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+    {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(e),
+    }
+
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to use symlinked local SQLite database {}",
+                path.display()
+            ),
+        ));
+    }
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "local SQLite database path is not a regular file: {}",
+                path.display()
+            ),
+        ));
+    }
+    if metadata.uid() != current_uid() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "local SQLite database is not owned by the current user: {}",
+                path.display()
+            ),
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_private_db_file(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // SAFETY: getuid has no preconditions and cannot fail.
+    unsafe { libc::getuid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn open_creates_private_db_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("local.db");
+        SqliteDb::open(&path).unwrap();
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/crates/local/src/error.rs
+++ b/crates/local/src/error.rs
@@ -11,6 +11,9 @@ pub enum LocalError {
     #[error("serialization error: {0}")]
     Serde(#[from] serde_json::Error),
 
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
     #[error("configuration error: {0}")]
     Config(String),
 

--- a/crates/local/src/profile.rs
+++ b/crates/local/src/profile.rs
@@ -26,7 +26,7 @@ pub struct LocalProfile {
 
 impl Default for LocalProfile {
     fn default() -> Self {
-        let data_dir = std::env::temp_dir().join("everruns-local");
+        let data_dir = default_data_dir();
         Self {
             workspace_root: data_dir.join("workspace"),
             data_dir,
@@ -74,14 +74,107 @@ impl LocalProfile {
         self
     }
 
-    /// Ensure `data_dir` and `workspace_root` exist on disk.
+    /// Ensure `data_dir` and `workspace_root` exist on disk with private
+    /// permissions. Local stores can contain prompts, tool output, and schedule
+    /// metadata, so pre-existing unsafe paths are rejected instead of followed.
     pub fn ensure_dirs(&self) -> std::io::Result<()> {
-        std::fs::create_dir_all(&self.data_dir)?;
-        std::fs::create_dir_all(&self.workspace_root)?;
+        ensure_private_dir(&self.data_dir)?;
+        ensure_private_dir(&self.workspace_root)?;
         Ok(())
     }
 
     pub fn data_dir(&self) -> &Path {
         &self.data_dir
+    }
+}
+
+fn default_data_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("everruns")
+        .join("local")
+}
+
+#[cfg(unix)]
+fn ensure_private_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    std::fs::create_dir_all(path)?;
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to use symlinked local profile directory {}",
+                path.display()
+            ),
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("local profile path is not a directory: {}", path.display()),
+        ));
+    }
+    if metadata.uid() != current_uid() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "local profile directory is not owned by the current user: {}",
+                path.display()
+            ),
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_private_dir(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // SAFETY: getuid has no preconditions and cannot fail.
+    unsafe { libc::getuid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_profile_uses_user_local_data_dir() {
+        assert!(
+            !LocalProfile::default()
+                .data_dir
+                .starts_with(std::env::temp_dir())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_dirs_hardens_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let profile = LocalProfile::new(root.path().join("profile"));
+        profile.ensure_dirs().unwrap();
+
+        let data_mode = std::fs::metadata(&profile.data_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let workspace_mode = std::fs::metadata(&profile.workspace_root)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(data_mode, 0o700);
+        assert_eq!(workspace_mode, 0o700);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent local information disclosure from the default `everruns-local` profile which used a predictable temp path and inherited permissive filesystem permissions.
- Ensure on-disk local stores (SQLite DB, workspace) are placed in a per-user data dir and opened/created with private permissions to avoid other local users reading or manipulating sensitive session data.

### Description
- Change `LocalProfile::default()` to prefer `dirs::data_local_dir()` (falling back to `std::env::temp_dir()`) instead of a hardcoded `/tmp/everruns-local` path.
- Harden directory creation by replacing `ensure_dirs` with `ensure_private_dir` which rejects symlinks/non-directories and enforces `0700` ownership/permissions on Unix for `data_dir` and `workspace_root`.
- Harden DB creation by calling `ensure_private_db_file` from `SqliteDb::open`, creating the DB with `0600` when newly created and rejecting symlink/non-regular/foreign-owned files on Unix before opening.
- Add `Io(#[from] std::io::Error)` to `LocalError` and add `dirs`/`libc` dependencies required for ownership/dirs checks.
- Add focused unit tests for default profile location, directory hardening, and DB file permission hardening, and preserve composability/runtime seam tests.

### Testing
- Ran `cargo fmt --check` which passed after the changes.
- Ran `cargo test -p everruns-local` and all `everruns-local` tests passed (including `profile::tests::default_profile_uses_user_local_data_dir`, `profile::tests::ensure_dirs_hardens_permissions`, `db::tests::open_creates_private_db_file`, and the composability/schedule/task-registry/platform-store tests).
- Ran `cargo clippy -p everruns-local --all-targets --all-features -- -D warnings` which completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60dfb744832ba4929b6b113e8972)