### PR TITLE
fix(rate-limit): gate grpc worker tool calls

### DIFF
--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -284,9 +284,12 @@ service WorkerService {
     // Base URL for UI links
     rpc PlatformGetBaseUrl(PlatformGetBaseUrlRequest) returns (PlatformGetBaseUrlResponse);
 
-    // === Budget operations ===
+    // === Budget and rate-limit operations ===
     // Check budget status for a session (used by check_budget tool)
     rpc CheckBudgetsForSession(CheckBudgetsForSessionRequest) returns (CheckBudgetsForSessionResponse);
+
+    // Gate outbound tool calls through the control-plane org rate limiter.
+    rpc CheckOutboundToolRateLimit(CheckOutboundToolRateLimitRequest) returns (CheckOutboundToolRateLimitResponse);
 
     // === Machine payment operations ===
     // Execute a paid capability request through the control-plane payment authority.
@@ -1857,6 +1860,14 @@ message CheckBudgetsForSessionResponse {
     string status = 1;
     repeated BudgetSummaryProto budgets = 2;
     optional string hint = 3;
+}
+
+message CheckOutboundToolRateLimitRequest {
+    string org_key = 1;
+}
+
+message CheckOutboundToolRateLimitResponse {
+    bool allowed = 1;
 }
 
 // === Machine payment messages ===

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1738,6 +1738,7 @@ impl ServerAppBuilder {
             let grpc_platform_definition = platform_definition.clone();
             let grpc_provider_resolver = provider_resolver.clone();
             let grpc_permission_resolver = auth_state.permission_resolver.clone();
+            let grpc_org_rate_limiter = Arc::new(org_rate_limiter.clone());
 
             let grpc_task_broadcaster = task_broadcaster.clone();
             let grpc_virtual_registry = virtual_registry.clone();
@@ -1765,6 +1766,7 @@ impl ServerAppBuilder {
                     let grpc_platform_definition = grpc_platform_definition.clone();
                     let grpc_provider_resolver = grpc_provider_resolver.clone();
                     let grpc_permission_resolver = grpc_permission_resolver.clone();
+                    let grpc_org_rate_limiter = grpc_org_rate_limiter.clone();
                     let grpc_task_broadcaster = grpc_task_broadcaster.clone();
                     let grpc_virtual_registry = grpc_virtual_registry.clone();
                     let grpc_token = grpc_token.clone();
@@ -1784,6 +1786,7 @@ impl ServerAppBuilder {
                             grpc_svc.set_task_broadcaster(broadcaster);
                         }
                         grpc_svc.set_permission_resolver(grpc_permission_resolver);
+                        grpc_svc.set_org_rate_limiter(grpc_org_rate_limiter);
                         // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
                         // Mitigation: Bearer token auth + optional mTLS validated before spawn.
                         let auth_interceptor =

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -42,6 +42,8 @@ use everruns_internal_protocol::proto::{
     CheckBudgetsForSessionResponse,
     CheckCircuitBreakerRequest,
     CheckCircuitBreakerResponse,
+    CheckOutboundToolRateLimitRequest,
+    CheckOutboundToolRateLimitResponse,
     CircuitBreakerState as ProtoCircuitBreakerState,
     // Connection token resolution
     ClaimDueLeasedResourcesRequest,
@@ -516,6 +518,8 @@ pub struct WorkerServiceImpl {
     presign_secret: Option<String>,
     /// Budget service for check_budget tool
     budget_service: Arc<crate::domains::budgets::BudgetService>,
+    /// Central org rate limiter for gRPC-backed outbound tool calls.
+    org_rate_limiter: Option<Arc<crate::auth::rate_limit::OrgRateLimiter>>,
     /// Active permission resolver for user-scoped command execution over gRPC.
     permission_resolver: Arc<dyn PermissionResolver>,
     /// System utility LLM for sanctioned internal analysis commands.
@@ -654,6 +658,7 @@ impl WorkerServiceImpl {
             api_base_url,
             presign_secret,
             budget_service,
+            org_rate_limiter: None,
             permission_resolver: Arc::new(everruns_core::DefaultPermissionResolver),
             utility_llm_service,
         }
@@ -662,6 +667,10 @@ impl WorkerServiceImpl {
     /// Set the task notification broadcaster (must be called after async initialization)
     pub fn set_task_broadcaster(&mut self, broadcaster: Arc<TaskBroadcaster>) {
         self.task_broadcaster = Some(broadcaster);
+    }
+
+    pub fn set_org_rate_limiter(&mut self, limiter: Arc<crate::auth::rate_limit::OrgRateLimiter>) {
+        self.org_rate_limiter = Some(limiter);
     }
 
     pub fn set_permission_resolver(&mut self, resolver: Arc<dyn PermissionResolver>) {

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -4213,6 +4213,27 @@ impl WorkerService for WorkerServiceImpl {
         }))
     }
 
+    async fn check_outbound_tool_rate_limit(
+        &self,
+        request: Request<CheckOutboundToolRateLimitRequest>,
+    ) -> Result<Response<CheckOutboundToolRateLimitResponse>, Status> {
+        let req = request.into_inner();
+        let allowed = match &self.org_rate_limiter {
+            Some(limiter) => limiter.check_outbound_tool_call(&req.org_key).await.is_ok(),
+            None => {
+                tracing::error!(
+                    org_key = %req.org_key,
+                    "gRPC outbound tool rate limiter is not configured; denying tool call"
+                );
+                false
+            }
+        };
+
+        Ok(Response::new(CheckOutboundToolRateLimitResponse {
+            allowed,
+        }))
+    }
+
     async fn execute_machine_payment(
         &self,
         request: Request<ExecuteMachinePaymentRequest>,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -3649,6 +3649,42 @@ fn proto_value_to_json(value: prost_types::Value) -> serde_json::Value {
 }
 
 // ============================================================================
+// OutboundToolRateLimiter — gate tool execution via control-plane limiter
+// ============================================================================
+
+pub struct GrpcOutboundToolRateLimiter {
+    client: GrpcClient,
+}
+
+impl GrpcOutboundToolRateLimiter {
+    pub fn new(client: GrpcClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl everruns_core::traits::OutboundToolRateLimiter for GrpcOutboundToolRateLimiter {
+    async fn check_org(&self, org_id: &everruns_core::typed_id::OrgId) -> bool {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::CheckOutboundToolRateLimitRequest {
+            org_key: org_id.to_string(),
+        };
+
+        match client.check_outbound_tool_rate_limit(request).await {
+            Ok(response) => response.into_inner().allowed,
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    org_id = %org_id,
+                    "gRPC outbound tool rate-limit check failed; denying tool call"
+                );
+                false
+            }
+        }
+    }
+}
+
+// ============================================================================
 // BudgetChecker — check budget status from check_budget tool
 // ============================================================================
 

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -26,8 +26,9 @@ use uuid::Uuid;
 use crate::grpc_adapters::{
     GrpcAgentStore, GrpcBudgetChecker, GrpcClient, GrpcEventEmitter, GrpcHarnessStore,
     GrpcImageArtifactStore, GrpcImageResolver, GrpcLeasedResourceStore, GrpcMessageRetriever,
-    GrpcPaymentAuthority, GrpcProviderCredentialStore, GrpcProviderStore, GrpcSessionFileStore,
-    GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
+    GrpcOutboundToolRateLimiter, GrpcPaymentAuthority, GrpcProviderCredentialStore,
+    GrpcProviderStore, GrpcSessionFileStore, GrpcSessionSqlDbStore, GrpcSessionStorageStore,
+    GrpcSessionStore,
 };
 use crate::mcp_executor::McpServerInfo;
 use crate::worker_adapters::{TurnContext, WorkerAdapters};
@@ -479,6 +480,15 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             GrpcPaymentAuthority::new(self.client.clone(), org_id)
                 .with_agent_id(agent_id.map(|id| id.to_string())),
         ))
+    }
+
+    fn outbound_tool_rate_limiter(
+        &self,
+        _org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::traits::OutboundToolRateLimiter>> {
+        Some(Arc::new(GrpcOutboundToolRateLimiter::new(
+            self.client.clone(),
+        )))
     }
 
     fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {


### PR DESCRIPTION
### Motivation

- Production gRPC-backed workers were inheriting a default `None` for the outbound tool-call limiter, allowing outbound tool calls to bypass the per-org rate limit (TM-TOOL-009) that was only enforced for in-process/direct workers.

### Description

- Add a `CheckOutboundToolRateLimit` RPC to the internal worker protocol (`crates/internal-protocol/proto/worker.proto`) to let external workers consult the control-plane rate limiter before executing tools.
- Expose and store the central `OrgRateLimiter` on the gRPC service (`WorkerServiceImpl`) and add a setter `set_org_rate_limiter` so the server startup path can inject the limiter in non-dev mode (`crates/server/src/grpc_service/mod.rs`, `crates/server/src/app_builder.rs`).
- Implement the server-side handler `check_outbound_tool_rate_limit` that delegates to `OrgRateLimiter::check_outbound_tool_call` and fails closed (deny) if the limiter is not configured (`crates/server/src/grpc_service/worker_service_impl.rs`).
- Add `GrpcOutboundToolRateLimiter` on the worker side which calls the new gRPC endpoint and returns `false` on RPC errors, and return that limiter from `GrpcWorkerAdapters::outbound_tool_rate_limiter` so production gRPC workers are gated (`crates/worker/src/grpc_adapters.rs`, `crates/worker/src/grpc_worker_adapters.rs`).

### Testing

- Ran `cargo check -p everruns-worker -p everruns-server` and compilation/checks completed successfully.
- Ran `cargo fmt --check` and formatting check passed.
- Ran `git diff --check` (style/diff checks) and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60df4330832bb8ec8542542ce21b)