### PR TITLE
fix(security): gate user hooks before validation

### DIFF
--- a/crates/core/src/capabilities/user_hooks.rs
+++ b/crates/core/src/capabilities/user_hooks.rs
@@ -27,6 +27,8 @@ pub struct UserHooksConfig {
 }
 
 pub const USER_HOOKS_CAPABILITY_ID: &str = "user_hooks";
+pub const MAX_USER_HOOKS_CONFIG_BYTES: usize = 256 * 1024;
+pub const MAX_USER_HOOKS: usize = 64;
 
 pub struct UserHooksCapability;
 
@@ -201,8 +203,22 @@ impl Capability for UserHooksCapability {
         if config.is_null() {
             return Ok(());
         }
+        let config_bytes = serde_json::to_vec(config)
+            .map_err(|e| format!("user_hooks config serialization failed: {e}"))?
+            .len();
+        if config_bytes > MAX_USER_HOOKS_CONFIG_BYTES {
+            return Err(format!(
+                "user_hooks config is {config_bytes} bytes; maximum is {MAX_USER_HOOKS_CONFIG_BYTES}"
+            ));
+        }
         let parsed: UserHooksConfig = serde_json::from_value(config.clone())
             .map_err(|e| format!("user_hooks config parse failed: {e}"))?;
+        if parsed.hooks.len() > MAX_USER_HOOKS {
+            return Err(format!(
+                "user_hooks.hooks has {} entries; maximum is {MAX_USER_HOOKS}",
+                parsed.hooks.len()
+            ));
+        }
 
         for (idx, hook) in parsed.hooks.iter().enumerate() {
             hook.validate()
@@ -430,6 +446,45 @@ mod tests {
         });
         let err = cap.validate_config(&config).unwrap_err();
         assert!(err.contains("timeout_ms"), "{}", err);
+    }
+
+    #[test]
+    fn too_many_user_hooks_are_rejected_before_per_hook_validation() {
+        let cap = UserHooksCapability;
+        let hooks = (0..=MAX_USER_HOOKS)
+            .map(|_| {
+                serde_json::json!({
+                    "event": "pre_tool_use",
+                    "matcher": { "match_regex": "[" },
+                    "executor": { "type": "bash", "command": "true" }
+                })
+            })
+            .collect::<Vec<_>>();
+        let config = serde_json::json!({ "hooks": hooks });
+
+        let err = cap.validate_config(&config).unwrap_err();
+        assert!(
+            err.contains("maximum is") && !err.contains("regex"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
+    fn oversized_user_hooks_config_is_rejected() {
+        let cap = UserHooksCapability;
+        let config = serde_json::json!({
+            "hooks": [
+                {
+                    "event": "pre_tool_use",
+                    "description": "x".repeat(MAX_USER_HOOKS_CONFIG_BYTES),
+                    "executor": { "type": "bash", "command": "true" }
+                }
+            ]
+        });
+
+        let err = cap.validate_config(&config).unwrap_err();
+        assert!(err.contains("maximum is"), "{}", err);
     }
 
     #[test]

--- a/crates/core/src/user_hook_types.rs
+++ b/crates/core/src/user_hook_types.rs
@@ -199,6 +199,8 @@ pub enum ExecutorSpec {
 }
 
 pub const MAX_HOOK_ENV_VARS: usize = 16;
+pub const MAX_HOOK_COMMAND_BYTES: usize = 16 * 1024;
+pub const MAX_HOOK_MATCHER_STRING_BYTES: usize = 2 * 1024;
 
 // ============================================================================
 // OnError
@@ -307,6 +309,10 @@ pub enum HookSpecError {
     MatcherOnNonToolEvent(&'static str),
     #[error("hook has more than {MAX_HOOK_ENV_VARS} env vars")]
     TooManyEnvVars,
+    #[error("hook bash command is longer than {MAX_HOOK_COMMAND_BYTES} bytes")]
+    CommandTooLong,
+    #[error("hook matcher field `{0}` is longer than {MAX_HOOK_MATCHER_STRING_BYTES} bytes")]
+    MatcherFieldTooLong(&'static str),
     #[error("hook has both match_regex and deny_regex set; choose one")]
     AmbiguousRegex,
     #[error("hook regex `{0}` failed to compile: {1}")]
@@ -350,11 +356,20 @@ impl UserHookSpec {
                 if command.trim().is_empty() {
                     return Err(HookSpecError::EmptyCommand);
                 }
+                if command.len() > MAX_HOOK_COMMAND_BYTES {
+                    return Err(HookSpecError::CommandTooLong);
+                }
                 if env.len() > MAX_HOOK_ENV_VARS {
                     return Err(HookSpecError::TooManyEnvVars);
                 }
             }
         }
+
+        validate_optional_matcher_string("tool_name", &self.matcher.tool_name)?;
+        validate_optional_matcher_string("tool_name_glob", &self.matcher.tool_name_glob)?;
+        validate_optional_matcher_string("args_jsonpath", &self.matcher.args_jsonpath)?;
+        validate_optional_matcher_string("match_regex", &self.matcher.match_regex)?;
+        validate_optional_matcher_string("deny_regex", &self.matcher.deny_regex)?;
 
         if self.matcher.match_regex.is_some() && self.matcher.deny_regex.is_some() {
             return Err(HookSpecError::AmbiguousRegex);
@@ -375,6 +390,19 @@ impl UserHookSpec {
     fn matcher_is_empty(&self) -> bool {
         self.matcher.is_empty()
     }
+}
+
+fn validate_optional_matcher_string(
+    field: &'static str,
+    value: &Option<String>,
+) -> Result<(), HookSpecError> {
+    if value
+        .as_ref()
+        .is_some_and(|value| value.len() > MAX_HOOK_MATCHER_STRING_BYTES)
+    {
+        return Err(HookSpecError::MatcherFieldTooLong(field));
+    }
+    Ok(())
 }
 
 fn validate_glob(glob: &str) -> Result<(), HookSpecError> {
@@ -601,6 +629,48 @@ mod tests {
             source: HookSource::UserConfig,
         };
         assert!(matches!(spec.validate(), Err(HookSpecError::EmptyCommand)));
+    }
+
+    #[test]
+    fn validate_oversized_command_rejected() {
+        let spec = UserHookSpec {
+            id: None,
+            event: HookEvent::PreToolUse,
+            matcher: HookMatcher::default(),
+            executor: ExecutorSpec::Bash {
+                command: "x".repeat(MAX_HOOK_COMMAND_BYTES + 1),
+                env: Default::default(),
+            },
+            timeout_ms: 5000,
+            on_error: OnError::Warn,
+            description: None,
+            source: HookSource::UserConfig,
+        };
+        assert!(matches!(
+            spec.validate(),
+            Err(HookSpecError::CommandTooLong)
+        ));
+    }
+
+    #[test]
+    fn validate_oversized_matcher_regex_rejected_before_compile() {
+        let spec = UserHookSpec {
+            id: None,
+            event: HookEvent::PreToolUse,
+            matcher: HookMatcher {
+                match_regex: Some("[".repeat(MAX_HOOK_MATCHER_STRING_BYTES + 1)),
+                ..Default::default()
+            },
+            executor: bash_exec(),
+            timeout_ms: 5000,
+            on_error: OnError::Warn,
+            description: None,
+            source: HookSource::UserConfig,
+        };
+        assert!(matches!(
+            spec.validate(),
+            Err(HookSpecError::MatcherFieldTooLong("match_regex"))
+        ));
     }
 
     #[test]

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -502,18 +502,22 @@ impl SessionService {
 
         let session_capabilities = sanitize_session_capabilities(req.capabilities);
 
-        // Validate session-level capability refs before persisting
-        crate::domains::capabilities::validation::validate_capability_refs(
-            &self.db,
-            org_id,
-            &session_capabilities,
-        )
-        .await?;
+        // EVE-AARDVARK: authorize high-risk session capability assignment
+        // before full config validation so unauthorized callers cannot force
+        // expensive validation for capabilities they are not allowed to use.
         self.require_admin_for_high_risk_session_capabilities(
             caller,
             org_id,
             harness_id.uuid(),
             agent_id.map(|id| id.uuid()),
+            &session_capabilities,
+        )
+        .await?;
+
+        // Validate session-level capability refs before persisting.
+        crate::domains::capabilities::validation::validate_capability_refs(
+            &self.db,
+            org_id,
             &session_capabilities,
         )
         .await?;


### PR DESCRIPTION
### Motivation
- Prevent low-privilege authenticated org members from forcing expensive `user_hooks` config parsing and regex compilation before the high-risk admin gate rejects the session creation request, which can be abused for CPU/memory exhaustion (availability DoS).
- Ensure the `user_hooks` high-risk capability is authorized before deserializing/validating large or malicious configs.

### Description
- Reordered session creation so `require_admin_for_high_risk_session_capabilities` runs before `validate_capability_refs` in `crates/server/src/domains/sessions/service.rs` to avoid pre-authorization work on high-risk configs.
- Added global caps in `crates/core/src/capabilities/user_hooks.rs`: `MAX_USER_HOOKS_CONFIG_BYTES` and `MAX_USER_HOOKS`, and enforced them in `validate_config` to bound total config size and number of hooks.
- Added per-hook limits and early checks in `crates/core/src/user_hook_types.rs`: `MAX_HOOK_COMMAND_BYTES` and `MAX_HOOK_MATCHER_STRING_BYTES`, a `validate_optional_matcher_string` helper, and checks to fail before compiling attacker-supplied regexes.
- Added regression/unit tests covering hook-count rejection, oversized config rejection, oversized command rejection, and oversized matcher regex rejection, and adjusted existing validation behavior accordingly.

### Testing
- Ran formatting check: `cargo fmt --check` — passed.
- Ran targeted unit tests: `cargo test -p everruns-core user_hooks --lib` and additional unit tests for oversized inputs — all relevant tests passed (new tests included and green).
- Built/checked the server crate: `cargo check -p everruns-server` — succeeded.
- Static/lint checks: `cargo clippy -p everruns-core -p everruns-server --all-targets --all-features -- -D warnings` — passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60e071d0832b953c61d21add5789)