### PR TITLE
test(core): gate llmsim integration tests

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -180,3 +180,18 @@ insta = { version = "1.40", features = ["json", "redactions"] }
 a2a-server.workspace = true
 axum.workspace = true
 tempfile.workspace = true
+
+[[test]]
+name = "mid_turn_reasoning_effort_test"
+path = "tests/mid_turn_reasoning_effort_test.rs"
+required-features = ["llmsim"]
+
+[[test]]
+name = "message_metadata_test"
+path = "tests/message_metadata_test.rs"
+required-features = ["llmsim"]
+
+[[test]]
+name = "reason_atom_test"
+path = "tests/reason_atom_test.rs"
+required-features = ["llmsim"]


### PR DESCRIPTION
### Motivation
- Prevent Cargo from attempting to compile integration test binaries that import `llmsim_driver` / `in_memory_loop` when `everruns-core` is built with `--no-default-features` because those modules are now feature-gated behind `llmsim`.

### Description
- Add three `[[test]]` entries to `crates/core/Cargo.toml` (`mid_turn_reasoning_effort_test`, `message_metadata_test`, `reason_atom_test`) with `required-features = ["llmsim"]` so Cargo will skip them unless the `llmsim` feature is enabled.

### Testing
- Ran `cargo fmt --check` (success), verified via `cargo metadata --no-deps` that the three test targets now report `required-features = ["llmsim"]` (success), built the gated tests with `cargo test -p everruns-core --features llmsim --test ... --no-run` (success), and confirmed `cargo test -p everruns-core --no-default-features --no-run` still fails on a pre-existing unrelated `web-fetch` feature-gate issue (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60e1c524832bbfefdd2510560c83)