### PR TITLE
fix(evals): avoid mutable scorer labels in exports

### DIFF
--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -618,17 +618,6 @@ impl Command for ExportEvalRunDataset {
         let retriever = crate::storage::message_store::DbMessageRetriever::new(ctx.db.clone());
         let compaction = CompactionConfig::default();
 
-        // Scorer identities are not persisted on the result (only the ordered
-        // Vec<Score>), so join the case definitions' scorer kinds positionally to
-        // name reward scorers. `list_cases` is org-scoped through the same caller.
-        let scorer_names_by_case: std::collections::HashMap<_, Vec<String>> = q::service(ctx)
-            .list_cases(&ctx.caller, &eval_id.to_string())
-            .await
-            .map_err(classify_anyhow)?
-            .into_iter()
-            .map(|case| (case.public_id, super::dataset::scorer_names(&case.scorers)))
-            .collect();
-
         let mut body = String::new();
         for result in &run.results {
             if !super::dataset::case_passes_filters(result, &self.req.filters) {
@@ -644,17 +633,12 @@ impl Command for ExportEvalRunDataset {
                 CommandError::internal(anyhow::anyhow!("load session messages: {e}"))
             })?;
             let messages = build_model_view_messages(&stored, &compaction, None).messages;
-            let names = scorer_names_by_case
-                .get(&result.eval_case_id)
-                .map(Vec::as_slice)
-                .unwrap_or(&[]);
             let record = super::dataset::build_record(
                 self.req.format,
                 &run,
                 result,
                 &messages,
                 &self.req.redaction,
-                names,
             );
             let line =
                 serde_json::to_string(&record).map_err(|e| CommandError::internal(e.into()))?;

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -7,7 +7,7 @@
 
 use std::sync::LazyLock;
 
-use everruns_core::eval::{CaseResultStatus, EvalCaseResult, EvalRun, Scorer};
+use everruns_core::eval::{CaseResultStatus, EvalCaseResult, EvalRun};
 use everruns_core::message::{ContentPart, Message, MessageRole};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -171,31 +171,20 @@ pub fn source_key(run: &EvalRun, result: &EvalCaseResult) -> String {
     format!("{}/{}", run.public_id, result.public_id)
 }
 
-/// The case's scorer kinds in definition order, used to name reward scorers.
-pub fn scorer_names(scorers: &[Scorer]) -> Vec<String> {
-    scorers.iter().map(|s| s.kind().to_string()).collect()
-}
-
 /// The reward block shared by both formats.
 ///
-/// `scorer_names` are the case's scorer kinds in definition order (see
-/// [`scorer_names`]). Scores are persisted as an ordered `Vec<Score>` with no
-/// scorer identity, and the runner emits exactly one score per scorer in order,
-/// so the names join positionally. The join is only applied when the lengths
-/// match; otherwise each scorer falls back to its positional `scorer_{i}` label.
-fn reward(result: &EvalCaseResult, scorer_names: &[String]) -> Value {
+/// Scores are persisted as an ordered `Vec<Score>` without immutable scorer
+/// identity. Current eval-case scorer definitions are mutable, so historical
+/// results must keep stable positional labels instead of joining against current
+/// scorer kinds at export time.
+fn reward(result: &EvalCaseResult) -> Value {
     let scores = result.scores.as_ref().and_then(Value::as_array);
-    let aligned = scores.is_some_and(|arr| arr.len() == scorer_names.len());
     let scorers: Vec<Value> = scores
         .map(|arr| {
             arr.iter()
                 .enumerate()
                 .map(|(i, s)| {
-                    let name = if aligned {
-                        json!(scorer_names[i])
-                    } else {
-                        json!(format!("scorer_{i}"))
-                    };
+                    let name = json!(format!("scorer_{i}"));
                     json!({
                         "name": name,
                         "value": s.get("value"),
@@ -285,7 +274,6 @@ pub fn build_record(
     result: &EvalCaseResult,
     messages: &[Message],
     redaction: &RedactionOptions,
-    scorer_names: &[String],
 ) -> Value {
     let mut record = match format {
         DatasetFormat::Trajectory => json!({
@@ -294,7 +282,7 @@ pub fn build_record(
             "case_id": result.eval_case_id.to_string(),
             "case_name": result.case_name,
             "session_id": result.session_id.map(|s| s.to_string()),
-            "reward": reward(result, scorer_names),
+            "reward": reward(result),
             "messages": serde_json::to_value(messages).unwrap_or_else(|_| json!([])),
             "metadata": metadata(run, result),
         }),
@@ -316,7 +304,7 @@ pub fn build_record(
             json!({
                 "source_key": source_key(run, result),
                 "messages": chat,
-                "reward": reward(result, scorer_names),
+                "reward": reward(result),
             })
         }
     };
@@ -461,7 +449,6 @@ mod tests {
             &r,
             &msgs,
             &RedactionOptions::default(),
-            &[],
         );
         assert_eq!(rec["reward"]["pass"], json!(true));
         assert_eq!(rec["reward"]["score"], json!(1.0));
@@ -483,7 +470,6 @@ mod tests {
             &r,
             &msgs,
             &RedactionOptions::default(),
-            &[],
         );
         let chat = rec["messages"].as_array().unwrap();
         assert_eq!(chat[0]["role"], json!("user"));
@@ -504,7 +490,6 @@ mod tests {
             &RedactionOptions {
                 redact_content: true,
             },
-            &[],
         );
         let serialized = serde_json::to_string(&rec).unwrap();
         assert!(!serialized.contains("secret business content"));
@@ -525,7 +510,6 @@ mod tests {
             &RedactionOptions {
                 redact_content: true,
             },
-            &[],
         );
         assert_eq!(rec["messages"][0]["content"], json!(REDACTED));
     }
@@ -543,7 +527,6 @@ mod tests {
             &r,
             &[],
             &RedactionOptions::default(),
-            &[],
         );
         let serialized = serde_json::to_string(&rec).unwrap();
         // Secrets outside `messages` (case_name, scorer reason) are scrubbed too.
@@ -553,8 +536,7 @@ mod tests {
     }
 
     #[test]
-    fn reward_joins_scorer_names_positionally() {
-        use everruns_core::eval::Scorer;
+    fn reward_uses_stable_positional_scorer_labels() {
         let r = result_with(
             CaseResultStatus::Passed,
             json!([
@@ -562,47 +544,16 @@ mod tests {
                 {"pass": false, "value": 0.0, "reason": "too many turns"},
             ]),
         );
-        let names = scorer_names(&[
-            Scorer::Contains {
-                text: "ok".into(),
-                weight: 1.0,
-            },
-            Scorer::TurnsWithin {
-                max: 3,
-                weight: 1.0,
-            },
-        ]);
         let rec = build_record(
             DatasetFormat::Trajectory,
             &run(),
             &r,
             &[],
             &RedactionOptions::default(),
-            &names,
-        );
-        let scorers = rec["reward"]["scorers"].as_array().unwrap();
-        assert_eq!(scorers[0]["name"], json!("contains"));
-        assert_eq!(scorers[1]["name"], json!("turns_within"));
-    }
-
-    #[test]
-    fn reward_falls_back_to_positional_label_on_length_mismatch() {
-        // One score but two scorer names -> misaligned, so fall back to scorer_{i}
-        // rather than risk attaching the wrong name.
-        let r = result_with(
-            CaseResultStatus::Passed,
-            json!([{"pass": true, "value": 1.0, "reason": "ok"}]),
-        );
-        let rec = build_record(
-            DatasetFormat::Trajectory,
-            &run(),
-            &r,
-            &[],
-            &RedactionOptions::default(),
-            &["contains".to_string(), "regex".to_string()],
         );
         let scorers = rec["reward"]["scorers"].as_array().unwrap();
         assert_eq!(scorers[0]["name"], json!("scorer_0"));
+        assert_eq!(scorers[1]["name"], json!("scorer_1"));
     }
 
     #[test]
@@ -621,7 +572,6 @@ mod tests {
             &RedactionOptions {
                 redact_content: true,
             },
-            &[],
         );
         let serialized = serde_json::to_string(&rec).unwrap();
         assert!(!serialized.contains("SECRETIMAGEDATA"));


### PR DESCRIPTION
### Motivation
- Dataset export previously joined historical score positions to the current eval-case scorer definitions at export time, which can silently mislabel historical reward metadata when scorers are edited or reordered after a run.
- To preserve historical data integrity, exports should emit stable positional labels until immutable per-result scorer identity is recorded.

### Description
- Removed the export-time `list_cases` lookup and usage that built a `scorer_names_by_case` map in `crates/server/src/domains/evals/commands.rs` so exports no longer pull current case scorer definitions at export time.
- Changed the `reward` serialization in `crates/server/src/domains/evals/dataset.rs` to always emit positional labels (`scorer_{i}`) instead of joining against mutable scorer names.
- Simplified `build_record` to remove the `scorer_names` parameter and updated call sites accordingly to rely on the stable positional labels.
- Updated unit tests to assert the new stable positional scorer labeling behavior (`reward_uses_stable_positional_scorer_labels`).

### Testing
- Ran formatting and focused unit tests with `cargo fmt --check` and `cargo test -p everruns-server --lib domains::evals::dataset --all-features`.
- Focused dataset tests passed: `10 passed; 0 failed; 0 ignored` (the modified dataset unit tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60dfbe38832bbd6708421307ceb1)