### PR TITLE
fix(providers): allow OAuth provider creation without key

### DIFF
--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import ProvidersPage from "@/app/(main)/settings/providers/page";
+import { CredentialFields } from "@/app/(main)/settings/providers/credential-fields";
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -120,6 +121,42 @@ jest.mock("@/lib/query-keys", () => ({
     organizations: { all: ["organizations"], detail: (id: string) => ["organization", id] },
   },
 }));
+
+describe("CredentialFields", () => {
+  const apiKeySchema = {
+    fields: [
+      { name: "api_key", label: "API Key", field_type: "password" as const, required: true },
+    ],
+    instructions_markdown: "",
+  };
+
+  it("marks required ungrouped credentials as required by default", () => {
+    render(
+      <CredentialFields
+        schema={apiKeySchema}
+        values={{}}
+        onChange={jest.fn()}
+        idPrefix="credentials"
+      />,
+    );
+
+    expect(screen.getByLabelText("API Key")).toBeRequired();
+  });
+
+  it("does not require credentials when the add flow allows empty OAuth setup", () => {
+    render(
+      <CredentialFields
+        schema={apiKeySchema}
+        values={{}}
+        onChange={jest.fn()}
+        idPrefix="credentials"
+        allowEmptySubmit
+      />,
+    );
+
+    expect(screen.getByLabelText("API Key")).not.toBeRequired();
+  });
+});
 
 describe("ProvidersPage", () => {
   let queryClient: QueryClient;

--- a/apps/ui/src/app/(main)/settings/providers/credential-fields.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/credential-fields.tsx
@@ -21,11 +21,13 @@ function CredentialField({
   value,
   onChange,
   idPrefix,
+  nativeRequired,
 }: {
   field: CredentialFormField;
   value: string;
   onChange: (name: string, value: string) => void;
   idPrefix: string;
+  nativeRequired: boolean;
 }) {
   const id = `${idPrefix}-${field.name}`;
   return (
@@ -44,9 +46,7 @@ function CredentialField({
         value={value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(field.name, e.target.value)}
         placeholder={field.placeholder}
-        // Grouped fields belong to mutually-exclusive methods, so they cannot be
-        // natively required; the backend enforces "one complete method".
-        required={field.required && !field.group}
+        required={nativeRequired}
       />
       {field.help_text ? <p className="text-xs text-muted-foreground">{field.help_text}</p> : null}
     </div>
@@ -58,11 +58,17 @@ export function CredentialFields({
   values,
   onChange,
   idPrefix,
+  allowEmptySubmit = false,
 }: {
   schema: CredentialFormSchema;
   values: Record<string, string>;
   onChange: (name: string, value: string) => void;
   idPrefix: string;
+  /**
+   * OAuth-capable add flows can intentionally create a provider before any
+   * credential exists, then connect the credential in a follow-up browser flow.
+   */
+  allowEmptySubmit?: boolean;
 }) {
   const ungrouped = schema.fields.filter((f) => !f.group);
   // Preserve declaration order of group labels.
@@ -84,6 +90,7 @@ export function CredentialFields({
           value={values[field.name] ?? ""}
           onChange={onChange}
           idPrefix={idPrefix}
+          nativeRequired={field.required && !field.group && !allowEmptySubmit}
         />
       ))}
       {groupLabels.map((label, index) => (
@@ -106,6 +113,7 @@ export function CredentialFields({
                 value={values[field.name] ?? ""}
                 onChange={onChange}
                 idPrefix={idPrefix}
+                nativeRequired={field.required && !field.group && !allowEmptySubmit}
               />
             ))}
         </div>

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -199,6 +199,7 @@ export function AddProviderDialog({
               values={credentials}
               onChange={updateCredential}
               idPrefix="add-provider"
+              allowEmptySubmit={supportsOAuth}
             />
           ) : null}
           {supportsOAuth ? (


### PR DESCRIPTION
### Motivation
- The schema-driven provider form marked ungrouped `api_key` fields as natively `required`, which blocked the documented keyless create-then-OAuth flow for drivers that support OAuth (e.g. OpenRouter) because browser constraint validation prevented submitting an empty credential form.

### Description
- Added an `allowEmptySubmit` option to `CredentialFields` and a `nativeRequired` prop to `CredentialField` so callers can suppress native `required` attributes when an empty-credential submit is intentional.
- Wired the Add Provider dialog to pass `allowEmptySubmit={supportsOAuth}` so OAuth-capable add flows can submit without native browser validation while other flows keep the original required behavior.
- Added focused tests in `settings-providers.test.tsx` asserting that ungrouped required fields are required by default and are not native-required when `allowEmptySubmit` is enabled.
- Change is scoped to the UI form validation behavior and preserves backend validation and credential storage semantics.

### Testing
- Installed UI deps with `pnpm --dir apps/ui install` and ran the targeted unit tests via `pnpm --dir apps/ui test -- settings-providers.test.tsx --runInBand`, which resulted in `Test Suites: 1 passed, Tests: 13 passed`.
- Ran `pnpm --dir apps/ui format:check`, `pnpm --dir apps/ui typecheck`, and `pnpm --dir apps/ui lint`, all of which completed successfully.
- Attempted the repository `just pre-push` checks; the wrapper hung in the Rust linting step and was terminated before completion, so full pre-push CI was not completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60ded004832b9c6c1719e84b6a88)