### PR TITLE
fix(core): clear reasoning effort override per turn

### DIFF
--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -544,9 +544,9 @@ impl InMemoryAgenticLoopBuilder {
         );
         let mut act_atom = ActAtom::new(tool_registry.clone(), event_emitter.clone())
             .with_tool_registry(Arc::new(tool_registry.clone()));
-        if let Some(handle) = self.reasoning_effort_handle {
+        if let Some(handle) = &self.reasoning_effort_handle {
             reason_atom = reason_atom.with_reasoning_effort_handle(handle.clone());
-            act_atom = act_atom.with_reasoning_effort_handle(handle);
+            act_atom = act_atom.with_reasoning_effort_handle(handle.clone());
         }
 
         Ok(InMemoryAgenticLoop {
@@ -564,6 +564,7 @@ impl InMemoryAgenticLoopBuilder {
             reason_atom: Arc::new(reason_atom),
             act_atom: Arc::new(act_atom),
             max_iterations: self.max_iterations,
+            reasoning_effort_handle: self.reasoning_effort_handle,
         })
     }
 }
@@ -619,6 +620,7 @@ pub struct InMemoryAgenticLoop {
     reason_atom: Arc<ReasonAtom>,
     act_atom: Arc<ActAtom<ToolRegistry, BridgingEventEmitter>>,
     max_iterations: usize,
+    reasoning_effort_handle: Option<crate::traits::ReasoningEffortHandle>,
 }
 
 impl InMemoryAgenticLoop {
@@ -670,6 +672,13 @@ impl InMemoryAgenticLoop {
     /// let result = runner.run_turn(input).await?;
     /// ```
     pub async fn run_turn(&self, input: impl Into<InputMessage>) -> Result<TurnResult> {
+        // The live effort override is turn-scoped: tools may set it for later
+        // LLM steps in this turn, but stale values must not override the next
+        // turn's message controls.
+        if let Some(handle) = &self.reasoning_effort_handle {
+            handle.set(None);
+        }
+
         // Add user message
         let message = self
             .message_retriever

--- a/crates/core/tests/mid_turn_reasoning_effort_test.rs
+++ b/crates/core/tests/mid_turn_reasoning_effort_test.rs
@@ -213,3 +213,81 @@ async fn without_handle_mutation_effort_is_stable_across_steps() {
         "effort must stay stable when no tool changes it"
     );
 }
+
+#[tokio::test]
+async fn mid_turn_effort_override_is_cleared_before_next_turn() {
+    let effort_capture: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let handle = ReasoningEffortHandle::new();
+
+    let sim = LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: "set_effort".to_string(),
+            arguments: json!({}),
+            id: Some("call_set_effort".to_string()),
+        }]),
+        SimTurn::Assistant("First turn done.".to_string()),
+        SimTurn::Assistant("Second turn done.".to_string()),
+    ])
+    .with_effort_capture(effort_capture.clone());
+
+    let runner = InMemoryAgenticLoop::builder()
+        .with_llm_sim(sim)
+        .tool(SetEffortTool {
+            new_effort: "high".to_string(),
+        })
+        .reasoning_effort_handle(handle.clone())
+        .max_iterations(5)
+        .build()
+        .await
+        .expect("build in-memory loop");
+
+    let first_input = InputMessage {
+        role: MessageRole::User,
+        content: vec![ContentPart::text("First turn.")],
+        controls: Some(Controls {
+            reasoning: Some(ReasoningConfig {
+                effort: Some("low".to_string()),
+            }),
+            ..Default::default()
+        }),
+        metadata: None,
+        tags: vec![],
+    };
+    let first_result = runner.run_turn(first_input).await.expect("first run_turn");
+    assert!(
+        first_result.success,
+        "first turn should succeed: {first_result:?}"
+    );
+    assert_eq!(handle.get().as_deref(), Some("high"));
+
+    let second_input = InputMessage {
+        role: MessageRole::User,
+        content: vec![ContentPart::text("Second turn.")],
+        controls: Some(Controls {
+            reasoning: Some(ReasoningConfig {
+                effort: Some("low".to_string()),
+            }),
+            ..Default::default()
+        }),
+        metadata: None,
+        tags: vec![],
+    };
+    let second_result = runner
+        .run_turn(second_input)
+        .await
+        .expect("second run_turn");
+    assert!(
+        second_result.success,
+        "second turn should succeed: {second_result:?}"
+    );
+
+    let efforts = effort_capture.lock().unwrap().clone();
+    assert_eq!(
+        efforts
+            .iter()
+            .map(|effort| effort.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("low"), Some("high"), Some("low")],
+        "second turn should use its message-derived effort, not the stale override"
+    );
+}

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -896,6 +896,13 @@ pub async fn execute_input_activity<A: RuntimeHostAdapter>(
     org_id: i64,
     input: InputAtomInput,
 ) -> everruns_core::error::Result<InputAtomResult> {
+    // The live effort override is turn-scoped. Clear any value left by the
+    // previous turn before ReasonAtom can prefer it over this turn's message
+    // controls.
+    if let Some(handle) = adapter.reasoning_effort_handle(input.context.session_id) {
+        handle.set(None);
+    }
+
     RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
         .turn_started(input.context.turn_id, input.context.input_message_id)
         .await;


### PR DESCRIPTION
### Motivation
- A turn-scoped `ReasoningEffortHandle` could persist across turns because the shared handle was wired at loop/session scope, causing a tool-set override in one turn to override the next turn's `controls.reasoning.effort`.

### Description
- Preserve the configured handle on `InMemoryAgenticLoop` and clear it at the start of each `run_turn` so stale overrides cannot leak into the next turn.
- Wire the same turn-boundary clearing into the runtime path by clearing the adapter-provided handle in `execute_input_activity` before the turn starts.
- Ensure atoms receive clones of the handle when configured and fix cloning usage when constructing atoms in the builder.
- Add a multi-turn regression test `mid_turn_effort_override_is_cleared_before_next_turn` that verifies efforts observed across two turns are `[low, high, low]`.

### Testing
- Ran the focused test suite: `cargo test -p everruns-core --test mid_turn_reasoning_effort_test`, which passed (3 tests, 0 failed).
- Verified formatting and build checks with `cargo fmt --check` and `cargo check -p everruns-runtime`, both succeeded.
- Performed `git diff --check` and local repository status verification with no outstanding issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b60e0b174832b9a9032e23214ca31)