### PR TITLE
fix(server): unify control-plane FS path normalization (EVE-670)

### DIFF
--- a/crates/core/src/session_path.rs
+++ b/crates/core/src/session_path.rs
@@ -15,13 +15,20 @@
 /// It is purely a *view*; addressing is done by [`crate::mount_fs::MountFs`].
 pub const WORKSPACE_PREFIX: &str = "/workspace";
 
-/// Canonical leading-slash session path from any accepted spelling: strips the
-/// `/workspace` alias, ensures a single leading slash, trims a trailing slash.
+/// Canonical leading-slash session path from any accepted spelling: collapses
+/// repeated slashes, strips the `/workspace` alias, ensures a single leading
+/// slash, and trims a trailing slash.
+///
+/// This is the single normalizer for every session-path surface — the agent
+/// (via `MountFs`/the VFS backends) and the control-plane HTTP FS API both route
+/// through it, so a path resolves to the same key regardless of entry point.
 ///
 /// Examples: `/workspace` → `/`, `/workspace/a.txt` → `/a.txt`,
-/// `/workspacefoo` → `/workspacefoo`, `a.txt` → `/a.txt`, `/sub/dir/` → `/sub/dir`.
+/// `/workspacefoo` → `/workspacefoo`, `a.txt` → `/a.txt`, `/sub/dir/` → `/sub/dir`,
+/// `/a//b/` → `/a/b`.
 pub fn to_session_path(input: &str) -> String {
-    let stripped = strip_workspace_alias(input.trim());
+    let collapsed = collapse_slashes(input.trim());
+    let stripped = strip_workspace_alias(&collapsed);
     if stripped.is_empty() || stripped == "/" {
         return "/".to_string();
     }
@@ -34,6 +41,25 @@ pub fn to_session_path(input: &str) -> String {
         normalized.pop();
     }
     normalized
+}
+
+/// Collapse runs of `/` into a single `/` (`a//b` → `a/b`). Leaves the rest of
+/// the string untouched.
+fn collapse_slashes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_slash = false;
+    for ch in s.chars() {
+        if ch == '/' {
+            if !prev_slash {
+                out.push(ch);
+            }
+            prev_slash = true;
+        } else {
+            out.push(ch);
+            prev_slash = false;
+        }
+    }
+    out
 }
 
 /// Model-facing display for a canonical session path: the `/workspace` alias.
@@ -80,6 +106,14 @@ mod tests {
         assert_eq!(to_session_path("foo.txt"), "/foo.txt");
         assert_eq!(to_session_path("/sub/dir/"), "/sub/dir");
         assert_eq!(to_session_path("  /workspace/x  "), "/x");
+    }
+
+    #[test]
+    fn to_session_path_collapses_repeated_slashes() {
+        assert_eq!(to_session_path("/a//b"), "/a/b");
+        assert_eq!(to_session_path("//a///b//"), "/a/b");
+        assert_eq!(to_session_path("//workspace//x"), "/x");
+        assert_eq!(to_session_path("///"), "/");
     }
 
     #[test]

--- a/crates/server/src/domains/session_files/queries.rs
+++ b/crates/server/src/domains/session_files/queries.rs
@@ -4,8 +4,6 @@ use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
 use uuid::Uuid;
 
-const WORKSPACE_PREFIX: &str = "/workspace";
-
 pub fn service(ctx: &Ctx) -> Arc<WorkspaceFileService> {
     ctx.session_file_service
         .clone()
@@ -73,25 +71,13 @@ pub async fn verify_session_for_write(
     Ok(workspace_key)
 }
 
+/// Normalize a control-plane FS path to its canonical session-store key.
+///
+/// Delegates to the single cross-surface normalizer (EVE-670) so the HTTP FS API
+/// and the agent resolve a given path to the same key: collapse repeated
+/// slashes, strip the `/workspace` alias, leading slash, no trailing slash.
 pub fn normalize_path(path: &str) -> String {
-    let path = path.trim_start_matches('/');
-    if path.is_empty() {
-        return "/".to_string();
-    }
-
-    let abs_path = format!("/{}", path);
-
-    if abs_path == WORKSPACE_PREFIX {
-        "/".to_string()
-    } else if let Some(stripped) = abs_path.strip_prefix(WORKSPACE_PREFIX) {
-        if stripped.starts_with('/') {
-            stripped.to_string()
-        } else {
-            abs_path
-        }
-    } else {
-        abs_path
-    }
+    everruns_core::session_path::to_session_path(path)
 }
 
 pub fn is_reserved_path(path: &str) -> bool {
@@ -102,4 +88,23 @@ pub fn is_reserved_path(path: &str) -> bool {
 pub fn classify_storage(error: anyhow::Error) -> CommandError {
     tracing::error!("Session file domain error: {error}");
     CommandError::internal(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// EVE-670: the control-plane FS API normalizes to the same canonical key as
+    /// the agent (strips the `/workspace` alias, collapses repeated slashes,
+    /// trims the trailing slash), so a file resolves identically regardless of
+    /// entry point. Full behavior is covered in `everruns_core::session_path`.
+    #[test]
+    fn normalize_path_matches_canonical_session_path() {
+        assert_eq!(normalize_path("/workspace/src/lib.rs"), "/src/lib.rs");
+        assert_eq!(normalize_path("src/lib.rs"), "/src/lib.rs");
+        assert_eq!(normalize_path("/workspace"), "/");
+        assert_eq!(normalize_path("/a//b/"), "/a/b");
+        // A real top-level `workspace/` dir is not the alias.
+        assert_eq!(normalize_path("/workspacefoo"), "/workspacefoo");
+    }
 }

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -120,26 +120,15 @@ impl WorkspaceFileService {
         self
     }
 
-    /// Normalize a path: ensure it starts with /, no trailing slash, no double slashes
+    /// Normalize a path to its canonical session-store key.
+    ///
+    /// Delegates to the single cross-surface normalizer (EVE-670): collapse
+    /// repeated slashes, strip the `/workspace` alias, ensure a leading slash,
+    /// no trailing slash. Previously this kept `/workspace` literal, so the HTTP
+    /// FS API and the agent could key the same path differently; routing through
+    /// the shared normalizer makes them agree.
     fn normalize_path(path: &str) -> String {
-        let mut normalized = path.trim().to_string();
-
-        // Ensure starts with /
-        if !normalized.starts_with('/') {
-            normalized = format!("/{}", normalized);
-        }
-
-        // Remove trailing slash (except for root)
-        if normalized.len() > 1 && normalized.ends_with('/') {
-            normalized.pop();
-        }
-
-        // Remove double slashes
-        while normalized.contains("//") {
-            normalized = normalized.replace("//", "/");
-        }
-
-        normalized
+        everruns_core::session_path::to_session_path(path)
     }
 
     /// Validate that a path is valid
@@ -1914,7 +1903,9 @@ mod tests {
 
         db.create_session_file(CreateSessionFileRow {
             session_id: SessionId::from_uuid(sid),
-            path: "/workspace/repo".to_string(),
+            // Stored canonically (without the `/workspace` alias), as
+            // normalize_initial_file_path / the agent VFS key real repos.
+            path: "/repo".to_string(),
             content: None,
             is_directory: true,
             is_readonly: true,
@@ -1954,7 +1945,9 @@ mod tests {
 
         db.create_session_file(CreateSessionFileRow {
             session_id: SessionId::from_uuid(sid),
-            path: "/workspace/repo".to_string(),
+            // Stored canonically (without the `/workspace` alias), as
+            // normalize_initial_file_path / the agent VFS key real repos.
+            path: "/repo".to_string(),
             content: None,
             is_directory: true,
             is_readonly: true,


### PR DESCRIPTION
## What
Make `everruns_core::session_path::to_session_path` the **single** path normalizer for every session-FS surface, and route the control-plane HTTP FS service through it. Removes two duplicate, mutually-inconsistent server normalizers.

## Why
After EVE-660 the *agent* filesystem unified on `MountFs` → `session_path::to_session_path`, but the control-plane HTTP FS API (`/v1/workspaces/{id}/fs/*`) kept its own handling — and it was internally inconsistent:

- `queries::normalize_path` stripped the `/workspace` alias, but didn't clean slashes.
- `WorkspaceFileService::normalize_path` cleaned slashes (`//`, trailing), but kept `/workspace` **literal**.
- Both differed from the agent's normalizer.

Consequences:
- The HTTP FS API and the agent could key the **same path to different DB rows**.
- **Latent bug:** a `/workspace`-prefixed control-plane request bypassed readonly enforcement — it compared `/workspace/repo/...` against the canonically-stored `/repo` (readonly repos are stored without the alias, per `normalize_initial_file_path`), which never matched, so writes under a readonly repo were allowed.

## How
- One normalizer: `to_session_path` now also **collapses repeated slashes** (`/a//b` → `/a/b`) so it's a strict superset of both server normalizers. The agent side is unaffected — `MountFs` already produces clean paths.
- `queries::normalize_path` and `WorkspaceFileService::normalize_path` both delegate to it; the duplicate `WORKSPACE_PREFIX` const and hand-rolled logic are deleted.
- The canonical stored form is **without** `/workspace` (what `normalize_initial_file_path` and the agent VFS already use); this aligns the control-plane with it.

## Risk
- **Medium (data-correctness).** Changes which DB key a path resolves to for *edge-case* inputs to the control-plane (`/workspace`-prefixed, `//`, trailing slash). For the normal contract — the `{*path}` route segment is relative (`src/lib.rs` → `/src/lib.rs`) — behavior is unchanged, and it now *matches* the agent. Files created via the agent (always canonical) are unaffected. A file previously created via the HTTP API with an explicit `/workspace` prefix (uncommon; the UI sends relative paths) would now resolve to the alias-stripped key — i.e. it converges with the agent's view rather than diverging.
- Verified against a real PostgreSQL DB (see below); the readonly-enforcement change is a *fix*, not a regression.

## Security
- **Threat categories reviewed: TM-FS** (readonly enforcement, path keying). This **closes** a latent gap: `/workspace`-prefixed control-plane writes now correctly resolve under canonically-stored readonly directories and are rejected. No new surface; no auth/tenant changes (workspace/session scoping is unchanged and sits above normalization).

## Follow-ups
No follow-ups. Completes the EVE-660 path-model unification across all surfaces.

## Checklist
- [x] Tests added or updated (`session_path` `//`-collapse unit tests; a control-plane `normalize_path` regression test; corrected two readonly-enforcement tests to the canonical stored form)
- [x] Backward compatibility considered (canonical relative paths unchanged; only `/workspace`-prefixed / multi-slash control-plane inputs converge to the agent's key)
- [x] Security review performed (TM-FS; closes a readonly-enforcement gap)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Closes EVE-670.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRp8hhzBAc4CeeUrhTaePW)_