### PR TITLE
feat(ui): add early-access banner with user-preferences store

### DIFF
--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -53,6 +53,10 @@ jest.mock("@/components/command-palette", () => ({
   CommandPalette: () => <div data-testid="command-palette">Command Palette</div>,
 }));
 
+jest.mock("@/components/layout/early-access-banner", () => ({
+  EarlyAccessBanner: () => <div data-testid="early-access-banner">Early Access Banner</div>,
+}));
+
 jest.mock("@/hooks/use-command-palette", () => ({
   CommandPaletteContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   useCommandPaletteState: () => ({}),

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import { Suspense, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { Sidebar } from "@/components/layout/sidebar";
+import { EarlyAccessBanner } from "@/components/layout/early-access-banner";
 import { CommandPalette } from "@/components/command-palette";
 import { AuthUnavailableState } from "@/components/layout/auth-unavailable-state";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
@@ -88,9 +89,12 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   }
 
   const appChrome = (
-    <div className="flex h-screen">
-      <Sidebar />
-      <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
+    <div className="flex h-screen flex-col">
+      <EarlyAccessBanner />
+      <div className="flex min-h-0 flex-1">
+        <Sidebar />
+        <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
+      </div>
       <CommandPalette />
     </div>
   );

--- a/apps/ui/src/components/layout/early-access-banner.tsx
+++ b/apps/ui/src/components/layout/early-access-banner.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+// Early-access banner shown above the app shell. Warns that Everruns is still
+// stabilizing and links to GitHub. Dismissal is persisted per-user via the
+// user-preferences key/value service, so it stays dismissed across devices.
+import { useState } from "react";
+import { FlaskConical, ArrowRight, X } from "lucide-react";
+
+import { GithubIcon } from "@/components/icons/github-icon";
+import { useUserPreference, useSetUserPreference } from "@/hooks/use-user-preferences";
+
+const BANNER_DISMISSED_KEY = "ui.early_access_banner.dismissed";
+const GITHUB_URL = "https://github.com/everruns/everruns";
+
+export function EarlyAccessBanner() {
+  const { data: preference, isLoading } = useUserPreference(BANNER_DISMISSED_KEY);
+  const setPreference = useSetUserPreference();
+  // Local flag hides the banner immediately on click, before the write settles.
+  const [dismissedLocally, setDismissedLocally] = useState(false);
+
+  const dismissed = dismissedLocally || preference?.value === true;
+
+  // Wait for the stored state before first paint so the banner doesn't flash in
+  // for users who already dismissed it.
+  if (isLoading || dismissed) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    setDismissedLocally(true);
+    setPreference.mutate({ key: BANNER_DISMISSED_KEY, value: true });
+  };
+
+  return (
+    <div className="flex h-11 flex-none items-center gap-2.5 border-b border-[hsl(var(--accent)/0.35)] bg-[hsl(var(--accent)/0.12)] px-[18px] text-primary">
+      <span className="inline-flex text-accent-foreground">
+        <FlaskConical className="h-[15px] w-[15px]" />
+      </span>
+      <span className="text-[13px] tracking-[-0.01em]">
+        <strong className="font-semibold">Early access.</strong> Everruns is still stabilizing —
+        expect breaking changes and rough edges.
+      </span>
+      <span className="flex-1" />
+      <a
+        href={GITHUB_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 whitespace-nowrap text-[13px] font-medium text-primary hover:underline hover:underline-offset-[3px]"
+      >
+        <GithubIcon className="h-[14px] w-[14px]" /> Follow along on GitHub{" "}
+        <ArrowRight className="h-[13px] w-[13px]" />
+      </a>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={handleDismiss}
+        className="inline-flex h-[26px] w-[26px] cursor-pointer items-center justify-center border-0 bg-transparent text-primary/70 hover:bg-[hsl(var(--accent)/0.18)] hover:text-primary"
+      >
+        <X className="h-[15px] w-[15px]" />
+      </button>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-user-preferences.ts
+++ b/apps/ui/src/hooks/use-user-preferences.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getUserPreference,
+  setUserPreference,
+  type UserPreference,
+} from "@/lib/api/user-preferences";
+import { queryKeys } from "@/lib/query-keys";
+
+/**
+ * Read a single user preference by key. `data` is null when the preference has
+ * not been set yet.
+ */
+export function useUserPreference(key: string, enabled: boolean = true) {
+  return useQuery({
+    queryKey: queryKeys.userPreferences.detail(key),
+    queryFn: () => getUserPreference(key),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/** Create or update a user preference value. */
+export function useSetUserPreference() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ key, value }: { key: string; value: unknown }) => setUserPreference(key, value),
+    onSuccess: (preference: UserPreference) => {
+      queryClient.setQueryData(queryKeys.userPreferences.detail(preference.key), preference);
+      queryClient.invalidateQueries({ queryKey: queryKeys.userPreferences.list() });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/user-preferences.ts
+++ b/apps/ui/src/lib/api/user-preferences.ts
@@ -1,0 +1,41 @@
+import { api, ApiError } from "./client";
+
+// Per-user key/value store for client/UI settings (e.g. dismissed banners).
+// Values are arbitrary JSON, persisted server-side so preferences follow the
+// user across devices and browsers.
+export interface UserPreference {
+  key: string;
+  value: unknown;
+  updated_at: string;
+}
+
+export async function listUserPreferences(): Promise<UserPreference[]> {
+  const response = await api.get<UserPreference[]>("/v1/user/preferences");
+  return response.data;
+}
+
+/**
+ * Read a single preference by key. Returns null when the preference has not
+ * been set yet (the API responds 404 in that case).
+ */
+export async function getUserPreference(key: string): Promise<UserPreference | null> {
+  try {
+    const response = await api.get<UserPreference>(
+      `/v1/user/preferences/${encodeURIComponent(key)}`,
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function setUserPreference(key: string, value: unknown): Promise<UserPreference> {
+  const response = await api.put<UserPreference>(
+    `/v1/user/preferences/${encodeURIComponent(key)}`,
+    { value },
+  );
+  return response.data;
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -169,6 +169,13 @@ export const queryKeys = {
     list: () => ["user-connections"] as const,
   },
 
+  // User preference (key/value) queries
+  userPreferences: {
+    all: ["user-preferences"] as const,
+    list: () => ["user-preferences"] as const,
+    detail: (key: string) => ["user-preferences", key] as const,
+  },
+
   payments: {
     all: ["payments"] as const,
     accounts: (params: Record<string, unknown> = {}) => ["payments", "accounts", params] as const,

--- a/crates/server/migrations/086_user_preferences.sql
+++ b/crates/server/migrations/086_user_preferences.sql
@@ -1,0 +1,29 @@
+-- User preferences: a per-user key/value store for client/UI settings.
+--
+-- Mirrors `session_key_values` but scoped to a user instead of a session, so
+-- preferences (e.g. dismissed banners) persist per-user across devices and
+-- browsers. Values are stored as TEXT; callers may serialize JSON into them so
+-- the schema stays agnostic about the shape of any individual preference.
+CREATE TABLE user_preferences (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+    -- Key name (unique per user)
+    key VARCHAR(255) NOT NULL,
+
+    -- Value (stored as text, can be JSON)
+    value TEXT NOT NULL,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- One value per key per user
+    CONSTRAINT user_preferences_unique_key UNIQUE (user_id, key)
+);
+
+CREATE INDEX idx_user_preferences_user_id ON user_preferences(user_id);
+
+CREATE TRIGGER update_user_preferences_updated_at
+    BEFORE UPDATE ON user_preferences
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -67,6 +67,7 @@ pub mod sse;
 pub mod task_webhooks;
 pub mod tool_results;
 pub mod user_connections;
+pub mod user_preferences;
 pub mod users;
 pub mod validation;
 pub mod voice;

--- a/crates/server/src/api/user_preferences.rs
+++ b/crates/server/src/api/user_preferences.rs
@@ -1,0 +1,156 @@
+// User Preferences API — a per-user key/value store for client/UI settings.
+//
+// Decision: User-scoped (not org-scoped). Preferences belong to the
+// authenticated user and persist across orgs, devices, and browsers. Values are
+// arbitrary JSON; the storage layer keeps them as TEXT so the schema stays
+// agnostic about any individual preference's shape (e.g. a dismissed banner
+// flag).
+
+use crate::auth::middleware::{AuthState, AuthUser};
+use crate::storage::StorageBackend;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use super::common::impl_auth_state;
+use crate::storage::models::UserPreferenceRow;
+
+/// App state for user preference routes.
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self { db, auth }
+    }
+}
+
+impl_auth_state!(AppState);
+
+/// A single stored preference. `value` is arbitrary JSON.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PreferenceResponse {
+    pub key: String,
+    #[schema(value_type = Object)]
+    pub value: serde_json::Value,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Request body for setting a preference value.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetPreferenceRequest {
+    #[schema(value_type = Object)]
+    pub value: serde_json::Value,
+}
+
+fn row_to_response(row: UserPreferenceRow) -> PreferenceResponse {
+    // Stored as TEXT containing serialized JSON. Fall back to treating the raw
+    // text as a string value if it was written as a non-JSON literal.
+    let value = serde_json::from_str(&row.value)
+        .unwrap_or_else(|_| serde_json::Value::String(row.value.clone()));
+    PreferenceResponse {
+        key: row.key,
+        value,
+        updated_at: row.updated_at,
+    }
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/user/preferences", get(list_preferences))
+        .route(
+            "/v1/user/preferences/{key}",
+            get(get_preference)
+                .put(set_preference)
+                .delete(delete_preference),
+        )
+        .with_state(state)
+}
+
+/// GET /v1/user/preferences — list all of the user's preferences.
+pub async fn list_preferences(
+    State(state): State<AppState>,
+    auth: AuthUser,
+) -> Result<Json<Vec<PreferenceResponse>>, StatusCode> {
+    let rows = state.db.list_user_preferences(auth.id).await.map_err(|e| {
+        tracing::error!("Failed to list user preferences: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(rows.into_iter().map(row_to_response).collect()))
+}
+
+/// GET /v1/user/preferences/{key} — read a single preference by key.
+pub async fn get_preference(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(key): Path<String>,
+) -> Result<Json<PreferenceResponse>, StatusCode> {
+    let row = state
+        .db
+        .get_user_preference(auth.id, &key)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get user preference: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(row_to_response(row)))
+}
+
+/// PUT /v1/user/preferences/{key} — create or update a preference value.
+pub async fn set_preference(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(key): Path<String>,
+    Json(body): Json<SetPreferenceRequest>,
+) -> Result<Json<PreferenceResponse>, StatusCode> {
+    let serialized = serde_json::to_string(&body.value).map_err(|e| {
+        tracing::error!("Failed to serialize preference value: {}", e);
+        StatusCode::BAD_REQUEST
+    })?;
+
+    let row = state
+        .db
+        .set_user_preference(auth.id, &key, &serialized)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to set user preference: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(row_to_response(row)))
+}
+
+/// DELETE /v1/user/preferences/{key} — remove a preference.
+pub async fn delete_preference(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(key): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let deleted = state
+        .db
+        .delete_user_preference(auth.id, &key)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete user preference: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1353,6 +1353,9 @@ impl ServerAppBuilder {
             .merge(api::payments::routes(payments_state))
             .merge(api::reporting::routes(reporting_state))
             .merge(api::user_connections::routes(user_connections_state))
+            .merge(api::user_preferences::routes(
+                api::user_preferences::AppState::new(db.clone(), auth_state.clone()),
+            ))
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::audit_logs::routes(audit_logs_state))
             .merge(api::commands::routes(commands_state))

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2894,6 +2894,31 @@ impl StorageBackend {
         dispatch!(self, delete_user_connection, user_id, provider)
     }
 
+    pub async fn list_user_preferences(&self, user_id: Uuid) -> Result<Vec<UserPreferenceRow>> {
+        dispatch!(self, list_user_preferences, user_id)
+    }
+
+    pub async fn get_user_preference(
+        &self,
+        user_id: Uuid,
+        key: &str,
+    ) -> Result<Option<UserPreferenceRow>> {
+        dispatch!(self, get_user_preference, user_id, key)
+    }
+
+    pub async fn set_user_preference(
+        &self,
+        user_id: Uuid,
+        key: &str,
+        value: &str,
+    ) -> Result<UserPreferenceRow> {
+        dispatch!(self, set_user_preference, user_id, key, value)
+    }
+
+    pub async fn delete_user_preference(&self, user_id: Uuid, key: &str) -> Result<bool> {
+        dispatch!(self, delete_user_preference, user_id, key)
+    }
+
     pub async fn get_connection_token_for_session(
         &self,
         session_id: SessionId,

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -44,6 +44,7 @@ mod sessions;
 mod skills;
 pub mod subagent_spawn_handles;
 mod user_connections;
+mod user_preferences;
 mod users;
 mod workspaces;
 
@@ -125,6 +126,8 @@ pub struct InMemoryDatabase {
     session_secrets: RwLock<HashMap<(SessionId, String), SessionSecretRow>>,
     // User connections (external service accounts)
     user_connections: RwLock<HashMap<Uuid, UserConnectionRow>>,
+    // User preferences: (user_id, key) -> row
+    user_preferences: RwLock<HashMap<(Uuid, String), UserPreferenceRow>>,
     // Pinned sessions: (user_id, session_id) -> (org_id, pinned_at)
     pinned_sessions: RwLock<HashMap<(Uuid, SessionId), PinnedSessionData>>,
     // Durable UI notifications
@@ -267,6 +270,7 @@ impl Default for InMemoryDatabase {
             session_key_values: RwLock::new(HashMap::new()),
             session_secrets: RwLock::new(HashMap::new()),
             user_connections: RwLock::new(HashMap::new()),
+            user_preferences: RwLock::new(HashMap::new()),
             pinned_sessions: RwLock::new(HashMap::new()),
             notifications: RwLock::new(HashMap::new()),
             notification_turn_requests: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -3463,3 +3463,61 @@ async fn test_export_user_data() {
     let missing = db.export_user_data(uuid::Uuid::now_v7()).await.unwrap();
     assert!(missing.is_none());
 }
+
+#[tokio::test]
+async fn test_user_preferences_crud_and_isolation() {
+    let db = InMemoryDatabase::new();
+    let user_a = uuid::Uuid::now_v7();
+    let user_b = uuid::Uuid::now_v7();
+
+    // Missing key reads as None.
+    assert!(
+        db.get_user_preference(user_a, "theme")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // Set creates the row.
+    let created = db
+        .set_user_preference(user_a, "theme", "\"dark\"")
+        .await
+        .unwrap();
+    assert_eq!(created.key, "theme");
+    assert_eq!(created.value, "\"dark\"");
+
+    // Set again upserts (updates value, keeps identity, no duplicate row).
+    let updated = db
+        .set_user_preference(user_a, "theme", "\"light\"")
+        .await
+        .unwrap();
+    assert_eq!(updated.id, created.id, "upsert must reuse the same row");
+    assert_eq!(updated.value, "\"light\"");
+    assert_eq!(db.list_user_preferences(user_a).await.unwrap().len(), 1);
+
+    // Preferences are isolated per user.
+    db.set_user_preference(user_b, "theme", "\"system\"")
+        .await
+        .unwrap();
+    assert_eq!(
+        db.get_user_preference(user_a, "theme")
+            .await
+            .unwrap()
+            .unwrap()
+            .value,
+        "\"light\""
+    );
+    assert_eq!(db.list_user_preferences(user_b).await.unwrap().len(), 1);
+
+    // Delete removes only the targeted key and reports whether a row was hit.
+    assert!(db.delete_user_preference(user_a, "theme").await.unwrap());
+    assert!(!db.delete_user_preference(user_a, "theme").await.unwrap());
+    assert!(
+        db.get_user_preference(user_a, "theme")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    // user_b is unaffected by user_a's delete.
+    assert_eq!(db.list_user_preferences(user_b).await.unwrap().len(), 1);
+}

--- a/crates/server/src/storage/memory/user_preferences.rs
+++ b/crates/server/src/storage/memory/user_preferences.rs
@@ -1,0 +1,73 @@
+// In-memory storage: User Preferences (per-user key/value store)
+
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::Result;
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    // ============================================
+    // User Preferences
+    // ============================================
+
+    pub async fn list_user_preferences(&self, user_id: Uuid) -> Result<Vec<UserPreferenceRow>> {
+        let mut prefs: Vec<_> = self
+            .user_preferences
+            .read()
+            .values()
+            .filter(|p| p.user_id == user_id)
+            .cloned()
+            .collect();
+        prefs.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(prefs)
+    }
+
+    pub async fn get_user_preference(
+        &self,
+        user_id: Uuid,
+        key: &str,
+    ) -> Result<Option<UserPreferenceRow>> {
+        Ok(self
+            .user_preferences
+            .read()
+            .get(&(user_id, key.to_string()))
+            .cloned())
+    }
+
+    pub async fn set_user_preference(
+        &self,
+        user_id: Uuid,
+        key: &str,
+        value: &str,
+    ) -> Result<UserPreferenceRow> {
+        let now = Self::now();
+        let mut prefs = self.user_preferences.write();
+        let map_key = (user_id, key.to_string());
+
+        let row = match prefs.get(&map_key) {
+            Some(existing) => UserPreferenceRow {
+                value: value.to_string(),
+                updated_at: now,
+                ..existing.clone()
+            },
+            None => UserPreferenceRow {
+                id: Uuid::now_v7(),
+                user_id,
+                key: key.to_string(),
+                value: value.to_string(),
+                created_at: now,
+                updated_at: now,
+            },
+        };
+        prefs.insert(map_key, row.clone());
+        Ok(row)
+    }
+
+    pub async fn delete_user_preference(&self, user_id: Uuid, key: &str) -> Result<bool> {
+        Ok(self
+            .user_preferences
+            .write()
+            .remove(&(user_id, key.to_string()))
+            .is_some())
+    }
+}

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1919,6 +1919,21 @@ pub struct CreateSkillFileRow {
 }
 
 // ============================================
+// User Preference models
+// ============================================
+
+/// User preference (key/value) row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct UserPreferenceRow {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub key: String,
+    pub value: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ============================================
 // User Connection models
 // ============================================
 

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -38,6 +38,7 @@ mod session_tasks;
 mod sessions;
 mod skills;
 mod user_connections;
+mod user_preferences;
 mod users;
 mod workspaces;
 

--- a/crates/server/src/storage/repositories/user_preferences.rs
+++ b/crates/server/src/storage/repositories/user_preferences.rs
@@ -1,0 +1,86 @@
+// PostgreSQL repository: User Preferences (per-user key/value store)
+
+use super::super::models::*;
+use super::Database;
+use anyhow::Result;
+use uuid::Uuid;
+
+impl Database {
+    // ============================================
+    // User Preferences
+    // ============================================
+
+    /// List all preferences for a user, ordered by key.
+    pub async fn list_user_preferences(&self, user_id: Uuid) -> Result<Vec<UserPreferenceRow>> {
+        let rows = sqlx::query_as::<_, UserPreferenceRow>(
+            r#"
+            SELECT id, user_id, key, value, created_at, updated_at
+            FROM user_preferences
+            WHERE user_id = $1
+            ORDER BY key ASC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Get a single preference for a user by key.
+    pub async fn get_user_preference(
+        &self,
+        user_id: Uuid,
+        key: &str,
+    ) -> Result<Option<UserPreferenceRow>> {
+        let row = sqlx::query_as::<_, UserPreferenceRow>(
+            r#"
+            SELECT id, user_id, key, value, created_at, updated_at
+            FROM user_preferences
+            WHERE user_id = $1 AND key = $2
+            "#,
+        )
+        .bind(user_id)
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Create or update a preference value for a user by key.
+    pub async fn set_user_preference(
+        &self,
+        user_id: Uuid,
+        key: &str,
+        value: &str,
+    ) -> Result<UserPreferenceRow> {
+        let row = sqlx::query_as::<_, UserPreferenceRow>(
+            r#"
+            INSERT INTO user_preferences (user_id, key, value)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (user_id, key)
+            DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+            RETURNING id, user_id, key, value, created_at, updated_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(key)
+        .bind(value)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Delete a user's preference by key. Returns true when a row was removed.
+    pub async fn delete_user_preference(&self, user_id: Uuid, key: &str) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM user_preferences WHERE user_id = $1 AND key = $2")
+            .bind(user_id)
+            .bind(key)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}


### PR DESCRIPTION
## What
Adds the **Everruns early-access banner** to the authenticated app shell, plus a reusable **per-user key/value preferences service** that persists the banner's dismissed state.

- New banner above the sidebar/main row: flask icon, "Early access. Everruns is still stabilizing — expect breaking changes and rough edges.", a "Follow along on GitHub" link, and a dismiss button. Faithful to the provided design (accent variant).
- New `user_preferences` store (`/v1/user/preferences`) — a generic, user-scoped key/value API backed by a new table across both the Postgres and in-memory storage backends.

## Why
The product is in early access and needs a clear, dismissible signal in the UI. Dismissal must persist per-user (not per-browser), so it required a small shared preferences service rather than `localStorage`. The service is intentionally generic so future UI/client settings can reuse it.

## How
- **Backend**: `user_preferences` table (migration `086`, mirrors the existing `session_key_values` pattern but scoped to `user_id` with a FK cascade on user delete). `UserPreferenceRow` model, Postgres + in-memory repositories, `StorageBackend` dispatch, and a user-scoped axum API (`GET` list, `GET/PUT/DELETE {key}`) authenticated via `AuthUser`. Values are arbitrary JSON stored as TEXT.
- **Frontend**: `user-preferences` API client + React Query hook (`useUserPreference` / `useSetUserPreference`), an `EarlyAccessBanner` client component wired into `(main)/layout.tsx`. Dismissal writes `ui.early_access_banner.dismissed=true`; the banner waits for the stored value before first paint to avoid a flash for users who already dismissed it.

## Risk
- **Low.** Additive feature; no changes to existing endpoints or schemas. New table is isolated with a FK cascade. UI change is a self-contained banner plus a layout wrapper (banner renders nothing until state resolves / when dismissed).
- What could break: the `(main)` layout now wraps the sidebar/main in a flex column — verified the existing full-height/scroll behavior is preserved, and the UI production build passes.

## Security
- **Threat categories reviewed:** TM-API, TM-TENANT, TM-SQL, TM-WEB.
- **Findings and resolutions:**
  - *TM-TENANT / TM-AUTHZ:* every query is scoped to `auth.id`; a user can only read/write/delete their own preferences. No cross-user access path.
  - *TM-SQL:* all queries are parameterized via `sqlx` bind params (no string interpolation); unique constraint `(user_id, key)` + FK cascade. Validated against a real Postgres (all 86 migrations applied, upsert/trigger/cascade exercised).
  - *TM-API:* endpoints require an authenticated `AuthUser`; `key` is a single path segment used only as a bind param.
  - *TM-WEB:* banner renders static copy and a fixed external link with `rel="noopener noreferrer"`; no user-controlled HTML, no XSS.
  - *TM-DOS (noted):* preference values are unbounded TEXT and a user may create many keys — identical to the existing `session_key_values` precedent and bounded by the standard request body limit; acceptable for authenticated, self-scoped data.
- No new dependencies.

## Validation
- `cargo check`, `cargo clippy` (0 warnings), `cargo fmt --check` ✓
- `cargo test` — new `test_user_preferences_crud_and_isolation` (in-memory repo: CRUD, upsert, per-user isolation) ✓
- Postgres smoke test: applied all migrations `001..086` on a fresh DB; exercised the exact repository SQL — insert/upsert (trigger advances `updated_at`), ordered list, delete, and FK cascade on user delete ✓
- UI: `tsc --noEmit`, `oxlint`, `oxfmt --check`, and `next build` ✓

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — in-memory repository test (`test_user_preferences_crud_and_isolation`)
- [x] Backward compatibility considered — additive only
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01LQMukTt5k3qLJGMVeCNb9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQMukTt5k3qLJGMVeCNb9f)_