### PR TITLE
fix(bench): make load test self-sufficient against current seed data

### DIFF
--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -38,8 +38,11 @@ use serde::{Deserialize, Serialize};
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 use tokio::sync::Semaphore;
 
-/// Seed harness ID from seed.rs (DEFAULT_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
-const DEFAULT_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+/// Built-in harness selected by name. Harnesses are created per-org by
+/// `org_init` with runtime UUIDv7 ids (no deterministic seed id anymore), so the
+/// load test resolves the id at runtime via `GET /v1/harnesses` instead of
+/// hardcoding it. `platform-chat` is the default conversational harness.
+const DEFAULT_HARNESS_NAME: &str = "platform-chat";
 
 /// Seed llmsim-latency model ID from seed.rs (LLMSIM_LATENCY = 0x01933b5a_0000_7000_8000_000000000402)
 /// Uses LatencyProfile::fast() with TTFT and inter-token delays for realistic streaming simulation.
@@ -601,10 +604,51 @@ impl LoadTestRunner {
         }
     }
 
+    /// Enable the configured model so it can be used as an agent's default.
+    ///
+    /// The llmsim seed models ship `enabled: false` (kept out of UI pickers),
+    /// but agent/session creation rejects disabled models with a 404. Enabling
+    /// is idempotent, so this is safe to run before every load test.
+    async fn ensure_model_enabled(&self) -> anyhow::Result<()> {
+        let url = format!("{}/v1/models/{}", self.config.api_url, self.config.model_id);
+        self.http
+            .patch(&url)
+            .json(&serde_json::json!({ "enabled": true }))
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    /// Resolve the harness id to use, selecting the built-in `platform-chat`
+    /// harness by name (falling back to the first harness if absent).
+    async fn resolve_harness_id(&self) -> anyhow::Result<String> {
+        let url = format!("{}/v1/harnesses", self.config.api_url);
+        let body: serde_json::Value = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        let harnesses = body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .ok_or_else(|| anyhow::anyhow!("harness list missing `data` array"))?;
+        let pick = harnesses
+            .iter()
+            .find(|h| h.get("name").and_then(|n| n.as_str()) == Some(DEFAULT_HARNESS_NAME))
+            .or_else(|| harnesses.first())
+            .and_then(|h| h.get("id").and_then(|i| i.as_str()))
+            .ok_or_else(|| anyhow::anyhow!("no harnesses available on server"))?;
+        Ok(pick.to_string())
+    }
+
     /// Create agent via SDK
     async fn create_load_test_agent(&self) -> anyhow::Result<String> {
         let req = CreateAgentRequest::new(
-            format!("Load Test Agent {}", chrono::Utc::now().timestamp()),
+            format!("load-test-agent-{}", chrono::Utc::now().timestamp()),
             "You are a helpful assistant for load testing. Respond concisely.",
         )
         .default_model_id(&self.config.model_id);
@@ -614,11 +658,16 @@ impl LoadTestRunner {
     }
 
     /// Create session via raw reqwest (SDK lacks harness_id support)
-    async fn create_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<String> {
+    async fn create_session(
+        &self,
+        agent_id: &str,
+        harness_id: &str,
+        session_num: usize,
+    ) -> anyhow::Result<String> {
         let url = format!("{}/v1/sessions", self.config.api_url);
 
         let req = CreateSessionRequest {
-            harness_id: DEFAULT_HARNESS_ID.to_string(),
+            harness_id: harness_id.to_string(),
             agent_id: Some(agent_id.to_string()),
             title: Some(format!("Load Test Session {}", session_num)),
             model_id: Some(self.config.model_id.clone()),
@@ -756,9 +805,14 @@ impl LoadTestRunner {
         }
     }
 
-    async fn run_session(&self, agent_id: &str, session_num: usize) -> anyhow::Result<()> {
+    async fn run_session(
+        &self,
+        agent_id: &str,
+        harness_id: &str,
+        session_num: usize,
+    ) -> anyhow::Result<()> {
         // Create session
-        let session_id = match self.create_session(agent_id, session_num).await {
+        let session_id = match self.create_session(agent_id, harness_id, session_num).await {
             Ok(id) => id,
             Err(e) => {
                 self.metrics.sessions_failed.fetch_add(1, Ordering::Relaxed);
@@ -839,6 +893,9 @@ impl LoadTestRunner {
         // Fetch server info before the test
         let server_info = self.fetch_server_info().await;
 
+        // Resolve the harness id at runtime (no deterministic seed id anymore).
+        let harness_id = self.resolve_harness_id().await?;
+
         println!("═══════════════════════════════════════════════════════════");
         println!(
             "              Everruns Load Test [{}]",
@@ -870,8 +927,14 @@ impl LoadTestRunner {
             "  Total messages:       {}",
             self.config.sessions * self.config.messages_per_session
         );
-        println!("  Harness:              {} (default)", DEFAULT_HARNESS_ID);
+        println!(
+            "  Harness:              {} ({})",
+            harness_id, DEFAULT_HARNESS_NAME
+        );
         println!();
+
+        // Enable the llmsim model (seed ships it disabled) before using it.
+        self.ensure_model_enabled().await?;
 
         // Create agent via SDK
         println!("Creating load test agent...");
@@ -914,11 +977,14 @@ impl LoadTestRunner {
             .map(|session_num| {
                 let runner = self.clone();
                 let agent_id = agent_id.clone();
+                let harness_id = harness_id.clone();
                 let semaphore = semaphore.clone();
 
                 async move {
                     let _permit = semaphore.acquire().await.unwrap();
-                    runner.run_session(&agent_id, session_num).await
+                    runner
+                        .run_session(&agent_id, &harness_id, session_num)
+                        .await
                 }
             })
             .collect();


### PR DESCRIPTION
## What
Make the load test harness (`crates/server/benches/load_test.rs`) work against current server seed data and validation. No production code changes.

## Why
Running `just load-test quick` against a fresh dev stack failed before sending a single message. The harness had drifted from current server behavior in three independent ways:

1. **Agent name validation** — agent creation now requires names matching `[a-z0-9]+(-[a-z0-9]+)*`, but the harness generated `"Load Test Agent {ts}"` (spaces + capitals) → 400.
2. **Stale harness id** — harnesses are no longer seeded with a deterministic `0x600` id; `org_init` creates them per-org with runtime UUIDv7 ids. The hardcoded `harness_01933b5a…0601` → 404 "Harness not found" on every session create.
3. **Disabled model** — the `llmsim-latency` seed model ships `enabled: false`, and agent/session creation reject disabled models with a 404 "Model not found".

## How
- Generate a pattern-valid agent name (`load-test-agent-{ts}`).
- Resolve the harness id at runtime via `GET /v1/harnesses`, selecting the built-in `platform-chat` harness (fallback: first available) instead of hardcoding it.
- Enable the configured model via `PATCH /v1/models/{id}` (idempotent) before creating the agent.

## Risk
- **Low.** Changes are confined to a benchmark binary; no library or server runtime code is touched. Worst case is a broken benchmark, caught by CI compile.

## Security
- Threat categories reviewed: **TM-API** (the harness calls `PATCH /v1/models/{id}` and `GET /v1/harnesses`). No new server endpoints, auth/authz, query, or tool surface is introduced — the harness is purely an API client running in dev/bench contexts.
- Findings and resolutions: **No security-relevant server code changes.** Enabling a seed model is a normal authenticated API operation; no secrets, input parsing, or trust boundaries are affected.

## Validation
- `just load-test quick` against a fresh `just start-dev` stack: **10/10 sessions, 100/100 messages, 0 failures**, throughput 13.2 msg/sec, P50 201ms / P95 255ms / P99 265ms. Harness resolved dynamically to the seeded `platform-chat` id.
- `cargo fmt -p everruns-server -- --check` — clean.
- `cargo clippy -p everruns-server --bench load_test --all-features -- -D warnings` — clean.
- Full CI green on the rebased commit (the only red checks across earlier runs were a flaky `check-server-test-enumeration.sh` SIGPIPE race and a flaky durable test `test_health_counters_stay_consistent_through_transitions`, both unrelated to this diff and both green on re-run).

## Follow-ups
- The harness aborts a whole session on the first failed message. Against a capacity-limited server the medium/heavy profiles surface `429 Too Many Requests` backpressure, which cascades into early session termination rather than a clean throughput read. A future change could add bounded retry/backoff on transient 429s so capacity-limited runs report throughput instead of failures. Deferred: out of scope for this correctness fix and only affects overloaded runs, not the harness's ability to run.

## Checklist
- [x] Tests added or updated (benchmark harness fix; validated via a live `just load-test quick` run)
- [x] Backward compatibility considered (test-only; n/a for product surface)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (none were filed)