### PR TITLE
chore(core): bump llmsim to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,9 +4745,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmsim"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539672f1cd48a53f2554427acb6c69cf4e2c24a706acb89c22b4681fe0c4b2a0"
+checksum = "a05ca538f4ed6223baae5513aa5c2c248a0c6b7e1ba448b7192068527d19eafd"
 dependencies = [
  "async-stream",
  "futures-core",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -122,7 +122,7 @@ inventory.workspace = true
 # tiktoken-rs, clap, tracing-subscriber, crossterm, ratatui) — the driver only
 # uses the in-process library types (generator, latency, openai, script,
 # stream).
-llmsim = { version = "0.5.0", default-features = false, optional = true }
+llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
 everruns-openui = { path = "../openui", version = "0.17.1", optional = true }

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -1771,9 +1771,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llmsim"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539672f1cd48a53f2554427acb6c69cf4e2c24a706acb89c22b4681fe0c4b2a0"
+checksum = "a05ca538f4ed6223baae5513aa5c2c248a0c6b7e1ba448b7192068527d19eafd"
 dependencies = [
  "async-stream",
  "futures-core",


### PR DESCRIPTION
## What
Bumps the `llmsim` dependency from `0.5.0` to `0.5.1` (patch). Updates `crates/core/Cargo.toml`, the workspace `Cargo.lock`, and the `examples/weekend-concierge-host/Cargo.lock` to the new version and checksum.

## Why
`0.5.1` is the latest published release of `llmsim`, the in-process LLM simulator used by the `llmsim_driver` for testing. Keeping the dependency current.

## How
- `crates/core/Cargo.toml`: `llmsim = "0.5.0"` → `"0.5.1"` (still `default-features = false, optional = true`).
- `Cargo.lock`: refreshed `llmsim` entry via `cargo update -p llmsim --precise 0.5.1`.
- `examples/weekend-concierge-host/Cargo.lock`: surgical `llmsim` version + checksum bump to match (avoiding unrelated churn; pre-existing `everruns-*` version drift in that lock left untouched).

The `0.5.1` dependency set is identical to `0.5.0` (verified against the crates.io sparse index), and the driver only uses the in-process library types with `default-features = false`.

## Risk
- Low.
- Only the test-simulation driver could break. Verified locally: `cargo build -p everruns-core --features llmsim` succeeds, and all driver-exercising integration tests pass (`tool_calling` 24, `reason_atom` 27, `subagent` 9, `background_execution` 4, `message_metadata` 2, `mid_turn_reasoning_effort` 2). `cargo fetch --locked` resolves the workspace lock cleanly.

## Security
- Threat categories reviewed: dependency/supply-chain. No first-party code changed — only a dependency version and its lockfile checksums. `llmsim` is a dev/test simulator behind an optional feature; the new checksum (`a05ca538…`) was taken from the crates.io sparse index. No new threat surface introduced.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing driver tests cover the dependency; re-run and pass)
- [x] Backward compatibility considered (identical dependency set, patch bump)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (none)