### PR TITLE
refactor(server): supervise startup background tasks

### DIFF
--- a/crates/server/src/api/prometheus.rs
+++ b/crates/server/src/api/prometheus.rs
@@ -23,6 +23,7 @@ use axum::response::IntoResponse;
 use axum::{Router, extract::State, routing::get};
 use everruns_config::{env_bool, env_opt_string};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use tokio::task::JoinHandle;
 
 /// Configuration for the Prometheus metrics endpoint.
 pub struct PrometheusConfig {
@@ -92,7 +93,7 @@ pub fn route(handle: PrometheusHandle) -> Router {
 /// Used in production to keep metrics on an internal-only port (e.g. 127.0.0.1:9090)
 /// that is not reachable from outside the pod/host. Scrapers access via sidecar,
 /// pod-local networking, or service mesh.
-pub fn spawn_metrics_server(handle: PrometheusHandle, addr: String) {
+pub fn spawn_metrics_server(handle: PrometheusHandle, addr: String) -> JoinHandle<()> {
     tokio::spawn(async move {
         let app = route(handle);
         match tokio::net::TcpListener::bind(&addr).await {
@@ -106,7 +107,7 @@ pub fn spawn_metrics_server(handle: PrometheusHandle, addr: String) {
                 tracing::error!(addr = %addr, error = %e, "Failed to bind metrics server");
             }
         }
-    });
+    })
 }
 
 // ============================================================================

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -17,6 +17,7 @@ use crate::openapi::ApiDoc;
 use crate::pg_listener_config::resolve_pg_listener_database_url;
 use crate::server::{ServerConfig, build_router_with_prefix};
 use crate::storage::{EncryptionService, StorageBackend};
+use crate::supervised_task::{RestartPolicy, TaskSupervisor};
 use crate::{api, seed, services};
 
 use crate::middleware::RequestIdLayer;
@@ -62,6 +63,63 @@ type BackgroundTaskFn =
 
 type PersonalAccessTokenRoutesWrapFn = Box<dyn FnOnce(Router) -> Router + Send>;
 
+#[derive(Clone)]
+struct CoreDeps {
+    db: Arc<StorageBackend>,
+    runner: Arc<dyn AgentRunner>,
+    auth: auth::AuthState,
+    encryption: Option<Arc<EncryptionService>>,
+    event_delivery: EventDelivery,
+}
+
+impl CoreDeps {
+    fn new(
+        db: Arc<StorageBackend>,
+        runner: Arc<dyn AgentRunner>,
+        auth: auth::AuthState,
+        encryption: Option<Arc<EncryptionService>>,
+        event_delivery: EventDelivery,
+    ) -> Self {
+        Self {
+            db,
+            runner,
+            auth,
+            encryption,
+            event_delivery,
+        }
+    }
+}
+
+fn github_app_token_minter(
+    auth_config: &auth::AuthConfig,
+) -> Option<crate::storage::GitHubAppTokenMinter> {
+    auth_config.github_connection.as_ref().map(|config| {
+        crate::storage::GitHubAppTokenMinter::new(config.app_id.clone(), config.private_key.clone())
+    })
+}
+
+fn build_connection_resolver(
+    db: &Arc<StorageBackend>,
+    encryption: &Arc<EncryptionService>,
+    auth_config: &auth::AuthConfig,
+) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {
+    Arc::new(crate::storage::DbConnectionResolver::new(
+        db.as_ref().clone(),
+        encryption.as_ref().clone(),
+        github_app_token_minter(auth_config),
+    ))
+}
+
+fn optional_connection_resolver(
+    db: &Arc<StorageBackend>,
+    encryption: &Option<Arc<EncryptionService>>,
+    auth_config: &auth::AuthConfig,
+) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
+    encryption
+        .as_ref()
+        .map(|enc| build_connection_resolver(db, enc, auth_config))
+}
+
 struct ServerTaskNotifier {
     broadcaster: Arc<crate::task_notifications::TaskBroadcaster>,
 }
@@ -70,6 +128,136 @@ struct ServerTaskNotifier {
 impl DurableTaskNotifier for ServerTaskNotifier {
     async fn notify_task_available(&self, activity_type: &str) {
         self.broadcaster.notify_task_available(activity_type).await;
+    }
+}
+
+struct StorageInit {
+    db: Arc<StorageBackend>,
+    runner: Arc<dyn AgentRunner>,
+    shared_durable_store: Option<Arc<InMemoryWorkflowEventStore>>,
+    database_url: Option<String>,
+    database_unpooled_url: Option<String>,
+    task_broadcaster: Option<Arc<crate::task_notifications::TaskBroadcaster>>,
+}
+
+async fn init_storage(config: &ServerConfig, migrations: Vec<MigrationFn>) -> Result<StorageInit> {
+    let database_unpooled_url = std::env::var("DATABASE_UNPOOLED_URL").ok();
+
+    if config.dev_mode {
+        tracing::info!("Starting in DEV MODE (in-memory storage, no PostgreSQL required)");
+
+        let db = Arc::new(StorageBackend::in_memory());
+        let shared_store = Arc::new(InMemoryWorkflowEventStore::new());
+        let runner =
+            create_runner_with_backend(RunnerBackend::SharedInMemory(shared_store.clone()))
+                .await
+                .context("Failed to create in-memory agent runner")?;
+
+        tracing::info!(
+            "Using in-memory storage and durable execution engine with in-process worker"
+        );
+        return Ok(StorageInit {
+            db,
+            runner,
+            shared_durable_store: Some(shared_store),
+            database_url: None,
+            database_unpooled_url,
+            task_broadcaster: None,
+        });
+    }
+
+    let database_url =
+        std::env::var("DATABASE_URL").context("DATABASE_URL environment variable required")?;
+
+    // TM-NEW: Warn when DATABASE_URL lacks TLS in production.
+    if !database_url.contains("sslmode=") {
+        tracing::warn!(
+            "DATABASE_URL does not specify sslmode. \
+             For production, use sslmode=require or sslmode=verify-full \
+             to encrypt database connections."
+        );
+    } else if database_url.contains("sslmode=disable") {
+        tracing::warn!(
+            "DATABASE_URL has sslmode=disable — database connections are unencrypted. \
+             For production, use sslmode=require or sslmode=verify-full."
+        );
+    }
+
+    let backend = StorageBackend::postgres(&database_url)
+        .await
+        .context("Failed to connect to database")?;
+    tracing::info!("Connected to PostgreSQL database");
+
+    // Optional S3-compatible blob backend for file/image content offload
+    // (specs/object-storage.md). Defaults to inline PostgreSQL storage.
+    let blob_store = crate::storage::blob_store::blob_store_from_env()
+        .context("Invalid object-storage configuration (STORAGE_S3_*)")?;
+    let backend = backend.with_blob_store(blob_store);
+
+    if !config.no_migrations {
+        tracing::info!("Running database migrations...");
+        let pool = backend.pool().expect("PostgreSQL backend should have pool");
+        if let Err(e) = sqlx::migrate!("./migrations").run(pool).await {
+            tracing::error!(
+                error = %e,
+                "Database migration failed - check migration files and database state"
+            );
+            return Err(e)
+                .context("Database migration failed - check migration files and database state");
+        }
+        tracing::info!("Database migrations complete");
+
+        for migration_fn in migrations {
+            if let Err(e) = migration_fn(pool.clone()).await {
+                tracing::error!(error = %e, "Custom database migration failed");
+                return Err(e);
+            }
+        }
+    } else {
+        tracing::info!("Skipping database migrations (--no-migrations)");
+    }
+
+    let pool = backend
+        .pool()
+        .expect("PostgreSQL backend should have pool")
+        .clone();
+    let task_broadcaster = crate::task_notifications::TaskBroadcaster::from_env(
+        Some(database_url.as_str()),
+        database_unpooled_url.as_deref(),
+    )
+    .await
+    .map(Arc::new);
+    let runner_backend = if let Some(broadcaster) = task_broadcaster.clone() {
+        RunnerBackend::PostgresWithNotifier {
+            pool,
+            task_notifier: Arc::new(ServerTaskNotifier { broadcaster }),
+        }
+    } else {
+        RunnerBackend::Postgres(pool)
+    };
+    let runner = create_runner_with_backend(runner_backend)
+        .await
+        .context("Failed to create agent runner")?;
+
+    tracing::info!("Using Durable execution engine runner (PostgreSQL-backed)");
+    Ok(StorageInit {
+        db: Arc::new(backend),
+        runner,
+        shared_durable_store: None,
+        database_url: Some(database_url),
+        database_unpooled_url,
+        task_broadcaster,
+    })
+}
+
+fn spawn_background_tasks(
+    supervisor: &mut TaskSupervisor,
+    server_context: &ServerContext,
+    background_tasks: Vec<BackgroundTaskFn>,
+) {
+    for task_fn in background_tasks {
+        let ctx = server_context.clone();
+        supervisor.track("custom_background_task", tokio::spawn(task_fn(ctx)));
     }
 }
 
@@ -328,106 +516,20 @@ impl ServerAppBuilder {
                 .clone()
                 .unwrap_or_else(crate::platform::oss_platform_definition),
         );
+        let mut supervisor = TaskSupervisor::new();
 
         // =====================================================================
         // Phase 1: Storage backend & runner
         // =====================================================================
-        let database_unpooled_url = std::env::var("DATABASE_UNPOOLED_URL").ok();
-        let task_broadcaster: Option<Arc<crate::task_notifications::TaskBroadcaster>>;
-        let (db, runner, shared_durable_store, database_url) = if self.config.dev_mode {
-            tracing::info!("Starting in DEV MODE (in-memory storage, no PostgreSQL required)");
-
-            let db = Arc::new(StorageBackend::in_memory());
-            let shared_store = Arc::new(InMemoryWorkflowEventStore::new());
-            let runner =
-                create_runner_with_backend(RunnerBackend::SharedInMemory(shared_store.clone()))
-                    .await
-                    .context("Failed to create in-memory agent runner")?;
-            task_broadcaster = None;
-
-            tracing::info!(
-                "Using in-memory storage and durable execution engine with in-process worker"
-            );
-            (db, runner, Some(shared_store), None)
-        } else {
-            let database_url = std::env::var("DATABASE_URL")
-                .context("DATABASE_URL environment variable required")?;
-
-            // TM-NEW: Warn when DATABASE_URL lacks TLS in production
-            if !database_url.contains("sslmode=") {
-                tracing::warn!(
-                    "DATABASE_URL does not specify sslmode. \
-                     For production, use sslmode=require or sslmode=verify-full \
-                     to encrypt database connections."
-                );
-            } else if database_url.contains("sslmode=disable") {
-                tracing::warn!(
-                    "DATABASE_URL has sslmode=disable — database connections are unencrypted. \
-                     For production, use sslmode=require or sslmode=verify-full."
-                );
-            }
-
-            let backend = StorageBackend::postgres(&database_url)
-                .await
-                .context("Failed to connect to database")?;
-            tracing::info!("Connected to PostgreSQL database");
-
-            // Optional S3-compatible blob backend for file/image content offload
-            // (specs/object-storage.md). Defaults to inline PostgreSQL storage.
-            let blob_store = crate::storage::blob_store::blob_store_from_env()
-                .context("Invalid object-storage configuration (STORAGE_S3_*)")?;
-            let backend = backend.with_blob_store(blob_store);
-
-            if !self.config.no_migrations {
-                tracing::info!("Running database migrations...");
-                let pool = backend.pool().expect("PostgreSQL backend should have pool");
-                if let Err(e) = sqlx::migrate!("./migrations").run(pool).await {
-                    tracing::error!(
-                        error = %e,
-                        "Database migration failed - check migration files and database state"
-                    );
-                    return Err(e).context(
-                        "Database migration failed - check migration files and database state",
-                    );
-                }
-                tracing::info!("Database migrations complete");
-
-                // Run custom migrations
-                for migration_fn in self.migrations {
-                    if let Err(e) = migration_fn(pool.clone()).await {
-                        tracing::error!(error = %e, "Custom database migration failed");
-                        return Err(e);
-                    }
-                }
-            } else {
-                tracing::info!("Skipping database migrations (--no-migrations)");
-            }
-
-            let pool = backend
-                .pool()
-                .expect("PostgreSQL backend should have pool")
-                .clone();
-            task_broadcaster = crate::task_notifications::TaskBroadcaster::from_env(
-                Some(database_url.as_str()),
-                database_unpooled_url.as_deref(),
-            )
-            .await
-            .map(Arc::new);
-            let runner_backend = if let Some(broadcaster) = task_broadcaster.clone() {
-                RunnerBackend::PostgresWithNotifier {
-                    pool,
-                    task_notifier: Arc::new(ServerTaskNotifier { broadcaster }),
-                }
-            } else {
-                RunnerBackend::Postgres(pool)
-            };
-            let runner = create_runner_with_backend(runner_backend)
-                .await
-                .context("Failed to create agent runner")?;
-
-            tracing::info!("Using Durable execution engine runner (PostgreSQL-backed)");
-            (Arc::new(backend), runner, None, Some(database_url))
-        };
+        let migrations = self.migrations;
+        let StorageInit {
+            db,
+            runner,
+            shared_durable_store,
+            database_url,
+            database_unpooled_url,
+            task_broadcaster,
+        } = init_storage(&self.config, migrations).await?;
 
         // =====================================================================
         // Phase 2: Seed & infrastructure services
@@ -451,14 +553,17 @@ impl ServerAppBuilder {
         // Seed must run after encryption is resolved: single-tenant/dev seeding
         // materializes DEFAULT_*_API_KEY env vars into the default org's
         // provider rows (encrypted), which requires the encryption service.
-        seed::spawn_seed_task_with_platform_definition(
-            db.clone(),
-            seed::SeedAuthContext {
-                mode: auth_config.mode.clone(),
-                admin: auth_config.admin.clone(),
-            },
-            platform_definition.as_ref().clone(),
-            encryption.clone(),
+        supervisor.track(
+            "seed",
+            seed::spawn_seed_task_with_platform_definition(
+                db.clone(),
+                seed::SeedAuthContext {
+                    mode: auth_config.mode.clone(),
+                    admin: auth_config.admin.clone(),
+                },
+                platform_definition.as_ref().clone(),
+                encryption.clone(),
+            ),
         );
 
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
@@ -562,20 +667,8 @@ impl ServerAppBuilder {
                                 database.clone(),
                                 enc.as_ref().clone(),
                             ));
-                        let github_app_minter =
-                            auth_config.github_connection.as_ref().map(|config| {
-                                crate::storage::GitHubAppTokenMinter::new(
-                                    config.app_id.clone(),
-                                    config.private_key.clone(),
-                                )
-                            });
                         let connection_resolver =
-                            Some(Arc::new(crate::storage::DbConnectionResolver::new(
-                                db.as_ref().clone(),
-                                enc.as_ref().clone(),
-                                github_app_minter,
-                            ))
-                                as Arc<dyn everruns_core::traits::UserConnectionResolver>);
+                            Some(build_connection_resolver(&db, enc, &auth_config));
                         let service =
                             Arc::new(crate::domains::session_sandbox::SessionSandboxService::new(
                                 db.clone(),
@@ -597,20 +690,8 @@ impl ServerAppBuilder {
                     }
                 },
                 crate::storage::StorageBackend::InMemory(mem_db) => {
-                    let github_app_minter = auth_config.github_connection.as_ref().map(|config| {
-                        crate::storage::GitHubAppTokenMinter::new(
-                            config.app_id.clone(),
-                            config.private_key.clone(),
-                        )
-                    });
-                    let connection_resolver = encryption.as_ref().map(|enc| {
-                        Arc::new(crate::storage::DbConnectionResolver::new(
-                            db.as_ref().clone(),
-                            enc.as_ref().clone(),
-                            github_app_minter,
-                        ))
-                            as Arc<dyn everruns_core::traits::UserConnectionResolver>
-                    });
+                    let connection_resolver =
+                        optional_connection_resolver(&db, &encryption, &auth_config);
                     let service =
                         Arc::new(crate::domains::session_sandbox::SessionSandboxService::new(
                             db.clone(),
@@ -700,6 +781,13 @@ impl ServerAppBuilder {
         let sse_tracker = Arc::new(crate::api::sse::SseConnectionTracker::new(
             crate::api::sse::SseConnectionLimits::from_env(),
         ));
+        let core_deps = CoreDeps::new(
+            db.clone(),
+            runner.clone(),
+            auth_state.clone(),
+            encryption.clone(),
+            event_delivery.clone(),
+        );
 
         let event_broadcaster = if matches!(event_delivery, EventDelivery::Nats(_)) {
             tracing::info!(
@@ -778,17 +866,17 @@ impl ServerAppBuilder {
             )
         });
         let messages_state = api::messages::AppState::new(
-            db.clone(),
-            runner.clone(),
-            auth_state.clone(),
+            core_deps.db.clone(),
+            core_deps.runner.clone(),
+            core_deps.auth.clone(),
             notifications_enabled,
-            event_delivery.clone(),
+            core_deps.event_delivery.clone(),
         );
         let tool_results_state = api::tool_results::AppState::new(
-            db.clone(),
-            runner.clone(),
-            auth_state.clone(),
-            event_delivery.clone(),
+            core_deps.db.clone(),
+            core_deps.runner.clone(),
+            core_deps.auth.clone(),
+            core_deps.event_delivery.clone(),
         );
         // Slack delivery dispatcher: event-driven message posting (replaces 120s polling).
         // Must be created before events_state takes ownership of event_broadcaster.
@@ -842,27 +930,30 @@ impl ServerAppBuilder {
                     driver_registry.clone(),
                     provider_resolver.clone(),
                 ));
-            crate::domains::observers::spawn_observer_worker(
-                crate::domains::observers::ObserverWorkerDeps {
-                    db: db.clone(),
-                    judge: Some(judge),
-                },
-                observer_wake,
-                crate::domains::observers::ObserverWorkerConfig::default(),
+            supervisor.track(
+                "observer_scoring",
+                crate::domains::observers::spawn_observer_worker(
+                    crate::domains::observers::ObserverWorkerDeps {
+                        db: db.clone(),
+                        judge: Some(judge),
+                    },
+                    observer_wake,
+                    crate::domains::observers::ObserverWorkerConfig::default(),
+                ),
             );
             tracing::info!("Observers enabled: scoring worker started");
         }
 
         let providers_state = api::providers::AppState::new(
-            db.clone(),
-            encryption.clone(),
+            core_deps.db.clone(),
+            core_deps.encryption.clone(),
             driver_registry.clone(),
-            auth_state.clone(),
+            core_deps.auth.clone(),
             Some(provider_resolver.clone()),
         );
         let models_state = api::models::AppState::new(
-            db.clone(),
-            auth_state.clone(),
+            core_deps.db.clone(),
+            core_deps.auth.clone(),
             Some(provider_resolver.clone()),
         );
         let voice_state = api::voice::AppState::new(
@@ -1106,8 +1197,11 @@ impl ServerAppBuilder {
         )
         .with_virtual_registry(virtual_registry.clone());
         let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
-        let session_storage_state =
-            api::session_storage::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
+        let session_storage_state = api::session_storage::AppState::new(
+            core_deps.db.clone(),
+            core_deps.encryption.clone(),
+            core_deps.auth.clone(),
+        );
         let session_databases_state = api::session_databases::AppState::new(
             sqldb_store.clone(),
             db.clone(),
@@ -1497,7 +1591,10 @@ impl ServerAppBuilder {
         //  - otherwise → do not expose /metrics HTTP endpoint
         if let Some(ref handle) = prometheus_handle {
             if let Some(ref addr) = prometheus_config.metrics_addr {
-                api::prometheus::spawn_metrics_server(handle.clone(), addr.clone());
+                supervisor.track(
+                    "prometheus_metrics_server",
+                    api::prometheus::spawn_metrics_server(handle.clone(), addr.clone()),
+                );
             } else if prometheus_config.public_on_main {
                 app = app.merge(api::prometheus::route(handle.clone()));
             } else {
@@ -1641,48 +1738,78 @@ impl ServerAppBuilder {
 
             let grpc_task_broadcaster = task_broadcaster.clone();
             let grpc_virtual_registry = virtual_registry.clone();
+            let grpc_addr: std::net::SocketAddr = grpc_addr
+                .parse()
+                .context("Invalid SERVER_GRPC_BIND_ADDR/WORKER_GRPC_ADDR")?;
+            let grpc_token = grpc_service::require_grpc_auth_token_result()
+                .context("Invalid gRPC authentication configuration")?;
+            let grpc_tls_config = grpc_service::grpc_server_tls_from_env_result()
+                .context("Invalid gRPC TLS configuration")?;
+            if let Some(tls) = grpc_tls_config.clone() {
+                tonic::transport::Server::builder()
+                    .tls_config(tls)
+                    .context("Invalid gRPC TLS configuration")?;
+            }
 
-            tokio::spawn(async move {
-                let mut grpc_svc = grpc_service::WorkerServiceImpl::with_virtual_registry(
-                    (*grpc_event_service).clone(),
-                    grpc_db,
-                    grpc_encryption,
-                    Some(grpc_runner),
-                    grpc_platform_definition.as_ref().clone(),
-                    Some(grpc_virtual_registry),
-                    Some(grpc_provider_resolver),
-                );
-                if let Some(broadcaster) = grpc_task_broadcaster {
-                    grpc_svc.set_task_broadcaster(broadcaster);
-                }
-                grpc_svc.set_permission_resolver(grpc_permission_resolver);
-                // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
-                // Mitigation: Bearer token auth + optional mTLS
-                let grpc_token = grpc_service::require_grpc_auth_token();
-                let auth_interceptor = grpc_service::GrpcAuthInterceptor::new(Some(grpc_token));
-                let tls_config = grpc_service::grpc_server_tls_from_env();
-                let addr = grpc_addr
-                    .parse()
-                    .expect("Invalid SERVER_GRPC_BIND_ADDR/WORKER_GRPC_ADDR");
-                tracing::info!("gRPC server listening on {}", addr);
+            supervisor.spawn(
+                "grpc_server",
+                RestartPolicy::always_after(std::time::Duration::from_secs(5)),
+                move || {
+                    let grpc_event_service = grpc_event_service.clone();
+                    let grpc_db = grpc_db.clone();
+                    let grpc_encryption = grpc_encryption.clone();
+                    let grpc_runner = grpc_runner.clone();
+                    let grpc_platform_definition = grpc_platform_definition.clone();
+                    let grpc_provider_resolver = grpc_provider_resolver.clone();
+                    let grpc_permission_resolver = grpc_permission_resolver.clone();
+                    let grpc_task_broadcaster = grpc_task_broadcaster.clone();
+                    let grpc_virtual_registry = grpc_virtual_registry.clone();
+                    let grpc_token = grpc_token.clone();
+                    let grpc_tls_config = grpc_tls_config.clone();
 
-                let mut builder = tonic::transport::Server::builder();
-                if let Some(tls) = tls_config {
-                    builder = builder
-                        .tls_config(tls)
-                        .expect("Invalid gRPC TLS configuration");
-                }
-                if let Err(e) = builder
-                    .layer(tonic::service::interceptor::InterceptorLayer::new(
-                        auth_interceptor,
-                    ))
-                    .add_service(grpc_svc.into_server())
-                    .serve(addr)
-                    .await
-                {
-                    tracing::error!("gRPC server error: {}", e);
-                }
-            });
+                    async move {
+                        let mut grpc_svc = grpc_service::WorkerServiceImpl::with_virtual_registry(
+                            (*grpc_event_service).clone(),
+                            grpc_db,
+                            grpc_encryption,
+                            Some(grpc_runner),
+                            grpc_platform_definition.as_ref().clone(),
+                            Some(grpc_virtual_registry),
+                            Some(grpc_provider_resolver),
+                        );
+                        if let Some(broadcaster) = grpc_task_broadcaster {
+                            grpc_svc.set_task_broadcaster(broadcaster);
+                        }
+                        grpc_svc.set_permission_resolver(grpc_permission_resolver);
+                        // THREAT[TM-DURABLE-002]: gRPC unauthenticated access
+                        // Mitigation: Bearer token auth + optional mTLS validated before spawn.
+                        let auth_interceptor =
+                            grpc_service::GrpcAuthInterceptor::new(Some(grpc_token));
+                        tracing::info!("gRPC server listening on {}", grpc_addr);
+
+                        let mut builder = tonic::transport::Server::builder();
+                        if let Some(tls) = grpc_tls_config {
+                            match builder.tls_config(tls) {
+                                Ok(tls_builder) => builder = tls_builder,
+                                Err(e) => {
+                                    tracing::error!(error = %e, "Invalid gRPC TLS configuration");
+                                    return;
+                                }
+                            }
+                        }
+                        if let Err(e) = builder
+                            .layer(tonic::service::interceptor::InterceptorLayer::new(
+                                auth_interceptor,
+                            ))
+                            .add_service(grpc_svc.into_server())
+                            .serve(grpc_addr)
+                            .await
+                        {
+                            tracing::error!("gRPC server error: {}", e);
+                        }
+                    }
+                },
+            );
 
             // -- Stale task reclamation --
             {
@@ -1696,19 +1823,28 @@ impl ServerAppBuilder {
                     let reclaim_event_service = event_service.clone();
                     let reclaim_session_service = reclaim_session_service.clone();
 
-                    tokio::spawn(async move {
-                        let store = PostgresWorkflowEventStore::new(pool);
-                        let mut interval = tokio::time::interval(reclaim_interval);
+                    supervisor.spawn(
+                        "stale_task_reclaim",
+                        RestartPolicy::always_after(Duration::from_secs(5)),
+                        move || {
+                            let pool = pool.clone();
+                            let reclaim_error_reporter = reclaim_error_reporter.clone();
+                            let reclaim_event_service = reclaim_event_service.clone();
+                            let reclaim_session_service = reclaim_session_service.clone();
 
-                        tracing::info!(
-                            stale_threshold_secs = stale_threshold.as_secs(),
-                            reclaim_interval_secs = reclaim_interval.as_secs(),
-                            "Started stale task reclamation background task"
-                        );
+                            async move {
+                                let store = PostgresWorkflowEventStore::new(pool);
+                                let mut interval = tokio::time::interval(reclaim_interval);
 
-                        loop {
-                            interval.tick().await;
-                            match store.reclaim_stale_tasks(stale_threshold).await {
+                                tracing::info!(
+                                    stale_threshold_secs = stale_threshold.as_secs(),
+                                    reclaim_interval_secs = reclaim_interval.as_secs(),
+                                    "Started stale task reclamation background task"
+                                );
+
+                                loop {
+                                    interval.tick().await;
+                                    match store.reclaim_stale_tasks(stale_threshold).await {
                                 Ok(result) => {
                                     if !result.reclaimed_ids.is_empty() {
                                         tracing::info!(
@@ -1797,9 +1933,11 @@ impl ServerAppBuilder {
                                             .await;
                                     });
                                 }
+                                    }
+                                }
                             }
-                        }
-                    });
+                        },
+                    );
                 }
             }
 
@@ -1820,58 +1958,67 @@ impl ServerAppBuilder {
                     ));
                     let sync_interval = Duration::from_secs(sync_interval_hours * 3600);
 
-                    tokio::spawn(async move {
-                        let mut interval = tokio::time::interval(sync_interval);
-                        interval.tick().await;
+                    supervisor.spawn(
+                        "model_sync",
+                        RestartPolicy::always_after(Duration::from_secs(5)),
+                        move || {
+                            let sync_service = sync_service.clone();
+                            async move {
+                                let mut interval = tokio::time::interval(sync_interval);
+                                interval.tick().await;
 
-                        tracing::info!(
-                            interval_hours = sync_interval_hours,
-                            "Started model discovery sync background task"
-                        );
+                                tracing::info!(
+                                    interval_hours = sync_interval_hours,
+                                    "Started model discovery sync background task"
+                                );
 
-                        loop {
-                            interval.tick().await;
-                            tracing::info!("Starting scheduled model sync for all providers");
+                                loop {
+                                    interval.tick().await;
+                                    tracing::info!(
+                                        "Starting scheduled model sync for all providers"
+                                    );
 
-                            match sync_service.sync_all().await {
-                                Ok(results) => {
-                                    for (provider_id, result) in results {
-                                        match result {
-                                            services::SyncResult::Success {
-                                                created,
-                                                updated,
-                                                stale,
-                                            } => {
-                                                tracing::info!(
-                                                    %provider_id,
-                                                    created,
-                                                    updated,
-                                                    stale,
-                                                    "Model sync completed for provider"
-                                                );
+                                    match sync_service.sync_all().await {
+                                        Ok(results) => {
+                                            for (provider_id, result) in results {
+                                                match result {
+                                                    services::SyncResult::Success {
+                                                        created,
+                                                        updated,
+                                                        stale,
+                                                    } => {
+                                                        tracing::info!(
+                                                            %provider_id,
+                                                            created,
+                                                            updated,
+                                                            stale,
+                                                            "Model sync completed for provider"
+                                                        );
+                                                    }
+                                                    services::SyncResult::NotSupported => {
+                                                        tracing::debug!(
+                                                            %provider_id,
+                                                            "Model sync not supported for provider"
+                                                        );
+                                                    }
+                                                    services::SyncResult::Failed { error } => {
+                                                        tracing::warn!(
+                                                            %provider_id,
+                                                            %error,
+                                                            "Model sync failed for provider"
+                                                        );
+                                                    }
+                                                }
                                             }
-                                            services::SyncResult::NotSupported => {
-                                                tracing::debug!(
-                                                    %provider_id,
-                                                    "Model sync not supported for provider"
-                                                );
-                                            }
-                                            services::SyncResult::Failed { error } => {
-                                                tracing::warn!(
-                                                    %provider_id,
-                                                    %error,
-                                                    "Model sync failed for provider"
-                                                );
-                                            }
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to run model sync: {}", e);
                                         }
                                     }
                                 }
-                                Err(e) => {
-                                    tracing::error!("Failed to run model sync: {}", e);
-                                }
                             }
-                        }
-                    });
+                        },
+                    );
                 } else {
                     tracing::info!(
                         "Model sync background task disabled (MODEL_SYNC_INTERVAL_HOURS=0)"
@@ -1882,16 +2029,22 @@ impl ServerAppBuilder {
             // -- Event retention --
             if let Some(pool) = db.pool() {
                 let retention_days = crate::event_retention::retention_days_from_env();
-                crate::event_retention::spawn_retention_task(pool.clone(), retention_days);
+                supervisor.track_optional(
+                    "event_retention",
+                    crate::event_retention::spawn_retention_task(pool.clone(), retention_days),
+                );
             }
 
             // -- Object-storage blob GC --
             // Reconciles bucket contents against the sidecar pointer tables and
             // reclaims orphaned objects. No-ops for the inline (db) backend
             // (no external objects to collect). See specs/object-storage.md.
-            crate::blob_gc::spawn_blob_gc_task(
-                db.clone(),
-                crate::blob_gc::BlobGcConfig::from_env(),
+            supervisor.track_optional(
+                "blob_gc",
+                crate::blob_gc::spawn_blob_gc_task(
+                    db.clone(),
+                    crate::blob_gc::BlobGcConfig::from_env(),
+                ),
             );
         } else {
             // DEV MODE: Start in-process task worker
@@ -1952,31 +2105,26 @@ impl ServerAppBuilder {
                 // slot empty — `runtime_host::connection_resolver()` always calls into the
                 // adapter at runtime and would otherwise panic.
                 let connection_resolver: Arc<dyn everruns_core::traits::UserConnectionResolver> =
-                    if let Some(ref enc) = encryption {
-                        let github_app_minter =
-                            auth_config.github_connection.as_ref().map(|config| {
-                                crate::storage::GitHubAppTokenMinter::new(
-                                    config.app_id.clone(),
-                                    config.private_key.clone(),
-                                )
-                            });
-                        Arc::new(crate::storage::DbConnectionResolver::new(
-                            db.as_ref().clone(),
-                            enc.as_ref().clone(),
-                            github_app_minter,
-                        ))
-                    } else {
-                        Arc::new(crate::storage::NoopConnectionResolver)
-                    };
+                    optional_connection_resolver(&db, &encryption, &auth_config)
+                        .unwrap_or_else(|| Arc::new(crate::storage::NoopConnectionResolver));
                 adapters = adapters.with_connection_resolver(connection_resolver);
 
                 let worker_config = TaskWorkerConfig::dev_mode();
-                tokio::spawn(async move {
-                    let mut worker = TaskWorker::new(worker_config, shared_store, adapters);
-                    if let Err(e) = worker.run().await {
-                        tracing::error!("Task worker error: {}", e);
-                    }
-                });
+                supervisor.spawn(
+                    "dev_task_worker",
+                    RestartPolicy::always_after(std::time::Duration::from_secs(5)),
+                    move || {
+                        let worker_config = worker_config.clone();
+                        let shared_store = shared_store.clone();
+                        let adapters = adapters.clone();
+                        async move {
+                            let mut worker = TaskWorker::new(worker_config, shared_store, adapters);
+                            if let Err(e) = worker.run().await {
+                                tracing::error!("Task worker error: {}", e);
+                            }
+                        }
+                    },
+                );
 
                 tracing::info!("DEV MODE: Task worker started - server is fully functional");
             } else {
@@ -1988,9 +2136,12 @@ impl ServerAppBuilder {
         if let Some(ref dispatcher) = slack_dispatcher {
             let dispatcher = dispatcher.clone();
             let recovery_enc = encryption.clone();
-            tokio::spawn(async move {
-                dispatcher.recover(recovery_enc.as_ref()).await;
-            });
+            supervisor.track(
+                "slack_delivery_recovery",
+                tokio::spawn(async move {
+                    dispatcher.recover(recovery_enc.as_ref()).await;
+                }),
+            );
         }
 
         // -- Agent health-check reaper (both prod and dev) --
@@ -2033,64 +2184,66 @@ impl ServerAppBuilder {
         }
 
         // -- Tool result timeout sweep (both prod and dev) --
-        crate::tool_result_timeout::spawn_tool_result_timeout_sweep(
-            db.clone(),
-            runner.clone(),
-            event_delivery.clone(),
+        supervisor.track(
+            "tool_result_timeout_sweep",
+            crate::tool_result_timeout::spawn_tool_result_timeout_sweep(
+                db.clone(),
+                runner.clone(),
+                event_delivery.clone(),
+            ),
         );
 
         // -- Session schedule poller (both prod and dev) --
         // Provide a built-in probe registry so monitors with a `spec["tool"]`
         // can run their probe directly without delegating to an agent turn.
         let probe_registry = std::sync::Arc::new(everruns_core::ToolRegistry::with_defaults());
-        crate::session_scheduler::spawn_session_scheduler(
-            db.clone(),
-            session_schedule_service,
-            event_service,
-            runner,
-            Some(probe_registry),
-            std::time::Duration::from_secs(15),
+        supervisor.track(
+            "session_scheduler",
+            crate::session_scheduler::spawn_session_scheduler(
+                db.clone(),
+                session_schedule_service,
+                event_service,
+                runner,
+                Some(probe_registry),
+                std::time::Duration::from_secs(15),
+            ),
         );
 
         // -- Source-backed Memory sync (both prod and dev) --
-        let memory_connection_resolver = encryption.as_ref().map(|enc| {
-            let github_app_minter = auth_config.github_connection.as_ref().map(|config| {
-                crate::storage::GitHubAppTokenMinter::new(
-                    config.app_id.clone(),
-                    config.private_key.clone(),
-                )
-            });
-            Arc::new(crate::storage::DbConnectionResolver::new(
-                db.as_ref().clone(),
-                enc.as_ref().clone(),
-                github_app_minter,
-            )) as Arc<dyn everruns_core::traits::UserConnectionResolver>
-        });
-        crate::domains::memory::source_sync::spawn_memory_source_sync_task(
-            db.clone(),
-            memory_connection_resolver.clone(),
+        let memory_connection_resolver =
+            optional_connection_resolver(&db, &encryption, &auth_config);
+        supervisor.track_optional(
+            "memory_source_sync",
+            crate::domains::memory::source_sync::spawn_memory_source_sync_task(
+                db.clone(),
+                memory_connection_resolver.clone(),
+            ),
         );
 
         // -- Knowledge Index Syncout (both prod and dev) --
         // Reuses the same GitHub connection resolver as Memory sync, plus the
         // shared provider resolver / driver registry (for embeddings) and the
         // platform-selected vector store. See specs/knowledge-indexes.md.
-        crate::domains::knowledge_indexes::source_sync::spawn_knowledge_index_sync_task(
-            db.clone(),
-            memory_connection_resolver,
-            provider_resolver.clone(),
-            driver_registry.clone(),
-            platform_definition.vector_store(),
+        supervisor.track_optional(
+            "knowledge_index_sync",
+            crate::domains::knowledge_indexes::source_sync::spawn_knowledge_index_sync_task(
+                db.clone(),
+                memory_connection_resolver,
+                provider_resolver.clone(),
+                driver_registry.clone(),
+                platform_definition.vector_store(),
+            ),
         );
 
         // -- Reporting projection and missing-work reconciliation (both prod and dev) --
-        crate::domains::reporting::background::spawn_reporting_background_task(db.clone());
+        for handle in
+            crate::domains::reporting::background::spawn_reporting_background_task(db.clone())
+        {
+            supervisor.track("reporting_background", handle);
+        }
 
         // -- Custom background tasks --
-        for task_fn in self.background_tasks {
-            let ctx = server_context.clone();
-            tokio::spawn(task_fn(ctx));
-        }
+        spawn_background_tasks(&mut supervisor, &server_context, self.background_tasks);
 
         // =====================================================================
         // Phase 8: Start HTTP server

--- a/crates/server/src/blob_gc.rs
+++ b/crates/server/src/blob_gc.rs
@@ -32,6 +32,7 @@ use sqlx::PgPool;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 /// Default interval between GC sweeps (6 hours). Orphans are harmless besides
@@ -320,19 +321,19 @@ async fn sweep_with_live_keys(
 /// in-memory dev backend or a PostgreSQL deployment running the default inline
 /// (`db`) storage. Those backends keep bytes inline in PostgreSQL and have no
 /// external objects, so there is nothing to garbage-collect.
-pub fn spawn_blob_gc_task(db: Arc<StorageBackend>, config: BlobGcConfig) {
+pub fn spawn_blob_gc_task(db: Arc<StorageBackend>, config: BlobGcConfig) -> Option<JoinHandle<()>> {
     let Some(blob_store) = db.blob_store() else {
         debug!("Blob GC disabled: no object-storage backend (inline/db storage has no orphans)");
-        return;
+        return None;
     };
     let Some(pool) = db.pool().cloned() else {
         // Object-storage is only wired on the PostgreSQL backend; defensive.
         debug!("Blob GC disabled: no PostgreSQL pool");
-        return;
+        return None;
     };
     if !config.enabled() {
         info!("Blob GC disabled (STORAGE_BLOB_GC_INTERVAL_SECONDS=0)");
-        return;
+        return None;
     }
 
     info!(
@@ -343,7 +344,7 @@ pub fn spawn_blob_gc_task(db: Arc<StorageBackend>, config: BlobGcConfig) {
         "Starting object-storage blob GC background task"
     );
 
-    tokio::spawn(async move {
+    Some(tokio::spawn(async move {
         let mut ticker = tokio::time::interval(config.interval);
         ticker.tick().await; // skip the immediate first tick
 
@@ -360,7 +361,7 @@ pub fn spawn_blob_gc_task(db: Arc<StorageBackend>, config: BlobGcConfig) {
                 }
             }
         }
-    });
+    }))
 }
 
 #[cfg(test)]

--- a/crates/server/src/domains/knowledge_indexes/source_sync.rs
+++ b/crates/server/src/domains/knowledge_indexes/source_sync.rs
@@ -24,6 +24,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 use tokio::task;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::services::ProviderResolverService;
@@ -377,16 +378,16 @@ pub fn spawn_knowledge_index_sync_task(
     provider_resolver: Arc<ProviderResolverService>,
     driver_registry: Arc<DriverRegistry>,
     vector_store: Arc<dyn VectorStore>,
-) {
+) -> Option<JoinHandle<()>> {
     if !env_bool("KNOWLEDGE_INDEX_SYNC_ENABLED", true) {
         tracing::info!("Knowledge index sync background task disabled");
-        return;
+        return None;
     }
 
     let config = KnowledgeIndexSyncConfig::from_env();
     if config.poll_interval.is_zero() {
         tracing::info!("Knowledge index sync background task disabled by zero interval");
-        return;
+        return None;
     }
 
     let service = KnowledgeIndexSyncService::new(
@@ -397,7 +398,7 @@ pub fn spawn_knowledge_index_sync_task(
         vector_store,
         config.clone(),
     );
-    tokio::spawn(async move {
+    Some(tokio::spawn(async move {
         let mut interval = tokio::time::interval(config.poll_interval);
         tracing::info!(
             interval_secs = config.poll_interval.as_secs(),
@@ -427,7 +428,7 @@ pub fn spawn_knowledge_index_sync_task(
                 }
             }
         }
-    });
+    }))
 }
 
 // ============================================================================

--- a/crates/server/src/domains/memory/source_sync.rs
+++ b/crates/server/src/domains/memory/source_sync.rs
@@ -8,6 +8,7 @@ use git2::{AutotagOption, Cred, FetchOptions, RemoteCallbacks, build::RepoBuilde
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 use tokio::task;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::domains::memory::types::{
@@ -133,20 +134,20 @@ impl VolumeSourceSyncService {
 pub fn spawn_memory_source_sync_task(
     db: Arc<StorageBackend>,
     connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
-) {
+) -> Option<JoinHandle<()>> {
     if !env_bool("VOLUME_SOURCE_SYNC_ENABLED", true) {
         tracing::info!("Memory source sync background task disabled");
-        return;
+        return None;
     }
 
     let config = VolumeSourceSyncConfig::from_env();
     if config.poll_interval.is_zero() {
         tracing::info!("Memory source sync background task disabled by zero interval");
-        return;
+        return None;
     }
 
     let service = VolumeSourceSyncService::new(db, connection_resolver, config.clone());
-    tokio::spawn(async move {
+    Some(tokio::spawn(async move {
         let mut interval = tokio::time::interval(config.poll_interval);
         tracing::info!(
             interval_secs = config.poll_interval.as_secs(),
@@ -174,7 +175,7 @@ pub fn spawn_memory_source_sync_task(
                 }
             }
         }
-    });
+    }))
 }
 
 async fn snapshot_memory_source(

--- a/crates/server/src/domains/observers/worker.rs
+++ b/crates/server/src/domains/observers/worker.rs
@@ -8,6 +8,7 @@
 
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 
 use everruns_core::eval::Score;
 use everruns_core::observer::{ObserverScorerConfig, ScorerMethod};
@@ -59,7 +60,7 @@ pub fn spawn_observer_worker(
     deps: ObserverWorkerDeps,
     wake: Arc<tokio::sync::Notify>,
     config: ObserverWorkerConfig,
-) {
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         tracing::info!("Observer scoring worker started");
         loop {
@@ -85,7 +86,7 @@ pub fn spawn_observer_worker(
                 _ = tokio::time::sleep(config.poll_interval) => {}
             }
         }
-    });
+    })
 }
 
 /// Claim and score one batch. Returns the number of scores processed.

--- a/crates/server/src/domains/reporting/background.rs
+++ b/crates/server/src/domains/reporting/background.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 
 use crate::domains::reporting::ReportingService;
 use crate::storage::StorageBackend;
@@ -34,28 +35,29 @@ impl ReportingBackgroundConfig {
     }
 }
 
-pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) {
+pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) -> Vec<JoinHandle<()>> {
     if !env_bool("REPORTING_BACKGROUND_ENABLED", true) {
         tracing::info!("Reporting background task disabled");
-        return;
+        return Vec::new();
     }
 
     if !matches!(db.as_ref(), StorageBackend::Postgres(_)) {
         tracing::debug!("Reporting background task disabled for non-Postgres storage");
-        return;
+        return Vec::new();
     }
 
     let config = ReportingBackgroundConfig::from_env();
     if config.projector_interval.is_zero() && config.backfill_interval.is_zero() {
         tracing::info!("Reporting background task disabled by zero intervals");
-        return;
+        return Vec::new();
     }
 
+    let mut handles = Vec::new();
     if !config.projector_interval.is_zero() {
         let service = ReportingService::new(db.clone());
         let interval_secs = config.projector_interval.as_secs();
         let limit = config.projector_limit;
-        tokio::spawn(async move {
+        handles.push(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
             tracing::info!(
                 interval_secs,
@@ -80,14 +82,14 @@ pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) {
                     }
                 }
             }
-        });
+        }));
     }
 
     if !config.backfill_interval.is_zero() {
         let service = ReportingService::new(db);
         let interval_secs = config.backfill_interval.as_secs();
         let limit = config.backfill_limit;
-        tokio::spawn(async move {
+        handles.push(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
             tracing::info!(
                 interval_secs,
@@ -114,8 +116,10 @@ pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) {
                     }
                 }
             }
-        });
+        }));
     }
+
+    handles
 }
 
 fn env_bool(name: &str, default: bool) -> bool {

--- a/crates/server/src/event_retention.rs
+++ b/crates/server/src/event_retention.rs
@@ -5,6 +5,7 @@
 
 use sqlx::PgPool;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
 /// Default retention period in days (0 = disabled)
@@ -23,10 +24,10 @@ pub fn retention_days_from_env() -> u64 {
 
 /// Spawn the event retention background task.
 /// Runs every hour and archives events older than the configured retention period.
-pub fn spawn_retention_task(pool: PgPool, retention_days: u64) {
+pub fn spawn_retention_task(pool: PgPool, retention_days: u64) -> Option<JoinHandle<()>> {
     if retention_days == 0 {
         info!("Event retention disabled (EVENT_RETENTION_DAYS=0 or unset)");
-        return;
+        return None;
     }
 
     info!(
@@ -34,7 +35,7 @@ pub fn spawn_retention_task(pool: PgPool, retention_days: u64) {
         "Starting event retention background task"
     );
 
-    tokio::spawn(async move {
+    Some(tokio::spawn(async move {
         let interval = Duration::from_secs(3600); // 1 hour
         let mut ticker = tokio::time::interval(interval);
         ticker.tick().await; // skip first immediate tick
@@ -58,7 +59,7 @@ pub fn spawn_retention_task(pool: PgPool, retention_days: u64) {
                 }
             }
         }
-    });
+    }))
 }
 
 /// Archive events older than `retention_days` from `events` to `archived_events`.

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -290,12 +290,19 @@ pub fn grpc_auth_token_from_env() -> Option<String> {
 /// TM-DURABLE-002: Validate that WORKER_GRPC_AUTH_TOKEN is set in production.
 /// Panics if the token is missing when not in dev mode.
 pub fn require_grpc_auth_token() -> String {
-    grpc_auth_token_from_env().unwrap_or_else(|| {
-        panic!(
+    require_grpc_auth_token_result().unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Fallible variant used by server startup so invalid infrastructure config
+/// fails before the gRPC server is spawned.
+pub fn require_grpc_auth_token_result() -> anyhow::Result<String> {
+    match grpc_auth_token_from_env() {
+        Some(token) => Ok(token),
+        None => anyhow::bail!(
             "WORKER_GRPC_AUTH_TOKEN must be set when not in dev mode. \
              Without it, gRPC endpoints are unauthenticated."
-        )
-    })
+        ),
+    }
 }
 
 /// Build server-side TLS config from environment variables for mutual TLS (mTLS).
@@ -306,19 +313,32 @@ pub fn require_grpc_auth_token() -> String {
 ///
 /// Returns `None` when TLS env vars are not configured (plain HTTP/2).
 pub fn grpc_server_tls_from_env() -> Option<tonic::transport::ServerTlsConfig> {
+    grpc_server_tls_from_env_result().unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Fallible variant used by server startup to validate TLS material before
+/// spawning the gRPC server task.
+pub fn grpc_server_tls_from_env_result() -> anyhow::Result<Option<tonic::transport::ServerTlsConfig>>
+{
     use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 
     let cert_path = std::env::var("WORKER_GRPC_TLS_CERT")
         .ok()
-        .filter(|s| !s.is_empty())?;
+        .filter(|s| !s.is_empty());
+    let Some(cert_path) = cert_path else {
+        return Ok(None);
+    };
     let key_path = std::env::var("WORKER_GRPC_TLS_KEY")
         .ok()
-        .filter(|s| !s.is_empty())?;
+        .filter(|s| !s.is_empty());
+    let Some(key_path) = key_path else {
+        return Ok(None);
+    };
 
     let cert_pem = std::fs::read_to_string(&cert_path)
-        .unwrap_or_else(|e| panic!("Failed to read WORKER_GRPC_TLS_CERT at {cert_path}: {e}"));
+        .map_err(|e| anyhow::anyhow!("Failed to read WORKER_GRPC_TLS_CERT at {cert_path}: {e}"))?;
     let key_pem = std::fs::read_to_string(&key_path)
-        .unwrap_or_else(|e| panic!("Failed to read WORKER_GRPC_TLS_KEY at {key_path}: {e}"));
+        .map_err(|e| anyhow::anyhow!("Failed to read WORKER_GRPC_TLS_KEY at {key_path}: {e}"))?;
 
     let identity = Identity::from_pem(cert_pem, key_pem);
     let mut tls = ServerTlsConfig::new().identity(identity);
@@ -328,15 +348,16 @@ pub fn grpc_server_tls_from_env() -> Option<tonic::transport::ServerTlsConfig> {
         .ok()
         .filter(|s| !s.is_empty())
     {
-        let ca_pem = std::fs::read_to_string(&ca_path)
-            .unwrap_or_else(|e| panic!("Failed to read WORKER_GRPC_TLS_CA_CERT at {ca_path}: {e}"));
+        let ca_pem = std::fs::read_to_string(&ca_path).map_err(|e| {
+            anyhow::anyhow!("Failed to read WORKER_GRPC_TLS_CA_CERT at {ca_path}: {e}")
+        })?;
         tls = tls.client_ca_root(Certificate::from_pem(ca_pem));
         tracing::info!("gRPC mTLS enabled: server cert + client CA verification");
     } else {
         tracing::info!("gRPC TLS enabled: server cert only (no client verification)");
     }
 
-    Some(tls)
+    Ok(Some(tls))
 }
 
 /// Tonic interceptor that validates bearer token on every gRPC request.

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -651,6 +651,19 @@ fn test_require_grpc_auth_token_panics_without_env() {
 }
 
 #[test]
+fn test_require_grpc_auth_token_result_errors_without_env() {
+    let _lock = lock_env();
+    unsafe { std::env::remove_var("WORKER_GRPC_AUTH_TOKEN") };
+
+    let error = require_grpc_auth_token_result().expect_err("missing token should error");
+    assert!(
+        error
+            .to_string()
+            .contains("WORKER_GRPC_AUTH_TOKEN must be set")
+    );
+}
+
+#[test]
 fn test_require_grpc_auth_token_returns_value() {
     let _lock = lock_env();
     unsafe { std::env::set_var("WORKER_GRPC_AUTH_TOKEN", "test-token-123") };
@@ -672,6 +685,28 @@ fn test_grpc_server_tls_returns_none_when_no_env_vars() {
         config.is_none(),
         "Should return None when TLS not configured"
     );
+}
+
+#[test]
+fn test_grpc_server_tls_result_errors_on_missing_cert_file() {
+    let _lock = lock_env();
+    unsafe {
+        std::env::set_var("WORKER_GRPC_TLS_CERT", "/nonexistent/cert.pem");
+        std::env::set_var("WORKER_GRPC_TLS_KEY", "/nonexistent/key.pem");
+        std::env::remove_var("WORKER_GRPC_TLS_CA_CERT");
+    }
+
+    let error = grpc_server_tls_from_env_result().expect_err("missing cert should error");
+    assert!(
+        error
+            .to_string()
+            .contains("Failed to read WORKER_GRPC_TLS_CERT")
+    );
+
+    unsafe {
+        std::env::remove_var("WORKER_GRPC_TLS_CERT");
+        std::env::remove_var("WORKER_GRPC_TLS_KEY");
+    }
 }
 
 #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -113,6 +113,9 @@ pub mod session_scheduler;
 // Session-task orphan reconciler schedule seeder
 pub mod session_task_reaper_scheduler;
 
+// Retained background-task supervision for server-owned control-plane loops
+pub mod supervised_task;
+
 // Background sweep: time out sessions stuck in waiting_for_tool_results
 pub mod tool_result_timeout;
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -23,6 +23,7 @@ use everruns_core::{
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 /// Well-known UUIDs for seed data
@@ -2366,13 +2367,13 @@ pub struct SeedAuthContext {
 /// Seeding failures are non-fatal - logged as warnings but don't crash the server.
 ///
 /// Uses `DeploymentGrade::from_env()` to determine which agents to seed.
-pub fn spawn_seed_task(db: Arc<StorageBackend>, auth_ctx: SeedAuthContext) {
+pub fn spawn_seed_task(db: Arc<StorageBackend>, auth_ctx: SeedAuthContext) -> JoinHandle<()> {
     spawn_seed_task_with_platform_definition(
         db,
         auth_ctx,
         crate::platform::oss_platform_definition_for_grade(DeploymentGrade::from_env()),
         None,
-    );
+    )
 }
 
 /// Spawn seeding as a background task using an explicit platform definition.
@@ -2388,7 +2389,7 @@ pub fn spawn_seed_task_with_platform_definition(
     auth_ctx: SeedAuthContext,
     platform_definition: PlatformDefinition,
     encryption: Option<Arc<EncryptionService>>,
-) {
+) -> JoinHandle<()> {
     let grade = DeploymentGrade::from_env();
     tracing::info!(deployment_grade = %grade, "Starting seeding task");
 
@@ -2458,7 +2459,7 @@ pub fn spawn_seed_task_with_platform_definition(
                 );
             }
         }
-    });
+    })
 }
 
 /// Reconcile built-in harnesses for every organization (including the default org).

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -37,6 +37,7 @@ use everruns_worker::AgentRunner;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 /// How often the orphaned-monitor reconciliation sweep runs regardless of the
@@ -63,7 +64,7 @@ pub fn spawn_session_scheduler(
     runner: Arc<dyn AgentRunner>,
     probe_tool_registry: Option<Arc<ToolRegistry>>,
     poll_interval: Duration,
-) {
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(poll_interval);
         // Skip the immediate first tick — let the server finish starting.
@@ -103,7 +104,7 @@ pub fn spawn_session_scheduler(
                 last_sweep = Some(std::time::Instant::now());
             }
         }
-    });
+    })
 }
 
 /// One iteration of the poll loop.

--- a/crates/server/src/supervised_task.rs
+++ b/crates/server/src/supervised_task.rs
@@ -1,0 +1,172 @@
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::time::Duration;
+
+use futures_util::FutureExt;
+use tokio::task::JoinHandle;
+
+/// Restart behavior for a supervised task.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RestartPolicy {
+    /// Log task termination and keep the handle for shutdown aborts, but do not
+    /// restart it.
+    Never,
+    /// Restart after any normal return or panic. Long-lived server control-plane
+    /// loops use this so one panic does not permanently disable a subsystem.
+    Always { delay: Duration },
+}
+
+impl RestartPolicy {
+    pub const fn always_after(delay: Duration) -> Self {
+        Self::Always { delay }
+    }
+}
+
+#[derive(Debug)]
+struct SupervisedTaskHandle {
+    name: &'static str,
+    handle: JoinHandle<()>,
+}
+
+/// Retains handles for server-owned background tasks.
+///
+/// Dropping the supervisor aborts any still-running task, which gives startup
+/// phases a single owner for background work instead of scattering detached
+/// `tokio::spawn` calls throughout `app_builder`.
+#[derive(Default, Debug)]
+pub struct TaskSupervisor {
+    handles: Vec<SupervisedTaskHandle>,
+}
+
+impl TaskSupervisor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn track(&mut self, name: &'static str, handle: JoinHandle<()>) {
+        self.handles.push(SupervisedTaskHandle { name, handle });
+    }
+
+    pub fn track_optional(&mut self, name: &'static str, handle: Option<JoinHandle<()>>) {
+        if let Some(handle) = handle {
+            self.track(name, handle);
+        }
+    }
+
+    pub fn spawn<F, Fut>(&mut self, name: &'static str, restart: RestartPolicy, mut task: F)
+    where
+        F: FnMut() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let handle = tokio::spawn(async move {
+            loop {
+                let result = AssertUnwindSafe(task()).catch_unwind().await;
+                metrics::counter!("server_background_task_exits_total", "task" => name)
+                    .increment(1);
+
+                match result {
+                    Ok(()) => tracing::warn!(task = name, "Supervised background task exited"),
+                    Err(_) => {
+                        metrics::counter!("server_background_task_panics_total", "task" => name)
+                            .increment(1);
+                        tracing::error!(task = name, "Supervised background task panicked");
+                    }
+                }
+
+                match restart {
+                    RestartPolicy::Never => break,
+                    RestartPolicy::Always { delay } => {
+                        metrics::counter!("server_background_task_restarts_total", "task" => name)
+                            .increment(1);
+                        tracing::warn!(
+                            task = name,
+                            restart_delay_ms = delay.as_millis() as u64,
+                            "Restarting supervised background task"
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+            }
+        });
+        self.track(name, handle);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.handles.len()
+    }
+}
+
+impl Drop for TaskSupervisor {
+    fn drop(&mut self) {
+        for task in &self.handles {
+            if !task.handle.is_finished() {
+                tracing::info!(task = task.name, "Aborting supervised background task");
+                task.handle.abort();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    #[tokio::test]
+    async fn tracks_spawned_handles() {
+        let mut supervisor = TaskSupervisor::new();
+        supervisor.track("test", tokio::spawn(async {}));
+        assert_eq!(supervisor.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn restarts_panicking_tasks_when_configured() {
+        let mut supervisor = TaskSupervisor::new();
+        let runs = Arc::new(AtomicUsize::new(0));
+        let runs_for_task = runs.clone();
+
+        supervisor.spawn(
+            "restart-test",
+            RestartPolicy::always_after(Duration::from_millis(1)),
+            move || {
+                let runs = runs_for_task.clone();
+                async move {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    panic!("intentional test panic");
+                }
+            },
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while runs.load(Ordering::SeqCst) < 2 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("supervisor should restart a panicking task");
+    }
+
+    #[tokio::test]
+    async fn drop_aborts_tracked_task() {
+        let mut supervisor = TaskSupervisor::new();
+        let handle = tokio::spawn(async {
+            futures::future::pending::<()>().await;
+        });
+        let abort_handle = handle.abort_handle();
+
+        supervisor.track("pending", handle);
+        drop(supervisor);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !abort_handle.is_finished() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("tracked task should be aborted when supervisor drops");
+    }
+}

--- a/crates/server/src/tool_result_timeout.rs
+++ b/crates/server/src/tool_result_timeout.rs
@@ -11,6 +11,7 @@ use everruns_core::events::{
 use everruns_core::typed_id::{MessageId, SessionId, TurnId};
 use everruns_worker::AgentRunner;
 use std::sync::Arc;
+use tokio::task::JoinHandle;
 
 /// Default timeout for waiting_for_tool_results sessions (5 minutes).
 const DEFAULT_TIMEOUT_SECS: u64 = 300;
@@ -24,7 +25,7 @@ pub fn spawn_tool_result_timeout_sweep(
     db: Arc<StorageBackend>,
     runner: Arc<dyn AgentRunner>,
     event_delivery: crate::event_delivery::EventDelivery,
-) {
+) -> JoinHandle<()> {
     let timeout_secs = std::env::var("TOOL_RESULT_TIMEOUT_SECS")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -48,7 +49,7 @@ pub fn spawn_tool_result_timeout_sweep(
                 tracing::warn!(error = %e, "Tool result timeout sweep error");
             }
         }
-    });
+    })
 }
 
 async fn sweep_timed_out_sessions(


### PR DESCRIPTION
## What
- Extracted server storage bootstrap from `ServerAppBuilder::run()` into `init_storage()` with a small `StorageInit` result.
- Added `CoreDeps` and a shared connection-resolver helper to stop duplicating the GitHub App token minter / `DbConnectionResolver` setup.
- Added `TaskSupervisor` for server-owned background tasks: retained handles, abort-on-drop, task exit/panic metrics, and optional restart.
- Converted startup-owned long-lived spawn helpers to return handles and retained them in the app builder.
- Validated gRPC auth token, bind address, and TLS config before spawning the gRPC server task.
- Fixed the server-test-enumeration script for macOS Bash 3 and `pipefail` + `grep -q` behavior.

## Why
EVE-648 called out two related startup risks: `run()` had become hard to reason about, and background workers were spawned with dropped handles, making task death silent. This starts decomposing the startup phases and gives the long-lived background fleet a single owner.

## How
- Moved storage setup, migrations, runner setup, and task broadcaster setup behind `init_storage()`.
- Centralized connection resolver construction in `build_connection_resolver()` / `optional_connection_resolver()`.
- Introduced `supervised_task::{TaskSupervisor, RestartPolicy}` and used it for server-owned workers including gRPC, stale-task reclaim, model sync, dev worker, metrics, schedulers, sync loops, reporting, seed, and custom background tasks.
- Left per-connection and per-item one-shot spawns detached where retaining every handle would be unbounded and not useful for process liveness.
- Added fallible gRPC config helpers while preserving the existing panic wrappers for existing callers/tests.

## Risk
- Medium
- Startup task ownership changed; regressions would show up as missing background workers, failed startup on invalid gRPC config, or unexpected task restarts.
- The gRPC server now fails startup for invalid token/TLS/address config before spawning, instead of panicking inside a detached task.

## Security
- Threat categories reviewed: TM-DURABLE, TM-AUTHZ, TM-DOS, TM-OBS.
- Findings and resolutions: gRPC worker auth/TLS handling now fails closed before spawn; no secrets are logged; existing `THREAT[TM-DURABLE-002]` mitigation is preserved; background-task metrics/logging add observability without exposing task payloads.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo check -p everruns-server`
- `cargo test -p everruns-server --lib supervised_task`
- `cargo test -p everruns-server --lib test_require_grpc_auth_token_result_errors_without_env`
- `cargo test -p everruns-server --lib test_grpc_server_tls_result_errors_on_missing_cert_file`
- `cargo build -p everruns-server --bin everruns-server`
- `PORT_PREFIX=271 just start-dev --no-watch` + `GET http://127.0.0.1:27101/health`
- `bash scripts/lib/check-server-test-enumeration.sh`
- `just pre-push`
