### PR TITLE
chore(deps): bump cargo group (19 updates) + migrate breaking APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
  "uuid 1.23.4",
 ]
@@ -243,15 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
 ]
 
 [[package]]
@@ -805,7 +796,7 @@ dependencies = [
  "multer",
  "pin-project-lite",
  "serde_core",
- "serde_html_form",
+ "serde_html_form 0.2.8",
  "serde_path_to_error",
  "tower-layer",
  "tower-service",
@@ -879,7 +870,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
- "md-5 0.11.0",
+ "md-5",
  "num-traits",
  "os_display",
  "regex",
@@ -1004,6 +995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,31 +1048,46 @@ dependencies = [
 
 [[package]]
 name = "buffa"
-version = "0.2.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb26cf6d5fa531c242d47df5d6bad0e379c26dcfa0270680a028d09030f7f1a"
+checksum = "ec95898e2ef31d6266042f21c398fa5ff8334d14d6b2ac5fb38b55448d94f595"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "compact_str",
+ "ecow",
  "hashbrown 0.15.5",
  "once_cell",
  "serde",
  "serde_json",
+ "smol_str",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "buffa-codegen"
-version = "0.2.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8f1742cc45062edd1df41e7cbf56dd87388638472ddcff39ab5828214e67dc"
+checksum = "855364959e603cad456c1656bcf57f431ae6e5b4d4e4f166f7d594df882b6218"
 dependencies = [
  "buffa",
+ "buffa-descriptor",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "buffa-descriptor"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74c0bf128c53f22b0fc3c1e8e66969cd21375879061293fd4e5298e839099a9"
+dependencies = [
+ "buffa",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1337,6 +1353,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -1371,11 +1388,12 @@ dependencies = [
 
 [[package]]
 name = "connectrpc"
-version = "0.2.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348832a19a9d7e3854438c0f5693996c660d696bdf9ba49954b7c0a7bd28822b"
+checksum = "003fac88ace432fd8e6adbe13da8b20e90613b89e70c72186c505ad1bea307b2"
 dependencies = [
  "async-compression",
+ "async-trait",
  "base64 0.22.1",
  "buffa",
  "bytes",
@@ -1399,14 +1417,15 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "wasm-bindgen-futures",
  "zstd",
 ]
 
 [[package]]
 name = "connectrpc-build"
-version = "0.2.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f62358d843d4d9f945eece93673bec2fef96a2d6e33ecfd585c21bee4592386"
+checksum = "e5d70e6771939f6cb0943d7672929c9eed2f735cbdce219040cffb09ec5bbf9f"
 dependencies = [
  "anyhow",
  "buffa",
@@ -1417,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "connectrpc-codegen"
-version = "0.2.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f604d1f5a75de6fbf25795d50c62748204c3f9f53474f97287916380f6e1afc7"
+checksum = "02bca5ca0b62a25e3b41dd8c021e62aa1c8151f51b6258c2aa44f5bd83fded7b"
 dependencies = [
  "anyhow",
  "buffa",
@@ -1574,6 +1593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,13 +1625,14 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cron"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
- "winnow 0.6.26",
+ "phf",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1899,17 +1929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2080,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,12 +2156,6 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -2386,10 +2408,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "webbrowser",
 ]
 
@@ -2440,7 +2462,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tar",
  "tokio",
  "tracing",
@@ -2469,6 +2491,7 @@ dependencies = [
  "everruns-openui",
  "fetchkit",
  "futures",
+ "hex",
  "http 1.4.2",
  "include_dir",
  "insta",
@@ -2478,20 +2501,20 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.9",
- "similar 2.7.0",
+ "sha2 0.11.0",
+ "similar 3.1.1",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2518,11 +2541,11 @@ dependencies = [
  "indicatif",
  "minijinja",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sqlx",
- "sysinfo 0.38.4",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -2869,7 +2892,7 @@ dependencies = [
  "chrono",
  "everruns-core",
  "insta",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -2931,7 +2954,7 @@ dependencies = [
  "ignore",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -3010,7 +3033,7 @@ dependencies = [
  "git2",
  "governor",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3025,17 +3048,17 @@ dependencies = [
  "object_store",
  "parking_lot",
  "prost-types",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.4",
  "serde",
- "serde_html_form",
+ "serde_html_form 0.4.0",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
- "sysinfo 0.33.1",
+ "sysinfo",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -3045,7 +3068,7 @@ dependencies = [
  "tokio-tungstenite",
  "tonic",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3134,6 +3157,17 @@ dependencies = [
  "tracing",
  "turmoil",
  "uuid 1.23.4",
+]
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
 ]
 
 [[package]]
@@ -3307,6 +3341,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3326,7 +3361,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3529,6 +3564,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,6 +3733,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
 
 [[package]]
 name = "hashbrown"
@@ -4050,7 +4106,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4381,7 +4437,7 @@ dependencies = [
  "socket2 0.6.4",
  "widestring",
  "windows-registry",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-sys 0.61.2",
 ]
 
@@ -4405,6 +4461,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -4674,6 +4739,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4779,7 +4855,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -4865,6 +4941,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4881,18 +4970,18 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lua-src"
-version = "547.0.0"
+version = "550.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "luajit-src"
-version = "210.5.12+a4f56a4"
+version = "210.6.6+707c12b"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
 dependencies = [
  "cc",
  "which",
@@ -4904,7 +4993,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -4922,16 +5011,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "md-5"
@@ -4982,31 +5061,33 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
+ "evmap",
  "indexmap",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta",
  "rand 0.9.4",
  "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -5097,14 +5178,15 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.10.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
 dependencies = [
  "bstr",
  "either",
  "erased-serde",
  "futures-util",
+ "libc",
  "mlua-sys",
  "num-traits",
  "parking_lot",
@@ -5116,12 +5198,13 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
 dependencies = [
  "cc",
  "cfg-if",
+ "libc",
  "lua-src",
  "luajit-src",
  "pkg-config",
@@ -5170,7 +5253,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -5214,6 +5297,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5433,28 +5528,33 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.2",
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
- "md-5 0.10.6",
+ "itertools 0.15.0",
+ "md-5",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.4",
- "reqwest 0.12.28",
- "ring",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5465,6 +5565,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5777,7 +5878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "prost",
  "prost-types",
 ]
@@ -6100,7 +6201,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6166,7 +6267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6187,7 +6288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6354,9 +6455,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -6584,7 +6685,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -6662,7 +6763,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -6679,26 +6780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.13.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -6827,9 +6908,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6840,7 +6919,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6887,7 +6966,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7383,11 +7462,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0946d52b4b7e28823148aebbeceb901012c595ad737920d504fa8634bb099e6f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -7424,15 +7517,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7686,6 +7770,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7713,6 +7807,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -7885,7 +7985,7 @@ dependencies = [
  "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.11.0",
+ "md-5",
  "memchr",
  "rand 0.10.1",
  "serde",
@@ -8054,20 +8154,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows 0.57.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
@@ -8077,7 +8163,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -8189,7 +8275,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -8451,38 +8537,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -8496,26 +8561,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow 1.0.3",
 ]
@@ -8528,12 +8579,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -8649,8 +8694,24 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8745,13 +8806,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
@@ -8764,9 +8826,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.23.6"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -8774,9 +8836,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -8846,6 +8908,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -8934,7 +9002,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -9361,14 +9429,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -9416,22 +9481,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -9442,19 +9497,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -9463,10 +9506,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -9476,20 +9519,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -9497,17 +9529,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9537,7 +9558,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -9548,17 +9569,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9746,15 +9758,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -9770,12 +9773,6 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"
@@ -9950,20 +9947,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "typed-path",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ axum-extra = { version = "0.12", features = ["cookie", "multipart", "query"] }
 hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1", "http2"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace", "set-header"] }
+tower-http = { version = "0.7", features = ["cors", "trace", "set-header"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -110,11 +110,11 @@ utoipa = { version = "5.4", features = ["axum_extras", "chrono", "uuid"] }
 
 # Encryption
 aes-gcm = "0.10"
-rand = "0.9"
+rand = "0.10"
 base64 = "0.22"
 
 # Object storage (optional S3-compatible blob backend, specs/object-storage.md)
-object_store = { version = "0.12", features = ["aws"] }
+object_store = { version = "0.14", features = ["aws"] }
 
 # Rate limiting
 governor = "0.10"
@@ -128,8 +128,8 @@ async-nats = "0.49"
 # Authentication
 argon2 = "0.5"
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
-sha2 = "0.10"
-hmac = "0.12"
+sha2 = "0.11"
+hmac = "0.13"
 hex = "0.4"
 git2 = "0.21"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "stream", "rustls", "blocking", "form"] }
@@ -181,7 +181,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 
 # Prometheus metrics
 metrics = "0.24"
-metrics-exporter-prometheus = { version = "0.16", default-features = false }
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
 
 # In-process caching
 moka = { version = "0.12", features = ["future", "sync"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -38,7 +38,7 @@ futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-toml = "0.8"
+toml = "1.1"
 
 # Error handling
 anyhow.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,7 +36,7 @@ futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-toml = "0.8"
+toml = "1.1"
 
 # UUID and time
 uuid.workspace = true
@@ -44,7 +44,7 @@ chrono.workspace = true
 rand.workspace = true
 
 # Cron parsing for session-schedule minimum-interval enforcement
-cron = "0.15"
+cron = "0.17"
 
 # Tracing. `tracing` instrumentation is unconditional; the `tracing-subscriber`
 # registry/fmt layers are only used by telemetry init, so the dep is optional
@@ -63,12 +63,13 @@ tracing-opentelemetry = { workspace = true, optional = true }
 # Encoding
 base64.workspace = true
 sha2.workspace = true
+hex.workspace = true
 
 # Regex for argument substitution
 regex.workspace = true
 
 # Text diff rendering for edit_file previews
-similar = "2"
+similar = "3"
 
 # URL parsing
 url = "2"
@@ -87,13 +88,13 @@ bashkit = { version = "0.12.0", features = ["jq"] }
 # Sandboxed Lua interpreter for the experimental `lua` capability (vendored Lua
 # 5.4, never LuaJIT). Optional + behind the `lua` cargo feature so the default
 # build does not compile the C sources. See specs/lua-execution.md.
-mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"], optional = true }
+mlua = { version = "0.11", features = ["lua54", "vendored", "async", "send", "serialize"], optional = true }
 
 # Tree-sitter for structural outlines (EVE-248)
-tree-sitter = { version = "0.24", optional = true }
-tree-sitter-rust = { version = "0.23", optional = true }
+tree-sitter = { version = "0.26", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
 tree-sitter-typescript = { version = "0.23", optional = true }
-tree-sitter-python = { version = "0.23", optional = true }
+tree-sitter-python = { version = "0.25", optional = true }
 
 # TLS crypto provider (must be installed before any rustls usage)
 rustls.workspace = true

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -152,7 +152,7 @@ fn fs_display_path(file_store: &dyn SessionFileSystem, path: &str) -> String {
 fn file_content_hash(content: &str, encoding: &str) -> crate::error::Result<String> {
     let bytes = SessionFile::decode_content(content, encoding)
         .map_err(|error| anyhow::anyhow!("failed to decode file content for hashing: {error}"))?;
-    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(bytes))))
 }
 
 fn session_file_content_hash(file: &SessionFile) -> crate::error::Result<String> {
@@ -228,8 +228,8 @@ fn first_changed_line(before: &str, after: &str) -> Option<usize> {
 
 fn render_unified_diff(path: &str, before: &str, after: &str) -> String {
     TextDiff::from_lines(
-        &normalize_line_endings(before),
-        &normalize_line_endings(after),
+        normalize_line_endings(before).as_str(),
+        normalize_line_endings(after).as_str(),
     )
     .unified_diff()
     .context_radius(2)

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -827,7 +827,9 @@ mod engine {
         let counted = Arc::new(AtomicU64::new(0));
         {
             let counted = counted.clone();
-            lua.set_hook(
+            // mlua 0.11 makes `set_hook` fallible; surface a setup failure as an
+            // engine error rather than silently ignoring the result.
+            if let Err(e) = lua.set_hook(
                 HookTriggers::new().every_nth_instruction(HOOK_EVERY),
                 move |_lua, _debug| {
                     if Instant::now() >= deadline {
@@ -838,7 +840,9 @@ mod engine {
                     }
                     Ok(VmState::Continue)
                 },
-            );
+            ) {
+                return LuaOutcome::engine_error(format!("install hook: {e}"));
+            }
         }
 
         let stdout = Arc::new(Mutex::new(String::new()));

--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -15,7 +15,7 @@
 // Defaults match official SDKs: 2 retries, 1s initial, 60s max, 2x multiplier.
 
 use crate::error::AgentLoopError;
-use rand::Rng;
+use rand::RngExt;
 use std::future::Future;
 use std::time::Duration;
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -442,7 +442,7 @@ impl OpenResponsesProtocolChatDriver {
             "tools": tools,
         });
         let payload = serde_json::to_vec(&fingerprint).ok()?;
-        let digest = format!("{:x}", Sha256::digest(payload));
+        let digest = hex::encode(Sha256::digest(payload));
         let digest_len = OPENAI_PROMPT_CACHE_KEY_MAX_LEN - PROMPT_CACHE_KEY_PREFIX.len();
         Some(format!(
             "{PROMPT_CACHE_KEY_PREFIX}{}",

--- a/crates/core/src/resource_names.rs
+++ b/crates/core/src/resource_names.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for naming external resources created from user-visible titles.
 
-use rand::Rng;
+use rand::RngExt;
 
 const SUFFIX_ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
 const SUFFIX_LEN: usize = 6;

--- a/crates/durable/Cargo.toml
+++ b/crates/durable/Cargo.toml
@@ -45,7 +45,7 @@ tracing.workspace = true
 # Utilities
 rand.workspace = true
 parking_lot = "0.12"
-cron = "0.15"
+cron = "0.17"
 hostname = "0.4"
 
 # Benchmark support

--- a/crates/durable/src/reliability/retry.rs
+++ b/crates/durable/src/reliability/retry.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for activity retries

--- a/crates/durable/src/worker/poller.rs
+++ b/crates/durable/src/worker/poller.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tracing::{debug, instrument, trace};

--- a/crates/observability/src/braintrust.rs
+++ b/crates/observability/src/braintrust.rs
@@ -30,7 +30,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use rand::Rng;
+use rand::RngExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -70,10 +70,10 @@ async-nats.workspace = true
 parking_lot.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
-cron = "0.15"
+cron = "0.17"
 inventory.workspace = true
 moka.workspace = true
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "8", default-features = false, features = ["deflate"] }
 urlencoding = "2"
 git2.workspace = true
 tempfile.workspace = true
@@ -124,8 +124,8 @@ a2a-client.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["json", "stream", "rustls", "blocking", "http2"] }
 futures.workspace = true
 http-body-util = "0.1"
-sysinfo = "0.33"
-serde_html_form = "0.2"  # Same deserializer axum-extra::extract::Query uses
+sysinfo = "0.38"
+serde_html_form = "0.4"  # Same deserializer axum-extra::extract::Query uses
 everruns-sdk.workspace = true
 wiremock = "0.6"
 flate2.workspace = true

--- a/crates/server/src/api/a2a_signing.rs
+++ b/crates/server/src/api/a2a_signing.rs
@@ -45,7 +45,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use parking_lot::RwLock;
 use sha2::Sha256;
 

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1004,7 +1004,7 @@ async fn import_from_example(
     // If an agent with the same name exists, keep trying suffixed variants
     // to avoid one-shot collisions and reduce failures under concurrency.
     let unique_name = {
-        use rand::Rng;
+        use rand::RngExt;
 
         let base = seed.name;
         let mut selected = None;

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -241,7 +241,7 @@ pub async fn import_harness(
     // Pick a non-colliding name with random suffix retry — same strategy as
     // agent example import. Concurrency-safe enough for a manual UI action.
     let unique_name = {
-        use rand::Rng;
+        use rand::RngExt;
         let base = example.definition.name.as_str();
         let mut selected = None;
 

--- a/crates/server/src/api/internal_images.rs
+++ b/crates/server/src/api/internal_images.rs
@@ -14,7 +14,7 @@ use axum::{
     response::Response,
     routing::get,
 };
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde::Deserialize;
 use sha2::Sha256;
 use std::sync::Arc;

--- a/crates/server/src/api/org_invitations.rs
+++ b/crates/server/src/api/org_invitations.rs
@@ -29,7 +29,7 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::{AuditEvent, EmailError, EmailMessage, EmailSender, ManagementAction, OrgRole};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;

--- a/crates/server/src/api/providers.rs
+++ b/crates/server/src/api/providers.rs
@@ -25,8 +25,8 @@ use everruns_core::{
     Caller, DriverId, DriverOAuthFlow, DriverRegistry, Policy, ProviderStatus,
     evaluate_policies_with,
 };
-use hmac::{Hmac, Mac};
-use rand::Rng;
+use hmac::{Hmac, KeyInit, Mac};
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 type HmacSha256 = Hmac<Sha256>;

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -33,7 +33,7 @@ use everruns_core::progress_reporting::sync_slack_reply_mode_tags;
 use everruns_core::validate_safe_url;
 use everruns_core::{App, AppStatus, Caller, SessionStrategy, SlackChannelConfig, SlackReplyMode};
 use everruns_worker::AgentRunner;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use moka::sync::Cache;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -107,7 +107,7 @@ impl SseStreamConfig {
     /// exactly max_connection_secs, creating a reconnection storm. Adding ±20% jitter
     /// spreads disconnects over a 2-minute window (for 5-min base = 4:00–6:00).
     pub fn jittered_max_connection_duration(&self) -> Duration {
-        use rand::Rng;
+        use rand::RngExt;
         let base = self.max_connection_secs as f64;
         let jitter_range = base * 0.2;
         let jitter = rand::rng().random_range(-jitter_range..jitter_range);

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -27,7 +27,7 @@ use everruns_core::{
     Caller, McpServerAuthMode, SessionId, mcp_oauth_provider_id_for_uuid,
     mcp_oauth_session_secret_name, validate_safe_url,
 };
-use rand::Rng;
+use rand::RngExt;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -21,7 +21,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::{Duration, Utc};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -249,7 +249,7 @@ impl AuthConfig {
         // In AuthMode::Admin or AuthMode::Full, refuse to start without a secret.
         let jwt_secret = std::env::var("AUTH_JWT_SECRET").unwrap_or_else(|_| {
             if mode == AuthMode::None {
-                use rand::Rng;
+                use rand::RngExt;
                 let bytes: [u8; 32] = rand::rng().random();
                 hex::encode(bytes)
             } else {

--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use chrono::{Duration, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -31,7 +31,7 @@ use axum::{
 };
 use axum_extra::extract::CookieJar;
 use chrono::{Duration, Utc};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;

--- a/crates/server/src/auth/personal_access_token.rs
+++ b/crates/server/src/auth/personal_access_token.rs
@@ -7,7 +7,7 @@
 // Decision: full token is shown only once at creation, stored hashed in DB.
 
 use chrono::{DateTime, Utc};
-use rand::Rng;
+use rand::RngExt;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -14,7 +14,7 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{Duration, Utc};
 use everruns_core::{DEFAULT_ORG_ID, OrgRole};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;

--- a/crates/server/src/blob_gc.rs
+++ b/crates/server/src/blob_gc.rs
@@ -549,8 +549,8 @@ mod tests {
 
     #[tokio::test]
     async fn sweep_deletes_old_orphans_keeps_live() {
-        use object_store::ObjectStore;
         use object_store::path::Path as ObjectPath;
+        use object_store::{ObjectStore, ObjectStoreExt};
 
         let inner: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
         let store: SharedBlobStore =

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2196,7 +2196,7 @@ fn build_task_webhook_request(url: &str, body: &[u8], secret: Option<&str>) -> E
         .require_dns_pinning();
 
     if let Some(secret) = secret {
-        use hmac::{Hmac, Mac};
+        use hmac::{Hmac, KeyInit, Mac};
         use sha2::Sha256;
         type HmacSha256 = Hmac<Sha256>;
         let mut mac =

--- a/crates/server/src/domains/agents/health_check/commands.rs
+++ b/crates/server/src/domains/agents/health_check/commands.rs
@@ -208,7 +208,7 @@ fn config_hash(resolved_prompt: &str, tool_listing: &str, model_id: Option<&str>
     hasher.update(tool_listing.as_bytes());
     hasher.update([0u8]);
     hasher.update(model_id.unwrap_or("").as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 fn service(ctx: &Ctx) -> Result<Arc<AgentHealthCheckService>, CommandError> {

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -3196,7 +3196,7 @@ inventory::submit! { CommandDescriptor::of::<AddWebhookChannelCmd>() }
 /// is the first 8 hex chars after `evra2a_`, suffixed with `...`, for
 /// non-secret UI display.
 pub fn generate_a2a_api_key() -> (String, String, String) {
-    use rand::RngCore;
+    use rand::Rng;
 
     let mut bytes = [0u8; 32];
     rand::rng().fill_bytes(&mut bytes);
@@ -3427,7 +3427,7 @@ inventory::submit! { CommandDescriptor::of::<RegenerateA2aApiKeyCmd>() }
 /// SHA-256 hex; the prefix is the first 8 hex chars after `evr_app_`, suffixed
 /// with `...`, for non-secret UI display.
 pub fn generate_app_api_key() -> (String, String, String) {
-    use rand::RngCore;
+    use rand::Rng;
 
     let mut bytes = [0u8; 32];
     rand::rng().fill_bytes(&mut bytes);

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -74,7 +74,7 @@ fn command_schema_hash(
     if let Some(positional_arg) = positional_arg {
         hasher.update(positional_arg.as_bytes());
     }
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 #[tonic::async_trait]

--- a/crates/server/src/storage/blob_store.rs
+++ b/crates/server/src/storage/blob_store.rs
@@ -17,7 +17,8 @@ use chrono::{DateTime, Utc};
 use everruns_config::{env_bool, env_opt_string, env_string};
 use futures::StreamExt;
 use object_store::{
-    Attribute, Attributes, ObjectStore, PutOptions, PutPayload, path::Path as ObjectPath,
+    Attribute, Attributes, ObjectStore, ObjectStoreExt, PutOptions, PutPayload,
+    path::Path as ObjectPath,
 };
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -9,7 +9,7 @@ use aes_gcm::{
 use anyhow::{Context, Result};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use moka::sync::Cache;
-use rand::RngCore;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -19,7 +19,7 @@ use everruns_core::tools::ToolExecutionResult;
 use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, ToolContext};
 use everruns_core::typed_id::SessionId;
 use everruns_server::storage::models::{AuditLogQuery, AuditLogRow};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde_json::{Value, json};
 use sha2::Sha256;
 use test_harness::TestServer;

--- a/crates/server/tests/slack_integration_test.rs
+++ b/crates/server/tests/slack_integration_test.rs
@@ -22,7 +22,7 @@ mod test_harness;
 use std::sync::Once;
 
 use axum::http::{Method, StatusCode};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde_json::{Value, json};
 use sha2::Sha256;
 use test_harness::TestServer;

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -26,8 +26,8 @@ urlencoding = "2"
 http = "1"
 http-body = "1"
 futures.workspace = true
-connectrpc = { version = "0.2.1", features = ["client", "client-tls"] }
-buffa = "0.2.0"
+connectrpc = { version = "0.7.0", features = ["client", "client-tls"] }
+buffa = "0.7.1"
 rustls.workspace = true
 rustls-native-certs = "0.8"
 
@@ -37,7 +37,7 @@ everruns-core.workspace = true
 ignored = ["connectrpc-build", "futures", "http-body", "prost", "protox"]
 
 [build-dependencies]
-connectrpc-build = "0.2.0"
+connectrpc-build = "0.7.0"
 protox = "0.9"
 prost.workspace = true
 

--- a/integrations/e2b/src/client.rs
+++ b/integrations/e2b/src/client.rs
@@ -275,7 +275,7 @@ impl E2BClient {
             .await
             .map_err(|e| format!("Failed reading sandbox command stream: {e}"))?
         {
-            let Some(event) = message.event.as_option() else {
+            let Some(event) = message.reborrow().event.as_option() else {
                 continue;
             };
             match &event.event {
@@ -363,10 +363,10 @@ impl E2BClient {
             .parse()
             .map_err(|e| format!("Invalid envd URI: {e}"))?;
         let mut config = ClientConfig::new(uri)
-            .protocol(Protocol::Connect)
-            .default_timeout(Duration::from_secs(E2B_DEFAULT_TIMEOUT_SECS));
+            .with_protocol(Protocol::Connect)
+            .with_default_timeout(Duration::from_secs(E2B_DEFAULT_TIMEOUT_SECS));
         for (name, value) in self.envd_headers(state)?.iter() {
-            config = config.default_header(name, value.clone());
+            config = config.with_default_header(name, value.clone());
         }
         Ok(proto::process::ProcessClient::new(http, config))
     }


### PR DESCRIPTION
## What
Lands the cargo dependency group from dependabot #2508 (19 updates, several breaking majors) **together with** the source-code migrations needed to compile. Dependabot only edits manifests/lockfile, so its PR does not build on its own — this PR supersedes #2508.

Bumps: `rand` 0.9→0.10, `sha2` 0.10→0.11, `hmac` 0.12→0.13, `object_store` 0.12→0.14, `tower-http` 0.6→0.7, `zip` 2→8, `connectrpc`/`buffa` 0.2→0.7, `mlua` 0.10→0.11, `tree-sitter` 0.24→0.26 (+ `-rust` 0.23→0.24, `-python` 0.23→0.25), `metrics-exporter-prometheus` 0.16→0.18, `similar` 2→3, `cron` 0.15→0.17, `sysinfo` 0.33→0.38, `serde_html_form` 0.2→0.4, `which` 7→8, `quick-xml` 0.40, `toml` 0.8→1.1.

## Why
Keep dependencies current and unblock the security/maintenance patch stream. The breaking majors require code changes that dependabot cannot make.

## How
Applied #2508's `Cargo.toml`/`Cargo.lock`/per-crate manifests, then iterated `cargo check --workspace --all-targets --all-features` fixing each break at its call site per the crate migration guides:

- **rand 0.10**: `Rng::random`/`random_range`/`fill_bytes` moved to the new `RngExt` (and core `Rng`) traits. Switched `use rand::Rng` → `use rand::RngExt`, and `use rand::RngCore` → `use rand::Rng` where `fill_bytes` is used.
- **sha2 0.11**: digest `Array` output no longer implements `LowerHex`. Replaced `format!("{:x}", ..::digest(..))` with `hex::encode(..)` (added `hex` to `everruns-core`; all other sites already used `hex::encode`).
- **hmac 0.13**: `new_from_slice` now requires the `KeyInit` trait in scope. Added `hmac::KeyInit` to the existing `{Hmac, Mac}` imports.
- **object_store 0.14**: `get`/`delete` moved from `ObjectStore` to the new `ObjectStoreExt` trait. Imported `ObjectStoreExt`.
- **connectrpc/buffa 0.7** (e2b integration): `ClientConfig` builders renamed (`protocol` → `with_protocol`, `default_timeout` → `with_default_timeout`, `default_header` → `with_default_header`); `OwnedView` no longer derefs to its view, so stream messages access fields via `.reborrow()`.
- **mlua 0.11**: `Lua::set_hook` is now fallible; failures surface as a Lua engine error.

`similar` 3, `tower-http` 0.7, `zip` 8, `tree-sitter` 0.26, `cron` 0.17, `sysinfo` 0.38, `serde_html_form` 0.4, `which` 8, `quick-xml` 0.40, `toml` 1.1, `metrics-exporter-prometheus` 0.18 required no source changes (aside from a `similar` clippy `needless_borrows` tweak).

## Risk
- Low / Medium
- The migrations are mechanical and covered by existing tests. Highest-touch areas are crypto/signing (hmac/sha2) and blob storage (object_store) — all exercised by unit tests that pass.

## Security
- Threat categories reviewed: TM-AUTH (hmac/sha2 token + signature hashing), TM-API (object_store blob access). The hashing/HMAC outputs are byte-identical: `hex::encode` produces the same lowercase hex as the old `{:x}` formatting, and `KeyInit::new_from_slice` is the same key-init path. No change to secrets handling, auth flows, or trust boundaries.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing suites cover all migrated code paths)
- [x] Backward compatibility considered (internal code only; hash/HMAC outputs unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

### Validation
- `cargo check --workspace --all-targets --all-features`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo test` for core, server lib (1770), durable (176), observability (60), e2b unit (11): all pass. The single e2b live-API test fails only because `E2B_API_KEY` is unset (fail-closed by design).
- `just pre-push`: all checks pass.
- Rebased onto current `origin/main` (incl. EVE-651 observability crate extraction, EVE-645 error classification, and merged security/dependency changes); the extracted `everruns-observability` crate already carried the rand 0.10 migration. Lockfile regenerated cleanly.

Supersedes #2508.