### PR TITLE
feat(evals): ingest externally-executed eval runs

### DIFF
--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -76,6 +76,17 @@ pub enum EvalTarget {
         #[cfg_attr(feature = "openapi", schema(value_type = String))]
         app_id: AppId,
     },
+    /// Label-only target for externally-executed runs (e.g. imported from Mira).
+    ///
+    /// Carries provider/model labels and opaque params instead of session setup:
+    /// external runs are ingested already-complete, so everruns never builds a
+    /// session from this. Mirrors a provider-agnostic `(provider, model)` pair.
+    External {
+        provider: String,
+        model: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        params: Option<serde_json::Value>,
+    },
 }
 
 // ============================================
@@ -153,6 +164,43 @@ impl From<&str> for EvalRunStatus {
 }
 
 // ============================================
+// Eval Run Source
+// ============================================
+
+/// Where an eval run came from.
+///
+/// `Internal` runs are executed by everruns (sessions spawned per case).
+/// `External` runs are ingested already-complete from an external eval system
+/// (e.g. Mira) via the import API; everruns hosts and visualizes them but never
+/// executes them. See proposals/mira-results-publishing.md.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum EvalRunSource {
+    #[default]
+    Internal,
+    External,
+}
+
+impl std::fmt::Display for EvalRunSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvalRunSource::Internal => write!(f, "internal"),
+            EvalRunSource::External => write!(f, "external"),
+        }
+    }
+}
+
+impl From<&str> for EvalRunSource {
+    fn from(s: &str) -> Self {
+        match s {
+            "external" => EvalRunSource::External,
+            _ => EvalRunSource::Internal,
+        }
+    }
+}
+
+// ============================================
 // Case Result Status
 // ============================================
 
@@ -167,6 +215,9 @@ pub enum CaseResultStatus {
     Failed,
     Errored,
     Timeout,
+    /// Case was not executed (e.g. an external system skipped it: model
+    /// unavailable, filtered out). Excluded from pass/fail tallies.
+    Skipped,
 }
 
 impl std::fmt::Display for CaseResultStatus {
@@ -178,6 +229,7 @@ impl std::fmt::Display for CaseResultStatus {
             CaseResultStatus::Failed => write!(f, "failed"),
             CaseResultStatus::Errored => write!(f, "errored"),
             CaseResultStatus::Timeout => write!(f, "timeout"),
+            CaseResultStatus::Skipped => write!(f, "skipped"),
         }
     }
 }
@@ -190,6 +242,7 @@ impl From<&str> for CaseResultStatus {
             "failed" => CaseResultStatus::Failed,
             "errored" => CaseResultStatus::Errored,
             "timeout" => CaseResultStatus::Timeout,
+            "skipped" => CaseResultStatus::Skipped,
             _ => CaseResultStatus::Pending,
         }
     }
@@ -467,6 +520,15 @@ pub struct EvalRun {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter_tags: Option<Vec<String>>,
     pub status: EvalRunStatus,
+    /// Whether everruns executed this run (`internal`) or it was imported from
+    /// an external eval system (`external`).
+    #[serde(default)]
+    pub source: EvalRunSource,
+    /// Provenance for external runs: which system produced them, version, link
+    /// back, and any environment labels. `None` for internal runs. Open-vocab
+    /// JSON so new attribution fields need no schema change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<serde_json::Value>,
     /// What triggered this run.
     pub triggered_by: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/server/migrations/087_eval_external_runs.sql
+++ b/crates/server/migrations/087_eval_external_runs.sql
@@ -1,0 +1,32 @@
+-- Everruns as a host/viewer for externally-executed eval results (e.g. Mira).
+-- See proposals/mira-results-publishing.md.
+--
+-- An external run is ingested already-complete: everruns never spawns sessions
+-- for it. These columns let a run carry provenance and grouping without a new
+-- entity (we extend EvalRun rather than fork the model):
+--
+--   source         - 'internal' (everruns executed it) or 'external' (imported).
+--                    Defaults to 'internal' so every existing run is unchanged.
+--   source_run_id  - the external system's stable run id. One external run maps
+--                    to one EvalRun per eval, all sharing this id; it is both the
+--                    cross-eval group key and the idempotency key (re-publishing
+--                    the same id replaces the prior run for that eval).
+--   attribution    - open-vocab JSON provenance (system, version, url, env
+--                    labels). JSONB, not columns, so new fields need no schema
+--                    change — matching how per-result transcript/metrics ride in
+--                    the existing eval_case_results.metadata envelope.
+ALTER TABLE eval_runs
+    ADD COLUMN source TEXT NOT NULL DEFAULT 'internal',
+    ADD COLUMN source_run_id TEXT,
+    ADD COLUMN attribution JSONB;
+
+-- Grouping + idempotency lookups are always org-scoped by source_run_id.
+CREATE INDEX idx_eval_runs_source_run_id
+    ON eval_runs (org_id, source_run_id)
+    WHERE source_run_id IS NOT NULL;
+
+-- External systems may report a case as never executed ('skipped': model
+-- unavailable, filtered out). Widen the case-result status CHECK to allow it.
+ALTER TABLE eval_case_results DROP CONSTRAINT eval_case_results_status_check;
+ALTER TABLE eval_case_results ADD CONSTRAINT eval_case_results_status_check
+    CHECK (status IN ('pending', 'running', 'passed', 'failed', 'errored', 'timeout', 'skipped'));

--- a/crates/server/src/api/evals.rs
+++ b/crates/server/src/api/evals.rs
@@ -7,7 +7,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, patch, post};
 use axum::{Json, Router};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use serde_json::{Map, Value};
 
@@ -23,8 +23,9 @@ use crate::domains::evals::dataset::ExportEvalRunDatasetRequest;
 use crate::domains::evals::runner::EvalRunContext;
 use crate::domains::evals::{
     BulkUpdateEvalRunScores, CancelEvalRun, CreateEval, CreateEvalCase, CreateEvalRun, DeleteEval,
-    DeleteEvalCase, ExportEvalRunArtifacts, ExportEvalRunDataset, GetEval, GetEvalCase, GetEvalRun,
-    ListEvalCases, ListEvalRuns, ListEvals, UpdateEval, UpdateEvalCase, UpdateEvalResultScores,
+    DeleteEvalCase, EvalImportPreflightCmd, ExportEvalRunArtifacts, ExportEvalRunDataset, GetEval,
+    GetEvalCase, GetEvalRun, ImportEvalRun, ListEvalCases, ListEvalRuns, ListEvals, UpdateEval,
+    UpdateEvalCase, UpdateEvalResultScores,
 };
 use crate::storage::StorageBackend;
 use everruns_core::Caller;
@@ -233,6 +234,135 @@ pub struct BulkUpdateEvalRunScoresRequest {
     pub metadata: Option<serde_json::Value>,
 }
 
+// ============================================
+// Import (external eval results) — everruns as host/viewer.
+// See proposals/mira-results-publishing.md.
+// ============================================
+
+/// A whole external run group: one external run, one entry per eval. Maps to
+/// one everruns EvalRun per eval, all sharing `source.run_id`.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ImportEvalRunRequest {
+    pub source: ImportEvalSource,
+    pub evals: Vec<ImportEvalGroup>,
+}
+
+/// Attribution for the external system that produced the run.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ImportEvalSource {
+    /// External system name, e.g. "mira".
+    pub system: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Stable external run id: cross-eval group key + idempotency key.
+    pub run_id: String,
+    /// Optional environment/labels (git commit, host, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// One eval's worth of results within the run. The eval is upserted by `name`.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ImportEvalGroup {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub cases: Vec<ImportEvalCaseEntry>,
+}
+
+/// One case result. The case is upserted by `name` (identity-only: everruns
+/// never re-executes it).
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ImportEvalCaseEntry {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Display-only input turns shown in the UI.
+    #[serde(default)]
+    pub input: Vec<String>,
+    /// Provider/model labels this result was produced against.
+    pub target: ImportEvalTarget,
+    pub status: ImportCaseStatus,
+    /// Named, attributed scores. Stored opaque; everruns does not re-grade.
+    #[serde(default)]
+    pub scores: Vec<ImportScore>,
+    /// Normalized transcript (messages, tool calls, events, parts, files).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript: Option<serde_json::Value>,
+    /// Open-vocab metrics bag (cost_usd, cache/reasoning tokens, ttft, ...).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turns: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+/// Provider/model labels for an externally-executed result.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ImportEvalTarget {
+    pub provider: String,
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+/// Verdict for an imported case (trusted as-is; not recomputed).
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ImportCaseStatus {
+    Passed,
+    Failed,
+    Errored,
+    Timeout,
+    Skipped,
+}
+
+impl ImportCaseStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ImportCaseStatus::Passed => "passed",
+            ImportCaseStatus::Failed => "failed",
+            ImportCaseStatus::Errored => "errored",
+            ImportCaseStatus::Timeout => "timeout",
+            ImportCaseStatus::Skipped => "skipped",
+        }
+    }
+}
+
+/// A single named score from an external scorer.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct ImportScore {
+    pub scorer: String,
+    pub value: f64,
+    pub pass: bool,
+    #[serde(default)]
+    pub reason: String,
+    /// Scorer was not applicable (excluded from aggregate).
+    #[serde(default)]
+    pub na: bool,
+}
+
+/// Preflight capability report so optional-feature clients (e.g. Mira) can
+/// check before publishing instead of failing mid-import.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct EvalImportPreflight {
+    /// Whether the `evals` feature is enabled for this org.
+    pub evals_enabled: bool,
+    /// Whether the caller may import (holds eval-management permission).
+    pub can_import: bool,
+}
+
 /// Query parameters for listing evals
 #[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
 pub struct ListEvalsQuery {
@@ -247,6 +377,10 @@ pub struct ListEvalsQuery {
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/evals", post(create_eval).get(list_evals))
+        // Import (external eval results). Static segments take priority over
+        // `{eval_id}`, so these never shadow eval-by-id routes.
+        .route("/v1/evals/import", post(import_eval_run))
+        .route("/v1/evals/import/preflight", get(import_preflight))
         .route(
             "/v1/evals/{eval_id}",
             get(get_eval).patch(update_eval).delete(delete_eval),
@@ -281,6 +415,27 @@ pub fn routes(state: AppState) -> Router {
             patch(bulk_update_run_scores),
         )
         .with_state(state)
+}
+
+// ============================================
+// Import handlers
+// ============================================
+
+async fn import_eval_run(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<ImportEvalRunRequest>,
+) -> ApiResult<ListResponse<EvalRun>> {
+    let runs = ImportEvalRun { req }.run(&state.ctx(&org)).await?;
+    Ok(Json(ListResponse::new(runs)))
+}
+
+async fn import_preflight(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> ApiResult<EvalImportPreflight> {
+    let report = EvalImportPreflightCmd {}.run(&state.ctx(&org)).await?;
+    Ok(Json(report))
 }
 
 // ============================================

--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -1,7 +1,8 @@
 use super::queries as q;
 use super::types::{
     BulkUpdateEvalRunScoresRequest, CreateEvalCaseRequest, CreateEvalRequest, CreateEvalRunRequest,
-    ListEvalsQuery, UpdateEvalCaseRequest, UpdateEvalRequest, UpdateEvalResultScoresRequest,
+    EvalImportPreflight, ImportEvalRunRequest, ListEvalsQuery, UpdateEvalCaseRequest,
+    UpdateEvalRequest, UpdateEvalResultScoresRequest,
 };
 use crate::domains::common::*;
 use everruns_core::eval::{Eval, EvalCase, EvalCaseResult, EvalRun};
@@ -98,6 +99,76 @@ impl Command for ListEvals {
 }
 
 inventory::submit! { CommandDescriptor::of::<ListEvals>() }
+
+/// Import a full external run group (everruns as host/viewer for external eval
+/// systems). See proposals/mira-results-publishing.md.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ImportEvalRun {
+    #[serde(flatten)]
+    pub req: ImportEvalRunRequest,
+}
+
+impl Command for ImportEvalRun {
+    type Output = Vec<EvalRun>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "import_eval_run",
+            category: "evals",
+            description: "Import externally-executed eval results.",
+            method: "POST",
+            path: "/v1/evals/import",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_IMPORT)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalRun>, CommandError> {
+        require_evals_enabled(ctx)?;
+        q::service(ctx)
+            .import_run(&ctx.caller, self.req)
+            .await
+            .map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ImportEvalRun>() }
+
+/// Preflight: report whether the caller can import (feature enabled + has the
+/// eval-management permission) without failing. No policy gate so any org
+/// member can probe; the report just returns `false`.
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct EvalImportPreflightCmd {}
+
+impl Command for EvalImportPreflightCmd {
+    type Output = EvalImportPreflight;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "eval_import_preflight",
+            category: "evals",
+            description: "Report whether the caller can import eval results.",
+            method: "GET",
+            path: "/v1/evals/import/preflight",
+        }
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<EvalImportPreflight, CommandError> {
+        let evals_enabled = ctx.feature_flags.evals;
+        let can_import = evals_enabled
+            && ctx
+                .permission_resolver
+                .has_permission(&ctx.caller, &everruns_core::Permission::OrgAgentsManage);
+        Ok(EvalImportPreflight {
+            evals_enabled,
+            can_import,
+        })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<EvalImportPreflightCmd>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetEval {

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -370,6 +370,8 @@ mod tests {
             model_override: Some("gpt-test".into()),
             filter_tags: None,
             status: everruns_core::eval::EvalRunStatus::Completed,
+            source: everruns_core::eval::EvalRunSource::Internal,
+            attribution: None,
             triggered_by: "test".into(),
             started_at: None,
             completed_at: None,

--- a/crates/server/src/domains/evals/runner.rs
+++ b/crates/server/src/domains/evals/runner.rs
@@ -277,6 +277,9 @@ async fn execute_case_inner(
         EvalTarget::App { .. } => {
             anyhow::bail!("App targets not yet supported in eval execution");
         }
+        EvalTarget::External { .. } => {
+            anyhow::bail!("External targets are imported results and are not executable");
+        }
     };
 
     // Internal caller bypasses policy checks (eval execution is system-initiated)

--- a/crates/server/src/domains/evals/service.rs
+++ b/crates/server/src/domains/evals/service.rs
@@ -5,15 +5,16 @@
 
 use crate::api::evals::{
     BulkUpdateEvalRunScoresRequest, CreateEvalCaseRequest, CreateEvalRequest, CreateEvalRunRequest,
-    ExternalScoreStatus, UpdateEvalCaseRequest, UpdateEvalRequest, UpdateEvalResultScoresRequest,
+    ExternalScoreStatus, ImportEvalCaseEntry, ImportEvalRunRequest, UpdateEvalCaseRequest,
+    UpdateEvalRequest, UpdateEvalResultScoresRequest,
 };
 use crate::domains::evals::limits::EvalLimits;
 use crate::domains::evals::runner::{EvalRunContext, spawn_eval_run};
 use crate::errors::{BadRequestError, ResourceNotFoundError};
 use crate::storage::StorageBackend;
 use crate::storage::models::{
-    CreateEvalCaseRow, CreateEvalRow, CreateEvalRunError, CreateEvalRunRow,
-    UpdateEvalCaseResultRow, UpdateEvalCaseRow, UpdateEvalRow,
+    CreateEvalCaseRow, CreateEvalRow, CreateEvalRunError, CreateEvalRunRow, ImportEvalCaseInput,
+    ImportEvalRunInput, UpdateEvalCaseResultRow, UpdateEvalCaseRow, UpdateEvalRow,
 };
 use anyhow::Result;
 use everruns_core::eval::*;
@@ -59,6 +60,16 @@ pub const DATASET_EXPORT: Policy = Policy {
         Rule::UserHasPermission(Permission::OrgAgentsManage),
         Rule::UserHasPermission(Permission::OrgSessionsManage),
     ],
+};
+
+/// Policy: Import externally-executed eval runs (everruns as host/viewer).
+///
+/// Unlike `EVAL_RUN`, importing creates no sessions — the run is ingested
+/// already-complete — so it requires only eval-management, not session
+/// management. See proposals/mira-results-publishing.md.
+pub const EVAL_IMPORT: Policy = Policy {
+    id: "eval.import",
+    rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
 };
 
 pub struct EvalService {
@@ -654,6 +665,128 @@ impl EvalService {
     }
 
     // ============================================
+    // Import (external eval results)
+    // ============================================
+
+    /// Ingest a full external run group (one external run → one EvalRun per
+    /// eval, sharing `source.run_id`). Upserts evals/cases by name and stores
+    /// fully-scored, completed results. Everruns trusts the external verdicts;
+    /// it never re-grades. See proposals/mira-results-publishing.md.
+    pub async fn import_run(
+        &self,
+        caller: &Caller,
+        req: ImportEvalRunRequest,
+    ) -> Result<Vec<EvalRun>> {
+        if req.evals.is_empty() {
+            return Err(BadRequestError::new("import must include at least one eval").into());
+        }
+        if req.source.system.trim().is_empty() {
+            return Err(BadRequestError::new("source.system is required").into());
+        }
+        if req.source.run_id.trim().is_empty() {
+            return Err(BadRequestError::new("source.run_id is required").into());
+        }
+
+        let attribution = serde_json::json!({
+            "system": req.source.system,
+            "version": req.source.version,
+            "url": req.source.url,
+            "run_id": req.source.run_id,
+            "metadata": req.source.metadata,
+        });
+        let triggered_by = format!("import:{}", req.source.system);
+
+        let mut runs = Vec::with_capacity(req.evals.len());
+        for group in req.evals {
+            if group.name.trim().is_empty() {
+                return Err(BadRequestError::new("eval name is required").into());
+            }
+
+            let mut import_cases = Vec::with_capacity(group.cases.len());
+            let mut acc = ImportSummaryAcc::default();
+            for case in group.cases {
+                if case.name.trim().is_empty() {
+                    return Err(BadRequestError::new("case name is required").into());
+                }
+                for score in &case.scores {
+                    if !score.value.is_finite() || !(0.0..=1.0).contains(&score.value) {
+                        return Err(BadRequestError::new(format!(
+                            "score value for scorer '{}' must be between 0.0 and 1.0",
+                            score.scorer
+                        ))
+                        .into());
+                    }
+                }
+
+                let status = case.status.as_str();
+                acc.add(status, &case);
+
+                let target = EvalTarget::External {
+                    provider: case.target.provider.clone(),
+                    model: case.target.model.clone(),
+                    params: case.target.params.clone(),
+                };
+                let conversation = serde_json::to_value(
+                    case.input
+                        .iter()
+                        .map(|content| EvalInputMessage {
+                            content: content.clone(),
+                        })
+                        .collect::<Vec<_>>(),
+                )?;
+                // Per-result transcript + open-vocab metrics ride in the
+                // metadata envelope rather than dedicated columns.
+                let mut envelope = serde_json::Map::new();
+                if let Some(t) = &case.transcript {
+                    envelope.insert("transcript".to_string(), t.clone());
+                }
+                if let Some(m) = &case.metrics {
+                    envelope.insert("metrics".to_string(), m.clone());
+                }
+                let metadata =
+                    (!envelope.is_empty()).then_some(serde_json::Value::Object(envelope));
+                let scores = (!case.scores.is_empty())
+                    .then(|| serde_json::to_value(&case.scores))
+                    .transpose()?;
+
+                import_cases.push(ImportEvalCaseInput {
+                    case_name: case.name,
+                    case_description: case.description,
+                    conversation,
+                    target_snapshot: Some(serde_json::to_value(&target)?),
+                    status: status.to_string(),
+                    scores,
+                    metadata,
+                    turns: case.turns.map(|v| v as i32),
+                    latency_ms: case.latency_ms.map(|v| v as i64),
+                    input_tokens: case.input_tokens.map(|v| v as i64),
+                    output_tokens: case.output_tokens.map(|v| v as i64),
+                    error_message: case.error_message,
+                    artifacts: None,
+                });
+            }
+
+            let input = ImportEvalRunInput {
+                eval_name: group.name,
+                eval_description: group.description,
+                eval_tags: group.tags,
+                run_public_id: EvalRunId::from_uuid(Uuid::now_v7()).to_string(),
+                source: "external".to_string(),
+                source_run_id: req.source.run_id.clone(),
+                attribution: Some(attribution.clone()),
+                triggered_by: triggered_by.clone(),
+                summary: Some(serde_json::to_value(acc.finish())?),
+                cases: import_cases,
+            };
+
+            let run_row = self.db.import_eval_run(caller.org_id, input).await?;
+            runs.push(run_row_to_run(run_row, vec![]));
+        }
+
+        Ok(runs)
+    }
+
+    // ============================================
     // Helpers
     // ============================================
 
@@ -797,6 +930,8 @@ fn run_row_to_run(
         model_override: row.model_override,
         filter_tags: row.filter_tags,
         status: EvalRunStatus::from(row.status.as_str()),
+        source: EvalRunSource::from(row.source.as_str()),
+        attribution: row.attribution,
         triggered_by: row.triggered_by,
         started_at: row.started_at,
         completed_at: row.completed_at,
@@ -932,7 +1067,7 @@ fn build_run_summary(
             CaseResultStatus::Passed => passed += 1,
             CaseResultStatus::Failed => failed += 1,
             CaseResultStatus::Errored | CaseResultStatus::Timeout => errored += 1,
-            CaseResultStatus::Pending | CaseResultStatus::Running => {}
+            CaseResultStatus::Pending | CaseResultStatus::Running | CaseResultStatus::Skipped => {}
         }
 
         if matches!(status, CaseResultStatus::Passed | CaseResultStatus::Failed) {
@@ -975,6 +1110,87 @@ fn build_run_summary(
         total_input_tokens,
         total_output_tokens,
     }
+}
+
+/// Accumulates a `RunSummary` for an imported run. Mirrors `build_run_summary`
+/// but reads the import request directly. `total` counts executed cases
+/// (passed/failed/errored); skipped cases are excluded from all tallies.
+#[derive(Default)]
+struct ImportSummaryAcc {
+    total: u32,
+    passed: u32,
+    failed: u32,
+    errored: u32,
+    total_score: f64,
+    total_turns: f64,
+    total_latency: u64,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+}
+
+impl ImportSummaryAcc {
+    fn add(&mut self, status: &str, case: &ImportEvalCaseEntry) {
+        match status {
+            "passed" => self.passed += 1,
+            "failed" => self.failed += 1,
+            "errored" | "timeout" => self.errored += 1,
+            _ => return, // skipped / not executed: excluded from tallies
+        }
+        self.total += 1;
+        if matches!(status, "passed" | "failed") {
+            self.total_score += import_case_avg_score(case);
+            self.total_turns += case.turns.unwrap_or_default() as f64;
+            self.total_latency += case.latency_ms.unwrap_or_default();
+            self.total_input_tokens += case.input_tokens.unwrap_or_default();
+            self.total_output_tokens += case.output_tokens.unwrap_or_default();
+        }
+    }
+
+    fn finish(self) -> RunSummary {
+        let total = self.total;
+        RunSummary {
+            total,
+            passed: self.passed,
+            failed: self.failed,
+            errored: self.errored,
+            pass_rate: if total > 0 {
+                self.passed as f64 / total as f64
+            } else {
+                0.0
+            },
+            avg_score: if total > 0 {
+                self.total_score / total as f64
+            } else {
+                0.0
+            },
+            avg_turns: if total > 0 {
+                self.total_turns / total as f64
+            } else {
+                0.0
+            },
+            avg_latency_ms: if total > 0 {
+                self.total_latency / total as u64
+            } else {
+                0
+            },
+            total_input_tokens: self.total_input_tokens,
+            total_output_tokens: self.total_output_tokens,
+        }
+    }
+}
+
+/// Mean of applicable (non-N/A) score values for an imported case.
+fn import_case_avg_score(case: &ImportEvalCaseEntry) -> f64 {
+    let applicable: Vec<f64> = case
+        .scores
+        .iter()
+        .filter(|score| !score.na)
+        .map(|score| score.value)
+        .collect();
+    if applicable.is_empty() {
+        return 0.0;
+    }
+    applicable.iter().sum::<f64>() / applicable.len() as f64
 }
 
 fn case_result_avg_score(
@@ -1140,6 +1356,140 @@ mod tests {
                 .unwrap(),
             2
         );
+    }
+
+    fn import_request(run_id: &str, failed_value: f64) -> ImportEvalRunRequest {
+        use crate::api::evals::{
+            ImportCaseStatus, ImportEvalCaseEntry, ImportEvalGroup, ImportEvalSource,
+            ImportEvalTarget, ImportScore,
+        };
+        let target = ImportEvalTarget {
+            provider: "anthropic".into(),
+            model: "claude".into(),
+            params: None,
+        };
+        ImportEvalRunRequest {
+            source: ImportEvalSource {
+                system: "mira".into(),
+                version: Some("0.1.0".into()),
+                url: None,
+                run_id: run_id.into(),
+                metadata: None,
+            },
+            evals: vec![ImportEvalGroup {
+                name: "coding".into(),
+                description: Some("imported".into()),
+                tags: vec!["ci".into()],
+                cases: vec![
+                    ImportEvalCaseEntry {
+                        name: "case-a".into(),
+                        description: None,
+                        input: vec!["solve it".into()],
+                        target: target.clone(),
+                        status: ImportCaseStatus::Passed,
+                        scores: vec![ImportScore {
+                            scorer: "contains".into(),
+                            value: 1.0,
+                            pass: true,
+                            reason: "ok".into(),
+                            na: false,
+                        }],
+                        transcript: Some(serde_json::json!({"messages": []})),
+                        metrics: Some(serde_json::json!({"cost_usd": 0.01})),
+                        turns: Some(2),
+                        latency_ms: Some(1200),
+                        input_tokens: Some(100),
+                        output_tokens: Some(50),
+                        error_message: None,
+                    },
+                    ImportEvalCaseEntry {
+                        name: "case-b".into(),
+                        description: None,
+                        input: vec!["other".into()],
+                        target,
+                        status: ImportCaseStatus::Failed,
+                        scores: vec![ImportScore {
+                            scorer: "contains".into(),
+                            value: failed_value,
+                            pass: false,
+                            reason: "no".into(),
+                            na: false,
+                        }],
+                        transcript: None,
+                        metrics: None,
+                        turns: Some(1),
+                        latency_ms: Some(800),
+                        input_tokens: Some(80),
+                        output_tokens: Some(20),
+                        error_message: None,
+                    },
+                ],
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn import_run_creates_external_run() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_id = 7i64;
+        let caller = Caller::internal(org_id);
+        let svc = EvalService::new(db.clone());
+
+        let runs = svc
+            .import_run(&caller, import_request("mira-run-1", 0.0))
+            .await
+            .unwrap();
+
+        assert_eq!(runs.len(), 1);
+        let run = &runs[0];
+        assert_eq!(run.source, EvalRunSource::External);
+        assert_eq!(run.status, EvalRunStatus::Completed);
+        let summary = run.summary.as_ref().expect("summary");
+        assert_eq!(summary.total, 2);
+        assert_eq!(summary.passed, 1);
+        assert_eq!(summary.failed, 1);
+        assert!((summary.pass_rate - 0.5).abs() < 1e-9);
+
+        // Eval auto-provisioned by name.
+        let evals = db.list_evals(org_id, None, false).await.unwrap();
+        assert_eq!(evals.len(), 1);
+        assert_eq!(evals[0].name, "coding");
+
+        // Results stored with transcript/metrics in the metadata envelope.
+        let result_rows = db.list_eval_case_results(run.internal_id).await.unwrap();
+        assert_eq!(result_rows.len(), 2);
+        let passed = result_rows
+            .iter()
+            .find(|r| r.status == "passed")
+            .expect("passed result");
+        let meta = passed.metadata.as_ref().expect("metadata envelope");
+        assert!(meta.get("transcript").is_some());
+        assert_eq!(meta["metrics"]["cost_usd"], 0.01);
+    }
+
+    #[tokio::test]
+    async fn import_run_is_idempotent_on_source_run_id() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_id = 8i64;
+        let caller = Caller::internal(org_id);
+        let svc = EvalService::new(db.clone());
+
+        svc.import_run(&caller, import_request("mira-run-1", 0.0))
+            .await
+            .unwrap();
+        // Re-publish the same run id with a different failed score.
+        svc.import_run(&caller, import_request("mira-run-1", 0.4))
+            .await
+            .unwrap();
+
+        // Still one eval and exactly one run (the prior was replaced).
+        let evals = db.list_evals(org_id, None, false).await.unwrap();
+        assert_eq!(evals.len(), 1);
+        let run_rows = db.list_eval_runs(evals[0].id).await.unwrap();
+        assert_eq!(run_rows.len(), 1);
+        // And exactly two results (not four) — old ones were cascaded away.
+        let result_rows = db.list_eval_case_results(run_rows[0].id).await.unwrap();
+        assert_eq!(result_rows.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/evals/types.rs
+++ b/crates/server/src/domains/evals/types.rs
@@ -1,5 +1,6 @@
 pub use crate::api::evals::{
     BulkUpdateEvalResultScoresItem, BulkUpdateEvalRunScoresRequest, CreateEvalCaseRequest,
-    CreateEvalRequest, CreateEvalRunRequest, ExternalScoreStatus, ListEvalsQuery,
-    UpdateEvalCaseRequest, UpdateEvalRequest, UpdateEvalResultScoresRequest,
+    CreateEvalRequest, CreateEvalRunRequest, EvalImportPreflight, ExternalScoreStatus,
+    ImportEvalRunRequest, ListEvalsQuery, UpdateEvalCaseRequest, UpdateEvalRequest,
+    UpdateEvalResultScoresRequest,
 };

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3762,6 +3762,17 @@ impl StorageBackend {
         )
     }
 
+    /// Ingest one externally-executed eval run (upsert eval + cases by name,
+    /// replace any prior run sharing `source_run_id`, write a completed external
+    /// run with fully-populated results). See `ImportEvalRunInput`.
+    pub async fn import_eval_run(
+        &self,
+        org_id: i64,
+        input: ImportEvalRunInput,
+    ) -> Result<EvalRunRow> {
+        dispatch!(self, import_eval_run, org_id, input)
+    }
+
     pub async fn list_eval_runs(&self, eval_id: Uuid) -> Result<Vec<EvalRunRow>> {
         dispatch!(self, list_eval_runs, eval_id)
     }

--- a/crates/server/src/storage/memory/evals.rs
+++ b/crates/server/src/storage/memory/evals.rs
@@ -285,6 +285,9 @@ impl InMemoryDatabase {
             started_at: None,
             completed_at: None,
             summary: None,
+            source: "internal".to_string(),
+            source_run_id: None,
+            attribution: None,
             created_at: now,
             updated_at: now,
         };
@@ -348,6 +351,9 @@ impl InMemoryDatabase {
             started_at: None,
             completed_at: None,
             summary: None,
+            source: "internal".to_string(),
+            source_run_id: None,
+            attribution: None,
             created_at: now,
             updated_at: now,
         };
@@ -393,6 +399,167 @@ impl InMemoryDatabase {
         }
         runs.insert(row.id, row.clone());
         Ok(row)
+    }
+
+    pub async fn import_eval_run(
+        &self,
+        org_id: i64,
+        input: ImportEvalRunInput,
+    ) -> Result<EvalRunRow> {
+        let now = Self::now();
+
+        // Upsert eval by (org, name), preferring a non-deleted one.
+        let eval_id = {
+            let existing = self
+                .evals
+                .read()
+                .values()
+                .filter(|e| {
+                    e.org_id == org_id && e.name == input.eval_name && e.status != "deleted"
+                })
+                .min_by_key(|e| e.created_at)
+                .map(|e| e.id);
+            match existing {
+                Some(id) => id,
+                None => {
+                    let id = Uuid::now_v7();
+                    let row = EvalRow {
+                        id,
+                        org_id,
+                        public_id: format!("eval_{:032x}", id.as_u128()),
+                        name: input.eval_name.clone(),
+                        description: input.eval_description.clone(),
+                        target: None,
+                        model_override: None,
+                        tags: input.eval_tags.clone(),
+                        status: "active".to_string(),
+                        created_at: now,
+                        updated_at: now,
+                        archived_at: None,
+                        deleted_at: None,
+                    };
+                    self.evals.write().insert(id, row);
+                    id
+                }
+            }
+        };
+
+        // Idempotency: drop any prior run for this eval sharing source_run_id,
+        // and its results (mirrors the FK cascade in Postgres).
+        {
+            let mut runs = self.eval_runs.write();
+            let stale: Vec<Uuid> = runs
+                .values()
+                .filter(|r| {
+                    r.org_id == org_id
+                        && r.eval_id == eval_id
+                        && r.source_run_id.as_deref() == Some(input.source_run_id.as_str())
+                })
+                .map(|r| r.id)
+                .collect();
+            for run_id in &stale {
+                runs.remove(run_id);
+            }
+            if !stale.is_empty() {
+                self.eval_case_results
+                    .write()
+                    .retain(|_, res| !stale.contains(&res.eval_run_id));
+            }
+        }
+
+        let run_id = Uuid::now_v7();
+        let run = EvalRunRow {
+            id: run_id,
+            eval_id,
+            org_id,
+            public_id: input.run_public_id.clone(),
+            target: None,
+            model_override: None,
+            filter_tags: None,
+            status: "completed".to_string(),
+            triggered_by: input.triggered_by.clone(),
+            started_at: Some(now),
+            completed_at: Some(now),
+            summary: input.summary.clone(),
+            source: input.source.clone(),
+            source_run_id: Some(input.source_run_id.clone()),
+            attribution: input.attribution.clone(),
+            created_at: now,
+            updated_at: now,
+        };
+        self.eval_runs.write().insert(run_id, run.clone());
+
+        // New cases append after existing ones for stable display order.
+        let mut position = self
+            .eval_cases
+            .read()
+            .values()
+            .filter(|c| c.eval_id == eval_id)
+            .count() as i32;
+
+        for case in input.cases {
+            // Upsert case by (eval, name); external cases are identity-only.
+            let case_id = {
+                let existing = self
+                    .eval_cases
+                    .read()
+                    .values()
+                    .find(|c| c.eval_id == eval_id && c.name == case.case_name)
+                    .map(|c| c.id);
+                match existing {
+                    Some(id) => id,
+                    None => {
+                        let id = Uuid::now_v7();
+                        let row = EvalCaseRow {
+                            id,
+                            eval_id,
+                            public_id: format!("evalcase_{:032x}", id.as_u128()),
+                            name: case.case_name.clone(),
+                            description: case.case_description.clone(),
+                            target: None,
+                            tags: vec![],
+                            conversation: case.conversation.clone(),
+                            post: None,
+                            artifacts: None,
+                            scorers: serde_json::Value::Array(vec![]),
+                            max_turns: None,
+                            timeout_seconds: None,
+                            position,
+                            created_at: now,
+                            updated_at: now,
+                        };
+                        position += 1;
+                        self.eval_cases.write().insert(id, row);
+                        id
+                    }
+                }
+            };
+
+            let result_id = Uuid::now_v7();
+            let result = EvalCaseResultRow {
+                id: result_id,
+                eval_run_id: run_id,
+                eval_case_id: case_id,
+                public_id: format!("evalresult_{:032x}", result_id.as_u128()),
+                session_id: None,
+                target: case.target_snapshot.clone(),
+                target_snapshot: case.target_snapshot.clone(),
+                status: case.status.clone(),
+                scores: case.scores.clone(),
+                metadata: case.metadata.clone(),
+                turns: case.turns,
+                latency_ms: case.latency_ms,
+                input_tokens: case.input_tokens,
+                output_tokens: case.output_tokens,
+                error_message: case.error_message.clone(),
+                artifacts: case.artifacts.clone(),
+                created_at: now,
+                updated_at: now,
+            };
+            self.eval_case_results.write().insert(result_id, result);
+        }
+
+        Ok(run)
     }
 
     pub async fn list_eval_runs(&self, eval_id: Uuid) -> Result<Vec<EvalRunRow>> {

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2583,6 +2583,12 @@ pub struct EvalRunRow {
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
     pub summary: Option<serde_json::Value>,
+    /// 'internal' (everruns executed) or 'external' (imported). See migration 086.
+    pub source: String,
+    /// External system's run id: cross-eval group key and idempotency key.
+    pub source_run_id: Option<String>,
+    /// Open-vocab provenance for external runs (system, version, url, labels).
+    pub attribution: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -2642,6 +2648,45 @@ pub struct CreateEvalCaseResultRow {
     pub eval_case_id: Uuid,
     pub target: Option<serde_json::Value>,
     pub target_snapshot: Option<serde_json::Value>,
+    pub artifacts: Option<serde_json::Value>,
+}
+
+/// Input for importing one externally-executed eval run (a single eval's worth
+/// of a Mira-style run group). The storage layer upserts the eval and its cases
+/// by name, replaces any prior run sharing `source_run_id`, then writes a
+/// completed external run with fully-populated results. See `import_eval_run`.
+#[derive(Debug, Clone)]
+pub struct ImportEvalRunInput {
+    pub eval_name: String,
+    pub eval_description: Option<String>,
+    pub eval_tags: Vec<String>,
+    pub run_public_id: String,
+    pub source: String,
+    pub source_run_id: String,
+    pub attribution: Option<serde_json::Value>,
+    pub triggered_by: String,
+    pub summary: Option<serde_json::Value>,
+    pub cases: Vec<ImportEvalCaseInput>,
+}
+
+/// One case-result within an imported external run. The case is identity-only
+/// (name + optional display conversation); everruns never re-executes it, so
+/// scorers are left empty. Transcript and open-vocab metrics ride inside
+/// `metadata` rather than dedicated columns.
+#[derive(Debug, Clone)]
+pub struct ImportEvalCaseInput {
+    pub case_name: String,
+    pub case_description: Option<String>,
+    pub conversation: serde_json::Value,
+    pub target_snapshot: Option<serde_json::Value>,
+    pub status: String,
+    pub scores: Option<serde_json::Value>,
+    pub metadata: Option<serde_json::Value>,
+    pub turns: Option<i32>,
+    pub latency_ms: Option<i64>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub error_message: Option<String>,
     pub artifacts: Option<serde_json::Value>,
 }
 

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -312,7 +312,7 @@ impl Database {
             INSERT INTO eval_runs (eval_id, org_id, public_id, target, model_override, filter_tags, triggered_by)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
-                      triggered_by, started_at, completed_at, summary, created_at, updated_at
+                      triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
             "#,
         )
         .bind(input.eval_id)
@@ -386,7 +386,7 @@ impl Database {
             INSERT INTO eval_runs (eval_id, org_id, public_id, target, model_override, filter_tags, triggered_by)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
-                      triggered_by, started_at, completed_at, summary, created_at, updated_at
+                      triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
             "#,
         )
         .bind(input.eval_id)
@@ -428,11 +428,166 @@ impl Database {
         Ok(row)
     }
 
+    /// Ingest one externally-executed eval run. Upserts the eval and its cases
+    /// by name, replaces any prior run sharing `source_run_id` (idempotent
+    /// re-publish), then writes a completed external run with fully-populated
+    /// results. All in one transaction so a failed import leaves no partial run.
+    pub async fn import_eval_run(
+        &self,
+        org_id: i64,
+        input: ImportEvalRunInput,
+    ) -> Result<EvalRunRow> {
+        let mut tx = self.pool.begin().await?;
+
+        // Serialize concurrent imports for the same (org, eval name) so two
+        // publishes don't both create the eval.
+        sqlx::query(
+            "SELECT pg_advisory_xact_lock(hashtextextended('eval_import:' || $1::text || ':' || $2, 0))",
+        )
+        .bind(org_id)
+        .bind(&input.eval_name)
+        .execute(&mut *tx)
+        .await?;
+
+        // Upsert eval by (org, name), preferring a non-deleted one.
+        let existing_eval: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM evals WHERE org_id = $1 AND name = $2 AND status != 'deleted' ORDER BY created_at ASC LIMIT 1",
+        )
+        .bind(org_id)
+        .bind(&input.eval_name)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let eval_id = match existing_eval {
+            Some((id,)) => id,
+            None => {
+                let eval_public_id = format!("eval_{:032x}", Uuid::now_v7().as_u128());
+                let row: (Uuid,) = sqlx::query_as(
+                    r#"
+                    INSERT INTO evals (org_id, public_id, name, description, target, model_override, tags)
+                    VALUES ($1, $2, $3, $4, NULL, NULL, $5)
+                    RETURNING id
+                    "#,
+                )
+                .bind(org_id)
+                .bind(&eval_public_id)
+                .bind(&input.eval_name)
+                .bind(&input.eval_description)
+                .bind(&input.eval_tags)
+                .fetch_one(&mut *tx)
+                .await?;
+                row.0
+            }
+        };
+
+        // Idempotency: replace any prior run for this eval sharing source_run_id.
+        // eval_case_results cascade on eval_runs delete (migration 009).
+        sqlx::query(
+            "DELETE FROM eval_runs WHERE org_id = $1 AND eval_id = $2 AND source_run_id = $3",
+        )
+        .bind(org_id)
+        .bind(eval_id)
+        .bind(&input.source_run_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let now = chrono::Utc::now();
+        let run = sqlx::query_as::<_, EvalRunRow>(
+            r#"
+            INSERT INTO eval_runs (eval_id, org_id, public_id, status, triggered_by, started_at, completed_at, summary, source, source_run_id, attribution)
+            VALUES ($1, $2, $3, 'completed', $4, $5, $5, $6, $7, $8, $9)
+            RETURNING id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
+                      triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
+            "#,
+        )
+        .bind(eval_id)
+        .bind(org_id)
+        .bind(&input.run_public_id)
+        .bind(&input.triggered_by)
+        .bind(now)
+        .bind(&input.summary)
+        .bind(&input.source)
+        .bind(&input.source_run_id)
+        .bind(&input.attribution)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        // New cases append after existing ones for stable display order.
+        let mut position =
+            sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM eval_cases WHERE eval_id = $1")
+                .bind(eval_id)
+                .fetch_one(&mut *tx)
+                .await?
+                .0 as i32;
+
+        for case in input.cases {
+            // Upsert case by (eval, name). External cases are identity-only:
+            // empty scorers, conversation kept only for display.
+            let existing_case: Option<(Uuid,)> = sqlx::query_as(
+                "SELECT id FROM eval_cases WHERE eval_id = $1 AND name = $2 LIMIT 1",
+            )
+            .bind(eval_id)
+            .bind(&case.case_name)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            let case_id = match existing_case {
+                Some((id,)) => id,
+                None => {
+                    let case_public_id = format!("evalcase_{:032x}", Uuid::now_v7().as_u128());
+                    let row: (Uuid,) = sqlx::query_as(
+                        r#"
+                        INSERT INTO eval_cases (eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers, max_turns, timeout_seconds, position)
+                        VALUES ($1, $2, $3, $4, NULL, '{}', $5, NULL, NULL, '[]'::jsonb, NULL, NULL, $6)
+                        RETURNING id
+                        "#,
+                    )
+                    .bind(eval_id)
+                    .bind(&case_public_id)
+                    .bind(&case.case_name)
+                    .bind(&case.case_description)
+                    .bind(&case.conversation)
+                    .bind(position)
+                    .fetch_one(&mut *tx)
+                    .await?;
+                    position += 1;
+                    row.0
+                }
+            };
+
+            let result_public_id = format!("evalresult_{:032x}", Uuid::now_v7().as_u128());
+            sqlx::query(
+                r#"
+                INSERT INTO eval_case_results (eval_run_id, eval_case_id, public_id, target, target_snapshot, status, scores, metadata, turns, latency_ms, input_tokens, output_tokens, error_message, artifacts)
+                VALUES ($1, $2, $3, $4, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                "#,
+            )
+            .bind(run.id)
+            .bind(case_id)
+            .bind(result_public_id)
+            .bind(&case.target_snapshot)
+            .bind(&case.status)
+            .bind(&case.scores)
+            .bind(&case.metadata)
+            .bind(case.turns)
+            .bind(case.latency_ms)
+            .bind(case.input_tokens)
+            .bind(case.output_tokens)
+            .bind(&case.error_message)
+            .bind(&case.artifacts)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(run)
+    }
+
     pub async fn list_eval_runs(&self, eval_id: Uuid) -> Result<Vec<EvalRunRow>> {
         let rows = sqlx::query_as::<_, EvalRunRow>(
             r#"
             SELECT id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
-                   triggered_by, started_at, completed_at, summary, created_at, updated_at
+                   triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
             FROM eval_runs
             WHERE eval_id = $1
             ORDER BY created_at DESC
@@ -452,7 +607,7 @@ impl Database {
         let row = sqlx::query_as::<_, EvalRunRow>(
             r#"
             SELECT id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
-                   triggered_by, started_at, completed_at, summary, created_at, updated_at
+                   triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
             FROM eval_runs
             WHERE org_id = $1 AND public_id = $2
             "#,
@@ -488,7 +643,7 @@ impl Database {
                 updated_at = NOW()
             WHERE id = $1
             RETURNING id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
-                      triggered_by, started_at, completed_at, summary, created_at, updated_at
+                      triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -505,7 +660,7 @@ impl Database {
         let row = sqlx::query_as::<_, EvalRunRow>(
             r#"
             SELECT id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
-                   triggered_by, started_at, completed_at, summary, created_at, updated_at
+                   triggered_by, started_at, completed_at, summary, source, source_run_id, attribution, created_at, updated_at
             FROM eval_runs
             WHERE eval_id = $1
             ORDER BY created_at DESC

--- a/proposals/mira-results-publishing.md
+++ b/proposals/mira-results-publishing.md
@@ -1,0 +1,201 @@
+# Proposal: Everruns as a host for Mira eval results
+
+Status: draft proposal (pre-spec). Spans three repos: `everruns` (primary),
+`mira`, `saas`. On acceptance this splits into specs + Linear issues per
+workstream.
+
+## Problem
+
+Everruns has an unreleased **evals** system (flag `evals`). It is
+*execution-coupled*: an `EvalRun` only exists because everruns itself spawned a
+real session per case, drove the conversation, and scored it with nine built-in
+scorer rules. The only external write path is score *write-back*
+(`PATCH .../scores`) onto results everruns already executed. There is **no way
+to import a run everruns did not run.**
+
+Mira owns execution + scoring end to end. It runs any subject (Anthropic,
+OpenAI, a CLI process, or the everruns runtime), produces a rich `Transcript`
+(tokens, cost, time-to-first-token, tool calls, open-vocab metrics, multimodal
+parts, raw event JSONL, files) and renders good *local* reports — but has **no
+external sink.** (`mira-everruns` is consumptive: Mira drives the everruns
+runtime *as a subject*. It is not a publishing channel.)
+
+So three things are true at once:
+
+1. People who want hosted, shareable, comparable eval results have to run inside
+   everruns' session system — friction that is bad for onboarding external
+   parties.
+2. Mira can produce those results but cannot publish them anywhere.
+3. Everruns' eval UI cannot yet *compare* runs even when it has them
+   (Phase-1 only: single-run table; no matrix, deltas, trends, or transcript
+   drill-down).
+
+## Goal
+
+Make everruns a capable **host** for eval results — including results it did not
+execute — and give Mira a first-class way to publish to it. Concretely:
+
+- **(a)** Everruns ingests a complete, externally-executed eval run and stores
+  it as first-class eval data.
+- **(b)** Everruns' eval UI can compare and visualize runs (matrix, deltas,
+  regressions, trends, per-case transcript drill-down) — source-agnostic.
+- **(c)** Mira publishes a finished run to everruns with one command / CI step.
+
+### Non-goals
+
+- Re-running or re-scoring Mira results inside everruns. External verdicts are
+  trusted and stored as-is.
+- Changing the Mira ⇄ subject protocol. Publishing is a host-side concern, not a
+  protocol change.
+- Mapping Mira's open-vocab scorers onto everruns' nine-variant scorer enum.
+- A new standalone "results host" entity. We extend the existing eval model
+  (decision below).
+
+## Core decision: decouple "results as data" from "execution as orchestration"
+
+Today the only way to get a run into everruns is to make everruns run it. We
+split those concerns by extending the existing model with an external source,
+rather than introducing a parallel entity. (Considered and rejected: a separate
+lightweight imported-results entity — cleaner separation, but a second data
+model and a second UI to maintain forever, for a feature whose whole value is
+appearing *next to* native runs in the same comparison views.)
+
+The existing model already carries most of what we need:
+
+- `EvalCaseResult` holds **per-result** `target` + `target_snapshot`, so one
+  `EvalRun` can already represent a full *case × target* matrix within an eval.
+- Results allow `session_id` to be **optional** already — external results have
+  no everruns session.
+- The external score write-back path proves arbitrary `{scorer, value, pass,
+  reason}` scores round-trip through the `scores` JSONB.
+
+## Mapping Mira → everruns
+
+A Mira *run* spans multiple evals × targets; an everruns `EvalRun` is scoped to
+one `Eval`. So:
+
+- Mira **eval** → everruns **`Eval`** (upsert by slug).
+- Mira **run** → a **run-group** of everruns `EvalRun`s (one per Mira eval),
+  tied by a shared `source_run_id` = Mira's stable, sortable run id.
+- Within each `EvalRun`, all targets live across `EvalCaseResult`s via
+  per-result `target_snapshot`. Cross-eval matrix = query EvalRuns by
+  `source_run_id`. No new entity — just new columns on `eval_runs`.
+- Mira **sample** → everruns **`EvalCase`** (upsert by sample key within eval).
+- Mira **`RunResult`** → everruns **`EvalCaseResult`**.
+
+| Mira | Everruns | Notes |
+|---|---|---|
+| `eval` (name) | `Eval` (slug) | upsert; auto-provision on publish |
+| run `run_id` | `EvalRun.source_run_id` | group key + idempotency key |
+| `sample` (key) | `EvalCase` (key) | identity-only for external; no conversation/scorers reconstructed |
+| `target {provider, model}` + `params` | `EvalCaseResult.target_snapshot` | new label-only target variant (below) |
+| `RunResult.scores[] {scorer, value, pass, na, reason}` | result `scores` JSONB | opaque, names preserved; `na` kept in payload |
+| `passed` / `skipped` | result `status` | add `skipped` status to preserve semantics |
+| `Transcript.final_response` | result transcript blob | stored, rendered natively |
+| `Transcript.events[]` / `files{}` / `output[]` parts | result transcript blob / artifacts | structured store, not a synthesized session |
+| `usage {input, output, cache_read, reasoning, cost_usd}` | `input_tokens` / `output_tokens` + `metadata` | extras (cost, cache, reasoning) in metadata |
+| `timing {duration_ms, ttft_ms}` | `latency_ms` + `metadata` | ttft in metadata |
+| `iterations` / `tool_calls_count` | `turns` + `metadata` | |
+| `metrics {}` (open vocab) | `metadata` | recall@k, p95, energy, etc. |
+| `RunSummary` (per eval × target) | `RunSummary` | scored/passed/failed map; na/skipped/cost/tool_calls as extras |
+| run `Environment` (git, os, mira version, labels) | `EvalRun.metadata` | provenance |
+
+## Workstream (a): everruns ingest backend
+
+**Data model**
+
+- `eval_runs`: add `source` (`internal` | `external`), `executed_by`
+  (`"mira"` + version), `source_run_id` (group key, nullable for internal).
+  External runs are born `completed`; they never spawn sessions.
+- `EvalTarget`: add a label-only variant
+  `External { provider, model, params }` (the existing variants are
+  `Session{...}` / `App{app_id}`, both session-setup contracts that do not fit
+  an externally-executed run).
+- `EvalCaseResult.status`: add `skipped` to preserve Mira's "case never
+  executed" semantics. Fold cost / cache / reasoning tokens / ttft / iterations
+  / open-vocab metrics into the existing `metadata` JSONB.
+- **Transcript storage**: store Mira's transcript (final response + event JSONL
+  + files + multimodal parts) as a structured blob attached to the result.
+  *Decision:* store-and-render natively. Rejected alternatives — link out to
+  Mira's HTML report (defeats the point of hosting) or synthesize a fake
+  read-only everruns session (event schemas differ; brittle).
+
+**API**
+
+- `POST /v1/evals:import` (run-group ingest): one call accepts a whole Mira run
+  — run meta, and per eval the cases + results + scores + transcripts. Server
+  upserts evals/cases by slug, creates the `EvalRun`(s) under one
+  `source_run_id`, writes results. **Idempotent** on `source_run_id`
+  (re-publish replaces the group).
+- Auto-provisioning: publishing creates the `Eval`/`EvalCase` rows if absent so
+  external authors never pre-register in everruns. (Open question OQ-1 — could
+  be gated behind explicit registration if we want less magic.)
+
+**Auth & permissions**
+
+- Reuse **Personal Access Tokens** — already a supported `Bearer` method in all
+  auth modes including `external` (PropelAuth / SaaS). No new auth subsystem; CI
+  publishes with a PAT.
+- New policy `eval.import`, gated by `OrgAgentsManage` only. Unlike `eval.run`
+  it does **not** require `OrgSessionsManage` (no sessions are created).
+- Org-scoped, fail-closed, feature-flagged under `evals` like the rest.
+
+## Workstream (b): everruns eval UI — comparison & visualization
+
+The run-detail page branches on `source`: external runs swap "open session"
+links for the transcript drill-down. Everything else is **source-agnostic** —
+the new views read results + summaries identically whether everruns or Mira
+produced them. New surfaces (the Phase-2 gap):
+
+- **Multi-run comparison**: pick N runs → per-case table with score deltas and
+  **regression highlighting** (passed → failed).
+- **Model matrix**: target × eval grid (Mira's signature view), reading a
+  `source_run_id` group.
+- **Per-scorer aggregation**, and **trends** (pass-rate / cost / latency across
+  runs over time).
+- **Per-case transcript drill-down** rendering Mira events + multimodal parts.
+- Filtering / search / export.
+
+## Workstream (c): Mira publish sink
+
+- New integration crate `mira-publish-everruns` (keeps `mira-eval` core
+  provider-agnostic, same boundary as `mira-everruns`).
+- CLI: `mira publish <run_dir> --to everruns` and `mira run --publish everruns`.
+- Config in `mira.toml`: everruns base URL, PAT (from env), eval slug / project.
+- Maps `RunMeta` + `RunResult[]` (already persisted in the run folder) to the
+  import payload. Idempotent on Mira's `run_id`.
+- **Decoupled from `mira-everruns`**: any provider or CLI subject can publish.
+  You do *not* have to run inside the everruns runtime to host results in
+  everruns — this is the onboarding win.
+
+## Optional: external-party viewing (SaaS)
+
+For stakeholders without an org seat: token-based **shareable read-only
+eval-results pages** in SaaS, reusing the isolated support-app pattern
+(separate surface, non-bearer share token, no PropelAuth). Lets external parties
+view comparisons without being onboarded into the run system. Deferrable past v1.
+
+## Phasing
+
+1. **Backend ingest** (a): model columns, `External` target, `:import`
+   endpoint, `eval.import` policy + PAT, transcript storage. Unblocks Mira.
+2. **Mira sink** (c): `mira-publish-everruns` + CLI. End-to-end publish works;
+   results visible in the existing single-run UI.
+3. **Comparison UI** (b): matrix, deltas, regressions, trends, drill-down.
+4. **SaaS sharing** (optional): shareable read-only pages.
+
+(1) and (2) are the minimum for "Mira can publish and you can see it." (3) is
+the bulk of the user-facing value. (4) is additive.
+
+## Open questions
+
+- **OQ-1 Auto-provisioning vs. explicit registration.** Publish silently
+  upserts evals/cases by slug (low friction) vs. requiring the eval to be
+  registered in everruns first (safer, more friction). Proposal assumes
+  auto-provision; flagged for confirmation.
+- **OQ-2 Transcript fidelity for v1.** Full native render of Mira's event
+  stream (more UI work) vs. "summary + scores in everruns, full transcript via
+  link to Mira's HTML" as a v1 shortcut. Proposal assumes native render as the
+  end state; v1 could ship the shortcut.
+- **OQ-3 Slug collisions / ownership.** How an org namespaces eval slugs coming
+  from multiple Mira projects (prefix? project field on import?).

--- a/proposals/mira-results-publishing.md
+++ b/proposals/mira-results-publishing.md
@@ -222,8 +222,13 @@ eval-results pages** in SaaS, reusing the isolated support-app pattern
 (1)+(2) are the minimum for "Mira can publish and you can see it." (3) is the
 bulk of the user-facing value. (4) is additive.
 
-## Remaining open question
+## Resolved: slug namespacing
 
-- **OQ-3 Slug namespacing.** How an org namespaces eval slugs coming from
-  multiple external projects (prefix? a `project` field on import? per-source
-  namespace?). Affects collisions when several systems publish to one org.
+Identity of an imported eval is the **eval name within the org** — no
+namespacing for now. The upsert-by-name is load-bearing: re-publishing the same
+eval lands on the same `Eval` row so runs accumulate into history (trends,
+comparison). Collisions (two unrelated suites named the same, or a clash with a
+native eval) merge — treated as a name-hygiene problem, acceptable because
+`eval.import` is gated on `OrgAgentsManage` (few, trusted publishers per org).
+A future optional `project` field can add `(project, name)` identity without
+breaking this (absent project = today's behavior); deferred until it bites.

--- a/proposals/mira-results-publishing.md
+++ b/proposals/mira-results-publishing.md
@@ -1,4 +1,4 @@
-# Proposal: Everruns as a host for Mira eval results
+# Proposal: Everruns as a host/viewer for external eval results
 
 Status: draft proposal (pre-spec). Spans three repos: `everruns` (primary),
 `mira`, `saas`. On acceptance this splits into specs + Linear issues per
@@ -6,12 +6,12 @@ workstream.
 
 ## Problem
 
-Everruns has an unreleased **evals** system (flag `evals`). It is
+Everruns has an unreleased **evals** system (flag `evals`, not GA). It is
 *execution-coupled*: an `EvalRun` only exists because everruns itself spawned a
 real session per case, drove the conversation, and scored it with nine built-in
-scorer rules. The only external write path is score *write-back*
-(`PATCH .../scores`) onto results everruns already executed. There is **no way
-to import a run everruns did not run.**
+scorer rules (a **closed enum**). The only external write path is score
+*write-back* onto results everruns already executed. There is **no way to
+import a run everruns did not run.**
 
 Mira owns execution + scoring end to end. It runs any subject (Anthropic,
 OpenAI, a CLI process, or the everruns runtime), produces a rich `Transcript`
@@ -32,128 +32,153 @@ So three things are true at once:
 
 ## Goal
 
-Make everruns a capable **host** for eval results — including results it did not
-execute — and give Mira a first-class way to publish to it. Concretely:
+**Everruns becomes a vendor-neutral host and viewer for external eval systems.**
+Mira is the first client, but the import API, scoring model, transcript view,
+and attribution are designed for *any* external eval source — not Mira
+specifically. Concretely:
 
 - **(a)** Everruns ingests a complete, externally-executed eval run and stores
-  it as first-class eval data.
-- **(b)** Everruns' eval UI can compare and visualize runs (matrix, deltas,
-  regressions, trends, per-case transcript drill-down) — source-agnostic.
-- **(c)** Mira publishes a finished run to everruns with one command / CI step.
+  it as first-class eval data, with **attribution** to its source.
+- **(b)** Everruns' eval UI compares and visualizes runs (matrix, deltas,
+  regressions, trends) and renders a **generic, provider-agnostic transcript
+  view** — source-agnostic throughout.
+- **(c)** Mira publishes a finished run to everruns with one command / CI step,
+  **reusing everruns CLI auth**, after a **permission preflight**.
 
 ### Non-goals
 
-- Re-running or re-scoring Mira results inside everruns. External verdicts are
-  trusted and stored as-is.
-- Changing the Mira ⇄ subject protocol. Publishing is a host-side concern, not a
-  protocol change.
-- Mapping Mira's open-vocab scorers onto everruns' nine-variant scorer enum.
-- A new standalone "results host" entity. We extend the existing eval model
-  (decision below).
+- Re-running or re-scoring external results inside everruns. **External verdicts
+  are trusted and stored as-is** — everruns is a viewer, not a re-grader.
+- Changing the Mira ⇄ subject protocol. Publishing is a host-side concern.
+- A new standalone "results host" entity. We extend the existing eval model.
+  Because evals are **not GA**, we are free to restructure existing shapes
+  (naming, columns → extensible structures) rather than only adding alongside.
 
-## Core decision: decouple "results as data" from "execution as orchestration"
+## Core decisions (resolved)
 
-Today the only way to get a run into everruns is to make everruns run it. We
-split those concerns by extending the existing model with an external source,
-rather than introducing a parallel entity. (Considered and rejected: a separate
-lightweight imported-results entity — cleaner separation, but a second data
-model and a second UI to maintain forever, for a feature whose whole value is
-appearing *next to* native runs in the same comparison views.)
+These were the open questions; here is where they land.
 
-The existing model already carries most of what we need:
+1. **Extend `EvalRun` with `source = external`**, not a parallel entity.
+   Rejected: a second model + second UI forever, for a feature whose value is
+   appearing *next to* native runs in the same comparison views.
 
-- `EvalCaseResult` holds **per-result** `target` + `target_snapshot`, so one
-  `EvalRun` can already represent a full *case × target* matrix within an eval.
-- Results allow `session_id` to be **optional** already — external results have
-  no everruns session.
-- The external score write-back path proves arbitrary `{scorer, value, pass,
-  reason}` scores round-trip through the `scores` JSONB.
+2. **Vendor-neutral, not Mira-specific.** Everything below is keyed on a generic
+   `source` (system name + version + link), so a future external system reuses
+   the same path. Mira is the reference implementation.
 
-## Mapping Mira → everruns
+3. **Auto-provision is OK**, but **gated behind a permission preflight.**
+   Publishing silently upserts evals/cases by slug — *after* the client
+   confirms the user has `eval.import` and the `evals` feature is enabled.
+   Evals are optional, so the client must degrade gracefully when they are off.
+
+4. **Scoring becomes extensible, not a closed enum.** Everruns' nine-variant
+   scorer enum becomes an open model where a score is an attributed,
+   named entry (`{scorer, value, pass, reason, source}`) — the built-in rules
+   are one source; external systems are another. Decouples *scorer-as-rule*
+   (something everruns can execute) from *score-as-data* (a result everruns
+   stores and displays).
+
+5. **Generic transcript view.** Build a provider-agnostic transcript viewer in
+   the everruns UI that renders a normalized transcript schema (messages, tool
+   calls, events, multimodal parts, files). External transcripts normalize into
+   it; native everruns sessions can render through it too. Not a Mira-only
+   widget, not a link-out to Mira's HTML.
+
+6. **Stop modeling per-result signal as columns.** cost, cache/reasoning tokens,
+   ttft, tool calls, iterations, latency, even token counts — move to an
+   **extensible metrics bag** (open-vocab `metrics`/`metadata`) instead of
+   accreting columns that never keep up. New signal is just a new key.
+
+7. **Attribution is first-class.** External evals/runs/results must *look
+   natural* in everruns while clearly carrying provenance: which external system
+   produced them, version, and a link back. Surfaced as an attribution
+   badge/field on evals, runs, and results — vendor-neutral.
+
+## Mapping external run → everruns (Mira as reference)
 
 A Mira *run* spans multiple evals × targets; an everruns `EvalRun` is scoped to
 one `Eval`. So:
 
-- Mira **eval** → everruns **`Eval`** (upsert by slug).
-- Mira **run** → a **run-group** of everruns `EvalRun`s (one per Mira eval),
-  tied by a shared `source_run_id` = Mira's stable, sortable run id.
+- external **eval** → everruns **`Eval`** (upsert by slug).
+- external **run** → a **run-group** of everruns `EvalRun`s (one per eval),
+  tied by a shared `source_run_id` = the external system's stable run id.
 - Within each `EvalRun`, all targets live across `EvalCaseResult`s via
   per-result `target_snapshot`. Cross-eval matrix = query EvalRuns by
-  `source_run_id`. No new entity — just new columns on `eval_runs`.
-- Mira **sample** → everruns **`EvalCase`** (upsert by sample key within eval).
-- Mira **`RunResult`** → everruns **`EvalCaseResult`**.
+  `source_run_id`. No new entity — new columns on `eval_runs`.
+- external **sample/case** → everruns **`EvalCase`** (upsert by key within eval;
+  identity-only — name + key + optional display input; conversation/scorers
+  empty, since everruns never re-runs it).
 
 | Mira | Everruns | Notes |
 |---|---|---|
-| `eval` (name) | `Eval` (slug) | upsert; auto-provision on publish |
+| `eval` (name) | `Eval` (slug) | upsert; auto-provision after preflight |
 | run `run_id` | `EvalRun.source_run_id` | group key + idempotency key |
-| `sample` (key) | `EvalCase` (key) | identity-only for external; no conversation/scorers reconstructed |
-| `target {provider, model}` + `params` | `EvalCaseResult.target_snapshot` | new label-only target variant (below) |
-| `RunResult.scores[] {scorer, value, pass, na, reason}` | result `scores` JSONB | opaque, names preserved; `na` kept in payload |
-| `passed` / `skipped` | result `status` | add `skipped` status to preserve semantics |
-| `Transcript.final_response` | result transcript blob | stored, rendered natively |
-| `Transcript.events[]` / `files{}` / `output[]` parts | result transcript blob / artifacts | structured store, not a synthesized session |
-| `usage {input, output, cache_read, reasoning, cost_usd}` | `input_tokens` / `output_tokens` + `metadata` | extras (cost, cache, reasoning) in metadata |
-| `timing {duration_ms, ttft_ms}` | `latency_ms` + `metadata` | ttft in metadata |
-| `iterations` / `tool_calls_count` | `turns` + `metadata` | |
-| `metrics {}` (open vocab) | `metadata` | recall@k, p95, energy, etc. |
-| `RunSummary` (per eval × target) | `RunSummary` | scored/passed/failed map; na/skipped/cost/tool_calls as extras |
-| run `Environment` (git, os, mira version, labels) | `EvalRun.metadata` | provenance |
+| run `Environment` + study/version | `EvalRun` attribution + `metadata` | source = `mira` + version, git, labels |
+| `sample` (key) | `EvalCase` (key) | identity-only |
+| `target {provider, model}` + `params` | `EvalCaseResult.target_snapshot` | new label-only target variant |
+| `scores[] {scorer, value, pass, na, reason}` | result scores (extensible) | named + attributed; `na` preserved |
+| `passed` / `skipped` | result `status` | add `skipped` status |
+| `Transcript` (final, events, files, parts) | normalized transcript blob | rendered by the generic transcript view |
+| `usage` / `timing` / `iterations` / `tool_calls` / `metrics{}` | result **metrics bag** | open-vocab; cost, cache, reasoning, ttft, p95, recall@k, … |
+| `RunSummary` (per eval × target) | `RunSummary` | grouped; extras live in the metrics bag |
 
 ## Workstream (a): everruns ingest backend
 
-**Data model**
+**Data model** (evals not GA → restructure freely)
 
-- `eval_runs`: add `source` (`internal` | `external`), `executed_by`
-  (`"mira"` + version), `source_run_id` (group key, nullable for internal).
+- `eval_runs`: add `source` (`internal` | `external`), source attribution
+  (`system` name, `version`, optional `url`), `source_run_id` (group key).
   External runs are born `completed`; they never spawn sessions.
-- `EvalTarget`: add a label-only variant
-  `External { provider, model, params }` (the existing variants are
-  `Session{...}` / `App{app_id}`, both session-setup contracts that do not fit
-  an externally-executed run).
-- `EvalCaseResult.status`: add `skipped` to preserve Mira's "case never
-  executed" semantics. Fold cost / cache / reasoning tokens / ttft / iterations
-  / open-vocab metrics into the existing `metadata` JSONB.
-- **Transcript storage**: store Mira's transcript (final response + event JSONL
-  + files + multimodal parts) as a structured blob attached to the result.
-  *Decision:* store-and-render natively. Rejected alternatives — link out to
-  Mira's HTML report (defeats the point of hosting) or synthesize a fake
-  read-only everruns session (event schemas differ; brittle).
+- `EvalTarget`: add a label-only variant `External { provider, model, params }`
+  (existing `Session{...}` / `App{app_id}` variants are session-setup contracts
+  that do not fit an externally-executed run).
+- **Scoring model → extensible.** Replace the closed scorer enum's role as the
+  *only* score shape with an open, attributed score record. Built-in rules
+  remain as one `source`; external/named scorers are first-class. (See
+  decision 4.)
+- **Per-result signal → metrics bag.** Migrate cost / tokens / cache / reasoning
+  / ttft / turns / latency / iterations / open-vocab metrics into an extensible
+  `metrics` structure rather than columns. (See decision 6.)
+- `EvalCaseResult.status`: add `skipped`.
+- **Normalized transcript** stored per result (messages, tool calls, events,
+  multimodal parts, files) — the schema the generic view reads.
+- **Attribution** fields on `Eval` / `EvalRun` / `EvalCaseResult`.
 
 **API**
 
-- `POST /v1/evals:import` (run-group ingest): one call accepts a whole Mira run
-  — run meta, and per eval the cases + results + scores + transcripts. Server
-  upserts evals/cases by slug, creates the `EvalRun`(s) under one
-  `source_run_id`, writes results. **Idempotent** on `source_run_id`
-  (re-publish replaces the group).
-- Auto-provisioning: publishing creates the `Eval`/`EvalCase` rows if absent so
-  external authors never pre-register in everruns. (Open question OQ-1 — could
-  be gated behind explicit registration if we want less magic.)
+- `POST /v1/evals/import` (run-group ingest): one call accepts a whole external
+  run — run meta + attribution, and per eval the cases + results + scores +
+  normalized transcripts. Server upserts evals/cases by slug, creates the
+  `EvalRun`(s) under one `source_run_id`, writes results. **Idempotent** on
+  `source_run_id` (re-publish replaces the group).
+- **Preflight**: a capability/permission check the client calls *first* —
+  reports whether `evals` is enabled and whether the caller holds `eval.import`.
+  Lets optional-feature clients degrade gracefully. (Can reuse / extend an
+  existing capabilities or `GET /v1/auth/me` style endpoint.)
 
 **Auth & permissions**
 
-- Reuse **Personal Access Tokens** — already a supported `Bearer` method in all
-  auth modes including `external` (PropelAuth / SaaS). No new auth subsystem; CI
-  publishes with a PAT.
-- New policy `eval.import`, gated by `OrgAgentsManage` only. Unlike `eval.run`
-  it does **not** require `OrgSessionsManage` (no sessions are created).
-- Org-scoped, fail-closed, feature-flagged under `evals` like the rest.
+- Reuse **Personal Access Tokens** (`evr_pat_…`, sent `Authorization: Bearer`),
+  already supported in all auth modes including `external`/PropelAuth (SaaS).
+  No new auth subsystem.
+- New policy `eval.import`, gated by `OrgAgentsManage` only (no
+  `OrgSessionsManage` — no sessions created). Org-scoped, fail-closed,
+  feature-flagged under `evals`.
 
-## Workstream (b): everruns eval UI — comparison & visualization
+## Workstream (b): everruns eval UI — comparison + generic transcript
 
-The run-detail page branches on `source`: external runs swap "open session"
-links for the transcript drill-down. Everything else is **source-agnostic** —
-the new views read results + summaries identically whether everruns or Mira
-produced them. New surfaces (the Phase-2 gap):
+The run-detail page is **source-agnostic**: it reads results + summaries + the
+normalized transcript identically whether everruns or an external system
+produced them. External runs carry an attribution badge. New surfaces:
 
+- **Generic transcript view**: provider-agnostic component rendering the
+  normalized transcript (messages, tool calls, events, multimodal parts, files).
+  Reusable across native sessions and external runs.
 - **Multi-run comparison**: pick N runs → per-case table with score deltas and
   **regression highlighting** (passed → failed).
-- **Model matrix**: target × eval grid (Mira's signature view), reading a
-  `source_run_id` group.
-- **Per-scorer aggregation**, and **trends** (pass-rate / cost / latency across
-  runs over time).
-- **Per-case transcript drill-down** rendering Mira events + multimodal parts.
+- **Model matrix**: target × eval grid (reads a `source_run_id` group).
+- **Per-scorer aggregation** (works because scores are named/attributed), and
+  **trends** (pass-rate / cost / latency across runs over time).
 - Filtering / search / export.
 
 ## Workstream (c): Mira publish sink
@@ -161,9 +186,17 @@ produced them. New surfaces (the Phase-2 gap):
 - New integration crate `mira-publish-everruns` (keeps `mira-eval` core
   provider-agnostic, same boundary as `mira-everruns`).
 - CLI: `mira publish <run_dir> --to everruns` and `mira run --publish everruns`.
-- Config in `mira.toml`: everruns base URL, PAT (from env), eval slug / project.
+- **CLI auth pass-through**: reuse everruns CLI credentials. Resolution order
+  mirrors everruns' own CLI — `--api-key` flag > `EVERRUNS_API_KEY` env >
+  everruns credentials file (`~/.config/everruns/credentials.json`, multi-profile,
+  `--profile`), `EVERRUNS_API_URL` for the base URL. If you've run
+  `everruns login`, `mira publish` just works.
+- **Preflight before publish**: call the capability check; if `evals` is off or
+  the user lacks `eval.import`, fail clearly (this is an optional feature, not an
+  error in the eval run itself).
 - Maps `RunMeta` + `RunResult[]` (already persisted in the run folder) to the
-  import payload. Idempotent on Mira's `run_id`.
+  import payload; normalizes the Mira `Transcript` into everruns' transcript
+  schema. Idempotent on Mira's `run_id`.
 - **Decoupled from `mira-everruns`**: any provider or CLI subject can publish.
   You do *not* have to run inside the everruns runtime to host results in
   everruns — this is the onboarding win.
@@ -172,30 +205,25 @@ produced them. New surfaces (the Phase-2 gap):
 
 For stakeholders without an org seat: token-based **shareable read-only
 eval-results pages** in SaaS, reusing the isolated support-app pattern
-(separate surface, non-bearer share token, no PropelAuth). Lets external parties
-view comparisons without being onboarded into the run system. Deferrable past v1.
+(separate surface, non-bearer share token, no PropelAuth). Deferrable past v1.
 
 ## Phasing
 
-1. **Backend ingest** (a): model columns, `External` target, `:import`
-   endpoint, `eval.import` policy + PAT, transcript storage. Unblocks Mira.
-2. **Mira sink** (c): `mira-publish-everruns` + CLI. End-to-end publish works;
-   results visible in the existing single-run UI.
-3. **Comparison UI** (b): matrix, deltas, regressions, trends, drill-down.
+1. **Backend ingest** (a): `source`/attribution + `source_run_id` columns,
+   `External` target, extensible scoring + metrics bag, normalized transcript
+   storage, `/v1/evals/import`, preflight, `eval.import` policy + PAT. Unblocks
+   Mira.
+2. **Mira sink** (c): `mira-publish-everruns` + CLI + auth pass-through +
+   preflight. End-to-end publish; results visible in the existing single-run UI.
+3. **UI** (b): generic transcript view, then matrix / comparison / deltas /
+   regressions / trends.
 4. **SaaS sharing** (optional): shareable read-only pages.
 
-(1) and (2) are the minimum for "Mira can publish and you can see it." (3) is
-the bulk of the user-facing value. (4) is additive.
+(1)+(2) are the minimum for "Mira can publish and you can see it." (3) is the
+bulk of the user-facing value. (4) is additive.
 
-## Open questions
+## Remaining open question
 
-- **OQ-1 Auto-provisioning vs. explicit registration.** Publish silently
-  upserts evals/cases by slug (low friction) vs. requiring the eval to be
-  registered in everruns first (safer, more friction). Proposal assumes
-  auto-provision; flagged for confirmation.
-- **OQ-2 Transcript fidelity for v1.** Full native render of Mira's event
-  stream (more UI work) vs. "summary + scores in everruns, full transcript via
-  link to Mira's HTML" as a v1 shortcut. Proposal assumes native render as the
-  end state; v1 could ship the shortcut.
-- **OQ-3 Slug collisions / ownership.** How an org namespaces eval slugs coming
-  from multiple Mira projects (prefix? project field on import?).
+- **OQ-3 Slug namespacing.** How an org namespaces eval slugs coming from
+  multiple external projects (prefix? a `project` field on import? per-source
+  namespace?). Affects collisions when several systems publish to one org.

--- a/specs/evals.md
+++ b/specs/evals.md
@@ -252,6 +252,30 @@ All endpoints under `/v1/evals`. See `crates/server/src/api/evals.rs`.
 | `PATCH` | `/v1/evals/{eval_id}/runs/{run_id}/results/{result_id}/scores` | Write external scores back to a completed result |
 | `PATCH` | `/v1/evals/{eval_id}/runs/{run_id}/scores` | Bulk write external scores back to a completed run |
 
+### Import (external eval results)
+
+Everruns also hosts and visualizes runs it did **not** execute, so external eval
+systems (e.g. Mira) can publish results without onboarding into the session
+system. See `proposals/mira-results-publishing.md`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/evals/import` | Ingest a full external run group (one run → one EvalRun per eval) |
+| `GET` | `/v1/evals/import/preflight` | Report `{ evals_enabled, can_import }` so optional-feature clients check before publishing |
+
+- An imported `EvalRun` carries `source = external` plus `attribution` (system,
+  version, url, run id, labels); internal runs are unchanged (`source =
+  internal`). Evals and cases are upserted **by name** within the org (no
+  namespacing — name collisions merge; see proposal). External cases are
+  identity-only: everruns never re-executes or re-scores them.
+- Idempotent on the external `source.run_id`: re-publishing replaces the prior
+  run for each eval in the group.
+- Scores are stored opaque (named, attributed) — everruns trusts the external
+  verdict. Per-result transcript and an open-vocab metrics bag ride in the
+  result `metadata` envelope rather than dedicated columns.
+- Gated by `EVAL_IMPORT` (`OrgAgentsManage` only — no sessions are created, so
+  unlike `EVAL_RUN` it does not require `OrgSessionsManage`).
+
 #### Run Limits (EVE-509)
 
 `POST /runs` enforces two limits at trigger time, returning HTTP 400 on violation:


### PR DESCRIPTION
## What
Adds an **import** path to the evals system so everruns can host and visualize eval runs it did **not** execute. This is the everruns/backend half of `proposals/mira-results-publishing.md` (Phase 1) — the foundation for Mira (and any external eval system) to publish results into everruns.

- `POST /v1/evals/import` — ingest a full external run group (one external run → one `EvalRun` per eval, all sharing the external `source.run_id`). Idempotent: re-publishing the same `run_id` replaces the prior run for each eval.
- `GET /v1/evals/import/preflight` — reports `{ evals_enabled, can_import }` so optional-feature clients (e.g. Mira) can check before publishing instead of failing mid-import.

## Why
Today an `EvalRun` only exists because everruns spawned a session per case and scored it. There is no way to bring in a run executed elsewhere. That forces anyone who wants hosted, comparable eval results to onboard into the session system. Decoupling "results as data" from "execution as orchestration" lets external systems run evals on their own infra (any provider/CLI) and publish finished results to everruns purely for hosting and visualization.

## How
Extend the existing eval model rather than fork it:
- `EvalRun` gains `source` (`internal` | `external`), `source_run_id` (cross-eval group + idempotency key), and an open-vocab `attribution` JSONB (migration `086`). Internal runs are unchanged (`source = internal`).
- New `EvalTarget::External { provider, model, params }` (label-only target) and `CaseResultStatus::Skipped`.
- Evals and cases are **upserted by name** within the org (no namespacing — name collisions merge, per the proposal's resolved decision). External cases are identity-only: everruns never re-executes or re-scores them; it trusts the external verdict.
- Per-result **transcript** and an open-vocab **metrics bag** ride inside the existing result `metadata` envelope rather than dedicated columns (extensible by design).
- One new storage method `import_eval_run` (Postgres + in-memory) does the upsert + idempotent replace + completed-run insert transactionally.
- New `EVAL_IMPORT` policy: `OrgAgentsManage` only — unlike `EVAL_RUN` it does not require `OrgSessionsManage`, since no sessions are created.

## Risk
- **Low/Medium.** Net-new endpoints behind the `evals` feature flag (not GA). The only change to existing runs is three nullable/defaulted columns on `eval_runs` and a widened `eval_case_results.status` CHECK (adds `skipped`). No existing behavior altered.

## Security
- Threat categories reviewed: **TM-AUTH**, **TM-API**.
- Findings and resolutions:
  - Authorization: gated by `EVAL_IMPORT` (`OrgAgentsManage`); all reads/writes use `caller.org_id`; eval/case upsert and the idempotency delete are scoped by `org_id` (+ `eval_id`, `source_run_id`), so no cross-org reach. Preflight has no policy gate but returns only two booleans.
  - Input validation: score values validated to `0.0–1.0`; SQL is fully parameterized (advisory-lock key uses bound params). Request size is bounded by the server's global body limit.
  - Follow-up (below): no explicit per-import case/payload cap yet.

## Follow-ups
- Add an explicit per-import case/payload limit (mirroring `EVAL_MAX_CASES_PER_RUN`) so a single import can't store an unbounded number of results. Bounded today only by the global request-body limit.
- Mira-side publish sink + UI comparison/transcript views land in later phases of the proposal.

## Checklist
- [x] Tests added or updated (import creates external run; idempotent re-publish)
- [x] Backward compatibility considered (additive; internal runs unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ryzx9dSfPsZxmQuthEDfDF)_