### PR TITLE
fix(ui): lazy-load command palette data, gate evals on feature flag

### DIFF
--- a/apps/ui/src/__tests__/command-palette.test.tsx
+++ b/apps/ui/src/__tests__/command-palette.test.tsx
@@ -28,33 +28,37 @@ jest.mock("@base-ui/react/dialog", () => {
   };
 });
 
+let mockOpen = true;
 jest.mock("@/hooks/use-command-palette", () => ({
   useCommandPalette: () => ({
-    open: true,
+    open: mockOpen,
     setOpen: mockSetOpen,
   }),
 }));
 
+const mockUseGlobalSearch = jest.fn(() => [
+  {
+    id: "organization:org_second",
+    category: "organization",
+    icon: Boxes,
+    title: "Second Org",
+    subtitle: "Switch organization > org_second",
+    href: "/settings/organization",
+    onSelect: mockOnSelect,
+  },
+]);
 jest.mock("@/hooks/use-global-search", () => ({
-  useGlobalSearch: () => [
-    {
-      id: "organization:org_second",
-      category: "organization",
-      icon: Boxes,
-      title: "Second Org",
-      subtitle: "Switch organization > org_second",
-      href: "/settings/organization",
-      onSelect: mockOnSelect,
-    },
-  ],
+  useGlobalSearch: (query: string) => mockUseGlobalSearch(query),
 }));
 
 describe("CommandPalette", () => {
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    mockOpen = true;
     mockSetOpen.mockClear();
     mockPush.mockClear();
     mockOnSelect.mockClear();
+    mockUseGlobalSearch.mockClear();
   });
 
   it("runs a search result action directly instead of routing", () => {
@@ -65,5 +69,22 @@ describe("CommandPalette", () => {
     expect(mockSetOpen).toHaveBeenCalledWith(false);
     expect(mockOnSelect).toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("does not run global search (and its data fetching) while closed", () => {
+    mockOpen = false;
+    render(<CommandPalette />);
+
+    // The search UI and all its entity queries are only mounted when open, so
+    // navigating to an unrelated page must not trigger any list fetches.
+    expect(mockUseGlobalSearch).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /Second Org/i })).toBeNull();
+  });
+
+  it("runs global search once the palette is open", () => {
+    render(<CommandPalette />);
+
+    expect(mockUseGlobalSearch).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /Second Org/i })).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/command-palette.test.tsx
+++ b/apps/ui/src/__tests__/command-palette.test.tsx
@@ -36,7 +36,7 @@ jest.mock("@/hooks/use-command-palette", () => ({
   }),
 }));
 
-const mockUseGlobalSearch = jest.fn(() => [
+const mockUseGlobalSearch = jest.fn((_query: string) => [
   {
     id: "organization:org_second",
     category: "organization",

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -21,7 +21,7 @@ jest.mock("@/hooks/use-capabilities", () => ({
   useCapabilities: () => ({ data: [] }),
   useDeclarativeCapabilities: () => ({ data: [] }),
 }));
-const mockUseEvals = jest.fn(() => ({ data: [] }));
+const mockUseEvals = jest.fn((_options?: { enabled?: boolean }) => ({ data: [] }));
 jest.mock("@/hooks/use-evals", () => ({
   useEvals: (options?: { enabled?: boolean }) => mockUseEvals(options),
 }));

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -30,6 +30,9 @@ jest.mock("@/hooks/use-apps", () => ({
 jest.mock("@/hooks/use-agent-identities", () => ({
   useAgentIdentities: () => ({ data: [] }),
 }));
+jest.mock("@/providers/feature-flags-provider", () => ({
+  useFeatureFlag: () => false,
+}));
 
 const mockSetCurrentOrg = jest.fn();
 

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -21,8 +21,9 @@ jest.mock("@/hooks/use-capabilities", () => ({
   useCapabilities: () => ({ data: [] }),
   useDeclarativeCapabilities: () => ({ data: [] }),
 }));
+const mockUseEvals = jest.fn(() => ({ data: [] }));
 jest.mock("@/hooks/use-evals", () => ({
-  useEvals: () => ({ data: [] }),
+  useEvals: (options?: { enabled?: boolean }) => mockUseEvals(options),
 }));
 jest.mock("@/hooks/use-apps", () => ({
   useApps: () => ({ data: [] }),
@@ -30,8 +31,9 @@ jest.mock("@/hooks/use-apps", () => ({
 jest.mock("@/hooks/use-agent-identities", () => ({
   useAgentIdentities: () => ({ data: [] }),
 }));
+let mockEvalsFlag = false;
 jest.mock("@/providers/feature-flags-provider", () => ({
-  useFeatureFlag: () => false,
+  useFeatureFlag: () => mockEvalsFlag,
 }));
 
 const mockSetCurrentOrg = jest.fn();
@@ -59,6 +61,19 @@ jest.mock("@/providers/org-provider", () => ({
 describe("useGlobalSearch", () => {
   beforeEach(() => {
     mockSetCurrentOrg.mockClear();
+    mockUseEvals.mockClear();
+    mockEvalsFlag = false;
+  });
+
+  it("defers the evals fetch when the feature flag is off", () => {
+    renderHook(() => useGlobalSearch(""));
+    expect(mockUseEvals).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it("enables the evals fetch when the feature flag is on", () => {
+    mockEvalsFlag = true;
+    renderHook(() => useGlobalSearch(""));
+    expect(mockUseEvals).toHaveBeenCalledWith({ enabled: true });
   });
 
   it("finds organizations and switches to the selected organization", () => {

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -69,8 +69,29 @@ function groupResults(
 
 export function CommandPalette() {
   const { open, setOpen } = useCommandPalette();
-  const router = useRouter();
   const pathname = usePathname();
+
+  // Close on route change
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname, setOpen]);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:animation-duration-[200ms] fixed inset-0 z-50 bg-black/50" />
+        <DialogPrimitive.Popup className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]">
+          {/* Mount the search UI (and its data fetching) only while open, so we
+              don't fetch every entity list on every page load. */}
+          {open && <CommandPaletteContent setOpen={setOpen} />}
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }) {
+  const router = useRouter();
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -82,20 +103,10 @@ export function CommandPalette() {
   // Flat list for keyboard navigation
   const flatResults = grouped.flatMap((g) => g.items);
 
-  // Close on route change
+  // Focus input once the palette mounts.
   useEffect(() => {
-    setOpen(false);
-  }, [pathname, setOpen]);
-
-  // Reset state when opening
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-      setSelectedIndex(0);
-      // Focus input after dialog renders
-      requestAnimationFrame(() => inputRef.current?.focus());
-    }
-  }, [open]);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
 
   // Reset selected index when query changes.
   useEffect(() => {
@@ -154,94 +165,85 @@ export function CommandPalette() {
   let flatIndex = 0;
 
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Backdrop className="data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:animation-duration-[200ms] fixed inset-0 z-50 bg-black/50" />
-        <DialogPrimitive.Popup
-          className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+    <div className="bg-background w-full max-w-lg border shadow-2xl animate-in fade-in-0 zoom-in-95 duration-150">
+      {/* Search input */}
+      <div className="flex items-center gap-3 border-b px-4">
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-        >
-          <div className="bg-background w-full max-w-lg border shadow-2xl animate-in fade-in-0 zoom-in-95 duration-150">
-            {/* Search input */}
-            <div className="flex items-center gap-3 border-b px-4">
-              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <input
-                ref={inputRef}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search pages, organizations, agents..."
-                className="flex-1 bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
-                aria-label="Search pages, organizations, agents"
-              />
-              <kbd className="hidden sm:inline-flex h-5 items-center gap-1 border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-                ESC
-              </kbd>
-            </div>
+          placeholder="Search pages, organizations, agents..."
+          className="flex-1 bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
+          aria-label="Search pages, organizations, agents"
+        />
+        <kbd className="hidden sm:inline-flex h-5 items-center gap-1 border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+          ESC
+        </kbd>
+      </div>
 
-            {/* Results */}
-            <div ref={listRef} className="max-h-[min(50vh,400px)] overflow-y-auto p-1.5">
-              {flatResults.length === 0 && query.trim() ? (
-                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-                  No results for &ldquo;{query}&rdquo;
-                </div>
-              ) : (
-                grouped.map((group) => (
-                  <div key={group.category}>
-                    <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-                      {CATEGORY_LABELS[group.category]}
-                    </div>
-                    {group.items.map((result) => {
-                      const idx = flatIndex++;
-                      const isSelected = idx === selectedIndex;
-                      return (
-                        <button
-                          key={result.id}
-                          type="button"
-                          data-selected={isSelected}
-                          className={cn(
-                            "flex w-full items-center gap-3 px-3 py-2 text-sm transition-colors",
-                            isSelected
-                              ? "bg-accent text-accent-foreground"
-                              : "text-foreground hover:bg-accent/50",
-                          )}
-                          onClick={() => navigate(result)}
-                          onMouseEnter={() => setSelectedIndex(idx)}
-                        >
-                          <result.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                          <div className="flex-1 text-left min-w-0">
-                            <span className="truncate block">{result.title}</span>
-                            {result.subtitle && (
-                              <span className="truncate block text-xs text-muted-foreground">
-                                {result.subtitle}
-                              </span>
-                            )}
-                          </div>
-                          {isSelected && (
-                            <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-                ))
-              )}
-            </div>
-
-            {/* Footer hints */}
-            <div className="flex items-center gap-4 border-t px-4 py-2 text-[11px] text-muted-foreground">
-              <span className="inline-flex items-center gap-1">
-                <ArrowUp className="h-3 w-3" />
-                <ArrowDown className="h-3 w-3" />
-                navigate
-              </span>
-              <span className="inline-flex items-center gap-1">
-                <CornerDownLeft className="h-3 w-3" />
-                select
-              </span>
-            </div>
+      {/* Results */}
+      <div ref={listRef} className="max-h-[min(50vh,400px)] overflow-y-auto p-1.5">
+        {flatResults.length === 0 && query.trim() ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No results for &ldquo;{query}&rdquo;
           </div>
-        </DialogPrimitive.Popup>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
+        ) : (
+          grouped.map((group) => (
+            <div key={group.category}>
+              <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                {CATEGORY_LABELS[group.category]}
+              </div>
+              {group.items.map((result) => {
+                const idx = flatIndex++;
+                const isSelected = idx === selectedIndex;
+                return (
+                  <button
+                    key={result.id}
+                    type="button"
+                    data-selected={isSelected}
+                    className={cn(
+                      "flex w-full items-center gap-3 px-3 py-2 text-sm transition-colors",
+                      isSelected
+                        ? "bg-accent text-accent-foreground"
+                        : "text-foreground hover:bg-accent/50",
+                    )}
+                    onClick={() => navigate(result)}
+                    onMouseEnter={() => setSelectedIndex(idx)}
+                  >
+                    <result.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="flex-1 text-left min-w-0">
+                      <span className="truncate block">{result.title}</span>
+                      {result.subtitle && (
+                        <span className="truncate block text-xs text-muted-foreground">
+                          {result.subtitle}
+                        </span>
+                      )}
+                    </div>
+                    {isSelected && (
+                      <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Footer hints */}
+      <div className="flex items-center gap-4 border-t px-4 py-2 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1">
+          <ArrowUp className="h-3 w-3" />
+          <ArrowDown className="h-3 w-3" />
+          navigate
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <CornerDownLeft className="h-3 w-3" />
+          select
+        </span>
+      </div>
+    </div>
   );
 }

--- a/apps/ui/src/hooks/create-crud-hooks.ts
+++ b/apps/ui/src/hooks/create-crud-hooks.ts
@@ -14,6 +14,8 @@ import { useResourceOrgFallback } from "./use-resource-org-fallback";
 
 interface UseCrudListOptions {
   includeArchived?: boolean;
+  /** Defaults to true; pass false to defer the fetch (e.g. behind a feature flag). */
+  enabled?: boolean;
 }
 
 type QueryKeyValue = readonly unknown[];
@@ -84,6 +86,7 @@ export function createCrudHooks<TItem, TCreate, TUpdate>({
     return useOrgScopedQuery({
       queryKey: queryKeys.list(includeArchived),
       queryFn: () => api.list(includeArchived),
+      enabled: options.enabled ?? true,
       staleTime,
     });
   }

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -56,6 +56,7 @@ import { getDisplayName } from "@/lib/entity-lifecycle";
 import { localizedCapabilityName } from "@/lib/capability-localization";
 import { useLocale } from "@/providers/locale-provider";
 import { useOrg } from "@/providers/org-provider";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
 
 export type SearchResultCategory =
   | "navigation"
@@ -279,7 +280,10 @@ export function useGlobalSearch(query: string) {
   const { data: mcpServersData } = useMcpServers();
   const { data: capabilitiesData } = useCapabilities();
   const { data: declarativeCapabilitiesData } = useDeclarativeCapabilities();
-  const { data: evalsData } = useEvals();
+  // Evals is an experimental, flag-gated feature; only fetch when enabled to
+  // avoid a 404 on every palette open for orgs without the flag.
+  const evalsEnabled = useFeatureFlag("evals");
+  const { data: evalsData } = useEvals({ enabled: evalsEnabled });
   const { data: appsData } = useApps();
   const { data: agentIdentitiesData } = useAgentIdentities();
 


### PR DESCRIPTION
## What
Stop the global command palette from eagerly fetching every entity list on every page load, and stop calling the flag-gated `/api/v1/evals` endpoint for orgs without the feature.

## Why
`CommandPalette` is rendered in the shared `(main)` layout, so it mounts on every authenticated page. It called `useGlobalSearch()` at the top level, which eagerly fired ~10 list queries (agents, sessions, harnesses, skills, mcp-servers, capabilities, declarative-capabilities, evals, apps, agent-identities) on every navigation — even while the palette was closed. On top of that, `/api/v1/evals` returned `404` on every page because evals is an experimental, feature-flagged capability that isn't enabled for the org, yet the palette fetched it unconditionally. Net result: ~10 unnecessary requests per page load plus a recurring console error.

## How
- Split `CommandPalette` into a thin parent (open/close state + dialog scaffolding) and a `CommandPaletteContent` child that holds `useGlobalSearch` and all data fetching. The child is rendered only while the palette is open (`{open && <CommandPaletteContent />}`), so nothing fetches until the user opens it. React Query already caches results for the session, so re-opening is instant.
- Added an optional `enabled` flag to the shared `useList` CRUD hook and gated `useEvals({ enabled: useFeatureFlag("evals") })` in `useGlobalSearch`, so the evals query never fires (no 404) when the flag is off.
- Moved the keyboard handler onto the search `<input>` (its natural origin) instead of a static wrapper div.

## Risk
- Low. UI-only change, no API/schema changes. `useList`'s new option is additive and defaults to `enabled: true`, so all other callers are unchanged. Behavior on open is identical to before (query state resets on each open, matching the previous reset-on-open effect).
- What could break: command palette open/close, keyboard nav, and search results — all covered by tests below.

## Security
- Threat categories reviewed: TM-WEB. No auth/authz/SQL/API/input-parsing surface touched; DOM is reorganized and one fetch is gated behind a feature flag. No `dangerouslySetInnerHTML`, no new untrusted-input rendering, no CORS/CSP/cookie changes. The change is a net reduction in requests (including endpoints the org isn't entitled to).
- Findings and resolutions: none.

## Follow-ups
No follow-ups. Only `evals` is feature-flagged among the searched entities; the lazy-mount change already eliminates the eager per-page fetches for every other entity, so no further per-entity gating is needed.

## Checklist
- [x] Tests added or updated — new tests assert the palette does not run global search while closed, runs it once open, and that evals is gated by the feature flag
- [x] Backward compatibility considered — `useList` option is additive, defaults preserve existing behavior
- [x] Security review performed against relevant threat model categories (TM-WEB)
- [x] Final CI ran checks affected by this PR — UI Build/Lint/Test and UI Playwright Smoke green; heavy Rust/Docker/integration jobs skipped by path filtering (no opt-out labels used)
- [x] All review comments addressed (code change or written reasoning)

### Validation
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` clean
- `pnpm run build` (Next.js production build) succeeds
- Full UI test suite: 1049 passing, including the new behavioral tests
- Note: a full-stack browser smoke test was not run because Doppler secrets (and thus the backend + auth needed to reach the command palette) are unavailable in this agent environment. Runtime behavior is instead validated by component-level tests that exercise the real `CommandPalette`/`useGlobalSearch` lazy-mount and flag-gating logic.

https://claude.ai/code/session_014GzzBi3ZuSbVtkj7aci2R6