### PR TITLE
feat(ui): surface OpenRouter OAuth in Add Provider dialog

### DIFF
--- a/apps/ui/src/__tests__/add-provider-oauth.test.tsx
+++ b/apps/ui/src/__tests__/add-provider-oauth.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { AddProviderDialog } from "@/app/(main)/settings/providers/provider-dialogs";
+
+// Render the real credential form, but swap the base-ui Select for a native
+// <select> so the provider-type picker is drivable in jsdom (mirrors the mock
+// used by knowledge-indexes-page.test.tsx).
+jest.mock("@/components/ui/select", () => {
+  function collectOptions(node: React.ReactNode): React.ReactNode[] {
+    const options: React.ReactNode[] = [];
+    React.Children.forEach(node, (child) => {
+      if (!React.isValidElement(child)) return;
+      if ((child.type as { isSelectItem?: boolean }).isSelectItem) {
+        const props = child.props as { value: string; children: React.ReactNode };
+        options.push(
+          <option key={props.value} value={props.value}>
+            {props.value}
+          </option>,
+        );
+        return;
+      }
+      options.push(...collectOptions((child.props as { children?: React.ReactNode }).children));
+    });
+    return options;
+  }
+
+  function Select({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) {
+    return (
+      <select
+        aria-label="Provider Type"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+      >
+        {collectOptions(children)}
+      </select>
+    );
+  }
+
+  function SelectItem(_: { value: string; children: React.ReactNode }) {
+    return null;
+  }
+  SelectItem.isSelectItem = true;
+
+  return {
+    Select,
+    SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectItem,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectValue: () => null,
+  };
+});
+
+const mockCreateProvider = jest.fn();
+const mockUseProvidersConfig = jest.fn();
+
+jest.mock("@/hooks/use-providers", () => ({
+  useCreateProvider: () => ({ mutateAsync: mockCreateProvider, isPending: false }),
+  useUpdateProvider: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useProvidersConfig: () => mockUseProvidersConfig(),
+}));
+
+jest.mock("@/lib/api/providers", () => ({
+  providerSupportsOAuth: (driver: string) => driver === "openrouter",
+  providerOAuthAuthorizeUrl: (id: string) => `/api/v1/providers/${id}/oauth/authorize`,
+}));
+
+const apiKeyDriver = (driver: string, supportsOAuth: boolean) => ({
+  driver,
+  supports_oauth: supportsOAuth,
+  credential_schema: {
+    fields: [
+      { name: "api_key", label: "API Key", field_type: "password", required: !supportsOAuth },
+    ],
+    instructions_markdown: "",
+  },
+});
+
+describe("AddProviderDialog OAuth connect", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseProvidersConfig.mockReturnValue({
+      data: {
+        policies: {},
+        drivers: [apiKeyDriver("openai", false), apiKeyDriver("openrouter", true)],
+      },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("offers a Connect button for OAuth drivers and not for key-only drivers", async () => {
+    render(<AddProviderDialog open onOpenChange={() => {}} />);
+
+    // Default driver (openai) is key-only: no Connect button.
+    expect(screen.queryByRole("button", { name: /Connect with/i })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Provider Type"), { target: { value: "openrouter" } });
+
+    expect(
+      await screen.findByRole("button", { name: "Connect with OpenRouter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("creates the provider without a key before starting the OAuth flow", async () => {
+    mockCreateProvider.mockResolvedValue({ id: "provider-new" });
+
+    render(<AddProviderDialog open onOpenChange={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("Provider Type"), { target: { value: "openrouter" } });
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "My OpenRouter" } });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Connect with OpenRouter" }));
+
+    // The Connect button creates the provider with no credentials; the returned
+    // id is what the authorize redirect (asserted via providerOAuthAuthorizeUrl
+    // elsewhere) binds its OAuth state to.
+    await waitFor(() => {
+      expect(mockCreateProvider).toHaveBeenCalledWith({
+        name: "My OpenRouter",
+        provider_type: "openrouter",
+        base_url: undefined,
+        credentials: undefined,
+      });
+    });
+  });
+});

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -132,6 +132,25 @@ export function AddProviderDialog({
   const updateCredential = (key: string, value: string) =>
     setCredentials((prev) => ({ ...prev, [key]: value }));
 
+  // Create the provider, then hand the browser straight to the driver's OAuth
+  // authorize endpoint. The flow needs a provider id to bind its state cookie
+  // to, so creation has to happen first; doing both in one click is why OAuth is
+  // actionable here instead of a "create first, then connect" hint. The dialog
+  // unmounts on navigation, so local form state needs no reset.
+  const handleCreateAndConnect = async () => {
+    const submitted = nonEmptyCredentials(credentials);
+    const data: CreateProviderRequest = {
+      name,
+      provider_type: providerType,
+      base_url: baseUrl || undefined,
+      credentials: Object.keys(submitted).length > 0 ? submitted : undefined,
+    };
+    const provider = await createProvider.mutateAsync(data);
+    window.location.href = providerOAuthAuthorizeUrl(provider.id);
+  };
+
+  const submitDisabled = createProvider.isPending || !name || (baseUrlRequired && !baseUrl.trim());
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -203,19 +222,26 @@ export function AddProviderDialog({
             />
           ) : null}
           {supportsOAuth ? (
-            <p className="text-sm text-muted-foreground">
-              Prefer not to paste a key? Create the provider without one, then use “Connect with{" "}
-              {getProviderLabel(providerType)}” to authorize a key in your browser.
-            </p>
+            <div className="space-y-2">
+              <Button
+                type="button"
+                className="w-full"
+                onClick={handleCreateAndConnect}
+                disabled={submitDisabled}
+              >
+                Connect with {getProviderLabel(providerType)}
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Authorize in your browser to set up a key automatically — no copy &amp; paste
+                needed. Or paste a key above and use “Create Provider”.
+              </p>
+            </div>
           ) : null}
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={createProvider.isPending || !name || (baseUrlRequired && !baseUrl.trim())}
-            >
+            <Button type="submit" disabled={submitDisabled}>
               {createProvider.isPending ? "Creating..." : "Create Provider"}
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## What
Replace the passive OAuth hint in the **Add Provider** dialog with a real
**"Connect with {provider}"** button. For OAuth-capable drivers (OpenRouter
today), the button creates the provider with no key and hands the browser to the
driver's authorize endpoint in one click. Manual key entry + "Create Provider"
is unchanged.

## Why
OpenRouter OAuth is fully implemented end-to-end (authorize/callback endpoints,
PKCE, `provider.manage` checks, the `Connect with OpenRouter` button in the
Set/Update Credentials dialog). But the **Add Provider** dialog only showed text
— "Create the provider without one, then use Connect with OpenRouter…" — and no
actionable control. Users reasonably concluded OAuth wasn't supported when
adding a provider. The OAuth flow binds its CSRF state cookie to a provider id,
so a provider row must exist first; combining create + authorize into one button
makes OAuth discoverable at the add step without changing that contract.

## How
- `AddProviderDialog`: a `handleCreateAndConnect` handler creates the provider
  (credentials only sent when non-empty, as before), then navigates to
  `providerOAuthAuthorizeUrl(provider.id)`.
- The button renders only when the selected driver declares OAuth
  (`supports_oauth` from the providers config, with the existing client shim as
  fallback). Hoisted the create-disabled condition into a shared `submitDisabled`
  so both buttons gate identically.

## Risk
- Low.
- Pure client-side affordance over an already-shipped, server-secured flow. No
  new endpoints, no auth/authz or credential-handling changes. Worst case is a
  mis-gated button, covered by tests.

## Security
- Threat categories reviewed: **TM-WEB**, **TM-AUTH** (OAuth trigger surface).
- Findings and resolutions:
  - The redirect URL is built from a server-issued provider id plus the backend
    base URL — not user-controlled input — so no open-redirect/injection surface
    is added. No `dangerouslySetInnerHTML` or untrusted clickable links.
  - All OAuth security (HttpOnly `SameSite=Lax` PKCE state cookie bound to
    provider/org, `provider.manage` re-check on callback, SSRF validation of the
    driver-declared authorize URL) is server-side and unchanged by this diff. No
    threat-model update required.

## Validation
- `pnpm run format:check`, `pnpm run lint`, `tsc --noEmit`, full `jest`
  (1047 tests) and `pnpm run build` all pass locally.
- New `add-provider-oauth.test.tsx` renders the real dialog: asserts the Connect
  button gates on OAuth drivers and that clicking it creates the provider with no
  credentials.
- End-to-end smoke test against `just start-dev`: selected OpenRouter in the Add
  Provider dialog → "Connect with OpenRouter" appears and API Key becomes
  optional → filled a name → clicked Connect → the provider was created and the
  browser was handed to the external OpenRouter authorize redirect.
- CI: UI Build/Lint/Test, UI Playwright Smoke, CodeQL all green; Rust/docker/
  integration jobs skipped by path filtering (UI-only diff); CI Opt-Out Policy
  green (no opt-out labels used).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (none raised)

https://claude.ai/code/session_01Taa9pk1fUiG3C7mTncd6ps