### PR TITLE
fix(ui): reword empty feature-flags state for SaaS users

### DIFF
--- a/apps/ui/src/app/(main)/settings/features/page.tsx
+++ b/apps/ui/src/app/(main)/settings/features/page.tsx
@@ -18,7 +18,6 @@ export default function FeaturesSettingsPage() {
   const updateFlags = useUpdateOrgFeatureFlags();
 
   const availableFlags = data?.flags.filter((f) => f.system_enabled) ?? [];
-  const unavailableCount = data?.flags.filter((f) => !f.system_enabled).length ?? 0;
 
   const handleToggle = (flag: OrgFeatureFlagSetting, enabled: boolean) => {
     if (!canManage) return;
@@ -61,9 +60,7 @@ export default function FeaturesSettingsPage() {
 
       {!isLoading && availableFlags.length === 0 && (
         <Card className="p-6 text-sm text-muted-foreground">
-          No optional features are available to enable on this deployment.
-          {unavailableCount > 0 &&
-            ` (${unavailableCount} feature${unavailableCount === 1 ? "" : "s"} require operator configuration.)`}
+          No experimental features are currently available for your organization.
         </Card>
       )}
 


### PR DESCRIPTION
## What
Reword the empty-state on **Settings → Features** when no experimental flags are available to opt into.

Before:
> No optional features are available to enable on this deployment. (7 features require operator configuration.)

After:
> No experimental features are currently available for your organization.

Also drops the now-unused `unavailableCount` computation that only fed the deleted parenthetical.

## Why
The previous copy leaked self-hosted/internal vocabulary into a SaaS surface:
- **"operator configuration"** points users at a role and a lever they don't control. On `app.everruns.com` the deployment operator is Everruns, not the org admin viewing the page — so the message is not actionable and reads like a misconfiguration.
- **The raw count ("7 features")** advertises hidden capabilities without naming any, inviting "how do I get these?" with no answer the user can act on.

The two-gate model is unchanged (`effective = system_enabled && org_enabled`, `crates/core/src/feature_flags.rs`); only the user-facing copy for the closed deployment gate is reworded to be org-scoped and free of operator jargon.

## How
Single string-literal change in the `availableFlags.length === 0` branch of `apps/ui/src/app/(main)/settings/features/page.tsx`, plus removal of the dead `unavailableCount` variable.

## Risk
- Low
- Static copy change in one empty-state branch. No logic, data, or API surface affected.

## Validation
- `pnpm run format:check` ✓
- `pnpm run lint` (oxlint) ✓
- `pnpm run typecheck` (tsc --noEmit) ✓
- `pnpm run build` ✓ — `/settings/features` compiles
- Note: the empty-state branch is not reachable in dev grade (experimental flags auto-enable there), so build + typecheck is the appropriate evidence rather than a local render.

## Security
- Threat categories reviewed: **TM-WEB**. No security-relevant code changes — this replaces one static string literal and removes a derived count; there is no user input, no new sink, and no XSS surface. If anything it slightly *reduces* information disclosure by no longer surfacing the internal "operator" concept and hidden-feature count.
- Findings and resolutions: none.

## Follow-ups
- Deployment-side (out of scope for this copy fix): none of the 7 experimental `FEATURE_*` flags are enabled on `app.everruns.com`, which is why the empty state shows at all. If those features should be opt-in-able in prod, an operator needs to set the corresponding `FEATURE_*` env vars — tracked separately, not a UI change.

## Checklist
- [x] Tests added or updated — N/A (static copy change; no behavioral logic to assert)
- [x] Backward compatibility considered — UI copy only
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01Gtng1c1C7dVJQhHGpUh1AC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtng1c1C7dVJQhHGpUh1AC)_