### PR TITLE
feat(ui): reimplement create app page and detail identity editor

### DIFF
--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -5,54 +5,20 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useCreateApp } from "@/hooks/use-apps";
 import { usePageTitle } from "@/hooks";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AgentSelect } from "@/components/agent/agent-select";
-import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import { Badge } from "@/components/ui/badge";
 import {
   PageContainer,
   PageBreadcrumb,
   PageMasthead,
-  PageColumns,
-  PageMain,
-  PageRail,
-  RailSection,
   PageFooter,
   BackLink,
 } from "@/components/layout";
-import { Check, Plus, RefreshCw } from "lucide-react";
-import type {
-  AgUiToolVisibility,
-  ChannelType,
-  InvocationSessionMode,
-  SessionStrategy,
-  SlackReplyMode,
-} from "@/lib/api/types";
-import {
-  getAgUiToolVisibilityDisplayName,
-  getChannelTypeDisplayName,
-  getInvocationSessionModeDisplayName,
-  getSessionStrategyDisplayName,
-  getSlackReplyModeDisplayName,
-} from "@/lib/app-channels";
-import { DEFAULT_AG_UI_GENERIC_TOOL_TEXT } from "@/lib/api/types";
-import { generateChannelToken } from "@/lib/channel-tokens";
-import {
-  CRON_MIN_INTERVAL_SECONDS,
-  getCronIntervalSeconds,
-  isSupportedCronExpression,
-} from "@/components/apps/cron-label";
+import { Plus, Rocket } from "lucide-react";
 
 export default function NewAppPage() {
   usePageTitle("New App", "Apps");
@@ -66,97 +32,28 @@ export default function NewAppPage() {
   const [description, setDescription] = useState("");
   const [agentId, setAgentId] = useState(() => searchParams.get("agent_id") ?? "");
   const [harnessId, setHarnessId] = useState(() => searchParams.get("harness_id") ?? "");
-  const [agentIdentityId, setAgentIdentityId] = useState("");
-  const [channelType, setChannelType] = useState<ChannelType | "">("");
-  const [slackSigningSecret, setSlackSigningSecret] = useState("");
-  const [slackBotToken, setSlackBotToken] = useState("");
-  const [slackTeamId, setSlackTeamId] = useState("");
-  const [slackChannelId, setSlackChannelId] = useState("");
-  const [slackSessionStrategy, setSlackSessionStrategy] = useState<SessionStrategy>("per_thread");
-  const [slackReplyMode, setSlackReplyMode] = useState<SlackReplyMode>("all_messages");
-  const [scheduleCronExpression, setScheduleCronExpression] = useState("0 */5 * * * * *");
-  const [scheduleTimezone, setScheduleTimezone] = useState("UTC");
-  const [invocationSessionMode, setInvocationSessionMode] =
-    useState<InvocationSessionMode>("shared_session");
-  const [channelMessage, setChannelMessage] = useState("");
-  const [webhookToken, setWebhookToken] = useState("");
-  const [agUiToken, setAgUiToken] = useState("");
-  const [agUiToolVisibility, setAgUiToolVisibility] = useState<AgUiToolVisibility>("generic");
-  const [agUiGenericToolText, setAgUiGenericToolText] = useState(DEFAULT_AG_UI_GENERIC_TOOL_TEXT);
+  // Validation runs on submit, then errors stay live as fields change (mirrors
+  // the design's "Create draft → inline error" flow rather than disabling the button).
+  const [submitted, setSubmitted] = useState(false);
 
-  const handleChannelTypeChange = (value: string) => {
-    const nextChannelType = value === "__none__" ? "" : (value as ChannelType);
-    setChannelType(nextChannelType);
-    if (nextChannelType === "ag_ui" && channelType !== "ag_ui" && !agUiToken) {
-      setAgUiToken(generateChannelToken());
-    }
-  };
-
-  const buildChannelConfig = () => {
-    switch (channelType) {
-      case "ag_ui":
-        return {
-          anonymous: true,
-          ...(agUiToken.trim() ? { token: agUiToken.trim() } : {}),
-          tool_visibility: agUiToolVisibility,
-          generic_tool_text: agUiGenericToolText.trim() || DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
-        };
-      case "slack":
-        return {
-          signing_secret: slackSigningSecret,
-          bot_token: slackBotToken,
-          session_strategy: slackSessionStrategy,
-          reply_mode: slackReplyMode,
-          ...(slackTeamId ? { team_id: slackTeamId } : {}),
-          ...(slackChannelId ? { channel_id: slackChannelId } : {}),
-        };
-      case "schedule":
-        return {
-          cron_expression: scheduleCronExpression,
-          timezone: scheduleTimezone || "UTC",
-          session_mode: invocationSessionMode,
-          message: channelMessage,
-        };
-      case "webhook":
-        return {
-          token: webhookToken,
-          session_mode: invocationSessionMode,
-          message: channelMessage,
-        };
-      default:
-        return undefined;
-    }
-  };
-
-  const isChannelConfigValid =
-    channelType === ""
-      ? true
-      : channelType === "ag_ui"
-        ? agUiToolVisibility !== "generic" || agUiGenericToolText.trim().length <= 120
-        : channelType === "slack"
-          ? !!slackSigningSecret && !!slackBotToken
-          : channelType === "schedule"
-            ? !!scheduleCronExpression &&
-              !!channelMessage.trim() &&
-              isSupportedCronExpression(scheduleCronExpression) &&
-              (getCronIntervalSeconds(scheduleCronExpression) ?? 0) >= CRON_MIN_INTERVAL_SECONDS
-            : !!webhookToken && !!channelMessage.trim();
+  const nameError = submitted && !name.trim();
+  const harnessError = submitted && !harnessId;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitted(true);
+
+    if (!name.trim() || !harnessId) return;
 
     try {
       const app = await createApp.mutateAsync({
-        name,
-        description: description || undefined,
+        name: name.trim(),
+        description: description.trim() || undefined,
         agent_id: agentId || undefined,
-        agent_identity_id: agentIdentityId || undefined,
         harness_id: harnessId,
-        channel_type: channelType || undefined,
-        channel_config: channelType ? buildChannelConfig() : undefined,
       });
 
-      // Redirect to the detail page for channel-specific setup.
+      // Channels and agent identity are configured on the detail page.
       router.push(`/apps/${app.id}`);
     } catch (error) {
       console.error("Failed to create app:", error);
@@ -164,425 +61,127 @@ export default function NewAppPage() {
   };
 
   return (
-    <PageContainer>
+    <PageContainer fullWidth className="mx-auto max-w-3xl">
       <PageBreadcrumb items={[{ label: "Apps", href: "/apps" }, { label: "New app" }]} />
 
       <PageMasthead
-        icon={<Plus />}
+        icon={<Rocket />}
         title="New app"
         badges={<Badge variant="accent">Draft</Badge>}
         description="Deploy an agent to a channel — Slack, AG-UI, webhook, or schedule."
-        actions={
-          <>
-            <Button
-              type="submit"
-              form="app-edit-form"
-              disabled={createApp.isPending || !name || !harnessId || !isChannelConfigValid}
-            >
-              <Check className="size-4" />
-              {createApp.isPending ? "Creating..." : "Create App"}
-            </Button>
-            <Button type="button" variant="outline" onClick={() => router.back()}>
-              Discard
-            </Button>
-          </>
-        }
       />
 
-      <form id="app-edit-form" onSubmit={handleSubmit}>
-        <PageColumns>
-          <PageMain>
-            <Card>
-              <CardHeader>
-                <CardTitle>App details</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="space-y-2">
-                  <Label htmlFor="name">Name</Label>
-                  <Input
-                    id="name"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder="Support Bot"
-                    required
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="description">Description</Label>
-                  <Input
-                    id="description"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Customer support bot for #help channel"
-                  />
-                </div>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="harness">Harness</Label>
-                    <HarnessSelect value={harnessId} onValueChange={setHarnessId} />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="agent">Agent (optional)</Label>
-                    <AgentSelect
-                      value={agentId}
-                      onValueChange={setAgentId}
-                      includeNoneOption
-                      noneLabel="Choose later"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="agent_identity">Agent identity</Label>
-                    <AgentIdentitySelect
-                      value={agentIdentityId}
-                      onValueChange={setAgentIdentityId}
-                    />
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="channel_type">Channel (optional)</Label>
-                  <Select value={channelType || "__none__"} onValueChange={handleChannelTypeChange}>
-                    <SelectTrigger id="channel_type">
-                      <SelectValue placeholder="Choose later" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">Choose later</SelectItem>
-                      <SelectItem value="slack">{getChannelTypeDisplayName("slack")}</SelectItem>
-                      <SelectItem value="ag_ui">{getChannelTypeDisplayName("ag_ui")}</SelectItem>
-                      <SelectItem value="schedule">
-                        {getChannelTypeDisplayName("schedule")}
-                      </SelectItem>
-                      <SelectItem value="webhook">
-                        {getChannelTypeDisplayName("webhook")}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {channelType === "slack" && (
-                  <div className="space-y-4 rounded-md border p-4">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="slack_signing_secret">Signing Secret</Label>
-                        <Input
-                          id="slack_signing_secret"
-                          type="password"
-                          value={slackSigningSecret}
-                          onChange={(e) => setSlackSigningSecret(e.target.value)}
-                          placeholder="Slack signing secret"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="slack_bot_token">Bot Token</Label>
-                        <Input
-                          id="slack_bot_token"
-                          type="password"
-                          value={slackBotToken}
-                          onChange={(e) => setSlackBotToken(e.target.value)}
-                          placeholder="xoxb-..."
-                        />
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="slack_team_id">Workspace ID (optional)</Label>
-                        <Input
-                          id="slack_team_id"
-                          value={slackTeamId}
-                          onChange={(e) => setSlackTeamId(e.target.value)}
-                          placeholder="T0123456789"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="slack_channel_id">Channel ID (optional)</Label>
-                        <Input
-                          id="slack_channel_id"
-                          value={slackChannelId}
-                          onChange={(e) => setSlackChannelId(e.target.value)}
-                          placeholder="C0123456789"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="slack_session_strategy">Session Strategy</Label>
-                        <Select
-                          value={slackSessionStrategy}
-                          onValueChange={(value) =>
-                            setSlackSessionStrategy(value as SessionStrategy)
-                          }
-                        >
-                          <SelectTrigger id="slack_session_strategy">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="per_thread">
-                              {getSessionStrategyDisplayName("per_thread")}
-                            </SelectItem>
-                            <SelectItem value="per_channel">
-                              {getSessionStrategyDisplayName("per_channel")}
-                            </SelectItem>
-                            <SelectItem value="per_user">
-                              {getSessionStrategyDisplayName("per_user")}
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="slack_reply_mode">Reply Mode</Label>
-                        <Select
-                          value={slackReplyMode}
-                          onValueChange={(value) => setSlackReplyMode(value as SlackReplyMode)}
-                        >
-                          <SelectTrigger id="slack_reply_mode">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="all_messages">
-                              {getSlackReplyModeDisplayName("all_messages")}
-                            </SelectItem>
-                            <SelectItem value="report_progress_only">
-                              {getSlackReplyModeDisplayName("report_progress_only")}
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {channelType === "ag_ui" && (
-                  <div className="space-y-4 rounded-md border p-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="ag_ui_token">Endpoint Token</Label>
-                      <div className="flex gap-2">
-                        <Input
-                          id="ag_ui_token"
-                          value={agUiToken}
-                          onChange={(e) => setAgUiToken(e.target.value)}
-                          className="font-mono"
-                          placeholder="Generated bearer token"
-                        />
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="icon"
-                          onClick={() => setAgUiToken(generateChannelToken())}
-                          aria-label="Regenerate AG-UI token"
-                        >
-                          <RefreshCw className="h-4 w-4" />
-                        </Button>
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        AG-UI clients must send this as `Authorization: Bearer &lt;token&gt;` or
-                        `X-Everruns-AG-UI-Token`.
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="ag_ui_tool_visibility">Tool Activity</Label>
-                      <Select
-                        value={agUiToolVisibility}
-                        onValueChange={(value) =>
-                          setAgUiToolVisibility(value as AgUiToolVisibility)
-                        }
-                      >
-                        <SelectTrigger id="ag_ui_tool_visibility">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="none">
-                            {getAgUiToolVisibilityDisplayName("none")}
-                          </SelectItem>
-                          <SelectItem value="generic">
-                            {getAgUiToolVisibilityDisplayName("generic")}
-                          </SelectItem>
-                          <SelectItem value="narrated">
-                            {getAgUiToolVisibilityDisplayName("narrated")}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <p className="text-xs text-muted-foreground">
-                        Tool names, arguments, and results are never sent to public AG-UI clients.
-                      </p>
-                    </div>
-
-                    {agUiToolVisibility === "generic" && (
-                      <div className="space-y-2">
-                        <Label htmlFor="ag_ui_generic_tool_text">Generic Activity Text</Label>
-                        <Input
-                          id="ag_ui_generic_tool_text"
-                          value={agUiGenericToolText}
-                          onChange={(e) => setAgUiGenericToolText(e.target.value)}
-                          maxLength={120}
-                          placeholder={DEFAULT_AG_UI_GENERIC_TOOL_TEXT}
-                        />
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {channelType === "schedule" && (
-                  <div className="space-y-4 rounded-md border p-4">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="schedule_cron_expression">Cron Expression</Label>
-                        <Input
-                          id="schedule_cron_expression"
-                          value={scheduleCronExpression}
-                          onChange={(e) => setScheduleCronExpression(e.target.value)}
-                          placeholder="0 */5 * * * * *"
-                        />
-                        {scheduleCronExpression &&
-                          isSupportedCronExpression(scheduleCronExpression) &&
-                          (getCronIntervalSeconds(scheduleCronExpression) ?? 0) <
-                            CRON_MIN_INTERVAL_SECONDS && (
-                            <p className="text-xs text-destructive">
-                              Minimum interval is {Math.floor(CRON_MIN_INTERVAL_SECONDS / 60)}{" "}
-                              minutes.
-                            </p>
-                          )}
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="schedule_timezone">Timezone</Label>
-                        <Input
-                          id="schedule_timezone"
-                          value={scheduleTimezone}
-                          onChange={(e) => setScheduleTimezone(e.target.value)}
-                          placeholder="UTC"
-                        />
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="schedule_session_mode">Invocation Session Mode</Label>
-                      <Select
-                        value={invocationSessionMode}
-                        onValueChange={(value) =>
-                          setInvocationSessionMode(value as InvocationSessionMode)
-                        }
-                      >
-                        <SelectTrigger id="schedule_session_mode">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="shared_session">
-                            {getInvocationSessionModeDisplayName("shared_session")}
-                          </SelectItem>
-                          <SelectItem value="session_per_invocation">
-                            {getInvocationSessionModeDisplayName("session_per_invocation")}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="schedule_message">Invocation Message</Label>
-                      <Textarea
-                        id="schedule_message"
-                        value={channelMessage}
-                        onChange={(e) => setChannelMessage(e.target.value)}
-                        placeholder="Run repository checks for {{app.name}}"
-                      />
-                    </div>
-                  </div>
-                )}
-
-                {channelType === "webhook" && (
-                  <div className="space-y-4 rounded-md border p-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="webhook_token">Webhook Token</Label>
-                      <Input
-                        id="webhook_token"
-                        type="password"
-                        value={webhookToken}
-                        onChange={(e) => setWebhookToken(e.target.value)}
-                        placeholder="shared-secret"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="webhook_session_mode">Invocation Session Mode</Label>
-                      <Select
-                        value={invocationSessionMode}
-                        onValueChange={(value) =>
-                          setInvocationSessionMode(value as InvocationSessionMode)
-                        }
-                      >
-                        <SelectTrigger id="webhook_session_mode">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="shared_session">
-                            {getInvocationSessionModeDisplayName("shared_session")}
-                          </SelectItem>
-                          <SelectItem value="session_per_invocation">
-                            {getInvocationSessionModeDisplayName("session_per_invocation")}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="webhook_message">Invocation Message</Label>
-                      <Textarea
-                        id="webhook_message"
-                        value={channelMessage}
-                        onChange={(e) => setChannelMessage(e.target.value)}
-                        placeholder="Process webhook payload for {{payload.repo.name}}"
-                      />
-                    </div>
-                  </div>
-                )}
-
-                <p className="text-sm text-muted-foreground">
-                  {channelType === "slack"
-                    ? "Slack needs credentials up front. You can still refine webhook setup and manifest details on the app detail page."
-                    : channelType === "ag_ui"
-                      ? "After creating the app, publish it and point your AG-UI client at the channel endpoint on the detail page."
-                      : channelType === "schedule"
-                        ? "This creates an app-level scheduled invocation channel. It activates only when the app is published."
-                        : channelType === "webhook"
-                          ? "This creates an authenticated app webhook channel. The detail page will show the endpoint URL to call."
-                          : `Create the draft now, then assign an agent or add ${getChannelTypeDisplayName("slack")}, ${getChannelTypeDisplayName("ag_ui")}, ${getChannelTypeDisplayName("schedule")}, or ${getChannelTypeDisplayName("webhook")} later from the detail page.`}
-                </p>
-
-                {createApp.error && (
-                  <p className="text-sm text-destructive">Error: {createApp.error.message}</p>
-                )}
-              </CardContent>
-            </Card>
-          </PageMain>
-
-          <PageRail>
-            <RailSection label="Summary">
-              <div className="flex flex-col gap-3 text-sm">
-                <div>
-                  <p className="font-medium">Name</p>
-                  <p className="text-muted-foreground">{name || "(not set)"}</p>
-                </div>
-                <div>
-                  <p className="font-medium">Channel</p>
-                  <p className="text-muted-foreground">
-                    {channelType ? getChannelTypeDisplayName(channelType) : "Choose later"}
-                  </p>
-                </div>
-                <div>
-                  <p className="font-medium">Agent</p>
-                  <p className="text-muted-foreground">{agentId ? "Assigned" : "Choose later"}</p>
-                </div>
-              </div>
-            </RailSection>
-
-            <RailSection label="About">
-              <p className="text-sm text-muted-foreground">
-                Apps deploy your agents to channels like Slack and AG-UI. Create the draft first,
-                then refine channel setup on the detail page.
+      <form id="app-create-form" onSubmit={handleSubmit}>
+        <Card>
+          <CardContent className="flex flex-col gap-6">
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight">App details</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Name and description shown across Everruns.
               </p>
-            </RailSection>
-          </PageRail>
-        </PageColumns>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Support Bot"
+                aria-invalid={nameError}
+                required
+              />
+              {nameError ? (
+                <p className="text-xs text-destructive">Enter a name to continue.</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Shown in the apps list and channel headers.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">
+                Description <span className="font-normal text-muted-foreground">optional</span>
+              </Label>
+              <Input
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Customer support bot for #help channel"
+              />
+            </div>
+
+            <hr className="border-border" />
+
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight">Deployment</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Choose a harness now. You can change it or bind an agent anytime.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="harness">
+                  Harness <span className="text-destructive">*</span>
+                </Label>
+                <HarnessSelect
+                  id="harness"
+                  value={harnessId}
+                  onValueChange={(value) => setHarnessId(value)}
+                  placeholder="Select a harness"
+                  className="w-full"
+                />
+                {harnessError ? (
+                  <p className="text-xs text-destructive">Select a harness to continue.</p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    The execution harness this app runs on.
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="agent">
+                  Agent <span className="font-normal text-muted-foreground">optional</span>
+                </Label>
+                <AgentSelect
+                  value={agentId}
+                  onValueChange={setAgentId}
+                  includeNoneOption
+                  noneLabel="Choose later"
+                  className="w-full"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Bind an agent now or assign one later.
+                </p>
+              </div>
+            </div>
+
+            <hr className="border-border" />
+
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="max-w-md text-sm text-muted-foreground">
+                Create the draft now — change the harness or bind an agent anytime from the detail
+                page.
+              </p>
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" onClick={() => router.back()}>
+                  Cancel
+                </Button>
+                <Button type="submit" form="app-create-form" disabled={createApp.isPending}>
+                  <Plus className="size-4" />
+                  {createApp.isPending ? "Creating..." : "Create draft"}
+                </Button>
+              </div>
+            </div>
+
+            {createApp.error && (
+              <p className="text-sm text-destructive">Error: {createApp.error.message}</p>
+            )}
+          </CardContent>
+        </Card>
       </form>
 
       <PageFooter>

--- a/apps/ui/src/components/agent-identity/agent-identity-select.tsx
+++ b/apps/ui/src/components/agent-identity/agent-identity-select.tsx
@@ -18,6 +18,8 @@ interface AgentIdentitySelectProps {
   includeNone?: boolean;
   noneLabel?: string;
   disabled?: boolean;
+  /** Additional className for the trigger. */
+  className?: string;
 }
 
 export function AgentIdentitySelect({
@@ -27,6 +29,7 @@ export function AgentIdentitySelect({
   includeNone = true,
   noneLabel = "No identity",
   disabled,
+  className,
 }: AgentIdentitySelectProps) {
   const { data: identities = [] } = useAgentIdentities({ includeArchived: !!value });
   const identityMap = useMemo(
@@ -50,7 +53,7 @@ export function AgentIdentitySelect({
       onValueChange={(next) => onValueChange(next === "none" ? "" : next)}
       disabled={disabled}
     >
-      <SelectTrigger>
+      <SelectTrigger className={className}>
         <SelectValue placeholder={placeholder}>{displayLabel}</SelectValue>
       </SelectTrigger>
       <SelectContent>

--- a/apps/ui/src/components/apps/app-detail.tsx
+++ b/apps/ui/src/components/apps/app-detail.tsx
@@ -7,7 +7,13 @@ import { Archive, GlobeLock, Play, Plus, Rocket } from "lucide-react";
 import { useAgents, usePageTitle } from "@/hooks";
 import { useHarnesses } from "@/hooks/use-harnesses";
 import { usePolicies } from "@/hooks/use-policies";
-import { useApp, useDeleteApp, usePublishApp, useUnpublishApp } from "@/hooks/use-apps";
+import {
+  useApp,
+  useDeleteApp,
+  usePublishApp,
+  useUnpublishApp,
+  useUpdateApp,
+} from "@/hooks/use-apps";
 import { triggerChannel } from "@/lib/api/apps";
 import { queryKeys } from "@/lib/query-keys";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -30,9 +36,11 @@ import {
   PageColumns,
   PageMain,
   PageRail,
+  RailSection,
   PageFooter,
   BackLink,
 } from "@/components/layout";
+import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import type { App, AppChannel } from "@/lib/api/types";
 import {
   getDisplayName,
@@ -82,6 +90,7 @@ export function AppDetail({ appId }: { appId: string }) {
   const deleteAppMutation = useDeleteApp();
   const publishApp = usePublishApp();
   const unpublishApp = useUnpublishApp();
+  const updateApp = useUpdateApp();
   const [expandedChannelId, setExpandedChannelId] = useState<string | null>(null);
 
   usePageTitle(app ? getDisplayName(app) : null, "App");
@@ -287,6 +296,22 @@ export function AppDetail({ appId }: { appId: string }) {
         </PageMain>
 
         <PageRail>
+          <RailSection label="Agent identity">
+            <AgentIdentitySelect
+              value={app.agent_identity_id ?? ""}
+              onValueChange={(identityId) =>
+                updateApp.mutate({
+                  appId: app.id,
+                  data: { agent_identity_id: identityId || null },
+                })
+              }
+              disabled={!canManage || updateApp.isPending}
+              className="w-full"
+            />
+            <p className="mt-2 text-xs text-muted-foreground">
+              Identity this app presents when it runs sessions.
+            </p>
+          </RailSection>
           <LiveActivityRail appId={app.id} />
         </PageRail>
       </PageColumns>

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -197,7 +197,7 @@ draft → published → draft → archived → deleted
 
 ## UI
 
-The App detail page is a channels-first operations page. It folds App configuration into the header, renders a Health / Invocations 24h / Success rate / Activity stat strip, lists channels as expandable rows, and shows a live activity rail. Channel creation and editing are full-page routes, not dialogs:
+The App detail page is a channels-first operations page. It folds App configuration into the header, renders a Health / Invocations 24h / Success rate / Activity stat strip, lists channels as expandable rows, and shows a live activity rail with an agent-identity control that persists changes inline. Channel creation and editing are full-page routes, not dialogs:
 
 - `/apps/{app_id}/channels/new`
 - `/apps/{app_id}/channels/{channel_id}`
@@ -211,7 +211,7 @@ Apps are the publish surface for Harnesses and Agents. To avoid forcing users to
 - Harness detail → `/apps/new?harness_id={harness_id}`
 - Agent detail → `/apps/new?agent_id={agent_id}`
 
-The create form reads `harness_id` and `agent_id` from the query string to seed its selectors. Because a Harness is required, the harness shortcut yields a directly submittable draft; the agent shortcut still requires the user to pick a harness.
+The create form is a streamlined draft form: an **App details** section (name, description) and a **Deployment** section (required Harness, optional Agent). Channel and agent-identity configuration are deferred to the detail page, so creation always yields a draft. The form reads `harness_id` and `agent_id` from the query string to seed its selectors. Because a Harness is required, the harness shortcut yields a directly submittable draft; the agent shortcut still requires the user to pick a harness.
 
 ## Data Model
 

--- a/test_cases/ui/agent_identities/TC003_assign_identity_to_app.md
+++ b/test_cases/ui/agent_identities/TC003_assign_identity_to_app.md
@@ -2,7 +2,9 @@
 
 ## Description
 
-Verify that an agent identity can be assigned to an app during creation.
+Verify that an agent identity can be assigned to an app from the app detail
+page. Identity is no longer set during app creation; it is configured after the
+draft exists, alongside channels.
 
 ## Preconditions
 
@@ -11,12 +13,11 @@ Verify that an agent identity can be assigned to an app during creation.
 
 ## Steps
 
-1. Navigate to create a new app
-2. Fill in required fields
-3. Assign the existing identity in the creation form
-4. Submit
+1. Create a new app (name + harness) and submit.
+2. On the app detail page, locate the "Agent identity" control in the right rail.
+3. Select the existing identity.
 
 ## Expected Result
 
-- App is created with the assigned identity
-- App detail shows the identity association
+- The identity selection persists (reloading the detail page shows it selected).
+- App detail shows the identity association.

--- a/test_cases/ui/agent_identities/TC004_swap_identity_on_app.md
+++ b/test_cases/ui/agent_identities/TC004_swap_identity_on_app.md
@@ -12,9 +12,9 @@ Verify that an app's agent identity can be changed after creation.
 
 ## Steps
 
-1. Navigate to the app's edit page
-2. Change the assigned identity to a different one
-3. Save
+1. Navigate to the app's detail page
+2. In the "Agent identity" rail control, select a different identity
+3. The change saves automatically
 
 ## Expected Result
 


### PR DESCRIPTION
## What
Reimplement the New App page to match the simplified Slate design, and add an agent-identity editor to the App detail page.

- **Create page** (`apps/new/page.tsx`): restructured into an **App details** section (name, description) and a **Deployment** section (required Harness, optional Agent), with field hints, optional/required treatment, and inline validation on submit. The action cluster moves into the card footer (`Cancel` / `Create draft`). Channel configuration and the agent-identity selector are removed from creation; on submit the page redirects to the detail page where those are configured. Query-param prefill (`harness_id` / `agent_id`) is preserved. Net −522/+149 lines.
- **Detail page** (`app-detail.tsx`): new "Agent identity" rail control that persists inline via `useUpdateApp`, gated on `canManage`.
- **`AgentIdentitySelect`**: gains a `className` prop so it can fill its container.
- Specs and identity test cases (TC003/TC004) updated to match the new flow.

## Why
The create form had grown to ~590 lines and front-loaded channel/identity configuration that the detail page already owns (it has "Add channel" and full channel routes). The redesign makes creation a focused "draft" step and moves post-creation configuration to where it belongs. Because identity was previously only settable at creation, it is added to the detail page so the capability is retained.

## How
Built on the existing layout primitives (`PageMasthead`, `Card`, `RailSection`) and data-driven selects (`HarnessSelect`, `AgentSelect`, `AgentIdentitySelect`). Creation now sends only `name`, `description`, `agent_id`, `harness_id` to the existing `POST /v1/apps`. Identity edits use the existing `PATCH /v1/apps/{id}` via `useUpdateApp`.

## Risk
- Low.
- Purely client-side UI; no API, schema, or migration changes. The create API still accepts `channel_type`/`channel_config`/`agent_identity_id` — those inputs simply move to the detail page. Worst case is a UI regression in the create/identity flows.

## Validation
- `pnpm typecheck`, `lint` (oxlint), `format:check` (oxfmt), and production `pnpm build` all pass locally.
- Manual smoke test against a local `just start-dev` stack: create page renders the redesigned layout; valid submit creates the app and redirects to the detail page; invalid submit is blocked with the inline "Select a harness to continue." error; the detail-page identity control assigns an identity and persists it (confirmed via the API).
- CI green: UI Build/Lint/Test, UI Playwright Smoke, CodeQL, CI Opt-Out Policy.

## Security
- Threat categories reviewed: **TM-AUTHZ**, **TM-WEB**. No new threat surface — identity edits go through the existing, server-authorized `PATCH /v1/apps/{id}` mutation and are gated client-side on the `app.manage` policy (server remains the enforcement point). The create page sends a strict subset of the previous fields to the same endpoint. No injection surface (selected IDs sent as JSON; React escapes rendering).
- Findings and resolutions: none. No `THREAT` comments touched; no threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (manual test cases TC003/TC004 revised to the new flow)
- [x] Backward compatibility considered (API unchanged; inputs relocated to detail page)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (none posted)

https://claude.ai/code/session_013NFZdKrc2ZUJB5K72D8Boc