### PR TITLE
feat(observers): Observers UI + llm_judge model-access validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+- feat(observers): Observers UI — create/edit observers, scorer catalog, and a per-observer Quality tab by [@chaliy](https://github.com/chaliy)
+- fix(observers): reject `llm_judge` scorers that reference a model the org cannot use by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.1] - 2026-06-27
 
 ### Highlights

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -38,6 +38,7 @@ import {
   BarChart3,
   GitBranch,
   Rocket,
+  Telescope,
   Terminal,
   Boxes,
 } from "lucide-react";
@@ -84,6 +85,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("overview");
   const agentVersionsEnabled = useFeatureFlag("agent_versions");
+  const observersEnabled = useFeatureFlag("observers");
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
   usePageTitle(agent ? getDisplayName(agent) : null, "Agent");
   // Fetch only top 10 sessions for the overview
@@ -258,6 +260,14 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                 <Button variant="outline">
                   <Rocket className="size-4" />
                   Create app
+                </Button>
+              </Link>
+            )}
+            {observersEnabled && agent.status === "active" && (
+              <Link href={{ pathname: "/observers/new", query: { agent_id: agentId } }}>
+                <Button variant="outline">
+                  <Telescope className="size-4" />
+                  Observe this agent
                 </Button>
               </Link>
             )}

--- a/apps/ui/src/app/(main)/observers/[observerId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/observers/[observerId]/edit/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useObserver, usePageTitle } from "@/hooks";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { ObserverForm } from "@/components/observers/observer-form";
+
+export default function EditObserverPage({ params }: { params: Promise<{ observerId: string }> }) {
+  const { observerId } = use(params);
+  const observersEnabled = useFeatureFlag("observers");
+  const { data: observer, isLoading } = useObserver(observerId);
+  usePageTitle(observer ? `Edit ${observer.name}` : "Edit Observer", "Observers");
+
+  if (!observersEnabled) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Observers is not enabled</p>
+          <p className="text-sm">This feature is currently disabled.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="mb-4 h-8 w-1/3" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!observer) {
+    return (
+      <ResourceNotFound
+        title="Observer not found"
+        description="This observer may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/observers"
+        backLabel="Back to observers"
+        resourceId={observerId}
+      />
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href={`/observers/${observerId}`}
+        className="mb-6 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to observer
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Edit Observer</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ObserverForm observer={observer} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/observers/[observerId]/page.tsx
+++ b/apps/ui/src/app/(main)/observers/[observerId]/page.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { use, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  useObserver,
+  useObserverScores,
+  useUpdateObserver,
+  useDeleteObserver,
+  useAgents,
+  useHarnesses,
+  usePageTitle,
+} from "@/hooks";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Notice, NoticeDescription } from "@/components/ui/notice";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Pencil, Pause, Play, Archive, Settings, BarChart3 } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { describeRule } from "@/components/observers/scorer-editor";
+import { QualitySummary } from "@/components/observers/quality-summary";
+import {
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+  getDisplayName,
+} from "@/lib/entity-lifecycle";
+import type { Observer, ObserverScorerConfig, TraceScore } from "@/lib/api/types";
+
+function scoreStatusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "completed":
+      return "default";
+    case "pending":
+    case "scoring":
+      return "secondary";
+    case "errored":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function scorerSummary(scorer: ObserverScorerConfig): string {
+  if (scorer.method === "llm_judge") {
+    return `llm_judge (pass ≥ ${scorer.pass_threshold})`;
+  }
+  return describeRule(scorer.rule);
+}
+
+function ConfigurationTab({
+  observer,
+  agentNames,
+  harnessNames,
+}: {
+  observer: Observer;
+  agentNames: Map<string, string>;
+  harnessNames: Map<string, string>;
+}) {
+  const { agent_ids, harness_ids, session_tags } = observer.match;
+  const hasMatch =
+    (agent_ids?.length ?? 0) > 0 ||
+    (harness_ids?.length ?? 0) > 0 ||
+    (session_tags?.length ?? 0) > 0;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Match rules</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {!hasMatch && (
+            <p className="text-muted-foreground">No filters — considers all production sessions.</p>
+          )}
+          {agent_ids && agent_ids.length > 0 && (
+            <div>
+              <p className="mb-1 text-xs font-medium text-muted-foreground">Agents</p>
+              <div className="flex flex-wrap gap-1">
+                {agent_ids.map((id) => (
+                  <Badge key={id} variant="outline">
+                    {agentNames.get(id) ?? id}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+          {harness_ids && harness_ids.length > 0 && (
+            <div>
+              <p className="mb-1 text-xs font-medium text-muted-foreground">Harnesses</p>
+              <div className="flex flex-wrap gap-1">
+                {harness_ids.map((id) => (
+                  <Badge key={id} variant="outline">
+                    {harnessNames.get(id) ?? id}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+          {session_tags && session_tags.length > 0 && (
+            <div>
+              <p className="mb-1 text-xs font-medium text-muted-foreground">Session tags</p>
+              <div className="flex flex-wrap gap-1">
+                {session_tags.map((tag) => (
+                  <Badge key={tag} variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+          <div>
+            <p className="mb-1 text-xs font-medium text-muted-foreground">Sampling rate</p>
+            <p>{Math.round(observer.sampling_rate * 100)}% of matching turns</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Scorers</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {observer.scorers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No scorers configured.</p>
+          ) : (
+            observer.scorers.map((scorer) => (
+              <div
+                key={scorer.key}
+                className="flex items-center justify-between gap-2 border bg-muted/50 p-2"
+              >
+                <span className="font-mono text-sm">{scorer.key}</span>
+                <span className="text-xs text-muted-foreground">{scorerSummary(scorer)}</span>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ScoreRow({ score }: { score: TraceScore }) {
+  const reason = score.reason ?? score.error_message ?? "";
+  const truncated = reason.length > 80 ? `${reason.slice(0, 80)}…` : reason;
+  return (
+    <TableRow>
+      <TableCell className="font-mono text-xs">{score.scorer_key}</TableCell>
+      <TableCell>{score.value !== undefined ? score.value.toFixed(2) : "—"}</TableCell>
+      <TableCell>
+        {score.pass === undefined ? (
+          "—"
+        ) : (
+          <Badge variant={score.pass ? "default" : "destructive"}>
+            {score.pass ? "pass" : "fail"}
+          </Badge>
+        )}
+      </TableCell>
+      <TableCell>{score.label ?? "—"}</TableCell>
+      <TableCell>
+        <Badge variant={scoreStatusVariant(score.status)}>{score.status}</Badge>
+      </TableCell>
+      <TableCell className="max-w-[240px] text-xs text-muted-foreground">
+        {truncated || "—"}
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        {new Date(score.created_at).toLocaleString()}
+      </TableCell>
+      <TableCell>
+        <Link href={`/sessions/${score.session_id}`} className="text-primary hover:underline">
+          View
+        </Link>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function QualityTab({ observerId }: { observerId: string }) {
+  const { data: scores, isLoading, error } = useObserverScores(observerId);
+
+  return (
+    <div className="space-y-6">
+      <Notice variant="info">
+        <NoticeDescription>
+          Trends are computed from recent sampled scores; full aggregation is a follow-up.
+        </NoticeDescription>
+      </Notice>
+
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={scores}
+        errorMessagePrefix="Failed to load scores"
+        emptyState={
+          <div className="py-12 text-center text-muted-foreground">
+            No scores yet. Scores appear here once matching production turns are sampled.
+          </div>
+        }
+      >
+        {(items) => (
+          <>
+            <QualitySummary scores={items} />
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Recent scores</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Scorer</TableHead>
+                      <TableHead>Value</TableHead>
+                      <TableHead>Pass</TableHead>
+                      <TableHead>Label</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Reasoning</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead>Session</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((score) => (
+                      <ScoreRow key={score.id} score={score} />
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </QueryStateWrapper>
+    </div>
+  );
+}
+
+export default function ObserverDetailPage({
+  params,
+}: {
+  params: Promise<{ observerId: string }>;
+}) {
+  const { observerId } = use(params);
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState("configuration");
+
+  const { data: observer, isLoading } = useObserver(observerId);
+  usePageTitle(observer?.name ?? null, "Observer");
+  const { data: agents = [] } = useAgents();
+  const { data: harnesses = [] } = useHarnesses();
+  const updateObserver = useUpdateObserver();
+  const deleteObserver = useDeleteObserver();
+
+  const agentNames = new Map(agents.map((a) => [a.id, getDisplayName(a)]));
+  const harnessNames = new Map(harnesses.map((h) => [h.id, getDisplayName(h)]));
+
+  const handleToggleStatus = async () => {
+    if (!observer) return;
+    const nextStatus = observer.status === "active" ? "paused" : "active";
+    try {
+      await updateObserver.mutateAsync({
+        observerId,
+        request: { status: nextStatus },
+      });
+    } catch (error) {
+      console.error("Failed to update observer status:", error);
+    }
+  };
+
+  const handleArchive = async () => {
+    try {
+      await deleteObserver.mutateAsync(observerId);
+      router.push("/observers");
+    } catch (error) {
+      console.error("Failed to archive observer:", error);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="mb-4 h-8 w-1/3" />
+        <Skeleton className="mb-8 h-4 w-2/3" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!observer) {
+    return (
+      <ResourceNotFound
+        title="Observer not found"
+        description="This observer may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/observers"
+        backLabel="Back to observers"
+        resourceId={observerId}
+      />
+    );
+  }
+
+  const isArchived = observer.status === "archived";
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/observers"
+        className="mb-6 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+      >
+        Back to Observers
+      </Link>
+
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <span className={getEntityNameClassName(observer.status)}>{observer.name}</span>
+            <CopyButton value={observer.id} />
+            <Badge variant={getEntityStatusBadgeVariant(observer.status)}>{observer.status}</Badge>
+          </h1>
+          {observer.description && (
+            <p className="mt-1 text-muted-foreground">{observer.description}</p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {!isArchived && (
+            <Link href={`/observers/${observerId}/edit`}>
+              <Button variant="outline">
+                <Pencil className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            </Link>
+          )}
+          {!isArchived && (
+            <Button
+              variant="outline"
+              onClick={handleToggleStatus}
+              disabled={updateObserver.isPending}
+            >
+              {observer.status === "active" ? (
+                <>
+                  <Pause className="mr-2 h-4 w-4" />
+                  Pause
+                </>
+              ) : (
+                <>
+                  <Play className="mr-2 h-4 w-4" />
+                  Resume
+                </>
+              )}
+            </Button>
+          )}
+          {!isArchived && (
+            <Button variant="outline" onClick={handleArchive} disabled={deleteObserver.isPending}>
+              <Archive className="mr-2 h-4 w-4" />
+              Archive
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="mb-6">
+          <TabsTrigger value="configuration">
+            <Settings className="mr-2 h-4 w-4" />
+            Configuration
+          </TabsTrigger>
+          <TabsTrigger value="quality">
+            <BarChart3 className="mr-2 h-4 w-4" />
+            Quality
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="configuration">
+          <ConfigurationTab
+            observer={observer}
+            agentNames={agentNames}
+            harnessNames={harnessNames}
+          />
+        </TabsContent>
+
+        <TabsContent value="quality">
+          <QualityTab observerId={observerId} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/observers/new/page.tsx
+++ b/apps/ui/src/app/(main)/observers/new/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { usePageTitle } from "@/hooks";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { ObserverForm, type ObserverFormInitial } from "@/components/observers/observer-form";
+import { SCORER_CATALOG } from "@/components/observers/scorer-catalog";
+
+function NewObserverForm() {
+  const searchParams = useSearchParams();
+  const agentId = searchParams.get("agent_id");
+
+  // Prefill from "Observe this agent": scope to the agent, default sampling, and
+  // seed the answer_completeness catalog scorer.
+  const initial: ObserverFormInitial | undefined = agentId
+    ? {
+        agent_ids: [agentId],
+        sampling_rate: 0.1,
+        scorers: (() => {
+          const template = SCORER_CATALOG.find((t) => t.key === "answer_completeness");
+          if (!template) return [];
+          return [
+            {
+              key: template.key,
+              scope: "turn" as const,
+              method: "llm_judge" as const,
+              rubric: template.rubric,
+              pass_threshold: template.pass_threshold,
+            },
+          ];
+        })(),
+      }
+    : undefined;
+
+  return <ObserverForm initial={initial} />;
+}
+
+export default function NewObserverPage() {
+  usePageTitle("New Observer", "Observers");
+  const observersEnabled = useFeatureFlag("observers");
+
+  if (!observersEnabled) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Observers is not enabled</p>
+          <p className="text-sm">This feature is currently disabled.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/observers"
+        className="mb-6 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to Observers
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Create New Observer</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Suspense fallback={null}>
+            <NewObserverForm />
+          </Suspense>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/observers/observers-page-client.tsx
+++ b/apps/ui/src/app/(main)/observers/observers-page-client.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { useObservers, usePageTitle } from "@/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { pluralize } from "@/lib/formatting";
+import type { Observer } from "@/lib/api/types";
+
+function ObserverCard({ observer }: { observer: Observer }) {
+  return (
+    <Link href={`/observers/${observer.id}`}>
+      <Card className="h-full cursor-pointer transition-colors hover:border-primary/50">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="truncate text-base">{observer.name}</CardTitle>
+            <Badge variant={getEntityStatusBadgeVariant(observer.status)}>{observer.status}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {observer.description && (
+            <p className="line-clamp-2 text-sm text-muted-foreground">{observer.description}</p>
+          )}
+          <div className="flex items-center gap-4 text-xs text-muted-foreground">
+            <span>{Math.round(observer.sampling_rate * 100)}% sampled</span>
+            <span>
+              {observer.scorers.length} {pluralize(observer.scorers.length, "scorer")}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+export default function ObserversPageClient() {
+  usePageTitle("Observers");
+  const observersEnabled = useFeatureFlag("observers");
+  const {
+    data: observers,
+    isLoading,
+    error,
+  } = useObservers({
+    includeArchived: false,
+    enabled: observersEnabled,
+  });
+
+  if (!observersEnabled) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Observers is not enabled</p>
+          <p className="text-sm">This feature is currently disabled.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="flex items-center gap-3 text-2xl font-bold">
+          Observers
+          <ExperimentalPageBadge />
+        </h1>
+        <Link href="/observers/new">
+          <Button variant="accent">
+            <Plus className="mr-2 h-4 w-4" />
+            New Observer
+          </Button>
+        </Link>
+      </div>
+
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={observers}
+        errorMessagePrefix="Failed to load observers"
+        emptyState={
+          <div className="py-12 text-center">
+            <p className="mb-4 text-muted-foreground">No observers yet</p>
+            <Link href="/observers/new">
+              <Button>
+                <Plus className="mr-2 h-4 w-4" />
+                Create observer
+              </Button>
+            </Link>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((observer) => (
+              <ObserverCard key={observer.id} observer={observer} />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/observers/page.tsx
+++ b/apps/ui/src/app/(main)/observers/page.tsx
@@ -1,0 +1,5 @@
+import ObserversPageClient from "./observers-page-client";
+
+export default function ObserversPage() {
+  return <ObserversPageClient />;
+}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -37,6 +37,7 @@ import {
   Server,
   Settings,
   Shield,
+  Telescope,
   UserRound,
   Workflow,
   Cog,
@@ -104,6 +105,13 @@ export const defaultBuildingBlocksNavigation: NavigationItem[] = [
   { name: "Plugins", href: "/plugins", icon: Puzzle },
   { name: "Apps", href: "/apps", icon: Rocket },
   { name: "Evals", href: "/evals", icon: ClipboardCheck, flag: "evals", experimental: true },
+  {
+    name: "Observers",
+    href: "/observers",
+    icon: Telescope,
+    flag: "observers",
+    experimental: true,
+  },
 ];
 
 export const defaultBottomNavigation: NavigationItem[] = [

--- a/apps/ui/src/components/observers/observer-form.tsx
+++ b/apps/ui/src/components/observers/observer-form.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+// Shared create/edit form for observers.
+//
+// Validation: requires a name, at least one scorer, and a non-empty rubric for
+// every llm_judge scorer and a non-empty key for every scorer. Server-side
+// errors (e.g. a judge model not available to the org) surface in an inline alert.
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+import { useAgents, useHarnesses } from "@/hooks";
+import { useCreateObserver, useUpdateObserver } from "@/hooks";
+import { getDisplayName } from "@/lib/entity-lifecycle";
+import { parseTagList } from "@/lib/form-validation";
+import { ScorerEditor } from "./scorer-editor";
+import type {
+  Observer,
+  ObserverScorerConfig,
+  CreateObserverRequest,
+  UpdateObserverRequest,
+} from "@/lib/api/types";
+
+export interface ObserverFormInitial {
+  name?: string;
+  description?: string;
+  sampling_rate?: number;
+  agent_ids?: string[];
+  harness_ids?: string[];
+  session_tags?: string[];
+  scorers?: ObserverScorerConfig[];
+}
+
+interface ObserverFormProps {
+  /** When set, the form edits an existing observer; otherwise it creates one. */
+  observer?: Observer;
+  /** Prefill values for the create form (e.g. from "Observe this agent"). */
+  initial?: ObserverFormInitial;
+}
+
+const DEFAULT_SAMPLING_RATE = 0.1;
+
+function scorerErrors(scorers: ObserverScorerConfig[]): Record<number, string> {
+  const errors: Record<number, string> = {};
+  scorers.forEach((scorer, index) => {
+    if (!scorer.key.trim()) {
+      errors[index] = "Key is required";
+      return;
+    }
+    if (scorer.method === "llm_judge" && !scorer.rubric.trim()) {
+      errors[index] = "Rubric is required for LLM judge scorers";
+    }
+  });
+  return errors;
+}
+
+export function ObserverForm({ observer, initial }: ObserverFormProps) {
+  const router = useRouter();
+  const createObserver = useCreateObserver();
+  const updateObserver = useUpdateObserver();
+
+  const { data: agents = [] } = useAgents();
+  const { data: harnesses = [] } = useHarnesses();
+
+  const [name, setName] = useState(observer?.name ?? initial?.name ?? "");
+  const [description, setDescription] = useState(
+    observer?.description ?? initial?.description ?? "",
+  );
+  const [samplingRate, setSamplingRate] = useState<number>(
+    observer?.sampling_rate ?? initial?.sampling_rate ?? DEFAULT_SAMPLING_RATE,
+  );
+  const [agentIds, setAgentIds] = useState<string[]>(
+    observer?.match.agent_ids ?? initial?.agent_ids ?? [],
+  );
+  const [harnessIds, setHarnessIds] = useState<string[]>(
+    observer?.match.harness_ids ?? initial?.harness_ids ?? [],
+  );
+  const [sessionTags, setSessionTags] = useState<string>(
+    (observer?.match.session_tags ?? initial?.session_tags ?? []).join(", "),
+  );
+  const [scorers, setScorers] = useState<ObserverScorerConfig[]>(
+    observer?.scorers ?? initial?.scorers ?? [],
+  );
+  const [submitted, setSubmitted] = useState(false);
+
+  const errors = useMemo(() => scorerErrors(scorers), [scorers]);
+  const hasScorerErrors = Object.keys(errors).length > 0;
+  const nameMissing = !name.trim();
+  const noScorers = scorers.length === 0;
+
+  const mutationError = observer ? updateObserver.error : createObserver.error;
+  const isPending = observer ? updateObserver.isPending : createObserver.isPending;
+
+  const toggleAgent = (id: string) => {
+    setAgentIds((prev) => (prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id]));
+  };
+
+  const toggleHarness = (id: string) => {
+    setHarnessIds((prev) => (prev.includes(id) ? prev.filter((h) => h !== id) : [...prev, id]));
+  };
+
+  const buildMatch = () => {
+    const tags = parseTagList(sessionTags);
+    return {
+      agent_ids: agentIds.length > 0 ? agentIds : undefined,
+      harness_ids: harnessIds.length > 0 ? harnessIds : undefined,
+      session_tags: tags.length > 0 ? tags : undefined,
+    };
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+
+    if (nameMissing || noScorers || hasScorerErrors) {
+      return;
+    }
+
+    const match = buildMatch();
+
+    try {
+      if (observer) {
+        const request: UpdateObserverRequest = {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          match,
+          sampling_rate: samplingRate,
+          scorers,
+        };
+        await updateObserver.mutateAsync({ observerId: observer.id, request });
+        router.push(`/observers/${observer.id}`);
+      } else {
+        const request: CreateObserverRequest = {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          match,
+          sampling_rate: samplingRate,
+          scorers,
+        };
+        const created = await createObserver.mutateAsync(request);
+        router.push(`/observers/${created.id}`);
+      }
+    } catch (error) {
+      // Surfaced inline via mutationError below.
+      console.error("Failed to save observer:", error);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="observer-name">Name</Label>
+            <Input
+              id="observer-name"
+              placeholder="Production quality monitor"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            {submitted && nameMissing && (
+              <p className="text-sm text-destructive">Name is required</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="observer-description">Description</Label>
+            <Textarea
+              id="observer-description"
+              placeholder="What this observer watches for..."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="observer-sampling">
+              Sampling rate ({Math.round(samplingRate * 100)}% of turns)
+            </Label>
+            <Input
+              id="observer-sampling"
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={samplingRate}
+              onChange={(e) => setSamplingRate(Number(e.target.value))}
+            />
+            <p className="text-xs text-muted-foreground">
+              Fraction of matching production turns this observer scores.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Match rules</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Optional filters. When left empty an observer considers all production sessions in the
+            org.
+          </p>
+
+          <div className="space-y-2">
+            <Label>Agents</Label>
+            {agents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No agents available.</p>
+            ) : (
+              <div className="flex max-h-48 flex-col gap-2 overflow-y-auto border p-3">
+                {agents.map((agent) => (
+                  <label key={agent.id} className="flex cursor-pointer items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={agentIds.includes(agent.id)}
+                      onCheckedChange={() => toggleAgent(agent.id)}
+                    />
+                    {getDisplayName(agent)}
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Harnesses</Label>
+            {harnesses.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No harnesses available.</p>
+            ) : (
+              <div className="flex max-h-48 flex-col gap-2 overflow-y-auto border p-3">
+                {harnesses.map((harness) => (
+                  <label
+                    key={harness.id}
+                    className="flex cursor-pointer items-center gap-2 text-sm"
+                  >
+                    <Checkbox
+                      checked={harnessIds.includes(harness.id)}
+                      onCheckedChange={() => toggleHarness(harness.id)}
+                    />
+                    {getDisplayName(harness)}
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="observer-tags">Session tags</Label>
+            <Input
+              id="observer-tags"
+              placeholder="comma, separated, tags"
+              value={sessionTags}
+              onChange={(e) => setSessionTags(e.target.value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Scorers</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ScorerEditor
+            scorers={scorers}
+            onChange={setScorers}
+            errors={submitted ? errors : undefined}
+          />
+          {submitted && noScorers && (
+            <p className="text-sm text-destructive">Add at least one scorer.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {mutationError && (
+        <Notice variant="destructive">
+          <NoticeTitle>Failed to save observer</NoticeTitle>
+          <NoticeDescription>{mutationError.message}</NoticeDescription>
+        </Notice>
+      )}
+
+      <div className="flex gap-4">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving..." : observer ? "Save changes" : "Create observer"}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => router.back()}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/ui/src/components/observers/quality-summary.tsx
+++ b/apps/ui/src/components/observers/quality-summary.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+// Client-side quality aggregation for the observer detail "Quality" tab.
+//
+// Trends are computed from recent sampled scores only; full server-side
+// aggregation is a follow-up. We group completed scores by scorer_key for the
+// summary cards and by day for the trend chart.
+
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { TraceScore } from "@/lib/api/types";
+
+export interface ScorerSummary {
+  scorerKey: string;
+  scored: number;
+  passRate: number | null;
+  avgValue: number | null;
+}
+
+export function summarizeScores(scores: TraceScore[]): ScorerSummary[] {
+  const byKey = new Map<string, TraceScore[]>();
+  for (const score of scores) {
+    if (score.status !== "completed") continue;
+    const list = byKey.get(score.scorer_key) ?? [];
+    list.push(score);
+    byKey.set(score.scorer_key, list);
+  }
+
+  return [...byKey.entries()]
+    .map(([scorerKey, list]) => {
+      const passable = list.filter((s) => s.pass !== undefined);
+      const valued = list.filter((s) => s.value !== undefined);
+      const passRate = passable.length
+        ? passable.filter((s) => s.pass).length / passable.length
+        : null;
+      const avgValue = valued.length
+        ? valued.reduce((sum, s) => sum + (s.value ?? 0), 0) / valued.length
+        : null;
+      return { scorerKey, scored: list.length, passRate, avgValue };
+    })
+    .sort((a, b) => a.scorerKey.localeCompare(b.scorerKey));
+}
+
+interface TrendPoint {
+  day: string;
+  passRate: number;
+  count: number;
+}
+
+function buildTrend(scores: TraceScore[]): TrendPoint[] {
+  const byDay = new Map<string, { passed: number; total: number }>();
+  for (const score of scores) {
+    if (score.status !== "completed" || score.pass === undefined) continue;
+    const day = score.created_at.slice(0, 10);
+    const entry = byDay.get(day) ?? { passed: 0, total: 0 };
+    entry.total += 1;
+    if (score.pass) entry.passed += 1;
+    byDay.set(day, entry);
+  }
+
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, { passed, total }]) => ({
+      day,
+      passRate: Math.round((passed / total) * 100),
+      count: total,
+    }));
+}
+
+function passRateColor(rate: number): string {
+  if (rate >= 0.9) return "text-green-600";
+  if (rate >= 0.7) return "text-yellow-600";
+  return "text-red-600";
+}
+
+export function QualitySummary({ scores }: { scores: TraceScore[] }) {
+  const summaries = useMemo(() => summarizeScores(scores), [scores]);
+  const trend = useMemo(() => buildTrend(scores), [scores]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {summaries.map((summary) => (
+          <Card key={summary.scorerKey}>
+            <CardHeader className="pb-2">
+              <CardTitle className="font-mono text-sm">{summary.scorerKey}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-1 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Scored</span>
+                <span>{summary.scored}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Pass rate</span>
+                <span
+                  className={
+                    summary.passRate !== null ? passRateColor(summary.passRate) : undefined
+                  }
+                >
+                  {summary.passRate !== null ? `${Math.round(summary.passRate * 100)}%` : "—"}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Avg value</span>
+                <span>{summary.avgValue !== null ? summary.avgValue.toFixed(2) : "—"}</span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {trend.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Pass rate trend</CardTitle>
+          </CardHeader>
+          <CardContent className="pb-2">
+            <ResponsiveContainer width="100%" height={220}>
+              <LineChart data={trend}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="day"
+                  tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  domain={[0, 100]}
+                  tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                  tickLine={false}
+                  axisLine={false}
+                  width={40}
+                />
+                <Tooltip />
+                <Line
+                  type="monotone"
+                  dataKey="passRate"
+                  name="Pass rate %"
+                  stroke="#22c55e"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/observers/scorer-catalog.ts
+++ b/apps/ui/src/components/observers/scorer-catalog.ts
@@ -1,0 +1,57 @@
+// Starter llm_judge scorer templates the user can add with one click.
+// Each template maps to a `method: "llm_judge"` scorer config when added.
+
+export interface ScorerTemplate {
+  /** Unique scorer key, used as the catalog identifier and the scorer key. */
+  key: string;
+  /** Short human label shown on the add button. */
+  label: string;
+  /** One-line description of what the scorer measures. */
+  description: string;
+  /** Judge rubric prompt. */
+  rubric: string;
+  /** Pass threshold (0–1). */
+  pass_threshold: number;
+}
+
+export const SCORER_CATALOG: ScorerTemplate[] = [
+  {
+    key: "answer_completeness",
+    label: "Answer completeness",
+    description: "How fully the answer addresses the user's question.",
+    rubric:
+      "Score 1.0 if the answer fully and directly addresses the user's question; lower if partial or off-topic.",
+    pass_threshold: 0.5,
+  },
+  {
+    key: "source_citation",
+    label: "Source citation",
+    description: "Whether claims are backed by cited sources or tool results.",
+    rubric: "Score 1.0 if claims are backed by cited sources/tool results; 0.0 if unsupported.",
+    pass_threshold: 0.5,
+  },
+  {
+    key: "user_frustration",
+    label: "User frustration",
+    description: "Whether the user seems satisfied or frustrated.",
+    rubric:
+      "Score 1.0 if the user seems satisfied; lower if they show frustration or repeat themselves.",
+    pass_threshold: 0.5,
+  },
+  {
+    key: "hallucination_risk",
+    label: "Hallucination risk",
+    description: "Whether the answer invents facts not supported by context.",
+    rubric:
+      "Score 1.0 if the answer stays grounded in the provided context and tool results; lower the more it asserts facts that are not supported, fabricated, or contradicted by available evidence.",
+    pass_threshold: 0.5,
+  },
+  {
+    key: "tool_error_rate",
+    label: "Tool error rate",
+    description: "Whether tools were used successfully without errors.",
+    rubric:
+      "Score 1.0 if any tools used in the turn completed successfully and their results were handled correctly; lower if tools errored, were retried excessively, or their failures were ignored.",
+    pass_threshold: 0.5,
+  },
+];

--- a/apps/ui/src/components/observers/scorer-editor.tsx
+++ b/apps/ui/src/components/observers/scorer-editor.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+// Scorers editor for the observer form.
+//
+// Scope is organized as tabs labelled "Answers" (turn), "Conversations" (session),
+// and "Tools" (tool). The backend only supports the `turn` scope today, so the
+// other two tabs are rendered disabled with a "Coming soon" note. All editable
+// scorers therefore live under the `turn` scope.
+
+import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+import { ModelPicker } from "@/components/models/model-picker";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SCORER_CATALOG } from "./scorer-catalog";
+import type { ObserverScorerConfig, ObserverScorerScope, ScorerRule } from "@/lib/api/types";
+
+// Rule variants offered for observers (file_contains excluded — server rejects it).
+const RULE_TYPES = [
+  "contains",
+  "not_contains",
+  "regex",
+  "tool_called",
+  "tool_not_called",
+  "tool_call_count",
+  "turns_within",
+  "json_schema",
+] as const;
+
+type RuleType = (typeof RULE_TYPES)[number];
+
+const RULE_LABELS: Record<RuleType, string> = {
+  contains: "Contains text",
+  not_contains: "Does not contain text",
+  regex: "Matches regex",
+  tool_called: "Tool called",
+  tool_not_called: "Tool not called",
+  tool_call_count: "Tool call count",
+  turns_within: "Turns within",
+  json_schema: "Matches JSON schema",
+};
+
+/** Human-readable one-line summary of a rule, for read-only config display. */
+export function describeRule(rule: ScorerRule): string {
+  switch (rule.type) {
+    case "contains":
+      return `contains("${rule.text}")`;
+    case "not_contains":
+      return `not_contains("${rule.text}")`;
+    case "regex":
+      return `regex(/${rule.pattern}/)`;
+    case "tool_called":
+      return `tool_called("${rule.tool}", min ${rule.min ?? 1})`;
+    case "tool_not_called":
+      return `tool_not_called("${rule.tool}")`;
+    case "tool_call_count":
+      return `tool_call_count(${rule.min ?? 0}–${rule.max ?? "∞"})`;
+    case "turns_within":
+      return `turns_within(${rule.max})`;
+    case "json_schema":
+      return "json_schema(…)";
+  }
+}
+
+function defaultRule(type: RuleType): ScorerRule {
+  switch (type) {
+    case "contains":
+      return { type, text: "" };
+    case "not_contains":
+      return { type, text: "" };
+    case "regex":
+      return { type, pattern: "" };
+    case "tool_called":
+      return { type, tool: "", min: 1 };
+    case "tool_not_called":
+      return { type, tool: "" };
+    case "tool_call_count":
+      return { type, min: 0 };
+    case "turns_within":
+      return { type, max: 1 };
+    case "json_schema":
+      return { type, schema: {} };
+  }
+}
+
+function defaultScorer(): ObserverScorerConfig {
+  return {
+    key: "",
+    scope: "turn",
+    method: "rule",
+    rule: defaultRule("contains"),
+  };
+}
+
+interface ScorerEditorProps {
+  scorers: ObserverScorerConfig[];
+  onChange: (scorers: ObserverScorerConfig[]) => void;
+  errors?: Record<number, string>;
+}
+
+export function ScorerEditor({ scorers, onChange, errors }: ScorerEditorProps) {
+  const [scopeTab, setScopeTab] = useState<ObserverScorerScope>("turn");
+
+  const updateScorer = (index: number, next: ObserverScorerConfig) => {
+    onChange(scorers.map((s, i) => (i === index ? next : s)));
+  };
+
+  const removeScorer = (index: number) => {
+    onChange(scorers.filter((_, i) => i !== index));
+  };
+
+  const addScorer = () => {
+    onChange([...scorers, defaultScorer()]);
+  };
+
+  const addFromTemplate = (templateKey: string) => {
+    const template = SCORER_CATALOG.find((t) => t.key === templateKey);
+    if (!template) return;
+    const next: ObserverScorerConfig = {
+      key: template.key,
+      scope: "turn",
+      method: "llm_judge",
+      rubric: template.rubric,
+      pass_threshold: template.pass_threshold,
+    };
+    onChange([...scorers, next]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Tabs value={scopeTab} onValueChange={(v) => setScopeTab(v as ObserverScorerScope)}>
+        <TabsList>
+          <TabsTrigger value="turn">Answers</TabsTrigger>
+          <TabsTrigger value="session" disabled>
+            Conversations
+          </TabsTrigger>
+          <TabsTrigger value="tool" disabled>
+            Tools
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="turn" className="space-y-4">
+          <div className="space-y-2">
+            <Label className="text-xs text-muted-foreground">Starter templates</Label>
+            <div className="flex flex-wrap gap-2">
+              {SCORER_CATALOG.map((template) => (
+                <Button
+                  key={template.key}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => addFromTemplate(template.key)}
+                  title={template.description}
+                >
+                  <Plus className="size-3.5" />
+                  {template.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {scorers.length === 0 ? (
+            <div className="border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No scorers yet. Add one from a template above or start from scratch.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {scorers.map((scorer, index) => (
+                <ScorerRow
+                  key={index}
+                  scorer={scorer}
+                  index={index}
+                  error={errors?.[index]}
+                  onChange={(next) => updateScorer(index, next)}
+                  onRemove={() => removeScorer(index)}
+                />
+              ))}
+            </div>
+          )}
+
+          <Button type="button" variant="outline" size="sm" onClick={addScorer}>
+            <Plus className="size-4" />
+            Add scorer
+          </Button>
+        </TabsContent>
+
+        <TabsContent value="session">
+          <ComingSoonNotice scope="conversation" />
+        </TabsContent>
+
+        <TabsContent value="tool">
+          <ComingSoonNotice scope="tool" />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function ComingSoonNotice({ scope }: { scope: string }) {
+  return (
+    <Notice variant="info">
+      <NoticeTitle>Coming soon</NoticeTitle>
+      <NoticeDescription>
+        {scope === "tool" ? "Tool-level scoring" : "Conversation-level scoring"} is not available
+        yet. Observers currently score individual answers (turns).
+      </NoticeDescription>
+    </Notice>
+  );
+}
+
+interface ScorerRowProps {
+  scorer: ObserverScorerConfig;
+  index: number;
+  error?: string;
+  onChange: (next: ObserverScorerConfig) => void;
+  onRemove: () => void;
+}
+
+function ScorerRow({ scorer, index, error, onChange, onRemove }: ScorerRowProps) {
+  const setMethod = (method: "rule" | "llm_judge") => {
+    if (method === scorer.method) return;
+    if (method === "rule") {
+      onChange({
+        key: scorer.key,
+        scope: "turn",
+        method: "rule",
+        rule: defaultRule("contains"),
+      });
+    } else {
+      onChange({
+        key: scorer.key,
+        scope: "turn",
+        method: "llm_judge",
+        rubric: "",
+        pass_threshold: 0.5,
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-4 border p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex-1 space-y-2">
+          <Label htmlFor={`scorer-key-${index}`}>Key</Label>
+          <Input
+            id={`scorer-key-${index}`}
+            placeholder="e.g. answer_completeness"
+            value={scorer.key}
+            onChange={(e) => onChange({ ...scorer, key: e.target.value })}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="mt-7"
+          onClick={onRemove}
+          aria-label="Remove scorer"
+        >
+          <Trash2 className="size-4 text-muted-foreground" />
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Method</Label>
+        <div className="flex gap-2">
+          {(["rule", "llm_judge"] as const).map((m) => (
+            <Button
+              key={m}
+              type="button"
+              variant={scorer.method === m ? "default" : "outline"}
+              size="sm"
+              onClick={() => setMethod(m)}
+            >
+              {m === "rule" ? "Rule" : "LLM judge"}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {scorer.method === "llm_judge" ? (
+        <LlmJudgeFields scorer={scorer} index={index} onChange={onChange} />
+      ) : (
+        <RuleFields scorer={scorer} index={index} onChange={onChange} />
+      )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+function LlmJudgeFields({
+  scorer,
+  index,
+  onChange,
+}: {
+  scorer: Extract<ObserverScorerConfig, { method: "llm_judge" }>;
+  index: number;
+  onChange: (next: ObserverScorerConfig) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor={`scorer-rubric-${index}`}>Rubric</Label>
+        <Textarea
+          id={`scorer-rubric-${index}`}
+          placeholder="Describe how the judge should score this turn..."
+          value={scorer.rubric}
+          onChange={(e) => onChange({ ...scorer, rubric: e.target.value })}
+          rows={3}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`scorer-model-${index}`}>
+          Judge model — defaults to your org default model when unset
+        </Label>
+        <ModelPicker
+          id={`scorer-model-${index}`}
+          value={scorer.model_id ?? ""}
+          onChange={(modelId) => onChange({ ...scorer, model_id: modelId || undefined })}
+          placeholder="Use org default model"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`scorer-threshold-${index}`}>Pass threshold (0–1)</Label>
+        <Input
+          id={`scorer-threshold-${index}`}
+          type="number"
+          min={0}
+          max={1}
+          step={0.05}
+          value={scorer.pass_threshold}
+          onChange={(e) => onChange({ ...scorer, pass_threshold: Number(e.target.value) })}
+        />
+      </div>
+    </div>
+  );
+}
+
+function RuleFields({
+  scorer,
+  index,
+  onChange,
+}: {
+  scorer: Extract<ObserverScorerConfig, { method: "rule" }>;
+  index: number;
+  onChange: (next: ObserverScorerConfig) => void;
+}) {
+  const rule = scorer.rule;
+
+  const setRule = (next: ScorerRule) => onChange({ ...scorer, rule: next });
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor={`scorer-rule-type-${index}`}>Rule type</Label>
+        <Select
+          value={rule.type}
+          onValueChange={(value) => setRule(defaultRule(value as RuleType))}
+        >
+          <SelectTrigger id={`scorer-rule-type-${index}`} className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RULE_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {RULE_LABELS[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <RuleParamFields rule={rule} index={index} onChange={setRule} />
+
+      <div className="space-y-2">
+        <Label htmlFor={`scorer-weight-${index}`}>Weight (optional, default 1.0)</Label>
+        <Input
+          id={`scorer-weight-${index}`}
+          type="number"
+          min={0}
+          step={0.1}
+          value={rule.weight ?? ""}
+          placeholder="1.0"
+          onChange={(e) => {
+            const raw = e.target.value;
+            setRule({
+              ...rule,
+              weight: raw === "" ? undefined : Number(raw),
+            } as ScorerRule);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function RuleParamFields({
+  rule,
+  index,
+  onChange,
+}: {
+  rule: ScorerRule;
+  index: number;
+  onChange: (next: ScorerRule) => void;
+}) {
+  switch (rule.type) {
+    case "contains":
+    case "not_contains":
+      return (
+        <div className="space-y-2">
+          <Label htmlFor={`rule-text-${index}`}>Text</Label>
+          <Input
+            id={`rule-text-${index}`}
+            value={rule.text}
+            onChange={(e) => onChange({ ...rule, text: e.target.value })}
+          />
+        </div>
+      );
+    case "regex":
+      return (
+        <div className="space-y-2">
+          <Label htmlFor={`rule-pattern-${index}`}>Pattern</Label>
+          <Input
+            id={`rule-pattern-${index}`}
+            value={rule.pattern}
+            onChange={(e) => onChange({ ...rule, pattern: e.target.value })}
+          />
+        </div>
+      );
+    case "tool_called":
+      return (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={`rule-tool-${index}`}>Tool</Label>
+            <Input
+              id={`rule-tool-${index}`}
+              value={rule.tool}
+              onChange={(e) => onChange({ ...rule, tool: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`rule-min-${index}`}>Minimum calls</Label>
+            <Input
+              id={`rule-min-${index}`}
+              type="number"
+              min={1}
+              value={rule.min ?? 1}
+              onChange={(e) => onChange({ ...rule, min: Number(e.target.value) })}
+            />
+          </div>
+        </div>
+      );
+    case "tool_not_called":
+      return (
+        <div className="space-y-2">
+          <Label htmlFor={`rule-tool-${index}`}>Tool</Label>
+          <Input
+            id={`rule-tool-${index}`}
+            value={rule.tool}
+            onChange={(e) => onChange({ ...rule, tool: e.target.value })}
+          />
+        </div>
+      );
+    case "tool_call_count":
+      return (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor={`rule-min-${index}`}>Min (optional)</Label>
+            <Input
+              id={`rule-min-${index}`}
+              type="number"
+              min={0}
+              value={rule.min ?? ""}
+              onChange={(e) =>
+                onChange({
+                  ...rule,
+                  min: e.target.value === "" ? undefined : Number(e.target.value),
+                })
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`rule-max-${index}`}>Max (optional)</Label>
+            <Input
+              id={`rule-max-${index}`}
+              type="number"
+              min={0}
+              value={rule.max ?? ""}
+              onChange={(e) =>
+                onChange({
+                  ...rule,
+                  max: e.target.value === "" ? undefined : Number(e.target.value),
+                })
+              }
+            />
+          </div>
+        </div>
+      );
+    case "turns_within":
+      return (
+        <div className="space-y-2">
+          <Label htmlFor={`rule-max-${index}`}>Max turns</Label>
+          <Input
+            id={`rule-max-${index}`}
+            type="number"
+            min={1}
+            value={rule.max}
+            onChange={(e) => onChange({ ...rule, max: Number(e.target.value) })}
+          />
+        </div>
+      );
+    case "json_schema":
+      return (
+        <div className="space-y-2">
+          <Label htmlFor={`rule-schema-${index}`}>JSON schema</Label>
+          <Textarea
+            id={`rule-schema-${index}`}
+            className="font-mono text-xs"
+            rows={5}
+            defaultValue={JSON.stringify(rule.schema, null, 2)}
+            onChange={(e) => {
+              try {
+                const parsed = JSON.parse(e.target.value);
+                onChange({ ...rule, schema: parsed });
+              } catch {
+                // Ignore invalid JSON while typing; keep last valid schema.
+              }
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            Must be valid JSON. Invalid input is ignored until corrected.
+          </p>
+        </div>
+      );
+  }
+}

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -29,3 +29,4 @@ export * from "./use-memory";
 export * from "./use-knowledge-indexes";
 export * from "./use-reporting";
 export * from "./use-plugins";
+export * from "./use-observers";

--- a/apps/ui/src/hooks/use-observers.ts
+++ b/apps/ui/src/hooks/use-observers.ts
@@ -1,0 +1,47 @@
+// Observer hooks
+"use client";
+
+import { observersCrudApi, listObserverScores } from "@/lib/api/observers";
+import type { CreateObserverRequest, UpdateObserverRequest } from "@/lib/api/types";
+import { queryKeys } from "@/lib/query-keys";
+import { createCrudHooks, useOrgScopedQuery } from "./create-crud-hooks";
+
+const observerCrudHooks = createCrudHooks<
+  Awaited<ReturnType<typeof observersCrudApi.get>>,
+  CreateObserverRequest,
+  UpdateObserverRequest
+>({
+  api: observersCrudApi,
+  queryKeys: queryKeys.observers,
+});
+
+export const useObservers = observerCrudHooks.useList;
+export const useObserver = observerCrudHooks.useDetail;
+export const useCreateObserver = observerCrudHooks.useCreate;
+export const useDeleteObserver = observerCrudHooks.useDelete;
+export const useDestroyObserver = observerCrudHooks.useDestroy;
+
+export function useUpdateObserver() {
+  const mutation = observerCrudHooks.useUpdate();
+
+  return {
+    ...mutation,
+    mutate: (
+      variables: { observerId: string; request: UpdateObserverRequest },
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate({ id: variables.observerId, request: variables.request }, options),
+    mutateAsync: (
+      variables: { observerId: string; request: UpdateObserverRequest },
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => mutation.mutateAsync({ id: variables.observerId, request: variables.request }, options),
+  };
+}
+
+// Trace scores hook
+export function useObserverScores(observerId: string | undefined) {
+  return useOrgScopedQuery({
+    queryKey: queryKeys.observers.scores(observerId ?? ""),
+    queryFn: () => listObserverScores(observerId!, { limit: 200 }),
+    enabled: !!observerId,
+  });
+}

--- a/apps/ui/src/lib/api/index.ts
+++ b/apps/ui/src/lib/api/index.ts
@@ -15,3 +15,4 @@ export * from "./agent-identities";
 export * from "./memory";
 export * from "./knowledge-indexes";
 export * from "./reporting";
+export * from "./observers";

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -1869,6 +1869,115 @@ export interface CreateEvalRunRequest {
   model_override?: string;
 }
 
+// ============================================
+// Observer types (online scoring of production sessions)
+// ============================================
+// Hand-written (not generated): the backend exposes a flattened tagged union for
+// scorer configs and a snake_case tagged union for rule scorers. See the
+// `/v1/observers` API contract.
+
+export type ObserverStatus = "active" | "paused" | "archived";
+
+/** Match rules deciding which production turns an observer samples. */
+export interface ObserverMatch {
+  agent_ids?: string[];
+  harness_ids?: string[];
+  session_tags?: string[];
+}
+
+/**
+ * Deterministic rule scorer variants (snake_case, discriminated by `type`).
+ * Mirrors the eval Scorer union, minus `file_contains` (rejected by the server
+ * for observers). `weight` defaults to 1.0 server-side.
+ */
+export type ScorerRule =
+  | { type: "contains"; text: string; weight?: number }
+  | { type: "not_contains"; text: string; weight?: number }
+  | { type: "regex"; pattern: string; weight?: number }
+  | { type: "tool_called"; tool: string; min?: number; weight?: number }
+  | { type: "tool_not_called"; tool: string; weight?: number }
+  | { type: "tool_call_count"; min?: number; max?: number; weight?: number }
+  | { type: "turns_within"; max: number; weight?: number }
+  | { type: "json_schema"; schema: object; weight?: number };
+
+/** Scope a scorer evaluates against. Only `turn` is currently supported. */
+export type ObserverScorerScope = "turn" | "session" | "tool";
+
+/**
+ * Per-scorer configuration. FLATTENED tagged union discriminated by `method`:
+ * the method-specific fields sit alongside `key`/`scope`, not nested.
+ */
+export type ObserverScorerConfig =
+  | {
+      key: string;
+      scope: ObserverScorerScope;
+      method: "rule";
+      rule: ScorerRule;
+    }
+  | {
+      key: string;
+      scope: ObserverScorerScope;
+      method: "llm_judge";
+      rubric: string;
+      model_id?: string;
+      pass_threshold: number;
+    };
+
+export interface Observer {
+  id: string;
+  name: string;
+  description?: string;
+  match: ObserverMatch;
+  sampling_rate: number;
+  scorers: ObserverScorerConfig[];
+  status: ObserverStatus;
+  created_at: string;
+  updated_at: string;
+  archived_at?: string;
+}
+
+export interface CreateObserverRequest {
+  name: string;
+  description?: string;
+  match?: ObserverMatch;
+  sampling_rate?: number;
+  scorers: ObserverScorerConfig[];
+}
+
+export interface UpdateObserverRequest {
+  name?: string;
+  description?: string;
+  match?: ObserverMatch;
+  sampling_rate?: number;
+  scorers?: ObserverScorerConfig[];
+  status?: ObserverStatus;
+}
+
+export type TraceScoreStatus = "pending" | "scoring" | "completed" | "errored" | "skipped";
+
+/** A single scored production turn produced by an observer. */
+export interface TraceScore {
+  id: string;
+  observer_id: string;
+  scorer_key: string;
+  session_id: string;
+  turn_id: string;
+  agent_id?: string;
+  agent_version_id?: string;
+  harness_id?: string;
+  status: TraceScoreStatus;
+  pass?: boolean;
+  value?: number;
+  label?: string;
+  reason?: string;
+  judge_input_tokens?: number;
+  judge_output_tokens?: number;
+  judge_cost_usd?: number;
+  error_message?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 // From legacy event-types.ts; retained as UI compatibility over generated OpenAPI schemas.
 /** Event context for correlation */
 export interface EventContext {

--- a/apps/ui/src/lib/api/observers.ts
+++ b/apps/ui/src/lib/api/observers.ts
@@ -1,0 +1,42 @@
+// Observer API functions
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
+
+import { api } from "./client";
+import { createCrudApi } from "./crud";
+import type { Observer, CreateObserverRequest, UpdateObserverRequest, TraceScore } from "./types";
+
+export const observersCrudApi = createCrudApi<
+  Observer,
+  CreateObserverRequest,
+  UpdateObserverRequest
+>("/v1/observers");
+
+export const createObserver = observersCrudApi.create;
+export const listObservers = observersCrudApi.list;
+export const getObserver = observersCrudApi.get;
+export const updateObserver = observersCrudApi.update;
+export const deleteObserver = observersCrudApi.delete;
+export const destroyObserver = observersCrudApi.destroy;
+
+export interface ListObserverScoresParams {
+  session_id?: string;
+  limit?: number;
+  offset?: number;
+}
+
+// Trace scores (nested under observer)
+export async function listObserverScores(
+  observerId: string,
+  params: ListObserverScoresParams = {},
+): Promise<TraceScore[]> {
+  const search = new URLSearchParams();
+  if (params.session_id) search.set("session_id", params.session_id);
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  if (params.offset !== undefined) search.set("offset", String(params.offset));
+  const query = search.toString();
+  const path = query
+    ? `/v1/observers/${observerId}/scores?${query}`
+    : `/v1/observers/${observerId}/scores`;
+  const response = await api.get<{ data: TraceScore[] }>(path);
+  return response.data.data;
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -246,6 +246,14 @@ export const queryKeys = {
     runDetail: (evalId: string, runId: string) => ["eval", evalId, "run", runId] as const,
   },
 
+  // Observer queries
+  observers: {
+    all: ["observers"] as const,
+    list: (includeArchived = false) => ["observers", { includeArchived }] as const,
+    detail: (observerId: string) => ["observer", observerId] as const,
+    scores: (observerId: string) => ["observer", observerId, "scores"] as const,
+  },
+
   // Policy queries
   policies: {
     config: (resource: string) => ["policies", resource] as const,

--- a/crates/server/src/domains/observers/service.rs
+++ b/crates/server/src/domains/observers/service.rs
@@ -128,9 +128,38 @@ impl ObserverService {
         Self { db }
     }
 
+    /// Verify every `llm_judge` scorer that names a model references one the
+    /// org can actually use. A judge with no `model_id` falls back to the org
+    /// default at scoring time, so only explicit ids are checked here.
+    ///
+    /// This mirrors runtime resolution (`get_model` is org-scoped and
+    /// enabled-only, same as `ProviderResolverService::resolve_model`): without
+    /// it a saved observer would point at an inaccessible model and silently
+    /// `skip` every score at scoring time instead of failing fast on save.
+    async fn validate_model_access(
+        &self,
+        org_id: i64,
+        scorers: &[ObserverScorerConfig],
+    ) -> Result<()> {
+        for scorer in scorers {
+            if let ScorerMethod::LlmJudge(judge) = &scorer.method
+                && let Some(model_id) = judge.model_id
+                && self.db.get_model(org_id, model_id.uuid()).await?.is_none()
+            {
+                anyhow::bail!(BadRequestError::new(format!(
+                    "scorer '{}' references a model that is not available to this organization",
+                    scorer.key
+                )));
+            }
+        }
+        Ok(())
+    }
+
     pub async fn create(&self, caller: &Caller, req: CreateObserverRequest) -> Result<Observer> {
         let sampling_rate = req.sampling_rate.unwrap_or(0.1);
         validate(sampling_rate, &req.scorers)?;
+        self.validate_model_access(caller.org_id, &req.scorers)
+            .await?;
 
         let active = self.db.count_active_observers(caller.org_id).await?;
         if active >= max_observers_per_org() {
@@ -200,6 +229,13 @@ impl ObserverService {
             None => serde_json::from_value(existing.scorers.clone())?,
         };
         validate(effective_rate, &effective_scorers)?;
+        // Only re-check models when the scorers are actually being changed; an
+        // unrelated patch (e.g. pause) must not fail because a previously valid
+        // model was later disabled.
+        if req.scorers.is_some() {
+            self.validate_model_access(caller.org_id, &effective_scorers)
+                .await?;
+        }
 
         let status = match req.status {
             Some(status) => {
@@ -435,5 +471,170 @@ mod tests {
         // not values derived from the internal row UUID.
         assert_eq!(scores[0].public_id, score_public);
         assert_eq!(scores[0].observer_id, observer.public_id);
+    }
+
+    use crate::storage::models::{CreateModelRow, CreateProviderRow};
+    use everruns_core::observer::LlmJudgeConfig;
+    use everruns_core::typed_id::ModelId;
+
+    /// Create a model in `org_id` and return its id. `enabled` controls whether
+    /// it is usable (disabled models are invisible to `get_model`).
+    async fn create_model(db: &StorageBackend, org_id: i64, enabled: bool) -> ModelId {
+        let provider = db
+            .create_provider(
+                org_id,
+                CreateProviderRow {
+                    name: "p".into(),
+                    provider_type: "openai".into(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        db.create_model(
+            org_id,
+            CreateModelRow {
+                provider_id: provider.id,
+                model_id: "gpt-test".into(),
+                display_name: "GPT Test".into(),
+                capabilities: vec![],
+                is_favorite: false,
+                enabled,
+                source: "manual".into(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    fn judge_scorer(key: &str, model_id: Option<ModelId>) -> ObserverScorerConfig {
+        ObserverScorerConfig {
+            key: key.into(),
+            scope: ObserverScope::Turn,
+            method: ScorerMethod::LlmJudge(LlmJudgeConfig {
+                rubric: "score the answer".into(),
+                model_id,
+                pass_threshold: 0.5,
+            }),
+        }
+    }
+
+    fn create_req(scorers: Vec<ObserverScorerConfig>) -> CreateObserverRequest {
+        CreateObserverRequest {
+            name: "o".into(),
+            description: None,
+            match_config: None,
+            sampling_rate: Some(1.0),
+            scorers,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_accepts_judge_with_accessible_model() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        let caller = Caller::internal(1);
+        let model = create_model(&db, 1, true).await;
+
+        svc.create(&caller, create_req(vec![judge_scorer("q", Some(model))]))
+            .await
+            .expect("accessible model should be accepted");
+    }
+
+    #[tokio::test]
+    async fn create_accepts_judge_without_model() {
+        // No explicit model means "use the org default" at scoring time, so it
+        // must be accepted even when the org has no model configured here.
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        let caller = Caller::internal(1);
+
+        svc.create(&caller, create_req(vec![judge_scorer("q", None)]))
+            .await
+            .expect("judge without a model should be accepted");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_judge_with_unknown_model() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        let caller = Caller::internal(1);
+
+        let err = svc
+            .create(
+                &caller,
+                create_req(vec![judge_scorer("q", Some(ModelId::new()))]),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not available to this organization"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_judge_with_disabled_model() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        let caller = Caller::internal(1);
+        let model = create_model(&db, 1, false).await;
+
+        let err = svc
+            .create(&caller, create_req(vec![judge_scorer("q", Some(model))]))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not available to this organization"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_model_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        // Model lives in org 2; caller is org 1 and must not be able to use it.
+        let other_model = create_model(&db, 2, true).await;
+        let caller = Caller::internal(1);
+
+        let err = svc
+            .create(
+                &caller,
+                create_req(vec![judge_scorer("q", Some(other_model))]),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not available to this organization"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn update_rechecks_model_access_when_scorers_change() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        let caller = Caller::internal(1);
+        let observer = svc
+            .create(&caller, create_req(vec![contains_scorer("k", "x")]))
+            .await
+            .unwrap();
+
+        let err = svc
+            .update(
+                &caller,
+                &observer.public_id.to_string(),
+                UpdateObserverRequest {
+                    name: None,
+                    description: None,
+                    match_config: None,
+                    sampling_rate: None,
+                    scorers: Some(vec![judge_scorer("q", Some(ModelId::new()))]),
+                    status: None,
+                },
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not available to this organization"), "{err}");
     }
 }

--- a/specs/online-evals.md
+++ b/specs/online-evals.md
@@ -6,6 +6,10 @@ Phase 1 surface: `Observer` entity (org-scoped, embedded match rules + scorers),
 
 Each scorer has a `method`: `rule` (the eval scorer vocabulary) or `llm_judge`. An `llm_judge` scorer carries a `rubric`, an optional `model_id` (defaults to the org's default model), and a `pass_threshold`. The judge call (`crates/server/src/domains/observers/judge.rs`) goes through the **org's own configured model/provider** (resolved via `ProviderResolverService`), returns structured `{value, label, reasoning}`, and stores token/cost accounting on the score. Judge usage is recorded on the `trace_score` row; metering into `usage_journal`/budgets is a follow-up.
 
+A scorer's `model_id` is validated on observer create/update (`ObserverService::validate_model_access`): the model must exist for the org and be enabled, mirroring runtime resolution (`get_model` is org-scoped + enabled-only). Without this an observer could be saved against an inaccessible model and then silently `skip` every score at scoring time. A judge with no `model_id` is always accepted — it resolves the org default at scoring time.
+
+UI: the `observers` feature flag also gates a UI surface (`apps/ui/src/app/(main)/observers/`) — observer list, a create/edit form with a starter scorer catalog and a judge model picker, an "Observe this agent" entry on the agent page, and a per-observer **Quality tab**. The Quality tab aggregates the `/scores` endpoint **client-side** (recent sampled scores → per-scorer pass rate / avg value / daily trend); the durable `fact_trace_score` projection below remains the path to real cross-observer aggregation. Scope is presented as tabs (Answers / Conversations / Tools), but only **Answers (turn)** is wired — `session`/`tool` scopes are shown disabled until the backend implements them.
+
 <!-- Design Decisions (proposed, not yet ratified):
   - Observer is the single user-facing abstraction: create an Observer, configure match rules
     (filters + sampling) and scorers inside it. Scorers/matchers are not standalone entities


### PR DESCRIPTION
## What
Adds the Observers UI surface (behind the existing `observers` feature flag) and closes a backend gap where an `llm_judge` scorer could reference a model the org cannot use.

- **Backend:** `ObserverService::validate_model_access` runs on observer create (and on update when scorers change). Any `llm_judge` scorer whose `model_id` is not an **enabled model in the caller's org** is rejected with a `BadRequestError`. A judge with no `model_id` is accepted (resolves the org default at scoring time).
- **UI** (`apps/ui/src/app/(main)/observers/`): observer list, create/edit form (match rules, sampling, scorers), a scorer editor with a starter judge-rubric catalog and a model picker, an observer detail page with a **Quality tab**, an "Observe this agent" entry on the agent page, and a sidebar nav entry.

## Why
The judge model is selected per-scorer via `LlmJudgeConfig.model_id`, but nothing validated it on save. An inaccessible/disabled/cross-org model was only caught at scoring time, where `resolve_model` returns `None` and the score is silently marked `skipped` — so a misconfigured observer became a permanent no-op with no feedback. There was also no UI at all for observers; configuration was API-only.

## How
- Validation mirrors runtime resolution: `get_model(org_id, uuid)` is org-scoped and enabled-only, so the create/update check fails fast on exactly the models that would later be unresolvable.
- The UI mirrors existing building-block patterns (CRUD api/hooks factories, query-keys, layout primitives, `ModelPicker`). Scorer scope is presented as tabs (Answers / Conversations / Tools); only **Answers (turn)** is wired because the backend implements only `Turn` scope — the other tabs render disabled. The Quality tab aggregates the existing `/scores` endpoint **client-side** (per-scorer pass rate / avg value / daily trend) and links each score back to its session. The judge model field omits `model_id` when unset and surfaces the server's model-access error inline.

## Risk
- **Low.** No migrations, no new endpoints, no new dependencies. The backend change only adds validation on a write path already gated by the `OBSERVER_MANAGE` policy (`OrgAgentsManage` + `OrgSessionsManage`). The UI is gated by the `observers` feature flag (off by default).

## Security
- Threat categories reviewed: **TM-TENANT**, **TM-AUTHZ**, **TM-API**, **TM-WEB**, **TM-LLM**.
  - TM-TENANT / TM-AUTHZ: the new model lookup is org-scoped (`get_model(caller.org_id, …)`); it cannot confirm or reference another org's model — a cross-org model id is rejected as "not available". Tested. Create/update remain behind the existing `OBSERVER_MANAGE` policy.
  - TM-API: no new endpoints; input is the existing `model_id` (a typed id) used only as a scoped DB lookup key — no injection surface.
  - TM-WEB: the new UI renders user/judge-provided text (rubric, reasoning, labels, session ids). All rendering is via React text interpolation; no `dangerouslySetInnerHTML`/`innerHTML`/`eval` were introduced (grep-verified).
  - TM-LLM: judge prompt construction is unchanged; this PR only constrains which model an org may select for its own judge calls.
- Findings: none. No `specs/threat-model.md` change needed — this is a defensive tightening of an existing path, not a new threat surface.

## Validation
- New: 5 model-access tests in `observers/service.rs` (unknown / disabled / cross-org / no-model / update-recheck), all green.
- `just pre-push` green locally; `apps/ui` production build compiles all observer routes.
- CI green: Clippy, Unit, Integration (PostgreSQL, incl. `observers_integration_test.rs`), Worker, UI Build/Lint/Test, UI Playwright Smoke, Docker Build, Build Release Binaries, OpenAPI Freshness, SDK Compat, CodeQL.

## Follow-ups
- **`session`/`tool` scorer scopes** — backend implements only `Turn`; the UI tabs are present but disabled. Wiring these requires `session.idled`/`tool.completed` scoring in the worker. Safe to defer: turn scope is the documented default and the UI clearly marks the rest "coming soon".
- **Server-side score aggregation (`fact_trace_score`)** — the Quality tab aggregates recent sampled scores client-side. Real cross-observer/agent trends need the durable reporting projection (specced as Phase 1.5 in `specs/online-evals.md`). Safe to defer: the client-side view is labeled as such in-UI and is correct for a single observer's recent scores.
- **Agent-level Quality tab** — this PR adds per-observer quality only; a roll-up on the agent page depends on the aggregation projection above.

## Checklist
- [x] Tests added or updated (5 new model-access tests in `observers/service.rs`)
- [x] Backward compatibility considered (no API/schema changes; flag-gated UI)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (none posted)