### PR TITLE
feat(ui): unify list empty states with shared EmptyState

### DIFF
--- a/apps/ui/src/app/(main)/agent-identities/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/page.tsx
@@ -17,6 +17,7 @@ import {
   IconTile,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -152,21 +153,25 @@ export default function AgentIdentitiesPage() {
               ))}
             </div>
           ) : filteredIdentities.length === 0 ? (
-            <div className="border border-dashed py-12 text-center">
-              <p className="mb-4 text-muted-foreground">
-                {search || statusTab !== "active"
+            <EmptyState
+              icon={<UserRound />}
+              title={
+                search || statusTab !== "active"
                   ? "No identities match your filters."
-                  : "No agent identities yet."}
-              </p>
-              {!search && statusTab === "active" && (
-                <Link href="/agent-identities/new">
-                  <Button>
-                    <Plus className="size-4" />
-                    Create your first identity
-                  </Button>
-                </Link>
-              )}
-            </div>
+                  : "No agent identities yet."
+              }
+              action={
+                !search &&
+                statusTab === "active" && (
+                  <Link href="/agent-identities/new">
+                    <Button variant="accent">
+                      <Plus className="size-4" />
+                      Create your first identity
+                    </Button>
+                  </Link>
+                )
+              }
+            />
           ) : (
             <div className="grid gap-4 md:grid-cols-2">
               {filteredIdentities.map((identity) => (

--- a/apps/ui/src/app/(main)/agents/all/agents-all-page-client.tsx
+++ b/apps/ui/src/app/(main)/agents/all/agents-all-page-client.tsx
@@ -12,6 +12,7 @@ import {
   PageContainer,
   PageBreadcrumb,
   PageMasthead,
+  EmptyState,
   PageColumns,
   PageMain,
   PageFooter,
@@ -52,15 +53,18 @@ export default function AgentsAllPageClient() {
             data={agents}
             errorMessagePrefix="Failed to load agents"
             emptyState={
-              <div className="border border-dashed py-12 text-center">
-                <p className="mb-4 text-muted-foreground">No agents yet</p>
-                <Link href="/agents/new">
-                  <Button>
-                    <Plus className="size-4" />
-                    Create your first agent
-                  </Button>
-                </Link>
-              </div>
+              <EmptyState
+                icon={<Boxes />}
+                title="No agents yet"
+                action={
+                  <Link href="/agents/new">
+                    <Button variant="accent">
+                      <Plus className="size-4" />
+                      Create your first agent
+                    </Button>
+                  </Link>
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -23,6 +23,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -262,21 +263,25 @@ export default function AgentsPage() {
             data={filteredAgents}
             errorMessagePrefix="Failed to load agents"
             emptyState={
-              <div className="border border-dashed py-12 text-center">
-                <p className="mb-4 text-muted-foreground">
-                  {search || statusTab !== "active"
+              <EmptyState
+                icon={<Boxes />}
+                title={
+                  search || statusTab !== "active"
                     ? "No agents match your filters."
-                    : "No agents yet"}
-                </p>
-                {!search && statusTab === "active" && (
-                  <Link href="/agents/new">
-                    <Button>
-                      <Plus className="size-4" />
-                      Create your first agent
-                    </Button>
-                  </Link>
-                )}
-              </div>
+                    : "No agents yet"
+                }
+                action={
+                  !search &&
+                  statusTab === "active" && (
+                    <Link href="/agents/new">
+                      <Button variant="accent">
+                        <Plus className="size-4" />
+                        Create your first agent
+                      </Button>
+                    </Link>
+                  )
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -15,6 +15,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -129,21 +130,28 @@ export default function AppsPage() {
             errorMessagePrefix="Failed to load apps"
             skeletonCount={3}
             emptyState={
-              <div className="border border-dashed py-12 text-center">
-                <p className="mb-4 text-muted-foreground">
-                  {search || statusTab !== "active"
-                    ? "No apps match your filters."
-                    : "Apps deploy your agents to channels like Slack and AG-UI. Create an app to connect an agent to the interface you need, or trigger it from schedules and authenticated webhooks."}
-                </p>
-                {!search && statusTab === "active" && (
-                  <Link href="/apps/new">
-                    <Button variant="accent">
-                      <Plus className="size-4" />
-                      Create your first app
-                    </Button>
-                  </Link>
-                )}
-              </div>
+              <EmptyState
+                icon={<Rocket />}
+                title={
+                  search || statusTab !== "active" ? "No apps match your filters." : "No apps yet"
+                }
+                description={
+                  !search && statusTab === "active"
+                    ? "Apps deploy your agents to channels like Slack and AG-UI. Create an app to connect an agent to the interface you need, or trigger it from schedules and authenticated webhooks."
+                    : undefined
+                }
+                action={
+                  !search &&
+                  statusTab === "active" && (
+                    <Link href="/apps/new">
+                      <Button variant="accent">
+                        <Plus className="size-4" />
+                        Create your first app
+                      </Button>
+                    </Link>
+                  )
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
+++ b/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
@@ -21,6 +21,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -206,21 +207,25 @@ export default function HarnessesPageClient() {
             data={filteredHarnesses}
             errorMessagePrefix="Failed to load harnesses"
             emptyState={
-              <div className="border border-dashed py-12 text-center">
-                <p className="mb-4 text-muted-foreground">
-                  {search || statusTab !== "active"
+              <EmptyState
+                icon={<Shield />}
+                title={
+                  search || statusTab !== "active"
                     ? "No harnesses match your filters."
-                    : "No harnesses yet"}
-                </p>
-                {!search && statusTab === "active" && (
-                  <Link href="/harnesses/new">
-                    <Button>
-                      <Plus className="size-4" />
-                      Create your first harness
-                    </Button>
-                  </Link>
-                )}
-              </div>
+                    : "No harnesses yet"
+                }
+                action={
+                  !search &&
+                  statusTab === "active" && (
+                    <Link href="/harnesses/new">
+                      <Button variant="accent">
+                        <Plus className="size-4" />
+                        Create your first harness
+                      </Button>
+                    </Link>
+                  )
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
@@ -34,6 +34,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -172,20 +173,23 @@ export default function KnowledgeIndexesPage() {
             errorMessagePrefix="Failed to load knowledge indexes"
             skeletonCount={6}
             emptyState={
-              <div className="border border-dashed py-12 text-center">
-                <Library className="mx-auto mb-4 size-10 text-muted-foreground" />
-                <p className="mb-4 text-muted-foreground">
-                  {search.trim() || statusTab !== "active"
+              <EmptyState
+                icon={<Library />}
+                title={
+                  search.trim() || statusTab !== "active"
                     ? "No knowledge indexes match your filters."
-                    : "No knowledge indexes yet"}
-                </p>
-                {!search.trim() && statusTab === "active" && (
-                  <Button variant="accent" onClick={() => setCreateOpen(true)}>
-                    <Plus className="size-4" />
-                    New index
-                  </Button>
-                )}
-              </div>
+                    : "No knowledge indexes yet"
+                }
+                action={
+                  !search.trim() &&
+                  statusTab === "active" && (
+                    <Button variant="accent" onClick={() => setCreateOpen(true)}>
+                      <Plus className="size-4" />
+                      New index
+                    </Button>
+                  )
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
@@ -41,7 +40,7 @@ import {
 } from "@/hooks/use-mcp-servers";
 import { usePolicies } from "@/hooks/use-policies";
 import { usePageTitle } from "@/hooks";
-import { Plus, Plug, Trash2, Key, X } from "lucide-react";
+import { Plus, Trash2, Key, X } from "lucide-react";
 import type {
   McpServer,
   CreateMcpServerRequest,
@@ -65,6 +64,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   IconTile,
   PageColumns,
   PageMain,
@@ -849,25 +849,28 @@ export default function McpServersPage() {
               </Table>
             }
             emptyState={
-              <Card className="p-8 text-center">
-                <Plug className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-                <h2 className="mb-2 text-lg font-medium">
-                  {search || statusTab !== "active"
+              <EmptyState
+                icon={<McpIcon />}
+                title={
+                  search || statusTab !== "active"
                     ? "No MCP servers match your filters"
-                    : "No MCP servers configured"}
-                </h2>
-                {!search && statusTab === "active" && (
-                  <>
-                    <p className="mb-4 text-muted-foreground">
-                      Add an MCP server to extend your agents with external tools and resources.
-                    </p>
+                    : "No MCP servers configured"
+                }
+                description={
+                  !search && statusTab === "active"
+                    ? "Add an MCP server to extend your agents with external tools and resources."
+                    : undefined
+                }
+                action={
+                  !search &&
+                  statusTab === "active" && (
                     <Button variant="accent" onClick={() => setAddServerOpen(true)}>
-                      <Plus className="mr-2 h-4 w-4" />
+                      <Plus className="size-4" />
                       Add Server
                     </Button>
-                  </>
-                )}
-              </Card>
+                  )
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/app/(main)/memory/page.tsx
+++ b/apps/ui/src/app/(main)/memory/page.tsx
@@ -27,6 +27,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -142,7 +143,18 @@ export default function MemoryPage() {
             errorMessagePrefix="Failed to load memory"
             skeletonCount={6}
             emptyState={
-              <EmptyState hasSearch={!!search.trim()} onCreate={() => setCreateOpen(true)} />
+              <EmptyState
+                icon={<Brain />}
+                title={search.trim() ? "No memory found" : "No memory"}
+                action={
+                  !search.trim() && (
+                    <Button variant="accent" onClick={() => setCreateOpen(true)}>
+                      <Plus className="size-4" />
+                      New Memory
+                    </Button>
+                  )
+                }
+              />
             }
           >
             {(items) => (
@@ -397,19 +409,4 @@ function formatSyncInterval(memory: Memory) {
     return hours === 1 ? "Hourly" : `Every ${hours} hours`;
   }
   return `Every ${Math.round(interval / 60)} minutes`;
-}
-
-function EmptyState({ hasSearch, onCreate }: { hasSearch: boolean; onCreate: () => void }) {
-  return (
-    <div className="flex flex-col items-center justify-center border border-dashed py-12 text-center">
-      <Brain className="mb-4 h-12 w-12 text-muted-foreground" />
-      <h3 className="mb-2 text-lg font-semibold">{hasSearch ? "No memory found" : "No memory"}</h3>
-      {!hasSearch && (
-        <Button variant="accent" onClick={onCreate}>
-          <Plus className="h-4 w-4" />
-          New Memory
-        </Button>
-      )}
-    </div>
-  );
 }

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -43,6 +43,7 @@ import {
   IconTile,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   PageColumns,
   PageMain,
   PageRail,
@@ -371,26 +372,29 @@ export default function SkillsPageClient() {
               </div>
             }
             emptyState={
-              <div className="border border-dashed py-12 text-center">
-                <BookOpen className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-                <p className="mb-4 text-muted-foreground">
-                  {search.trim() || statusTab !== "active"
+              <EmptyState
+                icon={<BookOpen />}
+                title={
+                  search.trim() || statusTab !== "active"
                     ? "No skills match your filters."
-                    : "No skills yet"}
-                </p>
-                {!search.trim() && statusTab === "active" && (
-                  <div className="flex justify-center gap-2">
-                    <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
-                      <Upload className="h-4 w-4 mr-2" />
-                      Upload ZIP
-                    </Button>
-                    <Button onClick={() => setAddSkillOpen(true)}>
-                      <Plus className="h-4 w-4 mr-2" />
-                      Add Skill
-                    </Button>
-                  </div>
-                )}
-              </div>
+                    : "No skills yet"
+                }
+                action={
+                  !search.trim() &&
+                  statusTab === "active" && (
+                    <>
+                      <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
+                        <Upload className="size-4" />
+                        Upload ZIP
+                      </Button>
+                      <Button variant="accent" onClick={() => setAddSkillOpen(true)}>
+                        <Plus className="size-4" />
+                        Add Skill
+                      </Button>
+                    </>
+                  )
+                }
+              />
             }
           >
             {(items) => (

--- a/apps/ui/src/components/layout/index.ts
+++ b/apps/ui/src/components/layout/index.ts
@@ -17,6 +17,7 @@ export {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  EmptyState,
   StatCard,
   StatGrid,
   PageColumns,

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -275,6 +275,45 @@ export function StatGrid({ children, className }: { children: ReactNode; classNa
   return <div className={cn("grid grid-cols-2 gap-3 lg:grid-cols-4", className)}>{children}</div>;
 }
 
+/* ──────────────────────────────── Empty state ──────────────────────────── */
+
+interface EmptyStateProps {
+  /** Leading glyph, rendered muted and centered above the title. */
+  icon?: ReactNode;
+  /** Headline — the primary message (e.g. "No agents yet"). */
+  title: ReactNode;
+  /** Optional supporting copy under the title. */
+  description?: ReactNode;
+  /** Optional call-to-action cluster, usually one primary button. */
+  action?: ReactNode;
+  className?: string;
+}
+
+/**
+ * The shared empty/zero state for list bodies: a dashed panel with an optional
+ * muted icon, a title, optional supporting copy, and an optional action. Every
+ * list page uses this so empty states read identically across the app.
+ */
+export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center border border-dashed px-6 py-12 text-center",
+        className,
+      )}
+    >
+      {icon && (
+        <span className="mb-4 inline-flex text-muted-foreground [&_svg]:size-10">{icon}</span>
+      )}
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      {description && (
+        <p className="mt-1.5 max-w-md text-sm text-muted-foreground">{description}</p>
+      )}
+      {action && <div className="mt-5 flex items-center justify-center gap-2">{action}</div>}
+    </div>
+  );
+}
+
 /* ──────────────────────────────── 4 · Body ─────────────────────────────── */
 
 /**


### PR DESCRIPTION
## What
Adds a shared `EmptyState` layout primitive and adopts it across the building-block list pages so their empty/zero states render identically.

Pages updated: knowledge indexes, memory, MCP servers, agents (`/agents` and `/agents/all`), apps, agent identities, skills, harnesses.

## Why
Each list page hand-rolled its own empty state, so they drifted apart:
- **Borders** — dashed `div` on most, a solid `Card` on MCP servers.
- **Icons** — some had a muted glyph, agents had none.
- **Headings** — muted `<p>` on some, bold `<h2>`/`<h3>` on others, with inconsistent sizes/weights.
- **Buttons** — gold `accent` on some, default dark on others.

The result was four (really eight) different "ideas" for the same UI moment. This unifies them behind one primitive.

## How
- New `EmptyState({ icon, title, description, action })` in `components/layout/page-layout.tsx`, exported from the layout barrel. Anatomy: dashed panel · muted icon · title · optional description · optional action cluster.
- Replaced each page's inline empty-state markup with `<EmptyState>`, passing the page's own entity icon and copy.
- Standardized the primary create CTA to the `accent` variant everywhere (agents/agent-identities/harnesses previously used the default button).
- Removed the now-dead local `EmptyState` helper in `memory/page.tsx` and the now-unused `Card`/`Plug` imports in `mcp-servers/page.tsx`.

No behavior change beyond presentation: titles still switch between the "no results for filter" and "nothing yet" messages, and actions still only render in the unfiltered, non-archived view.

## Risk
- Low — presentational refactor only. No data, network, auth, or routing changes.
- Worst case is a visual regression on an empty list, which is covered by the page tests and a manual smoke pass.

## Security
- Threat categories reviewed: **No security-relevant code changes.** Pure UI refactor — no new inputs, endpoints, auth/authz, or trust boundaries. `title`/`description` render through React's default text escaping (no `dangerouslySetInnerHTML`) and receive only static literals.
- Findings and resolutions: none.

## Follow-ups
The same drift exists on the settings/admin family of pages (capabilities, models, plugins, settings/*), which use a `Card`-based empty state. Migrating those to `EmptyState` is a natural next step but out of scope here to keep this PR focused on the building-block list pages. No other follow-ups.

## Checklist
- [x] Tests added or updated — existing page tests cover the empty states (e.g. MCP "No MCP servers configured"); 1051 tests across affected pages pass
- [x] Backward compatibility considered — internal UI only, no API/contract change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)