### PR TITLE
ci: guard workspace-excluded examples against silent compile drift

### DIFF
--- a/.github/workflows/examples-check.yml
+++ b/.github/workflows/examples-check.yml
@@ -1,0 +1,128 @@
+# Scheduled compile guard for workspace-EXCLUDED standalone crates.
+#
+# Crates listed in the root Cargo.toml `[workspace] exclude` array have their
+# own `[workspace]`/`Cargo.lock` and therefore are NOT built by any other CI
+# job (ci.yml only ever touches workspace members). They silently drift out of
+# sync with `everruns-core` and only break when someone checks them by hand —
+# this is exactly what happened to `examples/weekend-concierge-host` (EVE-663).
+#
+# A per-PR full compile is too costly: each excluded crate resolves a separate
+# dependency tree from scratch (no shared workspace target/ or Cargo.lock), so
+# building them on every PR would add minutes of cold compilation for code that
+# changes rarely. A periodic sweep is the right tradeoff — it catches drift
+# within a week of an `everruns-core` API change without taxing the PR hot path.
+#
+# The list of crates is DERIVED from the root Cargo.toml `exclude` array at run
+# time (see the "Discover excluded crates" step), so it cannot fall out of sync
+# with the workspace definition: add or remove an entry in Cargo.toml `exclude`
+# and this guard picks it up automatically.
+name: Examples Compile Check
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Mondays 15:00 UTC — one hour after integration-live-sweep so the
+    # two scheduled sweeps don't start simultaneously.
+    - cron: '0 15 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  excluded-examples-check:
+    name: Excluded Standalone Crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Distinct cache key: these crates have separate dependency trees from
+          # the workspace, so they must not share the workspace test/clippy cache.
+          shared-key: "examples-check"
+
+      # Parse the `exclude` array out of the root Cargo.toml so the guard's crate
+      # list is the single source of truth in Cargo.toml. Each excluded path must
+      # contain its own Cargo.toml (a standalone crate); paths without one are an
+      # error (a stale/typo'd exclude entry the maintainer should fix).
+      - name: Discover excluded crates
+        id: discover
+        run: |
+          set -euo pipefail
+          # Extract the contents of the `exclude = [ ... ]` array (it may span
+          # multiple lines), strip comments/quotes, and emit one path per line.
+          crates="$(
+            awk '
+              /^[[:space:]]*exclude[[:space:]]*=[[:space:]]*\[/ { collecting=1 }
+              collecting {
+                line=$0
+                sub(/.*\[/, "", line)   # drop everything up to the opening [
+                sub(/\].*/, "", line)   # drop the closing ] and trailing text
+                gsub(/#.*/, "", line)   # drop comments
+                n=split(line, parts, ",")
+                for (i=1; i<=n; i++) {
+                  p=parts[i]
+                  gsub(/[[:space:]"]/, "", p)
+                  if (p != "") print p
+                }
+              }
+              collecting && /\]/ { collecting=0 }
+            ' Cargo.toml
+          )"
+          if [ -z "$crates" ]; then
+            echo "::error::Could not parse any entries from the [workspace] exclude array in Cargo.toml" >&2
+            exit 1
+          fi
+          echo "Discovered excluded crates:"
+          echo "$crates"
+          {
+            echo "crates<<EOF"
+            echo "$crates"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Compile each excluded standalone crate against the current source tree.
+      # Runs every crate (no fail-fast) so one drifted example doesn't mask
+      # another, then fails the job if any did not compile.
+      - name: Check excluded crates compile
+        run: |
+          set -uo pipefail
+          failed=""
+          while IFS= read -r crate; do
+            [ -n "$crate" ] || continue
+            manifest="$crate/Cargo.toml"
+            if [ ! -f "$manifest" ]; then
+              echo "::error::Excluded path '$crate' has no Cargo.toml (stale exclude entry?)"
+              failed="$failed $crate(no-manifest)"
+              continue
+            fi
+            echo "::group::cargo check --manifest-path $manifest"
+            if cargo check --manifest-path "$manifest"; then
+              echo "OK: $crate"
+            else
+              echo "::error::Excluded crate failed to compile: $crate"
+              failed="$failed $crate"
+            fi
+            echo "::endgroup::"
+          done <<< "${{ steps.discover.outputs.crates }}"
+
+          if [ -n "$failed" ]; then
+            echo "One or more excluded standalone crates failed to compile:$failed"
+            exit 1
+          fi
+          echo "All excluded standalone crates compiled."

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -858,14 +858,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/research/infinity_context/src/dataset.rs
+++ b/research/infinity_context/src/dataset.rs
@@ -324,15 +324,12 @@ pub fn make_tool_event(
     result: impl Into<String>,
     sequence: i32,
 ) -> Event {
-    let data = ToolCompletedData {
-        tool_call_id: tool_call_id.into(),
-        tool_name: tool_name.into(),
-        success: true,
-        status: "success".to_string(),
-        result: Some(vec![ContentPart::text(result)]),
-        error: None,
-        duration_ms: None,
-    };
+    let data = ToolCompletedData::success(
+        tool_call_id.into(),
+        tool_name.into(),
+        vec![ContentPart::text(result)],
+        None,
+    );
     Event::new(session_id, EventContext::empty(), data).with_sequence(sequence)
 }
 

--- a/research/infinity_context/src/runner.rs
+++ b/research/infinity_context/src/runner.rs
@@ -13,9 +13,9 @@ use crate::scorer::{JudgeConfig, Score, Scorer, aggregate_scores, evaluate_all};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use everruns_core::Capability;
+use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::events::{EventData, LLM_GENERATION, TOOL_COMPLETED};
 use everruns_core::in_memory_loop::InMemoryAgenticLoop;
-use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::provider::DriverId;
 use everruns_core::traits::ResolvedModel;
 use serde::Serialize;
@@ -40,7 +40,11 @@ pub enum Approach {
 
 impl Approach {
     pub fn all() -> Vec<Approach> {
-        vec![Approach::Baseline, Approach::NaiveTrim, Approach::InfinityContext]
+        vec![
+            Approach::Baseline,
+            Approach::NaiveTrim,
+            Approach::InfinityContext,
+        ]
     }
 
     pub fn name(&self) -> &'static str {
@@ -74,7 +78,10 @@ impl std::str::FromStr for Approach {
             "baseline" => Ok(Approach::Baseline),
             "naive_trim" => Ok(Approach::NaiveTrim),
             "infinity_context" => Ok(Approach::InfinityContext),
-            _ => Err(anyhow::anyhow!("Unknown approach: {}. Valid: baseline, naive_trim, infinity_context", s)),
+            _ => Err(anyhow::anyhow!(
+                "Unknown approach: {}. Valid: baseline, naive_trim, infinity_context",
+                s
+            )),
         }
     }
 }
@@ -226,7 +233,9 @@ fn expectations_to_scorers(expectations: &[String]) -> Vec<Scorer> {
     expectations
         .iter()
         .enumerate()
-        .map(|(i, expectation)| Scorer::llm_judge(format!("expectation_{}", i), expectation.clone()))
+        .map(|(i, expectation)| {
+            Scorer::llm_judge(format!("expectation_{}", i), expectation.clone())
+        })
         .collect()
 }
 
@@ -333,10 +342,16 @@ fn create_judge_config() -> Option<JudgeConfig> {
 // ============================================================================
 
 /// Aggregate results for a single approach across all records
-pub fn aggregate_approach_results(approach_name: &str, results: Vec<RecordResult>) -> ApproachResults {
+pub fn aggregate_approach_results(
+    approach_name: &str,
+    results: Vec<RecordResult>,
+) -> ApproachResults {
     let total = results.len();
     let passed = results.iter().filter(|r| r.passed()).count();
-    let context_exceeded = results.iter().filter(|r| r.metrics.context_exceeded).count();
+    let context_exceeded = results
+        .iter()
+        .filter(|r| r.metrics.context_exceeded)
+        .count();
 
     let avg_score = if total > 0 {
         results.iter().map(|r| r.score).sum::<f64>() / total as f64
@@ -345,7 +360,11 @@ pub fn aggregate_approach_results(approach_name: &str, results: Vec<RecordResult
     };
 
     let avg_tokens = if total > 0 {
-        results.iter().map(|r| r.metrics.total_tokens).sum::<usize>() as f64 / total as f64
+        results
+            .iter()
+            .map(|r| r.metrics.total_tokens)
+            .sum::<usize>() as f64
+            / total as f64
     } else {
         0.0
     };
@@ -357,7 +376,11 @@ pub fn aggregate_approach_results(approach_name: &str, results: Vec<RecordResult
     };
 
     let avg_queries = if total > 0 {
-        results.iter().map(|r| r.metrics.history_queries).sum::<usize>() as f64 / total as f64
+        results
+            .iter()
+            .map(|r| r.metrics.history_queries)
+            .sum::<usize>() as f64
+            / total as f64
     } else {
         0.0
     };
@@ -412,14 +435,15 @@ async fn execute_with_agentic_loop(
             provider_metadata: None,
         };
 
-        // Build the agentic loop with seed events
+        // Build the agentic loop. Seed events are not a builder input; they are
+        // converted to conversation messages and seeded into the in-memory
+        // message retriever after build (see seed_messages_from_events below).
         let mut builder = InMemoryAgenticLoop::builder()
             .agent_name("Eval Agent")
             .system_prompt(build_system_prompt(config.approach))
             .model(model)
             .driver_registry(create_driver_registry())
-            .max_iterations(10)
-            .seed_events(record.input.events.clone());
+            .max_iterations(10);
 
         // Add capability based on approach
         match config.approach {
@@ -435,6 +459,14 @@ async fn execute_with_agentic_loop(
         }
 
         let agentic_loop = builder.build().await?;
+
+        // Pre-populate the session's conversation history from the scenario's
+        // seed events. `run_turn` then appends the task on top of this history.
+        let seed_messages = messages_from_events(&record.input.events);
+        agentic_loop
+            .message_retriever()
+            .seed(agentic_loop.session_id(), seed_messages)
+            .await;
 
         // Run the turn with the task as user input
         let result = agentic_loop.run_turn(record.task.as_str()).await?;
@@ -467,10 +499,37 @@ async fn execute_with_agentic_loop(
         }
 
         // Success - extract metrics and return
-        let metrics =
-            extract_metrics_from_events(&agentic_loop, record.input.events.len()).await;
+        let metrics = extract_metrics_from_events(&agentic_loop, record.input.events.len()).await;
         return Ok((result.response, metrics));
     }
+}
+
+/// Convert a scenario's seed events into the conversation messages that make up
+/// the session's prior history. Only the event variants the dataset emits
+/// (`make_input_event`, `make_output_event`, `make_tool_event`) carry messages;
+/// any other event types are ignored.
+fn messages_from_events(events: &[everruns_core::events::Event]) -> Vec<everruns_core::Message> {
+    events
+        .iter()
+        .filter_map(|event| match &event.data {
+            EventData::InputMessage(data) => Some(data.message.clone()),
+            EventData::OutputMessageCompleted(data) => Some(data.message.clone()),
+            EventData::ToolCompleted(data) => Some(everruns_core::Message::tool_result(
+                data.tool_call_id.clone(),
+                data.result.as_ref().map(|parts| {
+                    serde_json::Value::String(
+                        parts
+                            .iter()
+                            .filter_map(|part| part.as_text())
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    )
+                }),
+                data.error.clone(),
+            )),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Extract evaluation metrics from events emitted during execution.
@@ -547,7 +606,9 @@ fn build_system_prompt(approach: Approach) -> String {
             format!(
                 "{}\n\n{}",
                 base,
-                InfinityContextCapability.system_prompt_addition().unwrap_or("")
+                InfinityContextCapability
+                    .system_prompt_addition()
+                    .unwrap_or("")
             )
         }
     }

--- a/research/lua-vs-bash/.gitignore
+++ b/research/lua-vs-bash/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts
+target/
+Cargo.lock

--- a/research/lua-vs-bash/src/main.rs
+++ b/research/lua-vs-bash/src/main.rs
@@ -11,12 +11,12 @@
 
 use std::time::Instant;
 
-use everruns_core::capabilities::{LuaCapability, VirtualBashCapability};
+use everruns_core::capabilities::{BashkitShellCapability, LuaCapability};
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::session_file::InitialFile;
 use everruns_core::{
-    AgentId, CapabilityRegistry, HarnessId, DriverId, MessageRole, ResolvedModel,
-    PlatformDefinition, SessionId,
+    AgentId, CapabilityRegistry, DriverId, HarnessId, MessageRole, PlatformDefinition,
+    ResolvedModel, SessionId,
 };
 use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
 
@@ -95,7 +95,7 @@ struct RunMetrics {
 
 fn platform() -> PlatformDefinition {
     let mut caps = CapabilityRegistry::new();
-    caps.register(VirtualBashCapability);
+    caps.register(BashkitShellCapability);
     caps.register(LuaCapability);
 
     let mut drivers = DriverRegistry::new();
@@ -106,12 +106,7 @@ fn platform() -> PlatformDefinition {
     PlatformDefinition::new(caps, drivers)
 }
 
-async fn run_one(
-    task: &Task,
-    capability: &str,
-    model: &ResolvedModel,
-    seed: u64,
-) -> RunMetrics {
+async fn run_one(task: &Task, capability: &str, model: &ResolvedModel, seed: u64) -> RunMetrics {
     let harness_id = HarnessId::from_seed(seed as u128);
     let agent_id = AgentId::from_seed(seed as u128);
     let session_id = SessionId::from_seed(seed as u128);


### PR DESCRIPTION
## What
Adds a weekly scheduled CI workflow (`.github/workflows/examples-check.yml`) that `cargo check`s every standalone crate listed in the root `Cargo.toml` `[workspace] exclude` array. Also fixes pre-existing compile drift in two of those crates so the new guard is green today.

Excluded standalone crates covered (derived from `Cargo.toml` at runtime):
- `research/infinity_context`
- `research/lua-vs-bash`
- `examples/weekend-concierge-host`

## Why
Crates in the workspace `exclude` array have their own `[workspace]`/`Cargo.lock`, so **no** CI job builds them — `ci.yml` only ever touches workspace members. They silently drift out of sync with `everruns-core` and only break when checked by hand. This is exactly what happened to `examples/weekend-concierge-host` (EVE-663). EVE-666 asks for a lightweight guard so this class of silent drift cannot recur.

## How
A dedicated scheduled workflow rather than folding into `integration-live-sweep.yml`: it is clean and discoverable (a maintainer grep for "examples" finds it), keeps an unrelated concern out of the live-API-sweep file, and matches that file's conventions (runner, `dtolnay/rust-toolchain@1.96.0`, `Swatinem/rust-cache@v2`, `schedule:` + `workflow_dispatch:`, `permissions: contents: read`).

Robustness:
- The crate list is **derived from `Cargo.toml`'s `exclude` array at run time** (an `awk` parse), so it cannot fall out of sync with the workspace definition — add/remove an `exclude` entry and the guard follows automatically. A header comment documents this.
- Iterates every crate without fail-fast (one drifted example can't mask another), errors if an excluded path has no `Cargo.toml` (stale entry), and fails the job if any crate fails to compile.
- Uses a distinct rust-cache `shared-key` ("examples-check") because these crates have separate dependency trees from the workspace.

**Why scheduled, not per-PR:** each excluded crate resolves a separate dependency tree from scratch (no shared workspace `target/` or `Cargo.lock`), so a per-PR full compile would add minutes of cold compilation for code that changes rarely. A weekly sweep catches drift within a week of an `everruns-core` API change without taxing the PR hot path — the same tradeoff `integration-live-sweep.yml` already makes.

Pre-existing drift fixed (mirrors how EVE-663/#2481 adapted to the current `everruns-core` API):
- `research/lua-vs-bash`: `VirtualBashCapability` was renamed to `BashkitShellCapability` (with `virtual_bash` retained as a registry alias). Updated the import + registration; the `"virtual_bash"` capability **string** still resolves via that alias and is left unchanged.
- `research/infinity_context`:
  - `ToolCompletedData` gained fields (`capability_id`, `capability_name`, `display_name`, fingerprints, `narration`). Switched the literal to the `ToolCompletedData::success(...)` constructor.
  - The `InMemoryAgenticLoopBuilder::seed_events(...)` method no longer exists. Seed conversation history is now converted to messages and loaded via `message_retriever().seed(session_id, ...)` after `build()` (new `messages_from_events` helper).
- Added `research/lua-vs-bash/.gitignore` (mirrors `research/infinity_context/.gitignore`) so its `Cargo.lock` is not committed.
- `examples/weekend-concierge-host/Cargo.lock` refreshed from the stale `0.17.0` everruns-* pins to the current `0.17.1` (incidental, correct drift-correction).

## Risk
- Low
- CI-only addition plus three excluded research/example crates that no production build depends on. No workspace-member code, runtime, or API surface changes. Worst case if the YAML/parse were wrong: the scheduled job fails loudly — it cannot break PR CI or releases.

## Security
- Threat categories reviewed: No security-relevant code changes. The new workflow is `schedule:` + `workflow_dispatch:` only (never runs on untrusted PR code), declares `permissions: contents: read`, injects no secrets, and only runs `cargo check` on in-repo crates. No trust-boundary, auth, or data-handling impact.
- Findings and resolutions: None.

## Validation evidence
Ran locally on this branch:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/examples-check.yml'))"` → YAML OK.
- The workflow's `awk` parse of `Cargo.toml` `exclude` → emits exactly the three crates above.
- `cargo check --manifest-path <crate>/Cargo.toml` for each excluded crate (after fixes): `research/infinity_context` → compiles; `research/lua-vs-bash` → compiles; `examples/weekend-concierge-host` → compiles.
- `rustfmt --edition 2024 --check` on the three edited Rust files → clean.

## Follow-ups
- Pre-existing rustfmt drift exists in other untouched files of these excluded crates (e.g. `research/infinity_context/src/capabilities/infinity_context.rs`). Left out of scope: this guard runs `cargo check`, not `cargo fmt`. A future enhancement could add `cargo fmt --check` to the sweep once the excluded crates are formatted.