### PR TITLE
refactor(core): adopt shared tool scaffolding in session_tasks/subagents

### DIFF
--- a/crates/core/src/capabilities/session_tasks.rs
+++ b/crates/core/src/capabilities/session_tasks.rs
@@ -194,45 +194,51 @@ impl Tool for ListTasksTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let registry = match require_task_registry(context) {
-            Ok(r) => r,
-            Err(e) => return e,
-        };
-        let state = match arguments.get("state").and_then(Value::as_str) {
-            Some(raw) => match SessionTaskState::parse(raw) {
-                Some(state) => Some(state),
-                None => {
-                    return ToolExecutionResult::tool_error(format!(
-                        "Unknown state filter \"{raw}\". Valid states: queued, running, \
-                         awaiting_input, succeeded, failed, canceled."
-                    ));
-                }
-            },
-            None => None,
-        };
-        let filter = SessionTaskFilter {
-            kind: arguments
-                .get("kind")
-                .and_then(Value::as_str)
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(ToString::to_string),
-            state,
-        };
-        let tasks = match registry.list(context.session_id, Some(&filter)).await {
-            Ok(tasks) => tasks,
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-        let entries = tasks.iter().map(compact_task_json).collect::<Vec<_>>();
-        ToolExecutionResult::success(json!({
-            "tasks": entries,
-            "count": entries.len(),
-        }))
+        list_tasks_impl(arguments, context)
+            .await
+            .unwrap_or_else(|e| e)
     }
 
     fn requires_context(&self) -> bool {
         true
     }
+}
+
+async fn list_tasks_impl(
+    arguments: Value,
+    context: &ToolContext,
+) -> Result<ToolExecutionResult, ToolExecutionResult> {
+    let registry = require_task_registry(context)?;
+    let state = match arguments.get("state").and_then(Value::as_str) {
+        Some(raw) => match SessionTaskState::parse(raw) {
+            Some(state) => Some(state),
+            None => {
+                return Ok(ToolExecutionResult::tool_error(format!(
+                    "Unknown state filter \"{raw}\". Valid states: queued, running, \
+                     awaiting_input, succeeded, failed, canceled."
+                )));
+            }
+        },
+        None => None,
+    };
+    let filter = SessionTaskFilter {
+        kind: arguments
+            .get("kind")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string),
+        state,
+    };
+    let tasks = registry
+        .list(context.session_id, Some(&filter))
+        .await
+        .map_err(ToolExecutionResult::internal_error)?;
+    let entries = tasks.iter().map(compact_task_json).collect::<Vec<_>>();
+    Ok(ToolExecutionResult::success(json!({
+        "tasks": entries,
+        "count": entries.len(),
+    })))
 }
 
 // =============================================================================
@@ -284,36 +290,36 @@ impl Tool for GetTaskTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let task_id = match require_str(&arguments, "task_id") {
-            Ok(id) => id,
-            Err(e) => return e,
-        };
-        let task = match load_task(context, task_id).await {
-            Ok(task) => task,
-            Err(e) => return e,
-        };
-        let registry = match require_task_registry(context) {
-            Ok(r) => r,
-            Err(e) => return e,
-        };
-        let messages = registry
-            .list_messages(
-                context.session_id,
-                task_id,
-                Some(GET_TASK_MESSAGE_LIMIT),
-                None,
-            )
+        get_task_impl(arguments, context)
             .await
-            .unwrap_or_default();
-        ToolExecutionResult::success(json!({
-            "task": full_task_json(&task),
-            "messages": messages.iter().map(message_json).collect::<Vec<_>>(),
-        }))
+            .unwrap_or_else(|e| e)
     }
 
     fn requires_context(&self) -> bool {
         true
     }
+}
+
+async fn get_task_impl(
+    arguments: Value,
+    context: &ToolContext,
+) -> Result<ToolExecutionResult, ToolExecutionResult> {
+    let task_id = require_str(&arguments, "task_id")?;
+    let task = load_task(context, task_id).await?;
+    let registry = require_task_registry(context)?;
+    let messages = registry
+        .list_messages(
+            context.session_id,
+            task_id,
+            Some(GET_TASK_MESSAGE_LIMIT),
+            None,
+        )
+        .await
+        .unwrap_or_default();
+    Ok(ToolExecutionResult::success(json!({
+        "task": full_task_json(&task),
+        "messages": messages.iter().map(message_json).collect::<Vec<_>>(),
+    })))
 }
 
 // =============================================================================
@@ -371,74 +377,68 @@ impl Tool for MessageTaskTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let task_id = match require_str(&arguments, "task_id") {
-            Ok(id) => id.to_string(),
-            Err(e) => return e,
-        };
-        let message = match require_str(&arguments, "message") {
-            Ok(m) => m.to_string(),
-            Err(e) => return e,
-        };
-        let in_reply_to = arguments
-            .get("in_reply_to")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(ToString::to_string);
-
-        let task = match load_task(context, &task_id).await {
-            Ok(task) => task,
-            Err(e) => return e,
-        };
-        let registry = match require_task_registry(context) {
-            Ok(r) => r,
-            Err(e) => return e,
-        };
-
-        let mut new_message = NewTaskMessage::inbound_text(message);
-        new_message.in_reply_to = in_reply_to;
-        let recorded = match registry
-            .record_message(context.session_id, &task_id, new_message)
+        message_task_impl(arguments, context)
             .await
-        {
-            Ok(recorded) => recorded,
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-
-        // Best-effort delivery: the message is durably recorded either way;
-        // report delivery outcome instead of failing the whole call.
-        let delivery = match find_task_executor(&task.kind) {
-            Some(executor) => {
-                // Re-read: recording an input-request answer returns the task
-                // to running before the executor sees it.
-                let current = registry
-                    .get(context.session_id, &task_id)
-                    .await
-                    .ok()
-                    .flatten()
-                    .unwrap_or(task);
-                match executor.deliver(&current, &recorded, context).await {
-                    Ok(()) => "delivered".to_string(),
-                    Err(e) => format!("failed: {e}"),
-                }
-            }
-            None => format!(
-                "failed: no executor registered for task kind '{}'",
-                task.kind
-            ),
-        };
-
-        ToolExecutionResult::success(json!({
-            "task_id": task_id,
-            "message_id": recorded.id,
-            "recorded": true,
-            "delivery": delivery,
-        }))
+            .unwrap_or_else(|e| e)
     }
 
     fn requires_context(&self) -> bool {
         true
     }
+}
+
+async fn message_task_impl(
+    arguments: Value,
+    context: &ToolContext,
+) -> Result<ToolExecutionResult, ToolExecutionResult> {
+    let task_id = require_str(&arguments, "task_id")?.to_string();
+    let message = require_str(&arguments, "message")?.to_string();
+    let in_reply_to = arguments
+        .get("in_reply_to")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string);
+
+    let task = load_task(context, &task_id).await?;
+    let registry = require_task_registry(context)?;
+
+    let mut new_message = NewTaskMessage::inbound_text(message);
+    new_message.in_reply_to = in_reply_to;
+    let recorded = registry
+        .record_message(context.session_id, &task_id, new_message)
+        .await
+        .map_err(ToolExecutionResult::internal_error)?;
+
+    // Best-effort delivery: the message is durably recorded either way;
+    // report delivery outcome instead of failing the whole call.
+    let delivery = match find_task_executor(&task.kind) {
+        Some(executor) => {
+            // Re-read: recording an input-request answer returns the task
+            // to running before the executor sees it.
+            let current = registry
+                .get(context.session_id, &task_id)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or(task);
+            match executor.deliver(&current, &recorded, context).await {
+                Ok(()) => "delivered".to_string(),
+                Err(e) => format!("failed: {e}"),
+            }
+        }
+        None => format!(
+            "failed: no executor registered for task kind '{}'",
+            task.kind
+        ),
+    };
+
+    Ok(ToolExecutionResult::success(json!({
+        "task_id": task_id,
+        "message_id": recorded.id,
+        "recorded": true,
+        "delivery": delivery,
+    })))
 }
 
 // =============================================================================
@@ -488,51 +488,54 @@ impl Tool for CancelTaskTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let task_id = match require_str(&arguments, "task_id") {
-            Ok(id) => id.to_string(),
-            Err(e) => return e,
-        };
-        let registry = match require_task_registry(context) {
-            Ok(r) => r,
-            Err(e) => return e,
-        };
-        let task = match registry.request_cancel(context.session_id, &task_id).await {
-            Ok(Some(task)) => task,
-            Ok(None) => {
-                return ToolExecutionResult::tool_error(format!(
-                    "No task found with id: {task_id}"
-                ));
-            }
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-
-        // Best-effort executor wind-down; the intent is recorded regardless.
-        let executor_result = if task.state.is_terminal() {
-            "task already terminal".to_string()
-        } else {
-            match find_task_executor(&task.kind) {
-                Some(executor) => match executor.cancel(&task, context).await {
-                    Ok(()) => "cancellation requested".to_string(),
-                    Err(e) => format!("failed: {e}"),
-                },
-                None => format!(
-                    "no executor registered for task kind '{}'; cancel intent recorded",
-                    task.kind
-                ),
-            }
-        };
-
-        ToolExecutionResult::success(json!({
-            "task_id": task_id,
-            "state": task.state,
-            "cancel_requested": true,
-            "executor": executor_result,
-        }))
+        cancel_task_impl(arguments, context)
+            .await
+            .unwrap_or_else(|e| e)
     }
 
     fn requires_context(&self) -> bool {
         true
     }
+}
+
+async fn cancel_task_impl(
+    arguments: Value,
+    context: &ToolContext,
+) -> Result<ToolExecutionResult, ToolExecutionResult> {
+    let task_id = require_str(&arguments, "task_id")?.to_string();
+    let registry = require_task_registry(context)?;
+    let task = match registry.request_cancel(context.session_id, &task_id).await {
+        Ok(Some(task)) => task,
+        Ok(None) => {
+            return Ok(ToolExecutionResult::tool_error(format!(
+                "No task found with id: {task_id}"
+            )));
+        }
+        Err(e) => return Err(ToolExecutionResult::internal_error(e)),
+    };
+
+    // Best-effort executor wind-down; the intent is recorded regardless.
+    let executor_result = if task.state.is_terminal() {
+        "task already terminal".to_string()
+    } else {
+        match find_task_executor(&task.kind) {
+            Some(executor) => match executor.cancel(&task, context).await {
+                Ok(()) => "cancellation requested".to_string(),
+                Err(e) => format!("failed: {e}"),
+            },
+            None => format!(
+                "no executor registered for task kind '{}'; cancel intent recorded",
+                task.kind
+            ),
+        }
+    };
+
+    Ok(ToolExecutionResult::success(json!({
+        "task_id": task_id,
+        "state": task.state,
+        "cancel_requested": true,
+        "executor": executor_result,
+    })))
 }
 
 // =============================================================================
@@ -589,49 +592,52 @@ impl Tool for WaitTaskTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let task_id = match require_str(&arguments, "task_id") {
-            Ok(id) => id.to_string(),
-            Err(e) => return e,
-        };
-        let timeout_secs = arguments
-            .get("timeout_seconds")
-            .and_then(Value::as_u64)
-            .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS);
-        let deadline = Instant::now() + Duration::from_secs(timeout_secs);
-        let mut polls: u64 = 0;
-
-        loop {
-            let task = match load_task(context, &task_id).await {
-                Ok(task) => task,
-                Err(e) => return e,
-            };
-            if task.state.is_terminal() || task.state == SessionTaskState::AwaitingInput {
-                return ToolExecutionResult::success(json!({
-                    "task": full_task_json(&task),
-                    "timed_out": false,
-                }));
-            }
-            if Instant::now() >= deadline {
-                return ToolExecutionResult::success(json!({
-                    "task": full_task_json(&task),
-                    "timed_out": true,
-                    "message": format!("Task {task_id} still {} after {timeout_secs}s", task.state),
-                }));
-            }
-            polls += 1;
-            // Refresh polled kinds (e.g. remote A2A tasks) periodically so the
-            // registry snapshot converges even when nothing pushes updates.
-            if polls.is_multiple_of(WAIT_RECONCILE_EVERY)
-                && let Some(executor) = find_task_executor(&task.kind)
-            {
-                let _ = executor.reconcile(&task, context).await;
-            }
-            sleep(WAIT_POLL_INTERVAL).await;
-        }
+        wait_task_impl(arguments, context)
+            .await
+            .unwrap_or_else(|e| e)
     }
 
     fn requires_context(&self) -> bool {
         true
+    }
+}
+
+async fn wait_task_impl(
+    arguments: Value,
+    context: &ToolContext,
+) -> Result<ToolExecutionResult, ToolExecutionResult> {
+    let task_id = require_str(&arguments, "task_id")?.to_string();
+    let timeout_secs = arguments
+        .get("timeout_seconds")
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS);
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let mut polls: u64 = 0;
+
+    loop {
+        let task = load_task(context, &task_id).await?;
+        if task.state.is_terminal() || task.state == SessionTaskState::AwaitingInput {
+            return Ok(ToolExecutionResult::success(json!({
+                "task": full_task_json(&task),
+                "timed_out": false,
+            })));
+        }
+        if Instant::now() >= deadline {
+            return Ok(ToolExecutionResult::success(json!({
+                "task": full_task_json(&task),
+                "timed_out": true,
+                "message": format!("Task {task_id} still {} after {timeout_secs}s", task.state),
+            })));
+        }
+        polls += 1;
+        // Refresh polled kinds (e.g. remote A2A tasks) periodically so the
+        // registry snapshot converges even when nothing pushes updates.
+        if polls.is_multiple_of(WAIT_RECONCILE_EVERY)
+            && let Some(executor) = find_task_executor(&task.kind)
+        {
+            let _ = executor.reconcile(&task, context).await;
+        }
+        sleep(WAIT_POLL_INTERVAL).await;
     }
 }
 

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -266,221 +266,217 @@ impl Tool for SpawnSubagentTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let store = match get_platform_store(context) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-        let session_store = match get_session_store(context) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-
-        let name = match require_str(&arguments, "name") {
-            Ok(s) => s.trim().to_string(),
-            Err(e) => return e,
-        };
-        let instructions = match require_str(&arguments, "instructions") {
-            Ok(s) => s.to_string(),
-            Err(e) => return e,
-        };
-
-        let blueprint_param = arguments
-            .get("blueprint")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.trim().is_empty())
-            .map(|s| s.to_string());
-        let config_param = arguments.get("config").filter(|v| !v.is_null()).cloned();
-
-        // Reject config without blueprint
-        if config_param.is_some() && blueprint_param.is_none() {
-            return ToolExecutionResult::tool_error(
-                "The `config` parameter is only valid when `blueprint` is set.",
-            );
-        }
-
-        // Nesting check: reject if current session is already a subagent
-        let parent_session = match session_store.get_session(context.session_id).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return ToolExecutionResult::tool_error("Current session not found"),
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-
-        if parent_session.parent_session_id.is_some() {
-            return ToolExecutionResult::tool_error(
-                "Subagents cannot spawn other subagents (nesting not allowed).",
-            );
-        }
-
-        // Validate blueprint exists and is allowed for this parent session.
-        if let Some(ref bp_id) = blueprint_param {
-            let Some(ref registry) = context.capability_registry else {
-                return ToolExecutionResult::tool_error(
-                    "Blueprint support requires capability_registry context.",
-                );
-            };
-
-            let Some((blueprint_capability_id, blueprint)) =
-                registry.blueprint_with_capability(bp_id)
-            else {
-                return ToolExecutionResult::tool_error(format!(
-                    "Unknown blueprint: \"{bp_id}\". Check available blueprints."
-                ));
-            };
-
-            // Validate config against schema if blueprint has one.
-            if let Some(ref schema) = blueprint.config_schema
-                && config_param.is_none()
-                && schema
-                    .get("required")
-                    .is_some_and(|r| r.as_array().is_some_and(|arr| !arr.is_empty()))
-            {
-                return ToolExecutionResult::tool_error(format!(
-                    "Blueprint \"{bp_id}\" requires config. Schema: {}",
-                    serde_json::to_string_pretty(schema).unwrap_or_default()
-                ));
-            }
-
-            let allowed_capability_ids = if let Some(agent_id) = parent_session.agent_id {
-                match store.get_agent_by_id(agent_id).await {
-                    Ok(Some(agent)) => agent
-                        .capabilities
-                        .iter()
-                        .map(|c| c.capability_id().to_string())
-                        .collect::<Vec<_>>(),
-                    Ok(None) => vec![],
-                    Err(e) => return ToolExecutionResult::internal_error(e),
-                }
-            } else {
-                match store.get_harness(parent_session.harness_id).await {
-                    Ok(Some(harness)) => harness
-                        .capabilities
-                        .iter()
-                        .map(|c| c.capability_id().to_string())
-                        .collect::<Vec<_>>(),
-                    Ok(None) => vec![],
-                    Err(e) => return ToolExecutionResult::internal_error(e),
-                }
-            };
-
-            if !allowed_capability_ids
-                .iter()
-                .any(|capability_id| capability_id == &blueprint_capability_id)
-            {
-                return ToolExecutionResult::tool_error(format!(
-                    "Blueprint \"{bp_id}\" is not enabled for this session."
-                ));
-            }
-        }
-
-        // --- Durable spawn handle claim (EVE-535) ---
-        //
-        // When a spawn store and tool_call_id are available, attempt to claim a
-        // spawn slot before creating the child session.  On reclaim, this lets us
-        // reattach to the existing child instead of spawning a duplicate.
-        if let (Some(spawn_store), Some(tool_call_id)) =
-            (&context.subagent_spawn_store, &context.tool_call_id)
-        {
-            let claim_token = uuid::Uuid::new_v4();
-
-            let claim = match spawn_store
-                .try_claim_spawn(context.session_id, tool_call_id, claim_token)
-                .await
-            {
-                Ok(c) => c,
-                Err(e) => return ToolExecutionResult::internal_error(e),
-            };
-
-            match claim {
-                SpawnClaimResult::AlreadySettled {
-                    child_session_id,
-                    terminal_status,
-                    terminal_result,
-                } => {
-                    // Already settled on a previous execution: return stored result.
-                    let task_id = find_subagent_task(context, child_session_id)
-                        .await
-                        .map(|t| t.id);
-                    return ToolExecutionResult::success(json!({
-                        "subagent_id": child_session_id.to_string(),
-                        "name": name,
-                        "status": terminal_status,
-                        "result": terminal_result,
-                        "task_id": task_id,
-                        "blueprint": blueprint_param,
-                    }));
-                }
-                SpawnClaimResult::AlreadyRunning {
-                    child_session_id,
-                    claim_token: stored_claim_token,
-                } => {
-                    // Child was spawned before but hasn't settled yet — reattach.
-                    // Use the stored claim_token so settle succeeds on this replay.
-                    let task_id = find_subagent_task(context, child_session_id)
-                        .await
-                        .map(|t| t.id);
-                    return run_subagent_wait_and_settle(
-                        store,
-                        context,
-                        child_session_id,
-                        &name,
-                        &instructions,
-                        &blueprint_param,
-                        task_id,
-                        Some((
-                            spawn_store.as_ref(),
-                            tool_call_id.as_str(),
-                            stored_claim_token,
-                        )),
-                    )
-                    .await;
-                }
-                SpawnClaimResult::Claimed {
-                    spawn_handle_id,
-                    claim_token: actual_claim_token,
-                }
-                | SpawnClaimResult::ClaimedPendingChild {
-                    spawn_handle_id,
-                    claim_token: actual_claim_token,
-                } => {
-                    // First claim (or re-claim after crash before register):
-                    // create child and register it durably before waiting.
-                    return spawn_create_and_wait(
-                        store,
-                        context,
-                        &parent_session,
-                        &name,
-                        &instructions,
-                        &blueprint_param,
-                        &config_param,
-                        Some((
-                            spawn_store.as_ref(),
-                            tool_call_id.as_str(),
-                            spawn_handle_id,
-                            actual_claim_token,
-                        )),
-                    )
-                    .await;
-                }
-            }
-        }
-
-        // --- No-spawn-store path (dev / noop) ---
-        spawn_create_and_wait(
-            store,
-            context,
-            &parent_session,
-            &name,
-            &instructions,
-            &blueprint_param,
-            &config_param,
-            None,
-        )
-        .await
+        spawn_subagent_impl(arguments, context)
+            .await
+            .unwrap_or_else(|e| e)
     }
 
     fn requires_context(&self) -> bool {
         true
     }
+}
+
+async fn spawn_subagent_impl(
+    arguments: Value,
+    context: &ToolContext,
+) -> Result<ToolExecutionResult, ToolExecutionResult> {
+    let store = get_platform_store(context)?;
+    let session_store = get_session_store(context)?;
+
+    let name = require_str(&arguments, "name")?.trim().to_string();
+    let instructions = require_str(&arguments, "instructions")?.to_string();
+
+    let blueprint_param = arguments
+        .get("blueprint")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string());
+    let config_param = arguments.get("config").filter(|v| !v.is_null()).cloned();
+
+    // Reject config without blueprint
+    if config_param.is_some() && blueprint_param.is_none() {
+        return Ok(ToolExecutionResult::tool_error(
+            "The `config` parameter is only valid when `blueprint` is set.",
+        ));
+    }
+
+    // Nesting check: reject if current session is already a subagent
+    let parent_session = match session_store.get_session(context.session_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return Ok(ToolExecutionResult::tool_error("Current session not found")),
+        Err(e) => return Err(ToolExecutionResult::internal_error(e)),
+    };
+
+    if parent_session.parent_session_id.is_some() {
+        return Ok(ToolExecutionResult::tool_error(
+            "Subagents cannot spawn other subagents (nesting not allowed).",
+        ));
+    }
+
+    // Validate blueprint exists and is allowed for this parent session.
+    if let Some(ref bp_id) = blueprint_param {
+        let Some(ref registry) = context.capability_registry else {
+            return Ok(ToolExecutionResult::tool_error(
+                "Blueprint support requires capability_registry context.",
+            ));
+        };
+
+        let Some((blueprint_capability_id, blueprint)) = registry.blueprint_with_capability(bp_id)
+        else {
+            return Ok(ToolExecutionResult::tool_error(format!(
+                "Unknown blueprint: \"{bp_id}\". Check available blueprints."
+            )));
+        };
+
+        // Validate config against schema if blueprint has one.
+        if let Some(ref schema) = blueprint.config_schema
+            && config_param.is_none()
+            && schema
+                .get("required")
+                .is_some_and(|r| r.as_array().is_some_and(|arr| !arr.is_empty()))
+        {
+            return Ok(ToolExecutionResult::tool_error(format!(
+                "Blueprint \"{bp_id}\" requires config. Schema: {}",
+                serde_json::to_string_pretty(schema).unwrap_or_default()
+            )));
+        }
+
+        let allowed_capability_ids = if let Some(agent_id) = parent_session.agent_id {
+            match store.get_agent_by_id(agent_id).await {
+                Ok(Some(agent)) => agent
+                    .capabilities
+                    .iter()
+                    .map(|c| c.capability_id().to_string())
+                    .collect::<Vec<_>>(),
+                Ok(None) => vec![],
+                Err(e) => return Err(ToolExecutionResult::internal_error(e)),
+            }
+        } else {
+            match store.get_harness(parent_session.harness_id).await {
+                Ok(Some(harness)) => harness
+                    .capabilities
+                    .iter()
+                    .map(|c| c.capability_id().to_string())
+                    .collect::<Vec<_>>(),
+                Ok(None) => vec![],
+                Err(e) => return Err(ToolExecutionResult::internal_error(e)),
+            }
+        };
+
+        if !allowed_capability_ids
+            .iter()
+            .any(|capability_id| capability_id == &blueprint_capability_id)
+        {
+            return Ok(ToolExecutionResult::tool_error(format!(
+                "Blueprint \"{bp_id}\" is not enabled for this session."
+            )));
+        }
+    }
+
+    // --- Durable spawn handle claim (EVE-535) ---
+    //
+    // When a spawn store and tool_call_id are available, attempt to claim a
+    // spawn slot before creating the child session.  On reclaim, this lets us
+    // reattach to the existing child instead of spawning a duplicate.
+    if let (Some(spawn_store), Some(tool_call_id)) =
+        (&context.subagent_spawn_store, &context.tool_call_id)
+    {
+        let claim_token = uuid::Uuid::new_v4();
+
+        let claim = match spawn_store
+            .try_claim_spawn(context.session_id, tool_call_id, claim_token)
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => return Err(ToolExecutionResult::internal_error(e)),
+        };
+
+        match claim {
+            SpawnClaimResult::AlreadySettled {
+                child_session_id,
+                terminal_status,
+                terminal_result,
+            } => {
+                // Already settled on a previous execution: return stored result.
+                let task_id = find_subagent_task(context, child_session_id)
+                    .await
+                    .map(|t| t.id);
+                return Ok(ToolExecutionResult::success(json!({
+                    "subagent_id": child_session_id.to_string(),
+                    "name": name,
+                    "status": terminal_status,
+                    "result": terminal_result,
+                    "task_id": task_id,
+                    "blueprint": blueprint_param,
+                })));
+            }
+            SpawnClaimResult::AlreadyRunning {
+                child_session_id,
+                claim_token: stored_claim_token,
+            } => {
+                // Child was spawned before but hasn't settled yet — reattach.
+                // Use the stored claim_token so settle succeeds on this replay.
+                let task_id = find_subagent_task(context, child_session_id)
+                    .await
+                    .map(|t| t.id);
+                return Ok(run_subagent_wait_and_settle(
+                    store,
+                    context,
+                    child_session_id,
+                    &name,
+                    &instructions,
+                    &blueprint_param,
+                    task_id,
+                    Some((
+                        spawn_store.as_ref(),
+                        tool_call_id.as_str(),
+                        stored_claim_token,
+                    )),
+                )
+                .await);
+            }
+            SpawnClaimResult::Claimed {
+                spawn_handle_id,
+                claim_token: actual_claim_token,
+            }
+            | SpawnClaimResult::ClaimedPendingChild {
+                spawn_handle_id,
+                claim_token: actual_claim_token,
+            } => {
+                // First claim (or re-claim after crash before register):
+                // create child and register it durably before waiting.
+                return Ok(spawn_create_and_wait(
+                    store,
+                    context,
+                    &parent_session,
+                    &name,
+                    &instructions,
+                    &blueprint_param,
+                    &config_param,
+                    Some((
+                        spawn_store.as_ref(),
+                        tool_call_id.as_str(),
+                        spawn_handle_id,
+                        actual_claim_token,
+                    )),
+                )
+                .await);
+            }
+        }
+    }
+
+    // --- No-spawn-store path (dev / noop) ---
+    Ok(spawn_create_and_wait(
+        store,
+        context,
+        &parent_session,
+        &name,
+        &instructions,
+        &blueprint_param,
+        &config_param,
+        None,
+    )
+    .await)
 }
 
 // =============================================================================


### PR DESCRIPTION
## What
Migrate the per-tool methods in `crates/core/src/capabilities/session_tasks.rs` and `crates/core/src/capabilities/subagents.rs` to the `_impl(args, ctx) -> Result` + `?` composition pattern, using the shared `require_str*` / `get_platform_store` / `get_session_store` helpers from `capabilities/util.rs`. The public `execute_with_context` methods now simply call the `_impl` and map errors via `.unwrap_or_else(|e| e)`, mirroring how `platform_management.rs` was migrated in EVE-646 (#2507).

Migrated tool sites:
- `session_tasks.rs` (5 tools): `list_tasks`, `get_task`, `message_task`, `cancel_task`, `wait_task`.
- `subagents.rs` (`spawn_subagent`): the per-argument extraction sites (`get_platform_store`, `get_session_store`, `require_str` × 2) now compose with `?`.

This is the first (lower-risk) acceptance criterion of EVE-671. It is a **behavior-preserving refactor** — no observable behavior changes.

## Why
EVE-646 established shared capability-tool scaffolding and applied it fully to `platform_management.rs` as the reference, but deferred `session_tasks.rs` and `subagents.rs` because their methods mix loops and async early-returns. EVE-671 is the follow-up to finish adopting the scaffolding in those files, removing the hand-rolled `match … { Err(e) => return e }` boilerplate.

## How
Each tool's `execute_with_context` body was extracted into a free `_impl` async function returning `Result`:
- Helper lookups (`require_task_registry`, `require_str`, `get_platform_store`, `get_session_store`, `load_task`) now use `?` instead of `match … return e`.
- Store/registry calls that mapped errors to `internal_error` use `.map_err(ToolExecutionResult::internal_error)?` where a single value was extracted, or keep their explicit `match` where multiple non-error arms exist (e.g. `request_cancel`'s `Ok(None)` → `tool_error`, `Err` → `internal_error`).
- Loops (`wait_task`'s polling loop) and async early-returns (subagent claim branches, terminal returns) are preserved exactly; success-shaped early returns are wrapped in `Ok(...)`, error-shaped early returns in `Err(...)`. Because the public method funnels both through `unwrap_or_else(|e| e)`, the resulting `ToolExecutionResult` is identical.
- Every user-visible error string and JSON output shape is byte-for-byte unchanged.

## Risk
- Low
- A subtle reshaping of control flow could in principle change an error path. Mitigated by: all 2667 `everruns-core` lib tests (including the full `session_tasks` and `subagents` suites) pass **unmodified**, which is the proof of behavior preservation; no test required changing.

## Security
- Threat categories reviewed: No security-relevant code changes. This is a pure internal refactor of tool-method scaffolding within `everruns-core`. No trust boundaries, authentication/authorization, input-validation semantics, or external behavior change — the same arguments are validated with the same error messages, and the same store/registry calls run in the same order.
- Findings and resolutions: None.

## Follow-ups
The remaining EVE-671 acceptance criteria are intentionally deferred to separate PRs (each larger / more behavior-sensitive), so the EVE-671 Linear issue stays open after this merges:
- Criterion 3: a `Tool` trait default for `execute()` / `requires_context()` across ~90 tools — too broad for one safe PR.
- Criterion 4: collapse `SkillsCapability` into a preset of `ScopedSkillsCapability`, and unify `fake_aws` / `fake_warehouse` — large and behavior-sensitive.

## Validation
- `cargo build -p everruns-core` — success.
- `cargo test -p everruns-core` — pass; lib suite: `2667 passed; 0 failed`, all unchanged.
- `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --check -p everruns-core` — clean.

## Checklist
- [x] Tests added or updated (none needed; existing tests pass unchanged and prove behavior preservation)
- [x] Backward compatibility considered (internal refactor, no API/behavior change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)