### PR TITLE
test(durable): fix flaky health-counter check via counter reset

### DIFF
--- a/crates/durable/tests/agent_reliability_test.rs
+++ b/crates/durable/tests/agent_reliability_test.rs
@@ -171,6 +171,17 @@ async fn reset_durable_tables(pool: &PgPool) {
     .execute(pool)
     .await
     .expect("Failed to reset durable test tables");
+
+    // TRUNCATE bypasses the row-level triggers that maintain `durable_stat_counters`
+    // (migration 082), so the cumulative health counters would otherwise stay
+    // non-zero while the tables they track are now empty. That stale drift made
+    // `postgres_repository_test`'s counter==COUNT(*) health check flaky when this
+    // binary ran first against the shared DB. The triggers UPDATE pre-seeded rows,
+    // so the rows must remain — zero the values in place instead of truncating.
+    sqlx::query("UPDATE durable_stat_counters SET value = 0")
+        .execute(pool)
+        .await
+        .expect("Failed to reset durable stat counters");
 }
 
 fn create_executor(

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -54,6 +54,17 @@ async fn reset_durable_tables(pool: &PgPool) {
     .execute(pool)
     .await
     .expect("Failed to reset durable test tables");
+
+    // TRUNCATE bypasses the row-level triggers that maintain `durable_stat_counters`
+    // (migration 082), so the cumulative health counters would otherwise stay
+    // non-zero while the tables they track are now empty. That stale drift made
+    // `postgres_repository_test`'s counter==COUNT(*) health check flaky when this
+    // binary ran first against the shared DB. The triggers UPDATE pre-seeded rows,
+    // so the rows must remain — zero the values in place instead of truncating.
+    sqlx::query("UPDATE durable_stat_counters SET value = 0")
+        .execute(pool)
+        .await
+        .expect("Failed to reset durable stat counters");
 }
 
 /// Create a test store with a fresh database connection


### PR DESCRIPTION
## What

Fix the intermittently-failing `test_health_counters_stay_consistent_through_transitions` durable integration test by resetting `durable_stat_counters` alongside the `TRUNCATE`-based table reset used by sibling durable test binaries.

## Why

`postgres_repository_test`'s health check asserts the global invariant that each `durable_stat_counters` value equals a live `COUNT(*)` of the rows it tracks. Sibling integration binaries (`postgres_integration_test`, `agent_reliability_test`) reset shared state with `TRUNCATE ... RESTART IDENTITY CASCADE`, which **bypasses the row-level triggers (migration 082)** that decrement those cumulative counters. The counters therefore stayed non-zero while the truncated tables were empty. When a `TRUNCATE`-ing binary raced ahead of the health check on the shared CI postgres, the assertion observed `counter > 0` with `COUNT(*) = 0` and failed — e.g. `counter \`workflows_started\` (2) drifted from live COUNT(*) (0)`.

This is the failure that blocked PR #2527 (whose own diff is unrelated — server integration tests) and that also flaked main CI on `b9e8c9c` (a rerun passed, confirming a race rather than a regression).

## How

After the `TRUNCATE` in each `reset_durable_tables` helper, zero the counter values in place:

```sql
UPDATE durable_stat_counters SET value = 0
```

The counter triggers `UPDATE` pre-seeded rows (they do not upsert), so the rows must remain — values are zeroed rather than the table truncated. With every reset leaving counters consistent with the now-empty tables, the `counter == COUNT(*)` invariant holds across all interleavings on the shared DB.

## Risk

- Very low. Test-helper-only change; no production code touched. `cargo test -p everruns-durable --no-run` compiles all three affected binaries.

## Security

- No trust-boundary, authn/authz, or data-egress changes. Test-only.
- Findings and resolutions: none.

## Follow-ups

- The deeper isolation weakness (multiple durable test binaries sharing one DB and `TRUNCATE`-ing each other's in-flight rows) is pre-existing and out of scope; this change addresses the specific flaky counter assertion.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcNdUCEm3du9DTxsw7oWq8)_