### PR TITLE
feat(ui): cross-run eval comparison with regression highlighting

### DIFF
--- a/apps/ui/src/__tests__/run-comparison.test.tsx
+++ b/apps/ui/src/__tests__/run-comparison.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { RunComparison } from "@/components/evals/run-comparison";
+import type { EvalCaseResult, EvalRun } from "@/lib/api/types";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href={href}>{children}</a>
+  ),
+}));
+
+function result(caseName: string, status: EvalCaseResult["status"], value: number): EvalCaseResult {
+  return {
+    id: `evalresult_${caseName}_${status}`,
+    eval_case_id: `evalcase_${caseName}`,
+    case_name: caseName,
+    status,
+    scores: [{ scorer: "contains", value, pass: status === "passed" }],
+    created_at: "2026-04-19T10:00:00Z",
+    updated_at: "2026-04-19T10:00:00Z",
+  };
+}
+
+function run(id: string, createdAt: string, results: EvalCaseResult[], passRate: number): EvalRun {
+  return {
+    id,
+    status: "completed",
+    triggered_by: "user",
+    results,
+    summary: {
+      total: results.length,
+      passed: results.filter((r) => r.status === "passed").length,
+      failed: results.filter((r) => r.status === "failed").length,
+      errored: 0,
+      pass_rate: passRate,
+      avg_score: 0,
+      avg_turns: 0,
+      avg_latency_ms: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+    },
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+describe("RunComparison", () => {
+  it("flags a case that regressed between consecutive runs", () => {
+    const older = run("evalrun_old", "2026-04-19T10:00:00Z", [result("a", "passed", 1)], 1);
+    const newer = run("evalrun_new", "2026-04-20T10:00:00Z", [result("a", "failed", 0)], 0);
+
+    // Pass the runs out of chronological order to exercise the internal sort.
+    render(<RunComparison evalId="eval_1" runs={[newer, older]} />);
+
+    // The newer run's cell for case "a" is a regression (passed → failed).
+    expect(screen.getByTitle("Regressed from previous run")).toBeInTheDocument();
+    // Pass-rate row renders both runs.
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    // Case row label is present.
+    expect(screen.getByText("a")).toBeInTheDocument();
+  });
+
+  it("flags an improvement (failed → passed)", () => {
+    const older = run("evalrun_old", "2026-04-19T10:00:00Z", [result("a", "failed", 0)], 0);
+    const newer = run("evalrun_new", "2026-04-20T10:00:00Z", [result("a", "passed", 1)], 1);
+
+    render(<RunComparison evalId="eval_1" runs={[older, newer]} />);
+
+    expect(screen.getByTitle("Improved")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/evals/[evalId]/compare/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/compare/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { use, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useEval, useEvalRunComparison, usePageTitle } from "@/hooks";
+import { RunComparison } from "@/components/evals/run-comparison";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+
+function CompareContent({ evalId }: { evalId: string }) {
+  const searchParams = useSearchParams();
+  const runIds = (searchParams.get("runs") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const { data: ev } = useEval(evalId);
+  usePageTitle("Compare runs", ev?.name ?? null, "Eval");
+  const { runs, isLoading } = useEvalRunComparison(evalId, runIds);
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href={`/evals/${evalId}`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to {ev?.name ?? "Eval"}
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">Compare runs ({runIds.length})</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Per-case comparison</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {runIds.length < 2 ? (
+            <p className="text-center py-8 text-muted-foreground">
+              Select at least two runs from the eval&rsquo;s Runs tab to compare.
+            </p>
+          ) : isLoading ? (
+            <Skeleton className="h-64 w-full" />
+          ) : runs.length === 0 ? (
+            <p className="text-center py-8 text-muted-foreground">No results to compare.</p>
+          ) : (
+            <RunComparison evalId={evalId} runs={runs} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function EvalComparePage({ params }: { params: Promise<{ evalId: string }> }) {
+  const { evalId } = use(params);
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto p-6">
+          <Skeleton className="h-8 w-1/3 mb-4" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      }
+    >
+      <CompareContent evalId={evalId} />
+    </Suspense>
+  );
+}

--- a/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
@@ -164,34 +164,55 @@ function CaseCard({
   );
 }
 
-function RunRow({ evalId, run }: { evalId: string; run: EvalRun }) {
+function RunRow({
+  evalId,
+  run,
+  selected,
+  onToggleSelect,
+}: {
+  evalId: string;
+  run: EvalRun;
+  selected?: boolean;
+  onToggleSelect?: (runId: string) => void;
+}) {
   return (
-    <Link href={`/evals/${evalId}/runs/${run.id}`} className="block">
-      <Card className="hover:border-primary/50 transition-colors cursor-pointer">
-        <CardContent className="flex items-center justify-between py-4">
-          <div className="flex items-center gap-4">
-            <Badge variant={runStatusVariant(run.status)}>{run.status}</Badge>
-            <span className="text-sm text-muted-foreground">
-              {new Date(run.created_at).toLocaleString()}
-            </span>
-            <span className="text-xs text-muted-foreground">by {run.triggered_by}</span>
-            {run.target && <TargetBadge target={run.target} />}
-          </div>
-          <div className="flex items-center gap-4 text-sm">
-            {run.summary && (
-              <>
-                <span className={passRateColor(run.summary.pass_rate)}>
-                  {(run.summary.pass_rate * 100).toFixed(0)}% pass
-                </span>
-                <span className="text-muted-foreground">
-                  {run.summary.passed}/{run.summary.total} passed
-                </span>
-              </>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-    </Link>
+    <div className="flex items-center gap-3">
+      {onToggleSelect && (
+        <input
+          type="checkbox"
+          checked={!!selected}
+          onChange={() => onToggleSelect(run.id)}
+          aria-label={`Select run for comparison`}
+          className="h-4 w-4 shrink-0 cursor-pointer"
+        />
+      )}
+      <Link href={`/evals/${evalId}/runs/${run.id}`} className="block flex-1">
+        <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+          <CardContent className="flex items-center justify-between py-4">
+            <div className="flex items-center gap-4">
+              <Badge variant={runStatusVariant(run.status)}>{run.status}</Badge>
+              <span className="text-sm text-muted-foreground">
+                {new Date(run.created_at).toLocaleString()}
+              </span>
+              <span className="text-xs text-muted-foreground">by {run.triggered_by}</span>
+              {run.target && <TargetBadge target={run.target} />}
+            </div>
+            <div className="flex items-center gap-4 text-sm">
+              {run.summary && (
+                <>
+                  <span className={passRateColor(run.summary.pass_rate)}>
+                    {(run.summary.pass_rate * 100).toFixed(0)}% pass
+                  </span>
+                  <span className="text-muted-foreground">
+                    {run.summary.passed}/{run.summary.total} passed
+                  </span>
+                </>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </Link>
+    </div>
   );
 }
 
@@ -320,6 +341,12 @@ export default function EvalDetailPage({ params }: { params: Promise<{ evalId: s
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("cases");
   const [showAddCase, setShowAddCase] = useState(false);
+  const [selectedRuns, setSelectedRuns] = useState<string[]>([]);
+
+  const toggleRunSelection = (runId: string) =>
+    setSelectedRuns((prev) =>
+      prev.includes(runId) ? prev.filter((id) => id !== runId) : [...prev, runId],
+    );
 
   const { data: ev, isLoading: evalLoading } = useEval(evalId);
   usePageTitle(ev?.name ?? null, "Eval");
@@ -497,8 +524,29 @@ export default function EvalDetailPage({ params }: { params: Promise<{ evalId: s
               </div>
             ) : (
               <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    Select runs to compare them case by case.
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={selectedRuns.length < 2}
+                    onClick={() =>
+                      router.push(`/evals/${evalId}/compare?runs=${selectedRuns.join(",")}`)
+                    }
+                  >
+                    Compare ({selectedRuns.length})
+                  </Button>
+                </div>
                 {runs.map((run) => (
-                  <RunRow key={run.id} evalId={evalId} run={run} />
+                  <RunRow
+                    key={run.id}
+                    evalId={evalId}
+                    run={run}
+                    selected={selectedRuns.includes(run.id)}
+                    onToggleSelect={toggleRunSelection}
+                  />
                 ))}
               </div>
             )}

--- a/apps/ui/src/components/evals/run-comparison.tsx
+++ b/apps/ui/src/components/evals/run-comparison.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+// Cross-run comparison: a per-case × run grid. Runs are ordered oldest →
+// newest so a cell can be compared to the same case in the previous run and
+// flag regressions (passed → failed) and improvements (failed → passed). With a
+// pass-rate row on top, this is the "did this run regress vs last" view.
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { meanScore } from "@/components/evals/eval-format";
+import type { EvalCaseResult, EvalRun } from "@/lib/api/types";
+
+type Verdict = "passed" | "failed" | "skipped" | "none";
+
+interface CaseAgg {
+  verdict: Verdict;
+  score: number | null;
+}
+
+// A case can have several results in one run (the matrix). Roll them up to a
+// single per-case verdict/score for the comparison cell.
+function aggregateCase(results: EvalCaseResult[]): CaseAgg {
+  if (results.length === 0) return { verdict: "none", score: null };
+  const statuses = results.map((r) => r.status);
+  let verdict: Verdict;
+  if (statuses.every((s) => s === "passed")) {
+    verdict = "passed";
+  } else if (statuses.some((s) => s === "failed" || s === "errored" || s === "timeout")) {
+    verdict = "failed";
+  } else {
+    verdict = "skipped";
+  }
+  const scores = results.map((r) => meanScore(r.scores)).filter((v): v is number => v != null);
+  const score = scores.length > 0 ? scores.reduce((a, v) => a + v, 0) / scores.length : null;
+  return { verdict, score };
+}
+
+function caseKeyOf(r: EvalCaseResult): string {
+  return r.case_name ?? r.eval_case_id;
+}
+
+function verdictClasses(verdict: Verdict): string {
+  switch (verdict) {
+    case "passed":
+      return "bg-green-500/15 text-green-700 dark:text-green-400";
+    case "failed":
+      return "bg-red-500/15 text-red-700 dark:text-red-400";
+    case "skipped":
+      return "bg-muted text-muted-foreground";
+    default:
+      return "text-muted-foreground/50";
+  }
+}
+
+function runShortId(run: EvalRun): string {
+  // Public ids are `evalrun_<32 hex>`; the last 6 are enough to disambiguate.
+  return run.id.replace(/^evalrun_/, "").slice(-6);
+}
+
+export function RunComparison({ evalId, runs }: { evalId: string; runs: EvalRun[] }) {
+  // Oldest → newest so "previous run" is the column to the left.
+  const ordered = [...runs].sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  // Union of case keys, in first-seen order across runs.
+  const caseKeys: string[] = [];
+  // perRun[i] maps caseKey -> aggregate for run i.
+  const perRun: Array<Map<string, CaseAgg>> = ordered.map((run) => {
+    const byCase = new Map<string, EvalCaseResult[]>();
+    for (const r of run.results) {
+      const key = caseKeyOf(r);
+      if (!caseKeys.includes(key)) caseKeys.push(key);
+      const list = byCase.get(key) ?? [];
+      list.push(r);
+      byCase.set(key, list);
+    }
+    const aggs = new Map<string, CaseAgg>();
+    for (const [key, list] of byCase) aggs.set(key, aggregateCase(list));
+    return aggs;
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto">
+        <table className="w-full border-separate border-spacing-1">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 bg-background py-2 px-3 text-left text-sm font-medium text-muted-foreground">
+                Case
+              </th>
+              {ordered.map((run) => (
+                <th key={run.id} className="py-2 px-3 text-center align-bottom">
+                  <Link
+                    href={`/evals/${evalId}/runs/${run.id}`}
+                    className="text-xs font-medium hover:underline"
+                  >
+                    {runShortId(run)}
+                  </Link>
+                  <div className="text-[10px] font-normal text-muted-foreground whitespace-nowrap">
+                    {new Date(run.created_at).toLocaleDateString()}
+                  </div>
+                  {run.source === "external" && (
+                    <Badge variant="secondary" className="mt-1 text-[10px]">
+                      {run.attribution?.system ?? "external"}
+                    </Badge>
+                  )}
+                </th>
+              ))}
+            </tr>
+            <tr>
+              <th className="sticky left-0 z-10 bg-background py-1 px-3 text-left text-xs font-normal text-muted-foreground">
+                Pass rate
+              </th>
+              {ordered.map((run) => (
+                <th
+                  key={run.id}
+                  className="py-1 px-3 text-center text-xs font-medium text-muted-foreground"
+                >
+                  {run.summary ? `${(run.summary.pass_rate * 100).toFixed(0)}%` : "—"}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {caseKeys.map((caseKey) => (
+              <tr key={caseKey}>
+                <td className="sticky left-0 z-10 bg-background py-2 px-3 text-sm font-medium whitespace-nowrap">
+                  {caseKey}
+                </td>
+                {ordered.map((run, i) => {
+                  const agg = perRun[i].get(caseKey);
+                  const prev = i > 0 ? perRun[i - 1].get(caseKey) : undefined;
+                  const regressed = prev?.verdict === "passed" && agg?.verdict === "failed";
+                  const improved = prev?.verdict === "failed" && agg?.verdict === "passed";
+                  const ring = regressed
+                    ? "ring-2 ring-red-500"
+                    : improved
+                      ? "ring-2 ring-green-500"
+                      : "";
+                  const text =
+                    agg == null
+                      ? "·"
+                      : agg.score != null
+                        ? agg.score.toFixed(2)
+                        : agg.verdict === "passed"
+                          ? "✓"
+                          : agg.verdict === "failed"
+                            ? "✗"
+                            : "–";
+                  return (
+                    <td
+                      key={run.id}
+                      title={
+                        regressed
+                          ? "Regressed from previous run"
+                          : improved
+                            ? "Improved"
+                            : undefined
+                      }
+                      className={`py-2 px-3 text-center text-sm font-medium rounded-md ${verdictClasses(agg?.verdict ?? "none")} ${ring}`}
+                    >
+                      {text}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded ring-2 ring-red-500" /> regressed
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded ring-2 ring-green-500" /> improved
+        </span>
+        <span>cells show mean score (✓/✗ when no numeric score); runs ordered oldest → newest</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-evals.ts
+++ b/apps/ui/src/hooks/use-evals.ts
@@ -1,7 +1,7 @@
 // Eval hooks
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
 import {
   evalsCrudApi,
   listEvalCases,
@@ -17,8 +17,10 @@ import type {
   UpdateEvalRequest,
   CreateEvalCaseRequest,
   CreateEvalRunRequest,
+  EvalRun,
 } from "@/lib/api/types";
 import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
 import { createCrudHooks } from "./create-crud-hooks";
 import { useOrgScopedQuery } from "./create-crud-hooks";
 
@@ -101,6 +103,28 @@ export function useEvalRun(evalId: string | undefined, runId: string | undefined
     queryFn: () => getEvalRun(evalId!, runId!),
     enabled: !!evalId && !!runId,
   });
+}
+
+// Fetch several runs (with their case results) at once for cross-run
+// comparison. Org-scoped like `useEvalRun`; reuses the per-run query cache so a
+// run already viewed isn't refetched.
+export function useEvalRunComparison(evalId: string | undefined, runIds: string[]) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const queries = useQueries({
+    queries: runIds.map((runId) => ({
+      queryKey: [...queryKeys.evals.runDetail(evalId ?? "", runId), org],
+      queryFn: () => getEvalRun(evalId!, runId),
+      enabled: !!evalId && !!org && !!runId,
+    })),
+  });
+
+  return {
+    runs: queries.map((q) => q.data).filter((d): d is EvalRun => !!d),
+    isLoading: orgLoading || queries.some((q) => q.isLoading),
+    isError: queries.some((q) => q.isError),
+  };
 }
 
 export function useCreateEvalRun(evalId: string) {


### PR DESCRIPTION
## What
Adds **cross-run comparison** to evals (Phase 3, increment 3 of `proposals/mira-results-publishing.md`; builds on #2516/#2517). From an eval's **Runs** tab you can select 2+ runs and **Compare** them case by case.

- New `/evals/{evalId}/compare?runs=<ids>` route renders a **per-case × run grid**, runs ordered oldest → newest.
- Each cell shows the case's mean score (✓/✗ when no numeric score), tinted by verdict, and is **ring-highlighted when it regressed** (passed → failed) or **improved** (failed → passed) vs. the same case in the previous run. A **pass-rate row** sits on top for an at-a-glance trend.
- The Runs tab gains **selection checkboxes** and a `Compare (N)` button.

## Why
You could view a single run, but not answer "did this run regress vs the last one?" — the core reason to keep eval history. This makes regressions and improvements obvious across runs (including imported Mira runs, which carry an attribution chip in the column header).

## How
- New `useEvalRunComparison(evalId, runIds)` hook fetches the selected runs' details via React Query's `useQueries`, org-scoped like `useEvalRun` and reusing the per-run cache (a run already viewed isn't refetched).
- New `RunComparison` component aggregates each case across a run's (possibly multi-target) results into one verdict/score, then diffs consecutive runs for the ring highlighting.
- `RunRow` gains an optional selection checkbox; the eval-detail page tracks selected run ids and routes to the compare page.

## Risk
- **Low.** UI-only, behind the `evals` feature flag. Additive: no change to existing run viewing; the compare route is only reachable via the new button. No new endpoints (reuses `GET /v1/evals/{id}/runs/{runId}`).

## Security
- TM-UI: renders only data the eval read endpoints already return for the caller's org. Run ids come from the URL query and are passed straight to the existing org-scoped fetch (which 404s cross-org). No new data exposure.

## Follow-ups
- Trends over many runs (charts) and Phase 4 (optional SaaS shareable pages).

## Checklist
- [x] Tests added or updated (regression + improvement highlighting; 5 eval UI tests total green)
- [x] Backward compatibility considered (additive)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ryzx9dSfPsZxmQuthEDfDF)_