### PR TITLE
fix(server): map MCP/plugin not-found & validation errors to 404/400

### DIFF
--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -223,7 +223,7 @@ impl Command for CreateAgent {
                 network_access: req
                     .network_access
                     .as_ref()
-                    .map(|na| serde_json::to_value(na).unwrap()),
+                    .map(|na| serde_json::to_value(na).unwrap_or_default()),
                 max_iterations: max_iterations::to_db(req.max_iterations)
                     .map_err(classify_anyhow)?,
                 parallel_tool_calls: req.parallel_tool_calls,
@@ -252,7 +252,7 @@ impl Command for CreateAgent {
                 network_access: req
                     .network_access
                     .as_ref()
-                    .map(|na| serde_json::to_value(na).unwrap()),
+                    .map(|na| serde_json::to_value(na).unwrap_or_default()),
                 max_iterations: max_iterations::to_db(req.max_iterations)
                     .map_err(classify_anyhow)?,
                 parallel_tool_calls: req.parallel_tool_calls,
@@ -536,7 +536,7 @@ impl Command for UpdateAgentCmd {
                 .map_err(classify_anyhow)?,
             network_access: req
                 .network_access
-                .map(|na| Some(serde_json::to_value(na).unwrap())),
+                .map(|na| Some(serde_json::to_value(na).unwrap_or_default())),
             parallel_tool_calls: req.parallel_tool_calls.map(Some),
             ..Default::default()
         };
@@ -740,7 +740,7 @@ impl Command for UpsertAgent {
             network_access: req
                 .network_access
                 .as_ref()
-                .map(|na| serde_json::to_value(na).unwrap()),
+                .map(|na| serde_json::to_value(na).unwrap_or_default()),
         };
         let (row, was_created) = ctx
             .db

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -237,6 +237,9 @@ pub fn classify_anyhow(e: anyhow::Error) -> CommandError {
         "only api key mcp servers can store an api key",
         "api key auth mode requires",
         "oauth mcp servers require a user connection",
+        // EVE-649: org MCP servers reject stdio/local transports at
+        // create/update — client-supplied config, not an internal invariant.
+        "stdio mcp servers are not supported for organization mcp servers",
     ]
     .iter()
     .any(|pattern| lowered.contains(pattern));
@@ -1285,6 +1288,25 @@ mod error_tests {
         assert_eq!(err.status(), StatusCode::NOT_FOUND);
     }
 
+    // EVE-649: org MCP server create/update raise a stringly-typed
+    // `anyhow::bail!("stdio MCP servers are not supported for organization MCP
+    // servers")` on client-supplied transport config. Pin that it classifies
+    // as a 400 instead of falling through to Internal/500.
+    #[test]
+    fn classify_anyhow_maps_stdio_mcp_server_rejection_to_bad_request() {
+        let err = classify_anyhow(anyhow::anyhow!(
+            "stdio MCP servers are not supported for organization MCP servers"
+        ));
+        let CommandError {
+            kind: CommandErrorKind::BadRequest(_),
+            ..
+        } = &err
+        else {
+            panic!("stdio MCP server rejection must classify as BadRequest, got {err:?}");
+        };
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
     // EVE-437: every substring added to the `is_bad_request` list must in
     // fact map an `anyhow::bail!` to `CommandError::BadRequest` rather than
     // silently 500ing. New entries here pin the contract.
@@ -1303,6 +1325,8 @@ mod error_tests {
             "API key auth mode requires an API key",
             "API key auth mode requires a non-empty API key",
             "OAuth MCP servers require a user connection before tools can be refreshed",
+            // EVE-649: org MCP server transport validation
+            "stdio MCP servers are not supported for organization MCP servers",
         ];
         for raw in cases {
             let err = classify_anyhow(anyhow::anyhow!("{raw}"));

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -215,7 +215,7 @@ impl Command for CreateHarness {
             network_access: req
                 .network_access
                 .as_ref()
-                .map(|na| serde_json::to_value(na).unwrap()),
+                .map(|na| serde_json::to_value(na).unwrap_or_default()),
             embedder_metadata: serde_json::to_value(&req.embedder_metadata).unwrap_or_default(),
             is_built_in: false,
         };
@@ -495,7 +495,7 @@ impl Command for UpdateHarnessCmd {
                 .map(|servers| serde_json::to_value(&servers).unwrap_or_default()),
             network_access: req
                 .network_access
-                .map(|na| Some(serde_json::to_value(na).unwrap())),
+                .map(|na| Some(serde_json::to_value(na).unwrap_or_default())),
             embedder_metadata: req
                 .embedder_metadata
                 .map(|m| serde_json::to_value(&m).unwrap_or_default()),

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -636,7 +636,7 @@ impl SessionService {
             network_access: req
                 .network_access
                 .as_ref()
-                .map(|na| serde_json::to_value(na).unwrap()),
+                .map(|na| serde_json::to_value(na).unwrap_or_default()),
             max_iterations: max_iterations::to_db(req.max_iterations)?,
             parallel_tool_calls: req.parallel_tool_calls,
             blueprint_id: None,
@@ -786,7 +786,7 @@ impl SessionService {
             network_access: req
                 .network_access
                 .as_ref()
-                .map(|na| serde_json::to_value(na).unwrap()),
+                .map(|na| serde_json::to_value(na).unwrap_or_default()),
             max_iterations: max_iterations::to_db(req.max_iterations)?,
             parallel_tool_calls: req.parallel_tool_calls,
             blueprint_id: Some(blueprint_id),


### PR DESCRIPTION
## What
Safe error-mapping subset of EVE-649. Fixes a latent case where org MCP-server create/update validation returned **500** instead of **400**, and hardens copy-pasted serialization panics on agent/harness/session write paths.

Concretely:
- `classify_anyhow` (crates/server/src/domains/common.rs): add the org-MCP stdio/local transport rejection string `"stdio MCP servers are not supported for organization MCP servers"` (emitted by `anyhow::bail!` at mcp_servers/service.rs ~193 and ~296) to the bad-request substring allowlist, so it maps to 400.
- Replace `serde_json::to_value(network_access).unwrap()` with `.unwrap_or_default()` on the write paths in agents/commands.rs (4 sites), harnesses/commands.rs (2 sites), and sessions/service.rs (2 sites).

## Why
EVE-649 flagged MCP/plugin not-found and validation failures returning 500 instead of 404/400, plus copy-pasted `.unwrap()` panics on live write paths.

On investigation, most of issue #1 was already fixed on `main`:
- MCP-server not-found now raises `ResourceNotFoundError::new("MCP server")` -> 404 (EVE-645).
- Plugin marketplace/install/compile paths already return typed `CommandError::bad_request`/`not_found` (the plugins domain does not fall through `classify_anyhow` for these).
- The MCP auth-mode/key validation strings are already in the EVE-437 allowlist -> 400.

The one genuine remaining 500-instead-of-400 gap was the **stdio-transport rejection** for organization MCP servers, which was not in the allowlist. This PR closes it.

## How
- Extend the existing `is_bad_request` substring allowlist in `classify_anyhow` with the stdio-rejection string (matched against the lowercased anyhow message, consistent with the established EVE-437 convention). No new error system introduced.
- Add a dedicated test pinning the stdio rejection to BadRequest/400 and extend the EVE-437 substring test to cover it.
- Harden the `network_access` serialization panics to `unwrap_or_default()`, matching the sibling fields (`initial_files`/`tools`/`mcp_servers`/`embedder_metadata`) already using that pattern in the same struct literals. `NetworkAccessList` is two `Vec<String>` fields and serializes infallibly, so the success path is unchanged; the impossible error path now yields `Value::Null` (identical to the `None` branch) instead of panicking.

## Risk
- Low.
- Status-code-only behavior change for one validation path (500 -> 400). The panic-hardening is behavior-preserving on the success path (serialization of `NetworkAccessList` cannot fail).

## Security
- Threat categories reviewed: TM-API (error surface / response codes).
- Findings and resolutions: The stdio-rejection path was a latent 500 on attacker/user-triggerable validation input (a client supplying an unsupported transport for an org MCP server). It now correctly returns 400, matching the rest of the MCP config-validation surface, and avoids leaking an internal-error classification for what is plain client input. No authz logic touched. The serialization hardening removes a panic (DoS-adjacent) on live write paths without changing success behavior.

## Follow-ups
EVE-649 stays open; the larger, higher-risk items are intentionally deferred:
- The domain `Command`-trait migration of the Service-pattern domains (mcp_servers/models/providers/observers/sessions) and moving auth into `Command::policy()` (touches authz; out of scope for a focused error-mapping fix).
- The generic `resolve_by_id_or_name` helper to replace the ~14 inline copies.
- Standardizing list endpoints on `Paginated`.
- Splitting god-files.
- `budgets/service.rs` `row_to_ledger_entry` `.expect("... always have a budget_id")`: converting to a fallible return requires changing the signature and its `.map(...).collect()` caller and delegating wrapper across multiple files, so it is not a mechanical one-line change; deferred to avoid widening this PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)