### PR TITLE
perf(worker): native protobuf for session-task RPC payloads

### DIFF
--- a/crates/internal-protocol/Cargo.toml
+++ b/crates/internal-protocol/Cargo.toml
@@ -47,3 +47,10 @@ tracing.workspace = true
 [build-dependencies]
 tonic-prost-build.workspace = true
 protox = "0.9"
+
+# EVE-642 evidence bench: session-task payload encode/decode, old JSON-in-protobuf
+# path vs new native protobuf path. Custom main (harness = false), matching the
+# durable-crate bench convention.
+[[bench]]
+name = "session_task_encoding"
+harness = false

--- a/crates/internal-protocol/benches/session_task_encoding.rs
+++ b/crates/internal-protocol/benches/session_task_encoding.rs
@@ -1,0 +1,144 @@
+// EVE-642 evidence bench: measure the session-task RPC payload encode/decode
+// cost for the OLD JSON-in-protobuf path vs the NEW native-protobuf path.
+//
+// The RPC hot path serializes a `SessionTask` on the server and deserializes it
+// on the worker for every task/message, per element on list handlers. The OLD
+// path did `serde_json::to_vec` of the whole struct into a protobuf `bytes`
+// field (JSON encode) then `serde_json::from_slice` on the worker (JSON decode)
+// — JSON work layered on top of protobuf's own framing. The NEW path models the
+// ~20 structural fields as native protobuf and lets prost encode/decode them
+// once; only the genuinely free-form fields (spec / expected / message Data)
+// carry canonical serde_json bytes, serialized exactly once.
+//
+// This bench isolates the serialization work only (no network), which is exactly
+// the redundant CPU/allocation the migration removes. Run:
+//   cargo bench -p everruns-internal-protocol --bench session_task_encoding
+//
+// harness = false: plain `fn main`, matching the crate/durable bench convention.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use chrono::{TimeZone, Utc};
+use everruns_core::session_task as st;
+use everruns_core::typed_id::SessionId;
+use everruns_internal_protocol::{proto_to_session_task, session_task_to_proto};
+use prost::Message as _;
+
+fn sample_task() -> st::SessionTask {
+    st::SessionTask {
+        id: "task_0123456789abcdef".to_string(),
+        session_id: SessionId::new(),
+        kind: st::TASK_KIND_SUBAGENT.to_string(),
+        display_name: "Investigate CI flake in worker integration suite".to_string(),
+        spec: serde_json::json!({
+            "instructions": "Reproduce the flake and propose a fix",
+            "budget": { "steps": 40, "tokens": 200_000 },
+            "tags": ["ci", "flake", "worker"],
+            "context": {
+                "branch": "main",
+                "files": ["a.rs", "b.rs", "c.rs", "d.rs"],
+                "nested": { "deep": { "deeper": [1, 2, 3, 4, 5] } }
+            }
+        }),
+        state: st::SessionTaskState::Running,
+        state_detail: Some("iteration 7/40".to_string()),
+        progress: Some(st::TaskProgress {
+            current: Some(7),
+            total: Some(40),
+            unit: Some("steps".to_string()),
+            label: Some("running tests".to_string()),
+        }),
+        input_request: None,
+        cancel_requested_at: None,
+        summary: None,
+        result_path: Some("/.tasks/task_0123456789abcdef/result.json".to_string()),
+        artifacts: vec![st::TaskArtifact {
+            name: "log".to_string(),
+            artifact_type: "file".to_string(),
+            path: Some("/.tasks/task_0123456789abcdef/log.txt".to_string()),
+            url: None,
+        }],
+        error: None,
+        attempt: 1,
+        worker_id: Some("worker-node-3".to_string()),
+        heartbeat_at: Some(Utc.timestamp_opt(1_700_000_200, 0).unwrap()),
+        links: st::TaskLinks {
+            child_session_id: Some(SessionId::new()),
+            remote_task_id: None,
+            resource_ids: vec!["res_sandbox_1".to_string()],
+        },
+        wake_policy: st::TaskWakePolicy::OnActivity,
+        created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        started_at: Some(Utc.timestamp_opt(1_700_000_050, 0).unwrap()),
+        finished_at: None,
+        updated_at: Utc.timestamp_opt(1_700_000_300, 0).unwrap(),
+    }
+}
+
+/// OLD path: domain struct -> JSON bytes (server) -> JSON bytes -> domain (worker).
+/// This is the `serde_json::to_vec` / `from_slice` into a protobuf bytes field.
+fn old_round_trip(task: &st::SessionTask) -> st::SessionTask {
+    let bytes = serde_json::to_vec(task).expect("json encode");
+    serde_json::from_slice(&bytes).expect("json decode")
+}
+
+/// NEW path: domain struct -> native proto -> protobuf bytes (framing) -> proto -> domain.
+/// prost encodes/decodes once; no JSON layer.
+fn new_round_trip(task: &st::SessionTask) -> st::SessionTask {
+    let proto = session_task_to_proto(task);
+    let mut buf = Vec::with_capacity(proto.encoded_len());
+    proto.encode(&mut buf).expect("proto encode");
+    let decoded = everruns_internal_protocol::proto::SessionTaskProto::decode(buf.as_slice())
+        .expect("decode");
+    proto_to_session_task(decoded).expect("proto -> domain")
+}
+
+fn bench(name: &str, iters: u64, mut f: impl FnMut()) {
+    // Warm up.
+    for _ in 0..(iters / 10).max(1) {
+        f();
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    let elapsed = start.elapsed();
+    let per = elapsed.as_nanos() as f64 / iters as f64;
+    println!("{name:<28} {iters:>8} iters  {elapsed:>10.3?}  {per:>10.1} ns/op");
+}
+
+fn main() {
+    let task = sample_task();
+
+    // Report the wire-size difference (protobuf is more compact than JSON text).
+    let json_len = serde_json::to_vec(&task).unwrap().len();
+    let proto = session_task_to_proto(&task);
+    let proto_len = proto.encoded_len();
+    println!("payload size:  json bytes = {json_len}, protobuf bytes = {proto_len}");
+    println!();
+
+    // Simulate a list handler returning N elements per RPC: this is where the
+    // per-element re-encode dominates on the old path.
+    const LIST_N: usize = 50;
+    let iters: u64 = 20_000;
+
+    bench("old json (single)", iters, || {
+        black_box(old_round_trip(black_box(&task)));
+    });
+    bench("new native-proto (single)", iters, || {
+        black_box(new_round_trip(black_box(&task)));
+    });
+
+    let list_iters = iters / LIST_N as u64;
+    bench("old json (list x50)", list_iters, || {
+        for _ in 0..LIST_N {
+            black_box(old_round_trip(black_box(&task)));
+        }
+    });
+    bench("new native-proto (list x50)", list_iters, || {
+        for _ in 0..LIST_N {
+            black_box(new_round_trip(black_box(&task)));
+        }
+    });
+}

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -165,8 +165,9 @@ service WorkerService {
 
     // === Session task registry ===
     // Background work owned by a session (specs/session-tasks.md).
-    // Task and message payloads travel as canonical core JSON (bytes) so the
-    // rich record shape stays defined in one place (everruns-core).
+    // Task and message payloads travel as native protobuf messages (EVE-642):
+    // serialized once by protobuf framing, consumed directly on the worker.
+    // Lifecycle invariants stay defined in one place (everruns-core).
     rpc CreateSessionTask(CreateSessionTaskRequest) returns (SessionTaskResponse);
     rpc UpdateSessionTask(UpdateSessionTaskRequest) returns (OptionalSessionTaskResponse);
     rpc GetSessionTask(GetSessionTaskRequest) returns (OptionalSessionTaskResponse);
@@ -1954,26 +1955,192 @@ message DeregisterSessionResourceResponse {
 }
 
 // === Session task registry messages ===
+//
+// EVE-642: Task and message payloads are modeled as native protobuf messages so
+// the ~20 structural fields (ids, enums, timestamps, nested TaskLinks/TaskError/
+// artifacts) are serialized once by protobuf framing and consumed directly on
+// the worker — no whole-struct JSON encode/decode into a byte field, no
+// per-element Vec re-encode on list handlers.
+//
+// The genuinely free-form fields (kind-specific `spec`, input-request
+// `expected`, and message `Data` parts) carry canonical serde_json bytes: they
+// are already JSON-shaped `serde_json::Value`s, so serializing them exactly once
+// as compact JSON is cheaper than walking them into a google.protobuf.Value tree
+// (measured — see benches/session_task_encoding.rs). everruns-core remains the
+// source of truth for lifecycle invariants (apply_task_update, new_session_task).
+
+// Lifecycle state (mirrors everruns_core::session_task::SessionTaskState).
+enum SessionTaskState {
+    SESSION_TASK_STATE_UNSPECIFIED = 0;
+    SESSION_TASK_STATE_QUEUED = 1;
+    SESSION_TASK_STATE_RUNNING = 2;
+    SESSION_TASK_STATE_AWAITING_INPUT = 3;
+    SESSION_TASK_STATE_SUCCEEDED = 4;
+    SESSION_TASK_STATE_FAILED = 5;
+    SESSION_TASK_STATE_CANCELED = 6;
+}
+
+// Wake policy (mirrors everruns_core::session_task::TaskWakePolicy).
+enum TaskWakePolicy {
+    TASK_WAKE_POLICY_UNSPECIFIED = 0;
+    TASK_WAKE_POLICY_SILENT = 1;
+    TASK_WAKE_POLICY_ON_TERMINAL = 2;
+    TASK_WAKE_POLICY_ON_ACTIVITY = 3;
+}
+
+// Direction of a task message (mirrors TaskMessageDirection).
+enum TaskMessageDirection {
+    TASK_MESSAGE_DIRECTION_UNSPECIFIED = 0;
+    TASK_MESSAGE_DIRECTION_INBOUND = 1;
+    TASK_MESSAGE_DIRECTION_OUTBOUND = 2;
+}
+
+// Progress shape (mirrors everruns_core::background::BackgroundProgress).
+message TaskProgressProto {
+    optional uint64 current = 1;
+    optional uint64 total = 2;
+    optional string unit = 3;
+    optional string label = 4;
+}
+
+// Structured ask posted by a task awaiting input (mirrors TaskInputRequest).
+message TaskInputRequestProto {
+    string id = 1;
+    string prompt = 2;
+    // Free-form expected-answer descriptor; canonical serde_json bytes. Absent
+    // (empty) means None.
+    bytes expected_json = 3;
+}
+
+// Terminal error detail (mirrors TaskError).
+message TaskErrorProto {
+    string kind = 1;
+    string message = 2;
+}
+
+// Typed artifact link (mirrors TaskArtifact).
+message TaskArtifactProto {
+    string name = 1;
+    string artifact_type = 2;  // serde rename "type"
+    optional string path = 3;
+    optional string url = 4;
+}
+
+// Cross-references owned by a task (mirrors TaskLinks).
+message TaskLinksProto {
+    optional Uuid child_session_id = 1;
+    optional string remote_task_id = 2;
+    repeated string resource_ids = 3;
+}
+
+// A unit of background work owned by a session (mirrors SessionTask).
+message SessionTaskProto {
+    string id = 1;
+    Uuid session_id = 2;
+    string kind = 3;
+    string display_name = 4;
+    // Kind-specific spec; canonical serde_json bytes (free-form JSON value).
+    bytes spec_json = 5;
+    SessionTaskState state = 6;
+    optional string state_detail = 7;
+    optional TaskProgressProto progress = 8;
+    optional TaskInputRequestProto input_request = 9;
+    optional Timestamp cancel_requested_at = 10;
+    optional string summary = 11;
+    optional string result_path = 12;
+    repeated TaskArtifactProto artifacts = 13;
+    optional TaskErrorProto error = 14;
+    int32 attempt = 15;
+    optional string worker_id = 16;
+    optional Timestamp heartbeat_at = 17;
+    TaskLinksProto links = 18;
+    TaskWakePolicy wake_policy = 19;
+    Timestamp created_at = 20;
+    optional Timestamp started_at = 21;
+    optional Timestamp finished_at = 22;
+    Timestamp updated_at = 23;
+}
+
+// Input for creating a task (mirrors CreateSessionTask).
+message CreateSessionTaskProto {
+    Uuid session_id = 1;
+    optional string id = 2;
+    string kind = 3;
+    string display_name = 4;
+    // Kind-specific spec; canonical serde_json bytes (free-form JSON value).
+    bytes spec_json = 5;
+    SessionTaskState state = 6;
+    TaskLinksProto links = 7;
+    TaskWakePolicy wake_policy = 8;
+}
+
+// Partial update (mirrors SessionTaskUpdate). All Option fields are absent when
+// unchanged; the field-presence semantics match the Rust struct.
+message SessionTaskUpdateProto {
+    optional SessionTaskState state = 1;
+    optional string state_detail = 2;
+    optional TaskProgressProto progress = 3;
+    optional TaskInputRequestProto input_request = 4;
+    optional string summary = 5;
+    optional string result_path = 6;
+    // Present (possibly empty) replaces the artifact list; absent leaves it.
+    optional TaskArtifactListProto artifacts = 7;
+    optional TaskErrorProto error = 8;
+    optional TaskLinksProto links = 9;
+    optional string worker_id = 10;
+    optional Timestamp heartbeat_at = 11;
+    optional int32 expected_attempt = 12;
+    bool increment_attempt = 13;
+}
+
+// Wrapper so an absent artifacts update is distinguishable from an empty list.
+message TaskArtifactListProto {
+    repeated TaskArtifactProto artifacts = 1;
+}
+
+// One content part of a task message (mirrors TaskMessagePart).
+message TaskMessagePartProto {
+    oneof part {
+        string text = 1;
+        // Free-form data part; canonical serde_json bytes.
+        bytes data_json = 2;
+    }
+}
+
+// A stored message exchanged between a session and a task (mirrors TaskMessage).
+message TaskMessageProto {
+    string id = 1;
+    string task_id = 2;
+    TaskMessageDirection direction = 3;
+    repeated TaskMessagePartProto content = 4;
+    optional string in_reply_to = 5;
+    Timestamp created_at = 6;
+}
+
+// Input for recording a message (mirrors NewTaskMessage).
+message NewTaskMessageProto {
+    TaskMessageDirection direction = 1;
+    repeated TaskMessagePartProto content = 2;
+    optional string in_reply_to = 3;
+    optional int32 expected_attempt = 4;
+}
 
 message CreateSessionTaskRequest {
-    // everruns_core::session_task::CreateSessionTask as JSON
-    bytes create_json = 1;
+    CreateSessionTaskProto create = 1;
 }
 
 message SessionTaskResponse {
-    // everruns_core::session_task::SessionTask as JSON
-    bytes task_json = 1;
+    SessionTaskProto task = 1;
 }
 
 message OptionalSessionTaskResponse {
-    optional bytes task_json = 1;
+    optional SessionTaskProto task = 1;
 }
 
 message UpdateSessionTaskRequest {
     Uuid session_id = 1;
     string task_id = 2;
-    // everruns_core::session_task::SessionTaskUpdate as JSON
-    bytes update_json = 3;
+    SessionTaskUpdateProto update = 3;
 }
 
 message GetSessionTaskRequest {
@@ -1988,7 +2155,7 @@ message ListSessionTasksRequest {
 }
 
 message ListSessionTasksResponse {
-    repeated bytes task_json = 1;
+    repeated SessionTaskProto tasks = 1;
 }
 
 message RequestCancelSessionTaskRequest {
@@ -1999,13 +2166,11 @@ message RequestCancelSessionTaskRequest {
 message RecordSessionTaskMessageRequest {
     Uuid session_id = 1;
     string task_id = 2;
-    // everruns_core::session_task::NewTaskMessage as JSON
-    bytes message_json = 3;
+    NewTaskMessageProto message = 3;
 }
 
 message SessionTaskMessageResponse {
-    // everruns_core::session_task::TaskMessage as JSON
-    bytes message_json = 1;
+    TaskMessageProto message = 1;
 }
 
 message ListSessionTaskMessagesRequest {
@@ -2015,7 +2180,7 @@ message ListSessionTaskMessagesRequest {
 }
 
 message ListSessionTaskMessagesResponse {
-    repeated bytes message_json = 1;
+    repeated TaskMessageProto messages = 1;
 }
 
 // === List orphaned session tasks ===

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -1266,6 +1266,451 @@ pub fn schema_grep_match_to_proto(value: &everruns_core::GrepMatch) -> proto::Gr
 }
 
 // ============================================================================
+// Session task registry conversions (EVE-642)
+// ============================================================================
+//
+// Native protobuf conversions for the session-task RPC payloads. These replace
+// the previous JSON-in-protobuf byte fields so the data is serialized once by
+// protobuf framing and consumed directly on the worker. everruns-core remains
+// the source of truth for lifecycle invariants (apply_task_update etc.).
+
+use everruns_core::session_task as st;
+
+fn session_task_state_to_proto(state: st::SessionTaskState) -> proto::SessionTaskState {
+    match state {
+        st::SessionTaskState::Queued => proto::SessionTaskState::Queued,
+        st::SessionTaskState::Running => proto::SessionTaskState::Running,
+        st::SessionTaskState::AwaitingInput => proto::SessionTaskState::AwaitingInput,
+        st::SessionTaskState::Succeeded => proto::SessionTaskState::Succeeded,
+        st::SessionTaskState::Failed => proto::SessionTaskState::Failed,
+        st::SessionTaskState::Canceled => proto::SessionTaskState::Canceled,
+    }
+}
+
+fn proto_to_session_task_state(state: proto::SessionTaskState) -> st::SessionTaskState {
+    match state {
+        // Unspecified defaults to Queued to match `From<&str>` on the domain enum.
+        proto::SessionTaskState::Unspecified | proto::SessionTaskState::Queued => {
+            st::SessionTaskState::Queued
+        }
+        proto::SessionTaskState::Running => st::SessionTaskState::Running,
+        proto::SessionTaskState::AwaitingInput => st::SessionTaskState::AwaitingInput,
+        proto::SessionTaskState::Succeeded => st::SessionTaskState::Succeeded,
+        proto::SessionTaskState::Failed => st::SessionTaskState::Failed,
+        proto::SessionTaskState::Canceled => st::SessionTaskState::Canceled,
+    }
+}
+
+fn wake_policy_to_proto(policy: st::TaskWakePolicy) -> proto::TaskWakePolicy {
+    match policy {
+        st::TaskWakePolicy::Silent => proto::TaskWakePolicy::Silent,
+        st::TaskWakePolicy::OnTerminal => proto::TaskWakePolicy::OnTerminal,
+        st::TaskWakePolicy::OnActivity => proto::TaskWakePolicy::OnActivity,
+    }
+}
+
+fn proto_to_wake_policy(policy: proto::TaskWakePolicy) -> st::TaskWakePolicy {
+    match policy {
+        proto::TaskWakePolicy::Unspecified | proto::TaskWakePolicy::Silent => {
+            st::TaskWakePolicy::Silent
+        }
+        proto::TaskWakePolicy::OnTerminal => st::TaskWakePolicy::OnTerminal,
+        proto::TaskWakePolicy::OnActivity => st::TaskWakePolicy::OnActivity,
+    }
+}
+
+fn direction_to_proto(direction: st::TaskMessageDirection) -> proto::TaskMessageDirection {
+    match direction {
+        st::TaskMessageDirection::Inbound => proto::TaskMessageDirection::Inbound,
+        st::TaskMessageDirection::Outbound => proto::TaskMessageDirection::Outbound,
+    }
+}
+
+fn proto_to_direction(direction: proto::TaskMessageDirection) -> st::TaskMessageDirection {
+    match direction {
+        // Unspecified defaults to Inbound to match `From<&str>` on the domain enum.
+        proto::TaskMessageDirection::Unspecified | proto::TaskMessageDirection::Inbound => {
+            st::TaskMessageDirection::Inbound
+        }
+        proto::TaskMessageDirection::Outbound => st::TaskMessageDirection::Outbound,
+    }
+}
+
+fn progress_to_proto(p: &st::TaskProgress) -> proto::TaskProgressProto {
+    proto::TaskProgressProto {
+        current: p.current,
+        total: p.total,
+        unit: p.unit.clone(),
+        label: p.label.clone(),
+    }
+}
+
+fn proto_to_progress(p: proto::TaskProgressProto) -> st::TaskProgress {
+    st::TaskProgress {
+        current: p.current,
+        total: p.total,
+        unit: p.unit,
+        label: p.label,
+    }
+}
+
+// Free-form JSON fields (spec, expected, message Data) carry canonical
+// serde_json bytes: they are already `serde_json::Value`s, so serializing them
+// exactly once is cheaper than walking them into a google.protobuf.Value tree
+// (see benches/session_task_encoding.rs). Serialization of an in-memory Value
+// does not fail in practice; a hit on the fallback signals upstream corruption
+// and is logged rather than silently dropped.
+fn json_value_to_bytes(value: &serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(value).unwrap_or_else(|e| {
+        tracing::error!(error = %e, "internal-protocol: failed to encode free-form JSON; emitting null");
+        b"null".to_vec()
+    })
+}
+
+/// Decode canonical JSON bytes back into a Value. Empty bytes decode to Null so
+/// an absent proto `bytes` field maps to `Value::Null` (the schema default).
+fn bytes_to_json_value(bytes: &[u8]) -> serde_json::Value {
+    if bytes.is_empty() {
+        return serde_json::Value::Null;
+    }
+    serde_json::from_slice(bytes).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "internal-protocol: invalid free-form JSON bytes; using null");
+        serde_json::Value::Null
+    })
+}
+
+fn input_request_to_proto(r: &st::TaskInputRequest) -> proto::TaskInputRequestProto {
+    proto::TaskInputRequestProto {
+        id: r.id.clone(),
+        prompt: r.prompt.clone(),
+        // None -> empty bytes; Some(v) -> canonical JSON bytes.
+        expected_json: r
+            .expected
+            .as_ref()
+            .map(json_value_to_bytes)
+            .unwrap_or_default(),
+    }
+}
+
+fn proto_to_input_request(r: proto::TaskInputRequestProto) -> st::TaskInputRequest {
+    st::TaskInputRequest {
+        id: r.id,
+        prompt: r.prompt,
+        expected: if r.expected_json.is_empty() {
+            None
+        } else {
+            Some(bytes_to_json_value(&r.expected_json))
+        },
+    }
+}
+
+fn task_error_to_proto(e: &st::TaskError) -> proto::TaskErrorProto {
+    proto::TaskErrorProto {
+        kind: e.kind.clone(),
+        message: e.message.clone(),
+    }
+}
+
+fn proto_to_task_error(e: proto::TaskErrorProto) -> st::TaskError {
+    st::TaskError {
+        kind: e.kind,
+        message: e.message,
+    }
+}
+
+fn artifact_to_proto(a: &st::TaskArtifact) -> proto::TaskArtifactProto {
+    proto::TaskArtifactProto {
+        name: a.name.clone(),
+        artifact_type: a.artifact_type.clone(),
+        path: a.path.clone(),
+        url: a.url.clone(),
+    }
+}
+
+fn proto_to_artifact(a: proto::TaskArtifactProto) -> st::TaskArtifact {
+    st::TaskArtifact {
+        name: a.name,
+        artifact_type: a.artifact_type,
+        path: a.path,
+        url: a.url,
+    }
+}
+
+fn links_to_proto(l: &st::TaskLinks) -> proto::TaskLinksProto {
+    proto::TaskLinksProto {
+        child_session_id: l.child_session_id.map(|id| uuid_to_proto_uuid(id.uuid())),
+        remote_task_id: l.remote_task_id.clone(),
+        resource_ids: l.resource_ids.clone(),
+    }
+}
+
+fn proto_to_links(l: proto::TaskLinksProto) -> st::TaskLinks {
+    st::TaskLinks {
+        child_session_id: l
+            .child_session_id
+            .map(|u| SessionId::from_uuid(parse_uuid_lenient(&u.value))),
+        remote_task_id: l.remote_task_id,
+        resource_ids: l.resource_ids,
+    }
+}
+
+fn message_part_to_proto(part: &st::TaskMessagePart) -> proto::TaskMessagePartProto {
+    use proto::task_message_part_proto::Part;
+    let part = match part {
+        st::TaskMessagePart::Text { text } => Part::Text(text.clone()),
+        st::TaskMessagePart::Data { data } => Part::DataJson(json_value_to_bytes(data)),
+    };
+    proto::TaskMessagePartProto { part: Some(part) }
+}
+
+fn proto_to_message_part(part: proto::TaskMessagePartProto) -> st::TaskMessagePart {
+    use proto::task_message_part_proto::Part;
+    match part.part {
+        Some(Part::Text(text)) => st::TaskMessagePart::Text { text },
+        Some(Part::DataJson(data)) => st::TaskMessagePart::Data {
+            data: bytes_to_json_value(&data),
+        },
+        // A part with no variant set is malformed; represent it as empty text
+        // rather than dropping the message. Logged so the loss is visible.
+        None => {
+            tracing::warn!(
+                "internal-protocol: task message part missing variant; using empty text"
+            );
+            st::TaskMessagePart::Text {
+                text: String::new(),
+            }
+        }
+    }
+}
+
+/// Parse a raw UUID string leniently (session ids are validated upstream).
+fn parse_uuid_lenient(value: &str) -> uuid::Uuid {
+    uuid::Uuid::parse_str(value).unwrap_or_else(|e| {
+        tracing::warn!(value = %value, error = %e, "internal-protocol: invalid session UUID; using nil");
+        uuid::Uuid::nil()
+    })
+}
+
+/// Convert a domain `SessionTask` to its native proto message.
+pub fn session_task_to_proto(task: &st::SessionTask) -> proto::SessionTaskProto {
+    proto::SessionTaskProto {
+        id: task.id.clone(),
+        session_id: Some(uuid_to_proto_uuid(task.session_id.uuid())),
+        kind: task.kind.clone(),
+        display_name: task.display_name.clone(),
+        spec_json: json_value_to_bytes(&task.spec),
+        state: session_task_state_to_proto(task.state) as i32,
+        state_detail: task.state_detail.clone(),
+        progress: task.progress.as_ref().map(progress_to_proto),
+        input_request: task.input_request.as_ref().map(input_request_to_proto),
+        cancel_requested_at: task.cancel_requested_at.map(datetime_to_proto_timestamp),
+        summary: task.summary.clone(),
+        result_path: task.result_path.clone(),
+        artifacts: task.artifacts.iter().map(artifact_to_proto).collect(),
+        error: task.error.as_ref().map(task_error_to_proto),
+        attempt: task.attempt,
+        worker_id: task.worker_id.clone(),
+        heartbeat_at: task.heartbeat_at.map(datetime_to_proto_timestamp),
+        links: Some(links_to_proto(&task.links)),
+        wake_policy: wake_policy_to_proto(task.wake_policy) as i32,
+        created_at: Some(datetime_to_proto_timestamp(task.created_at)),
+        started_at: task.started_at.map(datetime_to_proto_timestamp),
+        finished_at: task.finished_at.map(datetime_to_proto_timestamp),
+        updated_at: Some(datetime_to_proto_timestamp(task.updated_at)),
+    }
+}
+
+/// Convert a native proto `SessionTaskProto` back to the domain struct.
+pub fn proto_to_session_task(
+    p: proto::SessionTaskProto,
+) -> Result<st::SessionTask, ConversionError> {
+    // Capture enum accessors before moving owned fields out of `p`.
+    let state = proto_to_session_task_state(p.state());
+    let wake_policy = proto_to_wake_policy(p.wake_policy());
+    let session_uuid = p
+        .session_id
+        .ok_or(ConversionError::MissingField("session_id"))?;
+    Ok(st::SessionTask {
+        id: p.id,
+        session_id: SessionId::from_uuid(parse_uuid_lenient(&session_uuid.value)),
+        kind: p.kind,
+        display_name: p.display_name,
+        spec: bytes_to_json_value(&p.spec_json),
+        state,
+        state_detail: p.state_detail,
+        progress: p.progress.map(proto_to_progress),
+        input_request: p.input_request.map(proto_to_input_request),
+        cancel_requested_at: p
+            .cancel_requested_at
+            .as_ref()
+            .map(proto_timestamp_to_datetime),
+        summary: p.summary,
+        result_path: p.result_path,
+        artifacts: p.artifacts.into_iter().map(proto_to_artifact).collect(),
+        error: p.error.map(proto_to_task_error),
+        attempt: p.attempt,
+        worker_id: p.worker_id,
+        heartbeat_at: p.heartbeat_at.as_ref().map(proto_timestamp_to_datetime),
+        links: p.links.map(proto_to_links).unwrap_or_default(),
+        wake_policy,
+        created_at: p
+            .created_at
+            .as_ref()
+            .map(proto_timestamp_to_datetime)
+            .ok_or(ConversionError::MissingField("created_at"))?,
+        started_at: p.started_at.as_ref().map(proto_timestamp_to_datetime),
+        finished_at: p.finished_at.as_ref().map(proto_timestamp_to_datetime),
+        updated_at: p
+            .updated_at
+            .as_ref()
+            .map(proto_timestamp_to_datetime)
+            .ok_or(ConversionError::MissingField("updated_at"))?,
+    })
+}
+
+/// Convert a domain `CreateSessionTask` to its native proto message.
+pub fn create_session_task_to_proto(
+    input: &st::CreateSessionTask,
+) -> proto::CreateSessionTaskProto {
+    proto::CreateSessionTaskProto {
+        session_id: Some(uuid_to_proto_uuid(input.session_id.uuid())),
+        id: input.id.clone(),
+        kind: input.kind.clone(),
+        display_name: input.display_name.clone(),
+        spec_json: json_value_to_bytes(&input.spec),
+        state: session_task_state_to_proto(input.state) as i32,
+        links: Some(links_to_proto(&input.links)),
+        wake_policy: wake_policy_to_proto(input.wake_policy) as i32,
+    }
+}
+
+/// Convert a native proto `CreateSessionTaskProto` back to the domain struct.
+pub fn proto_to_create_session_task(
+    p: proto::CreateSessionTaskProto,
+) -> Result<st::CreateSessionTask, ConversionError> {
+    // Capture enum accessors before moving owned fields out of `p`.
+    let state = proto_to_session_task_state(p.state());
+    let wake_policy = proto_to_wake_policy(p.wake_policy());
+    let session_uuid = p
+        .session_id
+        .ok_or(ConversionError::MissingField("session_id"))?;
+    Ok(st::CreateSessionTask {
+        session_id: SessionId::from_uuid(parse_uuid_lenient(&session_uuid.value)),
+        id: p.id,
+        kind: p.kind,
+        display_name: p.display_name,
+        spec: bytes_to_json_value(&p.spec_json),
+        state,
+        links: p.links.map(proto_to_links).unwrap_or_default(),
+        wake_policy,
+    })
+}
+
+/// Convert a domain `SessionTaskUpdate` to its native proto message.
+pub fn session_task_update_to_proto(u: &st::SessionTaskUpdate) -> proto::SessionTaskUpdateProto {
+    proto::SessionTaskUpdateProto {
+        state: u.state.map(|s| session_task_state_to_proto(s) as i32),
+        state_detail: u.state_detail.clone(),
+        progress: u.progress.as_ref().map(progress_to_proto),
+        input_request: u.input_request.as_ref().map(input_request_to_proto),
+        summary: u.summary.clone(),
+        result_path: u.result_path.clone(),
+        artifacts: u
+            .artifacts
+            .as_ref()
+            .map(|list| proto::TaskArtifactListProto {
+                artifacts: list.iter().map(artifact_to_proto).collect(),
+            }),
+        error: u.error.as_ref().map(task_error_to_proto),
+        links: u.links.as_ref().map(links_to_proto),
+        worker_id: u.worker_id.clone(),
+        heartbeat_at: u.heartbeat_at.map(datetime_to_proto_timestamp),
+        expected_attempt: u.expected_attempt,
+        increment_attempt: u.increment_attempt,
+    }
+}
+
+/// Convert a native proto `SessionTaskUpdateProto` back to the domain struct.
+pub fn proto_to_session_task_update(p: proto::SessionTaskUpdateProto) -> st::SessionTaskUpdate {
+    st::SessionTaskUpdate {
+        // `state` is an enum field wrapped in optional; decode the raw i32 only
+        // when present so an absent update leaves the field unchanged.
+        state: p.state.map(|s| {
+            proto_to_session_task_state(
+                proto::SessionTaskState::try_from(s)
+                    .unwrap_or(proto::SessionTaskState::Unspecified),
+            )
+        }),
+        state_detail: p.state_detail,
+        progress: p.progress.map(proto_to_progress),
+        input_request: p.input_request.map(proto_to_input_request),
+        summary: p.summary,
+        result_path: p.result_path,
+        artifacts: p
+            .artifacts
+            .map(|list| list.artifacts.into_iter().map(proto_to_artifact).collect()),
+        error: p.error.map(proto_to_task_error),
+        links: p.links.map(proto_to_links),
+        worker_id: p.worker_id,
+        heartbeat_at: p.heartbeat_at.as_ref().map(proto_timestamp_to_datetime),
+        expected_attempt: p.expected_attempt,
+        increment_attempt: p.increment_attempt,
+    }
+}
+
+/// Convert a domain `TaskMessage` to its native proto message.
+pub fn task_message_to_proto(m: &st::TaskMessage) -> proto::TaskMessageProto {
+    proto::TaskMessageProto {
+        id: m.id.clone(),
+        task_id: m.task_id.clone(),
+        direction: direction_to_proto(m.direction) as i32,
+        content: m.content.iter().map(message_part_to_proto).collect(),
+        in_reply_to: m.in_reply_to.clone(),
+        created_at: Some(datetime_to_proto_timestamp(m.created_at)),
+    }
+}
+
+/// Convert a native proto `TaskMessageProto` back to the domain struct.
+pub fn proto_to_task_message(
+    p: proto::TaskMessageProto,
+) -> Result<st::TaskMessage, ConversionError> {
+    let direction = p.direction();
+    Ok(st::TaskMessage {
+        id: p.id,
+        task_id: p.task_id,
+        direction: proto_to_direction(direction),
+        content: p.content.into_iter().map(proto_to_message_part).collect(),
+        in_reply_to: p.in_reply_to,
+        created_at: p
+            .created_at
+            .as_ref()
+            .map(proto_timestamp_to_datetime)
+            .ok_or(ConversionError::MissingField("created_at"))?,
+    })
+}
+
+/// Convert a domain `NewTaskMessage` to its native proto message.
+pub fn new_task_message_to_proto(m: &st::NewTaskMessage) -> proto::NewTaskMessageProto {
+    proto::NewTaskMessageProto {
+        direction: direction_to_proto(m.direction) as i32,
+        content: m.content.iter().map(message_part_to_proto).collect(),
+        in_reply_to: m.in_reply_to.clone(),
+        expected_attempt: m.expected_attempt,
+    }
+}
+
+/// Convert a native proto `NewTaskMessageProto` back to the domain struct.
+pub fn proto_to_new_task_message(p: proto::NewTaskMessageProto) -> st::NewTaskMessage {
+    let direction = p.direction();
+    st::NewTaskMessage {
+        direction: proto_to_direction(direction),
+        content: p.content.into_iter().map(proto_to_message_part).collect(),
+        in_reply_to: p.in_reply_to,
+        expected_attempt: p.expected_attempt,
+    }
+}
+
+// ============================================================================
 // Helper functions
 // ============================================================================
 
@@ -1919,5 +2364,209 @@ mod tests {
             parse_message_role("something_unknown"),
             MessageRole::User
         ));
+    }
+
+    // ------------------------------------------------------------------------
+    // Session task registry native-proto round-trip fidelity (EVE-642)
+    // ------------------------------------------------------------------------
+
+    fn sample_session_task() -> st::SessionTask {
+        st::SessionTask {
+            id: "task_abc123".to_string(),
+            session_id: SessionId::new(),
+            kind: st::TASK_KIND_SUBAGENT.to_string(),
+            display_name: "Investigate flake".to_string(),
+            spec: serde_json::json!({
+                "instructions": "run tests",
+                "retries": 3,
+                "nested": { "a": [1, 2, 3], "b": null, "flag": true },
+            }),
+            state: st::SessionTaskState::AwaitingInput,
+            state_detail: Some("iteration 4/10".to_string()),
+            progress: Some(st::TaskProgress {
+                current: Some(4),
+                total: Some(10),
+                unit: Some("steps".to_string()),
+                label: Some("running".to_string()),
+            }),
+            input_request: Some(st::TaskInputRequest {
+                id: "req_1".to_string(),
+                prompt: "Approve?".to_string(),
+                expected: Some(serde_json::json!({ "type": "boolean" })),
+            }),
+            cancel_requested_at: Some(Utc.timestamp_opt(1_700_000_100, 0).unwrap()),
+            summary: Some("did the thing".to_string()),
+            result_path: Some("/.tasks/task_abc123/result.json".to_string()),
+            artifacts: vec![
+                st::TaskArtifact {
+                    name: "report".to_string(),
+                    artifact_type: "file".to_string(),
+                    path: Some("/report.md".to_string()),
+                    url: None,
+                },
+                st::TaskArtifact {
+                    name: "pr".to_string(),
+                    artifact_type: "url".to_string(),
+                    path: None,
+                    url: Some("https://example.com/pr/1".to_string()),
+                },
+            ],
+            error: Some(st::TaskError {
+                kind: "timeout".to_string(),
+                message: "exceeded deadline".to_string(),
+            }),
+            attempt: 2,
+            worker_id: Some("worker-7".to_string()),
+            heartbeat_at: Some(Utc.timestamp_opt(1_700_000_200, 500_000_000).unwrap()),
+            links: st::TaskLinks {
+                child_session_id: Some(SessionId::new()),
+                remote_task_id: Some("rt_9".to_string()),
+                resource_ids: vec!["res_1".to_string(), "res_2".to_string()],
+            },
+            wake_policy: st::TaskWakePolicy::OnActivity,
+            created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            started_at: Some(Utc.timestamp_opt(1_700_000_050, 0).unwrap()),
+            finished_at: None,
+            updated_at: Utc.timestamp_opt(1_700_000_300, 0).unwrap(),
+        }
+    }
+
+    /// Full round-trip must preserve the task through the native proto and back
+    /// so switching the wire format from JSON-in-bytes to native protobuf is
+    /// lossless. Comparison is done via canonical JSON so the numeric widening
+    /// in `google.protobuf.Value` (spec/expected) is accounted for.
+    #[test]
+    fn session_task_native_proto_round_trip() {
+        let original = sample_session_task();
+        let proto = session_task_to_proto(&original);
+        let restored = proto_to_session_task(proto).expect("round-trip");
+
+        let a = serde_json::to_value(&original).unwrap();
+        let b = serde_json::to_value(&restored).unwrap();
+        assert_eq!(a, b, "session task must survive native-proto round-trip");
+    }
+
+    #[test]
+    fn create_session_task_native_proto_round_trip() {
+        let original = st::CreateSessionTask {
+            session_id: SessionId::new(),
+            id: Some("task_seed".to_string()),
+            kind: st::TASK_KIND_BACKGROUND_TOOL.to_string(),
+            display_name: "seed".to_string(),
+            spec: serde_json::json!({ "k": "v", "n": 12 }),
+            state: st::SessionTaskState::Running,
+            links: st::TaskLinks {
+                child_session_id: None,
+                remote_task_id: Some("rt".to_string()),
+                resource_ids: vec!["res".to_string()],
+            },
+            wake_policy: st::TaskWakePolicy::OnTerminal,
+        };
+        let proto = create_session_task_to_proto(&original);
+        let restored = proto_to_create_session_task(proto).expect("round-trip");
+
+        assert_eq!(
+            serde_json::to_value(&original).unwrap(),
+            serde_json::to_value(&restored).unwrap()
+        );
+    }
+
+    #[test]
+    fn session_task_update_native_proto_round_trip() {
+        // A fully-populated update (all Option/Vec fields set).
+        let full = st::SessionTaskUpdate {
+            state: Some(st::SessionTaskState::Failed),
+            state_detail: Some("boom".to_string()),
+            progress: Some(st::TaskProgress {
+                current: Some(1),
+                total: None,
+                unit: None,
+                label: Some("x".to_string()),
+            }),
+            input_request: Some(st::TaskInputRequest {
+                id: "r".to_string(),
+                prompt: "p".to_string(),
+                expected: None,
+            }),
+            summary: Some("s".to_string()),
+            result_path: Some("/r.json".to_string()),
+            artifacts: Some(vec![st::TaskArtifact {
+                name: "a".to_string(),
+                artifact_type: "file".to_string(),
+                path: Some("/a".to_string()),
+                url: None,
+            }]),
+            error: Some(st::TaskError {
+                kind: "orphaned".to_string(),
+                message: "m".to_string(),
+            }),
+            links: Some(st::TaskLinks::default()),
+            worker_id: Some("w".to_string()),
+            heartbeat_at: Some(Utc.timestamp_opt(1_700_000_000, 0).unwrap()),
+            expected_attempt: Some(3),
+            increment_attempt: true,
+        };
+        let restored = proto_to_session_task_update(session_task_update_to_proto(&full));
+        assert_eq!(
+            serde_json::to_value(&full).unwrap(),
+            serde_json::to_value(&restored).unwrap()
+        );
+
+        // An empty update must stay empty: crucially, an absent `artifacts`
+        // must not become `Some(vec![])`, which would wrongly clear artifacts.
+        let empty = st::SessionTaskUpdate::default();
+        let restored_empty = proto_to_session_task_update(session_task_update_to_proto(&empty));
+        assert!(restored_empty.state.is_none());
+        assert!(
+            restored_empty.artifacts.is_none(),
+            "absent artifacts update must round-trip as None, not Some(empty)"
+        );
+        assert!(!restored_empty.increment_attempt);
+        assert!(restored_empty.expected_attempt.is_none());
+
+        // An explicit empty artifact list (clear all) must survive as Some(empty).
+        let clear = st::SessionTaskUpdate {
+            artifacts: Some(vec![]),
+            ..Default::default()
+        };
+        let restored_clear = proto_to_session_task_update(session_task_update_to_proto(&clear));
+        assert_eq!(restored_clear.artifacts, Some(vec![]));
+    }
+
+    #[test]
+    fn task_message_native_proto_round_trip() {
+        let msg = st::TaskMessage {
+            id: "tmsg_1".to_string(),
+            task_id: "task_1".to_string(),
+            direction: st::TaskMessageDirection::Outbound,
+            content: vec![
+                st::TaskMessagePart::text("hello"),
+                st::TaskMessagePart::Data {
+                    data: serde_json::json!({ "k": [1, 2], "b": true }),
+                },
+            ],
+            in_reply_to: Some("tmsg_0".to_string()),
+            created_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        };
+        let restored = proto_to_task_message(task_message_to_proto(&msg)).expect("round-trip");
+        assert_eq!(
+            serde_json::to_value(&msg).unwrap(),
+            serde_json::to_value(&restored).unwrap()
+        );
+    }
+
+    #[test]
+    fn new_task_message_native_proto_round_trip() {
+        let msg = st::NewTaskMessage {
+            direction: st::TaskMessageDirection::Inbound,
+            content: vec![st::TaskMessagePart::text("answer")],
+            in_reply_to: Some("req_1".to_string()),
+            expected_attempt: Some(5),
+        };
+        let restored = proto_to_new_task_message(new_task_message_to_proto(&msg));
+        assert_eq!(
+            serde_json::to_value(&msg).unwrap(),
+            serde_json::to_value(&restored).unwrap()
+        );
     }
 }

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -2824,8 +2824,11 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<CreateSessionTaskRequest>,
     ) -> Result<Response<SessionTaskResponse>, Status> {
         let req = request.into_inner();
-        let input: everruns_core::CreateSessionTask = serde_json::from_slice(&req.create_json)
-            .map_err(|e| Status::invalid_argument(format!("Invalid task create JSON: {e}")))?;
+        let create = req
+            .create
+            .ok_or_else(|| Status::invalid_argument("Missing create payload"))?;
+        let input = everruns_internal_protocol::proto_to_create_session_task(create)
+            .map_err(|e| Status::invalid_argument(format!("Invalid task create payload: {e}")))?;
 
         let task = self
             .session_task_registry()
@@ -2837,8 +2840,7 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(SessionTaskResponse {
-            task_json: serde_json::to_vec(&task)
-                .map_err(|e| Status::internal(format!("Failed to encode task: {e}")))?,
+            task: Some(everruns_internal_protocol::session_task_to_proto(&task)),
         }))
     }
 
@@ -2848,8 +2850,10 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<OptionalSessionTaskResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let update: everruns_core::SessionTaskUpdate = serde_json::from_slice(&req.update_json)
-            .map_err(|e| Status::invalid_argument(format!("Invalid task update JSON: {e}")))?;
+        let update_proto = req
+            .update
+            .ok_or_else(|| Status::invalid_argument("Missing update payload"))?;
+        let update = everruns_internal_protocol::proto_to_session_task_update(update_proto);
 
         let task = self
             .session_task_registry()
@@ -2861,10 +2865,9 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(OptionalSessionTaskResponse {
-            task_json: task
-                .map(|t| serde_json::to_vec(&t))
-                .transpose()
-                .map_err(|e| Status::internal(format!("Failed to encode task: {e}")))?,
+            task: task
+                .as_ref()
+                .map(everruns_internal_protocol::session_task_to_proto),
         }))
     }
 
@@ -2885,10 +2888,9 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(OptionalSessionTaskResponse {
-            task_json: task
-                .map(|t| serde_json::to_vec(&t))
-                .transpose()
-                .map_err(|e| Status::internal(format!("Failed to encode task: {e}")))?,
+            task: task
+                .as_ref()
+                .map(everruns_internal_protocol::session_task_to_proto),
         }))
     }
 
@@ -2921,11 +2923,10 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(ListSessionTasksResponse {
-            task_json: tasks
+            tasks: tasks
                 .iter()
-                .map(serde_json::to_vec)
-                .collect::<Result<_, _>>()
-                .map_err(|e| Status::internal(format!("Failed to encode tasks: {e}")))?,
+                .map(everruns_internal_protocol::session_task_to_proto)
+                .collect(),
         }))
     }
 
@@ -2946,10 +2947,9 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(OptionalSessionTaskResponse {
-            task_json: task
-                .map(|t| serde_json::to_vec(&t))
-                .transpose()
-                .map_err(|e| Status::internal(format!("Failed to encode task: {e}")))?,
+            task: task
+                .as_ref()
+                .map(everruns_internal_protocol::session_task_to_proto),
         }))
     }
 
@@ -2959,8 +2959,10 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<SessionTaskMessageResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
-        let message: everruns_core::NewTaskMessage = serde_json::from_slice(&req.message_json)
-            .map_err(|e| Status::invalid_argument(format!("Invalid task message JSON: {e}")))?;
+        let message_proto = req
+            .message
+            .ok_or_else(|| Status::invalid_argument("Missing message payload"))?;
+        let message = everruns_internal_protocol::proto_to_new_task_message(message_proto);
 
         let stored = self
             .session_task_registry()
@@ -2972,8 +2974,7 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(SessionTaskMessageResponse {
-            message_json: serde_json::to_vec(&stored)
-                .map_err(|e| Status::internal(format!("Failed to encode task message: {e}")))?,
+            message: Some(everruns_internal_protocol::task_message_to_proto(&stored)),
         }))
     }
 
@@ -2994,11 +2995,10 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         Ok(Response::new(ListSessionTaskMessagesResponse {
-            message_json: messages
+            messages: messages
                 .iter()
-                .map(serde_json::to_vec)
-                .collect::<Result<_, _>>()
-                .map_err(|e| Status::internal(format!("Failed to encode task messages: {e}")))?,
+                .map(everruns_internal_protocol::task_message_to_proto)
+                .collect(),
         }))
     }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -3802,17 +3802,19 @@ impl everruns_core::traits::PaymentAuthority for GrpcPaymentAuthority {
 // GrpcSessionTaskRegistry - SessionTaskRegistry over gRPC
 // ============================================================================
 //
-// Task and message payloads travel as canonical core JSON (see worker.proto),
-// so lifecycle invariants stay server-side in DbSessionTaskRegistry and the
-// record shape is defined once in everruns-core.
+// Task and message payloads travel as native protobuf messages (EVE-642), so
+// there is no intermediate JSON encode/decode into byte fields. Lifecycle
+// invariants stay server-side in DbSessionTaskRegistry and the record shape is
+// defined once in everruns-core; the proto↔core conversions live in
+// everruns-internal-protocol.
 
-fn decode_task(bytes: &[u8]) -> Result<everruns_core::SessionTask> {
-    serde_json::from_slice(bytes)
+fn decode_task(proto: proto::SessionTaskProto) -> Result<everruns_core::SessionTask> {
+    everruns_internal_protocol::proto_to_session_task(proto)
         .map_err(|e| AgentLoopError::store(format!("Invalid session task payload: {e}")))
 }
 
-fn decode_task_message(bytes: &[u8]) -> Result<everruns_core::TaskMessage> {
-    serde_json::from_slice(bytes)
+fn decode_task_message(proto: proto::TaskMessageProto) -> Result<everruns_core::TaskMessage> {
+    everruns_internal_protocol::proto_to_task_message(proto)
         .map_err(|e| AgentLoopError::store(format!("Invalid task message payload: {e}")))
 }
 
@@ -3822,14 +3824,19 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
         &self,
         input: everruns_core::CreateSessionTask,
     ) -> Result<everruns_core::SessionTask> {
-        let create_json = serde_json::to_vec(&input)
-            .map_err(|e| AgentLoopError::store(format!("Failed to encode task create: {e}")))?;
+        let create = everruns_internal_protocol::create_session_task_to_proto(&input);
         let mut client = self.client.inner.lock().await;
         let response = client
-            .create_session_task(proto::CreateSessionTaskRequest { create_json })
+            .create_session_task(proto::CreateSessionTaskRequest {
+                create: Some(create),
+            })
             .await
             .map_err(grpc_status_to_error)?;
-        decode_task(&response.into_inner().task_json)
+        let task = response
+            .into_inner()
+            .task
+            .ok_or_else(|| AgentLoopError::store("Missing task in create response"))?;
+        decode_task(task)
     }
 
     async fn update(
@@ -3838,23 +3845,17 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
         task_id: &str,
         update: everruns_core::SessionTaskUpdate,
     ) -> Result<Option<everruns_core::SessionTask>> {
-        let update_json = serde_json::to_vec(&update)
-            .map_err(|e| AgentLoopError::store(format!("Failed to encode task update: {e}")))?;
+        let update = everruns_internal_protocol::session_task_update_to_proto(&update);
         let mut client = self.client.inner.lock().await;
         let response = client
             .update_session_task(proto::UpdateSessionTaskRequest {
                 session_id: Some(uuid_to_proto(session_id.uuid())),
                 task_id: task_id.to_string(),
-                update_json,
+                update: Some(update),
             })
             .await
             .map_err(grpc_status_to_error)?;
-        response
-            .into_inner()
-            .task_json
-            .as_deref()
-            .map(decode_task)
-            .transpose()
+        response.into_inner().task.map(decode_task).transpose()
     }
 
     async fn get(
@@ -3870,12 +3871,7 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
             })
             .await
             .map_err(grpc_status_to_error)?;
-        response
-            .into_inner()
-            .task_json
-            .as_deref()
-            .map(decode_task)
-            .transpose()
+        response.into_inner().task.map(decode_task).transpose()
     }
 
     async fn list(
@@ -3894,9 +3890,9 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
             .map_err(grpc_status_to_error)?;
         response
             .into_inner()
-            .task_json
-            .iter()
-            .map(|bytes| decode_task(bytes))
+            .tasks
+            .into_iter()
+            .map(decode_task)
             .collect()
     }
 
@@ -3913,12 +3909,7 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
             })
             .await
             .map_err(grpc_status_to_error)?;
-        response
-            .into_inner()
-            .task_json
-            .as_deref()
-            .map(decode_task)
-            .transpose()
+        response.into_inner().task.map(decode_task).transpose()
     }
 
     async fn record_message(
@@ -3927,18 +3918,21 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
         task_id: &str,
         message: everruns_core::NewTaskMessage,
     ) -> Result<everruns_core::TaskMessage> {
-        let message_json = serde_json::to_vec(&message)
-            .map_err(|e| AgentLoopError::store(format!("Failed to encode task message: {e}")))?;
+        let message = everruns_internal_protocol::new_task_message_to_proto(&message);
         let mut client = self.client.inner.lock().await;
         let response = client
             .record_session_task_message(proto::RecordSessionTaskMessageRequest {
                 session_id: Some(uuid_to_proto(session_id.uuid())),
                 task_id: task_id.to_string(),
-                message_json,
+                message: Some(message),
             })
             .await
             .map_err(grpc_status_to_error)?;
-        decode_task_message(&response.into_inner().message_json)
+        let message = response
+            .into_inner()
+            .message
+            .ok_or_else(|| AgentLoopError::store("Missing message in record response"))?;
+        decode_task_message(message)
     }
 
     async fn list_messages(
@@ -3959,9 +3953,9 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
             .map_err(grpc_status_to_error)?;
         response
             .into_inner()
-            .message_json
-            .iter()
-            .map(|bytes| decode_task_message(bytes))
+            .messages
+            .into_iter()
+            .map(decode_task_message)
             .collect()
     }
 }

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -386,8 +386,11 @@ No backward compatibility is required; data migrates forward once:
 - Storage: `session_tasks` + `session_task_messages` (migration 053);
   PostgreSQL and in-memory backends both route updates through
   `apply_task_update` in `crates/core/src/session_task.rs`. gRPC workers get
-  the registry via task RPCs in the internal worker protocol (payloads travel
-  as canonical core JSON).
+  the registry via task RPCs in the internal worker protocol; task and message
+  payloads travel as native protobuf messages (EVE-642), serialized once by
+  protobuf framing rather than JSON-encoded into byte fields. The proto↔core
+  conversions live in `everruns-internal-protocol`; everruns-core stays the
+  source of truth for lifecycle invariants.
 - Session-resource dual-write retired (migration 054): subagent, background_run,
   and agent_handoff no longer register in `session_resources`. A2A agent runs
   (`external_agent` tasks) now store their run records in session storage KV


### PR DESCRIPTION
## What
Replace the JSON-in-protobuf encoding of the session-task worker gRPC RPCs with native protobuf messages. Covers `CreateSessionTask`, `UpdateSessionTask`, `GetSessionTask`, `ListSessionTasks`, `RequestCancelSessionTask`, `RecordSessionTaskMessage`, and `ListSessionTaskMessages` (EVE-642).

## Why
The worker RPC path serialized whole domain structs to JSON via `serde_json::to_vec` into protobuf `bytes` fields (`task_json` / `message_json` / `create_json` / `update_json`), then re-parsed that JSON on the worker — JSON work layered on top of protobuf's own framing, with a `Vec` allocation per element on the list handlers. This is the workers' primary RPC path and list handlers paid it per element.

## How
- `crates/internal-protocol/proto/worker.proto`: model the session-task/message payloads as native protobuf messages (`SessionTaskProto`, `CreateSessionTaskProto`, `SessionTaskUpdateProto`, `TaskMessageProto`, `NewTaskMessageProto` plus nested `TaskProgressProto`/`TaskInputRequestProto`/`TaskErrorProto`/`TaskArtifactProto`/`TaskLinksProto`/`TaskMessagePartProto` and enums for state/wake-policy/direction). The request/response messages now carry these instead of JSON `bytes`.
- The ~20 structural fields (ids, enums, timestamps, nested links/error/artifacts/progress) are encoded once by protobuf framing and consumed directly on the worker.
- The genuinely free-form fields — kind-specific `spec`, input-request `expected`, and message `Data` parts — carry canonical `serde_json` bytes, **serialized exactly once**. They are already JSON-shaped `serde_json::Value`s; walking them into `google.protobuf.Value` trees was measurably slower (an early full-`Value` variant regressed vs the old path — see Evidence), so they stay as compact single-encode bytes.
- Proto↔core conversions live in `everruns-internal-protocol`; `everruns-core` stays the source of truth for lifecycle invariants (`apply_task_update`, `new_session_task`). Server handler (`worker_service_impl.rs`) and worker adapter (`grpc_adapters.rs`) both use the conversions; the worker no longer `serde_json::from_slice`s `*_json` fields, and list handlers no longer re-encode per element.
- Updated `specs/session-tasks.md` to describe the native-protobuf wire format.

## Risk
- Low / Medium. Internal server↔worker gRPC contract only (authenticated, bearer-token; not a public API). No DB migration, no schema/storage change. No backward-compat requirement for internal code (per AGENTS.md); server and worker deploy together off the same proto.
- What can break: any consumer of the old `*_json` byte fields — there are none besides the two updated call sites (grep confirms). Malformed payloads are handled defensively (log + fallback to `null`/nil) rather than panicking.

## Security
- Threat categories reviewed: TM-API (RPC input parsing), TM-DOS (allocation/size), TM-TENANT (org scoping).
- Findings and resolutions:
  - No new endpoints or auth changes; the RPC method set is unchanged, only payload encoding changed. Worker auth (bearer token / optional mTLS) and org-scoping semantics are untouched.
  - Input validation: `proto_to_*` and `bytes_to_json_value` never panic on malformed input — missing required fields return `ConversionError::MissingField`; invalid UUIDs/JSON log a warning and fall back to nil/`null`. This matches the prior lenient behavior and avoids a worker-crash DoS from a bad payload.
  - Resource exhaustion: payloads remain bounded by tonic's existing max-message-size; native protobuf is 39% smaller on the wire than the old JSON text, so this reduces, not increases, memory pressure. No new unbounded loops or allocations.
  - No secrets, logs-of-sensitive-data, SQL, or cross-tenant boundary changes.

## Evidence
Microbenchmark `crates/internal-protocol/benches/session_task_encoding.rs` (`cargo bench -p everruns-internal-protocol --bench session_task_encoding`), encode+decode round-trip of a representative `SessionTask`:

```
payload size:  json bytes = 1002, protobuf bytes = 614   (-39%)

old json (single)            6190.9 ns/op
new native-proto (single)    3495.6 ns/op   (~1.77x faster)
old json (list x50)        310239.8 ns/op
new native-proto (list x50) 168234.2 ns/op  (~1.84x faster)
```

The old path's `serde_json` whole-struct encode/decode is removed from the hot handlers. (An intermediate variant that modeled the free-form `spec`/`expected`/`data` as `google.protobuf.Value` measured *slower* than the old path — ~8272 ns/op — because walking arbitrary JSON into a `Value` tree costs more than encoding it once; hence the final hybrid keeps those fields as single-encode bytes.)

Round-trip fidelity tests added in `crates/internal-protocol/src/lib.rs`: `session_task_native_proto_round_trip`, `create_session_task_native_proto_round_trip`, `session_task_update_native_proto_round_trip` (including the absent-vs-empty `artifacts` distinction), `task_message_native_proto_round_trip`, `new_task_message_native_proto_round_trip`. All 23 internal-protocol tests pass; `just pre-push` green (fmt, clippy `--all-targets --all-features -D warnings`, lockfile, migrations, specs index, attribution).

## Follow-ups
No follow-ups. All exit criteria met in this PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal contract; server+worker deploy together, no shim required)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)