### PR TITLE
feat(mcp): align async tools with 2026 Tasks extension vocab

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -26,6 +26,7 @@
 // - Multi-org: org-scoped tools accept optional `organization_id` to override the default org
 
 mod cards;
+mod tasks;
 mod tool_registry;
 
 use crate::auth::AuthMethod;
@@ -601,6 +602,24 @@ async fn handle_mcp(
         }
         "resources/list" => handle_resources_list(req.id),
         "resources/read" => handle_resources_read(req.id, req.params, &org, &state).await,
+        // MCP 2026-07-28 Tasks extension (SEP-2663). Task handles map to
+        // sessions; these methods delegate to the same session logic the
+        // agent_run/session_get_status/session_send_message tools use. Gated to
+        // the negotiated 2026-07-28 protocol; 2025-* clients that somehow send
+        // these get method_not_found, matching "the method does not exist here".
+        "tasks/get" | "tasks/cancel" | "tasks/update"
+            if protocol_version == Some(MCP_PROTOCOL_VERSION_LATEST) =>
+        {
+            handle_tasks_method(
+                req.method.as_str(),
+                req.id,
+                req.params,
+                &auth_user,
+                &org,
+                &state,
+            )
+            .await
+        }
         "ping" => JsonRpcResponse::success(req.id, json!({})),
         _ => JsonRpcResponse::method_not_found(req.id),
     };
@@ -615,16 +634,22 @@ async fn handle_mcp(
 fn handle_initialize(id: Option<Value>, params: Value) -> JsonRpcResponse {
     let params: InitializeParams = serde_json::from_value(params).unwrap_or_default();
     let protocol_version = negotiate_protocol_version(params.protocol_version.as_deref());
+    let mut capabilities = json!({
+        "tools": {
+            "listChanged": false
+        },
+        "resources": {}
+    });
+    // Advertise the Tasks extension (SEP-2663) only under the negotiated
+    // 2026-07-28 protocol. 2025-* clients see the capabilities shape unchanged.
+    if let Some(extensions) = tasks::initialize_extensions(protocol_version) {
+        capabilities["extensions"] = extensions;
+    }
     JsonRpcResponse::success(
         id,
         json!({
             "protocolVersion": protocol_version,
-            "capabilities": {
-                "tools": {
-                    "listChanged": false
-                },
-                "resources": {}
-            },
+            "capabilities": capabilities,
             "serverInfo": {
                 "name": MCP_SERVER_NAME,
                 "version": MCP_SERVER_VERSION
@@ -854,8 +879,15 @@ async fn handle_tools_call(
     auth_user: &AuthUser,
     org: &ResolvedOrg,
     state: &AppState,
-    _protocol_version: &str,
+    protocol_version: &str,
 ) -> JsonRpcResponse {
+    // MCP 2026-07-28 Tasks extension: when the client advertised the extension
+    // and the negotiated protocol is 2026-07-28, agent_run / session_send_message
+    // long-running calls answer with a CreateTaskResult (`resultType: "task"`)
+    // task handle alongside their existing fields. `params` (not `arguments`)
+    // carries the per-request `_meta` opt-in, so we evaluate it here.
+    let tasks_enabled = tasks::tasks_enabled(protocol_version, &params);
+
     let tool_name = match params.get("name").and_then(|v| v.as_str()) {
         Some(name) => name,
         None => return JsonRpcResponse::invalid_params(id, "Missing 'name' in params"),
@@ -866,7 +898,7 @@ async fn handle_tools_call(
         .cloned()
         .unwrap_or(Value::Object(Default::default()));
 
-    let Some(tool_def) = find_tool_definition(tool_name, _protocol_version) else {
+    let Some(tool_def) = find_tool_definition(tool_name, protocol_version) else {
         let msg = format!("Unknown tool: {tool_name}");
         let envelope = McpExecuteError::new(McpErrorCode::ToolNotFound, &msg).with_hint(
             "Call tools/list to discover the current tool catalog for this protocol version.",
@@ -948,7 +980,7 @@ async fn handle_tools_call(
     match result {
         Ok(content) => {
             let structured_content =
-                if supports_rich_tool_shape(_protocol_version) && tool_def.has_output_schema() {
+                if supports_rich_tool_shape(protocol_version) && tool_def.has_output_schema() {
                     serde_json::from_str::<Value>(&content).ok()
                 } else {
                     None
@@ -961,7 +993,205 @@ async fn handle_tools_call(
                 result["structuredContent"] = structured_content;
             }
 
+            // Tasks extension: for the long-running conversation tools, add the
+            // CreateTaskResult task-handle fields (taskId = session_id) so a 2026
+            // client that opted in can treat the call as a standard Task. The
+            // legacy `content`/`structuredContent` fields stay untouched, so this
+            // is strictly additive.
+            if tasks_enabled && matches!(tool_name, "agent_run" | "session_send_message") {
+                augment_with_task_handle(&mut result, &content);
+            }
+
             JsonRpcResponse::success(id, result)
+        }
+        Err(msg) => {
+            let envelope = classify_mcp_execute_error(&msg);
+            JsonRpcResponse::success(id, error_result_payload(&msg, Some(&envelope)))
+        }
+    }
+}
+
+/// Merge Tasks-extension `CreateTaskResult` fields (`resultType`, `taskId`,
+/// `status`, `ttlMs`, `pollIntervalMs`) into a successful tools/call result,
+/// deriving them from the tool's JSON `content`. `agent_run` exposes the session
+/// as `session_id`/`status`; `session_send_message` as `session_id`/
+/// `session_status`. The task handle is `session_id`. If the content isn't
+/// parseable JSON with a session id (it always is for these tools), we leave the
+/// result unchanged rather than fabricate a handle.
+fn augment_with_task_handle(result: &mut Value, content: &str) {
+    let Ok(parsed) = serde_json::from_str::<Value>(content) else {
+        return;
+    };
+    let Some(session_id) = parsed.get("session_id").and_then(Value::as_str) else {
+        return;
+    };
+    let session_status = parsed
+        .get("status")
+        .or_else(|| parsed.get("session_status"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    let task = tasks::create_task_result(session_id, session_status);
+    if let (Some(result_obj), Some(task_obj)) = (result.as_object_mut(), task.as_object()) {
+        for (key, value) in task_obj {
+            result_obj.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+// ============================================================================
+// MCP 2026-07-28 Tasks extension methods (SEP-2663)
+// ============================================================================
+//
+// A task handle is a `session_id`; each method delegates to the session logic
+// the equivalent tool already uses. See `tasks.rs` for the mapping rationale.
+
+async fn handle_tasks_method(
+    method: &str,
+    id: Option<Value>,
+    params: Value,
+    auth_user: &AuthUser,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> JsonRpcResponse {
+    let Some(task_id) = params.get("taskId").and_then(Value::as_str) else {
+        return JsonRpcResponse::invalid_params(id, "Missing 'taskId' in params");
+    };
+
+    // A taskId is a session_id; org override rides the same `_meta`-free path as
+    // the tools by reading `organization_id` from params when present.
+    let org = match resolve_org_override(&params, auth_user, org, state).await {
+        Ok(org) => org,
+        Err(e) => return JsonRpcResponse::invalid_params(id, e),
+    };
+
+    match method {
+        "tasks/get" => handle_tasks_get(id, task_id, &params, &org, state).await,
+        "tasks/cancel" => handle_tasks_cancel(id, task_id, &org, state).await,
+        "tasks/update" => handle_tasks_update(id, task_id, &params, &org, state).await,
+        _ => JsonRpcResponse::method_not_found(id),
+    }
+}
+
+/// `tasks/get` → session status + events. Reuses `tool_session_get_status` and
+/// wraps its JSON into the Tasks `Task` object. On `completed`, the underlying
+/// tool's structured JSON is surfaced as `result`.
+async fn handle_tasks_get(
+    id: Option<Value>,
+    task_id: &str,
+    params: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> JsonRpcResponse {
+    // Reshape into the args `tool_session_get_status` expects (session_id +
+    // optional since_event_id/event_types passthrough).
+    let mut args = json!({ "session_id": task_id });
+    if let Some(since) = params.get("since_event_id") {
+        args["since_event_id"] = since.clone();
+    }
+    if let Some(types) = params.get("event_types") {
+        args["event_types"] = types.clone();
+    }
+
+    match tool_session_get_status(&args, org, state).await {
+        Ok(status_json) => {
+            let status_value: Value = serde_json::from_str(&status_json).unwrap_or(Value::Null);
+            let session_status = status_value
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let task_status = tasks::task_status_from_session_status(session_status);
+
+            let mut task = tasks::task_handle(task_id, task_status);
+            // The full session_get_status payload is the task's result view. For
+            // terminal `completed`, this is what the original tools/call would
+            // have returned; for `working`/`input_required` it's a progress
+            // snapshot the client can inspect.
+            task["result"] = status_value;
+            JsonRpcResponse::success(id, task)
+        }
+        Err(msg) => {
+            let envelope = classify_mcp_execute_error(&msg);
+            JsonRpcResponse::success(id, error_result_payload(&msg, Some(&envelope)))
+        }
+    }
+}
+
+/// `tasks/cancel` → cancel the running turn. Cooperative per SEP-2663: we
+/// acknowledge intent; the session may still reach a non-`cancelled` terminal.
+async fn handle_tasks_cancel(
+    id: Option<Value>,
+    task_id: &str,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> JsonRpcResponse {
+    match dispatch_command(
+        "cancel_session",
+        json!({ "session_id": task_id }),
+        org,
+        state,
+    )
+    .await
+    {
+        Ok(_) => {
+            // Report the post-cancel session status as the task status rather
+            // than asserting `cancelled`: cancellation returns the session to
+            // idle, and SEP-2663 explicitly allows a non-`cancelled` terminal.
+            let task_status =
+                match dispatch_command("get_session", json!({ "session_id": task_id }), org, state)
+                    .await
+                {
+                    Ok(session) => tasks::task_status_from_session_status(
+                        session.get("status").and_then(Value::as_str).unwrap_or(""),
+                    ),
+                    Err(_) => tasks::TaskStatus::Cancelled,
+                };
+            JsonRpcResponse::success(id, tasks::task_handle(task_id, task_status))
+        }
+        Err(msg) => {
+            let envelope = classify_mcp_execute_error(&msg);
+            JsonRpcResponse::success(id, error_result_payload(&msg, Some(&envelope)))
+        }
+    }
+}
+
+/// `tasks/update` → provide input to a task in `input_required`. Maps to sending
+/// a user message (`session_send_message`). SEP-2663 keys input under
+/// `inputResponses`; we accept either a single `message` string or the first
+/// string value found in the `inputResponses` map.
+async fn handle_tasks_update(
+    id: Option<Value>,
+    task_id: &str,
+    params: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> JsonRpcResponse {
+    let message = params.get("message").and_then(Value::as_str).or_else(|| {
+        params
+            .get("inputResponses")
+            .and_then(Value::as_object)
+            .and_then(|m| m.values().find_map(Value::as_str))
+    });
+
+    let Some(message) = message else {
+        return JsonRpcResponse::invalid_params(
+            id,
+            "tasks/update requires a 'message' string or an 'inputResponses' map with a string value",
+        );
+    };
+
+    let args = json!({ "session_id": task_id, "message": message });
+    match tool_session_send_message(&args, org, state).await {
+        Ok(send_json) => {
+            let parsed: Value = serde_json::from_str(&send_json).unwrap_or(Value::Null);
+            let session_status = parsed
+                .get("session_status")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let task_status = tasks::task_status_from_session_status(session_status);
+            let mut task = tasks::task_handle(task_id, task_status);
+            task["result"] = parsed;
+            JsonRpcResponse::success(id, task)
         }
         Err(msg) => {
             let envelope = classify_mcp_execute_error(&msg);

--- a/crates/server/src/api/mcp_endpoint/tasks.rs
+++ b/crates/server/src/api/mcp_endpoint/tasks.rs
@@ -1,0 +1,248 @@
+// MCP 2026-07-28 Tasks extension (SEP-2663, `io.modelcontextprotocol/tasks`).
+//
+// This is wire-level interop alignment, NOT new capability. Everruns already
+// implements the long-running `tools/call` pattern: `agent_run` returns a
+// `session_id` + poll hint, clients poll `session_get_status`, all state is
+// Postgres-backed with no server-side session memory. The Tasks extension is
+// the standardized vocabulary for exactly that pattern, so we map a task handle
+// onto a session:
+//
+//   task handle / `taskId`          ↔ `session_id`
+//   `tools/call` → CreateTaskResult ↔ `agent_run` / `session_send_message`
+//   `tasks/get`                     ↔ `session_get_status`
+//   `tasks/update` (provide input)  ↔ `session_send_message`
+//   `tasks/cancel`                  ↔ `cancel_session`
+//   lifecycle status                ↔ derived from session status
+//
+// The whole surface is gated on the negotiated protocol being 2026-07-28 AND
+// the client having advertised the extension in its per-request capabilities.
+// 2025-* clients (and 2026 clients that did not opt in) see the pre-existing
+// shapes unchanged — the task fields are strictly additive.
+//
+// Schema source: the official MCP Tasks extension docs
+// (https://modelcontextprotocol.io/extensions/tasks/overview) and SEP-2663
+// (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663 /
+// https://github.com/modelcontextprotocol/experimental-ext-tasks).
+//
+// ASSUMPTION / FIELDS TO RECONCILE: the extension is still an experimental RC
+// and the two authoritative sources disagree on the duration field spelling —
+// the overview page uses `ttlMs` / `pollIntervalMs`, while the PR summary uses
+// `ttlSeconds` / `pollIntervalMilliseconds`. We emit `ttlMs` / `pollIntervalMs`
+// (the docs page, which shows concrete JSON) and centralize them here so a
+// single edit reconciles the wire shape once the spec freezes.
+
+use serde_json::{Value, json};
+
+/// Extension capability key (SEP-2663). Advertised under
+/// `capabilities.extensions` and opted into by clients via per-request
+/// `_meta["io.modelcontextprotocol/clientCapabilities"].extensions`.
+pub(super) const TASKS_EXTENSION_KEY: &str = "io.modelcontextprotocol/tasks";
+
+/// Per-request client-capabilities `_meta` key (SEP-2133 extension framework).
+const CLIENT_CAPABILITIES_META_KEY: &str = "io.modelcontextprotocol/clientCapabilities";
+
+/// Suggested client poll interval for `tasks/get`, in milliseconds. Mirrors the
+/// `agent_run` poll hint cadence; advisory only.
+const DEFAULT_POLL_INTERVAL_MS: u64 = 1_000;
+
+/// Task time-to-live, in milliseconds. Sessions are durable in Postgres and
+/// never expire on their own, so we advertise a long TTL; this is advisory for
+/// clients deciding how long to keep polling a handle.
+const DEFAULT_TTL_MS: u64 = 24 * 60 * 60 * 1_000;
+
+/// Task lifecycle states (SEP-2663). `completed` / `failed` / `cancelled` are
+/// terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TaskStatus {
+    Working,
+    InputRequired,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl TaskStatus {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            TaskStatus::Working => "working",
+            TaskStatus::InputRequired => "input_required",
+            TaskStatus::Completed => "completed",
+            TaskStatus::Failed => "failed",
+            TaskStatus::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// Map an Everruns session status string to a Tasks lifecycle state.
+///
+/// Session statuses (see `everruns_core::SessionStatus`):
+/// - `started` / `active` → `working` (a turn is or will be running)
+/// - `waiting_for_tool_results` / `paused` → `input_required` (needs client
+///   input: tool results, or a budget/limit action)
+/// - `idle` → `completed` (turn finished; from the Tasks view the run's work is
+///   done and the result is available to read)
+///
+/// `failed` and `cancelled` are not persisted as session statuses today
+/// (cancellation emits a turn event and the session returns to idle), so they
+/// are unreachable from status alone. The variants exist so callers with
+/// stronger information (e.g. an explicit cancel just issued) can report them,
+/// and so the mapping is total against the SEP-2663 vocabulary.
+pub(super) fn task_status_from_session_status(session_status: &str) -> TaskStatus {
+    match session_status {
+        "started" | "active" | "running" => TaskStatus::Working,
+        "waiting_for_tool_results" | "paused" => TaskStatus::InputRequired,
+        "idle" | "completed" => TaskStatus::Completed,
+        "failed" => TaskStatus::Failed,
+        "cancelled" | "canceled" => TaskStatus::Cancelled,
+        // Unknown/legacy values: treat as still working rather than falsely
+        // terminal, so a client keeps polling instead of dropping the handle.
+        _ => TaskStatus::Working,
+    }
+}
+
+/// Does the negotiated protocol version plus the client's advertised
+/// capabilities enable the Tasks extension for this request?
+///
+/// Both must hold: the negotiated protocol is 2026-07-28 (the extension does
+/// not exist for 2025-* clients) AND the client opted in via per-request
+/// `_meta`. Servers MUST NOT return a task to a client that did not declare
+/// support (SEP-2663), which is what keeps this fully back-compat.
+pub(super) fn tasks_enabled(protocol_version: &str, params: &Value) -> bool {
+    protocol_version == super::MCP_PROTOCOL_VERSION_LATEST && client_advertised_tasks(params)
+}
+
+/// True when the request `_meta` advertises the tasks extension in the client's
+/// per-request capabilities.
+fn client_advertised_tasks(params: &Value) -> bool {
+    params
+        .get("_meta")
+        .and_then(|meta| meta.get(CLIENT_CAPABILITIES_META_KEY))
+        .and_then(|caps| caps.get("extensions"))
+        .and_then(|exts| exts.get(TASKS_EXTENSION_KEY))
+        .is_some()
+}
+
+/// The `extensions` map advertised in `initialize` capabilities when the
+/// negotiated protocol supports the Tasks extension. `None` for 2025-* so their
+/// `initialize` response is byte-for-byte unchanged.
+pub(super) fn initialize_extensions(protocol_version: &str) -> Option<Value> {
+    (protocol_version == super::MCP_PROTOCOL_VERSION_LATEST)
+        .then(|| json!({ TASKS_EXTENSION_KEY: {} }))
+}
+
+/// Build a `CreateTaskResult` (`resultType: "task"`) for a freshly created or
+/// advanced session, mapping `session_id` → `taskId`. Emitted from `agent_run`
+/// / `session_send_message` when the Tasks extension is active. The `status` is
+/// derived from the session status the tool already resolved.
+pub(super) fn create_task_result(session_id: &str, session_status: &str) -> Value {
+    let status = task_status_from_session_status(session_status);
+    let mut result = task_handle(session_id, status);
+    result["resultType"] = json!("task");
+    result
+}
+
+/// Base task-handle fields shared by `CreateTaskResult` and the `tasks/get`
+/// `Task` object.
+pub(super) fn task_handle(session_id: &str, status: TaskStatus) -> Value {
+    json!({
+        "taskId": session_id,
+        "status": status.as_str(),
+        "ttlMs": DEFAULT_TTL_MS,
+        "pollIntervalMs": DEFAULT_POLL_INTERVAL_MS,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{
+        MCP_PROTOCOL_VERSION_2025_06, MCP_PROTOCOL_VERSION_FALLBACK, MCP_PROTOCOL_VERSION_LATEST,
+    };
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn status_mapping_covers_session_states() {
+        assert_eq!(
+            task_status_from_session_status("started"),
+            TaskStatus::Working
+        );
+        assert_eq!(
+            task_status_from_session_status("active"),
+            TaskStatus::Working
+        );
+        assert_eq!(
+            task_status_from_session_status("waiting_for_tool_results"),
+            TaskStatus::InputRequired
+        );
+        assert_eq!(
+            task_status_from_session_status("paused"),
+            TaskStatus::InputRequired
+        );
+        assert_eq!(
+            task_status_from_session_status("idle"),
+            TaskStatus::Completed
+        );
+        assert_eq!(
+            task_status_from_session_status("failed"),
+            TaskStatus::Failed
+        );
+        assert_eq!(
+            task_status_from_session_status("cancelled"),
+            TaskStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn unknown_status_defaults_to_working() {
+        assert_eq!(
+            task_status_from_session_status("something_new"),
+            TaskStatus::Working
+        );
+    }
+
+    #[test]
+    fn status_strings_match_sep_2663_vocabulary() {
+        assert_eq!(TaskStatus::Working.as_str(), "working");
+        assert_eq!(TaskStatus::InputRequired.as_str(), "input_required");
+        assert_eq!(TaskStatus::Completed.as_str(), "completed");
+        assert_eq!(TaskStatus::Failed.as_str(), "failed");
+        assert_eq!(TaskStatus::Cancelled.as_str(), "cancelled");
+    }
+
+    #[test]
+    fn tasks_enabled_requires_latest_protocol_and_opt_in() {
+        let opted_in = json!({
+            "_meta": {
+                CLIENT_CAPABILITIES_META_KEY: {
+                    "extensions": { TASKS_EXTENSION_KEY: {} }
+                }
+            }
+        });
+        assert!(tasks_enabled(MCP_PROTOCOL_VERSION_LATEST, &opted_in));
+        // Right protocol, no opt-in.
+        assert!(!tasks_enabled(MCP_PROTOCOL_VERSION_LATEST, &json!({})));
+        // Opted in, but 2025-* protocol never exposes the extension.
+        assert!(!tasks_enabled(MCP_PROTOCOL_VERSION_2025_06, &opted_in));
+        assert!(!tasks_enabled(MCP_PROTOCOL_VERSION_FALLBACK, &opted_in));
+    }
+
+    #[test]
+    fn initialize_extensions_gated_by_version() {
+        assert_eq!(
+            initialize_extensions(MCP_PROTOCOL_VERSION_LATEST),
+            Some(json!({ TASKS_EXTENSION_KEY: {} }))
+        );
+        assert_eq!(initialize_extensions(MCP_PROTOCOL_VERSION_2025_06), None);
+        assert_eq!(initialize_extensions(MCP_PROTOCOL_VERSION_FALLBACK), None);
+    }
+
+    #[test]
+    fn create_task_result_uses_session_id_as_task_id() {
+        let result = create_task_result("session_abc", "started");
+        assert_eq!(result["resultType"], "task");
+        assert_eq!(result["taskId"], "session_abc");
+        assert_eq!(result["status"], "working");
+        assert!(result.get("ttlMs").is_some());
+        assert!(result.get("pollIntervalMs").is_some());
+    }
+}

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -3355,3 +3355,268 @@ async fn test_oauth_register_is_rate_limited() {
     let payload: Value = resp.json();
     assert_eq!(payload["error"], "too_many_requests");
 }
+
+// ============================================================================
+// MCP 2026-07-28 Tasks extension (SEP-2663)
+// ============================================================================
+
+/// The real 2026-07-28 protocol version. The file-level `..._LATEST` const is
+/// `2025-06-18` (the version that first exposed the richer tool shape); the
+/// Tasks extension needs the actual negotiated 2026 version.
+const MCP_PROTOCOL_VERSION_2026: &str = "2026-07-28";
+
+/// Per-request `_meta` block that advertises the Tasks extension opt-in, as an
+/// MCP 2026 client would send it.
+fn tasks_opt_in_meta() -> Value {
+    json!({
+        "io.modelcontextprotocol/clientCapabilities": {
+            "extensions": { "io.modelcontextprotocol/tasks": {} }
+        }
+    })
+}
+
+/// tools/call with the 2026 protocol header AND the tasks opt-in `_meta`.
+async fn mcp_task_tool_call(server: &TestServer, tool: &str, arguments: Value) -> Value {
+    mcp_call_with_headers(
+        server,
+        "tools/call",
+        json!({ "name": tool, "arguments": arguments, "_meta": tasks_opt_in_meta() }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await
+}
+
+/// A 2026 `initialize` advertises the tasks extension under
+/// `capabilities.extensions`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_capability_advertised_for_2026() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call(
+        &server,
+        "initialize",
+        json!({ "protocolVersion": MCP_PROTOCOL_VERSION_2026 }),
+    )
+    .await;
+
+    assert_eq!(resp["result"]["protocolVersion"], MCP_PROTOCOL_VERSION_2026);
+    assert!(
+        resp["result"]["capabilities"]["extensions"]["io.modelcontextprotocol/tasks"].is_object(),
+        "2026 initialize must advertise the tasks extension, got: {}",
+        resp["result"]["capabilities"]
+    );
+}
+
+/// 2025-* `initialize` responses are unchanged — no `extensions` key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_capability_absent_for_2025() {
+    let server = TestServer::in_memory().await;
+    for version in [MCP_PROTOCOL_VERSION_LATEST, MCP_PROTOCOL_VERSION_FALLBACK] {
+        let resp = mcp_call(&server, "initialize", json!({ "protocolVersion": version })).await;
+        assert_eq!(resp["result"]["protocolVersion"], version);
+        assert!(
+            resp["result"]["capabilities"].get("extensions").is_none(),
+            "2025 initialize ({version}) must not advertise extensions, got: {}",
+            resp["result"]["capabilities"]
+        );
+    }
+}
+
+/// A 2026 tasks-opted-in `agent_run` returns the CreateTaskResult task-handle
+/// shape (resultType/taskId/status) alongside the existing session fields.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run_returns_task_handle_for_2026() {
+    let server = TestServer::new().await;
+
+    let resp =
+        mcp_task_tool_call(&server, "agent_run", json!({ "message": "Hello via task" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "agent_run failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = &resp["result"];
+    // Additive task handle.
+    assert_eq!(result["resultType"], "task");
+    let task_id = result["taskId"].as_str().expect("taskId present");
+    assert!(task_id.starts_with("session_"), "taskId is session id");
+    assert_eq!(result["status"], "working");
+    assert!(result.get("ttlMs").is_some());
+    assert!(result.get("pollIntervalMs").is_some());
+
+    // Legacy content preserved: taskId equals the session_id in the body.
+    let body = tool_json(&resp);
+    assert_eq!(body["session_id"].as_str(), Some(task_id));
+}
+
+/// Without the opt-in `_meta`, a 2026 `agent_run` does NOT get task fields —
+/// the server must not push tasks onto a client that didn't advertise support.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run_no_task_handle_without_opt_in() {
+    let server = TestServer::new().await;
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tools/call",
+        json!({ "name": "agent_run", "arguments": { "message": "Hi" } }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    assert!(resp["result"].get("resultType").is_none());
+    assert!(resp["result"].get("taskId").is_none());
+}
+
+/// 2025-* clients never see task fields even if they somehow send the `_meta`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run_no_task_handle_for_2025() {
+    let server = TestServer::new().await;
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tools/call",
+        json!({ "name": "agent_run", "arguments": { "message": "Hi" }, "_meta": tasks_opt_in_meta() }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_LATEST)],
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "agent_run failed: {}",
+        tool_text(&resp)
+    );
+    assert!(resp["result"].get("resultType").is_none());
+    assert!(resp["result"].get("taskId").is_none());
+}
+
+/// tasks/get resolves a task handle (session_id) to a Task object with a
+/// lifecycle status and a result snapshot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_get_round_trip() {
+    let server = TestServer::new().await;
+
+    let run = mcp_task_tool_call(&server, "agent_run", json!({ "message": "task get" })).await;
+    let task_id = run["result"]["taskId"].as_str().unwrap().to_string();
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/get",
+        json!({ "taskId": task_id }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    let result = &resp["result"];
+    assert_eq!(result["taskId"].as_str(), Some(task_id.as_str()));
+    let status = result["status"].as_str().unwrap();
+    assert!(
+        [
+            "working",
+            "input_required",
+            "completed",
+            "failed",
+            "cancelled"
+        ]
+        .contains(&status),
+        "unexpected task status: {status}"
+    );
+    // The session_get_status payload is surfaced as the task result.
+    assert_eq!(
+        result["result"]["session_id"].as_str(),
+        Some(task_id.as_str())
+    );
+}
+
+/// tasks/get for 2025-* is method_not_found (extension doesn't exist there).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_get_rejected_for_2025() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/get",
+        json!({ "taskId": "session_00000000000000000000000000000000" }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_LATEST)],
+    )
+    .await;
+    assert_eq!(resp["error"]["code"], -32601, "expected method not found");
+}
+
+/// tasks/update sends input to a session and returns an updated Task object.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_update_round_trip() {
+    let server = TestServer::new().await;
+
+    let run = mcp_task_tool_call(&server, "agent_run", json!({ "message": "first" })).await;
+    let task_id = run["result"]["taskId"].as_str().unwrap().to_string();
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/update",
+        json!({ "taskId": task_id, "message": "follow up" }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    let result = &resp["result"];
+    assert_eq!(result["taskId"].as_str(), Some(task_id.as_str()));
+    assert!(result["status"].is_string());
+    // Underlying session_send_message result surfaced under `result`.
+    assert!(result["result"]["message_id"].as_str().is_some());
+}
+
+/// tasks/update accepts the SEP-2663 `inputResponses` map form too.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_update_accepts_input_responses_map() {
+    let server = TestServer::new().await;
+
+    let run = mcp_task_tool_call(&server, "agent_run", json!({ "message": "first" })).await;
+    let task_id = run["result"]["taskId"].as_str().unwrap().to_string();
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/update",
+        json!({ "taskId": task_id, "inputResponses": { "prompt": "map form input" } }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    assert_eq!(resp["result"]["taskId"].as_str(), Some(task_id.as_str()));
+    assert!(resp["result"]["result"]["message_id"].as_str().is_some());
+}
+
+/// tasks/cancel acknowledges cancellation of a task handle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_cancel_round_trip() {
+    let server = TestServer::new().await;
+
+    let run = mcp_task_tool_call(&server, "agent_run", json!({ "message": "cancel me" })).await;
+    let task_id = run["result"]["taskId"].as_str().unwrap().to_string();
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/cancel",
+        json!({ "taskId": task_id }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    let result = &resp["result"];
+    assert_eq!(result["taskId"].as_str(), Some(task_id.as_str()));
+    // Cooperative cancel: status is a valid lifecycle value (often the
+    // post-cancel session state rather than literally `cancelled`).
+    assert!(result["status"].is_string());
+}
+
+/// tasks/* with a missing taskId is an invalid-params error.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_get_missing_task_id() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/get",
+        json!({}),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+    assert_eq!(resp["error"]["code"], -32602, "expected invalid params");
+}

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -37,7 +37,7 @@ The endpoint is stateless request/response per JSON-RPC call — no `Mcp-Session
 - **Routing headers.** `2026-07-28` Streamable HTTP adds optional `Mcp-Method` and `Mcp-Name` request headers so gateways/load-balancers/rate-limiters can route on the operation without parsing the body. They are optional and the body stays authoritative; when present they must agree with the body (`Mcp-Method` vs the JSON-RPC `method`, and `Mcp-Name` vs `params.name` on `tools/call`), otherwise the request is rejected `400 Bad Request`. See [`specs/production-deployment.md`](production-deployment.md#mcp-endpoint-scaling) for the proxy contract.
 - **The richer tool shape** (`title`, `outputSchema`, `structuredContent`, entity-card tools) introduced in `2025-06-18` applies to `2025-06-18` and every later version, including `2026-07-28`; only the `2025-03-26` fallback omits it.
 
-The Tasks extension (server-directed long-running `tools/call` driven by `tasks/get`/`tasks/update`/`tasks/cancel`) is tracked separately as optional interop alignment for the existing `agent_run` → `session_get_status` poll pattern (Linear EVE-669); it is not yet implemented.
+The Tasks extension (server-directed long-running `tools/call` driven by `tasks/get`/`tasks/update`/`tasks/cancel`) is implemented as optional, additive interop alignment for the existing `agent_run` → `session_get_status` poll pattern. See [Tasks extension (2026-07-28)](#tasks-extension-2026-07-28) below.
 
 ### Supported Methods
 
@@ -49,6 +49,11 @@ The Tasks extension (server-directed long-running `tools/call` driven by `tasks/
 | `tools/call` | Execute a tool |
 | `resources/list` | Discover static Everruns resources |
 | `resources/read` | Read a static Everruns resource by URI |
+| `tasks/get` | (2026-07-28 Tasks extension) Poll a task handle for status + result |
+| `tasks/update` | (2026-07-28 Tasks extension) Provide input to a task in `input_required` |
+| `tasks/cancel` | (2026-07-28 Tasks extension) Request cancellation of a task |
+
+`tasks/list` is intentionally not implemented — SEP-2663 removed it, and Everruns never exposed a server-side task list. The `tasks/*` methods are only routed under the negotiated `2026-07-28` protocol; a `2025-*` client that sends them gets `-32601 Method not found`.
 
 ### Entity Cards
 
@@ -77,6 +82,81 @@ including the URI scheme, sandboxing requirements, and the planned
 | `text` | `text` | Plain text |
 | `image` | `data`, `mime_type` | Base64-encoded image |
 | `resource` | `uri`, `mime_type`, `text` | External resource reference |
+
+## Tasks extension (2026-07-28)
+
+Everruns' `/mcp` server implements the MCP Tasks extension
+(`io.modelcontextprotocol/tasks`, SEP-2663) as optional, **additive** interop
+alignment. It is not new capability: Everruns already runs long agent turns as
+the poll pattern (`agent_run` returns a session id + hint, clients poll
+`session_get_status`), all state Postgres-backed with no server-side session
+memory. Tasks is the standardized vocabulary for that same pattern, so a
+**task handle is a session id**.
+
+The whole surface is gated: it activates only when the negotiated protocol is
+`2026-07-28` **and** the client advertised the extension. `2025-*` clients (and
+`2026-07-28` clients that did not opt in) see today's shapes byte-for-byte
+unchanged.
+
+### Capability negotiation
+
+- **Server advertises** the extension in `initialize` capabilities under
+  `capabilities.extensions["io.modelcontextprotocol/tasks"]`, only when the
+  negotiated protocol is `2026-07-28`.
+- **Client opts in** per request via
+  `params._meta["io.modelcontextprotocol/clientCapabilities"].extensions["io.modelcontextprotocol/tasks"]`.
+  Per SEP-2663 the server must never return a task to a client that did not
+  declare support — this is what keeps the change back-compatible.
+
+### Session ↔ task mapping
+
+| Tasks extension | Everruns equivalent |
+|-----------------|---------------------|
+| task handle / `taskId` | `session_id` (Postgres-backed, instance-agnostic) |
+| `tools/call` returns `CreateTaskResult` | `agent_run` / `session_send_message` return the task handle alongside their existing fields |
+| `tasks/get` | `session_get_status` (status + events, surfaced under `result`) |
+| `tasks/update` (provide input on `input_required`) | `session_send_message` |
+| `tasks/cancel` | `cancel_session` (cooperative) |
+| lifecycle state | derived from session status |
+| `tasks/list` | not implemented (removed by SEP-2663) |
+
+### Status mapping
+
+Session status → task lifecycle state:
+
+| Session status | Task status |
+|----------------|-------------|
+| `started`, `active` | `working` |
+| `waiting_for_tool_results`, `paused` | `input_required` |
+| `idle` | `completed` |
+
+`failed` and `cancelled` are part of the SEP-2663 vocabulary but are not
+persisted session statuses today (cancellation emits a turn event and the
+session returns to `idle`), so they are unreachable from status alone. The
+mapping helper is total against the vocabulary so callers with stronger
+information can still report them.
+
+### Task-handle shape and additivity
+
+When active, `agent_run` / `session_send_message` merge `CreateTaskResult`
+fields (`resultType: "task"`, `taskId`, `status`, `ttlMs`, `pollIntervalMs`)
+into the tools/call `result`; the existing `content` / `structuredContent` are
+untouched. `tasks/get` returns a `Task` object (`taskId`, `status`, `ttlMs`,
+`pollIntervalMs`) with the full `session_get_status` payload under `result`.
+
+> **RC schema note.** The Tasks extension is still an experimental RC and its
+> authoritative sources disagree on the duration field spelling: the
+> [overview docs](https://modelcontextprotocol.io/extensions/tasks/overview)
+> use `ttlMs` / `pollIntervalMs` (with concrete JSON), while the
+> [SEP-2663 PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663)
+> summary uses `ttlSeconds` / `pollIntervalMilliseconds`. Everruns emits
+> `ttlMs` / `pollIntervalMs` and centralizes the field names in
+> `api/mcp_endpoint/tasks.rs` so a single edit reconciles the wire shape once
+> the spec freezes.
+
+Implementation: `crates/server/src/api/mcp_endpoint/tasks.rs` (mapping helpers,
+capability gating, task-handle shapes) and `mod.rs` (`handle_tasks_method` and
+the `handle_tools_call` augmentation).
 
 ## Architecture
 
@@ -393,7 +473,7 @@ MCP clients authenticate via OAuth 2.1 Bearer tokens, which don't carry org cont
 
 ### Per-Call `organization_id` Override
 
-All org-scoped tools (`agent_run`, `session_send_message`, `session_get_status`, `agent_get_card`, `discover`, `query`, `execute`) accept an optional `organization_id` parameter (format: `org_{32-hex}`). When provided:
+All org-scoped tools (`agent_run`, `session_send_message`, `session_get_status`, `agent_get_card`, `discover`, `query`, `execute`) accept an optional `organization_id` parameter (format: `org_{32-hex}`). The `2026-07-28` Tasks methods (`tasks/get`, `tasks/update`, `tasks/cancel`) accept it as a request param too, resolved through the same path. When provided:
 
 1. User membership is validated against the database (not stale JWT claims)
 2. A `ResolvedOrg` is constructed for the target org


### PR DESCRIPTION
## What
Implement the optional MCP `2026-07-28` **Tasks extension** (SEP-2663, `io.modelcontextprotocol/tasks`) as additive interop alignment for Everruns' existing `agent_run` → `session_get_status` poll pattern. A task handle is a `session_id`. Closes EVE-669.

## Why
Everruns' `/mcp` already implements the Tasks *pattern* (async `agent_run` returning a `session_id` + poll hint, Postgres-backed and instance-agnostic). This change lets 2026 MCP clients drive agent runs as standard Tasks using the spec's vocabulary. It is interop/naming alignment, **not** new capability, and is fully back-compat: `2025-*` protocol clients see today's shapes unchanged.

## How
- `crates/server/src/api/mcp_endpoint/tasks.rs` (new): capability gating, `session-status → task-status` mapping (`working|input_required|completed|failed|cancelled`), and the `CreateTaskResult`/`Task` handle shapes, with unit tests.
- `crates/server/src/api/mcp_endpoint/mod.rs`: `initialize` advertises `capabilities.extensions` (2026-only); `handle_tools_call` merges the task handle into `agent_run`/`session_send_message` results when the client opts in via `_meta`; new `handle_tasks_method` routes `tasks/get` → `session_get_status`, `tasks/cancel` → `cancel_session`, `tasks/update` → `session_send_message`. `tasks/list` is intentionally omitted. `tasks/*` are routed only under negotiated `2026-07-28`.
- `specs/mcp.md`: Protocol note, Supported Methods rows, and a new "Tasks extension (2026-07-28)" section with mapping/status tables and the RC schema note.

## Risk
Low. Additive and gated on protocol `2026-07-28` + explicit client opt-in; the `2025-*` request/response shapes are unchanged (covered by a back-compat test). No DB migration, no storage change, no auth change. Internal MCP surface only.

## Security
- Threat categories reviewed: TM-API (request parsing/method routing), TM-TENANT (org scoping), TM-DOS.
- `tasks/*` delegate to the existing, already-org-scoped session handlers (`session_get_status`, `cancel_session`, `session_send_message`) — no new data access path or auth bypass. `taskId` is the existing `session_id` (org-scoped lookups unchanged).
- Input validation: missing `taskId` → `-32602`; unknown method for a `2025-*` client → `-32601`; malformed input is rejected, not panicked on.
- No new secrets, SQL, or cross-tenant surface.

## Evidence
Tests (16 total): capability advertised for 2026 / absent for 2025; task-handle shape on `agent_run`; opt-in gating (no `_meta` → no task fields); `2025-*` back-compat; `tasks/get`/`update`/`cancel` round-trips; `inputResponses` map form; `tasks/get` rejected (`-32601`) for 2025; missing `taskId` (`-32602`); plus unit tests for status mapping/gating/shapes. Ran against a local Postgres: `mcp_endpoint_test` = **91 passed / 0 failed**; lib `mcp_endpoint` tests = **84 passed / 0 failed**. `just pre-push` green (fmt, clippy `--all-targets --all-features -D warnings`, lockfile, migration ordering/immutability, server test enumeration, specs index, attribution).

## Assumptions (flagged for review — RC schema not yet frozen)
Per the issue's guidance (confirm against the official spec; if fields can't be pinned, implement a reasonable additive shape and document), these are centralized in `tasks.rs` with a code comment so a single edit reconciles them once SEP-2663 freezes:
1. **Duration field spelling**: sources disagree — the docs page shows `ttlMs`/`pollIntervalMs` (with concrete JSON); the PR summary text says `ttlSeconds`/`pollIntervalMilliseconds`. This PR emits **`ttlMs`/`pollIntervalMs`**.
2. **`failed`/`cancelled` lifecycle states** aren't persisted session statuses today (cancel emits an event; the session returns to `idle`), so they're unreachable from status alone; the mapping is kept total and `tasks/cancel` reports the post-cancel session status (cooperative cancel, per spec) rather than asserting `cancelled`.
3. **`tasks/update` input** accepts either a `message` string or the SEP-2663 `inputResponses` map (first string value), since the underlying tool takes a single user message.

## Follow-ups
Reconcile the duration field names (Assumption 1) once the SEP-2663 RC schema is final. Sources: MCP Tasks docs (`modelcontextprotocol.io/extensions/tasks/overview`) + SEP-2663 PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (2025-* clients unaffected; verified by test)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_015UN8F2ke76NFJLE2jH6VPm)_