### PR TITLE
refactor(drivers): golden streaming harness + shared tool-call accumulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -2580,6 +2581,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -47,3 +47,6 @@ everruns-core = { path = "../core", version = "0.17.1", default-features = false
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
+# wiremock serves the golden streaming SSE fixtures; futures drains the stream.
+wiremock = "0.6"
+futures.workspace = true

--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -1,0 +1,324 @@
+// Golden-event wire tests for the Anthropic streaming driver (EVE-672).
+//
+// These pin the exact `LlmStreamEvent` sequence the Anthropic driver emits for
+// captured Messages-API SSE responses (text, extended thinking, and a
+// fragmented tool_use). They give the shared streaming refactor a golden
+// contract to preserve: the conversion internals may change, but these fixtures
+// must still produce the same events.
+//
+// Anthropic frames each SSE event with an `event:` type line and a `data:` JSON
+// line, and reports disjoint token buckets (input tokens are already
+// cache-exclusive), so `prompt_tokens` passes through unchanged.
+
+use everruns_anthropic::AnthropicChatDriver;
+use everruns_core::driver_registry::{
+    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent,
+};
+use futures::StreamExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn config(model: &str) -> LlmCallConfig {
+    LlmCallConfig {
+        model: model.to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Golden {
+    Text(String),
+    Thinking(String),
+    ThinkingSignature(String),
+    ToolCall {
+        name: String,
+        args: String,
+    },
+    Done {
+        total: Option<u32>,
+        prompt: Option<u32>,
+        completion: Option<u32>,
+        cache_read: Option<u32>,
+        cache_creation: Option<u32>,
+        finish: Option<String>,
+    },
+    Error(String),
+}
+
+fn golden(event: LlmStreamEvent) -> Golden {
+    match event {
+        LlmStreamEvent::TextDelta(t) => Golden::Text(t),
+        LlmStreamEvent::ThinkingDelta(t) => Golden::Thinking(t),
+        LlmStreamEvent::ThinkingSignature(s) => Golden::ThinkingSignature(s),
+        LlmStreamEvent::ToolCalls(calls) => {
+            let tc = &calls[0];
+            Golden::ToolCall {
+                name: tc.name.clone(),
+                args: tc.arguments.to_string(),
+            }
+        }
+        LlmStreamEvent::Done(meta) => {
+            let LlmCompletionMetadata {
+                total_tokens,
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+                finish_reason,
+                ..
+            } = *meta;
+            Golden::Done {
+                total: total_tokens,
+                prompt: prompt_tokens,
+                completion: completion_tokens,
+                cache_read: cache_read_tokens,
+                cache_creation: cache_creation_tokens,
+                finish: finish_reason,
+            }
+        }
+        LlmStreamEvent::Error(e) => Golden::Error(e),
+        other => panic!("unexpected event variant in golden capture: {other:?}"),
+    }
+}
+
+/// Drain a stream into its golden-event sequence, dropping the empty text
+/// deltas the driver emits as internal filler between meaningful events.
+async fn drain_golden(mut stream: LlmResponseStream) -> Vec<Golden> {
+    let mut out = Vec::new();
+    while let Some(item) = stream.next().await {
+        let g = golden(item.expect("stream item should not be a transport error"));
+        if matches!(&g, Golden::Text(t) if t.is_empty()) {
+            continue;
+        }
+        out.push(g);
+    }
+    out
+}
+
+/// Frame an Anthropic SSE event: `event: <type>` + `data: <json>` + blank line.
+fn sse_event(event: &str, data: &str) -> String {
+    format!("event: {event}\ndata: {data}\n\n")
+}
+
+async fn mount_sse(server: &MockServer, body: String) {
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(server)
+        .await;
+}
+
+fn driver(server: &MockServer) -> AnthropicChatDriver {
+    AnthropicChatDriver::with_base_url("test-key", format!("{}/v1/messages", server.uri()))
+}
+
+/// Text streaming: `message_start` carries input/cache usage, two text deltas
+/// stream, and `message_delta` + `message_stop` close with output tokens. The
+/// golden output is the two text deltas plus a `Done` with disjoint buckets
+/// (Anthropic reports input tokens already excluding cache reads).
+#[tokio::test]
+async fn text_stream_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        sse_event(
+            "message_start",
+            r#"{"type":"message_start","message":{"id":"msg_1","model":"claude","usage":{"input_tokens":10,"cache_read_input_tokens":4,"cache_creation_input_tokens":2}}}"#,
+        ),
+        sse_event(
+            "content_block_start",
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", world"}}"#,
+        ),
+        sse_event(
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":0}"#,
+        ),
+        sse_event(
+            "message_delta",
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}"#,
+        ),
+        sse_event("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("claude-sonnet-4-5"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::Text("Hello".into()),
+            Golden::Text(", world".into()),
+            Golden::Done {
+                total: Some(15),  // input(10) + output(5)
+                prompt: Some(10), // disjoint: input passes through
+                completion: Some(5),
+                cache_read: Some(4),
+                cache_creation: Some(2),
+                // message_stop always reports "stop" regardless of the
+                // message_delta stop_reason; the golden output pins that.
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}
+
+/// Extended-thinking streaming: a thinking block emits `thinking_delta`s and a
+/// terminal `signature_delta`, followed by a text block. The golden output
+/// pins the thinking deltas, the signature, and the visible text.
+#[tokio::test]
+async fn thinking_stream_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        sse_event(
+            "message_start",
+            r#"{"type":"message_start","message":{"id":"msg_2","usage":{"input_tokens":8}}}"#,
+        ),
+        sse_event(
+            "content_block_start",
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-abc"}}"#,
+        ),
+        sse_event(
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":0}"#,
+        ),
+        sse_event(
+            "content_block_start",
+            r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer"}}"#,
+        ),
+        sse_event(
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":1}"#,
+        ),
+        sse_event(
+            "message_delta",
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}"#,
+        ),
+        sse_event("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "think")],
+            &config("claude-sonnet-4-5"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::Thinking("Let me think".into()),
+            Golden::ThinkingSignature("sig-abc".into()),
+            Golden::Text("Answer".into()),
+            Golden::Done {
+                total: Some(15),
+                prompt: Some(8),
+                completion: Some(7),
+                cache_read: None,
+                cache_creation: None,
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}
+
+/// Tool-use streaming: a `tool_use` content block whose input JSON arrives
+/// fragmented via `input_json_delta`, finalized at `content_block_stop`, then a
+/// `message_delta` with `stop_reason: "tool_use"` emits the `ToolCalls` event.
+#[tokio::test]
+async fn fragmented_tool_use_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        sse_event(
+            "message_start",
+            r#"{"type":"message_start","message":{"id":"msg_3","usage":{"input_tokens":12}}}"#,
+        ),
+        sse_event(
+            "content_block_start",
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"get_weather"}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}"#,
+        ),
+        sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}"#,
+        ),
+        sse_event(
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":0}"#,
+        ),
+        sse_event(
+            "message_delta",
+            r#"{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}"#,
+        ),
+        sse_event("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "weather?")],
+            &config("claude-sonnet-4-5"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::ToolCall {
+                name: "get_weather".into(),
+                args: r#"{"city":"Paris"}"#.into(),
+            },
+            Golden::Done {
+                total: Some(21),
+                prompt: Some(12),
+                completion: Some(9),
+                cache_read: None,
+                cache_creation: None,
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -162,6 +162,7 @@ pub mod platform_store;
 pub mod resource_ownership;
 pub mod runtime_agent;
 pub mod runtime_context;
+pub mod stream_accumulator;
 pub mod tool_output_sanitizer;
 pub mod tools;
 pub mod traits;

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -19,7 +19,7 @@ use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::{Client, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
@@ -32,7 +32,8 @@ use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryDecision, SendOutcome, is_rate_limit_status, retry_request,
     send_error_message,
 };
-use crate::tool_types::{ToolCall, ToolDefinition};
+use crate::stream_accumulator::StreamToolCallAccumulator;
+use crate::tool_types::ToolDefinition;
 use crate::user_facing_error::is_provider_quota_message;
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
@@ -545,7 +546,7 @@ impl ChatDriver for OpenAIProtocolChatDriver {
         // OpenAI-compatible gateways (e.g. OpenRouter) report an authoritative
         // per-request cost in `usage.cost`; direct OpenAI leaves it absent.
         let provider_cost_usd = Arc::new(Mutex::new(Option::<f64>::None));
-        let accumulated_tool_calls = Arc::new(Mutex::new(Vec::<ToolCall>::new()));
+        let accumulated_tool_calls = Arc::new(Mutex::new(StreamToolCallAccumulator::new()));
         let finish_reason = Arc::new(Mutex::new(Option::<String>::None));
         // Captured from the first streaming chunk that carries an id field.
         // OpenRouter sets this to a "gen-..." identifier on every completion.
@@ -961,20 +962,6 @@ struct OpenAiStreamFunction {
     arguments: Option<String>,
 }
 
-/// Parses each accumulated tool call's argument string (assembled from streamed
-/// fragments) into JSON, falling back to an empty object on parse failure.
-fn finalize_tool_calls(tool_calls: Vec<ToolCall>) -> Vec<ToolCall> {
-    tool_calls
-        .into_iter()
-        .map(|mut tc| {
-            if let Some(args_str) = tc.arguments.as_str() {
-                tc.arguments = serde_json::from_str(args_str).unwrap_or(json!({}));
-            }
-            tc
-        })
-        .collect()
-}
-
 /// Drains tool calls that were accumulated but not yet emitted, returning a
 /// final `ToolCalls` event for the `[DONE]` handler. Returns `None` when nothing
 /// is pending (the common case, since the finish chunk normally drains them).
@@ -982,37 +969,30 @@ fn finalize_tool_calls(tool_calls: Vec<ToolCall>) -> Vec<ToolCall> {
 /// The fallback may only emit calls when the provider omitted a finish reason or
 /// reported `tool_calls`. Non-tool finish reasons such as `length` and
 /// `content_filter` indicate an incomplete or rejected response, so pending
-/// calls are discarded instead of being executed.
+/// calls are discarded instead of being executed. Malformed streamed argument
+/// JSON is likewise dropped (via the accumulator's strict flush) because this
+/// fallback runs without an explicit final tool-call completion chunk.
 fn take_pending_tool_calls(
-    accumulated_tool_calls: &mut Vec<ToolCall>,
+    accumulated_tool_calls: &mut StreamToolCallAccumulator,
     finish_reason: Option<&str>,
 ) -> Option<LlmStreamEvent> {
     if accumulated_tool_calls.is_empty() {
         return None;
     }
 
-    let calls = std::mem::take(accumulated_tool_calls);
+    // A non-tool finish reason means the response was cut/rejected; drain the
+    // accumulator (so a repeated flush cannot re-emit) but do not execute.
     if !matches!(finish_reason, None | Some("tool_calls")) {
+        let _ = accumulated_tool_calls.take_finalized();
         return None;
     }
 
-    finalize_pending_tool_calls(calls).map(LlmStreamEvent::ToolCalls)
-}
-
-/// Finalizes fallback-flushed tool calls. Unlike the normal `tool_calls` finish
-/// path, this rejects malformed streamed argument JSON instead of converting it
-/// to `{}` because fallback flushing happens without an explicit final tool-call
-/// completion chunk.
-fn finalize_pending_tool_calls(tool_calls: Vec<ToolCall>) -> Option<Vec<ToolCall>> {
-    tool_calls
-        .into_iter()
-        .map(|mut tc| {
-            if let Some(args_str) = tc.arguments.as_str() {
-                tc.arguments = serde_json::from_str(args_str).ok()?;
-            }
-            Some(tc)
-        })
-        .collect()
+    let calls = accumulated_tool_calls.take_pending_strict();
+    if calls.is_empty() {
+        None
+    } else {
+        Some(LlmStreamEvent::ToolCalls(calls))
+    }
 }
 
 /// Processes a single chat-completion stream choice, updating the running
@@ -1027,40 +1007,20 @@ fn finalize_pending_tool_calls(tool_calls: Vec<ToolCall>) -> Option<Vec<ToolCall
 fn process_stream_choice(
     choice: &OpenAiStreamChoice,
     total_tokens: &mut u32,
-    accumulated_tool_calls: &mut Vec<ToolCall>,
+    accumulated_tool_calls: &mut StreamToolCallAccumulator,
     finish_reason: &mut Option<String>,
 ) -> LlmStreamEvent {
-    // Accumulate streamed tool-call fragments.
+    // Accumulate streamed tool-call fragments, keyed by the chunk `index`. The
+    // shared accumulator appends argument fragments in place (EVE-636: amortized
+    // O(total)) and parses the JSON once at finalize.
     if let Some(tool_calls) = &choice.delta.tool_calls {
         for tc in tool_calls {
-            let idx = tc.index as usize;
-            while accumulated_tool_calls.len() <= idx {
-                accumulated_tool_calls.push(ToolCall {
-                    id: String::new(),
-                    name: String::new(),
-                    arguments: json!(""),
-                });
-            }
-
-            if let Some(id) = &tc.id {
-                accumulated_tool_calls[idx].id = id.clone();
-            }
-            if let Some(function) = &tc.function {
-                if let Some(name) = &function.name {
-                    accumulated_tool_calls[idx].name = name.clone();
-                }
-                if let Some(args) = &function.arguments {
-                    // EVE-636: accumulate fragments in place via push_str
-                    // (amortized O(total)) instead of re-copying + re-boxing into
-                    // a Value per delta (O(n^2)). `arguments` is kept as a
-                    // Value::String here and parsed once at finish via
-                    // finalize_tool_calls.
-                    if let serde_json::Value::String(s) = &mut accumulated_tool_calls[idx].arguments
-                    {
-                        s.push_str(args);
-                    }
-                }
-            }
+            accumulated_tool_calls.apply_indexed_delta(
+                tc.index,
+                tc.id.as_deref(),
+                tc.function.as_ref().and_then(|f| f.name.as_deref()),
+                tc.function.as_ref().and_then(|f| f.arguments.as_deref()),
+            );
         }
         return LlmStreamEvent::TextDelta(String::new());
     }
@@ -1081,8 +1041,7 @@ fn process_stream_choice(
         *finish_reason = Some(fr.clone());
 
         if fr == "tool_calls" && !accumulated_tool_calls.is_empty() {
-            let calls = std::mem::take(accumulated_tool_calls);
-            return LlmStreamEvent::ToolCalls(finalize_tool_calls(calls));
+            return LlmStreamEvent::ToolCalls(accumulated_tool_calls.take_finalized());
         }
     }
 
@@ -1096,6 +1055,7 @@ fn process_stream_choice(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_convert_message_preserves_multiple_system_messages() {
@@ -1590,7 +1550,7 @@ mod tests {
     #[test]
     fn test_empty_content_finish_chunk_still_emits_tool_calls() {
         let mut total_tokens = 0u32;
-        let mut acc: Vec<ToolCall> = Vec::new();
+        let mut acc = StreamToolCallAccumulator::new();
         let mut finish_reason: Option<String> = None;
 
         // Chunk 2: tool_calls delta opens the call (id + name).
@@ -1652,7 +1612,7 @@ mod tests {
     #[test]
     fn test_non_empty_content_is_emitted() {
         let mut total_tokens = 0u32;
-        let mut acc: Vec<ToolCall> = Vec::new();
+        let mut acc = StreamToolCallAccumulator::new();
         let mut finish_reason: Option<String> = None;
 
         let e = process_stream_choice(
@@ -1671,7 +1631,7 @@ mod tests {
     #[test]
     fn test_tool_call_arguments_accumulate_across_many_chunks() {
         let mut total_tokens = 0u32;
-        let mut acc: Vec<ToolCall> = Vec::new();
+        let mut acc = StreamToolCallAccumulator::new();
         let mut finish_reason: Option<String> = None;
 
         // Open the call (id + name, empty initial arguments).
@@ -1705,8 +1665,9 @@ mod tests {
             expected.push_str(&frag);
         }
 
-        // Mid-stream: accumulated as a raw string, not yet parsed.
-        assert_eq!(acc[0].arguments.as_str(), Some(expected.as_str()));
+        // Mid-stream the shared accumulator holds the fragments as a raw string
+        // (parsed once at finalize); its own unit tests cover that internal, so
+        // here we assert the observable finish-chunk result concatenates exactly.
 
         // Finish chunk: parsed exactly once into the structured value.
         let e = process_stream_choice(
@@ -1733,7 +1694,7 @@ mod tests {
     #[test]
     fn test_finish_chunk_without_content_emits_tool_calls() {
         let mut total_tokens = 0u32;
-        let mut acc: Vec<ToolCall> = Vec::new();
+        let mut acc = StreamToolCallAccumulator::new();
         let mut finish_reason: Option<String> = None;
 
         process_stream_choice(
@@ -1760,16 +1721,21 @@ mod tests {
         }
     }
 
+    /// Seed a single tool-call slot into an accumulator the way the streamed
+    /// chunks would (id + name + raw argument buffer), so the fallback-flush
+    /// tests exercise the real accumulation path.
+    fn seeded_acc(id: &str, name: &str, arguments: &str) -> StreamToolCallAccumulator {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.apply_indexed_delta(0, Some(id), Some(name), Some(arguments));
+        acc
+    }
+
     /// The [DONE] fallback flushes accumulated-but-unemitted tool calls when no
     /// finish reason was reported and drains the accumulator; once drained it
     /// returns None.
     #[test]
     fn test_take_pending_tool_calls_flushes_then_drains_without_finish_reason() {
-        let mut acc = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "read_file".to_string(),
-            arguments: json!(r#"{"path":"Cargo.toml"}"#),
-        }];
+        let mut acc = seeded_acc("call_1", "read_file", r#"{"path":"Cargo.toml"}"#);
 
         match take_pending_tool_calls(&mut acc, None) {
             Some(LlmStreamEvent::ToolCalls(calls)) => {
@@ -1785,11 +1751,7 @@ mod tests {
 
     #[test]
     fn test_take_pending_tool_calls_discards_non_tool_finish_reason() {
-        let mut acc = vec![ToolCall {
-            id: "call_cut".to_string(),
-            name: "read_file".to_string(),
-            arguments: json!(r#"{"path":"#),
-        }];
+        let mut acc = seeded_acc("call_cut", "read_file", r#"{"path":"#);
 
         assert!(take_pending_tool_calls(&mut acc, Some("length")).is_none());
         assert!(
@@ -1800,11 +1762,7 @@ mod tests {
 
     #[test]
     fn test_take_pending_tool_calls_rejects_malformed_fallback_arguments() {
-        let mut acc = vec![ToolCall {
-            id: "call_cut".to_string(),
-            name: "read_file".to_string(),
-            arguments: json!(r#"{"path":"#),
-        }];
+        let mut acc = seeded_acc("call_cut", "read_file", r#"{"path":"#);
 
         assert!(take_pending_tool_calls(&mut acc, None).is_none());
         assert!(
@@ -1816,7 +1774,7 @@ mod tests {
     #[test]
     fn test_non_tool_finish_reason_leaves_pending_calls_for_done_discard() {
         let mut total_tokens = 0u32;
-        let mut acc: Vec<ToolCall> = Vec::new();
+        let mut acc = StreamToolCallAccumulator::new();
         let mut finish_reason: Option<String> = None;
 
         process_stream_choice(
@@ -1839,17 +1797,6 @@ mod tests {
         assert_eq!(finish_reason.as_deref(), Some("length"));
         assert!(take_pending_tool_calls(&mut acc, finish_reason.as_deref()).is_none());
         assert!(acc.is_empty());
-    }
-
-    #[test]
-    fn test_finalize_tool_calls_parses_arguments() {
-        let calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "read_file".to_string(),
-            arguments: json!(r#"{"path":"src/main.rs"}"#),
-        }];
-        let finalized = finalize_tool_calls(calls);
-        assert_eq!(finalized[0].arguments, json!({"path": "src/main.rs"}));
     }
 
     #[test]

--- a/crates/core/src/stream_accumulator.rs
+++ b/crates/core/src/stream_accumulator.rs
@@ -1,0 +1,267 @@
+// Shared streaming tool-call accumulator (EVE-672)
+//
+// Native streaming drivers assemble tool calls from fragments spread across many
+// SSE chunks: OpenAI Chat Completions keys fragments by a numeric `index`,
+// OpenAI Open Responses keys them by an `item_id` string, and Gemini pushes
+// whole calls. Each driver previously open-coded this into an
+// `Arc<Mutex<Vec<...>>>` with subtly different growth, argument-append, and
+// finalize rules. This module centralizes the accumulation so the rules live in
+// one tested place and the drivers share a single `StreamToolCallAccumulator`.
+//
+// The accumulator keeps arguments as an un-parsed `String` fragment buffer and
+// parses the JSON exactly once at finalize (EVE-636: `push_str` is amortized
+// O(total), versus re-parsing a `Value` per delta which was O(n^2)). It exposes
+// two finalize modes matching the historical driver behavior:
+//
+// - `take_finalized`: normal finish path — malformed argument JSON degrades to
+//   an empty object (`{}`), because the provider signalled a real tool-call
+//   completion.
+// - `take_pending_strict`: fallback flush at `[DONE]`/end-of-stream without a
+//   tool-call finish — malformed argument JSON causes the call to be dropped,
+//   since there was no explicit completion to trust.
+
+use crate::tool_types::ToolCall;
+use serde_json::{Value, json};
+
+/// One in-progress tool call being assembled from streamed fragments.
+#[derive(Debug, Clone)]
+struct PartialToolCall {
+    /// Fragment key: the numeric `index` (Chat Completions) or the stream
+    /// `item_id` (Open Responses). Whole-call providers (Gemini) leave it empty.
+    key: String,
+    /// Provider call id, applied to the finalized [`ToolCall::id`].
+    id: String,
+    /// Function name.
+    name: String,
+    /// Accumulated JSON argument fragments (parsed once at finalize).
+    arguments: String,
+}
+
+/// Accumulates streamed tool-call fragments into finalized [`ToolCall`]s.
+///
+/// Fragments are addressed by a string `key` (the provider's per-call index or
+/// item id). Calls are emitted in first-seen order.
+#[derive(Debug, Default)]
+pub struct StreamToolCallAccumulator {
+    calls: Vec<PartialToolCall>,
+}
+
+impl StreamToolCallAccumulator {
+    /// Create an empty accumulator.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether any fragments have been accumulated.
+    pub fn is_empty(&self) -> bool {
+        self.calls.is_empty()
+    }
+
+    fn slot(&mut self, key: &str) -> &mut PartialToolCall {
+        if let Some(pos) = self.calls.iter().position(|c| c.key == key) {
+            return &mut self.calls[pos];
+        }
+        self.calls.push(PartialToolCall {
+            key: key.to_string(),
+            id: String::new(),
+            name: String::new(),
+            arguments: String::new(),
+        });
+        self.calls.last_mut().expect("just pushed")
+    }
+
+    /// Apply an OpenAI Chat Completions streamed tool-call delta, keyed by the
+    /// chunk's numeric `index`. Any of id/name/arguments may be absent in a
+    /// given delta; argument fragments are appended in place.
+    pub fn apply_indexed_delta(
+        &mut self,
+        index: u32,
+        id: Option<&str>,
+        name: Option<&str>,
+        arguments: Option<&str>,
+    ) {
+        let slot = self.slot(&index.to_string());
+        if let Some(id) = id {
+            slot.id = id.to_string();
+        }
+        if let Some(name) = name {
+            slot.name = name.to_string();
+        }
+        if let Some(args) = arguments {
+            slot.arguments.push_str(args);
+        }
+    }
+
+    /// Append an Open Responses `function_call_arguments.delta` fragment, keyed
+    /// by `item_id`. Creates the slot if the item was not yet announced.
+    pub fn append_arguments(&mut self, item_id: &str, delta: &str) {
+        self.slot(item_id).arguments.push_str(delta);
+    }
+
+    /// Record an Open Responses `output_item.added` function call, keyed by
+    /// `item_id`, setting its name and provider `call_id`.
+    pub fn set_item(&mut self, item_id: &str, call_id: &str, name: &str) {
+        let slot = self.slot(item_id);
+        slot.id = call_id.to_string();
+        slot.name = name.to_string();
+    }
+
+    /// Push a fully-formed tool call (Gemini emits whole `functionCall` parts
+    /// with already-parsed arguments, so there is nothing to reassemble).
+    pub fn push_complete(&mut self, id: String, name: String, arguments: Value) {
+        self.calls.push(PartialToolCall {
+            key: String::new(),
+            id,
+            name,
+            // Store as a compact JSON string so the single finalize path parses
+            // it back identically to the fragment-assembled calls.
+            arguments: arguments.to_string(),
+        });
+    }
+
+    /// Drain all accumulated calls, parsing each argument string once. Malformed
+    /// argument JSON degrades to an empty object — the normal finish path, where
+    /// the provider explicitly signalled tool-call completion.
+    pub fn take_finalized(&mut self) -> Vec<ToolCall> {
+        std::mem::take(&mut self.calls)
+            .into_iter()
+            .map(|c| ToolCall {
+                id: c.id,
+                name: c.name,
+                arguments: parse_arguments(&c.arguments).unwrap_or_else(|| json!({})),
+            })
+            .collect()
+    }
+
+    /// Drain all accumulated calls for a *fallback* flush (end-of-stream without
+    /// an explicit tool-call finish). Malformed argument JSON drops the call
+    /// rather than fabricating an empty object, since no completion was signalled.
+    pub fn take_pending_strict(&mut self) -> Vec<ToolCall> {
+        std::mem::take(&mut self.calls)
+            .into_iter()
+            .filter_map(|c| {
+                Some(ToolCall {
+                    id: c.id,
+                    name: c.name,
+                    arguments: parse_arguments(&c.arguments)?,
+                })
+            })
+            .collect()
+    }
+
+    /// Drain accumulated calls, keeping only those with a non-empty name and
+    /// parsing arguments once (empty/malformed → `{}`). Matches the Open
+    /// Responses finalize path, which skips announced-but-unnamed items.
+    pub fn take_named(&mut self) -> Vec<ToolCall> {
+        std::mem::take(&mut self.calls)
+            .into_iter()
+            .filter(|c| !c.name.is_empty())
+            .map(|c| ToolCall {
+                id: c.id,
+                name: c.name,
+                arguments: parse_arguments(&c.arguments).unwrap_or_else(|| json!({})),
+            })
+            .collect()
+    }
+}
+
+/// Parse an accumulated argument fragment buffer into JSON. An empty buffer is
+/// treated as an empty object; a non-empty buffer that fails to parse returns
+/// `None` so callers can choose their fallback.
+fn parse_arguments(buffer: &str) -> Option<Value> {
+    if buffer.is_empty() {
+        return Some(json!({}));
+    }
+    serde_json::from_str(buffer).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_delta_reassembles_fragmented_arguments() {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.apply_indexed_delta(0, Some("call_a"), Some("get_weather"), Some(""));
+        acc.apply_indexed_delta(0, None, None, Some("{\"city\":"));
+        acc.apply_indexed_delta(0, None, None, Some("\"Paris\"}"));
+
+        let calls = acc.take_finalized();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_a");
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Paris"}));
+        assert!(acc.is_empty());
+    }
+
+    #[test]
+    fn indexed_delta_grows_to_index_and_preserves_order() {
+        let mut acc = StreamToolCallAccumulator::new();
+        // Deltas can arrive for index 1 before index 0 has all fields, but the
+        // first-seen order is preserved.
+        acc.apply_indexed_delta(0, Some("c0"), Some("first"), Some("{}"));
+        acc.apply_indexed_delta(1, Some("c1"), Some("second"), Some("{}"));
+        let calls = acc.take_finalized();
+        assert_eq!(calls[0].name, "first");
+        assert_eq!(calls[1].name, "second");
+    }
+
+    #[test]
+    fn empty_arguments_finalize_to_empty_object() {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.apply_indexed_delta(0, Some("c"), Some("noop"), None);
+        let calls = acc.take_finalized();
+        assert_eq!(calls[0].arguments, json!({}));
+    }
+
+    #[test]
+    fn take_finalized_degrades_malformed_json_to_empty_object() {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.apply_indexed_delta(0, Some("c"), Some("bad"), Some("{not json"));
+        let calls = acc.take_finalized();
+        assert_eq!(calls[0].arguments, json!({}));
+    }
+
+    #[test]
+    fn take_pending_strict_drops_malformed_json() {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.apply_indexed_delta(0, Some("c"), Some("bad"), Some("{not json"));
+        acc.apply_indexed_delta(1, Some("d"), Some("good"), Some("{\"ok\":true}"));
+        let calls = acc.take_pending_strict();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "good");
+    }
+
+    #[test]
+    fn item_keyed_flow_matches_open_responses() {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.set_item("fc_1", "call_1", "get_weather");
+        acc.append_arguments("fc_1", "{\"city\":");
+        acc.append_arguments("fc_1", "\"Paris\"}");
+        let calls = acc.take_named();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].arguments, json!({"city": "Paris"}));
+    }
+
+    #[test]
+    fn take_named_skips_unnamed_items() {
+        let mut acc = StreamToolCallAccumulator::new();
+        // An arguments delta arrived before the item was announced with a name.
+        acc.append_arguments("fc_orphan", "{}");
+        acc.set_item("fc_1", "call_1", "named");
+        acc.append_arguments("fc_1", "{}");
+        let calls = acc.take_named();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "named");
+    }
+
+    #[test]
+    fn push_complete_serializes_and_reparses_identically() {
+        let mut acc = StreamToolCallAccumulator::new();
+        acc.push_complete("call_0".into(), "f".into(), json!({"a": 1, "b": "x"}));
+        let calls = acc.take_finalized();
+        assert_eq!(calls[0].arguments, json!({"a": 1, "b": "x"}));
+    }
+}

--- a/crates/core/tests/openai_protocol_wire.rs
+++ b/crates/core/tests/openai_protocol_wire.rs
@@ -1,0 +1,258 @@
+// Golden-event wire tests for the OpenAI Chat Completions protocol driver
+// (`OpenAIProtocolChatDriver`) — EVE-672.
+//
+// This driver backs Fireworks and Microsoft MAI, and its streamed tool-call
+// accumulation is the target of the shared `StreamAccumulator` unification. The
+// fixtures below pin the exact `LlmStreamEvent` sequence for text streaming,
+// for tool calls whose arguments arrive fragmented across chunks, and for the
+// EVE-522 edge case where an empty `content: ""` delta rides along with a
+// `finish_reason: "tool_calls"` chunk. Refactors under these tests must keep the
+// golden output byte-identical.
+
+use everruns_core::OpenAIProtocolChatDriver;
+use everruns_core::driver_registry::{
+    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent,
+};
+use futures::StreamExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn config(model: &str) -> LlmCallConfig {
+    LlmCallConfig {
+        model: model.to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Golden {
+    Text(String),
+    ToolCall {
+        name: String,
+        args: String,
+    },
+    Done {
+        total: Option<u32>,
+        prompt: Option<u32>,
+        completion: Option<u32>,
+        cache_read: Option<u32>,
+        finish: Option<String>,
+    },
+    Error(String),
+}
+
+fn golden(event: LlmStreamEvent) -> Golden {
+    match event {
+        LlmStreamEvent::TextDelta(t) => Golden::Text(t),
+        LlmStreamEvent::ToolCalls(calls) => {
+            let tc = &calls[0];
+            Golden::ToolCall {
+                name: tc.name.clone(),
+                args: tc.arguments.to_string(),
+            }
+        }
+        LlmStreamEvent::Done(meta) => {
+            let LlmCompletionMetadata {
+                total_tokens,
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                finish_reason,
+                ..
+            } = *meta;
+            Golden::Done {
+                total: total_tokens,
+                prompt: prompt_tokens,
+                completion: completion_tokens,
+                cache_read: cache_read_tokens,
+                finish: finish_reason,
+            }
+        }
+        LlmStreamEvent::Error(e) => Golden::Error(e),
+        other => panic!("unexpected event variant in golden capture: {other:?}"),
+    }
+}
+
+/// Drain a stream into its golden-event sequence, dropping the empty text
+/// deltas the driver emits as internal filler between meaningful events.
+async fn drain_golden(mut stream: LlmResponseStream) -> Vec<Golden> {
+    let mut out = Vec::new();
+    while let Some(item) = stream.next().await {
+        let g = golden(item.expect("stream item should not be a transport error"));
+        if matches!(&g, Golden::Text(t) if t.is_empty()) {
+            continue;
+        }
+        out.push(g);
+    }
+    out
+}
+
+async fn mount_sse(server: &MockServer, body: String) {
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(server)
+        .await;
+}
+
+fn driver(server: &MockServer) -> OpenAIProtocolChatDriver {
+    OpenAIProtocolChatDriver::with_base_url(
+        "test-key",
+        format!("{}/v1/chat/completions", server.uri()),
+    )
+}
+
+/// Text streaming: two content deltas, a `stop` finish chunk, then the usage
+/// chunk and `[DONE]`. The golden sequence is the two text deltas plus a single
+/// `Done` with the disjoint token buckets (OpenAI's prompt count is
+/// cache-inclusive; the driver subtracts cached reads).
+#[tokio::test]
+async fn text_stream_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":", world"},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12,"prompt_tokens_details":{"cached_tokens":4}}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("gpt-4o"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::Text("Hello".into()),
+            Golden::Text(", world".into()),
+            Golden::Done {
+                total: Some(12), // prompt(10) + completion(2)
+                prompt: Some(6), // 10 - 4 cached
+                completion: Some(2),
+                cache_read: Some(4),
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}
+
+/// Tool-call streaming where the function name and JSON arguments arrive
+/// fragmented across three chunks, terminated by a `finish_reason: "tool_calls"`
+/// chunk. The accumulator must reassemble the fragments into one parsed call and
+/// emit a single `ToolCalls` event at the finish, followed by `Done`.
+#[tokio::test]
+async fn fragmented_tool_call_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Paris\"}"}}]},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-2","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":8,"total_tokens":23}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "weather?")],
+            &config("gpt-4o"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::ToolCall {
+                name: "get_weather".into(),
+                args: r#"{"city":"Paris"}"#.into(),
+            },
+            Golden::Done {
+                total: Some(23),
+                prompt: Some(15),
+                completion: Some(8),
+                cache_read: None,
+                finish: Some("tool_calls".into()),
+            },
+        ]
+    );
+}
+
+/// EVE-522 edge case: some OpenAI-compatible gateways send an empty
+/// `content: ""` delta in the *same* chunk that carries
+/// `finish_reason: "tool_calls"`. The empty content must not short-circuit the
+/// finish handler, so the accumulated call is still flushed exactly once.
+#[tokio::test]
+async fn empty_content_with_tool_calls_finish_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"id":"chatcmpl-3","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","function":{"name":"ping","arguments":"{}"}}]},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-3","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}]}"#,
+        "",
+        r#"data: {"id":"chatcmpl-3","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "ping")],
+            &config("gpt-4o"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::ToolCall {
+                name: "ping".into(),
+                args: "{}".into(),
+            },
+            Golden::Done {
+                total: Some(10),
+                prompt: Some(9),
+                completion: Some(1),
+                cache_read: None,
+                finish: Some("tool_calls".into()),
+            },
+        ]
+    );
+}

--- a/crates/core/tests/openresponses_protocol_wire.rs
+++ b/crates/core/tests/openresponses_protocol_wire.rs
@@ -1,0 +1,209 @@
+// Golden-event wire tests for the Open Responses protocol driver
+// (`OpenResponsesProtocolChatDriver`) — EVE-672.
+//
+// This driver backs the OpenAI (Responses API) and OpenRouter providers. The
+// fixtures below pin the exact `LlmStreamEvent` sequence for text streaming and
+// for a fragmented function call terminated by `response.output_item.done` and
+// `response.completed`. They give the shared streaming refactor a golden
+// contract to preserve.
+//
+// The SSE frames use the provider's `type`-tagged JSON events (the same shape
+// exercised by the OpenRouter wire tests), so the fixtures stay readable while
+// still driving the driver's real stream-conversion path end to end.
+
+use everruns_core::OpenResponsesProtocolChatDriver;
+use everruns_core::driver_registry::{
+    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent,
+};
+use futures::StreamExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn config(model: &str) -> LlmCallConfig {
+    LlmCallConfig {
+        model: model.to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Golden {
+    Text(String),
+    ToolCall {
+        name: String,
+        args: String,
+    },
+    Done {
+        total: Option<u32>,
+        prompt: Option<u32>,
+        completion: Option<u32>,
+        cache_read: Option<u32>,
+        finish: Option<String>,
+    },
+    Error(String),
+}
+
+fn golden(event: LlmStreamEvent) -> Golden {
+    match event {
+        LlmStreamEvent::TextDelta(t) => Golden::Text(t),
+        LlmStreamEvent::ToolCalls(calls) => {
+            let tc = &calls[0];
+            Golden::ToolCall {
+                name: tc.name.clone(),
+                args: tc.arguments.to_string(),
+            }
+        }
+        LlmStreamEvent::Done(meta) => {
+            let LlmCompletionMetadata {
+                total_tokens,
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                finish_reason,
+                ..
+            } = *meta;
+            Golden::Done {
+                total: total_tokens,
+                prompt: prompt_tokens,
+                completion: completion_tokens,
+                cache_read: cache_read_tokens,
+                finish: finish_reason,
+            }
+        }
+        LlmStreamEvent::Error(e) => Golden::Error(e),
+        other => panic!("unexpected event variant in golden capture: {other:?}"),
+    }
+}
+
+async fn drain_golden(mut stream: LlmResponseStream) -> Vec<Golden> {
+    let mut out = Vec::new();
+    while let Some(item) = stream.next().await {
+        let g = golden(item.expect("stream item should not be a transport error"));
+        if matches!(&g, Golden::Text(t) if t.is_empty()) {
+            continue;
+        }
+        out.push(g);
+    }
+    out
+}
+
+async fn mount_sse(server: &MockServer, body: String) {
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(server)
+        .await;
+}
+
+fn driver(server: &MockServer) -> OpenResponsesProtocolChatDriver {
+    OpenResponsesProtocolChatDriver::with_base_url(
+        "test-key",
+        format!("{}/v1/responses", server.uri()),
+    )
+}
+
+/// Text streaming: two output-text deltas then a `response.completed` carrying
+/// usage. The golden output is the two text deltas plus a single `Done` with the
+/// disjoint token buckets (the driver subtracts the cached-read subset from the
+/// cache-inclusive input count).
+#[tokio::test]
+async fn text_stream_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"type":"response.output_text.delta","delta":"Hello"}"#,
+        "",
+        r#"data: {"type":"response.output_text.delta","delta":", world"}"#,
+        "",
+        r#"data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":2,"input_tokens_details":{"cached_tokens":4}}}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("gpt-5-mini"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::Text("Hello".into()),
+            Golden::Text(", world".into()),
+            Golden::Done {
+                total: Some(12), // input(10) + output(2)
+                prompt: Some(6), // 10 - 4 cached
+                completion: Some(2),
+                cache_read: Some(4),
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}
+
+/// Function call: an `output_item.added` announces the call, arguments arrive
+/// fragmented via `function_call_arguments.delta`, `output_item.done` flushes
+/// the assembled `ToolCalls` event, and `response.completed` closes with a
+/// `tool_calls` finish reason.
+#[tokio::test]
+async fn fragmented_function_call_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"get_weather"}}"#,
+        "",
+        r#"data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"city\":"}"#,
+        "",
+        r#"data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"\"Paris\"}"}"#,
+        "",
+        r#"data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"get_weather"}}"#,
+        "",
+        r#"data: {"type":"response.completed","response":{"id":"resp_2","status":"completed","output":[],"usage":{"input_tokens":15,"output_tokens":8}}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "weather?")],
+            &config("gpt-5-mini"),
+        )
+        .await
+        .expect("stream should start");
+
+    assert_eq!(
+        drain_golden(stream).await,
+        vec![
+            Golden::ToolCall {
+                name: "get_weather".into(),
+                args: r#"{"city":"Paris"}"#.into(),
+            },
+            Golden::Done {
+                total: Some(23),
+                prompt: Some(15),
+                completion: Some(8),
+                cache_read: None,
+                finish: Some("tool_calls".into()),
+            },
+        ]
+    );
+}

--- a/crates/fireworks/src/driver.rs
+++ b/crates/fireworks/src/driver.rs
@@ -531,8 +531,10 @@ mod tests {
         let descriptor = registry.descriptor(&DriverId::Fireworks).unwrap();
         assert_eq!(descriptor.services, vec![ServiceKind::Chat]);
         assert_eq!(descriptor.display_name, "Fireworks AI");
-        // Credential schema: required api_key + optional base_url.
-        assert_eq!(descriptor.credential_schema.fields.len(), 2);
+        // Credential schema: a single required api_key. The endpoint override is
+        // the provider's first-class `base_url`, not a credential field (see
+        // `fireworks_credential_schema`), so the schema has exactly one field.
+        assert_eq!(descriptor.credential_schema.fields.len(), 1);
         assert_eq!(descriptor.credential_schema.fields[0].name, "api_key");
         assert!(descriptor.credential_schema.fields[0].required);
 

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -43,3 +43,6 @@ everruns-core = { path = "../core", version = "0.17.1", default-features = false
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
+# wiremock serves the golden streaming SSE fixtures; futures drains the stream.
+wiremock = "0.6"
+futures.workspace = true

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -32,6 +32,7 @@ use everruns_core::is_provider_quota_message;
 use everruns_core::llm_retry::{
     LlmRetryConfig, RetryDecision, SendOutcome, retry_request, send_error_message,
 };
+use everruns_core::stream_accumulator::StreamToolCallAccumulator;
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -424,7 +425,7 @@ impl ChatDriver for GeminiChatDriver {
         let prompt_tokens = Arc::new(Mutex::new(0u32));
         let completion_tokens = Arc::new(Mutex::new(0u32));
         let cached_tokens = Arc::new(Mutex::new(Option::<u32>::None));
-        let accumulated_tool_calls = Arc::new(Mutex::new(Vec::<ToolCall>::new()));
+        let accumulated_tool_calls = Arc::new(Mutex::new(StreamToolCallAccumulator::new()));
         let tool_call_counter = Arc::new(Mutex::new(0u32));
         let shared_retry_metadata = if retry_metadata.had_retries() {
             Some(Arc::new(retry_metadata))
@@ -560,13 +561,11 @@ impl ChatDriver for GeminiChatDriver {
                                                         accumulated_tool_calls
                                                             .lock()
                                                             .unwrap()
-                                                            .push(ToolCall {
-                                                                id: call_id,
-                                                                name: function_call.name.clone(),
-                                                                arguments: function_call
-                                                                    .args
-                                                                    .clone(),
-                                                            });
+                                                            .push_complete(
+                                                                call_id,
+                                                                function_call.name.clone(),
+                                                                function_call.args.clone(),
+                                                            );
                                                     }
                                                     _ => {}
                                                 }
@@ -577,9 +576,10 @@ impl ChatDriver for GeminiChatDriver {
                                         if let Some(reason) = &candidate.finish_reason
                                             && (reason == "STOP" || reason == "MAX_TOKENS")
                                         {
-                                            let tool_calls: Vec<ToolCall> = std::mem::take(
-                                                &mut *accumulated_tool_calls.lock().unwrap(),
-                                            );
+                                            let tool_calls: Vec<ToolCall> = accumulated_tool_calls
+                                                .lock()
+                                                .unwrap()
+                                                .take_finalized();
                                             if !tool_calls.is_empty() {
                                                 let result =
                                                     Ok(LlmStreamEvent::ToolCalls(tool_calls));
@@ -689,7 +689,7 @@ impl ChatDriver for GeminiChatDriver {
                         None => {
                             // Stream ended - emit Done if we haven't already
                             let tool_calls: Vec<ToolCall> =
-                                std::mem::take(&mut *accumulated_tool_calls.lock().unwrap());
+                                accumulated_tool_calls.lock().unwrap().take_finalized();
                             if !tool_calls.is_empty() {
                                 let result = Ok(LlmStreamEvent::ToolCalls(tool_calls));
                                 return Some((

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -1,0 +1,245 @@
+// Golden-event wire tests for the Gemini streaming driver (EVE-672).
+//
+// These pin the exact `LlmStreamEvent` sequence the Gemini driver emits for a
+// captured `streamGenerateContent` SSE response. They exist so the shared
+// streaming refactor (EVE-672) can prove the driver's output is unchanged:
+// change the conversion internals and these fixtures must still produce the
+// same golden events.
+//
+// The driver talks to a wiremock server over its `base_url`, so no live Gemini
+// credentials are needed. Gemini streams `data: {json}` SSE frames and ends the
+// stream by closing the connection (no `[DONE]` marker), which the driver's
+// finish handling collapses into a single terminal `Done` event.
+
+use everruns_core::driver_registry::{
+    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent,
+};
+use everruns_gemini::GeminiChatDriver;
+use futures::StreamExt;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn config(model: &str) -> LlmCallConfig {
+    LlmCallConfig {
+        model: model.to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+    }
+}
+
+/// Normalized, comparable form of an `LlmStreamEvent` for golden assertions.
+/// Only the fields the driver populates deterministically are captured (usage
+/// counts, finish reason, tool-call name/args), so the golden sequence is a
+/// stable contract independent of `retry_metadata`/timing.
+#[derive(Debug, PartialEq)]
+enum Golden {
+    Text(String),
+    ToolCall {
+        name: String,
+        args: String,
+    },
+    Done {
+        total: Option<u32>,
+        prompt: Option<u32>,
+        completion: Option<u32>,
+        cache_read: Option<u32>,
+        finish: Option<String>,
+    },
+    Error(String),
+}
+
+fn golden(event: LlmStreamEvent) -> Golden {
+    match event {
+        LlmStreamEvent::TextDelta(t) => Golden::Text(t),
+        LlmStreamEvent::ToolCalls(calls) => {
+            let tc = &calls[0];
+            Golden::ToolCall {
+                name: tc.name.clone(),
+                args: tc.arguments.to_string(),
+            }
+        }
+        LlmStreamEvent::Done(meta) => {
+            let LlmCompletionMetadata {
+                total_tokens,
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                finish_reason,
+                ..
+            } = *meta;
+            Golden::Done {
+                total: total_tokens,
+                prompt: prompt_tokens,
+                completion: completion_tokens,
+                cache_read: cache_read_tokens,
+                finish: finish_reason,
+            }
+        }
+        LlmStreamEvent::Error(e) => Golden::Error(e),
+        other => panic!("unexpected event variant in golden capture: {other:?}"),
+    }
+}
+
+/// Drain a stream into its golden-event sequence, dropping the empty text
+/// deltas the driver emits as no-op filler between meaningful events (these are
+/// an internal artifact, not part of the observable contract).
+async fn drain_golden(mut stream: LlmResponseStream) -> Vec<Golden> {
+    let mut out = Vec::new();
+    while let Some(item) = stream.next().await {
+        let event = item.expect("stream item should not be a transport error");
+        let g = golden(event);
+        if matches!(&g, Golden::Text(t) if t.is_empty()) {
+            continue;
+        }
+        out.push(g);
+    }
+    out
+}
+
+async fn mount_sse(server: &MockServer, body: String) {
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/models/.+:streamGenerateContent$"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(server)
+        .await;
+}
+
+/// A text-only completion: two content deltas, a STOP finish, and usage. The
+/// golden sequence is the two text deltas followed by a single `Done` carrying
+/// the disjoint token buckets (Gemini's promptTokenCount is cache-inclusive, so
+/// the driver subtracts the cached count).
+#[tokio::test]
+async fn text_stream_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[{"text":", world"}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":4,"cachedContentTokenCount":3}}"#,
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let driver = GeminiChatDriver::with_base_url("test-key", server.uri());
+    let stream = driver
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("gemini-2.5-flash"),
+        )
+        .await
+        .expect("gemini stream should start");
+
+    let events = drain_golden(stream).await;
+    assert_eq!(
+        events,
+        vec![
+            Golden::Text("Hello".into()),
+            Golden::Text(", world".into()),
+            Golden::Done {
+                total: Some(16), // prompt(12) + completion(4)
+                prompt: Some(9), // 12 - 3 cached (disjoint convention)
+                completion: Some(4),
+                cache_read: Some(3),
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}
+
+/// A function-call completion: the driver accumulates the `functionCall` part
+/// and, at the STOP finish, emits a single `ToolCalls` event (with a synthetic
+/// `call_0` id). It drains the accumulator there but does not mark the stream
+/// done, so the subsequent end-of-stream emits a terminal `Done` carrying the
+/// usage. This `[ToolCalls, Done]` shape is the driver's current contract and
+/// what the shared refactor must preserve.
+#[tokio::test]
+async fn function_call_stream_golden_events() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"Paris"}}}]}}]}"#,
+        "",
+        r#"data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":6}}"#,
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let driver = GeminiChatDriver::with_base_url("test-key", server.uri());
+    let stream = driver
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "weather?")],
+            &config("gemini-2.5-flash"),
+        )
+        .await
+        .expect("gemini stream should start");
+
+    let events = drain_golden(stream).await;
+    assert_eq!(
+        events,
+        vec![
+            Golden::ToolCall {
+                name: "get_weather".into(),
+                args: r#"{"city":"Paris"}"#.into(),
+            },
+            Golden::Done {
+                total: Some(26), // prompt(20) + completion(6)
+                prompt: Some(20),
+                completion: Some(6),
+                cache_read: None,
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}
+
+/// When the provider closes the stream without any finish chunk, the driver
+/// still emits a terminal `Done` (end-of-stream fallback), defaulting the
+/// finish reason to "stop".
+#[tokio::test]
+async fn eos_without_finish_reason_emits_done() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"candidates":[{"content":{"parts":[{"text":"partial"}]}}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":1}}"#,
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let driver = GeminiChatDriver::with_base_url("test-key", server.uri());
+    let stream = driver
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("gemini-2.5-flash"),
+        )
+        .await
+        .expect("gemini stream should start");
+
+    let events = drain_golden(stream).await;
+    assert_eq!(
+        events,
+        vec![
+            Golden::Text("partial".into()),
+            Golden::Done {
+                total: Some(6),
+                prompt: Some(5),
+                completion: Some(1),
+                cache_read: None,
+                finish: Some("stop".into()),
+            },
+        ]
+    );
+}


### PR DESCRIPTION
## What
Follow-up to EVE-647 (#2504). Adds a golden-event streaming test harness for the provider drivers, then unifies the OpenAI Chat Completions and Gemini streamed tool-call accumulators onto one shared type. Also fixes a pre-existing Fireworks test failure unrelated to EVE-647. Closes EVE-672.

## Why
The streaming concerns in EVE-647 were deferred because the repo had no driver-level streaming mock/golden-event harness, so byte-identical output could not be proven by test and refactoring blind risked regressing core LLM streaming. This PR builds that harness first, then does the accumulator unification under it.

## How
- Golden-event harness: wiremock SSE fixtures pin the exact `LlmStreamEvent` sequence per driver family — Gemini, OpenAI Chat Completions (`openai_protocol`, backs Fireworks/MAI), Open Responses (`openresponses_protocol`, backs OpenAI/OpenRouter), and Anthropic. Cases cover text, fragmented tool-call argument reassembly, extended thinking + signature (Anthropic), the EVE-522 empty-content+`tool_calls`-finish edge, and end-of-stream without a finish chunk (Gemini). Events are normalized to a stable `Golden` form (usage buckets, finish reason, tool name/args) so the sequences are a durable contract independent of retry/timing metadata.
- Shared accumulator: `core::stream_accumulator::StreamToolCallAccumulator` assembles streamed tool-call fragments (index-keyed for Chat Completions, item-id-keyed for Open Responses, whole-call push for Gemini), keeps arguments as a raw fragment buffer, and parses the JSON exactly once at finalize (EVE-636). It exposes finalize modes matching prior driver behavior: `take_finalized` (malformed args → `{}`), `take_pending_strict` (fallback flush drops malformed args), `take_named` (skip unnamed items).
- Migrated the OpenAI Chat Completions and Gemini drivers off their ad-hoc `Arc<Mutex<Vec<ToolCall>>>` accumulators onto the shared type; the golden tests prove the observable output is unchanged.
- Fixed `register_driver_registers_fireworks`, which asserted a 2-field credential schema; the schema has one field (`api_key`) because `base_url` is the provider's first-class field, not a credential field.

## Risk
- Low. Test additions plus an internal refactor proven byte-identical by new golden tests. No wire-format, auth, or request-shape changes.

## Security
- Threat categories reviewed: TM-LLM (streaming/tool-call parsing). The accumulator parses provider-supplied JSON arguments with the same fallback rules as before; no change to prompt construction, API-key handling, model parameters, or any trust boundary. No auth/authz/SQL/FS/network changes.
- Findings and resolutions: none. New dev-deps (`wiremock`, `futures`) are test-only and already used elsewhere in the workspace; no version churn.

## Follow-ups
- Migrate the Open Responses driver onto the shared `StreamToolCallAccumulator`. Deferred because its `output_item.done` handler currently reads without draining, so a drop-in swap to the draining shared finalize would change multi-`output_item.done` semantics that no test presently pins — needs a golden fixture for that case first.
- EVE-672 criterion 4 (highest risk): swap Gemini to `eventsource-stream` and decompose its ~600-line `chat_completion_stream` into `build_request`/`send_with_retry`/`convert_stream`. Deferred to keep this PR clean and bounded; the golden harness added here now makes that rewrite provable/safe as a standalone change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal refactor; output unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_015UN8F2ke76NFJLE2jH6VPm)_