### PR TITLE
feat(ui): keyboard turn stepping for chat transcript

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -87,6 +87,7 @@ jest.mock("@/hooks", () => ({
     visibleAnchorIds: [],
     scrollToAnchor: jest.fn(),
   }),
+  useTurnKeyboardNavigation: () => undefined,
   useImageDropZone: () => ({
     isDraggingOver: false,
     dropZoneProps: {

--- a/apps/ui/src/__tests__/use-turn-keyboard-navigation.test.ts
+++ b/apps/ui/src/__tests__/use-turn-keyboard-navigation.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from "@testing-library/react";
+import { useTurnKeyboardNavigation } from "@/hooks/use-turn-keyboard-navigation";
+
+const IDS = ["a", "b", "c", "d"];
+
+function press(key: string, init: KeyboardEventInit = {}, target?: EventTarget) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init });
+  (target ?? document).dispatchEvent(event);
+  return event;
+}
+
+describe("useTurnKeyboardNavigation", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("steps to the next turn on Alt+ArrowDown from the reading anchor", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "b", onNavigate }),
+    );
+
+    const event = press("ArrowDown", { altKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith("c");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("steps to the previous turn on Alt+ArrowUp", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "c", onNavigate }),
+    );
+
+    press("ArrowUp", { altKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith("b");
+  });
+
+  it("advances monotonically on rapid presses without waiting for currentAnchorId", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "a", onNavigate }),
+    );
+
+    press("ArrowDown", { altKey: true });
+    press("ArrowDown", { altKey: true });
+
+    expect(onNavigate.mock.calls.map((call) => call[0])).toEqual(["b", "c"]);
+  });
+
+  it("clamps at the last turn and does not navigate past it", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "d", onNavigate }),
+    );
+
+    const event = press("ArrowDown", { altKey: true });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    // Still swallowed so it doesn't scroll the page.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("supports bare j/k when focus is not in an editable field", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "b", onNavigate }),
+    );
+
+    press("j");
+    expect(onNavigate).toHaveBeenLastCalledWith("c");
+    press("k");
+    expect(onNavigate).toHaveBeenLastCalledWith("b");
+  });
+
+  it("ignores bare j/k while typing in an input", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "b", onNavigate }),
+    );
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    press("j", {}, input);
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("still allows Alt+Arrow while focus is in an input", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: IDS, currentAnchorId: "b", onNavigate }),
+    );
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    press("ArrowDown", { altKey: true }, textarea);
+
+    expect(onNavigate).toHaveBeenCalledWith("c");
+  });
+
+  it("does nothing when there are no anchors", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({ anchorIds: [], currentAnchorId: null, onNavigate }),
+    );
+
+    press("ArrowDown", { altKey: true });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not bind listeners when disabled", () => {
+    const onNavigate = jest.fn();
+    renderHook(() =>
+      useTurnKeyboardNavigation({
+        anchorIds: IDS,
+        currentAnchorId: "b",
+        onNavigate,
+        enabled: false,
+      }),
+    );
+
+    press("ArrowDown", { altKey: true });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/app/dev/_components/dev-chat-nav-rail-preview.tsx
+++ b/apps/ui/src/app/dev/_components/dev-chat-nav-rail-preview.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useRef } from "react";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatNavRail, type ChatNavAnchor } from "@/components/chat/chat-nav-rail";
-import { useMessageScrollerVisibility } from "@/hooks";
+import { useMessageScrollerVisibility, useTurnKeyboardNavigation } from "@/hooks";
 import type { Event, InputMessageData, OutputMessageCompletedData } from "@/lib/api/types";
 import { getEventData, getTextFromContent } from "@/lib/api/types";
 
@@ -107,6 +107,13 @@ export function DevChatNavRailPreview() {
     scrollContainerRef,
     navAnchors.length,
   );
+
+  const navAnchorIds = useMemo(() => navAnchors.map((anchor) => anchor.id), [navAnchors]);
+  useTurnKeyboardNavigation({
+    anchorIds: navAnchorIds,
+    currentAnchorId,
+    onNavigate: scrollToAnchor,
+  });
 
   return (
     <div className="overflow-hidden border border-border/70 bg-background">

--- a/apps/ui/src/components/chat/chat-nav-rail.tsx
+++ b/apps/ui/src/components/chat/chat-nav-rail.tsx
@@ -34,6 +34,7 @@ export function ChatNavRail({ anchors, currentAnchorId, onJump }: ChatNavRailPro
   return (
     <nav
       aria-label={t("conversation_turns")}
+      aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
       // Offset from the right edge so markers clear the transcript scrollbar.
       className="pointer-events-none absolute inset-y-0 right-0 z-10 hidden flex-col items-end justify-center overflow-y-auto py-6 pr-3 md:flex"
     >

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -13,6 +13,7 @@ import {
   useModels,
   useScrollManager,
   useSessionCommands,
+  useTurnKeyboardNavigation,
 } from "@/hooks";
 import { useChatModelSelection } from "@/hooks/use-chat-model-selection";
 import { executeSessionCommand } from "@/lib/api/commands";
@@ -201,6 +202,15 @@ export function ChatPanel() {
     scrollContainerRef,
     navAnchors.length,
   );
+
+  // Keyboard turn stepping (Alt+↑/↓, or j/k outside inputs), built on the same
+  // anchors and scrollToAnchor the rail uses.
+  const navAnchorIds = useMemo(() => navAnchors.map((anchor) => anchor.id), [navAnchors]);
+  useTurnKeyboardNavigation({
+    anchorIds: navAnchorIds,
+    currentAnchorId,
+    onNavigate: scrollToAnchor,
+  });
 
   const { isDraggingOver, dropZoneProps, handlePaste } = useImageDropZone({
     onImageFiles: addFiles,

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -20,6 +20,7 @@ export * from "./use-notifications";
 export * from "./use-mount-effect";
 export * from "./use-scroll-manager";
 export * from "./use-message-scroller-visibility";
+export * from "./use-turn-keyboard-navigation";
 export * from "./use-image-drop-zone";
 export * from "./use-chat-model-selection";
 export * from "./use-agent-identities";

--- a/apps/ui/src/hooks/use-turn-keyboard-navigation.ts
+++ b/apps/ui/src/hooks/use-turn-keyboard-navigation.ts
@@ -1,0 +1,105 @@
+// Keyboard turn stepping for the chat transcript.
+//
+// Builds on the navigation rail's `scrollToAnchor`: Alt+↑/↓ steps to the
+// previous/next turn (works even while typing in the composer, since Alt+Arrow
+// is not a text-editing shortcut), and bare j/k do the same when focus is not
+// in an editable field.
+//
+// Decisions:
+// - Stepping is driven by an explicit index ref that advances one turn per
+//   keypress, so rapid presses and end-of-list jumps stay monotonic instead of
+//   reading a not-yet-settled `currentAnchorId`.
+// - The index re-syncs to `currentAnchorId` (the turn under the reading line)
+//   whenever the user scrolls, except for a short window after our own jump —
+//   otherwise the jump's own scroll would reset the index we just advanced.
+
+import { useEffect, useRef } from "react";
+
+// After a keyboard jump, ignore the resulting `currentAnchorId` change for this
+// long so smooth-scroll intermediates and unreachable end-of-list turns don't
+// reset the index we just advanced.
+const SELF_NAV_SUPPRESS_MS = 500;
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+}
+
+interface UseTurnKeyboardNavigationOptions {
+  /** Turn anchor ids in document order. */
+  anchorIds: string[];
+  /** Turn currently under the reading line (from the visibility hook). */
+  currentAnchorId: string | null;
+  /** Jump to a turn — typically the rail's `scrollToAnchor`. */
+  onNavigate: (id: string) => void;
+  enabled?: boolean;
+}
+
+export function useTurnKeyboardNavigation({
+  anchorIds,
+  currentAnchorId,
+  onNavigate,
+  enabled = true,
+}: UseTurnKeyboardNavigationOptions) {
+  const anchorIdsRef = useRef(anchorIds);
+  anchorIdsRef.current = anchorIds;
+  const onNavigateRef = useRef(onNavigate);
+  onNavigateRef.current = onNavigate;
+
+  // Index we treat as active for stepping. Advanced directly on each keypress.
+  const activeIndexRef = useRef(-1);
+  // Timestamp until which `currentAnchorId` echoes from our own jump are ignored.
+  const suppressUntilRef = useRef(0);
+
+  // Follow the reading anchor while the user scrolls, but not right after our
+  // own jump (whose scroll would otherwise clobber the advanced index).
+  useEffect(() => {
+    if (Date.now() < suppressUntilRef.current) return;
+    activeIndexRef.current = currentAnchorId ? anchorIdsRef.current.indexOf(currentAnchorId) : -1;
+  }, [currentAnchorId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const editable = isEditableTarget(event.target);
+      const altStep =
+        event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        (event.key === "ArrowDown" || event.key === "ArrowUp");
+      const vimStep =
+        !editable &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        (event.key === "j" || event.key === "k");
+      if (!altStep && !vimStep) return;
+
+      const ids = anchorIdsRef.current;
+      if (ids.length === 0) return;
+
+      const direction = event.key === "ArrowDown" || event.key === "j" ? 1 : -1;
+      const base = activeIndexRef.current;
+      const nextIndex =
+        base < 0
+          ? direction > 0
+            ? 0
+            : ids.length - 1
+          : Math.min(Math.max(base + direction, 0), ids.length - 1);
+
+      // Recognized shortcut: swallow it so Alt+Arrow / j/k don't also scroll
+      // the page or type into a focused control outside the composer.
+      event.preventDefault();
+      if (nextIndex === base) return;
+
+      activeIndexRef.current = nextIndex;
+      suppressUntilRef.current = Date.now() + SELF_NAV_SUPPRESS_MS;
+      onNavigateRef.current(ids[nextIndex]);
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [enabled]);
+}


### PR DESCRIPTION
## What
Follow-up to the turn navigation rail (#2542). Adds keyboard shortcuts to step between turns:
- **Alt+↓ / Alt+↑** → next / previous turn. Works even while the composer is focused (Alt+Arrow isn't a text-editing shortcut).
- **j / k** → same, but only when focus is not in an input, textarea, select, or contenteditable.

## Why
The rail is mouse-driven and desktop-only. Keyboard stepping makes turn navigation reachable without leaving the keyboard — useful for reviewing long agent transcripts while reading or composing. It was listed as a deferred follow-up on the rail PR.

## How
- **`useTurnKeyboardNavigation`** — a document-level `keydown` handler built on the rail's existing `scrollToAnchor` and the visibility hook's `currentAnchorId`. Stepping is driven by an explicit index that advances one turn per press, so rapid presses and end-of-list jumps stay monotonic instead of reading a not-yet-settled `currentAnchorId`. The index re-syncs to the reading anchor when the user scrolls manually, except for a short window after our own jump (so the jump's own scroll doesn't reset it).
- Alt+Arrow is handled regardless of focus (it's not a textarea shortcut); bare j/k are gated by an editable-target guard.
- `ChatNavRail` advertises the shortcuts via `aria-keyshortcuts`.
- The `/dev/chat-components` rail preview wires the hook up so it's interactive.

## Validation
- `pnpm run format:check`, `lint`, `typecheck` — all pass.
- `pnpm run test` — 1065 passed, including a new `use-turn-keyboard-navigation.test.ts` (Alt+Arrow both directions, j/k, editable guard, Alt+Arrow allowed in inputs, monotonic rapid stepping, boundary clamp, empty-anchor and disabled cases). Updated the `@/hooks` mock in `chat-panel.test.tsx`.
- Browser smoke test on `/dev/chat-components`: Alt+↓ ×2 stepped turn 1 → 3 (scrollTop 0 → 292), Alt+↑ stepped back to turn 2 (→ 146); bare j/k stepped with body focus; with the composer textarea focused, `j` typed into it and did not navigate (editable guard).
- CI: `Detect Changes` scoped this as UI-only; affected jobs green — UI Build/Lint/Test, UI Playwright Smoke, Build Check, CodeQL, CI Opt-Out Policy.

## Risk
- **Low.** Additive, frontend-only. No API/backend/schema/migration changes. The one global listener is a `keydown` on `document` that only acts on the specific shortcut combos and is otherwise a no-op.

## Security
- Threat categories reviewed: **TM-WEB**. No other categories touched.
- Findings and resolutions: no new user-controlled rendering, no network or storage, no `dangerouslySetInnerHTML`, no new dependencies. The handler only calls `scrollToAnchor` with ids from the already-rendered anchor list. No security-relevant surface beyond a scoped keyboard listener.

## Follow-ups
- A mobile affordance for turn navigation (the rail and these shortcuts are desktop-oriented) remains a separate design question.
- No other follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)