### PR TITLE
test(llm-tests): skip live matrix on transient transport errors

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -233,6 +233,62 @@ pub fn is_quota_exhausted(err: &str) -> bool {
     false
 }
 
+// ============================================================================
+// Transient transport / network flakiness
+// ============================================================================
+
+// The live LLM matrix talks to real providers over the network, so a turn can
+// fail because the HTTP/SSE connection was interrupted mid-stream rather than
+// because of any code regression. Historically these surface on `main` as
+// `LLM error: Stream error: Transport error: error decoding response body`
+// (reqwest/hyper failing to read the response body) and vary test-to-test,
+// which is the signature of infrastructure flakiness, not a contract break.
+//
+// We treat these the same way as quota exhaustion: skip the case with a loud
+// warning so `main` stays green, while genuine functional failures (auth,
+// schema, model availability, assertion mismatches) still fail loudly.
+//
+// Detection is kept specific to transport-layer signatures so ordinary API
+// errors are never swallowed. Auth/permission signals are excluded first, so a
+// broken credential can never be misread as a transient hiccup.
+pub fn is_transient_transport(err: &str) -> bool {
+    let e = err.to_lowercase();
+
+    // Never treat auth/permission failures as transient transport noise.
+    let auth_failure = e.contains("unauthorized")
+        || e.contains("forbidden")
+        || e.contains("invalid api key")
+        || e.contains("invalid_api_key")
+        || e.contains("permission")
+        || e.contains("authentication")
+        || e.contains(" 401")
+        || e.contains("401 ")
+        || e.contains(" 403")
+        || e.contains("403 ");
+    if auth_failure {
+        return false;
+    }
+
+    // Transport-layer / connection-teardown signatures from reqwest/hyper and
+    // the drivers' own error wrapping. These indicate the network stream was
+    // interrupted, not that the provider rejected the request on its merits.
+    e.contains("transport error")
+        || e.contains("error decoding response body")
+        || e.contains("connection reset")
+        || e.contains("connection closed")
+        || e.contains("connection aborted")
+        || e.contains("connection refused")
+        || e.contains("broken pipe")
+        || e.contains("incomplete message")
+        || e.contains("unexpected end of file")
+        || e.contains("unexpected eof")
+        || e.contains("error trying to connect")
+        || e.contains("tcp connect error")
+        || e.contains("dns error")
+        || e.contains("timed out")
+        || e.contains("timeout")
+}
+
 /// Skip the current test (with a loud stderr warning) if `result` failed due to
 /// the provider being out of quota/credits. Otherwise the test proceeds and its
 /// normal assertions run. `result` must expose `success: bool` and
@@ -252,6 +308,13 @@ macro_rules! skip_if_quota {
             if let Some(err) = __result.error.as_deref() {
                 if is_quota_exhausted(err) {
                     eprintln!("SKIP: provider {} out of quota: {}", $label, err);
+                    return;
+                }
+                if is_transient_transport(err) {
+                    eprintln!(
+                        "SKIP: provider {} transient transport error: {}",
+                        $label, err
+                    );
                     return;
                 }
             }
@@ -341,5 +404,53 @@ mod quota_detector_tests {
             "insufficient_quota but actually invalid api key"
         ));
         assert!(!is_quota_exhausted("permission denied for this model"));
+    }
+}
+
+#[cfg(test)]
+mod transient_transport_tests {
+    use super::is_transient_transport;
+
+    #[test]
+    fn matches_transport_flakes() {
+        // The exact message observed flaking `main` from live OpenAI streaming.
+        assert!(is_transient_transport(
+            "LLM error: Stream error: Transport error: error decoding response body"
+        ));
+        assert!(is_transient_transport("error decoding response body"));
+        assert!(is_transient_transport("connection reset by peer"));
+        assert!(is_transient_transport(
+            "connection closed before message completed"
+        ));
+        assert!(is_transient_transport("hyper: incomplete message"));
+        assert!(is_transient_transport(
+            "error trying to connect: tcp connect error"
+        ));
+        assert!(is_transient_transport("operation timed out"));
+        assert!(is_transient_transport("request timeout"));
+        // Case-insensitive.
+        assert!(is_transient_transport("TRANSPORT ERROR: broken pipe"));
+    }
+
+    #[test]
+    fn does_not_match_functional_or_auth_errors() {
+        // Genuine functional/contract breaks must still fail the test.
+        assert!(!is_transient_transport(
+            "Model not available: gpt-99-nonexistent"
+        ));
+        assert!(!is_transient_transport(
+            "Bad request: invalid schema for tool"
+        ));
+        assert!(!is_transient_transport("Internal server error"));
+        assert!(!is_transient_transport(""));
+        assert!(!is_transient_transport("rate_limit_exceeded"));
+        // Auth/permission failures must never be swallowed as transport noise,
+        // even when the message mentions a connection.
+        assert!(!is_transient_transport("401 Unauthorized: invalid api key"));
+        assert!(!is_transient_transport("403 Forbidden"));
+        assert!(!is_transient_transport(
+            "connection reset but actually 401 unauthorized"
+        ));
+        assert!(!is_transient_transport("permission denied for this model"));
     }
 }


### PR DESCRIPTION
## What
Extend the live LLM test matrix's best-effort skip mechanism (previously quota/billing only) with a narrowly-scoped `is_transient_transport` detector, so cases that fail because the provider's HTTP/SSE stream was interrupted mid-decode skip with a loud warning instead of failing the suite.

## Why
`main` CI has been intermittently red: **6 of the last 12 `main` runs** failed in `Integration Tests (PostgreSQL)`, always on a live-OpenAI case in `crates/llm-tests/tests/agent_run_basic.rs` panicking with:

```
LLM error: Stream error: Transport error: error decoding response body
```

The failing case varied run-to-run (`test_tool_call`, `test_basic_completion`, `test_file_system_tool_schemas_accepted`) with 18/19 passing each time — the signature of network flakiness talking to a live provider, not a code regression.

## How
- Add `is_transient_transport(err)` alongside the existing `is_quota_exhausted(err)`, matching only transport-layer signatures (transport error, `error decoding response body`, connection reset/closed/aborted/refused, broken pipe, incomplete message, unexpected EOF, connect/DNS errors, timeouts).
- Guard auth/permission signals first so a broken credential is never misread as a transient hiccup.
- Wire it into the `skip_if_quota!` macro (skips with a distinct warning).
- Add unit tests covering the observed flake message and confirming functional/auth errors still fail loudly.

## Risk
- Low
- Only affects the live LLM integration test matrix. Genuine functional failures (auth, schema, model availability, assertions) still fail; only transport-layer stream interruptions are now skipped rather than failing the whole suite.

## Security
- Threat categories reviewed: No security-relevant code changes — test-only change to skip logic for live integration tests. Auth/permission errors are explicitly excluded from the transient classification so credential breakage is never silently swallowed.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Si18tMqCNpvspX4hdkBzuP)_