### PR TITLE
chore(release): prepare v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-- feat(observers): Observers UI — create/edit observers, scorer catalog, and a per-observer Quality tab by [@chaliy](https://github.com/chaliy)
-- fix(observers): reject `llm_judge` scorers that reference a model the org cannot use by [@chaliy](https://github.com/chaliy)
+## [0.17.2] - 2026-07-02
+
+### Highlights
+
+- **Native Account Recovery** — Self-service account recovery flow with a branded onboarding shell ([#2541](https://github.com/everruns/everruns/pull/2541)).
+- **Observers** — New Observers UI to create/edit observers with a scorer catalog and a per-observer Quality tab; `llm_judge` scorers referencing a model the org cannot use are now rejected ([#2524](https://github.com/everruns/everruns/pull/2524)).
+- **Imported Eval Runs** — Ingest externally-executed eval runs and view them with attribution, transcript, and matrix ([#2516](https://github.com/everruns/everruns/pull/2516), [#2517](https://github.com/everruns/everruns/pull/2517)).
+- **Chat Transcript Turn Navigation** — Step through turns with the keyboard and a new turn navigation rail ([#2542](https://github.com/everruns/everruns/pull/2542), [#2548](https://github.com/everruns/everruns/pull/2548)).
+- **OpenRouter OAuth** — Connect OpenRouter directly from the Add Provider dialog ([#2519](https://github.com/everruns/everruns/pull/2519)).
+
+### What's Changed
+
+- feat(auth): native account recovery + branded onboarding shell ([#2541](https://github.com/everruns/everruns/pull/2541)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): keyboard turn stepping for chat transcript ([#2548](https://github.com/everruns/everruns/pull/2548)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add turn navigation rail to chat transcript ([#2542](https://github.com/everruns/everruns/pull/2542)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): async dataset export handle + e2e/tenant tests ([#2545](https://github.com/everruns/everruns/pull/2545)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): view imported eval runs — attribution, transcript, matrix ([#2517](https://github.com/everruns/everruns/pull/2517)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): ingest externally-executed eval runs ([#2516](https://github.com/everruns/everruns/pull/2516)) by [@chaliy](https://github.com/chaliy)
+- feat(observers): Observers UI + llm_judge model-access validation ([#2524](https://github.com/everruns/everruns/pull/2524)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): align async tools with 2026 Tasks extension vocab ([#2544](https://github.com/everruns/everruns/pull/2544)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): auto-negotiate legacy, current, and 2026 RC protocols ([#2502](https://github.com/everruns/everruns/pull/2502)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): surface OpenRouter OAuth in Add Provider dialog ([#2519](https://github.com/everruns/everruns/pull/2519)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): reimplement create app page and detail identity editor ([#2521](https://github.com/everruns/everruns/pull/2521)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): unify list empty states with shared EmptyState ([#2525](https://github.com/everruns/everruns/pull/2525)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add early-access banner with user-preferences store ([#2510](https://github.com/everruns/everruns/pull/2510)) by [@chaliy](https://github.com/chaliy)
+- fix(security): collapse public-app & OAuth-signup enumeration leaks ([#2533](https://github.com/everruns/everruns/pull/2533)) by [@chaliy](https://github.com/chaliy)
+- fix(security): route provider/LLM and MCP-OAuth HTTP through egress boundary ([#2530](https://github.com/everruns/everruns/pull/2530)) by [@chaliy](https://github.com/chaliy)
+- fix(security): gate user hooks before validation ([#2496](https://github.com/everruns/everruns/pull/2496)) by [@chaliy](https://github.com/chaliy)
+- fix(files): block network in HTML previews ([#2490](https://github.com/everruns/everruns/pull/2490)) by [@chaliy](https://github.com/chaliy)
+- fix(local): secure local profile storage ([#2494](https://github.com/everruns/everruns/pull/2494)) by [@chaliy](https://github.com/chaliy)
+- fix(api): register 13 plugin/marketplace handlers in OpenAPI ApiDoc ([#2523](https://github.com/everruns/everruns/pull/2523)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): allow OAuth provider creation without key ([#2500](https://github.com/everruns/everruns/pull/2500)) by [@chaliy](https://github.com/chaliy)
+- fix(schedules): make schedule cap creation atomic ([#2492](https://github.com/everruns/everruns/pull/2492)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): delete replaced workspace file blobs ([#2491](https://github.com/everruns/everruns/pull/2491)) by [@chaliy](https://github.com/chaliy)
+- fix(core): clear reasoning effort override per turn ([#2501](https://github.com/everruns/everruns/pull/2501)) by [@chaliy](https://github.com/chaliy)
+- fix(rate-limit): gate grpc worker tool calls ([#2495](https://github.com/everruns/everruns/pull/2495)) by [@chaliy](https://github.com/chaliy)
+- fix(server): idle sealed turns without input turn id ([#2497](https://github.com/everruns/everruns/pull/2497)) by [@chaliy](https://github.com/chaliy)
+- fix(server): unify control-plane FS path normalization (EVE-670) ([#2505](https://github.com/everruns/everruns/pull/2505)) by [@chaliy](https://github.com/chaliy)
+- fix(guardrails): fail open on malformed judge output ([#2493](https://github.com/everruns/everruns/pull/2493)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): avoid mutable scorer labels in exports ([#2499](https://github.com/everruns/everruns/pull/2499)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): lazy-load command palette data, gate evals on feature flag ([#2518](https://github.com/everruns/everruns/pull/2518)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): reword empty feature-flags state for SaaS users ([#2520](https://github.com/everruns/everruns/pull/2520)) by [@chaliy](https://github.com/chaliy)
+- perf(worker): use native protobuf for session-task RPC payloads ([#2543](https://github.com/everruns/everruns/pull/2543)) by [@chaliy](https://github.com/chaliy)
+- perf(durable): cut redundant event-log loads/replays and N+1 writes on hot path ([#2532](https://github.com/everruns/everruns/pull/2532)) by [@chaliy](https://github.com/chaliy)
+- perf(ui): lazy-load trajectory/metrics deps, gate live-activity poll ([#2522](https://github.com/everruns/everruns/pull/2522)) by [@chaliy](https://github.com/chaliy)
+- refactor: fold everruns-config into everruns-core ([#2547](https://github.com/everruns/everruns/pull/2547)) by [@chaliy](https://github.com/chaliy)
+- refactor(drivers): golden streaming harness + shared accumulator ([#2546](https://github.com/everruns/everruns/pull/2546)) by [@chaliy](https://github.com/chaliy)
+- refactor(drivers): extract shared provider-driver helpers (EVE-647) ([#2504](https://github.com/everruns/everruns/pull/2504)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): shared tool scaffolding, less boilerplate (EVE-646) ([#2507](https://github.com/everruns/everruns/pull/2507)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): adopt shared tool scaffolding in session_tasks/subagents ([#2528](https://github.com/everruns/everruns/pull/2528)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): collapse EventData identity into one tagged table ([#2487](https://github.com/everruns/everruns/pull/2487)) by [@chaliy](https://github.com/chaliy)
+- refactor(observability): extract exporters from core (EVE-651) by [@chaliy](https://github.com/chaliy)
+- refactor(errors): typed HTTP/fs/a2a error classification (EVE-645) by [@chaliy](https://github.com/chaliy)
+- refactor(server): supervise startup background tasks by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump cargo group (19 updates) + migrate breaking APIs ([#2515](https://github.com/everruns/everruns/pull/2515)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump next from 16.2.6 to 16.2.9 in /apps/ui ([#2540](https://github.com/everruns/everruns/pull/2540)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump @base-ui/react from 1.5.0 to 1.6.0 in /apps/ui ([#2539](https://github.com/everruns/everruns/pull/2539)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump @rjsf/validator-ajv8 from 6.5.3 to 6.6.2 in /apps/ui ([#2537](https://github.com/everruns/everruns/pull/2537)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump sharp from 0.34.5 to 0.35.2 in /apps/docs ([#2536](https://github.com/everruns/everruns/pull/2536)) by [@dependabot](https://github.com/dependabot)
 
 ## [0.17.1] - 2026-06-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,11 +2353,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.1"
+version = "0.17.2"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2933,11 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.1"
+version = "0.17.2"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -148,11 +148,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.17.1" }
+everruns-core = { path = "crates/core", version = "0.17.2" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.1" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.2" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.1" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.2" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.1", default-features = false }
+everruns-core = { path = "../core", version = "0.17.2", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.1", default-features = false }
+everruns-core = { path = "../core", version = "0.17.2", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.1", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.2", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.1", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.2", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.1", default-features = false }
+everruns-core = { path = "../core", version = "0.17.2", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.1", default-features = false }
+everruns-core = { path = "../core", version = "0.17.2", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.1", default-features = false }
+everruns-core = { path = "../core", version = "0.17.2", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures

--- a/deny.toml
+++ b/deny.toml
@@ -9,9 +9,22 @@
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 unmaintained = "none"
-# Advisory IDs to ignore, each with a justification comment. Keep this empty;
-# prefer upgrading the affected crate over ignoring.
-ignore = []
+# Advisory IDs to ignore, each with a justification comment. Prefer upgrading the
+# affected crate over ignoring; only ignore when no upstream fix path exists and
+# the advisory is not reachable in our usage.
+ignore = [
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml <0.41 DoS (quadratic attr
+    # duplicate check / unbounded namespace-declaration allocation) via NsReader
+    # on UNTRUSTED XML. Reaches us only transitively through object_store 0.14
+    # (its S3 XML response parser). object_store 0.14.0 is the latest release and
+    # pins quick-xml ^0.40, so there is no upstream upgrade path yet (a [patch] to
+    # 0.41 cannot satisfy ^0.40). Our sole object_store use is the blob store
+    # against an operator-configured S3 endpoint (blob_store_from_env), i.e. a
+    # trusted backend — not attacker-controlled XML — so neither DoS is reachable.
+    # Remove once object_store ships a release depending on quick-xml >=0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]
 
 [licenses]
 # Allow these license types


### PR DESCRIPTION
## What
Prepares the v0.17.2 release: bumps workspace version 0.17.1 → 0.17.2 (Cargo workspace, sub-crate publish pins, `apps/ui`), refreshes `Cargo.lock` (workspace crates only, no external dep drift), and adds the 0.17.2 CHANGELOG section.

## Why
Cut a patch release covering the 22 commits landed on `main` since v0.17.1 — native account recovery, Observers UI, imported eval runs, chat transcript turn navigation, OpenRouter OAuth, plus several security/perf fixes and internal refactors.

## How
- `Cargo.toml` `workspace.package.version` → 0.17.2
- `python3 scripts/sync-publish-pin-versions.py` to realign sub-crate path-dep pins (verified with `--check`)
- `apps/ui/package.json` version → 0.17.2
- `cargo update --workspace` to bump only everruns crates in `Cargo.lock`
- `CHANGELOG.md` new `## [0.17.2]` section with Highlights + What's Changed
- Verified migrations remain sequential (001..089)
- `deny.toml`: scoped ignore for RUSTSEC-2026-0194/0195 (quick-xml <0.41 DoS reachable only via untrusted XML; our sole path parses trusted operator-configured S3 responses through object_store 0.14, which pins quick-xml ^0.40 with no upstream upgrade path). Remove once object_store ships a release on quick-xml >=0.41.

## Risk
- Low
- Metadata-only release prep; no runtime code changes. CI is the source of truth.

## Security
- Threat categories reviewed: No security-relevant code changes in this PR (version/metadata + changelog + advisory-ignore only). Security fixes being released were reviewed in their own PRs (#2533, #2530, #2496, #2490, #2494).
- Findings and resolutions: The two quick-xml advisories are not reachable in our usage (S3 XML from an operator-configured endpoint, not attacker input); ignore documented with a follow-up to remove.

## Follow-ups
- Remove the `deny.toml` ignore for RUSTSEC-2026-0194/0195 once `object_store` publishes a release depending on `quick-xml >= 0.41`.

## Checklist
- [ ] Tests added or updated (n/a — release metadata)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

### Post-merge
After merging, the release workflow will automatically create the `v0.17.2` tag, a GitHub Release from CHANGELOG.md, and trigger the Docker image + crate publish builds.