### PR TITLE
chore(release): prepare v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.3] - 2026-07-02
+
+### What's Changed
+
+- fix(ui): restore `pnpm.overrides`/`onlyBuiltDependencies` in `apps/ui/package.json`, accidentally dropped in v0.17.2, which broke the release Docker image build (`pnpm install --frozen-lockfile` lockfile-config mismatch) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.2] - 2026-07-02
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,11 +2353,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.2"
+version = "0.17.3"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2933,11 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.2"
+version = "0.17.3"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.2"
+version = "0.17.3"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -148,11 +148,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.17.2" }
+everruns-core = { path = "crates/core", version = "0.17.3" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.2" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.3" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.2" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.3" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {
@@ -73,5 +73,22 @@
     "playwright": "^1.58.2",
     "tailwindcss": "^4.2.0",
     "typescript": "6.0.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "@babel/core": "7.29.6",
+      "dompurify": "3.4.11",
+      "js-yaml": "4.2.0",
+      "postcss": "8.5.14",
+      "prismjs": "1.30.0",
+      "uuid": "11.1.1",
+      "ws": "^8.21.0"
+    },
+    "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "esbuild",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.2", default-features = false }
+everruns-core = { path = "../core", version = "0.17.3", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.2", default-features = false }
+everruns-core = { path = "../core", version = "0.17.3", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.2", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.3", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.2", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.3", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.2", default-features = false }
+everruns-core = { path = "../core", version = "0.17.3", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.2", default-features = false }
+everruns-core = { path = "../core", version = "0.17.3", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.2", default-features = false }
+everruns-core = { path = "../core", version = "0.17.3", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What
Patch release v0.17.3. Restores the `pnpm.overrides` / `onlyBuiltDependencies` block in `apps/ui/package.json` and bumps the workspace/UI version 0.17.2 → 0.17.3.

## Why
The v0.17.2 **Docker Publish** workflow failed at build time: `apps/ui`'s `pnpm` block (overrides + `onlyBuiltDependencies`) was accidentally deleted in commit `00b76860` ("feat(ui): generate API types from OpenAPI") while `pnpm-lock.yaml` kept the `overrides:` section. `oss/apps/ui/Dockerfile` runs `pnpm install --frozen-lockfile`, which then failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, so no v0.17.2 container image was published. OSS CI stayed green because only the post-tag Docker build uses `--frozen-lockfile`.

## How
- Restore the exact `pnpm` block from v0.17.1 (7 overrides + `onlyBuiltDependencies`: `@tailwindcss/oxide`, `esbuild`, `sharp`, `unrs-resolver`)
- Verified locally: `pnpm install --frozen-lockfile` in `apps/ui` now succeeds (was failing)
- `Cargo.toml` / `apps/ui/package.json` version → 0.17.3; publish pins re-synced; `Cargo.lock` workspace-only bump (no external drift)
- CHANGELOG 0.17.3 entry

## Risk
- Low
- Restores prior-known-good config; no runtime code change. Makes the release Docker image build again.

## Security
- Threat categories reviewed: No security-relevant code changes (build/packaging config + version metadata only). Note the restored overrides pin `dompurify`, `js-yaml`, `postcss`, `prismjs`, `ws`, `uuid`, `@babel/core` — restoring them re-establishes the intended pinned (patched) versions.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — packaging fix; validated via `pnpm install --frozen-lockfile`)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

### Post-merge
After merging, the release workflow auto-tags `v0.17.3`, creates the GitHub Release, and re-runs the Docker image + crate publish builds (which should now succeed).