### PR TITLE
Revert "test(llm-tests): skip live matrix on transient transport errors (#2550)"

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -233,62 +233,6 @@ pub fn is_quota_exhausted(err: &str) -> bool {
     false
 }
 
-// ============================================================================
-// Transient transport / network flakiness
-// ============================================================================
-
-// The live LLM matrix talks to real providers over the network, so a turn can
-// fail because the HTTP/SSE connection was interrupted mid-stream rather than
-// because of any code regression. Historically these surface on `main` as
-// `LLM error: Stream error: Transport error: error decoding response body`
-// (reqwest/hyper failing to read the response body) and vary test-to-test,
-// which is the signature of infrastructure flakiness, not a contract break.
-//
-// We treat these the same way as quota exhaustion: skip the case with a loud
-// warning so `main` stays green, while genuine functional failures (auth,
-// schema, model availability, assertion mismatches) still fail loudly.
-//
-// Detection is kept specific to transport-layer signatures so ordinary API
-// errors are never swallowed. Auth/permission signals are excluded first, so a
-// broken credential can never be misread as a transient hiccup.
-pub fn is_transient_transport(err: &str) -> bool {
-    let e = err.to_lowercase();
-
-    // Never treat auth/permission failures as transient transport noise.
-    let auth_failure = e.contains("unauthorized")
-        || e.contains("forbidden")
-        || e.contains("invalid api key")
-        || e.contains("invalid_api_key")
-        || e.contains("permission")
-        || e.contains("authentication")
-        || e.contains(" 401")
-        || e.contains("401 ")
-        || e.contains(" 403")
-        || e.contains("403 ");
-    if auth_failure {
-        return false;
-    }
-
-    // Transport-layer / connection-teardown signatures from reqwest/hyper and
-    // the drivers' own error wrapping. These indicate the network stream was
-    // interrupted, not that the provider rejected the request on its merits.
-    e.contains("transport error")
-        || e.contains("error decoding response body")
-        || e.contains("connection reset")
-        || e.contains("connection closed")
-        || e.contains("connection aborted")
-        || e.contains("connection refused")
-        || e.contains("broken pipe")
-        || e.contains("incomplete message")
-        || e.contains("unexpected end of file")
-        || e.contains("unexpected eof")
-        || e.contains("error trying to connect")
-        || e.contains("tcp connect error")
-        || e.contains("dns error")
-        || e.contains("timed out")
-        || e.contains("timeout")
-}
-
 /// Skip the current test (with a loud stderr warning) if `result` failed due to
 /// the provider being out of quota/credits. Otherwise the test proceeds and its
 /// normal assertions run. `result` must expose `success: bool` and
@@ -308,13 +252,6 @@ macro_rules! skip_if_quota {
             if let Some(err) = __result.error.as_deref() {
                 if is_quota_exhausted(err) {
                     eprintln!("SKIP: provider {} out of quota: {}", $label, err);
-                    return;
-                }
-                if is_transient_transport(err) {
-                    eprintln!(
-                        "SKIP: provider {} transient transport error: {}",
-                        $label, err
-                    );
                     return;
                 }
             }
@@ -404,53 +341,5 @@ mod quota_detector_tests {
             "insufficient_quota but actually invalid api key"
         ));
         assert!(!is_quota_exhausted("permission denied for this model"));
-    }
-}
-
-#[cfg(test)]
-mod transient_transport_tests {
-    use super::is_transient_transport;
-
-    #[test]
-    fn matches_transport_flakes() {
-        // The exact message observed flaking `main` from live OpenAI streaming.
-        assert!(is_transient_transport(
-            "LLM error: Stream error: Transport error: error decoding response body"
-        ));
-        assert!(is_transient_transport("error decoding response body"));
-        assert!(is_transient_transport("connection reset by peer"));
-        assert!(is_transient_transport(
-            "connection closed before message completed"
-        ));
-        assert!(is_transient_transport("hyper: incomplete message"));
-        assert!(is_transient_transport(
-            "error trying to connect: tcp connect error"
-        ));
-        assert!(is_transient_transport("operation timed out"));
-        assert!(is_transient_transport("request timeout"));
-        // Case-insensitive.
-        assert!(is_transient_transport("TRANSPORT ERROR: broken pipe"));
-    }
-
-    #[test]
-    fn does_not_match_functional_or_auth_errors() {
-        // Genuine functional/contract breaks must still fail the test.
-        assert!(!is_transient_transport(
-            "Model not available: gpt-99-nonexistent"
-        ));
-        assert!(!is_transient_transport(
-            "Bad request: invalid schema for tool"
-        ));
-        assert!(!is_transient_transport("Internal server error"));
-        assert!(!is_transient_transport(""));
-        assert!(!is_transient_transport("rate_limit_exceeded"));
-        // Auth/permission failures must never be swallowed as transport noise,
-        // even when the message mentions a connection.
-        assert!(!is_transient_transport("401 Unauthorized: invalid api key"));
-        assert!(!is_transient_transport("403 Forbidden"));
-        assert!(!is_transient_transport(
-            "connection reset but actually 401 unauthorized"
-        ));
-        assert!(!is_transient_transport("permission denied for this model"));
     }
 }


### PR DESCRIPTION
Reverts #2550 (commit d5e1f73).

## Why

#2550 made the live LLM test matrix **skip** any case whose error matched a transient-transport signature (`transport error`, `error decoding response body`, `timed out`, `connection reset`, …). While it stops the recurring OpenAI streaming flake on `main`, skip-on-error converts a red into a silent green and can **mask real regressions** — most notably:

- The bare `timeout` / `timed out` matchers would swallow a genuine deadlock or non-terminating stream introduced by a code change.
- It skips on the *first* failure with no retry, so a persistently broken provider/driver that fails in a transport-ish way reads as green on every run.

Per maintainer decision, we prefer the flake to be visible (rerun when it hits) over the risk of hiding a functional break. This restores `crates/llm-tests/tests/llm_test_matrix/mod.rs` to its pre-#2550 state.

## Validation

- Rebased onto latest `origin/main` (was based on the now-reverted #2550 commit). Rebase was clean; the unrelated Fireworks live-model rename on `main` (`FIREWORKS_KIMI` → `FIREWORKS_GPT_OSS`, `e852e6b`) is preserved.
- Diff vs `main` is a pure 111-line deletion of the skip-on-transient-transport machinery — no other file touched.
- Confirmed no dangling references to the removed symbols (`is_transient_transport`, `skip_if_transient`) remain anywhere in the repo.
- `cargo fmt --check` clean on the touched file; migration ordering check passes (`001..092`).

## Security

No security-relevant code changes — this is a test-only revert in `crates/llm-tests/tests/`. It touches no auth, authz, API, tool, or data-access surface.

## Follow-ups

If we want to de-flake the live matrix later without the blind spot, the safer shape is **retry-then-fail** (retry a transport-signature failure 2–3× and only skip if it still fails transport-style), and dropping the bare timeout matchers. Not in this PR.

Note: after this merges, the push-only "Run LLM integration tests" step on `main` can occasionally flake on live-provider network weather again; rerun the failed job when it does.