### PR TITLE
feat(capabilities): cache-friendly Facts for dynamic context

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -192,8 +192,22 @@ impl AnthropicChatDriver {
         })
     }
 
-    fn mark_last_text_block_for_cache(messages: &mut [AnthropicMessage]) {
-        for msg in messages.iter_mut().rev() {
+    /// Place the message-level prompt-cache breakpoint on the last text block,
+    /// skipping `volatile_suffix_len` trailing messages.
+    ///
+    /// The runtime appends volatile content (a live `<facts>` block that changes
+    /// every turn) after the last stable message. Anchoring the breakpoint on
+    /// that volatile tail would make the cached prefix diverge from the next
+    /// turn's prefix right after the last stable message, evicting the
+    /// conversation-history cache. Skipping the volatile suffix keeps the
+    /// breakpoint on the last stable block, so the trailing block rides as an
+    /// uncached suffix while everything before it stays cached.
+    fn mark_last_text_block_for_cache(
+        messages: &mut [AnthropicMessage],
+        volatile_suffix_len: usize,
+    ) {
+        let anchor_len = messages.len().saturating_sub(volatile_suffix_len);
+        for msg in messages[..anchor_len].iter_mut().rev() {
             for block in msg.content.iter_mut().rev() {
                 if let AnthropicContentBlock::Text { cache_control, .. } = block {
                     *cache_control = Some(AnthropicCacheControl::ephemeral());
@@ -206,6 +220,7 @@ impl AnthropicChatDriver {
     fn convert_messages(
         messages: &[LlmMessage],
         prompt_cache_enabled: bool,
+        volatile_suffix_len: usize,
     ) -> (Option<String>, Vec<AnthropicMessage>) {
         // Accumulate all system messages into Anthropic's separate top-level
         // `system` field. Overwriting on each System message would drop the agent
@@ -348,7 +363,7 @@ impl AnthropicChatDriver {
         }
 
         if prompt_cache_enabled {
-            Self::mark_last_text_block_for_cache(&mut converted);
+            Self::mark_last_text_block_for_cache(&mut converted, volatile_suffix_len);
         }
 
         (system_prompt, converted)
@@ -446,7 +461,7 @@ impl ChatDriver for AnthropicChatDriver {
         // creates gen-ai spans from those events.
         let prompt_cache_enabled = config.prompt_cache.as_ref().is_some_and(|cfg| cfg.enabled);
         let (system_prompt, anthropic_messages) =
-            Self::convert_messages(&messages, prompt_cache_enabled);
+            Self::convert_messages(&messages, prompt_cache_enabled, config.volatile_suffix_len);
         let system = Self::system_prompt_for_request(system_prompt, prompt_cache_enabled);
 
         // `[1m]` model ids (e.g. `claude-opus-4-8[1m]`) are the gateway's
@@ -2057,11 +2072,50 @@ mod tests {
             },
         ];
 
-        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, true);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, true, 0);
         let json = serde_json::to_value(&converted).unwrap();
         let cache_controls = json.to_string().matches("cache_control").count();
 
         assert_eq!(cache_controls, 1);
+    }
+
+    #[test]
+    fn test_cache_anchor_skips_volatile_suffix() {
+        let msg = |role: LlmMessageRole, s: &str| LlmMessage {
+            role,
+            content: LlmMessageContent::Text(s.to_string()),
+            tool_calls: None,
+            tool_call_id: None,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        };
+        // A live `<facts>` block trails the last stable (assistant) message.
+        let messages = vec![
+            msg(LlmMessageRole::User, "stable user"),
+            msg(LlmMessageRole::Assistant, "stable reply"),
+            msg(LlmMessageRole::User, "<facts>\n- current_time: X\n</facts>"),
+        ];
+
+        // With no volatile suffix, the breakpoint anchors on the last message.
+        let (_, base) = AnthropicChatDriver::convert_messages(&messages, true, 0);
+        let base_json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            base_json[2]["content"][0]["cache_control"]["type"],
+            "ephemeral"
+        );
+
+        // Marking the facts message volatile moves the breakpoint back to the
+        // last stable message; the volatile tail stays uncached. This is what
+        // keeps the conversation-history cache from being evicted every turn.
+        let (_, anchored) = AnthropicChatDriver::convert_messages(&messages, true, 1);
+        let json = serde_json::to_value(&anchored).unwrap();
+        assert!(
+            json[2]["content"][0].get("cache_control").is_none(),
+            "volatile tail must not be cache-anchored"
+        );
+        assert_eq!(json[1]["content"][0]["cache_control"]["type"], "ephemeral");
+        assert_eq!(json.to_string().matches("cache_control").count(), 1);
     }
 
     #[test]
@@ -2259,7 +2313,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false, 0);
 
         assert_eq!(converted.len(), 1);
         // Content should have tool_use block but no empty text block
@@ -2356,7 +2410,7 @@ mod tests {
             },
         ];
 
-        let (system, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+        let (system, converted) = AnthropicChatDriver::convert_messages(&messages, false, 0);
 
         assert_eq!(system, Some("You are helpful".to_string()));
         assert_eq!(converted.len(), 1); // Only user message
@@ -2374,7 +2428,7 @@ mod tests {
             LlmMessage::text(LlmMessageRole::System, "B"),
         ];
 
-        let (system, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+        let (system, converted) = AnthropicChatDriver::convert_messages(&messages, false, 0);
 
         assert_eq!(system, Some("A\n\nB".to_string()));
         assert_eq!(converted.len(), 1); // Only the user message
@@ -2409,7 +2463,7 @@ mod tests {
             },
         ];
 
-        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false, 0);
 
         assert_eq!(converted.len(), 2);
         assert_eq!(converted[1].role, "user");
@@ -2444,7 +2498,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false, 0);
 
         assert!(converted.is_empty());
     }
@@ -2482,7 +2536,7 @@ mod tests {
             thinking: None,
             thinking_signature: None,
         };
-        let (_, converted) = AnthropicChatDriver::convert_messages(&[assistant, msg], false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&[assistant, msg], false, 0);
 
         assert_eq!(converted.len(), 2);
         assert_eq!(converted[1].role, "user");
@@ -2548,7 +2602,7 @@ mod tests {
             thinking: None,
             thinking_signature: None,
         };
-        let (_, converted) = AnthropicChatDriver::convert_messages(&[assistant, msg], false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&[assistant, msg], false, 0);
 
         match &converted[1].content[0] {
             AnthropicContentBlock::ToolResult { content, .. } => match content {

--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -32,6 +32,7 @@ fn config(model: &str) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/anthropic/tests/parallel_tool_calls_live.rs
+++ b/crates/anthropic/tests/parallel_tool_calls_live.rs
@@ -56,6 +56,7 @@ fn config_with(parallel: Option<bool>) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: parallel,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1407,8 +1407,29 @@ impl ReasonAtom {
             session_id,
             prior_usage: prior_usage.as_ref(),
         };
-        let context_messages =
+        let mut context_messages =
             model_view_providers.apply_model_view(patched_messages, &model_view_context);
+
+        // 9c. Append live dynamic facts (e.g. the current time) at the tail.
+        // Collected fresh each request so values are current, and delivered as a
+        // trailing user-role message so they never fold into the cached system
+        // prompt. `volatile_suffix_len` tells the Anthropic driver to anchor its
+        // message cache breakpoint *before* this block, so the volatile tail
+        // rides uncached while the conversation prefix stays cached.
+        let mut volatile_suffix_len = 0usize;
+        {
+            let facts_ctx = crate::capabilities::FactsContext::new(session_id);
+            let dynamic_facts = crate::capabilities::collect_dynamic_facts(
+                &resolved_capability_configs,
+                &self.capability_registry,
+                Some(model_with_provider.model.as_str()),
+                &facts_ctx,
+            );
+            if let Some(block) = crate::capabilities::render_facts_block(&dynamic_facts) {
+                context_messages.push(Message::user(block));
+                volatile_suffix_len = 1;
+            }
+        }
 
         // 10. Resolve images from image_file references (if any)
         //
@@ -1500,6 +1521,7 @@ impl ReasonAtom {
 
         let llm_config = llm_config_builder
             .previous_response_id(previous_response_id.clone())
+            .volatile_suffix_len(volatile_suffix_len)
             .build();
 
         tracing::debug!(
@@ -2006,6 +2028,7 @@ impl ReasonAtom {
                                 prompt_cache: None,
                                 openrouter_routing: None,
                                 parallel_tool_calls: None,
+                                volatile_suffix_len: 0,
                             };
 
                             match chat_driver
@@ -3549,6 +3572,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let request_options = build_request_options(&config, "openai").unwrap();
@@ -3582,6 +3606,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let request_options = build_request_options(&config, "gemini").unwrap();
@@ -3615,6 +3640,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         assert!(build_request_options(&config, "gemini").is_none());

--- a/crates/core/src/capabilities/current_time.rs
+++ b/crates/core/src/capabilities/current_time.rs
@@ -1,9 +1,10 @@
 //! CurrentTime Capability - provides tools to get current date and time
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
+use super::{Capability, CapabilityLocalization, CapabilityStatus, Fact, FactsContext};
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
+use chrono::SecondsFormat;
 use serde_json::Value;
 
 pub const CURRENT_TIME_CAPABILITY_ID: &str = "current_time";
@@ -46,6 +47,16 @@ impl Capability for CurrentTimeCapability {
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![Box::new(GetCurrentTimeTool)]
+    }
+
+    /// Contribute the current UTC time as a dynamic fact. The runtime appends
+    /// it to a live `<facts>` block at the conversation tail each turn, so the
+    /// model always knows "now" without a tool round-trip and without the
+    /// changing value invalidating the system-prompt cache. The
+    /// `get_current_time` tool remains for explicit timezone/format queries.
+    fn facts(&self, _config: &Value, _ctx: &FactsContext) -> Vec<Fact> {
+        let now = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        vec![Fact::dynamic("current_time", now)]
     }
 }
 
@@ -141,6 +152,24 @@ mod tests {
     fn test_capability_no_system_prompt() {
         let cap = CurrentTimeCapability;
         assert!(cap.system_prompt_addition().is_none());
+    }
+
+    #[test]
+    fn test_contributes_dynamic_current_time_fact() {
+        use crate::capabilities::{FactsContext, Volatility};
+        use crate::typed_id::SessionId;
+
+        let cap = CurrentTimeCapability;
+        let facts = cap.facts(
+            &serde_json::Value::Null,
+            &FactsContext::new(SessionId::new()),
+        );
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].key, "current_time");
+        assert_eq!(facts[0].volatility, Volatility::Dynamic);
+        // RFC3339 UTC, e.g. 2026-07-04T12:00:00Z
+        assert!(facts[0].value.ends_with('Z'), "got: {}", facts[0].value);
+        assert!(facts[0].value.contains('T'));
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/facts.rs
+++ b/crates/core/src/capabilities/facts.rs
@@ -1,0 +1,137 @@
+//! Facts — a first-class, cache-friendly way for capabilities to contribute
+//! key/value context to the model.
+//!
+//! A [`Fact`] carries a [`Volatility`] that decides *where* it is rendered so
+//! that provider prompt caching is never needlessly invalidated:
+//!
+//! - [`Volatility::Static`] facts fold into the cached system-prompt prefix at
+//!   build time. They are assumed not to change within a session, so keeping
+//!   them in the prefix is free.
+//! - [`Volatility::Dynamic`] facts are **never** placed in the prefix. Instead
+//!   the runtime appends a single live `<facts>` block at the *tail* of the
+//!   conversation on every turn (see `ReasonAtom`). Because the block trails
+//!   the last stable message, the cached prefix (system prompt + tools +
+//!   conversation history) stays byte-identical turn to turn; only the small
+//!   trailing block is re-processed.
+//!
+//! This is the generic mechanism behind "the current time is X" without either
+//! (a) baking a changing timestamp into the system prompt — which busts the
+//! system-prompt cache every turn — or (b) forcing the model to spend a tool
+//! round-trip to learn it. The Anthropic driver anchors its message-level cache
+//! breakpoint on the last *non-volatile* block (`LlmCallConfig.volatile_suffix_len`)
+//! so the trailing block rides as an uncached suffix.
+
+use crate::typed_id::SessionId;
+
+/// Where a [`Fact`] is rendered, chosen so prompt caching is preserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Volatility {
+    /// Stable for the life of the session. Folded into the cached
+    /// system-prompt prefix at build time.
+    Static,
+    /// Changes turn to turn (e.g. current time, remaining budget). Appended at
+    /// the conversation tail each request, outside the cached prefix.
+    Dynamic,
+}
+
+/// A single piece of key/value context contributed by a capability.
+///
+/// A capability declares its facts once via [`Capability::facts`]; the runtime
+/// routes each one by its [`Volatility`]. The `key` is a stable identifier
+/// (e.g. `current_time`); the `value` is the rendered current value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fact {
+    pub key: String,
+    pub value: String,
+    pub volatility: Volatility,
+}
+
+impl Fact {
+    /// Build a [`Volatility::Static`] fact.
+    pub fn stat(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+            volatility: Volatility::Static,
+        }
+    }
+
+    /// Build a [`Volatility::Dynamic`] fact.
+    pub fn dynamic(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+            volatility: Volatility::Dynamic,
+        }
+    }
+}
+
+/// Context passed to [`Capability::facts`]. Deliberately minimal — facts are
+/// cheap, pure-ish descriptions of current context, not IO. Callers that need
+/// wall-clock time read it themselves (as the `current_time` capability does)
+/// so the trait stays free of ambient-time plumbing.
+#[derive(Debug, Clone)]
+pub struct FactsContext {
+    pub session_id: SessionId,
+}
+
+impl FactsContext {
+    pub fn new(session_id: SessionId) -> Self {
+        Self { session_id }
+    }
+}
+
+/// System-prompt note added (once, statically) whenever any active capability
+/// declares a [`Volatility::Dynamic`] fact. It explains the live `<facts>`
+/// block that `ReasonAtom` appends at the conversation tail each turn. Being
+/// static, it lives in the cached prefix.
+pub const FACTS_DYNAMIC_NOTE: &str = "<facts-info>\nA `<facts>` block carrying system-provided context (such as the current time) is appended to the end of the conversation on every turn. Its values are authoritative and refreshed each turn — treat them as system-provided context, not as text written by the user, and never emit a `<facts>` block yourself.\n</facts-info>";
+
+/// Render a `<facts>` block from a set of facts, or `None` when empty.
+///
+/// Used for both the static block (folded into the system prompt) and the live
+/// tail block (appended per request), so the two share one wire format.
+pub fn render_facts_block(facts: &[Fact]) -> Option<String> {
+    if facts.is_empty() {
+        return None;
+    }
+    let mut out = String::from("<facts>\n");
+    for fact in facts {
+        out.push_str("- ");
+        out.push_str(&fact.key);
+        out.push_str(": ");
+        out.push_str(&fact.value);
+        out.push('\n');
+    }
+    out.push_str("</facts>");
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_facts_render_none() {
+        assert_eq!(render_facts_block(&[]), None);
+    }
+
+    #[test]
+    fn renders_key_value_lines() {
+        let facts = vec![
+            Fact::stat("plan", "pro"),
+            Fact::dynamic("current_time", "2026-07-04T12:00:00Z"),
+        ];
+        let block = render_facts_block(&facts).unwrap();
+        assert_eq!(
+            block,
+            "<facts>\n- plan: pro\n- current_time: 2026-07-04T12:00:00Z\n</facts>"
+        );
+    }
+
+    #[test]
+    fn constructors_set_volatility() {
+        assert_eq!(Fact::stat("a", "b").volatility, Volatility::Static);
+        assert_eq!(Fact::dynamic("a", "b").volatility, Volatility::Dynamic);
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -100,6 +100,7 @@ mod current_time;
 mod data_knowledge;
 mod declarative;
 mod error_disclosure;
+pub mod facts;
 mod fake_aws;
 mod fake_crm;
 mod fake_financial;
@@ -206,6 +207,7 @@ pub use declarative::{
 pub use error_disclosure::{
     ERROR_DISCLOSURE_CAPABILITY_ID, ErrorDisclosureCapability, resolve_error_disclosure,
 };
+pub use facts::{FACTS_DYNAMIC_NOTE, Fact, FactsContext, Volatility, render_facts_block};
 pub use fake_aws::{
     AwsCreateEc2InstanceTool, AwsCreateIamUserTool, AwsCreateRdsDatabaseTool,
     AwsCreateS3BucketTool, AwsGetCloudWatchMetricsTool, AwsListEc2InstancesTool,
@@ -805,6 +807,24 @@ pub trait Capability: Send + Sync {
     /// By default, returns None (no model-view transformation).
     fn model_view_provider(&self) -> Option<Arc<dyn ModelViewProvider>> {
         None
+    }
+
+    /// Returns key/value [`Fact`]s this capability contributes to the model.
+    ///
+    /// Facts are routed by their [`Volatility`] so prompt caching is preserved:
+    /// [`Volatility::Static`] facts fold into the cached system-prompt prefix at
+    /// build time; [`Volatility::Dynamic`] facts are appended at the
+    /// conversation tail on every turn (outside the cached prefix). This is the
+    /// generic seam for "changing facts" such as the current time — see
+    /// [`crate::capabilities::facts`].
+    ///
+    /// Called both at prompt-assembly time (to fold static facts and detect
+    /// whether any dynamic facts exist) and per request (to render the live
+    /// tail block), so implementations must be cheap and side-effect free.
+    ///
+    /// By default, returns an empty vector (no facts).
+    fn facts(&self, _config: &serde_json::Value, _ctx: &FactsContext) -> Vec<Fact> {
+        vec![]
     }
 
     /// Returns pre-tool execution hooks provided by this capability.
@@ -1861,6 +1881,37 @@ pub fn collect_model_view_providers(
     }
 }
 
+/// Collect [`Volatility::Dynamic`] facts from every active capability, in
+/// configured order. Called by `ReasonAtom` once per request so live values
+/// (e.g. the current time) are fresh, then rendered into the trailing `<facts>`
+/// block. Static facts are ignored here — they already live in the cached
+/// system prompt.
+pub fn collect_dynamic_facts(
+    capability_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+    model: Option<&str>,
+    ctx: &FactsContext,
+) -> Vec<Fact> {
+    let mut dynamic = Vec::new();
+    for cap_config in capability_configs {
+        let cap_id = cap_config.capability_ref.as_str();
+        if let Some(capability) = registry.get(cap_id) {
+            if capability.status() != CapabilityStatus::Available {
+                continue;
+            }
+            let effective: &dyn Capability = capability
+                .resolve_for_model(model)
+                .unwrap_or_else(|| capability.as_ref());
+            for fact in effective.facts(&cap_config.config, ctx) {
+                if fact.volatility == Volatility::Dynamic {
+                    dynamic.push(fact);
+                }
+            }
+        }
+    }
+    dynamic
+}
+
 pub fn collect_capability_mcp_servers(
     capability_configs: &[AgentCapabilityConfig],
     registry: &CapabilityRegistry,
@@ -2265,6 +2316,12 @@ pub async fn collect_capabilities_with_configs(
     // hooks so model-authored narration (human_intent) keeps precedence.
     let mut narration_hooks: Vec<Arc<dyn ToolCallHook>> = Vec::new();
     let mut mcp_servers = ScopedMcpServers::default();
+    // Facts contributed by capabilities. Static facts fold into the cached
+    // system prompt below; a single note is added when any dynamic fact exists,
+    // explaining the live `<facts>` block that `ReasonAtom` appends per turn.
+    let mut static_facts: Vec<Fact> = Vec::new();
+    let mut has_dynamic_facts = false;
+    let facts_ctx = FactsContext::new(ctx.session_id);
     let compaction_on = compaction_is_enabled(capability_configs, registry);
 
     for cap_config in capability_configs {
@@ -2346,6 +2403,17 @@ pub async fn collect_capabilities_with_configs(
                     content: contribution.clone(),
                 });
                 system_prompt_parts.push(contribution);
+            }
+
+            // Collect declared facts. Static facts fold into the cached prompt
+            // below; dynamic facts are re-collected per request by `ReasonAtom`
+            // and appended at the conversation tail, so here we only note their
+            // presence to add the explanatory system-prompt line.
+            for fact in effective.facts(&cap_config.config, &facts_ctx) {
+                match fact.volatility {
+                    Volatility::Static => static_facts.push(fact),
+                    Volatility::Dynamic => has_dynamic_facts = true,
+                }
             }
 
             // Collect tools and hooks (config-aware: capabilities can adapt based on per-agent config)
@@ -2487,6 +2555,25 @@ pub async fn collect_capabilities_with_configs(
         }
         narration_hooks.push(Arc::new(CapabilityNarrationHook(bg_cap.clone())));
         applied_ids.push(BACKGROUND_EXECUTION_CAPABILITY_ID.to_string());
+    }
+
+    // Fold static facts into the cached system-prompt prefix, and add the
+    // dynamic-facts note once when any capability declared a dynamic fact. Both
+    // are stable across turns, so they stay in the cached prefix; the live
+    // dynamic values are appended at the conversation tail per request.
+    if let Some(block) = facts::render_facts_block(&static_facts) {
+        system_prompt_attributions.push(SystemPromptAttribution {
+            capability_id: "facts".to_string(),
+            content: block.clone(),
+        });
+        system_prompt_parts.push(block);
+    }
+    if has_dynamic_facts {
+        system_prompt_attributions.push(SystemPromptAttribution {
+            capability_id: "facts".to_string(),
+            content: FACTS_DYNAMIC_NOTE.to_string(),
+        });
+        system_prompt_parts.push(FACTS_DYNAMIC_NOTE.to_string());
     }
 
     // Append per-capability narration adapters after every explicit tool-call
@@ -3007,10 +3094,22 @@ mod tests {
         )
         .await;
 
-        // CurrentTime has no system prompt addition but has a tool
-        assert_eq!(
-            applied.runtime_agent.system_prompt,
-            base_runtime_agent.system_prompt
+        // CurrentTime contributes a dynamic `current_time` fact, so the cached
+        // prompt gains the explanatory facts note (the live value is appended at
+        // the conversation tail per request). It also keeps its tool.
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains(FACTS_DYNAMIC_NOTE),
+            "current_time should contribute the dynamic-facts note"
+        );
+        assert!(
+            applied
+                .runtime_agent
+                .system_prompt
+                .contains(&base_runtime_agent.system_prompt),
+            "base prompt is preserved"
         );
         assert!(applied.tool_registry.has("get_current_time"));
         assert_eq!(applied.tool_registry.len(), 1);
@@ -3327,6 +3426,75 @@ mod tests {
             collect_capabilities(&["current_time".to_string()], &registry, &test_ctx()).await;
 
         assert!(collected.mounts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_facts_add_note_without_static_block() {
+        // `current_time` contributes a Dynamic fact, so the cached prompt gets
+        // the explanatory note but NOT a static `<facts>` block (the live value
+        // is appended at the conversation tail per request instead).
+        let registry = CapabilityRegistry::with_builtins();
+        let configs = vec![AgentCapabilityConfig::new("current_time".to_string())];
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+        let prompt = collected.system_prompt_parts.join("\n");
+        assert!(
+            prompt.contains(FACTS_DYNAMIC_NOTE),
+            "dynamic-facts note should be in the cached prompt"
+        );
+        assert!(
+            !prompt.contains("<facts>\n"),
+            "no static <facts> block for a purely-dynamic fact; got: {prompt}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_static_facts_fold_into_prompt() {
+        struct StaticFactCap;
+        impl Capability for StaticFactCap {
+            fn id(&self) -> &str {
+                "test_static_fact"
+            }
+            fn name(&self) -> &str {
+                "Static Fact"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn status(&self) -> CapabilityStatus {
+                CapabilityStatus::Available
+            }
+            fn facts(&self, _config: &serde_json::Value, _ctx: &FactsContext) -> Vec<Fact> {
+                vec![Fact::stat("workspace_root", "/workspace")]
+            }
+        }
+        let mut registry = CapabilityRegistry::new();
+        registry.register(StaticFactCap);
+        let configs = vec![AgentCapabilityConfig::new("test_static_fact".to_string())];
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+        let prompt = collected.system_prompt_parts.join("\n");
+        assert!(
+            prompt.contains("<facts>\n- workspace_root: /workspace\n</facts>"),
+            "static fact should fold into the cached prompt; got: {prompt}"
+        );
+        assert!(
+            !prompt.contains(FACTS_DYNAMIC_NOTE),
+            "no dynamic note when only static facts exist"
+        );
+    }
+
+    #[test]
+    fn test_collect_dynamic_facts_returns_current_time() {
+        let registry = CapabilityRegistry::with_builtins();
+        let configs = vec![AgentCapabilityConfig::new("current_time".to_string())];
+        let facts = collect_dynamic_facts(
+            &configs,
+            &registry,
+            None,
+            &FactsContext::new(SessionId::new()),
+        );
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].key, "current_time");
+        assert_eq!(facts[0].volatility, Volatility::Dynamic);
     }
 
     #[tokio::test]

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -1193,6 +1193,16 @@ pub struct LlmCallConfig {
     /// `tool_choice.disable_parallel_tool_use = true`. `None` preserves
     /// provider defaults (no field sent).
     pub parallel_tool_calls: Option<bool>,
+    /// Number of trailing messages that are volatile (regenerated every turn)
+    /// and must not anchor a message-level prompt-cache breakpoint.
+    ///
+    /// `ReasonAtom` sets this to the count of live `<facts>` messages it appends
+    /// at the conversation tail. Drivers that place a message cache breakpoint
+    /// on the last block (Anthropic) skip this many trailing messages so the
+    /// breakpoint lands on the last *stable* block — otherwise a tail that
+    /// changes each turn would evict the conversation-history cache. `0` (the
+    /// default) preserves the previous behavior exactly.
+    pub volatile_suffix_len: usize,
 }
 
 impl LlmCallConfig {
@@ -1228,6 +1238,7 @@ impl From<&RuntimeAgent> for LlmCallConfig {
             prompt_cache: runtime_agent.prompt_cache.clone(),
             openrouter_routing: runtime_agent.openrouter_routing.clone(),
             parallel_tool_calls: runtime_agent.parallel_tool_calls,
+            volatile_suffix_len: 0,
         }
     }
 }
@@ -1346,6 +1357,14 @@ impl LlmCallConfigBuilder {
     /// Set the request-level parallel tool calling preference (EVE-598).
     pub fn parallel_tool_calls(mut self, parallel_tool_calls: Option<bool>) -> Self {
         self.config.parallel_tool_calls = parallel_tool_calls;
+        self
+    }
+
+    /// Set the number of trailing volatile messages that must not anchor a
+    /// message-level prompt-cache breakpoint (see
+    /// [`LlmCallConfig::volatile_suffix_len`]).
+    pub fn volatile_suffix_len(mut self, len: usize) -> Self {
+        self.config.volatile_suffix_len = len;
         self
     }
 

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -1006,6 +1006,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         }
     }
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -2289,6 +2289,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
         let input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2328,6 +2329,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
         let first_input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2380,6 +2382,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
         let input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2422,6 +2425,7 @@ mod tests {
             }),
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
         let input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -3294,6 +3298,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         // Fire the request. The stream body is irrelevant for this assertion.
@@ -3379,6 +3384,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
@@ -3440,6 +3446,7 @@ mod tests {
                 ..Default::default()
             }),
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
@@ -3499,6 +3506,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let stream = driver
@@ -4091,6 +4099,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         // Simulate the driver's filter logic
@@ -4124,6 +4133,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let reasoning = config
@@ -4706,6 +4716,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         }
     }
 

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -100,6 +100,7 @@ impl UtilityLlmRequest {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
         Ok((self.messages, config))
     }

--- a/crates/core/tests/openai_protocol_wire.rs
+++ b/crates/core/tests/openai_protocol_wire.rs
@@ -31,6 +31,7 @@ fn config(model: &str) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/core/tests/openresponses_protocol_wire.rs
+++ b/crates/core/tests/openresponses_protocol_wire.rs
@@ -33,6 +33,7 @@ fn config(model: &str) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1136,6 +1136,7 @@ async fn test_driver_registry_integration() {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     };
 
     let response = driver

--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -40,6 +40,7 @@ async fn fireworks_chat_streams_response() {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     };
 
     let messages = vec![LlmMessage::text(

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -33,6 +33,7 @@ fn config(model: &str) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -575,6 +575,7 @@ mod tests {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         }
     }
 }

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -33,6 +33,7 @@ fn config(model: &str) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/openai/tests/parallel_tool_calls_live.rs
+++ b/crates/openai/tests/parallel_tool_calls_live.rs
@@ -55,6 +55,7 @@ fn config_with(parallel: Option<bool>) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: parallel,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -47,6 +47,7 @@ async fn openrouter_chat_with_session_id_and_routing_succeeds() {
             ..Default::default()
         }),
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     };
 
     let messages = vec![LlmMessage::text(

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -31,6 +31,7 @@ fn base_config(model: &str) -> LlmCallConfig {
         prompt_cache: None,
         openrouter_routing: None,
         parallel_tool_calls: None,
+        volatile_suffix_len: 0,
     }
 }
 

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -220,6 +220,7 @@ impl JudgeClient for LlmJudgeClient {
             prompt_cache: None,
             openrouter_routing: None,
             parallel_tool_calls: None,
+            volatile_suffix_len: 0,
         };
 
         let response = driver.chat_completion(messages, &config).await?;

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -228,13 +228,28 @@ Associates a capability with an agent via `ref` (CapabilityId) + optional `confi
 
 #### Capability Trait (everruns-core)
 
-See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`.
+See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `facts()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`.
 
 ##### System Prompt Methods
 
 - **`system_prompt_addition()`** — Sync, returns static `&str`. Used by sync collection path.
 - **`system_prompt_contribution(ctx)`** — Async, receives `SystemPromptContext` with session filesystem access. Default wraps `system_prompt_addition()` in XML tags. Capabilities needing dynamic content (e.g., `agent_instructions`, `skills`) override to read from session filesystem.
 - **`system_prompt_contribution_with_config(ctx, config)`** — Async, receives per-capability config JSON. Default delegates to `system_prompt_contribution(ctx)`. Used by `collect_capabilities_with_configs()`.
+
+##### Facts (Cache-Friendly Dynamic Context)
+
+`facts(config, ctx) -> Vec<Fact>` lets a capability contribute key/value context to the model without deciding *where* it goes. The runtime routes each `Fact` by its `Volatility` so provider prompt caching is never needlessly invalidated:
+
+| Volatility | Rendered | Cache effect |
+|---|---|---|
+| `Static` | Folded into a `<facts>` block in the cached system-prompt prefix at build time. | In the cached prefix; assumed stable for the session, so free to cache. |
+| `Dynamic` | Appended as a live `<facts>` block at the **conversation tail** on every request (`ReasonAtom`), delivered as a trailing user-role message. | Outside the cached prefix. The system prompt, tools, and conversation history stay byte-identical turn to turn; only the small trailing block is re-processed. |
+
+This is the generic mechanism behind "the current time is X": baking a changing timestamp into the system prompt would bust the system-prompt cache every turn, and a tool round-trip is slower and only informs the model when it asks. `current_time` contributes its value as a `Dynamic` fact (and keeps `get_current_time` for explicit timezone/format queries). Static facts share the same `<facts>` wire format; a single explanatory note (`FACTS_DYNAMIC_NOTE`) is added to the cached prompt once whenever any active capability declares a dynamic fact.
+
+`facts()` is called both at prompt-assembly time (to fold static facts and detect whether any dynamic facts exist) and once per request (to render the live tail block via `collect_dynamic_facts`), so implementations must be cheap and side-effect free. See `crates/core/src/capabilities/facts.rs`.
+
+**Cache-anchor interaction.** Appending a volatile tail would, by default, pull a driver's message-level cache breakpoint onto content that changes every turn — evicting the conversation-history cache. `ReasonAtom` therefore sets `LlmCallConfig.volatile_suffix_len` to the number of trailing volatile messages; the Anthropic driver anchors its breakpoint on the last *stable* block, letting the volatile tail ride as an uncached suffix. Drivers that do not implement message-level anchoring ignore the field and behave exactly as before (`0` is the default).
 
 ##### System Prompt Content Contract
 


### PR DESCRIPTION
## What
Adds a first-class `facts()` seam to the `Capability` trait. A capability declares key/value `Fact`s once; the runtime routes each by its `Volatility`:

- **`Static`** → folded into a `<facts>` block in the **cached system-prompt prefix** at build time.
- **`Dynamic`** → appended as a live `<facts>` block at the **conversation tail** on every request (a trailing user-role message), so it never enters the cached prefix.

`current_time` now contributes its value as a dynamic fact (and keeps `get_current_time` for explicit timezone/format queries). `LlmCallConfig.volatile_suffix_len` lets the Anthropic driver anchor its message-level cache breakpoint on the last *stable* block so the volatile tail rides as an uncached suffix.

## Why
Putting changing context (the current time, and by extension anything that mutates turn-to-turn) directly in the system prompt busts the provider prompt cache on every turn; forcing a tool round-trip is slower and only informs the model when it asks. Facts give capabilities a cache-aware way to surface dynamic context: the system prompt, tools, and conversation history stay byte-identical across turns, and only a small trailing block is re-processed. This is the everruns runtime analogue of the "represent the prompt as facts, append changes at the tail" pattern.

## How
- `crates/core/src/capabilities/facts.rs` — `Fact`, `Volatility`, `FactsContext`, `render_facts_block`, and `FACTS_DYNAMIC_NOTE`.
- `Capability::facts(config, ctx)` (default empty). `collect_capabilities_with_configs` folds static facts into the prompt and adds the note once when any dynamic fact exists; `collect_dynamic_facts` gathers live facts per request.
- `ReasonAtom` collects dynamic facts after the model-view pass, appends one trailing `<facts>` user message, and sets `volatile_suffix_len`.
- Anthropic `mark_last_text_block_for_cache` skips `volatile_suffix_len` trailing messages. The field defaults to `0`; every other driver is unchanged.
- `current_time` migrated to emit a dynamic `current_time` fact.
- Spec: `specs/capabilities.md` gains a "Facts (Cache-Friendly Dynamic Context)" section.

Most of the cross-crate diff is a mechanical `volatile_suffix_len: 0` added to existing `LlmCallConfig` literals (new required field).

## Risk
- **Low.** New trait method is defaulted (all ~40 capabilities keep compiling unchanged). The driver anchor change is gated on `volatile_suffix_len > 0`, which is only set when a dynamic-fact capability is active, so behavior is byte-for-byte unchanged otherwise.
- Behavior change worth noting: enabling `current_time` now adds a ~60-token static note to the cached prompt and a small live `<facts>` block at the tail each turn (previously it was tool-only).

## Validation
- New unit tests: facts rendering/volatility; `current_time` emits a dynamic fact; static facts fold into the prompt; dynamic facts add the note without a static block; `collect_dynamic_facts` returns the live fact.
- New Anthropic driver test `test_cache_anchor_skips_volatile_suffix` proves the breakpoint moves to the last stable block when a volatile suffix is present.
- Updated the existing `test_apply_capabilities_current_time` expectation for the new note.
- `cargo check --workspace --all-targets --all-features` clean; `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt --check` clean; affected `everruns-core` / `everruns-anthropic` test suites green; `pre-push` passes (the only red item is a pre-existing `dependabot[bot]` base commit flagged by the attribution check, not part of this diff).

## Security
- Threat categories reviewed: **TM-LLM** (prompt construction), **TM-DOS** (unbounded work).
- Findings and resolutions:
  - TM-LLM: dynamic facts are delivered as a trailing user-role message. Values here come from capability code, not user input (`current_time` uses `Utc::now()`). `FACTS_DYNAMIC_NOTE` instructs the model to treat `<facts>` as system-provided and never emit it. A capability that later routes user-controlled data through a fact must treat it with the same care as any prompt contribution; this change introduces no new external-input trust boundary.
  - TM-DOS: `facts()` returns a bounded list (one entry for `current_time`); rendering is linear; `volatile_suffix_len` uses `saturating_sub`. No unbounded loops or allocations.
  - No auth, tenancy, SQL, filesystem, or sandbox surface touched.

## Follow-ups
- Bedrock (and other Anthropic-format drivers) don't yet honor `volatile_suffix_len`; they fall back to `0` (unchanged behavior) and so don't get the conversation-cache-anchor optimization when dynamic facts are active. Safe to defer — it's a caching optimization, not a correctness issue, and the seam is already in place.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_013B5xNWq6HWqj1Uc5ZxSxcT

---
_Generated by [Claude Code](https://claude.ai/code/session_013B5xNWq6HWqj1Uc5ZxSxcT)_