### PR TITLE
test(llm-tests): update Fireworks Kimi to kimi-k2p6

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -135,11 +135,12 @@ pub const OPENROUTER_GPT4O_MINI: ProviderModelConfig = ProviderModelConfig::new(
 );
 
 // Fireworks AI serves open models via an OpenAI-compatible Chat Completions
-// API. kimi-k2p5 is a chat + tool-calling model. Exercises the Chat Completions
-// streaming path against a third (non-OpenAI/Azure) host.
+// API. kimi-k2p6 is a chat + tool-calling model (Fireworks' current default
+// Kimi K2 line; kimi-k2p5 was deprecated/removed from serverless). Exercises
+// the Chat Completions streaming path against a third (non-OpenAI/Azure) host.
 pub const FIREWORKS_KIMI: ProviderModelConfig = ProviderModelConfig::new(
     DriverId::Fireworks,
-    "accounts/fireworks/models/kimi-k2p5",
+    "accounts/fireworks/models/kimi-k2p6",
     "FIREWORKS_API_KEY",
 );
 


### PR DESCRIPTION
## What
Point the live LLM matrix's Fireworks case (`FIREWORKS_KIMI`) at `accounts/fireworks/models/kimi-k2p6` instead of the removed `kimi-k2p5`.

## Why
Main CI (push-only "Run LLM integration tests" step) went red on HEAD `f10d2d7`: `test_basic_completion::case_6_fireworks_kimi` and `test_tool_call::case_6_fireworks_kimi` panicked with `Model not available: accounts/fireworks/models/kimi-k2p5`. Fireworks deprecated and removed `kimi-k2p5` from serverless (confirmed against Fireworks' current Kimi catalog — `kimi-k2p6` is now the default line). This is a genuine provider-side model retirement, not the transient-transport flake the matrix already tolerates, so the case stays red until the id is updated.

## How
Swap the model id in `crates/llm-tests/tests/llm_test_matrix/mod.rs` to `kimi-k2p6` and update the explanatory comment. `kimi-k2p6` is a chat + tool-calling model, preserving the case's purpose: exercise the OpenAI-compatible Chat Completions streaming + tool path against a third (non-OpenAI/Azure) host.

## Risk
- Low. Test-only, single string-literal change. The live case runs push-only on `main` (skipped in PR context without provider keys), so green is confirmed on merge.

## Security
- Threat categories reviewed: No security-relevant code changes — test-only model-id update.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing live case retargeted)
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR (live Fireworks case runs on merge to main)
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016AeGKwJm8iuZQaSUKcyEJs)_