### PR TITLE
chore(specs): index signup-experience-redesign-brief in README

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -79,6 +79,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/brand.md` - Brand identity, colors, typography
 - `specs/diagrams.md` - Diagram specification
 - `specs/documentation.md` - Documentation site
+- `specs/signup-experience-redesign-brief.md` - Design brief for on-brand sign-up / onboarding screens
 
 ## MCP, integrations, and apps
 


### PR DESCRIPTION
## What
Add `specs/signup-experience-redesign-brief.md` to the `specs/README.md` index (under "UI and generative UI").

## Why
The spec was added in #2541 but never indexed, so `scripts/test-specs-index.sh` (run by the local `pre-push` gate) fails with "missing from specs/README.md". This restores full index coverage (127 specs).

## How
One-line entry describing the doc: a design brief for on-brand sign-up / onboarding screens.

## Risk
- None. Docs-only, single line.

## Security
- No security-relevant code changes. Docs-only.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — docs)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)