### PR TITLE
test(ui): drop CSS-class change-detector tests

### DIFF
--- a/apps/ui/src/__tests__/cron-label.test.ts
+++ b/apps/ui/src/__tests__/cron-label.test.ts
@@ -4,12 +4,6 @@ import {
   isSupportedCronExpression,
 } from "@/components/apps/cron-label";
 
-describe("CRON_MIN_INTERVAL_SECONDS", () => {
-  it("equals 300 (matches server-side default)", () => {
-    expect(CRON_MIN_INTERVAL_SECONDS).toBe(300);
-  });
-});
-
 describe("getCronIntervalSeconds", () => {
   it("returns 60 for every-minute 7-field expression", () => {
     expect(getCronIntervalSeconds("0 * * * * * *")).toBe(60);

--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -192,20 +192,6 @@ describe("SessionLayout", () => {
     return result!;
   }
 
-  it("uses h-full for proper height (not calc-based)", async () => {
-    const { container } = await renderLayout();
-
-    await waitFor(() => {
-      // The main wrapper div should use h-full, not h-[calc(100vh-4rem)]
-      const layoutDiv = container.querySelector('[class*="h-full"]');
-      expect(layoutDiv).toBeInTheDocument();
-    });
-
-    // Ensure the old broken calc-based height is NOT present
-    const calcDiv = container.querySelector('[class*="calc"]');
-    expect(calcDiv).not.toBeInTheDocument();
-  });
-
   it("renders children content", async () => {
     await renderLayout();
 
@@ -396,16 +382,5 @@ describe("SessionLayout", () => {
       expect(screen.getByRole("button", { name: /schedules/i })).toBeInTheDocument();
     });
     expect(screen.getByText("3")).toBeInTheDocument();
-  });
-
-  it("has flex-col layout for proper content stacking", async () => {
-    const { container } = await renderLayout();
-
-    await waitFor(() => {
-      const layoutDiv = container.querySelector(
-        '[class*="flex"][class*="flex-col"][class*="h-full"]',
-      );
-      expect(layoutDiv).toBeInTheDocument();
-    });
   });
 });

--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -123,17 +123,6 @@ describe("SettingsLayout", () => {
     expect(membersLink).toHaveClass("border-accent");
   });
 
-  it("has exactly 8 navigation items", () => {
-    render(
-      <SettingsLayout>
-        <div>Test Content</div>
-      </SettingsLayout>,
-    );
-
-    const navLinks = screen.getAllByRole("link");
-    expect(navLinks).toHaveLength(8);
-  });
-
   it("groups items under correct sections", () => {
     render(
       <SettingsLayout>
@@ -164,27 +153,6 @@ describe("SettingsLayout", () => {
     expect(personalSection).toHaveTextContent("Personal access tokens");
     expect(personalSection).not.toHaveTextContent("Organization");
     expect(personalSection).not.toHaveTextContent("Members");
-  });
-
-  it("renders section labels with uppercase styling", () => {
-    render(
-      <SettingsLayout>
-        <div>Test Content</div>
-      </SettingsLayout>,
-    );
-
-    const orgLabel = screen
-      .getAllByText("Organization")
-      .find((node) => node.classList.contains("uppercase"))!;
-    const personalLabel = screen.getByText("Personal");
-
-    expect(orgLabel).toHaveClass("uppercase");
-    expect(orgLabel).toHaveClass("tracking-[0.08em]");
-    expect(orgLabel).toHaveClass("text-[11px]");
-    expect(orgLabel).toHaveClass("font-mono");
-
-    expect(personalLabel).toHaveClass("uppercase");
-    expect(personalLabel).toHaveClass("tracking-[0.08em]");
   });
 
   it("applies inactive styles to non-active items", () => {

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -241,48 +241,10 @@ describe("Sidebar", () => {
     expect(screen.getByText(/^Everruns v\d+\.\d+\.\d+$/)).toBeInTheDocument();
   });
 
-  it("uses the compact sidebar shell treatment", () => {
-    const { container } = render(<Sidebar />);
-
-    expect(container.firstChild).toHaveClass("w-60");
-
-    const searchButton = screen.getByRole("button", { name: /search/i });
-    expect(searchButton).toHaveClass("gap-2");
-    expect(searchButton).toHaveClass("px-2.5");
-    expect(searchButton).toHaveClass("py-1.5");
-    expect(searchButton).toHaveClass("text-[13px]");
-
-    const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
-    expect(dashboardLink).toHaveClass("gap-2.5");
-    expect(dashboardLink).toHaveClass("py-1.5");
-    expect(dashboardLink).toHaveClass("text-[13px]");
-  });
-
-  it("has exactly 8 core navigation items", () => {
-    render(<Sidebar />);
-
-    // Get nav links (excluding logo link)
-    const navLinks = screen
-      .getAllByRole("link")
-      .filter(
-        (link) =>
-          link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard"),
-      );
-    const navItems = [
-      "Chat",
-      "Dashboard",
-      "Harnesses",
-      "Agents",
-      "Memory",
-      "Models",
-      "Capabilities",
-      "Settings",
-    ];
-    const foundNavLinks = navLinks.filter((link) =>
-      navItems.some((item) => link.textContent?.includes(item)),
-    );
-    expect(foundNavLinks).toHaveLength(8);
-  });
+  // Pure-styling and hardcoded-count change-detectors removed (compact-shell
+  // utility classes, exact nav-item count, nav overflow classes): they broke on
+  // cosmetic refactors while asserting no behavior. Active-state/routing tests
+  // that verify *which* item is highlighted are kept below.
 
   it("renders section labels for Building Blocks and Durable Execution", () => {
     render(<Sidebar />);
@@ -321,14 +283,6 @@ describe("Sidebar", () => {
 
     fireEvent.click(toggle);
     expect(screen.queryByText("Workers")).not.toBeInTheDocument();
-  });
-
-  it("nav element has overflow-y-auto and min-h-0 to prevent sidebar overflow", () => {
-    render(<Sidebar />);
-
-    const nav = screen.getByRole("navigation");
-    expect(nav).toHaveClass("min-h-0");
-    expect(nav).toHaveClass("overflow-y-auto");
   });
 
   it("highlights durable navigation for nested routes", () => {


### PR DESCRIPTION
## What
Final follow-up to #2549 / #2551 / #2558 / #2562. Removes 8 UI test assertions whose whole purpose was pinning static CSS classes, hardcoded counts, or a mirrored constant.

## Why
These break on cosmetic refactors while catching no behavior — the change-detector pattern flagged in the test-quality audit. They would still pass if the component logic were wrong.

## How
Removed:
- **sidebar**: compact-shell utility classes, exact-8-nav-item count, nav overflow classes
- **settings-layout**: exact-8-nav-item count, uppercase-label styling
- **session-layout**: `h-full` and `flex-col` layout class snapshots
- **cron-label**: `CRON_MIN_INTERVAL_SECONDS === 300` constant mirror

**Kept** every test that verifies real behavior *through* a class — the active-item / routing highlight tests (`border-accent` / `border-primary`), the inactive-state tests, and `scroll-area`'s overflow-constraint classes (which encode a real layout fix, not cosmetics). The `getCronIntervalSeconds` parsing tests are untouched.

## Risk
- Low. Test-only. `jest` on the four touched files (68 remaining tests pass), plus `oxfmt`/`oxlint` clean; full pre-push passed (UI format + lint included).

## Security
- Threat categories reviewed: No security-relevant code changes. Test-only diff; no production code touched.
- Findings and resolutions: None.

## Follow-ups
Completes the test-quality-audit cleanup series (specs index, capability-metadata sweep, model_profiles invariant, server/api serde trims, UI class detectors). Remaining UI blemishes (a few `className.toContain`/mock-interaction cases in streamdown/provider-icon) are lower-signal and left as-is.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only, no behavior change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)