### PR TITLE
chore(deps): bump fetchkit to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82150b89249abf4f7a6bce136567c795803faa601fcb041157b7a43f4c1e856b"
+checksum = "0402bf4c57789d00a50f3b9a6ead70eb991c95021669bc68c8b9d7c73af78c34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -76,7 +76,7 @@ url = "2"
 # Web fetching (optional; behind the `web-fetch` feature). fetchkit + the
 # ed25519 bot-auth key derivation pull a sizable HTTP/crypto subtree.
 bytes = "1"
-fetchkit = { version = "=0.4.0", features = ["bot-auth"], optional = true }
+fetchkit = { version = "=0.4.1", features = ["bot-auth"], optional = true }
 
 # Ed25519 key derivation (bot-auth public key registration)
 ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -949,9 +949,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fetchkit"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82150b89249abf4f7a6bce136567c795803faa601fcb041157b7a43f4c1e856b"
+checksum = "0402bf4c57789d00a50f3b9a6ead70eb991c95021669bc68c8b9d7c73af78c34"
 dependencies = [
  "async-trait",
  "base64",


### PR DESCRIPTION
## What
Bump the exact-pinned fetchkit dependency from 0.4.0 to 0.4.1.

Refresh both the workspace lockfile and the standalone weekend-concierge example lockfile so they resolve the same fetchkit version.

## Why
Keep the web_fetch dependency current while preserving the repo's exact-pin dependency policy.

## How
Updated crates/core/Cargo.toml to =0.4.1 and regenerated the affected Cargo.lock entries with cargo update -p fetchkit --precise 0.4.1.

## Risk
- Low
- This is a narrow patch dependency bump for the web_fetch capability. Possible breakage would be fetchkit API/runtime behavior changes in HTTP fetch, SSRF filtering, redirect handling, bot-auth signing, or file-save behavior.

## Security
- Threat categories reviewed: TM-API (web_fetch HTTP/SSRF surface), TM-DOS (fetch/body/resource limits), dependency supply-chain risk.
- Findings and resolutions: no code or policy changes were introduced. Existing web_fetch tests passed against fetchkit 0.4.1, including SSRF blocking, egress routing, redirects, save-to-file, prompt budget, timeout/DNS failure, and a live HTTP fetch smoke path. cargo info confirms fetchkit 0.4.1 resolves from crates.io with the expected MIT-licensed crate/repository metadata.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated: not added; existing focused web_fetch coverage exercises the bumped dependency.
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Validation:
- cargo test -p everruns-core --features web-fetch web_fetch
- cargo check (in examples/weekend-concierge-host)
- just pre-push (UI format/lint skipped because apps/ui/node_modules is absent; no UI files changed)