### PR TITLE
test(llm): update Fireworks live model

### DIFF
--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -3,7 +3,7 @@
 //! Exercises a real streamed chat completion through `FireworksChatDriver` plus
 //! live `/models` discovery and profile mapping. These are the live counterparts
 //! to the wiremock unit tests. (Live tool-calling is covered by the shared
-//! `everruns-llm-tests` matrix via the `FIREWORKS_KIMI` case.)
+//! `everruns-llm-tests` matrix via the `FIREWORKS_GPT_OSS` case.)
 //!
 //! Ignored by default (requires network + `FIREWORKS_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-fireworks --test chat_live -- --ignored --nocapture`
@@ -14,7 +14,7 @@ use everruns_core::driver_registry::{
 use everruns_fireworks::FireworksChatDriver;
 use futures::StreamExt;
 
-const LIVE_MODEL: &str = "accounts/fireworks/models/kimi-k2p5";
+const LIVE_MODEL: &str = "accounts/fireworks/models/gpt-oss-120b";
 
 fn api_key() -> String {
     std::env::var("FIREWORKS_API_KEY")
@@ -29,7 +29,7 @@ async fn fireworks_chat_streams_response() {
     let config = LlmCallConfig {
         model: LIVE_MODEL.to_string(),
         temperature: Some(0.0),
-        // Generous budget: kimi-k2 is a reasoning model and spends tokens on
+        // Generous budget: reasoning models can spend tokens on
         // hidden reasoning before emitting the visible answer.
         max_tokens: Some(512),
         tools: vec![],

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -37,7 +37,7 @@ use everruns_core::traits::ResolvedModel;
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
 #[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
-#[case::fireworks_kimi(FIREWORKS_KIMI)]
+#[case::fireworks_gpt_oss(FIREWORKS_GPT_OSS)]
 #[tokio::test]
 async fn test_basic_completion(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {
@@ -73,7 +73,7 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
 #[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
-#[case::fireworks_kimi(FIREWORKS_KIMI)]
+#[case::fireworks_gpt_oss(FIREWORKS_GPT_OSS)]
 #[tokio::test]
 async fn test_tool_call(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -135,11 +135,11 @@ pub const OPENROUTER_GPT4O_MINI: ProviderModelConfig = ProviderModelConfig::new(
 );
 
 // Fireworks AI serves open models via an OpenAI-compatible Chat Completions
-// API. kimi-k2p5 is a chat + tool-calling model. Exercises the Chat Completions
-// streaming path against a third (non-OpenAI/Azure) host.
-pub const FIREWORKS_KIMI: ProviderModelConfig = ProviderModelConfig::new(
+// API. gpt-oss-120b is a chat + tool-calling model. Exercises the Chat
+// Completions streaming path against a third (non-OpenAI/Azure) host.
+pub const FIREWORKS_GPT_OSS: ProviderModelConfig = ProviderModelConfig::new(
     DriverId::Fireworks,
-    "accounts/fireworks/models/kimi-k2p5",
+    "accounts/fireworks/models/gpt-oss-120b",
     "FIREWORKS_API_KEY",
 );
 


### PR DESCRIPTION
## What
Update the Fireworks live LLM matrix and ignored Fireworks smoke test from `accounts/fireworks/models/kimi-k2p5` to `accounts/fireworks/models/gpt-oss-120b`.

## Why
Post-merge main CI for #2566 failed because Fireworks now returns `Model not available: accounts/fireworks/models/kimi-k2p5` in the real LLM integration step. The existing driver discovery tests already exercise `gpt-oss-120b` as a chat/tool-capable Fireworks model.

## How
Rename the shared Fireworks matrix constant and update the two agent-run cases plus the ignored Fireworks live smoke test model reference.

## Risk
- Low
- Test-only change. Risk is limited to the selected Fireworks live model not supporting the expected chat/tool behavior in CI.

## Security
- Threat categories reviewed: No security-relevant code changes; this only updates live-test model identifiers and comments.
- Findings and resolutions: No findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
