### PR TITLE
feat(ui): unified auth entry and onboarding arc continuity

### DIFF
--- a/apps/ui/src/__tests__/org-setup-page.test.tsx
+++ b/apps/ui/src/__tests__/org-setup-page.test.tsx
@@ -79,10 +79,13 @@ describe("OrgSetupPage", () => {
     expect(await screen.findByText("Setting up Test Org")).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "OpenAI" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Anthropic" })).toBeInTheDocument();
+      // Card accessible names include the models subline, so match by prefix.
+      expect(screen.getByRole("button", { name: /^OpenAI/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^Anthropic/ })).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole("button", { name: "Azure OpenAI" })).not.toBeInTheDocument();
+    // The breadth strip mentions Azure OpenAI as plain text, but it must not
+    // be a selectable card during setup.
+    expect(screen.queryByRole("button", { name: /Azure OpenAI/ })).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+// Unified auth entry (Frames 1–2 of the onboarding arc): one door for both
+// log in and sign up, SSO-primary. Phase "email" shows the OAuth buttons and
+// an email field; phase "password" asks for the password with the email
+// locked in. Login vs signup is the same action — authenticate, and when the
+// account doesn't exist yet (401) and signup is open, create it with the same
+// credentials. All failure copy stays generic (TM-AUTH-014/019): the door
+// never reveals whether an email already has an account.
+
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -8,12 +16,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthShell } from "@/components/auth/auth-shell";
 import { OAuthProviderIcon } from "@/components/auth/oauth-provider-icon";
-import { useAuthConfig, useLogin } from "@/hooks/use-auth";
+import { useAuthConfig, useLogin, useRegister } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks";
 import { ApiError } from "@/lib/api/client";
-import { getOAuthUrl, login } from "@/lib/api/auth";
+import { getOAuthUrl, login, register } from "@/lib/api/auth";
 import { isBackendNavigationPath, sanitizeReturnTo } from "@/lib/auth-redirect";
-import { Loader2 } from "lucide-react";
+import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
 
 // Session storage key for preserving return_to across OAuth redirects
 const RETURN_TO_KEY = "everruns_return_to";
@@ -24,16 +32,25 @@ const oauthProviders: Record<string, { name: string }> = {
   github: { name: "GitHub" },
 };
 
+// New accounts require 8+ characters (server-enforced); used to decide
+// whether a failed login is worth retrying as a signup.
+const MIN_PASSWORD_LENGTH = 8;
+
+type Phase = "email" | "password";
+
 export default function LoginPage() {
-  usePageTitle("Sign in");
+  usePageTitle("Log in or sign up");
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: config, isLoading: configLoading } = useAuthConfig();
   const loginMutation = useLogin();
+  const registerMutation = useRegister();
 
+  const [phase, setPhase] = useState<Phase>("email");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
 
   // Sanitize to a safe relative path — prevents open-redirect into
   // attacker-controlled origins (see specs/authentication.md).
@@ -46,6 +63,13 @@ export default function LoginPage() {
     }
   }, [config, router]);
 
+  // Focus the password field when the second phase opens.
+  useEffect(() => {
+    if (phase === "password") {
+      passwordRef.current?.focus();
+    }
+  }, [phase]);
+
   const getRedirectTarget = (): string => {
     // Check URL param first, then sessionStorage (for OAuth flow).
     // Both are sanitized so a poisoned sessionStorage can't redirect off-origin.
@@ -54,35 +78,81 @@ export default function LoginPage() {
     return returnTo || stored || "/dashboard";
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const hasPasswordAuth = config?.password_auth_enabled ?? false;
+  const hasOAuthProviders = (config?.oauth_providers?.length ?? 0) > 0;
+  const canSignup = config?.signup_enabled ?? false;
+
+  const handleEmailContinue = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setPhase("password");
+  };
+
+  const handleBack = () => {
+    setPhase("email");
+    setPassword("");
+    setError(null);
+  };
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
+    const target = getRedirectTarget();
+    // For backend redirects (e.g. /oauth/authorize), call the API directly
+    // and navigate immediately — don't go through the mutation's onSuccess
+    // which refetches auth state and can trigger React re-renders that
+    // race with the navigation.
+    const backendTarget = isBackendNavigationPath(target);
+
     try {
-      const target = getRedirectTarget();
-      // For backend redirects (e.g. /oauth/authorize), call login() directly
-      // and navigate immediately — don't go through the mutation's onSuccess
-      // which refetches auth state and can trigger React re-renders that
-      // race with the navigation.
-      if (isBackendNavigationPath(target)) {
+      if (backendTarget) {
         await login({ email, password });
         window.location.assign(target);
         return;
       }
       await loginMutation.mutateAsync({ email, password });
       router.push(target);
+      return;
     } catch (err) {
       // EVE-452 / TM-AUTH-019: never render raw server messages on a login
       // failure. Inspect the error type/status instead so non-credential
       // problems (network, 500, CSRF) get a useful operator-facing fallback
       // string while the credential-failure path still gets the fixed
       // generic message that closes the enumeration oracle.
-      if (err instanceof ApiError && err.status === 401) {
-        setError("Invalid email or password.");
-      } else {
+      if (!(err instanceof ApiError && err.status === 401)) {
         setError("Login failed. Please try again.");
+        return;
       }
     }
+
+    // Unified door: a 401 may simply mean "no account yet". When signup is
+    // open and the password is registrable, retry as a signup with the same
+    // credentials. A register failure (existing account, wrong password, …)
+    // reports the same generic message as a failed login, so the outcome
+    // reveals nothing an attacker couldn't get from the register endpoint
+    // itself (TM-AUTH-014).
+    if (canSignup && password.length >= MIN_PASSWORD_LENGTH) {
+      try {
+        if (backendTarget) {
+          await register({ email, password });
+          window.location.assign(target);
+          return;
+        }
+        await registerMutation.mutateAsync({ email, password });
+        router.push(target);
+        return;
+      } catch {
+        setError("Invalid email or password.");
+        return;
+      }
+    }
+
+    setError(
+      canSignup && password.length < MIN_PASSWORD_LENGTH
+        ? `Invalid email or password. New accounts need at least ${MIN_PASSWORD_LENGTH} characters.`
+        : "Invalid email or password.",
+    );
   };
 
   const handleOAuthLogin = (provider: string) => {
@@ -108,14 +178,86 @@ export default function LoginPage() {
     return null;
   }
 
-  const hasPasswordAuth = config?.password_auth_enabled ?? false;
-  const hasOAuthProviders = (config?.oauth_providers?.length ?? 0) > 0;
-  const canSignup = config?.signup_enabled ?? false;
+  const isSubmitting = loginMutation.isPending || registerMutation.isPending;
 
+  // --- Phase 2: password, email locked in ---
+  if (phase === "password" && hasPasswordAuth) {
+    return (
+      <AuthShell>
+        <button
+          type="button"
+          onClick={handleBack}
+          className="mb-5 inline-flex items-center gap-[7px] text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="icon-sharp h-[15px] w-[15px]" strokeWidth={2} />
+          Back
+        </button>
+        <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">
+          Enter your password
+        </h2>
+        <p className="mt-[10px] text-sm text-muted-foreground">
+          Continuing as <b className="font-medium text-foreground">{email}</b>.
+          {canSignup && <> New here? We&apos;ll create your account with this email.</>}
+        </p>
+
+        <form onSubmit={handlePasswordSubmit} className="mt-6 space-y-4">
+          {error && <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="password">Password</Label>
+              <Link
+                href="/forgot-password"
+                className="text-xs text-muted-foreground hover:text-primary hover:underline"
+              >
+                Forgot password?
+              </Link>
+            </div>
+            <Input
+              id="password"
+              ref={passwordRef}
+              type="password"
+              placeholder="Enter your password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Continuing...
+              </>
+            ) : (
+              <>
+                Continue
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </form>
+
+        {hasOAuthProviders && (
+          <p className="mt-5 border-t pt-5 text-[12.5px] leading-relaxed text-muted-foreground">
+            Prefer Google or GitHub? Go back — it&apos;s one click and skips email verification.
+          </p>
+        )}
+      </AuthShell>
+    );
+  }
+
+  // --- Phase 1: one door, SSO-primary ---
   return (
     <AuthShell>
-      <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">Welcome back</h2>
-      <p className="mt-[10px] text-sm text-muted-foreground">Sign in to your Everruns account</p>
+      <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">
+        {canSignup ? "Log in or sign up" : "Welcome back"}
+      </h2>
+      <p className="mt-[10px] text-sm text-muted-foreground">
+        {canSignup
+          ? "Continue to your console. We'll create an account if you don't have one yet."
+          : "Sign in to your Everruns account"}
+      </p>
 
       <div className="mt-7 space-y-4">
         {/* OAuth Buttons */}
@@ -127,7 +269,7 @@ export default function LoginPage() {
                 <Button
                   key={provider}
                   variant="outline"
-                  className="h-11 w-full justify-start gap-[10px]"
+                  className="h-12 w-full justify-center gap-[10px] font-medium"
                   onClick={() => handleOAuthLogin(provider)}
                 >
                   <OAuthProviderIcon provider={provider} />
@@ -138,7 +280,7 @@ export default function LoginPage() {
           </div>
         )}
 
-        {/* OR divider between OAuth and password */}
+        {/* OR divider between OAuth and email */}
         {hasOAuthProviders && hasPasswordAuth && (
           <div className="flex items-center gap-[14px]">
             <span className="h-px flex-1 bg-border" />
@@ -147,51 +289,24 @@ export default function LoginPage() {
           </div>
         )}
 
-        {/* Email/Password Form */}
+        {/* Email step — the password comes on the next screen */}
         {hasPasswordAuth && (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {error && <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>}
+          <form onSubmit={handleEmailContinue} className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
               <Input
                 id="email"
                 type="email"
-                placeholder="you@example.com"
+                placeholder="you@company.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 autoComplete="email"
               />
             </div>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="password">Password</Label>
-                <Link
-                  href="/forgot-password"
-                  className="text-xs text-muted-foreground hover:text-primary hover:underline"
-                >
-                  Forgot password?
-                </Link>
-              </div>
-              <Input
-                id="password"
-                type="password"
-                placeholder="Enter your password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                autoComplete="current-password"
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={loginMutation.isPending}>
-              {loginMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Signing in...
-                </>
-              ) : (
-                "Sign in"
-              )}
+            <Button type="submit" className="w-full">
+              Continue with email
+              <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </form>
         )}
@@ -203,19 +318,6 @@ export default function LoginPage() {
           </div>
         )}
       </div>
-
-      {/* Sign up link */}
-      {canSignup && hasPasswordAuth && (
-        <p className="mt-[18px] text-sm text-muted-foreground">
-          Don&apos;t have an account?{" "}
-          <Link
-            href={returnTo ? `/register?return_to=${encodeURIComponent(returnTo)}` : "/register"}
-            className="font-medium text-primary hover:underline"
-          >
-            Sign up
-          </Link>
-        </p>
-      )}
     </AuthShell>
   );
 }

--- a/apps/ui/src/app/(auth)/register/page.tsx
+++ b/apps/ui/src/app/(auth)/register/page.tsx
@@ -1,205 +1,27 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import Link from "next/link";
+// The unified /login door ("Log in or sign up") replaced the separate
+// registration screen — signup now happens through the same entry. The route
+// stays for old links and bookmarks and simply forwards, preserving
+// return_to.
+
+import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { AuthShell } from "@/components/auth/auth-shell";
-import { OAuthProviderIcon } from "@/components/auth/oauth-provider-icon";
-import { useAuthConfig, useRegister } from "@/hooks/use-auth";
-import { usePageTitle } from "@/hooks";
-import { getOAuthUrl } from "@/lib/api/auth";
 import { sanitizeReturnTo } from "@/lib/auth-redirect";
 import { Loader2 } from "lucide-react";
 
-// Session storage key for preserving return_to across OAuth redirects
-// (must match the login page so the flow round-trips through either entry).
-const RETURN_TO_KEY = "everruns_return_to";
-
-// OAuth provider display names (logos come from OAuthProviderIcon)
-const oauthProviders: Record<string, { name: string }> = {
-  google: { name: "Google" },
-  github: { name: "GitHub" },
-};
-
 export default function RegisterPage() {
-  usePageTitle("Sign up");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data: config, isLoading: configLoading } = useAuthConfig();
-  const registerMutation = useRegister();
 
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-
-  // Sanitize to a safe relative path — prevents open-redirect into
-  // attacker-controlled origins (see specs/authentication.md).
-  const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
-
-  // Redirect if auth is not required or signup is disabled
   useEffect(() => {
-    if (config) {
-      if (config.mode === "none") {
-        router.replace("/dashboard");
-      } else if (!config.signup_enabled) {
-        router.replace("/login");
-      }
-    }
-  }, [config, router]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    // Minimal signup: only the documented 8-char minimum is enforced here; the
-    // server is the trust boundary and derives a display name from the email.
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters");
-      return;
-    }
-
-    try {
-      await registerMutation.mutateAsync({ email, password });
-      router.push(returnTo || "/dashboard");
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError("Registration failed. Please try again.");
-      }
-    }
-  };
-
-  const handleOAuthLogin = (provider: string) => {
-    // Persist return_to in sessionStorage so it survives the OAuth redirect chain
-    const target = returnTo || sessionStorage.getItem(RETURN_TO_KEY);
-    if (target) {
-      sessionStorage.setItem(RETURN_TO_KEY, target);
-    }
-    window.location.assign(getOAuthUrl(provider));
-  };
-
-  // Show loading state while fetching config
-  if (configLoading) {
-    return (
-      <div className="flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
-
-  // If signup is not available, show nothing (will redirect)
-  if (config?.mode === "none" || !config?.signup_enabled) {
-    return null;
-  }
-
-  const hasPasswordAuth = config?.password_auth_enabled ?? false;
-  const hasOAuthProviders = (config?.oauth_providers?.length ?? 0) > 0;
+    const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
+    router.replace(returnTo ? `/login?return_to=${encodeURIComponent(returnTo)}` : "/login");
+  }, [router, searchParams]);
 
   return (
-    <AuthShell
-      brand={{
-        eyebrow: "Everruns",
-        headline: "Ship AI agents that don't fall over.",
-      }}
-    >
-      <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">
-        Create an account
-      </h2>
-      <p className="mt-[10px] text-sm text-muted-foreground">Get started with Everruns</p>
-
-      <div className="mt-7 space-y-4">
-        {/* OAuth Buttons */}
-        {hasOAuthProviders && (
-          <div className="space-y-[10px]">
-            {config?.oauth_providers.map((provider) => {
-              const providerInfo = oauthProviders[provider];
-              return (
-                <Button
-                  key={provider}
-                  variant="outline"
-                  className="h-11 w-full justify-start gap-[10px]"
-                  onClick={() => handleOAuthLogin(provider)}
-                >
-                  <OAuthProviderIcon provider={provider} />
-                  Continue with {providerInfo?.name ?? provider}
-                </Button>
-              );
-            })}
-          </div>
-        )}
-
-        {/* OR divider between OAuth and password */}
-        {hasOAuthProviders && hasPasswordAuth && (
-          <div className="flex items-center gap-[14px]">
-            <span className="h-px flex-1 bg-border" />
-            <span className="font-mono text-[11px] text-muted-foreground">OR</span>
-            <span className="h-px flex-1 bg-border" />
-          </div>
-        )}
-
-        {/* Email/Password Form */}
-        {hasPasswordAuth && (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {error && <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>}
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="you@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                autoComplete="email"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder="At least 8 characters"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                autoComplete="new-password"
-                minLength={8}
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={registerMutation.isPending}>
-              {registerMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Creating account...
-                </>
-              ) : (
-                "Create account"
-              )}
-            </Button>
-          </form>
-        )}
-
-        {/* No auth methods available */}
-        {!hasPasswordAuth && !hasOAuthProviders && (
-          <div className="text-center text-muted-foreground py-4">
-            No authentication methods are currently configured.
-          </div>
-        )}
-      </div>
-
-      <p className="mt-[18px] text-sm text-muted-foreground">
-        Already have an account?{" "}
-        <Link
-          href={returnTo ? `/login?return_to=${encodeURIComponent(returnTo)}` : "/login"}
-          className="font-medium text-primary hover:underline"
-        >
-          Sign in
-        </Link>
-      </p>
-    </AuthShell>
+    <div className="flex items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
   );
 }

--- a/apps/ui/src/app/(auth)/verify-email/page.tsx
+++ b/apps/ui/src/app/(auth)/verify-email/page.tsx
@@ -1,26 +1,29 @@
 "use client";
 
+// Email-verification landing page (Frame 3 of the onboarding arc) — rendered
+// inside the shared AuthShell so verification feels like part of the journey
+// instead of a lone card. Reached from the emailed link; the verify gate
+// itself stays server-enforced.
+
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { AuthShell } from "@/components/auth/auth-shell";
 import { useVerifyEmail, useResendVerification } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks";
-import { Loader2 } from "lucide-react";
+import { Check, Loader2, Mail } from "lucide-react";
 
 type VerifyState = "verifying" | "success" | "error";
 
+const BRAND = {
+  eyebrow: "Everruns",
+  headline: "A verified identity is the first durable link in the chain.",
+};
+
 export default function VerifyEmailPage() {
   usePageTitle("Verify your email");
+  const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
   // The verification link may optionally carry the email so we can offer a
@@ -63,53 +66,58 @@ export default function VerifyEmailPage() {
 
   if (state === "verifying") {
     return (
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="flex justify-center mb-4">
-            <Image src="/logo.svg" alt="Everruns" width={48} height={48} />
-          </div>
-          <CardTitle className="text-2xl">Verifying your email</CardTitle>
-          <CardDescription>This will only take a moment.</CardDescription>
-        </CardHeader>
-        <CardContent className="flex justify-center py-4">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </CardContent>
-      </Card>
+      <AuthShell brand={BRAND}>
+        <div className="mb-6 flex h-12 w-12 items-center justify-center border border-accent/40 bg-accent/[0.12] text-accent-foreground">
+          <Mail className="icon-sharp h-[22px] w-[22px]" strokeWidth={1.8} />
+        </div>
+        <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">
+          Verifying your email
+        </h2>
+        <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+          This will only take a moment.
+        </p>
+        <div className="mt-7">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      </AuthShell>
     );
   }
 
   if (state === "success") {
     return (
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="flex justify-center mb-4">
-            <Image src="/logo.svg" alt="Everruns" width={48} height={48} />
-          </div>
-          <CardTitle className="text-2xl">Your email is verified</CardTitle>
-          <CardDescription>Thanks for confirming your email address.</CardDescription>
-        </CardHeader>
-        <CardFooter className="flex justify-center">
-          <Link href="/dashboard" className="text-sm text-primary hover:underline">
-            Continue
-          </Link>
-        </CardFooter>
-      </Card>
+      <AuthShell brand={BRAND}>
+        <div className="mb-6 flex h-12 w-12 items-center justify-center border border-accent/40 bg-accent/[0.12] text-accent-foreground">
+          <Check className="icon-sharp h-[22px] w-[22px]" strokeWidth={2.2} />
+        </div>
+        <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">
+          Your email is verified
+        </h2>
+        <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+          Thanks for confirming your email address. You can pick up right where you left off.
+        </p>
+        <Button className="mt-7" onClick={() => router.push("/dashboard")}>
+          Continue
+        </Button>
+      </AuthShell>
     );
   }
 
   // Failure state
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader className="text-center">
-        <div className="flex justify-center mb-4">
-          <Image src="/logo.svg" alt="Everruns" width={48} height={48} />
-        </div>
-        <CardTitle className="text-2xl">Verification failed</CardTitle>
-        <CardDescription>This verification link is invalid or has expired.</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+    <AuthShell brand={BRAND}>
+      <div className="mb-6 flex h-12 w-12 items-center justify-center border border-accent/40 bg-accent/[0.12] text-accent-foreground">
+        <Mail className="icon-sharp h-[22px] w-[22px]" strokeWidth={1.8} />
+      </div>
+      <h2 className="text-[28px] font-semibold leading-none tracking-[-0.02em]">
+        Verification failed
+      </h2>
+      <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
+        This verification link is invalid or has expired.
+      </p>
+
+      <div className="mt-7 space-y-4">
         {resent ? (
-          <div className="text-center text-sm text-muted-foreground">
+          <div className="text-sm text-muted-foreground">
             If an account exists for {email}, we&apos;ve sent a new verification link. Check your
             inbox.
           </div>
@@ -129,16 +137,17 @@ export default function VerifyEmailPage() {
             )}
           </Button>
         ) : (
-          <div className="text-center text-sm text-muted-foreground">
+          <div className="text-sm text-muted-foreground">
             Sign in to request a new verification email.
           </div>
         )}
-      </CardContent>
-      <CardFooter className="flex justify-center">
-        <Link href="/login" className="text-sm text-primary hover:underline">
-          Back to sign in
-        </Link>
-      </CardFooter>
-    </Card>
+
+        <p className="text-sm text-muted-foreground">
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Back to sign in
+          </Link>
+        </p>
+      </div>
+    </AuthShell>
   );
 }

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -17,6 +17,7 @@ import {
   Building2,
   Check,
   CircleDot,
+  Clock,
   Loader2,
   ArrowRight,
   Plus,
@@ -37,7 +38,7 @@ import { ProviderIcon } from "@/components/providers/provider-icon";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
 import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
-import { OSS_ONBOARDING_STEPS } from "@/components/onboarding/steps";
+import { useOnboardingArc } from "@/components/onboarding/onboarding-arc-context";
 import type { ApiError } from "@/lib/api/client";
 import type { DriverId } from "@/lib/api/types";
 
@@ -56,36 +57,45 @@ interface StepContext {
   baseHarnessId: string | null;
 }
 
+// Labels follow the onboarding-arc copy: the last item is an action ("first
+// provider" — more can be added later), rendered in-progress until a provider
+// actually exists rather than falsely ticking off.
 const SETUP_STEPS: SetupStep[] = [
   {
-    label: "Organization created",
-    description: "Your new organization has been provisioned",
+    label: "Organisation created",
+    description: "Your new organisation has been provisioned",
     check: (ctx) => ctx.orgLoaded,
   },
   {
-    label: "Harnesses initialised",
+    label: "Harnesses provisioned",
     description: "Built-in harnesses are ready",
     check: (ctx) => ctx.harnessCount > 0,
   },
   {
-    label: "Default settings configured",
+    label: "Settings initialised",
     description: "Default and base harnesses have been assigned",
     check: (ctx) => !!ctx.defaultHarnessId && !!ctx.baseHarnessId,
   },
   {
-    label: "LLM provider configured",
-    description: "API provider and credentials set up",
-    // Always shows as part of the animated sequence — actual config happens inline
+    label: "Connect your first provider",
+    description: "Add a model provider to finish setup",
+    // Always part of the animated sequence — actual config happens inline
     check: () => true,
   },
 ];
 
 const STEP_DELAY_MS = 400;
 
-const PROVIDER_OPTIONS: { type: SetupProviderType; label: string }[] = [
-  { type: "openai", label: "OpenAI" },
-  { type: "anthropic", label: "Anthropic" },
+const PROVIDER_OPTIONS: { type: SetupProviderType; label: string; models: string }[] = [
+  { type: "openai", label: "OpenAI", models: "GPT & o-series" },
+  { type: "anthropic", label: "Anthropic", models: "Claude Opus, Sonnet" },
 ];
+
+// The setup form features the two most common providers; the rest of the
+// driver catalog stays one click away after setup so the pair never reads as
+// "only two models exist".
+const MORE_PROVIDERS = ["Gemini", "Azure OpenAI", "Bedrock"];
+const MORE_PROVIDERS_EXTRA = 4; // openrouter, openai_completions, mai, fireworks
 
 // Docs base used elsewhere in the app (see capabilities page).
 const DOCS_URL = "https://docs.everruns.com";
@@ -105,6 +115,10 @@ export default function OrgSetupPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { currentOrg, organizations, setCurrentOrg, isSwitching } = useOrg();
+  // Arc position: Configure is OSS step 1, Done is OSS step 2. A wrapper arc
+  // (e.g. SaaS with a prepended "Verify") shifts indices/labels via context so
+  // the stepper stays continuous across the whole journey.
+  const arc = useOnboardingArc();
 
   const {
     data: org,
@@ -291,9 +305,9 @@ export default function OrgSetupPage() {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background bg-brand-dots p-4">
         <OnboardingShell
-          steps={OSS_ONBOARDING_STEPS}
-          currentIndex={2}
-          stepLabel="Step 3 of 3"
+          steps={arc.steps}
+          currentIndex={arc.stepIndex(2)}
+          stepLabel={arc.stepLabel(2)}
           brand={{
             eyebrow: "Setup complete",
             headline: "You're ready. Spin up an agent that ever runs.",
@@ -383,11 +397,11 @@ export default function OrgSetupPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background bg-brand-dots p-4">
       <OnboardingShell
-        steps={OSS_ONBOARDING_STEPS}
-        currentIndex={1}
-        stepLabel="Step 2 of 3"
+        steps={arc.steps}
+        currentIndex={arc.stepIndex(1)}
+        stepLabel={arc.stepLabel(1)}
         brand={{
-          eyebrow: "Step 2 / 3",
+          eyebrow: `Step ${arc.stepIndex(1) + 1} / ${arc.steps.length}`,
           headline: "Bring your own model. Keys encrypted at rest.",
           features: [
             { label: "Durable execution engine", done: true },
@@ -406,13 +420,32 @@ export default function OrgSetupPage() {
             {SETUP_STEPS.map((step, i) => {
               const passed = step.check(stepContext);
               const animated = i < completedCount;
+              const isProviderStep = i === SETUP_STEPS.length - 1;
 
-              // Completed and animated
+              // The provider step is an action, not a provisioning fact: it
+              // holds a gold in-progress badge until a provider actually
+              // exists instead of falsely ticking off with the animation.
+              if (isProviderStep && animated && !providerConnected) {
+                return (
+                  <div key={step.label} className="flex items-center gap-3">
+                    <div className="flex h-[26px] w-[26px] shrink-0 items-center justify-center border border-accent bg-accent/[0.14] text-accent-foreground">
+                      <Clock className="icon-sharp h-[13px] w-[13px]" strokeWidth={2} />
+                    </div>
+                    <div>
+                      <p className="text-sm font-semibold">{step.label}</p>
+                      <p className="text-xs text-accent-foreground">{step.description}</p>
+                    </div>
+                  </div>
+                );
+              }
+
+              // Completed and animated — sharp navy check badge (0px radius,
+              // matches the stepper)
               if (passed && animated) {
                 return (
                   <div key={step.label} className="flex items-center gap-3">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                      <Check className="h-4 w-4" />
+                    <div className="flex h-[26px] w-[26px] shrink-0 items-center justify-center border border-primary bg-primary text-primary-foreground">
+                      <Check className="icon-sharp h-[13px] w-[13px]" strokeWidth={2.5} />
                     </div>
                     <div>
                       <p className="text-sm font-medium">{step.label}</p>
@@ -426,8 +459,8 @@ export default function OrgSetupPage() {
               if (passed && !animated) {
                 return (
                   <div key={step.label} className="flex items-center gap-3">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center">
-                      <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                    <div className="flex h-[26px] w-[26px] shrink-0 items-center justify-center">
+                      <Loader2 className="h-4 w-4 animate-spin text-primary" />
                     </div>
                     <div>
                       <p className="text-sm font-medium">{step.label}</p>
@@ -440,8 +473,8 @@ export default function OrgSetupPage() {
               // Pending
               return (
                 <div key={step.label} className="flex items-center gap-3 opacity-40">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center">
-                    <CircleDot className="h-5 w-5 text-muted-foreground/50" />
+                  <div className="flex h-[26px] w-[26px] shrink-0 items-center justify-center">
+                    <CircleDot className="icon-sharp h-4 w-4 text-muted-foreground/50" />
                   </div>
                   <div>
                     <p className="text-sm font-medium">{step.label}</p>
@@ -463,10 +496,9 @@ export default function OrgSetupPage() {
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             ) : (
-              <div className="space-y-6">
+              <div className="space-y-5">
                 {/* Provider type selector */}
                 <div>
-                  <h2 className="text-sm font-semibold mb-3">Select your LLM provider</h2>
                   <div className="grid grid-cols-2 gap-3">
                     {PROVIDER_OPTIONS.map((opt) => {
                       const isSelected = selectedProvider === opt.type;
@@ -478,38 +510,50 @@ export default function OrgSetupPage() {
                             setSelectedProvider(opt.type);
                             setProviderError(null);
                           }}
-                          className={`relative flex flex-col items-center gap-2 border-2 p-4 transition-colors ${
+                          className={`relative flex items-center gap-3 border p-3.5 text-left transition-colors ${
                             isSelected
-                              ? "border-primary bg-primary/5"
+                              ? "border-accent bg-accent/[0.07]"
                               : "border-border hover:border-primary/40"
                           }`}
                         >
-                          <ProviderIcon providerType={opt.type} size="lg" />
-                          <span className="text-sm font-medium">{opt.label}</span>
-                          {/* Radio indicator */}
-                          <div
-                            className={`h-4 w-4 rounded-full border-2 transition-colors ${
-                              isSelected ? "border-primary" : "border-muted-foreground/40"
-                            }`}
-                          >
-                            {isSelected && (
-                              <div className="m-[2px] h-2 w-2 rounded-full bg-primary" />
-                            )}
-                          </div>
+                          <ProviderIcon providerType={opt.type} />
+                          <span className="min-w-0">
+                            <span
+                              className={`block text-sm ${isSelected ? "font-semibold" : "font-medium"}`}
+                            >
+                              {opt.label}
+                            </span>
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {opt.models}
+                            </span>
+                          </span>
+                          {/* Sharp gold selection badge (0px radius) */}
+                          {isSelected && (
+                            <span className="absolute right-2.5 top-2.5 flex h-[18px] w-[18px] items-center justify-center bg-accent text-accent-foreground">
+                              <Check className="icon-sharp h-[11px] w-[11px]" strokeWidth={3} />
+                            </span>
+                          )}
                         </button>
                       );
                     })}
                   </div>
 
-                  {/* Skip link */}
-                  <div className="mt-3 text-center">
-                    <button
-                      type="button"
-                      onClick={() => void finishOnboarding()}
-                      className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
-                    >
-                      Skip for now
-                    </button>
+                  {/* Breadth strip: the two featured cards must not read as
+                      the whole catalog. Informational only — the full picker
+                      lives in Settings → Providers after setup. */}
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <span className="text-xs text-muted-foreground">Also supported</span>
+                    {MORE_PROVIDERS.map((name) => (
+                      <span
+                        key={name}
+                        className="border px-2 py-[3px] text-xs text-muted-foreground"
+                      >
+                        {name}
+                      </span>
+                    ))}
+                    <span className="text-xs text-muted-foreground">
+                      + {MORE_PROVIDERS_EXTRA} more in Settings after setup
+                    </span>
                   </div>
                 </div>
 
@@ -537,15 +581,20 @@ export default function OrgSetupPage() {
                   )}
                 </div>
 
-                {/* Continue button */}
-                <Button
-                  className="w-full"
-                  onClick={handleContinue}
-                  disabled={createProvider.isPending}
-                >
-                  {createProvider.isPending ? "Configuring..." : "Finish setup"}
-                  {!createProvider.isPending && <ArrowRight className="ml-2 h-4 w-4" />}
-                </Button>
+                {/* Footer row: skip escape hatch left, primary action right */}
+                <div className="flex items-center justify-between pt-1">
+                  <button
+                    type="button"
+                    onClick={() => void finishOnboarding()}
+                    className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Skip for now
+                  </button>
+                  <Button onClick={handleContinue} disabled={createProvider.isPending}>
+                    {createProvider.isPending ? "Configuring..." : "Finish setup"}
+                    {!createProvider.isPending && <ArrowRight className="ml-2 h-4 w-4" />}
+                  </Button>
+                </div>
               </div>
             )}
           </div>

--- a/apps/ui/src/components/onboarding/onboarding-arc-context.tsx
+++ b/apps/ui/src/components/onboarding/onboarding-arc-context.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * Onboarding-arc context — lets an embedding wrapper (e.g. SaaS) extend the
+ * onboarding stepper with extra leading steps without forking the OSS
+ * surfaces that render it.
+ *
+ * Decision: the OSS pages (`ZeroOrgOnboarding`, org setup) index their
+ * position in the arc relative to the OSS step list. A wrapper that prepends
+ * steps (SaaS prepends "Verify") provides the full list plus the offset of
+ * the first OSS step within it; the OSS surfaces then render the wrapper's
+ * stepper and "Step N of M" labels without any page-level overrides. With no
+ * provider mounted, everything falls back to the plain OSS 3-step arc.
+ */
+import { createContext, useContext, type ReactNode } from "react";
+import type { OnboardingStep } from "./onboarding-stepper";
+import { OSS_ONBOARDING_STEPS } from "./steps";
+
+export interface OnboardingArcConfig {
+  /** Full step list for the arc, in render order. */
+  steps: OnboardingStep[];
+  /**
+   * Index of the first OSS step ("Organisation") within `steps`. OSS default
+   * is 0; SaaS passes 1 because it prepends a "Verify" step.
+   */
+  ossStepOffset: number;
+}
+
+const DEFAULT_ARC: OnboardingArcConfig = {
+  steps: OSS_ONBOARDING_STEPS,
+  ossStepOffset: 0,
+};
+
+const OnboardingArcContext = createContext<OnboardingArcConfig>(DEFAULT_ARC);
+
+export function OnboardingArcProvider({
+  value,
+  children,
+}: {
+  value: OnboardingArcConfig;
+  children: ReactNode;
+}) {
+  return <OnboardingArcContext.Provider value={value}>{children}</OnboardingArcContext.Provider>;
+}
+
+export interface OnboardingArc extends OnboardingArcConfig {
+  /** Absolute stepper index for a zero-based OSS step index. */
+  stepIndex: (ossIndex: number) => number;
+  /** Human "Step N of M" label for a zero-based OSS step index. */
+  stepLabel: (ossIndex: number) => string;
+}
+
+export function useOnboardingArc(): OnboardingArc {
+  const { steps, ossStepOffset } = useContext(OnboardingArcContext);
+  return {
+    steps,
+    ossStepOffset,
+    stepIndex: (ossIndex) => ossStepOffset + ossIndex,
+    stepLabel: (ossIndex) => `Step ${ossStepOffset + ossIndex + 1} of ${steps.length}`,
+  };
+}

--- a/apps/ui/src/components/onboarding/zero-org-onboarding.tsx
+++ b/apps/ui/src/components/onboarding/zero-org-onboarding.tsx
@@ -29,7 +29,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { OnboardingShell } from "./onboarding-shell";
-import { OSS_ONBOARDING_STEPS } from "./steps";
+import { useOnboardingArc } from "./onboarding-arc-context";
 
 /** State returned by a zero-org policy hook. */
 export type ZeroOrgPolicyState =
@@ -75,6 +75,10 @@ export function ZeroOrgOnboarding({
   const { setCurrentOrg } = useOrg();
   const createOrg = useCreateOrg();
   const policy = usePolicy();
+  // Arc position: this surface is the first OSS step ("Organisation"); a
+  // wrapper-provided arc (e.g. SaaS with a prepended "Verify") shifts the
+  // stepper index and labels via context.
+  const arc = useOnboardingArc();
   const [name, setName] = useState(suggestedName ?? "");
   // Show the auto-filled chip only while the prefilled value is unchanged.
   const showAutoFill = !!suggestedName && name === suggestedName;
@@ -96,11 +100,11 @@ export function ZeroOrgOnboarding({
   return (
     <div className="flex min-h-screen items-center justify-center bg-background bg-brand-dots p-4">
       <OnboardingShell
-        steps={OSS_ONBOARDING_STEPS}
-        currentIndex={0}
-        stepLabel="Step 1 of 3"
+        steps={arc.steps}
+        currentIndex={arc.stepIndex(0)}
+        stepLabel={arc.stepLabel(0)}
         brand={{
-          eyebrow: "Step 1 / 3",
+          eyebrow: `Step ${arc.stepIndex(0) + 1} / ${arc.steps.length}`,
           headline: "Your workspace for agents, harnesses, and durable runs.",
         }}
       >

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -131,6 +131,23 @@ The login page accepts exactly one public query parameter for auth resume:
 
 Implementations: `apps/ui/src/lib/auth-redirect.ts` (`sanitizeReturnTo`) and `apps/ui/src/app/(auth)/login/page.tsx`.
 
+### Unified Entry (Log In or Sign Up)
+
+`/login` is the single door for both returning and new users; `/register`
+forwards there (preserving `return_to`). The screen is SSO-primary (OAuth
+buttons first, email + password as the secondary path behind an email →
+password two-step). Login vs signup is the same action: the UI authenticates,
+and when the server returns 401, signup is enabled, and the password meets the
+registration minimum, it retries the same credentials against
+`POST /v1/auth/register`. Server contracts are unchanged — the unification is
+purely a UI-flow decision.
+
+Enumeration stance: the door never reveals whether an email has an account.
+Every failure path renders the same generic message, and the login→register
+fallback exposes nothing the public register endpoint doesn't already (its
+failures are equally generic). The visible difference between "logged in" and
+"account created" is inherent to open signup, not an oracle.
+
 ### External Mode and OAuth Providers
 
 `AUTH_MODE=external` and the built-in OAuth flow are mutually exclusive. External mode delegates user identity to a third-party provider (PropelAuth, Auth0, Clerk, etc.); the platform's own OAuth handlers (`/v1/auth/oauth/{provider}`, `/v1/auth/callback/{provider}`) are disabled.

--- a/specs/signup-experience-redesign-brief.md
+++ b/specs/signup-experience-redesign-brief.md
@@ -4,6 +4,13 @@ Status: design brief (not yet a spec). Purpose: give a design agent enough conte
 produce on-brand sign-up / onboarding screens for Everruns SaaS. Engineering will
 implement from the resulting designs.
 
+Implementation status: the resulting "Onboarding Arc" design (Frames 1–6) is
+implemented — persistent shell (`OnboardingShell`/`AuthShell` + stepper + navy
+brand panel), unified `/login` door (see `specs/authentication.md` § Unified
+Entry), verify-email under the shell, org creation (`ZeroOrgOnboarding`), the
+setup wizard as Configure, and the Done/first-action screen. Wrappers extend
+the stepper via `OnboardingArcProvider` (`onboarding-arc-context.tsx`).
+
 ---
 
 ## 1. What exists today

--- a/test_cases/ui/full_auth/TC001_user_signup.md
+++ b/test_cases/ui/full_auth/TC001_user_signup.md
@@ -2,7 +2,10 @@
 
 ## Description
 
-Verify that a new user can successfully sign up when AUTH_MODE is set to full and signup is enabled.
+Verify that a new user can successfully sign up through the unified
+"Log in or sign up" entry when AUTH_MODE is set to full and signup is enabled.
+There is no separate registration screen: authenticating with an unknown email
+creates the account with the same credentials.
 
 ## Preconditions
 
@@ -10,28 +13,31 @@ Verify that a new user can successfully sign up when AUTH_MODE is set to full an
 - `AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=`
 - `AUTH_DISABLE_SIGNUP=false`
 - `AUTH_DISABLE_PASSWORD=false`
+- No account exists for the test email
 
 ## Test Data
 
 | Field    | Value                    |
 |----------|--------------------------|
-| Name     | Test User                |
 | Email    | testuser@example.com     |
 | Password | TestPassword123!         |
 
 ## Steps
 
-1. Navigate to the login page
-2. Click the "Sign up" or "Create account" link
-3. Enter name: `Test User`
-4. Enter email: `testuser@example.com`
-5. Enter password: `TestPassword123!`
-6. Click the "Create account" button
+1. Navigate to the login page (`/login`)
+2. Verify the heading reads "Log in or sign up"
+3. Enter email: `testuser@example.com`
+4. Click "Continue with email"
+5. Verify the password screen shows "Continuing as testuser@example.com" and
+   mentions the account will be created for a new email
+6. Enter password: `TestPassword123!`
+7. Click "Continue"
 
 ## Expected Result
 
-- Account is created successfully
+- Account is created successfully (display name derived from the email)
 - User is automatically logged in after signup
 - User is redirected to the dashboard/main application
 - User session is established with the new account
-- User profile shows the correct name and email
+- User profile shows the correct email
+- Navigating to `/register` redirects to `/login` (single unified entry)

--- a/test_cases/ui/full_auth/TC002_signout_after_signin.md
+++ b/test_cases/ui/full_auth/TC002_signout_after_signin.md
@@ -23,11 +23,12 @@ Verify that a user can successfully sign out after signing in when AUTH_MODE is 
 
 1. Navigate to the login page
 2. Enter email: `testuser@example.com`
-3. Enter password: `TestPassword123!`
-4. Click the login button
-5. Verify user is logged in and on the dashboard
-6. Click on the user avatar/menu in the sidebar
-7. Click the "Sign out" button
+3. Click "Continue with email"
+4. Enter password: `TestPassword123!`
+5. Click "Continue"
+6. Verify user is logged in and on the dashboard
+7. Click on the user avatar/menu in the sidebar
+8. Click the "Sign out" button
 
 ## Expected Result
 

--- a/test_cases/ui/full_auth/TC003_login_signout_flow.md
+++ b/test_cases/ui/full_auth/TC003_login_signout_flow.md
@@ -23,16 +23,17 @@ Verify the complete flow of logging in with a previously signed up user and then
 
 1. Navigate to the login page (ensure not already logged in)
 2. Enter email: `testuser@example.com`
-3. Enter password: `TestPassword123!`
-4. Click the login button
-5. Verify successful login:
+3. Click "Continue with email"
+4. Enter password: `TestPassword123!`
+5. Click "Continue"
+6. Verify successful login:
    - User is redirected to dashboard
    - User name and email are displayed in sidebar
-6. Navigate to different pages (Dashboard, Agents, Capabilities)
-7. Return to Dashboard
-8. Click on the user avatar/menu in the sidebar
-9. Click the "Sign out" button
-10. Verify successful sign-out:
+7. Navigate to different pages (Dashboard, Agents, Capabilities)
+8. Return to Dashboard
+9. Click on the user avatar/menu in the sidebar
+10. Click the "Sign out" button
+11. Verify successful sign-out:
     - User is redirected to login page
     - Session is cleared
 

--- a/test_cases/ui/full_auth/TC004_failed_login_random_user.md
+++ b/test_cases/ui/full_auth/TC004_failed_login_random_user.md
@@ -1,34 +1,48 @@
-# TC004: Full Auth - Failed Login with Random User
+# TC004: Full Auth - Failed Login (Wrong Password / Unknown User)
 
 ## Description
 
-Verify that login fails when attempting to log in with credentials for a non-existent user in full authentication mode.
+Verify that authentication fails with a generic message when the password is
+wrong, and that the unified "Log in or sign up" door never reveals whether an
+account exists for an email.
+
+Note: with signup enabled, entering an unknown email with a valid (8+ char)
+password intentionally **creates** the account (unified door — see TC001).
+A failed outcome for an unknown user therefore requires either a wrong
+password for an existing account, or signup disabled.
 
 ## Preconditions
 
 - `AUTH_MODE=full`
 - `AUTH_JWT_SECRET=MJ5SiIlm9mTmiVJV8O2NLrxnuEZDFuO/iXkjVXGqWD0=`
-- `AUTH_DISABLE_SIGNUP=false`
 - `AUTH_DISABLE_PASSWORD=false`
+- An account exists for `testuser@example.com` (created via TC001)
 
 ## Test Data
 
 | Field    | Value                       |
 |----------|-----------------------------|
-| Email    | randomuser123@example.com   |
-| Password | RandomPassword456!          |
+| Email    | testuser@example.com        |
+| Password | WrongPassword456!           |
 
 ## Steps
 
-1. Navigate to the login page
-2. Enter email: `randomuser123@example.com`
-3. Enter password: `RandomPassword456!`
-4. Click the login button
+1. Navigate to the login page (`/login`)
+2. Enter email: `testuser@example.com`
+3. Click "Continue with email"
+4. Enter password: `WrongPassword456!`
+5. Click "Continue"
 
 ## Expected Result
 
-- Login fails
-- User is not authenticated
-- An appropriate error message is displayed (e.g., "Invalid credentials")
-- User remains on the login page
-- No session is established
+- Authentication fails; no session is established
+- A generic error message is displayed (e.g. "Invalid email or password.") —
+  it must not reveal whether the account exists or which field was wrong
+- User remains on the password screen and can retry or go back
+
+## Variant: signup disabled
+
+With `AUTH_DISABLE_SIGNUP=true`, repeat with an unknown email
+(`randomuser123@example.com` / any password): the heading reads "Welcome
+back", authentication fails with the same generic message, and no account is
+created.


### PR DESCRIPTION
## What
UI-only implementation of the approved "Onboarding Arc" design (Frames 1–6): a unified **Log in or sign up** door, the verify-email page under the branded shell, an extensible stepper arc, and the setup wizard polished to the design frames.

- **Unified entry (Frames 1–2).** `/login` is now one door for both log in and sign up: SSO buttons first, then an email → password two-step. On 401 with signup enabled and an 8+ char password, the same credentials are retried against `POST /v1/auth/register` — new users are created and logged in through the same flow. `/register` forwards to `/login` (preserving `return_to`).
- **Verify email (Frame 3).** `/verify-email` moves from the legacy centered `Card` onto the shared `AuthShell` (brand panel, gold icon badges). Logic unchanged (single-use token guard, enumeration-safe resend).
- **Arc extension point.** New `OnboardingArcProvider`/`useOnboardingArc` context: wrappers (SaaS) can prepend steps (e.g. "Verify") and the OSS surfaces (`ZeroOrgOnboarding`, org setup) render the extended stepper and "Step N of M" labels without forking — fixes the "Step 2 of 3 inside a 4-step journey" discontinuity.
- **Setup wizard (Frame 5).** Checklist copy per the frames; last item is now the action "Connect your first provider" with a gold in-progress badge until a provider actually exists (no more false tick). Sharp square badges (0px radius) replace the round ones. Provider cards get model sublines + a gold square selected-check; an "Also supported: Gemini, Azure OpenAI, Bedrock +4 more" strip prevents the two cards from implying only two providers exist. Footer row: "Skip for now" left, "Finish setup" right.

## Why
The sign-up arc was two disconnected experiences: separate login/register screens, a legacy-styled verify page, and a wizard whose stepper contradicted the wrapper's step count. The approved design makes the whole journey one continuous, progress-aware flow (see `specs/signup-experience-redesign-brief.md`).

## How
Pure UI + specs/test-cases changes; zero server changes. The unified door is a client-flow decision over the existing `login`/`register` endpoints. The arc context defaults to the OSS 3-step list, so self-host behavior is unchanged without a provider.

## Risk
- **Low–Medium.** No API changes; auth pages keep their generic-error contracts.
- Behavior change: with signup enabled, an unknown email + valid password now **creates an account** from `/login` instead of erroring (intended; TC001/TC004 updated). A typo'd email at login can therefore create a fresh account — the trade-off every unified-door product accepts; the email-verification gate still applies to the new account.

## Security
- Threat categories reviewed: **TM-AUTH**.
- Findings and resolutions:
  - **TM-AUTH-014 (enumeration):** all failure paths render the same generic "Invalid email or password."; the login→register fallback reveals nothing the public register endpoint doesn't already (its failures are equally generic). Documented in `specs/authentication.md` § Unified Entry.
  - **TM-AUTH-019 (raw server messages):** kept the typed-error handling — no server strings rendered on auth failures (the old register page rendered `err.message`; the unified door does not).
  - `return_to` handling unchanged (sanitized, sessionStorage round-trip preserved).

## Follow-ups
- SaaS wrapper wiring (`OnboardingArcProvider` with the 4-step Verify arc, root gateway pointing at the unified door) lands in the SaaS repo after this merges.
- Terms/Privacy footnote on the entry screen deferred until public terms/privacy pages exist.

## Checklist
- [x] Tests added or updated (org-setup test updated; full UI suite 122 suites / 1066 tests green; typecheck, lint, format, production build green; pre-push 10/10)
- [x] Backward compatibility considered (`/register` forwards with `return_to`; OSS arc default unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9cKZdLQcBjLxfDQJSRFzG)_