### PR TITLE
fix(ui): offer password reset from login credential-failure alert

### DIFF
--- a/apps/ui/src/app/(auth)/forgot-password/page.tsx
+++ b/apps/ui/src/app/(auth)/forgot-password/page.tsx
@@ -6,6 +6,7 @@
 // one (abuse-prone email-sending endpoint).
 
 import { useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,8 +21,10 @@ export default function ForgotPasswordPage() {
   usePageTitle("Reset your password");
   const { data: config } = useAuthConfig();
   const forgotPasswordMutation = useForgotPassword();
+  const searchParams = useSearchParams();
 
-  const [email, setEmail] = useState("");
+  // Prefilled when arriving from the login door's credential-failure alert.
+  const [email, setEmail] = useState(() => searchParams.get("email") ?? "");
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -61,6 +61,9 @@ export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // True when the current error is the generic credential failure — the one
+  // state where the user needs an explicit way forward (password reset).
+  const [showRecovery, setShowRecovery] = useState(false);
   // Disable the SSO buttons once one is clicked — the full-page redirect can
   // take a beat and double-clicks would restart the OAuth dance.
   const [oauthPending, setOauthPending] = useState(false);
@@ -109,6 +112,7 @@ export default function LoginPage() {
   const handleEmailContinue = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setShowRecovery(false);
     setPhase("password");
   };
 
@@ -116,6 +120,7 @@ export default function LoginPage() {
     setPhase("email");
     setPassword("");
     setError(null);
+    setShowRecovery(false);
     // Return focus to the email field so keyboard/screen-reader users are
     // not stranded on a removed element.
     setTimeout(() => emailRef.current?.focus(), 0);
@@ -124,6 +129,7 @@ export default function LoginPage() {
   const handlePasswordSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setShowRecovery(false);
 
     const target = getRedirectTarget();
     // For backend redirects (e.g. /oauth/authorize), call the API directly
@@ -178,6 +184,7 @@ export default function LoginPage() {
         return;
       } catch {
         setError("Invalid email or password.");
+        setShowRecovery(true);
         return;
       }
     }
@@ -187,6 +194,7 @@ export default function LoginPage() {
         ? `Invalid email or password. New accounts need at least ${MIN_PASSWORD_LENGTH} characters.`
         : "Invalid email or password.",
     );
+    setShowRecovery(true);
   };
 
   const handleOAuthLogin = (provider: string) => {
@@ -243,6 +251,17 @@ export default function LoginPage() {
           {error && (
             <div role="alert" className="bg-destructive/10 text-destructive text-sm p-3">
               {error}
+              {showRecovery && (
+                <>
+                  {" "}
+                  <Link
+                    href={`/forgot-password?email=${encodeURIComponent(email)}`}
+                    className="font-medium underline underline-offset-2 hover:no-underline"
+                  >
+                    Reset your password
+                  </Link>
+                </>
+              )}
             </div>
           )}
           <div className="space-y-2">


### PR DESCRIPTION
## What
A wrong password on the unified login door left users at a dead end: the generic "Invalid email or password." banner offered no action, the small "Forgot password?" label link was easy to miss, and the "New here? We'll create your account" subcopy misled after a failed login on an existing account (reported on dev.everruns.com).

- The credential-failure alert now carries a **"Reset your password"** link → `/forgot-password?email=<typed email>`.
- The forgot-password form prefills from that `?email=` param.
- The link renders only on credential failures (not captcha/transport errors), and clears on retry/back.

## Why
The recovery flow itself (forgot → emailed link → reset, branded shell, #2572) is sound; the failure was discoverability at the exact moment of failure.

## Risk
Low — additive UI affordance; the alert copy stays generic (no enumeration signal; the link renders regardless of account existence).

## Checklist
- [x] Tests added or updated (e2e: alert contains the link with encoded email, click lands on the prefilled reset form — 10/10 auth-door specs green; typecheck, lint, production build pass)
- [x] Backward compatibility considered (additive)
- [x] Security review performed (no new information disclosure; enumeration-safe copy unchanged)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9cKZdLQcBjLxfDQJSRFzG)_