### PR TITLE
fix(sessions): reject forged parent links

### DIFF
--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -516,17 +516,26 @@ pub async fn create_session(
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<Session>>), (StatusCode, Json<ErrorResponse>)> {
     check_session_create_rate_limit(&state, org.org_id).await?;
-    // `parent_session_id` is internal-only: the subagent/handoff spawn flow
-    // sets it via the platform store (DirectPlatformStore::create_session
-    // dispatches the command directly). External HTTP callers must never set
-    // it — that would let a client forge cross-session/cross-org parent links —
-    // so strip any client-supplied value at the public boundary.
     let mut req = req;
-    req.parent_session_id = None;
+    strip_internal_only_fields(&mut req);
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let session = CreateSession(req).run(&state.ctx(&org)).await?;
 
     Ok((StatusCode::CREATED, Json(urls.wrap(session))))
+}
+
+/// Strip request fields that only trusted internal dispatch paths may set.
+///
+/// `parent_session_id` is internal-only metadata used for subagent/handoff
+/// ownership. The trusted spawn flow sets it via `DirectPlatformStore`, which
+/// dispatches the `CreateSession` command directly and never passes through
+/// this HTTP handler. Any value on an inbound public request is therefore a
+/// forgery attempt (cross-session/cross-org parent link) and is dropped here,
+/// at the untrusted boundary — the command layer intentionally trusts the
+/// caller-set value so the spawn path (which runs as the session owner, not an
+/// internal caller) keeps working.
+fn strip_internal_only_fields(req: &mut CreateSessionRequest) {
+    req.parent_session_id = None;
 }
 
 /// POST /v1/sessions/{session_id}/fork - Fork a session into an independent copy
@@ -943,6 +952,20 @@ mod tests {
         assert!(req.tags.is_empty());
         assert_eq!(req.model_id, None);
         assert!(req.capabilities.is_empty());
+    }
+
+    #[test]
+    fn strip_internal_only_fields_drops_client_supplied_parent_session_id() {
+        // A public HTTP client must not be able to forge the internal-only
+        // parent link; the boundary drops any caller-supplied value.
+        let json = format!(r#"{{"harness_id": "{}"}}"#, TEST_HARNESS_ID);
+        let mut req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
+        req.parent_session_id = Some(SessionId::new());
+        assert!(req.parent_session_id.is_some());
+
+        strip_internal_only_fields(&mut req);
+
+        assert_eq!(req.parent_session_id, None);
     }
 
     #[test]

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -466,8 +466,11 @@ mod tests {
     use crate::domains::harnesses::CreateHarness;
     use crate::domains::harnesses::types::CreateHarnessRequest;
     use crate::storage::StorageBackend;
-    use everruns_core::{Caller, DEFAULT_ORG_ID, DefaultPermissionResolver, HarnessId};
+    use everruns_core::{
+        Caller, DEFAULT_ORG_ID, DefaultPermissionResolver, HarnessId, OrgRole, SessionId,
+    };
     use std::sync::Arc;
+    use uuid::Uuid;
 
     #[test]
     fn parse_provider_type_accepts_mixed_case_known_values() {
@@ -494,6 +497,29 @@ mod tests {
         .with_session_service(session_service);
         ctx.resource_limits.max_sessions_per_org = max_sessions_per_org;
         ctx
+    }
+
+    fn external_test_ctx(db: Arc<StorageBackend>, user_id: Uuid) -> Ctx {
+        let session_service = Arc::new(crate::domains::sessions::SessionService::new(db.clone()));
+        let capability_service =
+            Arc::new(crate::services::CapabilityService::new(db.clone(), None));
+        Ctx::new(
+            Caller {
+                org_id: DEFAULT_ORG_ID,
+                org_public_id: everruns_core::organization::org_public_id_from_internal(
+                    DEFAULT_ORG_ID,
+                ),
+                user_id: Some(user_id),
+                role: OrgRole::Owner,
+                is_platform_user: false,
+                is_internal: false,
+            },
+            db,
+            capability_service,
+            None,
+            Arc::new(DefaultPermissionResolver),
+        )
+        .with_session_service(session_service)
     }
 
     fn create_request(harness_id: HarnessId) -> CreateSessionRequest {
@@ -558,6 +584,45 @@ mod tests {
             .expect_err("second session exceeds the cap");
         assert_eq!(err.status().as_u16(), 409);
         assert!(err.message().contains("Session limit reached"));
+    }
+
+    #[tokio::test]
+    async fn create_session_with_non_internal_owner_sets_parent_session_id() {
+        // Trusted subagent/handoff spawns dispatch CreateSession through
+        // DirectPlatformStore, whose caller runs as the session owner
+        // (`is_internal == false`, see caller_resolution.rs). The internal
+        // parent link must survive that path. Forgery by untrusted clients is
+        // prevented at the HTTP boundary, which strips `parent_session_id`
+        // before dispatch (see `strip_internal_only_fields` in api/sessions.rs),
+        // so the command layer must not reject a caller-set parent link.
+        let db = Arc::new(StorageBackend::in_memory());
+        let internal_ctx = test_ctx(db.clone(), 10);
+        let harness_id = seed_harness(&internal_ctx).await;
+        let owner = db
+            .create_user(crate::storage::models::CreateUserRow {
+                email: format!("owner-{}@example.com", Uuid::now_v7()),
+                name: "Owner".to_string(),
+                avatar_url: None,
+                roles: vec!["user".to_string()],
+                password_hash: None,
+                email_verified: true,
+                auth_provider: None,
+                auth_provider_id: None,
+                external_id: None,
+            })
+            .await
+            .expect("create owner user");
+        let ctx = external_test_ctx(db, owner.id);
+        let parent = SessionId::new();
+        let mut req = create_request(harness_id);
+        req.parent_session_id = Some(parent);
+
+        let session = CreateSession(req)
+            .execute(&ctx)
+            .await
+            .expect("owner-caller spawn with a parent link should succeed");
+
+        assert_eq!(session.parent_session_id, Some(parent));
     }
 }
 


### PR DESCRIPTION
### Motivation
- `parent_session_id` is internal-only metadata used for subagent/handoff ownership. Untrusted callers must not be able to forge it (cross-session/cross-org parent links), but the trusted spawn path must be able to set it.

### Description (revised)
The original command-layer guard (`reject when parent_session_id.is_some() && !ctx.caller.is_internal`) was incorrect: the trusted subagent/handoff spawn path dispatches `CreateSession` through `DirectPlatformStore` as the **session owner** (`is_internal == false`, see `caller_resolution.rs` — "Do not replace with `Caller::internal`"), so the guard rejected legitimate spawns and failed the PostgreSQL integration test.

Enforcement belongs at the untrusted boundary, where it already lived:
- Extract the existing inline strip in `crates/server/src/api/sessions.rs` into `strip_internal_only_fields`, which drops any client-supplied `parent_session_id` before dispatch. This is the only external HTTP entry point that reaches `CreateSession`; the voice API and gRPC `platform_create_session` hardcode `None`, and MCP `tool_agent_run` never sets it.
- Remove the `is_internal` guard from `CreateSession::execute` so the trusted spawn path keeps working.
- Regression tests: `strip_internal_only_fields_drops_client_supplied_parent_session_id` (boundary) and `create_session_with_non_internal_owner_sets_parent_session_id` (a non-internal owner caller successfully creates a session with a parent link).

### Testing
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p everruns-server --lib parent_session_id` — both new tests pass.
- Rebased onto latest `main`.