### PR TITLE
fix(apps): harden schedule channel limits

### DIFF
--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -225,17 +225,30 @@ fn normalize_cron_expression(cron_expression: &str) -> Result<String, CommandErr
     Ok(normalized)
 }
 
-/// Returns the minimum interval in seconds between the next few consecutive
-/// triggers of `schedule`. Returns None when fewer than 2 upcoming times exist.
-fn cron_min_interval_seconds(schedule: &cron::Schedule) -> Option<i64> {
-    let upcoming: Vec<_> = schedule.upcoming(Utc).take(3).collect();
-    if upcoming.len() < 2 {
-        return None;
+/// Returns the minimum interval in seconds between consecutive triggers over a
+/// full leap-year-sized horizon. Cron expressions are periodic over this window
+/// for supported fields, so this catches non-uniform bursts that a small sample
+/// from the current wall clock could miss. Returns None when fewer than 2
+/// upcoming times exist in the horizon.
+fn cron_min_interval_seconds(schedule: &cron::Schedule, reject_below_seconds: i64) -> Option<i64> {
+    let start = Utc::now();
+    let end = start + Duration::days(366);
+    let mut previous: Option<DateTime<Utc>> = None;
+    let mut min_interval: Option<i64> = None;
+
+    for next in schedule.after(&start).take_while(|next| *next <= end) {
+        if let Some(previous) = previous {
+            let interval = (next - previous).num_seconds();
+            min_interval =
+                Some(min_interval.map_or(interval, |current: i64| current.min(interval)));
+            if interval < reject_below_seconds {
+                break;
+            }
+        }
+        previous = Some(next);
     }
-    upcoming
-        .windows(2)
-        .map(|w| (w[1] - w[0]).num_seconds())
-        .min()
+
+    min_interval
 }
 
 /// Gate feature-flagged channel types. Public Chat is only available to
@@ -337,7 +350,7 @@ fn normalize_and_validate_channel_config(
             // Enforce minimum cron interval.
             let schedule = cron::Schedule::from_str(&normalized).expect("already validated");
             let min_limit = schedule_channel_min_interval_seconds();
-            if let Some(interval) = cron_min_interval_seconds(&schedule)
+            if let Some(interval) = cron_min_interval_seconds(&schedule, min_limit)
                 && interval < min_limit
             {
                 return Err(CommandError::bad_request(format!(
@@ -3096,21 +3109,6 @@ impl Command for AddChannel {
 
         if self.req.channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
-            let enabled = self.req.enabled.unwrap_or(true);
-            if enabled {
-                // Soft cap — TOCTOU window acceptable for a noisy-neighbor limit.
-                let count = ctx
-                    .db
-                    .count_enabled_schedule_channels_for_org(ctx.org_id())
-                    .await
-                    .map_err(classify_anyhow)?;
-                let max = schedule_channel_max_per_org();
-                if count >= max {
-                    return Err(CommandError::bad_request(format!(
-                        "Organization may have at most {max} enabled schedule channel(s); currently has {count}"
-                    )));
-                }
-            }
         }
 
         let channel_config = normalize_and_validate_channel_config(
@@ -3131,11 +3129,22 @@ impl Command for AddChannel {
             enabled: self.req.enabled.unwrap_or(true),
         };
 
-        let row = ctx
-            .db
-            .create_app_channel(app.id, input)
-            .await
-            .map_err(classify_anyhow)?;
+        let row = if self.req.channel_type == ChannelType::Schedule && input.enabled {
+            ctx.db
+                .create_app_channel_enforcing_schedule_cap(
+                    ctx.org_id(),
+                    app.id,
+                    input,
+                    schedule_channel_max_per_org(),
+                )
+                .await
+                .map_err(classify_anyhow)?
+        } else {
+            ctx.db
+                .create_app_channel(app.id, input)
+                .await
+                .map_err(classify_anyhow)?
+        };
 
         let app = q::row_to_app(&ctx.db, encryption, app, ctx.org_id()).await;
         sync_schedule_binding_for_channel(ctx, &app, &row).await?;
@@ -3874,29 +3883,15 @@ impl Command for UpdateChannelCmd {
             &mut final_channel_config,
             &existing_decrypted,
         );
-        if final_channel_type == ChannelType::Schedule {
+        let enforce_schedule_cap = if final_channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
-            // Check cap whenever this PATCH would result in a new enabled schedule channel
-            // that wasn't already one — covers both disabled→enabled and
-            // non-schedule-type→schedule-type while remaining enabled.
-            // Soft cap — TOCTOU window acceptable for a noisy-neighbor limit.
             let final_enabled = self.req.enabled.unwrap_or(channel_row.enabled);
             let was_enabled_schedule =
                 current_channel_type == ChannelType::Schedule && channel_row.enabled;
-            if final_enabled && !was_enabled_schedule {
-                let count = ctx
-                    .db
-                    .count_enabled_schedule_channels_for_org(ctx.org_id())
-                    .await
-                    .map_err(classify_anyhow)?;
-                let max = schedule_channel_max_per_org();
-                if count >= max {
-                    return Err(CommandError::bad_request(format!(
-                        "Organization may have at most {max} enabled schedule channel(s); currently has {count}"
-                    )));
-                }
-            }
-        }
+            final_enabled && !was_enabled_schedule
+        } else {
+            false
+        };
         ensure_channel_type_enabled(ctx, &final_channel_type)?;
         let normalized_channel_config =
             normalize_and_validate_channel_config(final_channel_type, final_channel_config)?;
@@ -3921,12 +3916,23 @@ impl Command for UpdateChannelCmd {
             enabled: self.req.enabled,
         };
 
-        let row = ctx
-            .db
-            .update_app_channel(channel_row.id, input)
-            .await
-            .map_err(classify_anyhow)?
-            .ok_or_else(|| CommandError::not_found("Channel"))?;
+        let row = if enforce_schedule_cap {
+            ctx.db
+                .update_app_channel_enforcing_schedule_cap(
+                    ctx.org_id(),
+                    channel_row.id,
+                    input,
+                    schedule_channel_max_per_org(),
+                )
+                .await
+                .map_err(classify_anyhow)?
+        } else {
+            ctx.db
+                .update_app_channel(channel_row.id, input)
+                .await
+                .map_err(classify_anyhow)?
+        }
+        .ok_or_else(|| CommandError::not_found("Channel"))?;
 
         let app = q::row_to_app(&ctx.db, encryption, app, ctx.org_id()).await;
         sync_schedule_binding_for_channel(ctx, &app, &row).await?;
@@ -4111,7 +4117,7 @@ mod tests {
     fn cron_min_interval_every_5_min() {
         // "0 */5 * * * *" fires every 5 minutes = 300 s.
         let schedule = cron::Schedule::from_str("0 */5 * * * *").expect("valid cron");
-        let interval = cron_min_interval_seconds(&schedule).expect("interval exists");
+        let interval = cron_min_interval_seconds(&schedule, 1).expect("interval exists");
         assert_eq!(interval, 300);
     }
 
@@ -4119,7 +4125,16 @@ mod tests {
     fn cron_min_interval_every_minute() {
         // "0 * * * * *" fires every 60 s.
         let schedule = cron::Schedule::from_str("0 * * * * *").expect("valid cron");
-        let interval = cron_min_interval_seconds(&schedule).expect("interval exists");
+        let interval = cron_min_interval_seconds(&schedule, 1).expect("interval exists");
+        assert_eq!(interval, 60);
+    }
+
+    #[test]
+    fn cron_min_interval_detects_later_non_uniform_burst() {
+        let schedule =
+            cron::Schedule::from_str("0 0,6,12,18,24,30,36,42,48,54,55,56,57,58,59 * * * * *")
+                .expect("valid cron");
+        let interval = cron_min_interval_seconds(&schedule, 1).expect("interval exists");
         assert_eq!(interval, 60);
     }
 

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3586,6 +3586,23 @@ impl StorageBackend {
         dispatch!(self, create_app_channel, app_id, input)
     }
 
+    pub async fn create_app_channel_enforcing_schedule_cap(
+        &self,
+        org_id: i64,
+        app_id: Uuid,
+        input: CreateAppChannelRow,
+        max_enabled_schedule_channels: i64,
+    ) -> Result<AppChannelRow> {
+        dispatch!(
+            self,
+            create_app_channel_enforcing_schedule_cap,
+            org_id,
+            app_id,
+            input,
+            max_enabled_schedule_channels
+        )
+    }
+
     pub async fn list_app_channels(&self, app_id: Uuid) -> Result<Vec<AppChannelRow>> {
         dispatch!(self, list_app_channels, app_id)
     }
@@ -3607,6 +3624,23 @@ impl StorageBackend {
         input: UpdateAppChannel,
     ) -> Result<Option<AppChannelRow>> {
         dispatch!(self, update_app_channel, id, input)
+    }
+
+    pub async fn update_app_channel_enforcing_schedule_cap(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateAppChannel,
+        max_enabled_schedule_channels: i64,
+    ) -> Result<Option<AppChannelRow>> {
+        dispatch!(
+            self,
+            update_app_channel_enforcing_schedule_cap,
+            org_id,
+            id,
+            input,
+            max_enabled_schedule_channels
+        )
     }
 
     pub async fn delete_app_channel(&self, id: Uuid) -> Result<bool> {

--- a/crates/server/src/storage/memory/app_channels.rs
+++ b/crates/server/src/storage/memory/app_channels.rs
@@ -2,6 +2,7 @@
 
 use super::super::models::*;
 use super::InMemoryDatabase;
+use crate::errors::BadRequestError;
 use anyhow::Result;
 use uuid::Uuid;
 
@@ -30,6 +31,53 @@ impl InMemoryDatabase {
             updated_at: now,
         };
         self.app_channels.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn create_app_channel_enforcing_schedule_cap(
+        &self,
+        org_id: i64,
+        app_id: Uuid,
+        input: CreateAppChannelRow,
+        max_enabled_schedule_channels: i64,
+    ) -> Result<AppChannelRow> {
+        let apps = self.apps.read();
+        let org_app_ids: std::collections::HashSet<Uuid> = apps
+            .values()
+            .filter(|a| a.org_id == org_id)
+            .map(|a| a.id)
+            .collect();
+        drop(apps);
+
+        let mut channels = self.app_channels.write();
+        let count = channels
+            .values()
+            .filter(|ch| {
+                org_app_ids.contains(&ch.app_id) && ch.channel_type == "schedule" && ch.enabled
+            })
+            .count() as i64;
+        if count >= max_enabled_schedule_channels {
+            return Err(BadRequestError::new(format!(
+                "Organization may have at most {max_enabled_schedule_channels} enabled schedule channel(s); currently has {count}"
+            ))
+            .into());
+        }
+
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = AppChannelRow {
+            id,
+            app_id,
+            public_id: input.public_id,
+            channel_type: input.channel_type,
+            channel_config: input.channel_config,
+            channel_config_encrypted: input.channel_config_encrypted,
+            durable_schedule_id: input.durable_schedule_id,
+            enabled: input.enabled,
+            created_at: now,
+            updated_at: now,
+        };
+        channels.insert(id, row.clone());
         Ok(row)
     }
 
@@ -66,6 +114,55 @@ impl InMemoryDatabase {
         input: UpdateAppChannel,
     ) -> Result<Option<AppChannelRow>> {
         let mut channels = self.app_channels.write();
+        let Some(ch) = channels.get_mut(&id) else {
+            return Ok(None);
+        };
+        if let Some(channel_type) = input.channel_type {
+            ch.channel_type = channel_type;
+        }
+        if let Some(channel_config) = input.channel_config {
+            ch.channel_config = channel_config;
+        }
+        if let Some(encrypted) = input.channel_config_encrypted {
+            ch.channel_config_encrypted = Some(encrypted);
+        }
+        input.durable_schedule_id.apply(&mut ch.durable_schedule_id);
+        if let Some(enabled) = input.enabled {
+            ch.enabled = enabled;
+        }
+        ch.updated_at = Self::now();
+        Ok(Some(ch.clone()))
+    }
+
+    pub async fn update_app_channel_enforcing_schedule_cap(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateAppChannel,
+        max_enabled_schedule_channels: i64,
+    ) -> Result<Option<AppChannelRow>> {
+        let apps = self.apps.read();
+        let org_app_ids: std::collections::HashSet<Uuid> = apps
+            .values()
+            .filter(|a| a.org_id == org_id)
+            .map(|a| a.id)
+            .collect();
+        drop(apps);
+
+        let mut channels = self.app_channels.write();
+        let count = channels
+            .values()
+            .filter(|ch| {
+                org_app_ids.contains(&ch.app_id) && ch.channel_type == "schedule" && ch.enabled
+            })
+            .count() as i64;
+        if count >= max_enabled_schedule_channels {
+            return Err(BadRequestError::new(format!(
+                "Organization may have at most {max_enabled_schedule_channels} enabled schedule channel(s); currently has {count}"
+            ))
+            .into());
+        }
+
         let Some(ch) = channels.get_mut(&id) else {
             return Ok(None);
         };

--- a/crates/server/src/storage/repositories/app_channels.rs
+++ b/crates/server/src/storage/repositories/app_channels.rs
@@ -2,8 +2,22 @@
 
 use super::super::models::*;
 use super::Database;
+use crate::errors::BadRequestError;
 use anyhow::Result;
 use uuid::Uuid;
+
+fn schedule_cap_error(max: i64, count: i64) -> anyhow::Error {
+    BadRequestError::new(format!(
+        "Organization may have at most {max} enabled schedule channel(s); currently has {count}"
+    ))
+    .into()
+}
+
+fn schedule_cap_lock_key(org_id: i64) -> i64 {
+    // Namespace the advisory lock so schedule-cap checks for one org serialize
+    // without blocking unrelated PostgreSQL advisory lock users.
+    org_id ^ 0x4556_4552_5343_4844_i64
+}
 
 impl Database {
     // ============================================
@@ -32,6 +46,53 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
+        Ok(row)
+    }
+
+    pub async fn create_app_channel_enforcing_schedule_cap(
+        &self,
+        org_id: i64,
+        app_id: Uuid,
+        input: CreateAppChannelRow,
+        max_enabled_schedule_channels: i64,
+    ) -> Result<AppChannelRow> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(schedule_cap_lock_key(org_id))
+            .execute(&mut *tx)
+            .await?;
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM app_channels ac
+            JOIN apps a ON ac.app_id = a.id
+            WHERE a.org_id = $1 AND ac.channel_type = 'schedule' AND ac.enabled = true
+            "#,
+        )
+        .bind(org_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if count >= max_enabled_schedule_channels {
+            return Err(schedule_cap_error(max_enabled_schedule_channels, count));
+        }
+
+        let row = sqlx::query_as::<_, AppChannelRow>(
+            r#"
+            INSERT INTO app_channels (app_id, public_id, channel_type, channel_config, channel_config_encrypted, durable_schedule_id, enabled)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id, app_id, public_id, channel_type, channel_config, channel_config_encrypted, durable_schedule_id, enabled, created_at, updated_at
+            "#,
+        )
+        .bind(app_id)
+        .bind(&input.public_id)
+        .bind(&input.channel_type)
+        .bind(&input.channel_config)
+        .bind(&input.channel_config_encrypted)
+        .bind(input.durable_schedule_id)
+        .bind(input.enabled)
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
         Ok(row)
     }
 
@@ -127,6 +188,60 @@ impl Database {
         .fetch_optional(&self.pool)
         .await?;
 
+        Ok(row)
+    }
+
+    pub async fn update_app_channel_enforcing_schedule_cap(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateAppChannel,
+        max_enabled_schedule_channels: i64,
+    ) -> Result<Option<AppChannelRow>> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(schedule_cap_lock_key(org_id))
+            .execute(&mut *tx)
+            .await?;
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM app_channels ac
+            JOIN apps a ON ac.app_id = a.id
+            WHERE a.org_id = $1 AND ac.channel_type = 'schedule' AND ac.enabled = true
+            "#,
+        )
+        .bind(org_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if count >= max_enabled_schedule_channels {
+            return Err(schedule_cap_error(max_enabled_schedule_channels, count));
+        }
+
+        let row = sqlx::query_as::<_, AppChannelRow>(
+            r#"
+            UPDATE app_channels
+            SET
+                channel_type = COALESCE($2, channel_type),
+                channel_config = COALESCE($3, channel_config),
+                channel_config_encrypted = COALESCE($4, channel_config_encrypted),
+                durable_schedule_id = CASE WHEN $5 THEN $6 ELSE durable_schedule_id END,
+                enabled = COALESCE($7, enabled),
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, app_id, public_id, channel_type, channel_config, channel_config_encrypted, durable_schedule_id, enabled, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(&input.channel_type)
+        .bind(&input.channel_config)
+        .bind(&input.channel_config_encrypted)
+        .bind(input.durable_schedule_id.is_changed())
+        .bind(input.durable_schedule_id.into_value())
+        .bind(input.enabled)
+        .fetch_optional(&mut *tx)
+        .await?;
+        tx.commit().await?;
         Ok(row)
     }
 


### PR DESCRIPTION
### Motivation
- Prevent bypasses of schedule safety limits caused by sampling only a few upcoming cron occurrences and by a non-atomic count-then-write per-org cap that is vulnerable to race conditions.

### Description
- Validate schedule cron expressions over a 366-day horizon by replacing the small-sample helper with a horizon-based scan that can early-exit when an interval violates the configured minimum and update the call sites to pass the reject threshold.
- Enforce the enabled-schedule per-org cap atomically by routing schedule-enabled `create` and `update` flows through `create_app_channel_enforcing_schedule_cap` and `update_app_channel_enforcing_schedule_cap` storage methods instead of a separate count-then-insert/update check.
- Implement an org-scoped transaction advisory lock and count+write transaction in the PostgreSQL repository and add matching in-memory methods that hold the in-memory write lock across count and mutation, and expose both via the storage backend dispatcher.
- Add a regression unit test that detects a later non-uniform one-minute burst in a cron expression and map schedule-cap failures to a `BadRequest`-style error so callers receive a client-visible validation response.

### Testing
- Ran `cargo fmt --check` locally and it passed.
- Executed targeted unit tests `cargo test -p everruns-server cron_min_interval --lib` and `cargo test -p everruns-server schedule_channel_rejects_too_frequent_cron --lib`, and the targeted tests passed.
- Ran `git diff --check` and other local validation steps (format/check and focused tests) and observed no failures for the changed code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a406390dfc4832b81051a783507a61b)