### PR TITLE
feat(models): add Claude Sonnet 5 model profile

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1295,15 +1295,16 @@ struct AnthropicOutputConfig {
     effort: String,
 }
 
-/// Claude families that use adaptive thinking. On Fable 5 and Opus 4.8/4.7
-/// budget-based thinking is removed (400); on Opus 4.6 / Sonnet 4.6 it is
-/// deprecated and adaptive is the recommended form. Keep in sync with the
+/// Claude families that use adaptive thinking. On Fable 5, Opus 4.8/4.7, and
+/// Sonnet 5 budget-based thinking is removed (400); on Opus 4.6 / Sonnet 4.6 it
+/// is deprecated and adaptive is the recommended form. Keep in sync with the
 /// adaptive-thinking profiles in `everruns_core::model_profiles`.
 const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
+    "claude-sonnet-5",
     "claude-sonnet-4-6",
 ];
 
@@ -1317,6 +1318,7 @@ const MILLION_CONTEXT_FAMILIES: &[&str] = &[
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
+    "claude-sonnet-5",
     "claude-sonnet-4-6",
 ];
 
@@ -2014,6 +2016,7 @@ mod tests {
         assert!(uses_adaptive_thinking("claude-opus-4-8"));
         assert!(uses_adaptive_thinking("claude-opus-4-7-20260416"));
         assert!(uses_adaptive_thinking("claude-opus-4-6"));
+        assert!(uses_adaptive_thinking("claude-sonnet-5"));
         assert!(uses_adaptive_thinking("claude-sonnet-4-6"));
         // Budget-based families stay on extended thinking.
         assert!(!uses_adaptive_thinking("claude-opus-4-5"));
@@ -2777,6 +2780,10 @@ mod tests {
         assert_eq!(
             split_million_context("claude-opus-4-6[1m]"),
             ("claude-opus-4-6", true)
+        );
+        assert_eq!(
+            split_million_context("claude-sonnet-5[1m]"),
+            ("claude-sonnet-5", true)
         );
 
         // Date-suffixed 1M-capable id is still honored (family normalization).

--- a/crates/core/src/capabilities/claude_tool_search.rs
+++ b/crates/core/src/capabilities/claude_tool_search.rs
@@ -140,6 +140,7 @@ mod tests {
     fn test_native_support_lookup() {
         // Claude 4-family models support hosted tool_search; 3.x do not.
         assert!(model_supports_native_tool_search("claude-opus-4-8"));
+        assert!(model_supports_native_tool_search("claude-sonnet-5"));
         assert!(model_supports_native_tool_search("claude-sonnet-4-6"));
         assert!(model_supports_native_tool_search("claude-haiku-4-5"));
         assert!(model_supports_native_tool_search("claude-fable-5"));

--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -149,7 +149,7 @@ fn reasoning_effort_anthropic_extended_thinking() -> ReasoningEffortConfig {
 }
 
 /// Adaptive thinking config for recent Claude reasoning models
-/// (Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6)
+/// (Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6)
 /// Uses thinking.type="adaptive" with effort parameter instead of budget_tokens
 /// Default: high, supports: low, medium, high, max (mapped to xhigh)
 fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
@@ -296,6 +296,8 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["claude-opus-4-8[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-7[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-6[1m]"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-sonnet-5"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-sonnet-5[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-sonnet-4-6"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-sonnet-4-5"], ModelVendor::Anthropic, ANTHROPIC),
@@ -2169,6 +2171,7 @@ fn anthropic_family_supports_tool_search(family: &str) -> bool {
             | "claude-opus-4-5"
             | "claude-opus-4-1"
             | "claude-opus-4"
+            | "claude-sonnet-5"
             | "claude-sonnet-4-6"
             | "claude-sonnet-4-5"
             | "claude-sonnet-4"
@@ -2363,6 +2366,53 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
         "claude-opus-4-6[1m]" => {
             anthropic_profile_data("claude-opus-4-6").map(anthropic_1m_variant)
         }
+        "claude-sonnet-5[1m]" => {
+            anthropic_profile_data("claude-sonnet-5").map(anthropic_1m_variant)
+        }
+
+        // Claude Sonnet 5
+        // Source: Anthropic model card and docs.claude.com — Sonnet 5 is not yet
+        // in models.dev. Same API surface as Opus 4.8: adaptive thinking only
+        // (budget-based thinking returns 400) and non-default sampling parameters
+        // rejected, hence `temperature: false`. Pricing is the $3/$15 sticker; the
+        // introductory $2/$10 through 2026-08-31 is deliberately not encoded so
+        // the profile stays correct after it lapses. Release/knowledge dates are
+        // not published in the model card; the Models API exposes them at runtime.
+        "claude-sonnet-5" => Some(ModelProfile {
+            name: "Claude Sonnet 5".into(),
+            family: "claude-sonnet-5".into(),
+            description: None,
+            release_date: None,
+            last_updated: None,
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 3.00,
+                output: 15.00,
+                cache_read: Some(0.30),
+                cost_tiers: vec![],
+            }),
+            limits: Some(ModelLimits {
+                // Bare id is the 200K profile; `claude-sonnet-5[1m]` is the 1M twin.
+                context: 200_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
 
         "claude-sonnet-4-6" => Some(ModelProfile {
             name: "Claude Sonnet 4.6".into(),
@@ -3200,6 +3250,7 @@ mod tests {
         (DriverId::Anthropic, "claude-opus-4-8"),
         (DriverId::Anthropic, "claude-opus-4-7"),
         (DriverId::Anthropic, "claude-opus-4-6"),
+        (DriverId::Anthropic, "claude-sonnet-5"),
         (DriverId::Anthropic, "claude-sonnet-4-6"),
         (DriverId::Anthropic, "claude-opus-4-5"),
         (DriverId::Anthropic, "claude-sonnet-4-5"),
@@ -4092,6 +4143,18 @@ mod tests {
             assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
             assert!(m1.name.ends_with("(1M)"));
         }
+    }
+
+    #[test]
+    fn test_claude_sonnet_5_1m_variant() {
+        let base = get_model_profile(&DriverId::Anthropic, "claude-sonnet-5").unwrap();
+        assert_eq!(base.limits.as_ref().unwrap().context, 200_000);
+
+        let m1 = get_model_profile(&DriverId::Anthropic, "claude-sonnet-5[1m]").unwrap();
+        assert_eq!(m1.name, "Claude Sonnet 5 (1M)");
+        assert_eq!(m1.family, "claude-sonnet-5");
+        assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
+        assert_eq!(m1.cost.unwrap().input, base.cost.unwrap().input);
     }
 
     #[test]


### PR DESCRIPTION
## What
Adds the `claude-sonnet-5` model profile: registry descriptors for `claude-sonnet-5` and its `claude-sonnet-5[1m]` large-context twin, the profile payload (pricing, limits, modalities, adaptive-thinking effort set), hosted tool_search support for the family, and the Anthropic driver's adaptive-thinking / 1M-context family lists.

## Why
Claude Sonnet 5 is Anthropic's current Sonnet-tier model and had no profile, so cost estimation, model-picker metadata, adaptive thinking, the `context-1m` beta header, and hosted tool_search would not apply to it.

## How
Follows the exact pattern used for Opus 4.8 / Fable 5:
- `crates/core/src/model_profiles.rs`: registry entries, profile arm (bare id = 200K profile, `[1m]` twin derived via `anthropic_1m_variant`), `anthropic_family_supports_tool_search`, tests (`REGISTERED_MODELS` invariant + a 1M-twin test).
- `crates/anthropic/src/driver.rs`: `ADAPTIVE_THINKING_FAMILIES` and `MILLION_CONTEXT_FAMILIES` gain `claude-sonnet-5` (Sonnet 5 rejects budget-based thinking with a 400, adaptive-only like Opus 4.8), plus test coverage for `uses_adaptive_thinking` and `split_million_context`.
- Profile data sourced from the Anthropic model card / docs.claude.com (Sonnet 5 is not yet on models.dev, same as the Opus 4.8 / Fable 5 additions): $3/$15 per MTok (cache read $0.30), 128K max output, text/image/PDF input, `temperature: false` (non-default sampling params rejected). The introductory $2/$10 pricing (through 2026-08-31) is deliberately not encoded so the profile stays correct after it lapses; noted in a comment.

## Risk
- Low
- Purely additive static data; no existing profile, wire format, or lookup logic changed. Worst case is inaccurate cost estimation for the new id.

## Security
- Threat categories reviewed: TM-LLM (model parameters / driver request shaping). The change only adds static profile data and extends two family allowlists that gate the `context-1m` beta header and adaptive-thinking request shape — both additive, no key handling, no input parsing, no new endpoints. No THREAT comments near the touched code.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)