### PR TITLE
chore(release): prepare v0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.5] - 2026-07-08
+
+### Highlights
+
+- **Public Chat** — Turn an App into a standalone, branded public-facing chat site behind a feature flag, with anonymous or Google sign-in and Turnstile bot protection ([#2400](https://github.com/everruns/everruns/pull/2400)).
+- **Redesigned sign-up & login** — Explicit signup path with an email-confirmation gate, unified auth entry, and clearer credential-failure recovery ([#2574](https://github.com/everruns/everruns/pull/2574), [#2572](https://github.com/everruns/everruns/pull/2572), [#2571](https://github.com/everruns/everruns/pull/2571), [#2573](https://github.com/everruns/everruns/pull/2573), [#2570](https://github.com/everruns/everruns/pull/2570)).
+- **Eval run share links** — Publish read-only, revocable share links for eval runs ([#2565](https://github.com/everruns/everruns/pull/2565)).
+- **Background subagents** — `spawn_subagent` now runs in the background by default, waking the parent on completion ([#2576](https://github.com/everruns/everruns/pull/2576)).
+- **Claude Sonnet 5 model support** ([#2583](https://github.com/everruns/everruns/pull/2583)).
+
+### What's Changed
+
+- feat(runtime): add multi-root host workspace mounts by [@chaliy](https://github.com/chaliy)
+- feat(auth): link OAuth identity to existing account by verified email ([#2570](https://github.com/everruns/everruns/pull/2570)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): read-only share links for eval runs ([#2565](https://github.com/everruns/everruns/pull/2565)) by [@chaliy](https://github.com/chaliy)
+- fix(server): map MCP/plugin validation errors to 400 ([#2534](https://github.com/everruns/everruns/pull/2534)) by [@chaliy](https://github.com/chaliy)
+- feat(public-chat): isolated public chat app behind feature flag ([#2400](https://github.com/everruns/everruns/pull/2400)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): unified auth entry and onboarding arc continuity ([#2571](https://github.com/everruns/everruns/pull/2571)) by [@chaliy](https://github.com/chaliy)
+- feat(auth): abuse limits, password cap, logout revoke, oauth UX ([#2572](https://github.com/everruns/everruns/pull/2572)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): offer password reset from login credential-failure alert ([#2573](https://github.com/everruns/everruns/pull/2573)) by [@chaliy](https://github.com/chaliy)
+- feat(auth): explicit signup path with email-confirm gate ([#2574](https://github.com/everruns/everruns/pull/2574)) by [@chaliy](https://github.com/chaliy)
+- feat(subagents): background spawn_subagent with foreground opt-in ([#2576](https://github.com/everruns/everruns/pull/2576)) by [@chaliy](https://github.com/chaliy)
+- feat(models): add Claude Sonnet 5 model profile ([#2583](https://github.com/everruns/everruns/pull/2583)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): require verified email before auto-linking OAuth identity ([#2575](https://github.com/everruns/everruns/pull/2575)) by [@chaliy](https://github.com/chaliy)
+- fix(budgets): meter cached prompt tokens ([#2579](https://github.com/everruns/everruns/pull/2579)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): bound oversized run case loading ([#2581](https://github.com/everruns/everruns/pull/2581)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): rate limit session forks ([#2580](https://github.com/everruns/everruns/pull/2580)) by [@chaliy](https://github.com/chaliy)
+- fix(guardrails): buffer post-output guarded deltas ([#2578](https://github.com/everruns/everruns/pull/2578)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): harden schedule channel limits ([#2582](https://github.com/everruns/everruns/pull/2582)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): reject forged parent links ([#2577](https://github.com/everruns/everruns/pull/2577)) by [@chaliy](https://github.com/chaliy)
+- feat(bashkit): egress-routed outbound HTTP behind enable_http config ([#2588](https://github.com/everruns/everruns/pull/2588)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump rust 1.96.0 to 1.96.1-slim-bookworm in /docker ([#2586](https://github.com/everruns/everruns/pull/2586)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump rust 1.96.0-slim to 1.96.1-slim in /crates/worker ([#2585](https://github.com/everruns/everruns/pull/2585)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump rust 1.96.0-slim to 1.96.1-slim in /crates/server ([#2584](https://github.com/everruns/everruns/pull/2584)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump cargo group (ed25519-dalek 3, mlua 0.12, aws-smithy-types 1.6) ([#2589](https://github.com/everruns/everruns/pull/2589)) by [@dependabot](https://github.com/apps/dependabot)
+
 ## [0.17.4] - 2026-07-05
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -500,9 +500,9 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -524,7 +524,7 @@ checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -584,10 +584,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.1.13"
+name = "aws-smithy-http"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -614,7 +635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.1.0",
  "aws-smithy-types",
 ]
 
@@ -628,17 +649,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-runtime"
-version = "1.11.3"
+name = "aws-smithy-observability"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -655,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -673,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -687,6 +717,17 @@ name = "aws-smithy-schema"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -728,7 +769,7 @@ dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.1.0",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1165,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1662,18 +1703,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1690,18 +1731,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -2429,11 +2470,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.4"
+version = "0.17.5"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2450,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2467,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2521,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2541,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2599,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2624,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2639,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2654,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2671,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2687,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2708,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2723,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2740,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2763,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2778,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2793,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2820,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2837,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2850,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2866,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2884,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2908,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2928,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2944,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2958,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2976,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2996,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3011,11 +3052,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.4"
+version = "0.17.5"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3055,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3152,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3169,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3185,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4439,9 +4480,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+checksum = "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -4450,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -4704,11 +4745,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -6494,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quanta"
@@ -7304,9 +7345,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -9938,18 +9979,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.4"
+version = "0.17.5"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -149,11 +149,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.17.4" }
+everruns-core = { path = "crates/core", version = "0.17.5" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.4" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.5" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.4" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.5" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.4", default-features = false }
+everruns-core = { path = "../core", version = "0.17.5", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.4", default-features = false }
+everruns-core = { path = "../core", version = "0.17.5", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.4", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.5", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.4", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.5", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.4", default-features = false }
+everruns-core = { path = "../core", version = "0.17.5", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.4", default-features = false }
+everruns-core = { path = "../core", version = "0.17.5", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.4", default-features = false }
+everruns-core = { path = "../core", version = "0.17.5", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What
Prepares the v0.17.5 patch release: bumps workspace/UI/path-dep versions, regenerates lockfiles, and adds the CHANGELOG entry.

## Why
Release the accumulated changes since v0.17.4 (auth/signup redesign, Public Chat, eval share links, background subagents, Claude Sonnet 5 model support, plus several security-hardening fixes).

## How
Standard `/prepare-release` flow: `Cargo.toml` workspace version + synced path-dep pins, `apps/ui/package.json` version, `CHANGELOG.md` entry, `Cargo.lock`/pnpm lockfiles regenerated. No behavioral code changes in this PR itself.

## Risk
- Low — version/changelog/lockfile bump only.

## Security
- No security-relevant code changes in this PR. The release's included changes were already security-reviewed in their own PRs.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release metadata only)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories (n/a — no code changes)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.17.5`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhmEVULTPdMds9VWNuWdmJ)_