### PR TITLE
feat(export): add ATIF session export

### DIFF
--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -10,7 +10,9 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::{Command, Ctx};
-use crate::domains::messages::{CreateMessage, ExportSessionMessages, ListMessages};
+use crate::domains::messages::{
+    CreateMessage, ExportSessionMessages, ListMessages, SessionExportFormat,
+};
 use crate::middleware::RequestId;
 use crate::storage::StorageBackend;
 use axum::{
@@ -299,19 +301,30 @@ pub async fn list_messages(
     Ok(Json(ListResponse::new(messages)))
 }
 
-/// Export session messages as a JSONL file
+/// Query parameters for session export.
+#[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
+pub struct ExportSessionQuery {
+    /// Output format: `jsonl` (default) or `atif`.
+    #[serde(default)]
+    pub format: SessionExportFormat,
+}
+
+/// Export session messages as a JSONL file (default) or as an ATIF trajectory
 ///
-/// Returns all materialized messages (user, agent) as newline-delimited JSON.
-/// Delta events are excluded. Each line is a complete JSON object representing one message.
+/// Default (`format=jsonl`): all materialized messages (user, agent) as
+/// newline-delimited JSON, one complete JSON object per line; delta events are
+/// excluded. `format=atif` returns a single ATIF-v1.7 trajectory JSON document
+/// folded from the session's event log (see `specs/atif-adoption.md`).
 /// The response includes `Content-Disposition: attachment` for browser download.
 #[utoipa::path(
     get,
     path = "/v1/sessions/{session_id}/export",
     params(
-        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)"),
+        ("format" = Option<String>, Query, description = "Output format: jsonl (default) or atif")
     ),
     responses(
-        (status = 200, description = "JSONL file with one message per line", content_type = "application/x-ndjson"),
+        (status = 200, description = "JSONL file with one message per line, or one ATIF trajectory JSON document", content_type = "application/x-ndjson"),
         (status = 400, description = "Invalid ID format"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Session not found"),
@@ -323,20 +336,22 @@ pub async fn export_session_jsonl(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
+    axum::extract::Query(query): axum::extract::Query<ExportSessionQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
     let export = ExportSessionMessages {
         session_id: session_id.clone(),
+        format: query.format,
     }
     .run(&state.ctx(&org))
     .await?;
-    let filename = format!("{}.jsonl", session_id);
+    let (content_type, filename) = match query.format {
+        SessionExportFormat::Jsonl => ("application/x-ndjson", format!("{}.jsonl", session_id)),
+        SessionExportFormat::Atif => ("application/json", format!("{}.atif.json", session_id)),
+    };
     Ok((
         StatusCode::OK,
         [
-            (
-                axum::http::header::CONTENT_TYPE,
-                "application/x-ndjson".to_string(),
-            ),
+            (axum::http::header::CONTENT_TYPE, content_type.to_string()),
             (
                 axum::http::header::CONTENT_DISPOSITION,
                 format!("attachment; filename=\"{}\"", filename),

--- a/crates/server/src/atif.rs
+++ b/crates/server/src/atif.rs
@@ -1,0 +1,728 @@
+// ATIF (Agent Trajectory Interchange Format) adoption. See specs/atif-adoption.md.
+//
+// This module is the single place that folds a session's event log into an
+// ATIF-v1.7 trajectory JSON document (Harbor RFC 0001). It is pure over
+// `&[Event]` so every export path (session export today; eval dataset export
+// as a follow-up) and the tests share one folding implementation.
+//
+// Folding rules (see the mapping table in specs/atif-adoption.md):
+// - `input.message`             → one "user" step
+// - `output.message.completed`  → opens one "agent" step per reasoning
+//   iteration (everruns emits it once per LLM call); text content becomes the
+//   step `message`, tool-call content parts become `tool_calls`, message
+//   thinking becomes `reasoning_content`, usage becomes `metrics`
+// - `reason.completed`          → annotates the open agent step (duration,
+//   fallback usage); a failed reason with no message opens an error step
+// - `tool.completed`            → appended to the open agent step's
+//   `observation.results` with `source_call_id` = tool_call_id
+// - `turn.*`                    → boundaries, not steps; durations/iteration
+//   counts are recorded in root `extra.turns`
+//
+// Secret scrubbing (the same always-on scrubber used by the dataset export)
+// is applied to every produced trajectory before it leaves this module.
+
+use chrono::{DateTime, Utc};
+use everruns_core::events::{
+    Event, EventData, TokenUsage, TurnCancelledData, TurnCompletedData, TurnFailedData,
+    TurnSealedData,
+};
+use everruns_core::message::{ContentPart, Message};
+use serde_json::{Map, Value, json};
+
+use crate::domains::evals::dataset::{REDACTED, sanitize_value};
+
+/// Pinned ATIF schema version produced by exports.
+pub const ATIF_SCHEMA_VERSION: &str = "ATIF-v1.7";
+
+// ============================================================================
+// Trajectory building (export)
+// ============================================================================
+
+/// Options for building a trajectory.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AtifOptions {
+    /// Replace content-bearing strings (messages, reasoning, tool arguments,
+    /// observation contents) with a placeholder, preserving structure. Secret
+    /// scrubbing is applied regardless.
+    pub redact_content: bool,
+}
+
+/// Fold a session's events into one ATIF trajectory document.
+///
+/// `root_extra` lets callers attach provenance/reward at the ATIF extension
+/// point (`extra`); ATIF itself has no reward field, so callers that carry
+/// reward (the eval dataset export) put it there.
+pub fn build_trajectory(
+    session_id: Option<&str>,
+    events: &[Event],
+    mut root_extra: Map<String, Value>,
+    options: AtifOptions,
+) -> Value {
+    let mut fold = Fold::new(options.redact_content);
+    for event in events {
+        fold.push(event);
+    }
+    let (steps, turns, totals, model_name) = fold.finish();
+
+    if !turns.is_empty() {
+        root_extra.insert("turns".to_string(), Value::Array(turns));
+    }
+
+    let mut agent = Map::new();
+    agent.insert("name".to_string(), json!("everruns"));
+    agent.insert("version".to_string(), json!(env!("CARGO_PKG_VERSION")));
+    if let Some(model) = model_name {
+        agent.insert("model_name".to_string(), json!(model));
+    }
+
+    let mut root = Map::new();
+    root.insert("schema_version".to_string(), json!(ATIF_SCHEMA_VERSION));
+    if let Some(sid) = session_id {
+        root.insert("session_id".to_string(), json!(sid));
+    }
+    root.insert("agent".to_string(), Value::Object(agent));
+    root.insert(
+        "final_metrics".to_string(),
+        totals.to_final_metrics(steps.len()),
+    );
+    root.insert("steps".to_string(), Value::Array(steps));
+    if !root_extra.is_empty() {
+        root.insert("extra".to_string(), Value::Object(root_extra));
+    }
+
+    let mut value = Value::Object(root);
+    // Always-on secret scrubbing over every exported string. Content redaction
+    // was already applied structurally during the fold, so scrub-only here.
+    sanitize_value(&mut value, false);
+    value
+}
+
+/// Aggregated token totals across agent steps.
+#[derive(Debug, Default)]
+struct Totals {
+    prompt: u64,
+    completion: u64,
+    cached: u64,
+    cost_usd: Option<f64>,
+    any: bool,
+}
+
+impl Totals {
+    fn add(&mut self, usage: &TokenUsage) {
+        self.any = true;
+        self.prompt += prompt_tokens(usage);
+        self.completion += usage.output_tokens as u64;
+        self.cached += usage.cache_read_tokens.unwrap_or(0) as u64;
+        if let Some(cost) = usage.effective_cost_usd() {
+            *self.cost_usd.get_or_insert(0.0) += cost;
+        }
+    }
+
+    fn to_final_metrics(&self, total_steps: usize) -> Value {
+        let mut m = Map::new();
+        if self.any {
+            m.insert("total_prompt_tokens".to_string(), json!(self.prompt));
+            m.insert(
+                "total_completion_tokens".to_string(),
+                json!(self.completion),
+            );
+            m.insert("total_cached_tokens".to_string(), json!(self.cached));
+            if let Some(cost) = self.cost_usd {
+                m.insert("total_cost_usd".to_string(), json!(cost));
+            }
+        }
+        m.insert("total_steps".to_string(), json!(total_steps));
+        Value::Object(m)
+    }
+}
+
+/// Total prompt tokens for ATIF `prompt_tokens`: everruns keeps the prompt
+/// buckets disjoint (see `TokenUsage`), while ATIF expects the inclusive
+/// prompt count with `cached_tokens` as the cached subset.
+fn prompt_tokens(usage: &TokenUsage) -> u64 {
+    usage.input_tokens as u64
+        + usage.cache_read_tokens.unwrap_or(0) as u64
+        + usage.cache_creation_tokens.unwrap_or(0) as u64
+}
+
+fn usage_to_metrics(usage: &TokenUsage) -> Value {
+    let mut m = Map::new();
+    m.insert("prompt_tokens".to_string(), json!(prompt_tokens(usage)));
+    m.insert(
+        "completion_tokens".to_string(),
+        json!(usage.output_tokens as u64),
+    );
+    if let Some(cached) = usage.cache_read_tokens {
+        m.insert("cached_tokens".to_string(), json!(cached as u64));
+    }
+    if let Some(cost) = usage.effective_cost_usd() {
+        m.insert("cost_usd".to_string(), json!(cost));
+    }
+    Value::Object(m)
+}
+
+/// An in-progress agent step (one reasoning iteration).
+struct AgentStepAcc {
+    timestamp: DateTime<Utc>,
+    model_name: Option<String>,
+    message: String,
+    reasoning: Option<String>,
+    tool_calls: Vec<Value>,
+    observations: Vec<Value>,
+    usage: Option<TokenUsage>,
+    extra: Map<String, Value>,
+}
+
+impl AgentStepAcc {
+    fn new(timestamp: DateTime<Utc>) -> Self {
+        Self {
+            timestamp,
+            model_name: None,
+            message: String::new(),
+            reasoning: None,
+            tool_calls: Vec::new(),
+            observations: Vec::new(),
+            usage: None,
+            extra: Map::new(),
+        }
+    }
+
+    fn has_tool_call(&self, id: &str) -> bool {
+        self.tool_calls
+            .iter()
+            .any(|tc| tc.get("tool_call_id").and_then(Value::as_str) == Some(id))
+    }
+}
+
+struct Fold {
+    redact: bool,
+    steps: Vec<Value>,
+    turns: Vec<Value>,
+    totals: Totals,
+    open: Option<AgentStepAcc>,
+    pending_thinking: Option<String>,
+    last_model: Option<String>,
+}
+
+impl Fold {
+    fn new(redact: bool) -> Self {
+        Self {
+            redact,
+            steps: Vec::new(),
+            turns: Vec::new(),
+            totals: Totals::default(),
+            open: None,
+            pending_thinking: None,
+            last_model: None,
+        }
+    }
+
+    fn content_or_redacted(&self, content: String) -> String {
+        if self.redact {
+            REDACTED.to_string()
+        } else {
+            content
+        }
+    }
+
+    fn push(&mut self, event: &Event) {
+        match &event.data {
+            EventData::InputMessage(data) => {
+                self.flush();
+                let text = self.content_or_redacted(flatten_message_text(&data.message));
+                self.steps.push(json!({
+                    "timestamp": timestamp(event),
+                    "source": "user",
+                    "message": text,
+                }));
+            }
+            EventData::OutputMessageCompleted(data) => {
+                self.flush();
+                let mut acc = AgentStepAcc::new(event.ts);
+                acc.message = self.content_or_redacted(flatten_message_text(&data.message));
+                acc.reasoning = data
+                    .message
+                    .thinking
+                    .clone()
+                    .or_else(|| self.pending_thinking.take())
+                    .map(|t| self.content_or_redacted(t));
+                for part in &data.message.content {
+                    if let ContentPart::ToolCall(call) = part {
+                        acc.tool_calls.push(json!({
+                            "tool_call_id": call.id,
+                            "function_name": call.name,
+                            "arguments": self.arguments_or_redacted(&call.arguments),
+                        }));
+                    }
+                }
+                if let Some(meta) = &data.metadata {
+                    acc.model_name = Some(meta.model.clone());
+                    self.last_model = Some(meta.model.clone());
+                }
+                acc.usage = data.usage.clone();
+                if let Some(code) = &data.error_code {
+                    acc.extra.insert("error_code".to_string(), json!(code));
+                }
+                self.pending_thinking = None;
+                self.open = Some(acc);
+            }
+            EventData::ReasonThinkingCompleted(data) => {
+                self.pending_thinking = Some(data.thinking.clone());
+            }
+            EventData::ReasonCompleted(data) => {
+                if data.success {
+                    if let Some(acc) = self.open.as_mut() {
+                        if acc.usage.is_none() {
+                            acc.usage = data.usage.clone();
+                        }
+                        if let Some(d) = data.duration_ms {
+                            acc.extra.insert("reason_duration_ms".to_string(), json!(d));
+                        }
+                    }
+                } else {
+                    // A failed LLM call with no assistant message still counts
+                    // as an agent step so the failure is visible in sequence.
+                    self.flush();
+                    let mut acc = AgentStepAcc::new(event.ts);
+                    if let Some(err) = &data.error {
+                        acc.extra.insert(
+                            "error".to_string(),
+                            json!(self.content_or_redacted(err.clone())),
+                        );
+                    }
+                    if let Some(d) = data.duration_ms {
+                        acc.extra.insert("reason_duration_ms".to_string(), json!(d));
+                    }
+                    self.open = Some(acc);
+                    self.flush();
+                }
+            }
+            EventData::ToolStarted(data) => {
+                let arguments = self.arguments_or_redacted(&data.tool_call.arguments);
+                let acc = self.open.get_or_insert_with(|| AgentStepAcc::new(event.ts));
+                // Assistant messages normally carry tool-call parts already;
+                // this covers paths that only emit `tool.started`.
+                if !acc.has_tool_call(&data.tool_call.id) {
+                    acc.tool_calls.push(json!({
+                        "tool_call_id": data.tool_call.id,
+                        "function_name": data.tool_call.name,
+                        "arguments": arguments,
+                    }));
+                }
+            }
+            EventData::ToolCallRequested(data) => {
+                let calls: Vec<(String, String, Value)> = data
+                    .tool_calls
+                    .iter()
+                    .map(|call| {
+                        (
+                            call.id.clone(),
+                            call.name.clone(),
+                            self.arguments_or_redacted(&call.arguments),
+                        )
+                    })
+                    .collect();
+                let acc = self.open.get_or_insert_with(|| AgentStepAcc::new(event.ts));
+                for (id, name, arguments) in calls {
+                    if !acc.has_tool_call(&id) {
+                        acc.tool_calls.push(json!({
+                            "tool_call_id": id,
+                            "function_name": name,
+                            "arguments": arguments,
+                        }));
+                    }
+                }
+            }
+            EventData::ToolCompleted(data) => {
+                let content = if let Some(err) = &data.error {
+                    format!("[error] {err}")
+                } else {
+                    data.result
+                        .as_ref()
+                        .map(|parts| flatten_content_parts(parts))
+                        .unwrap_or_default()
+                };
+                let content = self.content_or_redacted(content);
+                let mut extra = Map::new();
+                extra.insert("tool_name".to_string(), json!(data.tool_name));
+                extra.insert("status".to_string(), json!(data.status));
+                if let Some(d) = data.duration_ms {
+                    extra.insert("duration_ms".to_string(), json!(d));
+                }
+                let acc = self.open.get_or_insert_with(|| AgentStepAcc::new(event.ts));
+                acc.observations.push(json!({
+                    "source_call_id": data.tool_call_id,
+                    "content": content,
+                    "extra": extra,
+                }));
+            }
+            // Turn events are boundaries, not steps: close the open step and
+            // record turn stats at the root extension point.
+            EventData::TurnCompleted(TurnCompletedData {
+                turn_id,
+                iterations,
+                duration_ms,
+                ..
+            }) => {
+                self.flush();
+                let mut t = Map::new();
+                t.insert("turn_id".to_string(), json!(turn_id.to_string()));
+                t.insert("status".to_string(), json!("completed"));
+                t.insert("iterations".to_string(), json!(iterations));
+                if let Some(d) = duration_ms {
+                    t.insert("duration_ms".to_string(), json!(d));
+                }
+                self.turns.push(Value::Object(t));
+            }
+            EventData::TurnFailed(TurnFailedData { turn_id, error, .. }) => {
+                self.flush();
+                self.turns.push(json!({
+                    "turn_id": turn_id.to_string(),
+                    "status": "failed",
+                    "error": self.content_or_redacted(error.clone()),
+                }));
+            }
+            EventData::TurnSealed(TurnSealedData {
+                turn_id,
+                reason,
+                iterations,
+                ..
+            }) => {
+                self.flush();
+                let mut t = Map::new();
+                t.insert("turn_id".to_string(), json!(turn_id.to_string()));
+                t.insert("status".to_string(), json!("sealed"));
+                t.insert("reason".to_string(), json!(reason));
+                if let Some(i) = iterations {
+                    t.insert("iterations".to_string(), json!(i));
+                }
+                self.turns.push(Value::Object(t));
+            }
+            EventData::TurnCancelled(TurnCancelledData {
+                turn_id, reason, ..
+            }) => {
+                self.flush();
+                let mut t = Map::new();
+                t.insert("turn_id".to_string(), json!(turn_id.to_string()));
+                t.insert("status".to_string(), json!("cancelled"));
+                if let Some(r) = reason {
+                    t.insert("reason".to_string(), json!(r));
+                }
+                self.turns.push(Value::Object(t));
+            }
+            // Everything else (deltas, lifecycle, budget, voice, ...) is
+            // observability detail with no ATIF equivalent.
+            _ => {}
+        }
+    }
+
+    fn arguments_or_redacted(&self, arguments: &Value) -> Value {
+        if self.redact {
+            Value::String(REDACTED.to_string())
+        } else {
+            arguments.clone()
+        }
+    }
+
+    fn flush(&mut self) {
+        let Some(acc) = self.open.take() else {
+            return;
+        };
+        if let Some(usage) = &acc.usage {
+            self.totals.add(usage);
+        }
+        let mut step = Map::new();
+        step.insert("timestamp".to_string(), json!(acc.timestamp.to_rfc3339()));
+        step.insert("source".to_string(), json!("agent"));
+        if let Some(model) = acc.model_name.or_else(|| self.last_model.clone()) {
+            step.insert("model_name".to_string(), json!(model));
+        }
+        step.insert("message".to_string(), json!(acc.message));
+        if let Some(reasoning) = acc.reasoning {
+            step.insert("reasoning_content".to_string(), json!(reasoning));
+        }
+        if !acc.tool_calls.is_empty() {
+            step.insert("tool_calls".to_string(), Value::Array(acc.tool_calls));
+        }
+        if !acc.observations.is_empty() {
+            step.insert(
+                "observation".to_string(),
+                json!({ "results": acc.observations }),
+            );
+        }
+        if let Some(usage) = &acc.usage {
+            step.insert("metrics".to_string(), usage_to_metrics(usage));
+        }
+        if !acc.extra.is_empty() {
+            step.insert("extra".to_string(), Value::Object(acc.extra));
+        }
+        self.steps.push(Value::Object(step));
+    }
+
+    /// Finish the fold: flush the trailing step and assign 1-based step ids.
+    fn finish(mut self) -> (Vec<Value>, Vec<Value>, Totals, Option<String>) {
+        self.flush();
+        for (i, step) in self.steps.iter_mut().enumerate() {
+            if let Value::Object(map) = step {
+                map.insert("step_id".to_string(), json!(i + 1));
+            }
+        }
+        (self.steps, self.turns, self.totals, self.last_model)
+    }
+}
+
+fn timestamp(event: &Event) -> String {
+    event.ts.to_rfc3339()
+}
+
+/// Flatten a message's text-bearing content to one string. Tool calls and
+/// results are represented elsewhere in the step; images become a marker.
+fn flatten_message_text(message: &Message) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for part in &message.content {
+        match part {
+            ContentPart::Text(t) => parts.push(t.text.clone()),
+            ContentPart::Image(_) | ContentPart::ImageFile(_) => parts.push("[image]".to_string()),
+            ContentPart::ToolCall(_) | ContentPart::ToolResult(_) => {}
+        }
+    }
+    parts.join("\n")
+}
+
+/// Flatten tool-result content parts to a single observation string.
+fn flatten_content_parts(parts: &[ContentPart]) -> String {
+    let mut out: Vec<String> = Vec::new();
+    for part in parts {
+        match part {
+            ContentPart::Text(t) => out.push(t.text.clone()),
+            ContentPart::Image(_) | ContentPart::ImageFile(_) => out.push("[image]".to_string()),
+            other => out.push(serde_json::to_string(other).unwrap_or_default()),
+        }
+    }
+    out.join("\n")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::events::{
+        EventContext, InputMessageData, ModelMetadata, OutputMessageCompletedData,
+        ReasonCompletedData, ToolCompletedData, TurnCompletedData, TurnFailedData,
+    };
+    use everruns_core::tool_types::ToolCall;
+    use everruns_core::typed_id::{SessionId, TurnId};
+
+    fn event(session: SessionId, data: impl Into<EventData>) -> Event {
+        Event::new(session, EventContext::empty(), data)
+    }
+
+    /// Synthetic session: user msg → iteration 1 (tool call + result) →
+    /// iteration 2 (final text) → turn.completed.
+    fn sample_events(session: SessionId) -> Vec<Event> {
+        let turn_id = TurnId::new();
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "search".to_string(),
+            arguments: json!({"query": "weather"}),
+        };
+
+        let mut first = Message::assistant_with_tools("checking", vec![tool_call]);
+        first.thinking = Some("let me look this up".to_string());
+
+        vec![
+            event(session, InputMessageData::new(Message::user("hi there"))),
+            event(
+                session,
+                OutputMessageCompletedData::new(first)
+                    .with_metadata(ModelMetadata {
+                        model: "test-model".to_string(),
+                        model_id: None,
+                        provider_id: None,
+                    })
+                    .with_usage(TokenUsage::with_cache(100, 20, Some(30), None)),
+            ),
+            event(
+                session,
+                ReasonCompletedData::success(
+                    "checking",
+                    true,
+                    1,
+                    Some(250),
+                    Some(TokenUsage::new(100, 20)),
+                ),
+            ),
+            event(
+                session,
+                ToolCompletedData::success(
+                    "call_1".to_string(),
+                    "search".to_string(),
+                    vec![ContentPart::text("sunny, 21C")],
+                    Some(40),
+                ),
+            ),
+            event(
+                session,
+                OutputMessageCompletedData::new(Message::assistant(
+                    "It is sunny. token sk-abcdef0123456789ABCDEF",
+                ))
+                .with_usage(TokenUsage::new(150, 10)),
+            ),
+            event(
+                session,
+                ReasonCompletedData::success("It is sunny.", false, 0, Some(120), None),
+            ),
+            event(
+                session,
+                TurnCompletedData {
+                    turn_id,
+                    iterations: 2,
+                    duration_ms: Some(1500),
+                    usage: None,
+                    input_content: None,
+                    final_message_id: None,
+                    final_answer_preview: None,
+                    time_to_first_token_ms: None,
+                    tool_call_count: Some(1),
+                    llm_call_count: Some(2),
+                    status: None,
+                },
+            ),
+        ]
+    }
+
+    #[test]
+    fn folds_events_into_atif_steps() {
+        let session = SessionId::new();
+        let value = build_trajectory(
+            Some("session_x"),
+            &sample_events(session),
+            Map::new(),
+            AtifOptions::default(),
+        );
+
+        assert_eq!(value["schema_version"], json!(ATIF_SCHEMA_VERSION));
+        assert_eq!(value["session_id"], json!("session_x"));
+        assert_eq!(value["agent"]["name"], json!("everruns"));
+        assert_eq!(value["agent"]["model_name"], json!("test-model"));
+
+        let steps = value["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 3);
+
+        // Step ids are 1-based and sequential.
+        for (i, step) in steps.iter().enumerate() {
+            assert_eq!(step["step_id"], json!(i + 1));
+        }
+
+        assert_eq!(steps[0]["source"], json!("user"));
+        assert_eq!(steps[0]["message"], json!("hi there"));
+
+        // Iteration 1: tool call, reasoning, observation, metrics.
+        let s1 = &steps[1];
+        assert_eq!(s1["source"], json!("agent"));
+        assert_eq!(s1["message"], json!("checking"));
+        assert_eq!(s1["reasoning_content"], json!("let me look this up"));
+        assert_eq!(s1["model_name"], json!("test-model"));
+        assert_eq!(s1["tool_calls"][0]["tool_call_id"], json!("call_1"));
+        assert_eq!(s1["tool_calls"][0]["function_name"], json!("search"));
+        assert_eq!(
+            s1["tool_calls"][0]["arguments"],
+            json!({"query": "weather"})
+        );
+        assert_eq!(
+            s1["observation"]["results"][0]["source_call_id"],
+            json!("call_1")
+        );
+        assert_eq!(
+            s1["observation"]["results"][0]["content"],
+            json!("sunny, 21C")
+        );
+        // prompt = input(100) + cache_read(30); cached = 30.
+        assert_eq!(s1["metrics"]["prompt_tokens"], json!(130));
+        assert_eq!(s1["metrics"]["completion_tokens"], json!(20));
+        assert_eq!(s1["metrics"]["cached_tokens"], json!(30));
+        assert_eq!(s1["extra"]["reason_duration_ms"], json!(250));
+
+        // Iteration 2: final message, secret scrubbed.
+        let s2 = &steps[2];
+        assert_eq!(s2["source"], json!("agent"));
+        let msg = s2["message"].as_str().unwrap();
+        assert!(msg.contains("It is sunny."));
+        assert!(!msg.contains("sk-abcdef0123456789ABCDEF"));
+        assert!(msg.contains(REDACTED));
+        assert!(s2.get("tool_calls").is_none());
+        assert!(s2.get("observation").is_none());
+
+        // Turn boundary recorded in extra, not as a step.
+        assert_eq!(value["extra"]["turns"][0]["status"], json!("completed"));
+        assert_eq!(value["extra"]["turns"][0]["iterations"], json!(2));
+        assert_eq!(value["extra"]["turns"][0]["duration_ms"], json!(1500));
+
+        // Aggregates: 130 + 150 prompt, 20 + 10 completion.
+        assert_eq!(value["final_metrics"]["total_prompt_tokens"], json!(280));
+        assert_eq!(value["final_metrics"]["total_completion_tokens"], json!(30));
+        assert_eq!(value["final_metrics"]["total_steps"], json!(3));
+    }
+
+    #[test]
+    fn failed_reason_and_turn_produce_error_step_and_turn_record() {
+        let session = SessionId::new();
+        let turn_id = TurnId::new();
+        let events = vec![
+            event(session, InputMessageData::new(Message::user("hi"))),
+            event(
+                session,
+                ReasonCompletedData::failure("provider exploded".to_string(), Some(50)),
+            ),
+            event(
+                session,
+                TurnFailedData {
+                    turn_id,
+                    error: "provider exploded".to_string(),
+                    error_code: None,
+                    error_fields: None,
+                    error_disclosure: None,
+                },
+            ),
+        ];
+        let value = build_trajectory(None, &events, Map::new(), AtifOptions::default());
+        let steps = value["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[1]["source"], json!("agent"));
+        assert_eq!(steps[1]["extra"]["error"], json!("provider exploded"));
+        assert_eq!(value["extra"]["turns"][0]["status"], json!("failed"));
+        assert_eq!(
+            value["extra"]["turns"][0]["error"],
+            json!("provider exploded")
+        );
+    }
+
+    #[test]
+    fn redact_content_blanks_content_but_keeps_structure() {
+        let session = SessionId::new();
+        let value = build_trajectory(
+            Some("session_x"),
+            &sample_events(session),
+            Map::new(),
+            AtifOptions {
+                redact_content: true,
+            },
+        );
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(!serialized.contains("hi there"));
+        assert!(!serialized.contains("sunny"));
+        assert!(!serialized.contains("weather"));
+        assert!(!serialized.contains("let me look this up"));
+        // Structure preserved.
+        let steps = value["steps"].as_array().unwrap();
+        assert_eq!(steps[1]["tool_calls"][0]["function_name"], json!("search"));
+        assert_eq!(
+            steps[1]["observation"]["results"][0]["source_call_id"],
+            json!("call_1")
+        );
+        assert_eq!(steps[0]["message"], json!(REDACTED));
+    }
+}

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -97,7 +97,7 @@ static SECRET_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     .collect()
 });
 
-const REDACTED: &str = "[REDACTED]";
+pub(crate) const REDACTED: &str = "[REDACTED]";
 
 /// Scrub credential-looking substrings from a single string.
 pub fn scrub_secrets(input: &str) -> String {
@@ -110,8 +110,9 @@ pub fn scrub_secrets(input: &str) -> String {
 
 /// Recursively scrub secrets in every string leaf of `value`. When
 /// `redact_content` is set, content-bearing fields are first replaced wholesale
-/// with a placeholder (structure is preserved).
-fn sanitize_value(value: &mut Value, redact_content: bool) {
+/// with a placeholder (structure is preserved). Shared with the ATIF exporter
+/// (`crate::atif`) so every export path applies the same scrubbing policy.
+pub(crate) fn sanitize_value(value: &mut Value, redact_content: bool) {
     match value {
         Value::String(s) => *s = scrub_secrets(s),
         Value::Array(items) => {

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -127,10 +127,25 @@ pub struct ExportSessionJsonl {
     pub body: String,
 }
 
+/// Output format for session export.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionExportFormat {
+    /// One materialized message per line (`application/x-ndjson`).
+    #[default]
+    Jsonl,
+    /// A single ATIF trajectory document folded from the session's event log
+    /// (`application/json`). See `specs/atif-adoption.md`.
+    Atif,
+}
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ExportSessionMessages {
     /// Session's prefixed public identifier.
     pub session_id: String,
+    /// Output format (defaults to `jsonl`).
+    #[serde(default)]
+    pub format: SessionExportFormat,
 }
 
 impl Command for ExportSessionMessages {
@@ -157,6 +172,29 @@ impl Command for ExportSessionMessages {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("Session"))?;
+
+        if self.format == SessionExportFormat::Atif {
+            // Fold the full event log into one ATIF trajectory document.
+            // Secret scrubbing is always applied by the ATIF builder.
+            let event_service = crate::services::EventService::new(
+                ctx.db.clone(),
+                crate::event_delivery::EventDelivery::in_memory(),
+            );
+            let events = event_service
+                .list(session_id.uuid(), None, None, &[], &[], None, None)
+                .await
+                .map_err(classify_anyhow)?;
+            let trajectory = crate::atif::build_trajectory(
+                Some(&session_id.to_string()),
+                &events,
+                serde_json::Map::new(),
+                crate::atif::AtifOptions::default(),
+            );
+            let body =
+                serde_json::to_string(&trajectory).map_err(|e| CommandError::internal(e.into()))?;
+            return Ok(ExportSessionJsonl { body });
+        }
+
         let messages = q::message_service(ctx)?
             .list(session_id.uuid())
             .await

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -63,6 +63,9 @@ pub mod harnesses;
 pub mod direct_worker_adapters;
 pub mod execution_metadata;
 pub mod knowledge_store;
+
+// ATIF trajectory interchange (specs/atif-adoption.md)
+pub mod atif;
 pub use direct_worker_adapters::DirectWorkerAdapters;
 pub mod max_iterations;
 

--- a/crates/server/tests/evals_integration_test.rs
+++ b/crates/server/tests/evals_integration_test.rs
@@ -853,3 +853,58 @@ async fn test_dataset_export_cross_org_returns_not_found() {
         .expect("missing dataset get");
     assert!(missing.is_none(), "unknown dataset id is not-found");
 }
+
+// ============================================================================
+// ATIF session export (specs/atif-adoption.md)
+// ============================================================================
+
+#[tokio::test]
+async fn test_session_export_atif_format() {
+    let server = TestServer::in_memory().await;
+    // Reuse the dataset-export seed: it creates a session with input/output
+    // message events (plus a credential the export must scrub).
+    let (eval_id, run_id) = seed_run_with_session_events(&server).await;
+    let service = EvalService::new(server.db.clone());
+    let caller = Caller::internal(TEST_ORG_ID);
+    let run = service
+        .get_run(&caller, &eval_id, &run_id)
+        .await
+        .expect("get run")
+        .expect("run exists");
+    let session_id = run.results[0].session_id.expect("case session");
+
+    let response = server
+        .get(&format!("/v1/sessions/{}/export?format=atif", session_id))
+        .await
+        .assert_status(StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+    let disposition = response
+        .headers()
+        .get("content-disposition")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(disposition.contains(&format!("{}.atif.json", session_id)));
+
+    let body = response.text();
+    let trajectory: serde_json::Value = serde_json::from_str(&body).expect("single JSON document");
+    assert_eq!(trajectory["schema_version"], json!("ATIF-v1.7"));
+    assert_eq!(trajectory["session_id"], json!(session_id.to_string()));
+    let steps = trajectory["steps"].as_array().expect("steps");
+    assert_eq!(steps[0]["source"], json!("user"));
+    assert!(!body.contains(SEEDED_SECRET), "secret must be scrubbed");
+
+    // Default format is unchanged: JSONL with one message per line.
+    let response = server
+        .get(&format!("/v1/sessions/{}/export", session_id))
+        .await
+        .assert_status(StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "application/x-ndjson"
+    );
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11542,8 +11542,8 @@
         "tags": [
           "sessions"
         ],
-        "summary": "Export session messages as a JSONL file",
-        "description": "Returns all materialized messages (user, agent) as newline-delimited JSON.\nDelta events are excluded. Each line is a complete JSON object representing one message.\nThe response includes `Content-Disposition: attachment` for browser download.",
+        "summary": "Export session messages as a JSONL file (default) or as an ATIF trajectory",
+        "description": "Default (`format=jsonl`): all materialized messages (user, agent) as\nnewline-delimited JSON, one complete JSON object per line; delta events are\nexcluded. `format=atif` returns a single ATIF-v1.7 trajectory JSON document\nfolded from the session's event log (see `specs/atif-adoption.md`).\nThe response includes `Content-Disposition: attachment` for browser download.",
         "operationId": "export_session_jsonl",
         "parameters": [
           {
@@ -11554,11 +11554,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Output format: jsonl (default) or atif",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "JSONL file with one message per line",
+            "description": "JSONL file with one message per line, or one ATIF trajectory JSON document",
             "content": {
               "application/x-ndjson": {}
             }

--- a/specs/README.md
+++ b/specs/README.md
@@ -142,6 +142,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/swe-bench-lite.md` - SWE-bench Lite evaluation harness
 - `specs/reporting.md` - Async reporting
 - `specs/dataset-export.md` - Reward-labeled trajectory dataset export from eval runs
+- `specs/atif-adoption.md` - ATIF (Agent Trajectory Interchange Format) export/import adoption
 - `specs/reporting-backends.md` - Phase 3 reference evaluation
 - `specs/fail-rs-testing.md` - Failure injection testing with fail-rs
 

--- a/specs/atif-adoption.md
+++ b/specs/atif-adoption.md
@@ -1,0 +1,102 @@
+# ATIF (Agent Trajectory Interchange Format) Adoption
+
+## Abstract
+
+[ATIF][atif-rfc] (Harbor RFC 0001) is a vendor-neutral JSON format for agent
+trajectories: one root document per trajectory with an `agent` descriptor, a
+sequential `steps[]` history (user/system/agent steps with tool calls,
+observations, and per-step token metrics), and an `extra` extension point at
+every level. For everruns it is an **interchange boundary**, not a new storage
+model: the session event log (`specs/events.md`) remains the ground truth, and
+ATIF documents are folded from it on export.
+
+Adopting ATIF lets reward-labeled everruns trajectories feed external
+post-training/analysis pipelines, and lets trajectories produced by other
+agents (e.g. yolop, Harbor-based harnesses) seed everruns eval cases.
+
+Adoption ships in independently reviewable PRs (see Delivery Plan); this spec
+captures the full design intent, with per-surface status noted below.
+
+## Version and tolerance
+
+- Exports pin `schema_version: "ATIF-v1.7"`.
+- Imports tolerate any `ATIF-*` version and ignore unknown fields at every
+  level (the format's own compatibility rule); only `schema_version`, a
+  non-empty `steps[]`, and at least one user step are required.
+
+## Event → ATIF mapping
+
+The fold lives in `crates/server/src/atif.rs` (one implementation shared by
+every export surface). Field-level detail is readable there; the mapping:
+
+| everruns events | ATIF |
+|---|---|
+| `input.message` | one `user` step |
+| `output.message.completed` (one per reasoning iteration) | one `agent` step: text → `message`, tool-call parts → `tool_calls[]`, thinking → `reasoning_content`, usage → `metrics` |
+| `reason.completed` | annotates the iteration's step (duration, fallback usage); failures become an agent step with `extra.error` |
+| `tool.completed` | `observation.results[]` on the iteration's step (`source_call_id` = tool_call_id) |
+| `turn.*` | boundaries, not steps; per-turn iterations/duration/status recorded in root `extra.turns` |
+| aggregate usage | `final_metrics` |
+
+Everything else in the event log (deltas, lifecycle, budget, voice, ...) has no
+ATIF equivalent and is dropped.
+
+## `extra.reward` convention
+
+ATIF has no reward field. Dataset-export records carry the eval reward at the
+root extension point: `extra.reward = { pass, score, scorers }` (same shape as
+the existing dataset formats), plus case identity (`source_key`, `eval_run_id`,
+`case_id`, `case_name`) for idempotent downstream joins.
+
+## Surfaces
+
+- **Session export** (✅ shipped): `GET /v1/sessions/{id}/export?format=atif`
+  returns one ATIF JSON document (see `specs/session-export.md`; default JSONL
+  unchanged).
+- **Dataset export** (◑ follow-up PR): `format: "atif"` on the eval dataset
+  export produces NDJSON with one complete ATIF trajectory per case (see
+  `specs/dataset-export.md`). Unlike the message-based formats, ATIF folds the
+  raw event log (per-iteration steps and observations), not the compaction
+  model view. Same policy gate, filters, and redaction controls.
+- **Import** (◑ follow-up PR): `POST /v1/evals/{eval_id}/atif_import` accepts
+  NDJSON or JSON (array, single object, or `{ "trajectories": [...] }`) and
+  upserts eval cases: user steps → the case `conversation` (multi-turn
+  preserved), the final agent message → a reference excerpt in the case
+  description. **Import creates unscored cases** — ATIF carries no assertion
+  semantics, so no scorer is auto-synthesized from the final message (a
+  whole-text `contains` scorer would be brittle); users attach scorers after
+  import. Idempotency keys on the case name (derived from `extra.case_name` →
+  `extra.source_key` → `trajectory_id` → `session_id`), so re-import
+  converges.
+
+## Security
+
+- Secret scrubbing (the dataset-export scrubber) is always on for every
+  produced ATIF document, on every export surface; `redact_content` blanks
+  message/reasoning/argument/observation content while preserving structure.
+- Import (follow-up) follows the OKF importer posture
+  (`specs/okf-adoption.md`): org-scoped through the eval lookup, gated by
+  `EVAL_MANAGE`, body capped, malformed input rejected with 400, no cross-org
+  existence leaks.
+
+## Delivery Plan
+
+Each item is an independently reviewable change (committed PR-sized). Status
+reflects what has shipped on `main`.
+
+1. ✅ **Serializer + session export** — `crates/server/src/atif.rs` fold,
+   `?format=atif` on session export, this spec, index/cross-link updates.
+2. ◑ **Dataset export + import** — `format: "atif"` on the eval dataset
+   export, `POST /v1/evals/{eval_id}/atif_import`, and the related spec
+   updates (`specs/dataset-export.md`, `specs/evals.md`). Ships as a
+   follow-up PR; endpoints above marked ◑ do not exist on `main` yet.
+
+## Non-goals (v1)
+
+- `subagent_trajectories` (session tasks are not folded into embedded
+  subagent trajectories yet).
+- ATIF image content parts (images are flattened to markers).
+- Importing trajectories as *results* (the existing external-run import in
+  `specs/evals.md` covers scored results; ATIF import produces cases).
+
+[atif-rfc]: https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md

--- a/specs/session-export.md
+++ b/specs/session-export.md
@@ -14,6 +14,14 @@ Each line is a JSON object representing one message (user or agent).
 Tool results are embedded as `tool_result` content parts within agent messages.
 Delta events are excluded — only materialized messages are exported.
 
+### `?format=atif`
+
+`GET /v1/sessions/{session_id}/export?format=atif` returns a single ATIF-v1.7
+trajectory JSON document instead (Content-Type `application/json`, filename
+`{session_id}.atif.json`), folded from the session's event log with always-on
+secret scrubbing. See `specs/atif-adoption.md`. The default (`jsonl`) behavior
+is unchanged.
+
 ### JSONL line schema
 
 ```json


### PR DESCRIPTION
## What
- New `crates/server/src/atif.rs`: a pure fold from a session's event log (`&[Event]`) to one ATIF-v1.7 trajectory JSON document (Harbor RFC 0001), with always-on secret scrubbing.
- Session export gains a `format` query parameter: `GET /v1/sessions/SESSION_ID/export?format=atif` returns one ATIF JSON document (`application/json`, attachment filename `SESSION_ID.atif.json`). The default (`format=jsonl`) behavior and response are unchanged.
- Spec: `specs/atif-adoption.md` (full adoption design with a Delivery Plan; the eval dataset-export/import surfaces are marked as follow-up), `specs/README.md` index entry, `specs/session-export.md` cross-link, regenerated `docs/api/openapi.json`.

## Why
ATIF is a vendor-neutral trajectory interchange format. Exporting sessions as ATIF lets everruns trajectories feed external post-training/analysis pipelines without a new storage model — the event log stays the ground truth and documents are folded on export.

## How
- `atif::build_trajectory` folds `input.message`, `output.message.completed`, `reason.completed`, `tool.completed`, and `turn.*` events into ATIF steps (mapping table in the spec and module header); everything else in the event log is observability detail with no ATIF equivalent and is dropped.
- `ExportSessionMessages` gains a `SessionExportFormat` (`jsonl` default, `atif`); the ATIF path lists the session's events and serializes one trajectory document.
- The dataset-export secret scrubber (`sanitize_value` in `domains/evals/dataset.rs`) is made `pub(crate)` and applied to every produced trajectory, so all export paths share one scrubbing policy.

## Risk
- Low.
- The default JSONL export is untouched (same handler, `format` defaults to `jsonl`; covered by the integration test). The new code path is additive and read-only.

## Security
- Threat categories reviewed: TM-API (new query parameter on an existing endpoint), TM-TENANT (session data access), TM-DOS (response size), plus data-exposure review of the exported content.
- TM-API: `format` deserializes into a closed two-variant enum via serde; unknown values are rejected by axum with 400. No new endpoint, no new parser over untrusted input (export only).
- TM-TENANT: the ATIF path reuses the same org-scoped session lookup as the existing JSONL export (`session_service.get` filters by `caller.org_id`; cross-org access yields 404 per TM-TENANT-002). Events are listed only after that check, by the resolved session UUID.
- Data exposure: always-on secret scrubbing (the dataset-export scrubber) is applied to the full trajectory document before it leaves `atif.rs`; verified by unit test, integration test, and smoke test (a seeded `sk-...` credential comes back `[REDACTED]`).
- TM-DOS: bounded by the session's own event log, same order of magnitude as the existing JSONL export of the same session; no user-controlled amplification.
- No auth or policy changes; no new dependencies; no migrations.

## Follow-ups
- ATIF eval dataset export + eval-case import ship as a follow-up PR (isolated shipping; serializer landed here). The spec's Delivery Plan marks those surfaces as not yet on `main`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

### Validation
- `cargo fmt --check` — clean
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` — clean
- `cargo test -p everruns-server --lib` — 1830 passed (includes 3 new `atif::tests`)
- `cargo test -p everruns-server --test evals_integration_test` — 11 passed (includes new `test_session_export_atif_format`: ATIF headers/body, secret scrubbed, default JSONL unchanged)
- `bash scripts/lib/pre-push.sh` — all checks passed (migrations sequential 001..092, specs index, test enumeration)
- `./scripts/export-openapi.sh` — regenerated; diff is exactly the session-export `format` parameter surface
- Smoke test (`doppler run -- just start-dev --no-watch`, in-memory dev mode): created agent + session + message via API, then `GET /v1/sessions/SESSION_ID/export?format=atif` returned 200 with `Content-Type: application/json`, `Content-Disposition: attachment; filename="SESSION_ID.atif.json"`, and a valid `ATIF-v1.7` document (user step + agent steps folded from real events); default export still returned `application/x-ndjson` JSONL. Services stopped after.