### PR TITLE
fix(auth): signup path from password screen + prefill + copy space

### DIFF
--- a/apps/ui/e2e/auth-door.spec.ts
+++ b/apps/ui/e2e/auth-door.spec.ts
@@ -122,9 +122,15 @@ test.describe("Unified auth door", () => {
     await page.getByLabel("Password", { exact: true }).fill("longenoughpass1");
     await page.getByRole("button", { name: "Create account" }).click();
     await expect(page.getByRole("heading", { level: 1, name: "Check your email" })).toBeVisible();
-    // Full-phrase assertion: guards the space between the email and the copy,
-    // which a substring match would miss (the JSX pipeline once ate it).
-    await expect(page.getByText("new@acme.com can be registered")).toBeVisible();
+    // Full-sentence assertion: guards every word boundary in the copy — the
+    // JSX pipeline once ate the space after the email, and a substring match
+    // let it through.
+    await expect(
+      page.getByText(
+        "If new@acme.com can be registered, we've sent a confirmation link. " +
+          "Click it to verify your email and get started — the link signs you in.",
+      ),
+    ).toBeVisible();
     expect(registered).toBe(true);
   });
 

--- a/apps/ui/e2e/auth-door.spec.ts
+++ b/apps/ui/e2e/auth-door.spec.ts
@@ -60,6 +60,23 @@ test.describe("Unified auth door", () => {
     await expect(page.getByLabel("Email")).toBeFocused();
   });
 
+  test("password phase offers signup with the typed address carried over", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByLabel("Email").fill("newcomer@acme.com");
+    await page.getByRole("button", { name: "Continue with email" }).click();
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Enter your password" }),
+    ).toBeVisible();
+    // A new user who mistook login for signup is never stuck here.
+    const signup = page.getByRole("link", { name: "Create an account" });
+    await expect(signup).toHaveAttribute("href", "/signup?email=newcomer%40acme.com");
+    await signup.click();
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Create your account" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Email")).toHaveValue("newcomer@acme.com");
+  });
+
   test("bad credentials render the calm generic error with a reset path", async ({ page }) => {
     await page.route("**/v1/auth/login", (route) =>
       route.fulfill({ status: 401, json: { error: "Invalid email or password" } }),
@@ -105,7 +122,9 @@ test.describe("Unified auth door", () => {
     await page.getByLabel("Password", { exact: true }).fill("longenoughpass1");
     await page.getByRole("button", { name: "Create account" }).click();
     await expect(page.getByRole("heading", { level: 1, name: "Check your email" })).toBeVisible();
-    await expect(page.getByText("can be registered")).toBeVisible();
+    // Full-phrase assertion: guards the space between the email and the copy,
+    // which a substring match would miss (the JSX pipeline once ate it).
+    await expect(page.getByText("new@acme.com can be registered")).toBeVisible();
     expect(registered).toBe(true);
   });
 

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -262,6 +262,18 @@ export default function LoginPage() {
           </Button>
         </form>
 
+        {canSignup && (
+          <p className="mt-5 text-[13px] text-muted-foreground">
+            New to Everruns?{" "}
+            <Link
+              href={`/signup?email=${encodeURIComponent(email)}`}
+              className="font-medium text-primary hover:underline"
+            >
+              Create an account
+            </Link>
+          </p>
+        )}
+
         {hasOAuthProviders && (
           <p className="mt-5 border-t pt-5 text-[12.5px] leading-relaxed text-muted-foreground">
             Prefer Google or GitHub? Go back — it&apos;s one click and skips email verification.

--- a/apps/ui/src/app/(auth)/signup/page.tsx
+++ b/apps/ui/src/app/(auth)/signup/page.tsx
@@ -99,8 +99,8 @@ export default function SignupPage() {
         </h1>
         <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
           If <b className="font-medium text-foreground">{submittedEmail}</b>
-          {" can be registered, we've sent a confirmation link."}{" "}
-          Click it to verify your email and get started — the link signs you in.
+          {" can be registered, we've sent a confirmation link. Click it to verify"}
+          {" your email and get started — the link signs you in."}
         </p>
         <p className="mt-6 text-[13px] text-muted-foreground">
           Wrong address?{" "}

--- a/apps/ui/src/app/(auth)/signup/page.tsx
+++ b/apps/ui/src/app/(auth)/signup/page.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useCallback } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -31,10 +31,13 @@ function providerLabel(provider: string): string {
 export default function SignupPage() {
   usePageTitle("Create your account");
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: config, isLoading: configLoading } = useAuthConfig();
   const registerMutation = useRegister();
 
-  const [email, setEmail] = useState("");
+  // Prefilled when arriving from the login door's password screen, where the
+  // address was already typed.
+  const [email, setEmail] = useState(() => searchParams.get("email") ?? "");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
@@ -95,9 +98,9 @@ export default function SignupPage() {
           Check your email
         </h1>
         <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
-          If <b className="font-medium text-foreground">{submittedEmail}</b> can be registered,
-          we&apos;ve sent a confirmation link. Click it to verify your email and get started — the
-          link signs you in.
+          If <b className="font-medium text-foreground">{submittedEmail}</b>
+          {" can be registered, we've sent a confirmation link."}{" "}
+          Click it to verify your email and get started — the link signs you in.
         </p>
         <p className="mt-6 text-[13px] text-muted-foreground">
           Wrong address?{" "}


### PR DESCRIPTION
## What

Three follow-ups to the login-first door:

1. **Password screen offers signup.** A new user who typed their email on the login screen used to land on "Enter your password" with no way forward except Back or a doomed attempt. The phase now repeats "New to Everruns? Create an account", linking `/signup?email=<typed address>` so the address carries over. Static copy shown to everyone — leaks nothing about account existence.
2. **`/signup` prefills email** from the `?email=` query param (same pattern forgot-password already uses).
3. **Copy bug: "aliceeverruns@gmail.comcan be registered".** The JSX source always had the space (`</b> can be registered`), but the SWC build step drops the leading space of that text node — the compiled bundle literally contained `"can be registered"`. Moved the sentence into an explicit `{" can be registered, …"}` expression child, which no transform can trim. Verified the space is present in the built chunk.

## Tests

- New e2e: password phase shows the signup link with the address carried over, and clicking it lands on `/signup` with the email prefilled.
- Existing check-your-email e2e upgraded from a substring match to the full phrase `"new@acme.com can be registered"` — a substring match is exactly why the eaten space slipped through before.
- `auth-door.spec.ts`: 12/12 green locally; lint + production build green.

## Security

No new endpoints or data flows. The signup link on the password screen is unconditional static copy (gated only on `signup_enabled`), so it reveals nothing about whether the typed address has an account.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9cKZdLQcBjLxfDQJSRFzG)_