### PR TITLE
feat(drivers): reconnect streaming LLM responses on transport failure

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -13,7 +13,6 @@
 
 use async_trait::async_trait;
 use chrono::DateTime;
-use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -34,9 +33,10 @@ use everruns_core::driver_registry::{
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
 use everruns_core::llm_retry::{
-    LlmRetryConfig, RateLimitInfo, RetryDecision, SendOutcome, is_rate_limit_status, retry_request,
-    send_error_message,
+    LlmRetryConfig, RateLimitInfo, RetryDecision, RetryMetadata, SendOutcome, is_rate_limit_status,
+    retry_request, send_error_message,
 };
+use everruns_core::stream_reconnect::connect_sse_with_reconnect;
 use everruns_core::tool_types::{DeferrablePolicy, ToolCall, ToolDefinition};
 
 const DEFAULT_API_URL: &str = "https://api.anthropic.com/v1/messages";
@@ -101,6 +101,198 @@ impl AnthropicChatDriver {
     pub fn with_retry_config(mut self, config: LlmRetryConfig) -> Self {
         self.retry_config = config;
         self
+    }
+
+    /// Send one streaming Messages request, applying the shared header-phase
+    /// retry loop (transient send failures, 429, 5xx, and the one-shot
+    /// `max_tokens` fallback), and return the raw response plus its retry
+    /// metadata.
+    ///
+    /// Invoked once per reconnect attempt by [`connect_sse_with_reconnect`]. The
+    /// `request` is shared (`Arc<Mutex>`) so a fallback-corrected body carries
+    /// across reconnects; it consumes no body bytes, so re-sending is
+    /// idempotent. Terminal classification and error messages are preserved
+    /// exactly.
+    async fn send_messages_request(
+        &self,
+        request: Arc<Mutex<AnthropicRequest>>,
+        needs_interleaved_thinking: bool,
+        wants_million_context: bool,
+        max_tokens_from_profile: bool,
+        model: &str,
+    ) -> Result<(reqwest::Response, RetryMetadata)> {
+        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let max_tokens_fallback_attempted = Arc::new(Mutex::new(false));
+        let beta_logged = Arc::new(Mutex::new(false));
+
+        retry_request(
+            &self.retry_config,
+            "AnthropicDriver",
+            || {
+                let request = Arc::clone(&request);
+                let beta_logged = Arc::clone(&beta_logged);
+                async move {
+                    // Build request with headers (must rebuild each iteration).
+                    let mut request_builder = self
+                        .client
+                        .post(&self.api_url)
+                        .header("x-api-key", &self.api_key)
+                        .header("anthropic-version", ANTHROPIC_VERSION)
+                        .header("Content-Type", "application/json");
+
+                    // Anthropic beta features, combined into a single
+                    // comma-separated `anthropic-beta` header:
+                    //  - interleaved-thinking: required for tool use with
+                    //    budget-based extended thinking (adaptive thinking
+                    //    interleaves on its own).
+                    //  - context-1m: opts the `[1m]` model ids into the 1M
+                    //    context window. It is GA / silently ignored on Opus 4.6+
+                    //    and Fable 5 (the only ids we attach it to), so always
+                    //    sending it is safe.
+                    let mut beta_features: Vec<&str> = Vec::new();
+                    if needs_interleaved_thinking {
+                        beta_features.push("interleaved-thinking-2025-05-14");
+                    }
+                    if wants_million_context {
+                        beta_features.push("context-1m-2025-08-07");
+                    }
+                    if !beta_features.is_empty() {
+                        let beta = beta_features.join(",");
+                        let mut logged = beta_logged.lock().unwrap();
+                        if !*logged {
+                            tracing::info!(beta = %beta, "AnthropicDriver: enabling anthropic-beta features");
+                            *logged = true;
+                        }
+                        drop(logged);
+                        request_builder = request_builder.header("anthropic-beta", beta);
+                    }
+
+                    // Snapshot the (possibly fallback-mutated) request as JSON
+                    // while holding the lock, then release it before awaiting the
+                    // send so the guard never crosses an `.await` point.
+                    let body = serde_json::to_value(&*request.lock().unwrap())
+                        .map_err(|e| {
+                            SendOutcome::Fatal(AgentLoopError::llm(format!(
+                                "Failed to serialize Anthropic request: {e}"
+                            )))
+                        })?;
+                    request_builder
+                        .json(&body)
+                        .send()
+                        .await
+                        .map_err(SendOutcome::Send)
+                }
+            },
+            |response, attempts, can_retry| {
+                let request = Arc::clone(&request);
+                let last_error = Arc::clone(&last_error);
+                let max_tokens_fallback_attempted = Arc::clone(&max_tokens_fallback_attempted);
+                let model = model.to_string();
+                async move {
+                    let status = response.status();
+
+                    if can_retry {
+                        // Parse rate limit info from headers before consuming body.
+                        let rate_limit_info = if is_rate_limit_status(status) {
+                            Some(RateLimitInfo::from_anthropic_headers(response.headers()))
+                        } else {
+                            None
+                        };
+
+                        let error_text = response.text().await.unwrap_or_default();
+
+                        // Don't retry a request-too-large error (not transient).
+                        if is_anthropic_request_too_large(status, &error_text) {
+                            return RetryDecision::Terminal(AgentLoopError::request_too_large(
+                                format!("Anthropic API error ({}): {}", status, error_text),
+                            ));
+                        }
+
+                        // Exhausted billing quota is not transient — fail fast.
+                        if is_provider_quota_message(&error_text) {
+                            return RetryDecision::Terminal(AgentLoopError::llm_kind(
+                                LlmErrorKind::QuotaExhausted,
+                                format!("Anthropic API error ({}): {}", status, error_text),
+                            ));
+                        }
+
+                        let wait = rate_limit_info
+                            .as_ref()
+                            .map(|info| info.recommended_wait(&self.retry_config, attempts))
+                            .unwrap_or_else(|| self.retry_config.calculate_backoff(attempts));
+
+                        *last_error.lock().unwrap() = Some(error_text);
+                        return RetryDecision::Retry {
+                            wait,
+                            rate_limit_info,
+                        };
+                    }
+
+                    // Non-retryable error or max retries exceeded
+                    let error_text = response.text().await.unwrap_or_default();
+                    let error_msg = format!("Anthropic API error ({}): {}", status, error_text);
+
+                    // Graceful fallback: if max_tokens derived from profile
+                    // exceeds the model limit (400 error), retry once with a safe
+                    // fallback value instead of failing immediately. Modeled as
+                    // `RetryNow` so it re-sends without counting an attempt or
+                    // sleeping, matching the original `continue`.
+                    {
+                        let mut fallback_attempted = max_tokens_fallback_attempted.lock().unwrap();
+                        if status == reqwest::StatusCode::BAD_REQUEST
+                            && !*fallback_attempted
+                            && max_tokens_from_profile
+                            && (error_text.contains("max_tokens")
+                                || error_text.contains("maximum output tokens"))
+                        {
+                            const FALLBACK_MAX_TOKENS: u32 = 16_384;
+                            let mut req = request.lock().unwrap();
+                            tracing::warn!(
+                                attempted = req.max_tokens,
+                                fallback = FALLBACK_MAX_TOKENS,
+                                model = %model,
+                                "max_tokens exceeds model limit, retrying with fallback. \
+                                 Update model profile for {}.",
+                                model,
+                            );
+                            req.max_tokens = FALLBACK_MAX_TOKENS;
+                            *fallback_attempted = true;
+                            return RetryDecision::RetryNow;
+                        }
+                    }
+
+                    // Check if this is a model-not-found error (404 with not_found_error)
+                    if is_anthropic_model_not_found(status, &error_text) {
+                        return RetryDecision::Terminal(AgentLoopError::model_not_available(model));
+                    }
+
+                    // Check if this is a request-too-large error
+                    if is_anthropic_request_too_large(status, &error_text) {
+                        return RetryDecision::Terminal(AgentLoopError::request_too_large(error_msg));
+                    }
+
+                    // Attach the semantic error kind while the HTTP status and
+                    // body are still available (see LlmErrorKind).
+                    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &error_text);
+
+                    if attempts > 0 {
+                        return RetryDecision::Terminal(AgentLoopError::llm_kind(
+                            kind,
+                            format!(
+                                "{} (after {} retries, last error: {})",
+                                error_msg,
+                                attempts,
+                                last_error.lock().unwrap().take().unwrap_or_default()
+                            ),
+                        ));
+                    }
+
+                    RetryDecision::Terminal(AgentLoopError::llm_kind(kind, error_msg))
+                }
+            },
+            |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
+        )
+        .await
     }
 
     /// Check if using a custom base URL
@@ -599,193 +791,28 @@ impl ChatDriver for AnthropicChatDriver {
             output_config,
         };
 
-        // Retry loop for rate limit (429) and transient errors. The shared
-        // executor (everruns_core::llm_retry::retry_request) owns the loop,
-        // backoff, send-error retry, and exhaustion logging. Anthropic-specific
-        // behavior preserved by the closures: per-attempt header rebuild, the
-        // one-shot `max_tokens` fallback (modeled as `RetryDecision::RetryNow`,
-        // which re-sends without counting an attempt), and the exact terminal
-        // error types/messages.
-        //
-        // `request` and `max_tokens_fallback_attempted` are shared between the
-        // send and classify closures (the classify closure mutates the request);
-        // both closures run sequentially, so the mutex is uncontended.
+        // Share the (possibly fallback-mutated) request across reconnect
+        // attempts: the classify closure mutates it for the one-shot max_tokens
+        // fallback, and reusing the Arc means a reconnect re-sends the corrected
+        // request.
         let request = Arc::new(Mutex::new(request));
-        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        let max_tokens_fallback_attempted = Arc::new(Mutex::new(false));
-        let beta_logged = Arc::new(Mutex::new(false));
 
-        let (response, retry_metadata) = retry_request(
-            &self.retry_config,
-            "AnthropicDriver",
-            || {
-                let request = Arc::clone(&request);
-                let beta_logged = Arc::clone(&beta_logged);
-                async move {
-                    // Build request with headers (must rebuild each iteration).
-                    let mut request_builder = self
-                        .client
-                        .post(&self.api_url)
-                        .header("x-api-key", &self.api_key)
-                        .header("anthropic-version", ANTHROPIC_VERSION)
-                        .header("Content-Type", "application/json");
-
-                    // Anthropic beta features, combined into a single
-                    // comma-separated `anthropic-beta` header:
-                    //  - interleaved-thinking: required for tool use with
-                    //    budget-based extended thinking (adaptive thinking
-                    //    interleaves on its own).
-                    //  - context-1m: opts the `[1m]` model ids into the 1M
-                    //    context window. It is GA / silently ignored on Opus 4.6+
-                    //    and Fable 5 (the only ids we attach it to), so always
-                    //    sending it is safe.
-                    let mut beta_features: Vec<&str> = Vec::new();
-                    if needs_interleaved_thinking {
-                        beta_features.push("interleaved-thinking-2025-05-14");
-                    }
-                    if wants_million_context {
-                        beta_features.push("context-1m-2025-08-07");
-                    }
-                    if !beta_features.is_empty() {
-                        let beta = beta_features.join(",");
-                        let mut logged = beta_logged.lock().unwrap();
-                        if !*logged {
-                            tracing::info!(beta = %beta, "AnthropicDriver: enabling anthropic-beta features");
-                            *logged = true;
-                        }
-                        drop(logged);
-                        request_builder = request_builder.header("anthropic-beta", beta);
-                    }
-
-                    // Snapshot the (possibly fallback-mutated) request as JSON
-                    // while holding the lock, then release it before awaiting the
-                    // send so the guard never crosses an `.await` point.
-                    let body = serde_json::to_value(&*request.lock().unwrap())
-                        .map_err(|e| {
-                            SendOutcome::Fatal(AgentLoopError::llm(format!(
-                                "Failed to serialize Anthropic request: {e}"
-                            )))
-                        })?;
-                    request_builder
-                        .json(&body)
-                        .send()
-                        .await
-                        .map_err(SendOutcome::Send)
-                }
-            },
-            |response, attempts, can_retry| {
-                let request = Arc::clone(&request);
-                let last_error = Arc::clone(&last_error);
-                let max_tokens_fallback_attempted = Arc::clone(&max_tokens_fallback_attempted);
-                let model = config.model.clone();
-                async move {
-                    let status = response.status();
-
-                    if can_retry {
-                        // Parse rate limit info from headers before consuming body.
-                        let rate_limit_info = if is_rate_limit_status(status) {
-                            Some(RateLimitInfo::from_anthropic_headers(response.headers()))
-                        } else {
-                            None
-                        };
-
-                        let error_text = response.text().await.unwrap_or_default();
-
-                        // Don't retry a request-too-large error (not transient).
-                        if is_anthropic_request_too_large(status, &error_text) {
-                            return RetryDecision::Terminal(AgentLoopError::request_too_large(
-                                format!("Anthropic API error ({}): {}", status, error_text),
-                            ));
-                        }
-
-                        // Exhausted billing quota is not transient — fail fast.
-                        if is_provider_quota_message(&error_text) {
-                            return RetryDecision::Terminal(AgentLoopError::llm_kind(
-                                LlmErrorKind::QuotaExhausted,
-                                format!("Anthropic API error ({}): {}", status, error_text),
-                            ));
-                        }
-
-                        let wait = rate_limit_info
-                            .as_ref()
-                            .map(|info| info.recommended_wait(&self.retry_config, attempts))
-                            .unwrap_or_else(|| self.retry_config.calculate_backoff(attempts));
-
-                        *last_error.lock().unwrap() = Some(error_text);
-                        return RetryDecision::Retry {
-                            wait,
-                            rate_limit_info,
-                        };
-                    }
-
-                    // Non-retryable error or max retries exceeded
-                    let error_text = response.text().await.unwrap_or_default();
-                    let error_msg = format!("Anthropic API error ({}): {}", status, error_text);
-
-                    // Graceful fallback: if max_tokens derived from profile
-                    // exceeds the model limit (400 error), retry once with a safe
-                    // fallback value instead of failing immediately. Modeled as
-                    // `RetryNow` so it re-sends without counting an attempt or
-                    // sleeping, matching the original `continue`.
-                    {
-                        let mut fallback_attempted = max_tokens_fallback_attempted.lock().unwrap();
-                        if status == reqwest::StatusCode::BAD_REQUEST
-                            && !*fallback_attempted
-                            && max_tokens_from_profile
-                            && (error_text.contains("max_tokens")
-                                || error_text.contains("maximum output tokens"))
-                        {
-                            const FALLBACK_MAX_TOKENS: u32 = 16_384;
-                            let mut req = request.lock().unwrap();
-                            tracing::warn!(
-                                attempted = req.max_tokens,
-                                fallback = FALLBACK_MAX_TOKENS,
-                                model = %model,
-                                "max_tokens exceeds model limit, retrying with fallback. \
-                                 Update model profile for {}.",
-                                model,
-                            );
-                            req.max_tokens = FALLBACK_MAX_TOKENS;
-                            *fallback_attempted = true;
-                            return RetryDecision::RetryNow;
-                        }
-                    }
-
-                    // Check if this is a model-not-found error (404 with not_found_error)
-                    if is_anthropic_model_not_found(status, &error_text) {
-                        return RetryDecision::Terminal(AgentLoopError::model_not_available(model));
-                    }
-
-                    // Check if this is a request-too-large error
-                    if is_anthropic_request_too_large(status, &error_text) {
-                        return RetryDecision::Terminal(AgentLoopError::request_too_large(error_msg));
-                    }
-
-                    // Attach the semantic error kind while the HTTP status and
-                    // body are still available (see LlmErrorKind).
-                    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &error_text);
-
-                    if attempts > 0 {
-                        return RetryDecision::Terminal(AgentLoopError::llm_kind(
-                            kind,
-                            format!(
-                                "{} (after {} retries, last error: {})",
-                                error_msg,
-                                attempts,
-                                last_error.lock().unwrap().take().unwrap_or_default()
-                            ),
-                        ));
-                    }
-
-                    RetryDecision::Terminal(AgentLoopError::llm_kind(kind, error_msg))
-                }
-            },
-            |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
-        )
-        .await?;
-
-        let byte_stream = response.bytes_stream();
-        let event_stream = byte_stream.eventsource();
+        // Establish the SSE stream, transparently reconnecting on a transport
+        // failure that lands before the first event (the "error decoding
+        // response body" flake). Header-phase retries (429/5xx, transient send
+        // failures, and the max_tokens fallback) are handled inside the
+        // per-attempt send.
+        let (event_stream, retry_metadata) =
+            connect_sse_with_reconnect(&self.retry_config, "AnthropicDriver", |_attempt| {
+                self.send_messages_request(
+                    Arc::clone(&request),
+                    needs_interleaved_thinking,
+                    wants_million_context,
+                    max_tokens_from_profile,
+                    &config.model,
+                )
+            })
+            .await?;
 
         let model = config.model.clone();
         let input_tokens = Arc::new(Mutex::new(0u32));

--- a/crates/core/src/driver_helpers.rs
+++ b/crates/core/src/driver_helpers.rs
@@ -36,6 +36,14 @@ const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 /// Idle pooled-connection lifetime, so reused HTTP keep-alive/HTTP-2
 /// connections are eventually recycled.
 const HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+/// Shorter idle lifetime for the streaming client. A provider/edge often closes
+/// idle keep-alive sockets after ~10-30s; reusing one the peer already closed is
+/// a dominant source of the mid-stream `error decoding response body` flake. The
+/// streaming reconnect layer (`stream_reconnect`) recovers from those, but
+/// recycling sooner avoids most of them outright — matching the official OpenAI
+/// SDK transport (httpx), whose default `keepalive_expiry` is 5s. Kept a little
+/// above 5s so genuinely rapid successive turns still reuse a warm connection.
+const HTTP_STREAM_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 /// DNS resolution is capped so a stuck resolver cannot stall a provider call
 /// past the outbound HTTP timeout. Mirrors `url_validation`'s lookup cap.
 const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -121,7 +129,7 @@ pub fn shared_streaming_http_client() -> reqwest::Client {
                 reqwest::Client::builder()
                     .connect_timeout(HTTP_CONNECT_TIMEOUT)
                     .read_timeout(HTTP_STREAM_READ_TIMEOUT)
-                    .pool_idle_timeout(HTTP_POOL_IDLE_TIMEOUT),
+                    .pool_idle_timeout(HTTP_STREAM_POOL_IDLE_TIMEOUT),
             )
             .build()
             // Fall back to a minimal but still SSRF-hardened client rather than

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -165,6 +165,7 @@ pub mod resource_ownership;
 pub mod runtime_agent;
 pub mod runtime_context;
 pub mod stream_accumulator;
+pub mod stream_reconnect;
 pub mod tool_output_sanitizer;
 pub mod tools;
 pub mod traits;

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -15,7 +15,6 @@
 // creates the appropriate gen-ai spans. No direct tracing in drivers.
 
 use async_trait::async_trait;
-use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::{Client, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
@@ -29,10 +28,11 @@ use crate::driver_registry::{
 };
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::llm_retry::{
-    LlmRetryConfig, RateLimitInfo, RetryDecision, SendOutcome, is_rate_limit_status, retry_request,
-    send_error_message,
+    LlmRetryConfig, RateLimitInfo, RetryDecision, RetryMetadata, SendOutcome, is_rate_limit_status,
+    retry_request, send_error_message,
 };
 use crate::stream_accumulator::StreamToolCallAccumulator;
+use crate::stream_reconnect::connect_sse_with_reconnect;
 use crate::tool_types::ToolDefinition;
 use crate::user_facing_error::is_provider_quota_message;
 
@@ -261,6 +261,128 @@ impl OpenAIProtocolChatDriver {
         &self.client
     }
 
+    /// Send one streaming chat-completion request, applying the shared
+    /// header-phase retry loop (transient send failures, 429, and 5xx), and
+    /// return the raw response plus its retry metadata.
+    ///
+    /// Invoked once per reconnect attempt by [`connect_sse_with_reconnect`]. It
+    /// re-sends the identical request and consumes no body bytes, so retrying it
+    /// is idempotent. The classifier preserves OpenAI's terminal classification
+    /// and error messages exactly.
+    async fn send_chat_completion_request(
+        &self,
+        request: &OpenAiRequest,
+        model: &str,
+    ) -> Result<(reqwest::Response, RetryMetadata)> {
+        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        retry_request(
+            &self.retry_config,
+            "OpenAIProtocolDriver",
+            || async {
+                // Apply auth: a pluggable provider (e.g. OAuth bearer token)
+                // takes precedence over the default host-keyed `api-key` /
+                // bearer logic. An auth-provider failure is fatal (no retry).
+                let request_builder = self.client.post(&self.api_url);
+                let request_builder = match &self.auth_provider {
+                    Some(provider) => {
+                        let (name, value) =
+                            provider.auth_header().await.map_err(SendOutcome::Fatal)?;
+                        request_builder.header(name, value)
+                    }
+                    None => apply_openai_api_auth(request_builder, &self.api_url, &self.api_key),
+                };
+                request_builder
+                    .header("Content-Type", "application/json")
+                    .json(request)
+                    .send()
+                    .await
+                    .map_err(SendOutcome::Send)
+            },
+            |response, attempts, can_retry| {
+                let last_error = Arc::clone(&last_error);
+                let model = model.to_string();
+                async move {
+                    let status = response.status();
+
+                    if can_retry {
+                        // Parse rate limit info from headers before consuming body.
+                        let rate_limit_info = if is_rate_limit_status(status) {
+                            Some(RateLimitInfo::from_openai_headers(response.headers()))
+                        } else {
+                            None
+                        };
+
+                        let error_text = response.text().await.unwrap_or_default();
+
+                        // Don't retry a request-too-large error (not transient).
+                        if is_openai_request_too_large(status, &error_text) {
+                            return RetryDecision::Terminal(AgentLoopError::request_too_large(
+                                format!("OpenAI API error ({}): {}", status, error_text),
+                            ));
+                        }
+
+                        // Exhausted billing quota is surfaced as a 429 but is not
+                        // transient — fail fast instead of burning retries.
+                        if is_provider_quota_message(&error_text) {
+                            return RetryDecision::Terminal(AgentLoopError::llm_kind(
+                                LlmErrorKind::QuotaExhausted,
+                                format!("OpenAI API error ({}): {}", status, error_text),
+                            ));
+                        }
+
+                        let wait = rate_limit_info
+                            .as_ref()
+                            .map(|info| info.recommended_wait(&self.retry_config, attempts))
+                            .unwrap_or_else(|| self.retry_config.calculate_backoff(attempts));
+
+                        *last_error.lock().unwrap() = Some(error_text);
+                        return RetryDecision::Retry {
+                            wait,
+                            rate_limit_info,
+                        };
+                    }
+
+                    // Non-retryable error or max retries exceeded
+                    let error_text = response.text().await.unwrap_or_default();
+                    let error_msg = format!("OpenAI API error ({}): {}", status, error_text);
+
+                    // Check if this is a model-not-found error
+                    if is_openai_model_not_found(status, &error_text) {
+                        return RetryDecision::Terminal(AgentLoopError::model_not_available(model));
+                    }
+
+                    // Check if this is a request-too-large error
+                    if is_openai_request_too_large(status, &error_text) {
+                        return RetryDecision::Terminal(AgentLoopError::request_too_large(
+                            error_msg,
+                        ));
+                    }
+
+                    // Attach the semantic error kind while the HTTP status and
+                    // body are still available (see LlmErrorKind).
+                    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &error_text);
+
+                    if attempts > 0 {
+                        return RetryDecision::Terminal(AgentLoopError::llm_kind(
+                            kind,
+                            format!(
+                                "{} (after {} retries, last error: {})",
+                                error_msg,
+                                attempts,
+                                last_error.lock().unwrap().take().unwrap_or_default()
+                            ),
+                        ));
+                    }
+
+                    RetryDecision::Terminal(AgentLoopError::llm_kind(kind, error_msg))
+                }
+            },
+            |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
+        )
+        .await
+    }
+
     fn convert_role(role: &LlmMessageRole) -> &'static str {
         match role {
             LlmMessageRole::System => "system",
@@ -424,120 +546,16 @@ impl ChatDriver for OpenAIProtocolChatDriver {
             metadata,
         };
 
-        // Retry loop for rate limit (429) and transient errors. The shared
-        // executor (llm_retry::retry_request) owns the loop/backoff/send-error
-        // retry/exhaustion logging; this classifier closure preserves the
-        // previous OpenAI terminal classification and error messages exactly.
-        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-
-        let (response, retry_metadata) = retry_request(
-            &self.retry_config,
-            "OpenAIProtocolDriver",
-            || async {
-                // Apply auth: a pluggable provider (e.g. OAuth bearer token)
-                // takes precedence over the default host-keyed `api-key` /
-                // bearer logic. An auth-provider failure is fatal (no retry).
-                let request_builder = self.client.post(&self.api_url);
-                let request_builder = match &self.auth_provider {
-                    Some(provider) => {
-                        let (name, value) =
-                            provider.auth_header().await.map_err(SendOutcome::Fatal)?;
-                        request_builder.header(name, value)
-                    }
-                    None => apply_openai_api_auth(request_builder, &self.api_url, &self.api_key),
-                };
-                request_builder
-                    .header("Content-Type", "application/json")
-                    .json(&request)
-                    .send()
-                    .await
-                    .map_err(SendOutcome::Send)
-            },
-            |response, attempts, can_retry| {
-                let last_error = Arc::clone(&last_error);
-                let model = config.model.clone();
-                async move {
-                    let status = response.status();
-
-                    if can_retry {
-                        // Parse rate limit info from headers before consuming body.
-                        let rate_limit_info = if is_rate_limit_status(status) {
-                            Some(RateLimitInfo::from_openai_headers(response.headers()))
-                        } else {
-                            None
-                        };
-
-                        let error_text = response.text().await.unwrap_or_default();
-
-                        // Don't retry a request-too-large error (not transient).
-                        if is_openai_request_too_large(status, &error_text) {
-                            return RetryDecision::Terminal(AgentLoopError::request_too_large(
-                                format!("OpenAI API error ({}): {}", status, error_text),
-                            ));
-                        }
-
-                        // Exhausted billing quota is surfaced as a 429 but is not
-                        // transient — fail fast instead of burning retries.
-                        if is_provider_quota_message(&error_text) {
-                            return RetryDecision::Terminal(AgentLoopError::llm_kind(
-                                LlmErrorKind::QuotaExhausted,
-                                format!("OpenAI API error ({}): {}", status, error_text),
-                            ));
-                        }
-
-                        let wait = rate_limit_info
-                            .as_ref()
-                            .map(|info| info.recommended_wait(&self.retry_config, attempts))
-                            .unwrap_or_else(|| self.retry_config.calculate_backoff(attempts));
-
-                        *last_error.lock().unwrap() = Some(error_text);
-                        return RetryDecision::Retry {
-                            wait,
-                            rate_limit_info,
-                        };
-                    }
-
-                    // Non-retryable error or max retries exceeded
-                    let error_text = response.text().await.unwrap_or_default();
-                    let error_msg = format!("OpenAI API error ({}): {}", status, error_text);
-
-                    // Check if this is a model-not-found error
-                    if is_openai_model_not_found(status, &error_text) {
-                        return RetryDecision::Terminal(AgentLoopError::model_not_available(model));
-                    }
-
-                    // Check if this is a request-too-large error
-                    if is_openai_request_too_large(status, &error_text) {
-                        return RetryDecision::Terminal(AgentLoopError::request_too_large(
-                            error_msg,
-                        ));
-                    }
-
-                    // Attach the semantic error kind while the HTTP status and
-                    // body are still available (see LlmErrorKind).
-                    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &error_text);
-
-                    if attempts > 0 {
-                        return RetryDecision::Terminal(AgentLoopError::llm_kind(
-                            kind,
-                            format!(
-                                "{} (after {} retries, last error: {})",
-                                error_msg,
-                                attempts,
-                                last_error.lock().unwrap().take().unwrap_or_default()
-                            ),
-                        ));
-                    }
-
-                    RetryDecision::Terminal(AgentLoopError::llm_kind(kind, error_msg))
-                }
-            },
-            |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
-        )
-        .await?;
-
-        let byte_stream = response.bytes_stream();
-        let event_stream = byte_stream.eventsource();
+        // Establish the SSE stream, transparently reconnecting on a transport
+        // failure that lands before the first event is decoded (the "error
+        // decoding response body" flake). Header-phase retries (429/5xx and
+        // transient send failures) are handled inside the per-attempt send;
+        // this adds the body-phase reconnect the official SDKs get for free.
+        let (event_stream, retry_metadata) =
+            connect_sse_with_reconnect(&self.retry_config, "OpenAIProtocolDriver", |_attempt| {
+                self.send_chat_completion_request(&request, &config.model)
+            })
+            .await?;
 
         let model = config.model.clone();
         let total_tokens = Arc::new(Mutex::new(0u32));

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -20,7 +20,6 @@
 // The Chat Completions API remains supported for backward compatibility.
 
 use async_trait::async_trait;
-use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::{
     Client,
@@ -48,6 +47,7 @@ use crate::openai_protocol::{
 };
 use crate::openresponses_types::{self as types, StreamingEvent};
 use crate::provider::DriverId;
+use crate::stream_reconnect::connect_sse_with_reconnect;
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::user_facing_error::is_provider_quota_message;
 
@@ -217,6 +217,132 @@ impl OpenResponsesProtocolChatDriver {
     pub fn with_retry_config(mut self, config: LlmRetryConfig) -> Self {
         self.retry_config = config;
         self
+    }
+
+    /// Send one streaming Responses request, applying the shared header-phase
+    /// retry loop (transient send failures, 429, and 5xx), and return the raw
+    /// response plus its retry metadata.
+    ///
+    /// Invoked once per reconnect attempt by [`connect_sse_with_reconnect`]; it
+    /// re-sends the identical request and consumes no body bytes, so retrying is
+    /// idempotent. The classifier preserves the Responses API terminal
+    /// classification and error messages exactly.
+    async fn send_responses_request(
+        &self,
+        request_body: &Value,
+        extension_headers: &HeaderMap,
+        model: &str,
+    ) -> Result<(reqwest::Response, RetryMetadata)> {
+        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        retry_request(
+            &self.retry_config,
+            "OpenResponsesProtocolDriver",
+            || async {
+                // Compose headers: provider decoration first, then the resolved
+                // auth header (awaited each attempt so refreshable providers can
+                // rotate tokens per retry). `insert` overrides any same-named
+                // decoration header, so auth always wins on conflict. An auth
+                // failure is fatal (no retry).
+                let mut headers = extension_headers.clone();
+                let (auth_name, auth_value) = self
+                    .resolve_auth_header(&self.api_url)
+                    .await
+                    .map_err(SendOutcome::Fatal)?;
+                headers.insert(auth_name, auth_value);
+
+                self.client
+                    .post(&self.api_url)
+                    .headers(headers)
+                    .header("Content-Type", "application/json")
+                    .json(request_body)
+                    .send()
+                    .await
+                    .map_err(SendOutcome::Send)
+            },
+            |response, attempts, can_retry| {
+                let last_error = Arc::clone(&last_error);
+                let model = model.to_string();
+                async move {
+                    let status = response.status();
+
+                    if can_retry {
+                        // Parse rate limit info from headers before consuming body.
+                        let response_headers = response.headers().clone();
+                        let mut rate_limit_info = if is_rate_limit_status(status) {
+                            Some(RateLimitInfo::from_openai_headers(&response_headers))
+                        } else {
+                            None
+                        };
+
+                        let error_text = response.text().await.unwrap_or_default();
+                        if let (Some(extension), Some(info)) =
+                            (self.request_extension.as_ref(), rate_limit_info.as_mut())
+                        {
+                            extension.update_rate_limit_info(info, &response_headers, &error_text);
+                        }
+
+                        // Exhausted billing quota is surfaced as a 429 but is not
+                        // transient — fail fast instead of burning retries.
+                        if is_provider_quota_message(&error_text) {
+                            return RetryDecision::Terminal(AgentLoopError::llm_kind(
+                                LlmErrorKind::QuotaExhausted,
+                                format!("OpenAI Responses API error ({}): {}", status, error_text),
+                            ));
+                        }
+
+                        let wait = rate_limit_info
+                            .as_ref()
+                            .map(|info| info.recommended_wait(&self.retry_config, attempts))
+                            .unwrap_or_else(|| self.retry_config.calculate_backoff(attempts));
+
+                        *last_error.lock().unwrap() = Some(error_text);
+                        return RetryDecision::Retry {
+                            wait,
+                            rate_limit_info,
+                        };
+                    }
+
+                    // Non-retryable error or max retries exceeded
+                    let error_text = response.text().await.unwrap_or_default();
+
+                    // Check if this is a model-not-found error
+                    if is_openai_model_not_found(status, &error_text) {
+                        return RetryDecision::Terminal(AgentLoopError::model_not_available(model));
+                    }
+
+                    // Check if this is a request-too-large error (context length).
+                    if is_openai_request_too_large(status, &error_text) {
+                        return RetryDecision::Terminal(AgentLoopError::request_too_large(
+                            format!("OpenAI Responses API ({}): {}", status, error_text),
+                        ));
+                    }
+
+                    let error_msg =
+                        format!("OpenAI Responses API error ({}): {}", status, error_text);
+
+                    // Attach the semantic error kind while the HTTP status and
+                    // body are still available (see LlmErrorKind).
+                    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &error_text);
+
+                    if attempts > 0 {
+                        return RetryDecision::Terminal(AgentLoopError::llm_kind(
+                            kind,
+                            format!(
+                                "{} (after {} retries, last error: {})",
+                                error_msg,
+                                attempts,
+                                last_error.lock().unwrap().take().unwrap_or_default()
+                            ),
+                        ));
+                    }
+
+                    RetryDecision::Terminal(AgentLoopError::llm_kind(kind, error_msg))
+                }
+            },
+            |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
+        )
+        .await
     }
 
     /// Get the API URL
@@ -979,123 +1105,18 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             extension.decorate_headers(&mut extension_headers, config)?;
         }
 
-        // Retry loop for rate limit (429) and transient errors. The shared
-        // executor (llm_retry::retry_request) owns the loop/backoff/send-error
-        // retry/exhaustion logging; this classifier closure preserves the
-        // previous terminal classification and error messages exactly.
-        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-
-        let (response, retry_metadata) = retry_request(
+        // Establish the SSE stream, transparently reconnecting on a transport
+        // failure that lands before the first event is decoded (the "error
+        // decoding response body" flake). Header-phase retries (429/5xx and
+        // transient send failures) are handled inside the per-attempt send.
+        let (event_stream, retry_metadata) = connect_sse_with_reconnect(
             &self.retry_config,
             "OpenResponsesProtocolDriver",
-            || async {
-                // Compose headers: provider decoration first, then the resolved
-                // auth header (awaited each attempt so refreshable providers can
-                // rotate tokens per retry). `insert` overrides any same-named
-                // decoration header, so auth always wins on conflict. An auth
-                // failure is fatal (no retry).
-                let mut headers = extension_headers.clone();
-                let (auth_name, auth_value) = self
-                    .resolve_auth_header(&self.api_url)
-                    .await
-                    .map_err(SendOutcome::Fatal)?;
-                headers.insert(auth_name, auth_value);
-
-                self.client
-                    .post(&self.api_url)
-                    .headers(headers)
-                    .header("Content-Type", "application/json")
-                    .json(&request_body)
-                    .send()
-                    .await
-                    .map_err(SendOutcome::Send)
+            |_attempt| {
+                self.send_responses_request(&request_body, &extension_headers, &config.model)
             },
-            |response, attempts, can_retry| {
-                let last_error = Arc::clone(&last_error);
-                let model = config.model.clone();
-                async move {
-                    let status = response.status();
-
-                    if can_retry {
-                        // Parse rate limit info from headers before consuming body.
-                        let response_headers = response.headers().clone();
-                        let mut rate_limit_info = if is_rate_limit_status(status) {
-                            Some(RateLimitInfo::from_openai_headers(&response_headers))
-                        } else {
-                            None
-                        };
-
-                        let error_text = response.text().await.unwrap_or_default();
-                        if let (Some(extension), Some(info)) =
-                            (self.request_extension.as_ref(), rate_limit_info.as_mut())
-                        {
-                            extension.update_rate_limit_info(info, &response_headers, &error_text);
-                        }
-
-                        // Exhausted billing quota is surfaced as a 429 but is not
-                        // transient — fail fast instead of burning retries.
-                        if is_provider_quota_message(&error_text) {
-                            return RetryDecision::Terminal(AgentLoopError::llm_kind(
-                                LlmErrorKind::QuotaExhausted,
-                                format!("OpenAI Responses API error ({}): {}", status, error_text),
-                            ));
-                        }
-
-                        let wait = rate_limit_info
-                            .as_ref()
-                            .map(|info| info.recommended_wait(&self.retry_config, attempts))
-                            .unwrap_or_else(|| self.retry_config.calculate_backoff(attempts));
-
-                        *last_error.lock().unwrap() = Some(error_text);
-                        return RetryDecision::Retry {
-                            wait,
-                            rate_limit_info,
-                        };
-                    }
-
-                    // Non-retryable error or max retries exceeded
-                    let error_text = response.text().await.unwrap_or_default();
-
-                    // Check if this is a model-not-found error
-                    if is_openai_model_not_found(status, &error_text) {
-                        return RetryDecision::Terminal(AgentLoopError::model_not_available(model));
-                    }
-
-                    // Check if this is a request-too-large error (context length).
-                    if is_openai_request_too_large(status, &error_text) {
-                        return RetryDecision::Terminal(AgentLoopError::request_too_large(
-                            format!("OpenAI Responses API ({}): {}", status, error_text),
-                        ));
-                    }
-
-                    let error_msg =
-                        format!("OpenAI Responses API error ({}): {}", status, error_text);
-
-                    // Attach the semantic error kind while the HTTP status and
-                    // body are still available (see LlmErrorKind).
-                    let kind = LlmErrorKind::from_provider_status(status.as_u16(), &error_text);
-
-                    if attempts > 0 {
-                        return RetryDecision::Terminal(AgentLoopError::llm_kind(
-                            kind,
-                            format!(
-                                "{} (after {} retries, last error: {})",
-                                error_msg,
-                                attempts,
-                                last_error.lock().unwrap().take().unwrap_or_default()
-                            ),
-                        ));
-                    }
-
-                    RetryDecision::Terminal(AgentLoopError::llm_kind(kind, error_msg))
-                }
-            },
-            |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
         )
         .await?;
-
-        let byte_stream = response.bytes_stream();
-        let event_stream = byte_stream.eventsource();
 
         let model = config.model.clone();
         let input_tokens = Arc::new(Mutex::new(0u32));

--- a/crates/core/src/stream_reconnect.rs
+++ b/crates/core/src/stream_reconnect.rs
@@ -1,0 +1,386 @@
+// Transparent reconnect for streaming (SSE) LLM responses.
+//
+// The per-request retry in [`crate::llm_retry::retry_request`] only covers the
+// phase up to receiving response *headers*: it retries connect/TLS/send failures
+// and retryable HTTP statuses (429/5xx). Once the body starts streaming, a
+// transport failure — `error decoding response body`, a truncated/incomplete
+// body, a connection reset mid-stream, a stale pooled keep-alive connection the
+// peer closed, or a read-timeout before the first token — is surfaced by reqwest
+// *after* a 200 and was previously fatal to the turn with no retry.
+//
+// The official OpenAI/Anthropic SDKs retry this connection-error class
+// (`APIConnectionError`) with bounded exponential backoff. This module brings
+// the native Rust drivers to parity: it reconnects when the SSE stream fails
+// *before the first event is decoded*, which is exactly the window where these
+// transport failures land (an immediate body-decode error). Once any event has
+// been decoded and forwarded, the stream is "committed" and errors pass through
+// unchanged — the consumer may already have acted on emitted deltas/tool-calls,
+// so re-sending would duplicate output. Non-transport SSE errors (UTF-8/parser)
+// are never reconnected, so a genuine protocol/driver bug is not masked (this is
+// the failure mode a blanket "skip on transport-ish error" would hide).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use bytes::Bytes;
+use eventsource_stream::{Event, EventStreamError, Eventsource};
+use futures::{Stream, StreamExt, stream};
+
+use crate::error::AgentLoopError;
+use crate::llm_retry::{LlmRetryConfig, RetryMetadata};
+
+/// SSE item type produced by `reqwest::Response::bytes_stream().eventsource()`.
+pub type SseItem = Result<Event, EventStreamError<reqwest::Error>>;
+
+/// A `'static` SSE event stream. Boxed so the returned stream is independent of
+/// the `connect` closure's borrows (the concrete stream owns its
+/// `reqwest::Response` and borrows nothing), letting callers build the
+/// `'static` `LlmResponseStream` they need.
+pub type SseStream = Pin<Box<dyn Stream<Item = SseItem> + Send>>;
+
+/// A `'static` raw byte stream, for drivers that parse SSE by hand over
+/// `reqwest::Response::bytes_stream()` (e.g. Gemini).
+pub type ByteStream = Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>;
+
+/// Classify a raw `reqwest` stream error as a transient transport failure that
+/// is safe to reconnect: a body/decode error ("error decoding response body",
+/// truncated/incomplete body, mid-body reset), a connect/request failure (a
+/// stale pooled keep-alive connection discovered dead), or a read timeout before
+/// the first byte. A status/redirect/builder error is not a mid-stream transport
+/// flake and is not reconnected.
+pub fn is_reconnectable_reqwest_error(err: &reqwest::Error) -> bool {
+    err.is_body() || err.is_decode() || err.is_connect() || err.is_request() || err.is_timeout()
+}
+
+/// Classify an SSE stream error as a transient transport failure that is safe to
+/// reconnect.
+///
+/// Only `Transport` (reqwest) errors qualify. A UTF-8 or parser error means the
+/// bytes that *did* arrive were a malformed SSE payload — a real protocol error
+/// we must surface, not paper over with a reconnect.
+pub fn is_reconnectable_stream_error(err: &EventStreamError<reqwest::Error>) -> bool {
+    match err {
+        EventStreamError::Transport(e) => is_reconnectable_reqwest_error(e),
+        EventStreamError::Utf8(_) | EventStreamError::Parser(_) => false,
+    }
+}
+
+/// Establish an SSE event stream with transparent reconnect on a
+/// pre-first-event transport failure.
+///
+/// `connect` performs one full send attempt — including
+/// [`retry_request`](crate::llm_retry::retry_request)'s header-phase retries —
+/// and returns the raw `reqwest::Response` plus its [`RetryMetadata`]. It is
+/// invoked once per reconnect attempt; because it re-sends the identical request
+/// and no body bytes have been consumed yet, retrying is safe/idempotent.
+///
+/// Reconnect fires only when the *first* SSE item is a reconnectable transport
+/// error and attempts remain (bounded by `retry_config.max_retries`, with the
+/// shared exponential backoff + jitter). The returned stream replays the peeked
+/// first item at its head, so no events are lost.
+///
+/// Note: this awaits the first SSE frame before returning, so a caller's
+/// `chat_completion_stream()` now resolves at first-token time rather than
+/// lazily. End-to-end latency is unchanged (the caller immediately polls the
+/// stream) and connection failures surface at a single, well-defined point. A
+/// provider that returns 200 but then sends no first frame is bounded by the
+/// streaming client's read timeout (`HTTP_STREAM_READ_TIMEOUT`), which then
+/// classifies as a reconnectable timeout.
+pub async fn connect_sse_with_reconnect<C, Fut>(
+    retry_config: &LlmRetryConfig,
+    driver_name: &str,
+    mut connect: C,
+) -> Result<(SseStream, RetryMetadata), AgentLoopError>
+where
+    C: FnMut(u32) -> Fut,
+    Fut: Future<Output = Result<(reqwest::Response, RetryMetadata), AgentLoopError>>,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        let (response, metadata) = connect(attempt).await?;
+        let events = Box::pin(response.bytes_stream().eventsource());
+
+        // Peek the first item: an immediate transport failure at stream open
+        // (the observed "error decoding response body") lands here.
+        let (first, rest) = events.into_future().await;
+
+        let reconnectable = matches!(&first, Some(Err(e)) if is_reconnectable_stream_error(e));
+        if reconnectable && attempt < retry_config.max_retries {
+            attempt += 1;
+            let wait = retry_config.calculate_backoff(attempt - 1);
+            if let Some(Err(e)) = &first {
+                tracing::warn!(
+                    driver = driver_name,
+                    attempt,
+                    max_retries = retry_config.max_retries,
+                    wait_secs = wait.as_secs_f64(),
+                    error = %e,
+                    "streaming transport failed before first event; reconnecting"
+                );
+            }
+            tokio::time::sleep(wait).await;
+            continue;
+        }
+
+        if attempt > 0 && !reconnectable {
+            tracing::info!(
+                driver = driver_name,
+                reconnects = attempt,
+                "streaming reconnect succeeded"
+            );
+        }
+
+        // Replay the peeked first item (0 or 1) ahead of the remaining stream.
+        return Ok((Box::pin(stream::iter(first).chain(rest)), metadata));
+    }
+}
+
+/// Byte-stream analogue of [`connect_sse_with_reconnect`] for drivers that parse
+/// SSE by hand over `reqwest::Response::bytes_stream()` (e.g. Gemini).
+///
+/// Reconnects when the *first* byte chunk is a reconnectable transport error and
+/// attempts remain. Once any chunk has been forwarded the stream is committed
+/// and errors pass through. Semantics, safety, and the first-token latency note
+/// match [`connect_sse_with_reconnect`].
+pub async fn connect_bytes_with_reconnect<C, Fut>(
+    retry_config: &LlmRetryConfig,
+    driver_name: &str,
+    mut connect: C,
+) -> Result<(ByteStream, RetryMetadata), AgentLoopError>
+where
+    C: FnMut(u32) -> Fut,
+    Fut: Future<Output = Result<(reqwest::Response, RetryMetadata), AgentLoopError>>,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        let (response, metadata) = connect(attempt).await?;
+        let bytes = Box::pin(response.bytes_stream());
+        let (first, rest) = bytes.into_future().await;
+
+        let reconnectable = matches!(&first, Some(Err(e)) if is_reconnectable_reqwest_error(e));
+        if reconnectable && attempt < retry_config.max_retries {
+            attempt += 1;
+            let wait = retry_config.calculate_backoff(attempt - 1);
+            if let Some(Err(e)) = &first {
+                tracing::warn!(
+                    driver = driver_name,
+                    attempt,
+                    max_retries = retry_config.max_retries,
+                    wait_secs = wait.as_secs_f64(),
+                    error = %e,
+                    "streaming transport failed before first chunk; reconnecting"
+                );
+            }
+            tokio::time::sleep(wait).await;
+            continue;
+        }
+
+        if attempt > 0 && !reconnectable {
+            tracing::info!(
+                driver = driver_name,
+                reconnects = attempt,
+                "streaming reconnect succeeded"
+            );
+        }
+
+        return Ok((Box::pin(stream::iter(first).chain(rest)), metadata));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Per-connection server behavior for the scripted SSE test server.
+    #[derive(Clone, Copy)]
+    enum Behavior {
+        /// 200 + chunked headers, then an incomplete chunk and abrupt close.
+        /// reqwest yields an incomplete-body transport error as the first item.
+        TruncateBeforeEvent,
+        /// 200 + one complete SSE data event, then an incomplete chunk + close.
+        /// First item is a good event (committed); the truncation follows.
+        EventThenTruncate,
+        /// 200 + a complete SSE stream (one content delta + `[DONE]`).
+        FullSse,
+    }
+
+    const CONTENT_EVENT: &str = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n";
+    const DONE_EVENT: &str = "data: [DONE]\n\n";
+
+    fn chunk(body: &str) -> String {
+        format!("{:x}\r\n{}\r\n", body.len(), body)
+    }
+
+    /// Spawn a TCP server that serves `behaviors[n]` to the n-th connection
+    /// (clamping to the last entry). Returns its base URL and a counter of
+    /// accepted connections.
+    async fn spawn_scripted_sse_server(behaviors: Vec<Behavior>) -> (String, Arc<AtomicU32>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_task = Arc::clone(&counter);
+
+        tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(_) => break,
+                };
+                let idx = counter_task.fetch_add(1, Ordering::SeqCst) as usize;
+                let behavior = behaviors[idx.min(behaviors.len() - 1)];
+
+                // Drain the request head so the client's write side completes.
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+
+                let headers = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n";
+                let _ = socket.write_all(headers.as_bytes()).await;
+
+                match behavior {
+                    Behavior::TruncateBeforeEvent => {
+                        // Declare a 5-byte chunk but send 2 bytes, then close:
+                        // an incomplete message with no decodable event.
+                        let _ = socket.write_all(b"5\r\nda").await;
+                    }
+                    Behavior::EventThenTruncate => {
+                        let _ = socket.write_all(chunk(CONTENT_EVENT).as_bytes()).await;
+                        let _ = socket.write_all(b"5\r\nda").await;
+                    }
+                    Behavior::FullSse => {
+                        let _ = socket.write_all(chunk(CONTENT_EVENT).as_bytes()).await;
+                        let _ = socket.write_all(chunk(DONE_EVENT).as_bytes()).await;
+                        let _ = socket.write_all(b"0\r\n\r\n").await;
+                    }
+                }
+                let _ = socket.flush().await;
+                // Drop `socket` to close the connection.
+            }
+        });
+
+        (format!("http://{addr}/"), counter)
+    }
+
+    /// Zero-backoff config so reconnect tests don't actually sleep.
+    fn fast_config(max_retries: u32) -> LlmRetryConfig {
+        LlmRetryConfig {
+            max_retries,
+            initial_backoff: Duration::from_millis(0),
+            max_backoff: Duration::from_millis(0),
+            backoff_multiplier: 1.0,
+            jitter_factor: 0.0,
+        }
+    }
+
+    async fn collect_via_reconnect(base: &str, config: &LlmRetryConfig) -> Vec<SseItem> {
+        let client = reqwest::Client::new();
+        let (stream, _meta) = connect_sse_with_reconnect(config, "test", |_attempt| {
+            let client = client.clone();
+            let base = base.to_string();
+            async move {
+                let resp = client
+                    .get(&base)
+                    .send()
+                    .await
+                    .map_err(|e| AgentLoopError::llm(e.to_string()))?;
+                Ok((resp, RetryMetadata::default()))
+            }
+        })
+        .await
+        .expect("connect should not terminally fail");
+        stream.collect().await
+    }
+
+    #[tokio::test]
+    async fn reconnects_on_truncated_first_then_succeeds() {
+        let (base, count) =
+            spawn_scripted_sse_server(vec![Behavior::TruncateBeforeEvent, Behavior::FullSse]).await;
+        let items = collect_via_reconnect(&base, &fast_config(2)).await;
+
+        // Two connections: the truncated one and the successful reconnect.
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            2,
+            "should reconnect exactly once"
+        );
+        // The reconnected stream yields the content event and [DONE], no error.
+        let texts: Vec<String> = items
+            .iter()
+            .filter_map(|i| i.as_ref().ok())
+            .map(|ev| ev.data.clone())
+            .collect();
+        assert!(
+            texts.iter().any(|d| d.contains("hi")),
+            "expected content event after reconnect, got {texts:?}"
+        );
+        assert!(
+            items.iter().all(|i| i.is_ok()),
+            "reconnected stream should carry no transport error"
+        );
+    }
+
+    #[tokio::test]
+    async fn exhausts_reconnects_and_surfaces_error() {
+        let (base, count) = spawn_scripted_sse_server(vec![Behavior::TruncateBeforeEvent]).await;
+        let items = collect_via_reconnect(&base, &fast_config(2)).await;
+
+        // 1 initial + 2 reconnects = 3 attempts, all truncated.
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            3,
+            "should exhaust max_retries"
+        );
+        assert!(
+            items.last().is_some_and(|i| i.is_err()),
+            "exhausted stream should surface the transport error, got {items:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_stream_makes_single_connection() {
+        let (base, count) = spawn_scripted_sse_server(vec![Behavior::FullSse]).await;
+        let items = collect_via_reconnect(&base, &fast_config(2)).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "healthy stream must not reconnect"
+        );
+        assert!(items.iter().all(|i| i.is_ok()));
+        assert!(items.iter().filter_map(|i| i.as_ref().ok()).count() >= 1);
+    }
+
+    #[tokio::test]
+    async fn error_after_first_event_passes_through_without_reconnect() {
+        // The first item is a good event (committed); the following truncation
+        // must NOT trigger a reconnect (that would duplicate emitted output).
+        let (base, count) = spawn_scripted_sse_server(vec![Behavior::EventThenTruncate]).await;
+        let items = collect_via_reconnect(&base, &fast_config(2)).await;
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "committed stream must not reconnect after emitting an event"
+        );
+        assert!(
+            items.first().is_some_and(|i| i.is_ok()),
+            "first item should be the committed event"
+        );
+        assert!(
+            items.last().is_some_and(|i| i.is_err()),
+            "trailing transport error should pass through"
+        );
+    }
+
+    #[test]
+    fn classifier_rejects_non_transport_errors() {
+        // A UTF-8 decode failure is a malformed payload, not a transport flake.
+        let utf8_err = String::from_utf8(vec![0xff, 0xfe]).unwrap_err();
+        let err: EventStreamError<reqwest::Error> = EventStreamError::Utf8(utf8_err);
+        assert!(!is_reconnectable_stream_error(&err));
+    }
+}

--- a/crates/core/tests/openai_reconnect_wire.rs
+++ b/crates/core/tests/openai_reconnect_wire.rs
@@ -1,0 +1,192 @@
+// Driver-level reconnect test for the OpenAI Chat Completions protocol driver.
+//
+// The golden wire tests (`openai_protocol_wire.rs`) use wiremock, which always
+// serves a complete body and so cannot exercise the mid-stream transport flake
+// (`error decoding response body`) that `stream_reconnect` recovers from. This
+// test drives the real `OpenAIProtocolChatDriver` against a raw TCP server that
+// *truncates* the first response body before any SSE event, then serves a full
+// stream on the reconnect — proving the driver transparently reconnects and
+// still yields the expected events.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use everruns_core::OpenAIProtocolChatDriver;
+use everruns_core::driver_registry::{
+    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+};
+use everruns_core::llm_retry::LlmRetryConfig;
+use futures::StreamExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn config(model: &str) -> LlmCallConfig {
+    LlmCallConfig {
+        model: model.to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+        volatile_suffix_len: 0,
+    }
+}
+
+fn chunk(body: &str) -> String {
+    format!("{:x}\r\n{}\r\n", body.len(), body)
+}
+
+/// Full, valid OpenAI SSE stream: one content delta, a stop finish chunk, a
+/// usage chunk, then `[DONE]`, framed as HTTP/1.1 chunked transfer encoding.
+fn full_sse_response() -> String {
+    let events = [
+        r#"data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+        "",
+        r#"data: {"id":"c1","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+
+    let mut resp = String::from(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n",
+    );
+    resp.push_str(&chunk(&events));
+    resp.push_str("0\r\n\r\n");
+    resp
+}
+
+/// Spawn a server that truncates the body of the first `truncate_count`
+/// connections (headers + an incomplete chunk, then close) and serves a full
+/// SSE stream on every connection after that. Returns its base URL and the
+/// accepted-connection counter.
+async fn spawn_flaky_openai_server(truncate_count: u32) -> (String, Arc<AtomicU32>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_task = Arc::clone(&counter);
+
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => break,
+            };
+            let n = counter_task.fetch_add(1, Ordering::SeqCst);
+
+            // Drain the request head so the client's write completes.
+            let mut buf = [0u8; 2048];
+            let _ = socket.read(&mut buf).await;
+
+            if n < truncate_count {
+                // 200 headers, then a chunk that declares 5 bytes but sends 2,
+                // then close: an incomplete body with no decodable SSE event.
+                let _ = socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nda",
+                    )
+                    .await;
+            } else {
+                let _ = socket.write_all(full_sse_response().as_bytes()).await;
+            }
+            let _ = socket.flush().await;
+            // Drop `socket` to close the connection.
+        }
+    });
+
+    (format!("http://{addr}/v1/chat/completions"), counter)
+}
+
+/// Zero-backoff retry config so the reconnect does not actually sleep.
+fn fast_retry() -> LlmRetryConfig {
+    LlmRetryConfig {
+        max_retries: 2,
+        initial_backoff: Duration::from_millis(0),
+        max_backoff: Duration::from_millis(0),
+        backoff_multiplier: 1.0,
+        jitter_factor: 0.0,
+    }
+}
+
+async fn drain(mut stream: LlmResponseStream) -> (Vec<String>, bool) {
+    let mut texts = Vec::new();
+    let mut saw_done = false;
+    while let Some(item) = stream.next().await {
+        match item.expect("driver stream item is Result-ok") {
+            LlmStreamEvent::TextDelta(t) if !t.is_empty() => texts.push(t),
+            LlmStreamEvent::Done(_) => saw_done = true,
+            LlmStreamEvent::Error(e) => panic!("unexpected stream error: {e}"),
+            _ => {}
+        }
+    }
+    (texts, saw_done)
+}
+
+/// The first connection truncates before any event; the driver must reconnect
+/// and stream the full response from the second connection.
+#[tokio::test]
+async fn driver_reconnects_on_truncated_first_response() {
+    let (url, count) = spawn_flaky_openai_server(1).await;
+    let driver =
+        OpenAIProtocolChatDriver::with_base_url("test-key", url).with_retry_config(fast_retry());
+
+    let stream = driver
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("gpt-4o"),
+        )
+        .await
+        .expect("stream should start (reconnect happens before first event)");
+
+    let (texts, saw_done) = drain(stream).await;
+
+    assert_eq!(
+        count.load(Ordering::SeqCst),
+        2,
+        "driver should reconnect once"
+    );
+    assert_eq!(texts, vec!["Hi".to_string()], "content from the reconnect");
+    assert!(saw_done, "stream should complete with a Done event");
+}
+
+/// When every attempt truncates, the driver exhausts its reconnect budget and
+/// surfaces the transport error instead of hanging or panicking.
+#[tokio::test]
+async fn driver_surfaces_error_after_exhausting_reconnects() {
+    // Always truncate. With max_retries = 2 that is 1 + 2 = 3 attempts.
+    let (url, count) = spawn_flaky_openai_server(u32::MAX).await;
+    let driver =
+        OpenAIProtocolChatDriver::with_base_url("test-key", url).with_retry_config(fast_retry());
+
+    let stream = driver
+        .chat_completion_stream(
+            vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+            &config("gpt-4o"),
+        )
+        .await
+        .expect("stream object is returned even when the body ultimately fails");
+
+    let mut saw_error = false;
+    let mut stream = stream;
+    while let Some(item) = stream.next().await {
+        if let Ok(LlmStreamEvent::Error(_)) = item {
+            saw_error = true;
+        }
+    }
+
+    assert_eq!(count.load(Ordering::SeqCst), 3, "1 initial + 2 reconnects");
+    assert!(
+        saw_error,
+        "exhausted reconnects should surface a stream error"
+    );
+}

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -30,9 +30,10 @@ use everruns_core::driver_registry::{
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
 use everruns_core::llm_retry::{
-    LlmRetryConfig, RetryDecision, SendOutcome, retry_request, send_error_message,
+    LlmRetryConfig, RetryDecision, RetryMetadata, SendOutcome, retry_request, send_error_message,
 };
 use everruns_core::stream_accumulator::StreamToolCallAccumulator;
+use everruns_core::stream_reconnect::connect_bytes_with_reconnect;
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -292,73 +293,37 @@ impl GeminiChatDriver {
     fn models_url(&self) -> String {
         format!("{}/models", self.base_url)
     }
-}
 
-#[async_trait]
-impl ChatDriver for GeminiChatDriver {
-    async fn chat_completion_stream(
+    /// Send one streaming `streamGenerateContent` request, applying the shared
+    /// header-phase retry loop (transient send failures, 429, and 5xx), and
+    /// return the raw response plus its retry metadata.
+    ///
+    /// Invoked once per reconnect attempt by [`connect_bytes_with_reconnect`]. It
+    /// re-sends the identical request and consumes no body bytes, so retrying is
+    /// idempotent. Terminal classification and error messages are preserved
+    /// exactly.
+    async fn send_generate_content_request(
         &self,
-        messages: Vec<LlmMessage>,
-        config: &LlmCallConfig,
-    ) -> Result<LlmResponseStream> {
-        let (system_instruction, contents) = Self::convert_messages(&messages);
-
-        let tools = Self::convert_tools(&config.tools);
-
-        let mut generation_config = GeminiGenerationConfig {
-            temperature: config.temperature,
-            max_output_tokens: config.max_tokens,
-        };
-
-        // If no max_tokens specified, use model's max output from profile, or 8192 fallback
-        if generation_config.max_output_tokens.is_none() {
-            generation_config.max_output_tokens = Some(
-                everruns_core::get_model_profile(&everruns_core::DriverId::Gemini, &config.model)
-                    .and_then(|p| {
-                        p.limits.and_then(|l| {
-                            u32::try_from(l.output)
-                                .ok()
-                                .and_then(|v| if v > 0 { Some(v) } else { None })
-                        })
-                    })
-                    .unwrap_or(8_192),
-            );
-        }
-
-        let request = GeminiRequest {
-            contents,
-            system_instruction,
-            tools,
-            generation_config: Some(generation_config),
-            cached_content: config
-                .prompt_cache
-                .as_ref()
-                .filter(|cfg| cfg.enabled)
-                .and_then(|cfg| cfg.gemini_cached_content.clone()),
-        };
-
-        // Retry loop for rate limit (429) and transient errors. The shared
-        // executor (everruns_core::llm_retry::retry_request) owns the loop,
-        // backoff, send-error retry, and success/exhaustion logging; this
-        // closure supplies Gemini's terminal classification, preserving the
-        // previous error types and messages exactly.
-        let url = self.stream_url(&config.model);
+        request: &GeminiRequest,
+        url: &str,
+        model: &str,
+    ) -> Result<(reqwest::Response, RetryMetadata)> {
         let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
-        let (response, retry_metadata) = retry_request(
+        retry_request(
             &self.retry_config,
             "GeminiDriver",
             || {
                 self.client
-                    .post(&url)
+                    .post(url)
                     .header("Content-Type", "application/json")
                     .header("x-goog-api-key", &self.api_key)
-                    .json(&request)
+                    .json(request)
                     .send()
                     .map(|r| r.map_err(SendOutcome::Send))
             },
             |response, attempts, can_retry| {
-                let model = config.model.clone();
+                let model = model.to_string();
                 let last_error = Arc::clone(&last_error);
                 async move {
                     let status = response.status();
@@ -418,7 +383,64 @@ impl ChatDriver for GeminiChatDriver {
             },
             |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
         )
-        .await?;
+        .await
+    }
+}
+
+#[async_trait]
+impl ChatDriver for GeminiChatDriver {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        let (system_instruction, contents) = Self::convert_messages(&messages);
+
+        let tools = Self::convert_tools(&config.tools);
+
+        let mut generation_config = GeminiGenerationConfig {
+            temperature: config.temperature,
+            max_output_tokens: config.max_tokens,
+        };
+
+        // If no max_tokens specified, use model's max output from profile, or 8192 fallback
+        if generation_config.max_output_tokens.is_none() {
+            generation_config.max_output_tokens = Some(
+                everruns_core::get_model_profile(&everruns_core::DriverId::Gemini, &config.model)
+                    .and_then(|p| {
+                        p.limits.and_then(|l| {
+                            u32::try_from(l.output)
+                                .ok()
+                                .and_then(|v| if v > 0 { Some(v) } else { None })
+                        })
+                    })
+                    .unwrap_or(8_192),
+            );
+        }
+
+        let request = GeminiRequest {
+            contents,
+            system_instruction,
+            tools,
+            generation_config: Some(generation_config),
+            cached_content: config
+                .prompt_cache
+                .as_ref()
+                .filter(|cfg| cfg.enabled)
+                .and_then(|cfg| cfg.gemini_cached_content.clone()),
+        };
+
+        // Establish the byte stream, transparently reconnecting on a transport
+        // failure that lands before the first chunk (the "error decoding
+        // response body" flake). Header-phase retries (429/5xx and transient
+        // send failures) are handled inside the per-attempt send. Gemini parses
+        // SSE by hand, so this uses the raw byte-stream reconnect variant.
+        let url = self.stream_url(&config.model);
+        let (byte_stream, retry_metadata) =
+            connect_bytes_with_reconnect(&self.retry_config, "GeminiDriver", |_attempt| {
+                self.send_generate_content_request(&request, &url, &config.model)
+            })
+            .await?;
 
         // Gemini streams SSE events with JSON data, each containing a candidate
         let model = config.model.clone();
@@ -432,9 +454,6 @@ impl ChatDriver for GeminiChatDriver {
         } else {
             None
         };
-
-        // Gemini SSE stream: each event has `data: {...}` lines
-        let byte_stream = response.bytes_stream();
 
         // Use a buffered approach to handle SSE events
         let converted_stream: LlmResponseStream = Box::pin(futures::stream::unfold(


### PR DESCRIPTION
## What
Add a streaming reconnect layer so the LLM drivers recover from mid-stream transport failures (`error decoding response body`, truncated/incomplete body, mid-stream connection reset, stale pooled keep-alive socket closed by the peer) instead of failing the turn.

## Why
`retry_request` only covers the request up to **response headers** — connect/TLS/send failures and retryable HTTP statuses. Once the SSE body starts streaming, a transport failure is surfaced by reqwest **after** a 200 and was **fatal to the turn with no retry**. The official OpenAI/Anthropic SDKs retry exactly this connection-error class (`APIConnectionError`) with bounded backoff; our native Rust drivers did not. This is the root cause of the recurring live-matrix flake:

```
LLM error: Stream error: Transport error: error decoding response body
```

It reproduces every few CI runs — not "network weather" but a structural gap: our streaming path has zero retry once the body starts, and the shared connection pool held idle keep-alive sockets for 90s (vs. httpx's 5s default), maximizing the stale-socket reuse race.

## How
New `crates/core/src/stream_reconnect.rs`:
- Reconnects when the stream fails **before the first event is decoded** — exactly where these transport failures land — bounded by the existing exponential backoff + jitter (`LlmRetryConfig`, default 2 retries).
- **Committed-after-first-event:** once any event is forwarded, errors pass through, so emitted deltas/tool-calls are never duplicated.
- **Typed classifier:** only reqwest transport errors (`is_body/is_decode/is_connect/is_request/is_timeout`) reconnect; UTF-8/parser errors pass through, so a genuine protocol bug is not masked (the exact failure mode a blanket skip would hide).
- Two variants: event-stream (`.eventsource()`) and raw byte-stream (for Gemini, which parses SSE by hand).

Wired into all four SSE drivers via extracted per-attempt send methods: OpenAI Chat Completions, OpenAI Responses, Anthropic (event-stream), and Gemini (byte-stream).

Also: streaming client `pool_idle_timeout` 90s → 15s so stale keep-alive sockets are recycled before reuse, closer to the official SDK transport (httpx, 5s).

## Risk
- **Low.** Driver-internal resilience; no API/schema/migration/UI surface. Happy-path SSE parsing is unchanged (existing golden wire tests pass through the new path).
- Behavioral nuance: `chat_completion_stream()` now resolves at first-token time (it peeks the first frame to decide reconnect) rather than lazily. End-to-end latency is unchanged. A provider that returns 200 then sends nothing is bounded by the 300s streaming read-timeout (which classifies as a reconnectable timeout) instead of the reason atom's 120s stall timer — a rare, self-healing case, documented in code.

## Security
- **Threat categories reviewed:** `TM-LLM` (provider API interaction, key handling), `TM-API` (outbound HTTP), `TM-DOS` (bounded retries).
- **Findings:** none.
  - Reconnect re-sends the identical request and re-resolves the auth header per attempt via the existing path — no key material added to logs (the reconnect `tracing::warn!` logs only the driver name and the transport error, which carry no secrets or request body).
  - SSRF hardening is preserved: reconnect reuses `shared_streaming_http_client()` (DNS-pinning `SsrfGuardResolver` + `redirect(none)`); each reconnect is a fresh send, so the DNS/SSRF check re-applies per attempt. No new external-input parsing.
  - Bounded by `max_retries` (default 2 → ≤3 attempts) with capped backoff and a shorter pool idle; no unbounded loop or resource growth.
- No `specs/threat-model.md` change needed (no new threat or changed mitigation).

## Follow-ups
- The flaky live Fireworks `gpt-oss-120b` `test_tool_call` case (`Should have called get_current_time`) is an independent live-model non-determinism issue, unrelated to this change and not masked by it. Tracked as a separate change: repin Fireworks to `llama-v3p3-70b-instruct` (a reliable tool-caller) so the third-host streaming + tool-call integration test is deterministic — no `#[ignore]`.

## Validation
- `stream_reconnect` unit tests (5) over a raw-TCP SSE server: reconnect-then-succeed, exhaust-then-error, clean single connection, error-after-first-event pass-through, classifier.
- `openai_reconnect_wire.rs` (2): drives the real `OpenAIProtocolChatDriver` against a server that truncates the first response — proves it reconnects and yields full content, and surfaces an error after exhausting retries.
- Existing golden wire tests (openai/openresponses/anthropic/gemini) pass through the new reconnect path.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean; `cargo check --workspace` green; `just pre-push` green.
- CI: all Rust jobs green (Clippy, Unit Tests, Integration PostgreSQL, Worker Tests, Build Release, SDK Compat, Docker, MSRV) plus CodeQL/Analyze.
- Smoke: the affected flow (SSE streaming transport → reconnect → parse) is exercised end-to-end at the HTTP layer by the tests above (real reqwest streaming against a real socket). A live-provider smoke needs Doppler secrets not available in this session; CI's live LLM matrix on push-to-main covers the live happy path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — none posted