### PR TITLE
fix(egress): keep host transports outside runtime policy

### DIFF
--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -253,10 +253,21 @@ impl DirectEgressService {
         }
     }
 
+    /// Construct the default direct transport for tenant/agent runtime egress.
+    ///
+    /// This honors `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED` and is the right default
+    /// for capabilities, MCP, integrations, and runtime HTTP surfaces.
+    pub fn for_runtime_traffic_from_env() -> Self {
+        Self::from_env()
+    }
+
     /// Construct with the global system allowlist resolved from the environment.
     ///
     /// Enforcement is active only when `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED` is
     /// set; otherwise this behaves exactly like [`DirectEgressService::new`].
+    /// Prefer [`DirectEgressService::for_runtime_traffic_from_env`] for new
+    /// runtime/agent call sites. Host-owned services should use direct provider
+    /// clients instead of `EgressService`.
     pub fn from_env() -> Self {
         Self::new().with_system_allowlist(SystemAllowlist::from_env())
     }
@@ -288,12 +299,9 @@ impl DirectEgressService {
                 url: request.url.clone(),
             });
         }
-        // Host-wide allowlist: when enabled, every outbound request must match
-        // one of the curated public resources, regardless of request kind or the
-        // per-request network access list. This is a separate, AND-ed gate — it
-        // is never merged into `request.network_access`, so harness/agent/session
-        // allowlists can only narrow within it and can never widen past it. The
-        // system allowlist is a hard ceiling with maximum priority.
+        // Host-wide allowlist: when enabled, every request routed through this
+        // runtime egress boundary must match one of the curated public
+        // resources. Host-owned services should not use `EgressService`.
         if let Some(allowlist) = &self.system_allowlist
             && !allowlist.is_url_allowed(&request.url)
         {
@@ -500,6 +508,13 @@ mod tests {
     #[tokio::test]
     async fn system_allowlist_blocks_unlisted_hosts() {
         use crate::system_allowlist::SystemAllowlist;
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/blocked"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
         let allowlist = SystemAllowlist::from_toml(
             r#"
             [groups.test]
@@ -512,10 +527,8 @@ mod tests {
         let error = service
             .send(EgressRequest::new(
                 "GET",
-                "https://blocked.example.com/path",
-                // Even system-owned traffic (no per-request network_access) is
-                // subject to the host-wide allowlist.
-                EgressRequestKind::Provider,
+                format!("{}/blocked", server.uri()),
+                EgressRequestKind::Capability,
             ))
             .await
             .unwrap_err();
@@ -692,7 +705,7 @@ mod tests {
             .send_stream(EgressRequest::new(
                 "GET",
                 format!("{}/stream", server.uri()),
-                EgressRequestKind::Provider,
+                EgressRequestKind::Capability,
             ))
             .await
             .unwrap();

--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -390,19 +390,9 @@ impl SystemEmailConfig {
     }
 
     pub fn into_sender(self) -> Arc<dyn EmailSender> {
-        self.into_sender_with_egress(Arc::new(crate::DirectEgressService::default()))
-    }
-
-    pub fn into_sender_with_egress(
-        self,
-        egress_service: Arc<dyn crate::EgressService>,
-    ) -> Arc<dyn EmailSender> {
         match self {
             Self::Disabled => Arc::new(DisabledEmailSender),
-            Self::Resend(config) => Arc::new(ResendEmailSender::with_egress_service(
-                config,
-                egress_service,
-            )),
+            Self::Resend(config) => Arc::new(ResendEmailSender::new(config)),
         }
     }
 }

--- a/crates/core/src/email/resend.rs
+++ b/crates/core/src/email/resend.rs
@@ -5,13 +5,11 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use super::{
     EmailAddress, EmailError, EmailMessage, EmailResult, EmailSender, EmailTag, RenderedEmail,
     SentEmail, system_email_from,
 };
-use crate::{EgressError, EgressRequest, EgressRequestKind, EgressService};
 
 const RESEND_API_BASE_URL: &str = "https://api.resend.com";
 const RESEND_REQUEST_TIMEOUT_MS: u64 = 30_000;
@@ -57,7 +55,7 @@ impl ResendEmailConfig {
 
 #[derive(Clone)]
 pub struct ResendEmailSender {
-    egress_service: Arc<dyn EgressService>,
+    http: reqwest::Client,
     config: ResendEmailConfig,
 }
 
@@ -71,17 +69,16 @@ impl std::fmt::Debug for ResendEmailSender {
 
 impl ResendEmailSender {
     pub fn new(config: ResendEmailConfig) -> Self {
-        Self::with_egress_service(config, Arc::new(crate::DirectEgressService::default()))
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(RESEND_REQUEST_TIMEOUT_MS))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("build Resend email HTTP client");
+        Self::with_http_client(config, http)
     }
 
-    pub fn with_egress_service(
-        config: ResendEmailConfig,
-        egress_service: Arc<dyn EgressService>,
-    ) -> Self {
-        Self {
-            egress_service,
-            config,
-        }
+    pub fn with_http_client(config: ResendEmailConfig, http: reqwest::Client) -> Self {
+        Self { http, config }
     }
 
     pub fn config(&self) -> &ResendEmailConfig {
@@ -94,39 +91,42 @@ impl EmailSender for ResendEmailSender {
     async fn send_email(&self, message: EmailMessage) -> EmailResult<SentEmail> {
         let rendered = message.validate()?;
         let request = ResendSendEmailRequest::from_message(system_email_from(), message, rendered);
-        let mut egress_request = EgressRequest::new(
-            "POST",
-            format!("{}/emails", self.config.api_base_url),
-            EgressRequestKind::SystemEmail,
-        )
-        .header("Authorization", format!("Bearer {}", self.config.api_key))
-        .header("Content-Type", "application/json")
-        .timeout_ms(RESEND_REQUEST_TIMEOUT_MS)
-        .body(serde_json::to_vec(&request).map_err(|error| {
+        let body = serde_json::to_vec(&request).map_err(|error| {
             EmailError::Transport(format!("failed to encode Resend request: {error}"))
-        })?);
+        })?;
+
+        let mut builder = self
+            .http
+            .post(format!("{}/emails", self.config.api_base_url))
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .body(body);
 
         if let Some(key) = &request.idempotency_key {
-            egress_request = egress_request.header("Idempotency-Key", key);
+            builder = builder.header("Idempotency-Key", key);
         }
 
-        let response = self
-            .egress_service
-            .send(egress_request)
+        let response = builder
+            .send()
             .await
-            .map_err(EmailError::egress)?;
-        if !(200..300).contains(&response.status) {
+            .map_err(|error| EmailError::Transport(error.to_string()))?;
+        let status = response.status();
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| EmailError::Transport(error.to_string()))?
+            .to_vec();
+        if !status.is_success() {
             return Err(EmailError::Provider {
                 provider: "resend",
-                status: response.status,
-                body: String::from_utf8_lossy(&response.body).into_owned(),
+                status: status.as_u16(),
+                body: String::from_utf8_lossy(&body).into_owned(),
             });
         }
 
-        let body: ResendSendEmailResponse =
-            serde_json::from_slice(&response.body).map_err(|error| {
-                EmailError::Transport(format!("failed to decode Resend response: {error}"))
-            })?;
+        let body: ResendSendEmailResponse = serde_json::from_slice(&body).map_err(|error| {
+            EmailError::Transport(format!("failed to decode Resend response: {error}"))
+        })?;
         Ok(SentEmail {
             provider: "resend",
             id: body.id,
@@ -135,12 +135,6 @@ impl EmailSender for ResendEmailSender {
 
     fn name(&self) -> &'static str {
         "ResendEmailSender"
-    }
-}
-
-impl EmailError {
-    fn egress(error: EgressError) -> Self {
-        Self::Transport(error.to_string())
     }
 }
 
@@ -258,5 +252,44 @@ mod tests {
         assert!(body.get("reply_to").is_none());
         assert!(body.get("headers").is_none());
         assert!(body.get("idempotency_key").is_none());
+    }
+
+    #[tokio::test]
+    async fn resend_sender_uses_direct_http_outside_runtime_egress_policy() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .and(header("Authorization", "Bearer re_test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "email_allowed"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let allowlist = crate::SystemAllowlist::from_toml(
+            r#"
+            [groups.test]
+            allowed = ["allowed.example.com"]
+            "#,
+        )
+        .unwrap();
+        assert!(
+            !allowlist.is_url_allowed(&format!("{}/emails", server.uri())),
+            "mock Resend endpoint should be outside the runtime system allowlist"
+        );
+
+        let sender = ResendEmailSender::new(test_config(server.uri()));
+        let sent = sender
+            .send_email(EmailMessage::minimal(
+                "delivered@example.com",
+                "Welcome",
+                "hello",
+                "<p>hello</p>",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(sent.id, "email_allowed");
     }
 }

--- a/crates/core/src/system_allowlist.rs
+++ b/crates/core/src/system_allowlist.rs
@@ -1,16 +1,16 @@
 //! System-wide outbound allowlist ("green list").
 //!
-//! An optional, host-owned global allowlist of well-known public resources
-//! (package registries, source hosting, AI/cloud provider APIs, ...). It is an
-//! internal, curated list — not agent/session/user configuration — shipped as
-//! an embedded TOML (`system_allowlist.toml`) and grouped by category so it
-//! stays manageable.
+//! An optional, host-owned global allowlist of well-known public resources for
+//! tenant/agent runtime egress. It is an internal, curated list — not
+//! agent/session/user configuration — shipped as an embedded TOML
+//! (`system_allowlist.toml`) and grouped by category so it stays manageable.
 //!
 //! When enabled via `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED`, the egress boundary
-//! denies any outbound request whose URL does not match one of the groups, in
-//! addition to (and independently of) the per-agent/session
-//! [`NetworkAccessList`]. It is disabled by default, so the default behavior is
-//! unchanged. See `specs/system-allowlist.md`.
+//! denies any request routed through `EgressService` whose URL does not match
+//! one of the groups, in addition to (and independently of) the
+//! per-agent/session [`NetworkAccessList`]. Host-owned services do not use this
+//! boundary. It is disabled by default, so the default behavior is unchanged.
+//! See `specs/system-allowlist.md`.
 
 use crate::network_access::NetworkAccessList;
 use serde::Deserialize;

--- a/crates/server/src/api/plugins.rs
+++ b/crates/server/src/api/plugins.rs
@@ -66,7 +66,7 @@ impl AppState {
             db,
             capability_service,
             auth,
-            egress_service: Arc::new(DirectEgressService::from_env()),
+            egress_service: Arc::new(DirectEgressService::for_runtime_traffic_from_env()),
         }
     }
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1381,10 +1381,9 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 tracing::warn!(error = %error, "Invalid scoped MCP server config, skipping");
                 vec![]
             } else {
-                let egress = self
-                    .egress_service
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(everruns_core::DirectEgressService::from_env()));
+                let egress = self.egress_service.clone().unwrap_or_else(|| {
+                    Arc::new(everruns_core::DirectEgressService::for_runtime_traffic_from_env())
+                });
                 build_scoped_mcp_tool_definitions(
                     &effective,
                     Some(session.id),

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -115,7 +115,11 @@ pub struct McpServerOAuthSettings {
 
 impl McpServerService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
-        Self::with_egress_service(db, encryption, Arc::new(DirectEgressService::from_env()))
+        Self::with_egress_service(
+            db,
+            encryption,
+            Arc::new(DirectEgressService::for_runtime_traffic_from_env()),
+        )
     }
 
     pub fn with_egress_service(

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -24,12 +24,12 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
     let capability_registry = CapabilityRegistry::with_builtins_for_grade(grade);
     let driver_registry = everruns_worker::create_driver_registry();
     let connectors = oss_connector_registry_for_grade(grade);
-    // Resolve the optional host-wide system allowlist from the environment
-    // (EVERRUNS_SYSTEM_ALLOWLIST_ENABLED). Disabled by default.
-    let egress_service = Arc::new(DirectEgressService::from_env());
+    // Runtime egress honors EVERRUNS_SYSTEM_ALLOWLIST_ENABLED for tenant/agent
+    // paths. System email uses its direct provider client outside egress.
+    let egress_service = Arc::new(DirectEgressService::for_runtime_traffic_from_env());
     let email_sender = SystemEmailConfig::from_env()
         .expect("Invalid system email configuration")
-        .into_sender_with_egress(egress_service.clone());
+        .into_sender();
     let utility_llm_service = SystemUtilityLlmConfig::from_env().into_service();
 
     let mut builder = PlatformDefinition::builder()

--- a/crates/worker/src/platform.rs
+++ b/crates/worker/src/platform.rs
@@ -21,10 +21,9 @@ pub fn default_platform_definition_for_grade(grade: DeploymentGrade) -> Platform
     PlatformDefinition::builder()
         .capability_registry(CapabilityRegistry::with_builtins_for_grade(grade))
         .driver_registry(crate::create_driver_registry())
-        // Honor the host-wide system allowlist in distributed workers too, so
-        // EVERRUNS_SYSTEM_ALLOWLIST_ENABLED applies to worker egress (LLM, MCP,
-        // capabilities) the same as the control plane. Disabled by default.
-        .egress_service(Arc::new(DirectEgressService::from_env()))
+        // Honor EVERRUNS_SYSTEM_ALLOWLIST_ENABLED for tenant/agent runtime
+        // egress (capabilities, MCP, integrations) in distributed workers too.
+        .egress_service(Arc::new(DirectEgressService::for_runtime_traffic_from_env()))
         .utility_llm_service(SystemUtilityLlmConfig::from_env().into_service())
         .build()
 }

--- a/specs/egress.md
+++ b/specs/egress.md
@@ -2,13 +2,15 @@
 
 ## Intent
 
-Provide one host-owned boundary for outbound network traffic.
+Provide one host-owned boundary for tenant/agent-directed outbound network
+traffic.
 
-The egress service owns HTTP/API traffic that leaves an Everruns deployment:
-LLM provider calls, capability HTTP calls, toolkit integrations, system email,
-utility LLM calls, sandbox-provider APIs, and future outbound protocols that can
-be represented over HTTP. Workers and the control plane must not create direct
-external HTTP clients at runtime once a call path has been migrated.
+The egress service owns runtime HTTP/API traffic whose destination is selected
+by an agent, a user-authored configuration surface, a capability, MCP, plugin
+fetching, or similar tenant-controlled execution. Host-owned platform services
+such as LLM provider transports, utility LLM, system email, and sandbox provider
+APIs (for example Daytona lifecycle/toolbox APIs) use direct provider clients
+outside `EgressService`.
 
 ## Terminology
 
@@ -45,8 +47,9 @@ Reasoning:
 - `EgressResponse` is the provider-neutral response body, status, and headers.
 - `EgressStreamResponse` is the streaming response body used by LLM SSE and
   other long-lived HTTP responses.
-- `EgressRequestKind` labels traffic as `llm_provider`, `capability`,
-  `integration`, `system_email`, `utility_llm`, `mcp`, or `other`.
+- `EgressRequestKind` labels runtime egress traffic as `capability`,
+  `integration`, `mcp`, or `other`; legacy/system labels may exist in code for
+  compatibility but host-owned services must not use this boundary.
 - `EgressSigning` expresses whether signing is disabled, optional via platform
   default, or required.
 - `EgressError` separates invalid requests, network access denial, unavailable
@@ -60,19 +63,18 @@ hard airgap behavior before installing a remote gateway implementation.
 
 ## Required Usage
 
-New outbound runtime code must use `EgressService` instead of constructing
-`reqwest::Client`, provider SDK clients, or toolkit-specific HTTP transports
-directly.
+New tenant/agent runtime outbound code must use `EgressService` instead of
+constructing `reqwest::Client`, provider SDK clients, or toolkit-specific HTTP
+transports directly.
 
 This applies to:
 
-- LLM drivers and model discovery.
 - capability tools, including library-backed tools such as fetchkit and bashkit
-  HTTP support.
-- integration crates for external provider APIs.
-- internal system services such as email and utility LLM.
+  HTTP support, when they fetch agent/user-selected URLs.
+- integration crates for external APIs when the API target is tenant/agent
+  selected rather than a fixed host-owned service endpoint.
 - remote MCP servers (tool discovery and tool execution).
-- background tasks that call external APIs.
+- background tasks that call tenant/agent-selected external APIs.
 
 Exceptions:
 
@@ -81,6 +83,11 @@ Exceptions:
   inside tests.
 - database, NATS, Valkey, and control-plane worker gRPC links are internal
   infrastructure traffic, not internet egress.
+- host-owned platform services such as LLM provider drivers/model discovery,
+  utility LLM, system email, sandbox provider APIs (including Daytona), cloud
+  infrastructure APIs, and other fixed deployment-owned transports use direct
+  provider clients. Their credentials and endpoints are deployment/platform
+  configuration, not tenant/agent egress policy.
 
 ## Network Access
 
@@ -93,14 +100,15 @@ The egress service enforces the policy before making the request. Individual
 capabilities may still perform earlier validation when they need better
 user-facing errors, but the egress boundary is the final enforcement point.
 
-System-owned fixed endpoints, such as a configured email provider or model
-provider URL, do not use the agent/session network access list unless that
-endpoint is derived from agent/session/user input.
+System-owned fixed endpoints, such as configured email, LLM, Daytona, or cloud
+provider URLs, do not use `EgressService` unless that endpoint is derived from
+agent/session/user input.
 
 An optional deployment-wide allowlist (`specs/system-allowlist.md`) sits at the
-same boundary. When enabled, it constrains *all* egress — every request kind,
-independent of `network_access` — to a curated set of public resources. It is
-the in-process precursor to the future gateway's outbound allowlist.
+same boundary for tenant/agent-directed egress. When enabled, it constrains
+capabilities, MCP, integrations, and generic runtime HTTP to a curated set of
+public resources. Host-owned system transports stay outside that policy because
+they do not route through `EgressService`.
 
 ## Signing
 
@@ -117,8 +125,8 @@ capability-local signing path.
 
 ## Future Egress Gateway
 
-The remote implementation will replace direct internet egress in workers and
-control-plane processes:
+The remote implementation will replace direct tenant/agent internet egress in
+workers and control-plane processes:
 
 ```mermaid
 graph LR
@@ -131,18 +139,17 @@ graph LR
 
 Deployment properties:
 
-- CP and workers need only internal network access to the gateway.
-- The gateway owns outbound allowlists, signatures, proxy configuration, audit
-  logs, and provider-specific transport policy.
+- CP and workers need only internal network access to the gateway for
+  tenant/agent runtime egress paths.
+- The gateway owns runtime outbound allowlists, signatures, proxy
+  configuration, audit logs, and tenant/agent transport policy.
 - In airgapped deployments, the gateway can be disabled, replaced with an
   approved relay, or bound to a preapproved network route.
 
 ## Migration Order
 
 1. Introduce `EgressService` and platform/runtime threading.
-2. Move internal system services onto it. `EmailSender` is migrated first;
-   `UtilityLlmService` follows with provider-driver migration.
-3. Move fetchkit/web_fetch and bashkit HTTP onto it.
+2. Move fetchkit/web_fetch and bashkit HTTP onto it.
    *Done for web_fetch*: runtime contexts route through
    `crates/core/src/capabilities/web_fetch/egress_transport.rs`; the fetchkit direct
    client remains only as the fallback for contexts without an egress service
@@ -152,10 +159,9 @@ Deployment properties:
    `crates/core/src/capabilities/bashkit_shell/egress_transport.rs` with no
    direct-client fallback — without an egress service the shell stays offline
    (see `specs/network-access.md`).
-4. Move LLM drivers and model discovery onto it.
-5. Move integration provider clients onto it.
-6. Add the remote Egress Gateway implementation and make worker/CP direct
-   internet egress removable by deployment policy.
+3. Move tenant/agent-selected integration clients onto it.
+4. Add the remote Egress Gateway implementation and make worker/CP direct
+   tenant/agent internet egress removable by deployment policy.
 
 Each migration should leave tests that prove the call path uses injected egress
 instead of a direct client.

--- a/specs/email.md
+++ b/specs/email.md
@@ -23,8 +23,10 @@ Email is not an agent capability, public API, or UI surface. It is a host servic
 - `EmailError` separates configuration, request validation, transport, and provider failures.
 - Platform/application state stores the sender as `Arc<dyn EmailSender>` when it must be shared across services.
 - `PlatformDefinition` carries the active system email sender as part of the platform profile.
-- Concrete senders use `EgressService` for provider HTTP; email remains a
-  domain-specific service above the outbound transport boundary.
+- Concrete senders use direct provider HTTP clients; email remains a
+  domain-specific host service outside the tenant/agent egress boundary.
+- System email is not governed by tenant/agent egress policy such as
+  `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED`.
 
 Messages support:
 
@@ -67,7 +69,7 @@ When `EMAIL_PROVIDER` is unset, the system email configuration is disabled. Prod
 
 The default OSS platform profile resolves `SystemEmailConfig::from_env()` during `oss_platform_definition_for_grade()` construction. Invalid email configuration fails startup when a provider is explicitly enabled.
 
-Embedders can bypass env-based setup by constructing a custom `PlatformDefinition` and calling `PlatformDefinition::builder().email_sender(...)` before passing it to `ServerAppBuilder::platform_definition(...)`.
+Embedders can bypass env-based setup by constructing a custom `PlatformDefinition` and calling `PlatformDefinition::builder().email_sender(...)` before passing it to `ServerAppBuilder::platform_definition(...)`. Reusable OSS helpers include `SystemEmailConfig::into_sender()`, `ResendEmailSender::new(...)`, and `ResendEmailSender::with_http_client(...)` for deployments that assemble their own platform profile.
 
 `ServerContext.email_sender` exposes the configured sender to internal background tasks and extension code. Request handlers should access the sender through their service/application state when a feature needs transactional email.
 

--- a/specs/fetchkit.md
+++ b/specs/fetchkit.md
@@ -53,7 +53,7 @@ Server-wide via environment variables:
 | `BOT_AUTH_AGENT_FQDN` | no | FQDN for `Signature-Agent` header (key discovery) |
 | `BOT_AUTH_VALIDITY_SECS` | no | signature validity window, default 300 |
 
-When `BOT_AUTH_SIGNING_KEY_SEED` is set, all `web_fetch` requests are signed by fetchkit on both paths: signing happens before each hop is handed to the transport (re-signed per redirect hop), so it applies equally when the hop crosses the egress boundary. Egress-routed hops additionally request `EgressSigning::PlatformDefault`, a no-op until a platform egress signer exists; when one lands, signing policy should consolidate behind `EgressService` so web_fetch, LLM drivers, and integrations share one outbound signing path (see `specs/egress.md`).
+When `BOT_AUTH_SIGNING_KEY_SEED` is set, all `web_fetch` requests are signed by fetchkit on both paths: signing happens before each hop is handed to the transport (re-signed per redirect hop), so it applies equally when the hop crosses the egress boundary. Egress-routed hops additionally request `EgressSigning::PlatformDefault`, a no-op until a platform egress signer exists; when one lands, signing policy should consolidate behind `EgressService` for tenant/agent runtime fetches (see `specs/egress.md`).
 
 Generate a seed: `python3 -c "import os, base64; print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode())"`
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -89,14 +89,13 @@ on-demand from `ProviderConfig`. All real built-in providers require API keys;
 via `ProviderMetadata`). See `crates/core/src/driver_registry.rs` for
 `DriverRegistry` and `DriverDescriptor`.
 
-### Egress Boundary
+### Host-Owned Transport
 
-Provider drivers and model discovery must route outbound HTTP through
-`EgressService` (see `specs/egress.md`). Drivers still own provider-specific
-request construction, streaming parse logic, retry classification, and error
-mapping, but they should not create direct external HTTP clients as the final
-transport. This keeps workers and control-plane processes compatible with a
-future remote Egress Gateway and airgapped deployments.
+Provider drivers and model discovery use direct provider HTTP clients. They are
+host-owned platform services: provider endpoints and credentials come from
+deployment/org provider configuration, not from agent-authored URLs or
+tenant/agent egress policy. Drivers still own provider-specific request
+construction, streaming parse logic, retry classification, and error mapping.
 
 ### Message Types
 

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -3,8 +3,9 @@
 ## Intent
 
 An optional, host-owned global allowlist ("green list") of well-known public
-resources that the egress boundary permits. It is a deployment-wide safety net
-that constrains *all* outbound traffic to a curated set of trusted public
+resources that the egress boundary permits for tenant/agent-directed outbound
+traffic. It is a deployment-wide safety net that constrains capability, MCP,
+integration, and generic runtime HTTP traffic to a curated set of trusted public
 services, independently of per-agent/session `NetworkAccessList`.
 
 Unlike `NetworkAccessList`, this is **not** end-user or agent configuration. It
@@ -52,8 +53,10 @@ Disabled by default. Controlled by a single environment variable:
 EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true   # or 1
 ```
 
-`DirectEgressService::from_env()` resolves the allowlist at construction. When
-unset or falsy, egress behavior is unchanged.
+`DirectEgressService::for_runtime_traffic_from_env()` resolves the allowlist at
+construction. When unset or falsy, egress behavior is unchanged. Host-owned
+system transports do not construct or call `EgressService`, so they do not read
+this toggle.
 
 The env var is read by every process that builds an egress service, so it
 applies uniformly across the **control plane** and **workers**:
@@ -62,23 +65,29 @@ applies uniformly across the **control plane** and **workers**:
 - `crates/worker/src/platform.rs` — distributed worker platform.
 - `crates/server/src/domains/mcp_servers/service.rs` — MCP server egress.
 
-Each must construct egress via `DirectEgressService::from_env()` (not
-`::default()`) so the toggle is honored everywhere. The list contents are *not*
-env-configurable — they are the curated embedded TOML; only the on/off toggle is
-environmental.
+Each runtime/agent egress surface must construct egress via
+`DirectEgressService::for_runtime_traffic_from_env()` (not `::default()`) so the
+toggle is honored everywhere. The list contents are *not* env-configurable —
+they are the curated embedded TOML; only the on/off toggle is environmental.
 
 ## Enforcement
 
-The `EgressService` is the single host-owned outbound boundary (see
+The `EgressService` is the tenant/agent runtime outbound boundary (see
 `specs/egress.md`). When the system allowlist is active, `DirectEgressService`
-denies any request whose URL does not match the allowlist, with
-`EgressError::NetworkAccessDenied`.
+denies tenant/agent-directed request kinds whose URL does not match the
+allowlist, with `EgressError::NetworkAccessDenied`.
 
-This check is **global**: it applies to every `EgressRequestKind` — LLM provider
-calls, capabilities, integrations, system email, utility LLM, and MCP — and is
-independent of the per-request `network_access`. Both the system allowlist
-(if active) and the per-request `NetworkAccessList` (if present) must permit a
-URL for the request to proceed.
+This check applies to `capability`, `integration`, `mcp`, and generic `other`
+requests, independent of the per-request `network_access`. Both the system
+allowlist (if active) and the per-request `NetworkAccessList` (if present) must
+permit a URL for those requests to proceed.
+
+Host-owned system transports are intentionally outside the tenant/agent policy:
+system email, utility LLM, LLM provider/model-discovery transports, Daytona
+provider APIs, and similar fixed deployment-owned clients are configured by the
+deployment, keep their credentials in platform services, and do not route
+through `EgressService`. They must not require adding provider endpoints such as
+`api.resend.com` to the tenant/agent allowlist.
 
 ### Maximum priority (hard ceiling)
 
@@ -86,8 +95,9 @@ The system allowlist is a separate, AND-ed gate — it is **never merged into**
 the harness/agent/session `NetworkAccessList`. Those layers can only narrow
 within the system allowlist (intersection on `allowed`, union on `blocked`);
 they can **never widen past it or override it**. When the allowlist is enabled,
-a session that explicitly allows a host still cannot reach it unless the system
-allowlist also lists it. The system allowlist always wins.
+a session that explicitly allows a host still cannot reach it through
+tenant/agent egress unless the system allowlist also lists it. The system
+allowlist always wins for the request kinds it governs.
 
 ### fetchkit / web_fetch
 
@@ -105,18 +115,19 @@ e.g. embedded hosts) the pre-flight check is the only enforcement.
 
 ### Operator responsibility
 
-Because enforcement covers provider traffic too, an operator enabling the
-allowlist must ensure every endpoint their deployment depends on (LLM providers,
-email provider, model discovery, configured MCP servers) is covered by a group.
-Self-hosted or uncommon endpoints not present in the curated groups will be
-blocked while the allowlist is enabled. The curated list intentionally includes
-the major AI and cloud providers so the common case works out of the box.
+Because enforcement covers tenant/agent runtime traffic, an operator enabling
+the allowlist must ensure endpoints reachable through capabilities,
+integrations, MCP, plugin fetches, and similar runtime HTTP paths are covered by
+a group. Self-hosted or uncommon runtime endpoints not present in the curated
+groups will be blocked while the allowlist is enabled. Host-owned system
+transports such as email, utility LLM, LLM providers, and Daytona are configured
+separately by deployment environment and are not governed by this list.
 
 ## Relationship to other controls
 
 | Control | Scope | Configured by |
 |---------|-------|---------------|
-| System allowlist | Whole deployment, all egress kinds | Maintainers (curated), operator toggles via env |
+| System allowlist | Tenant/agent runtime egress | Maintainers (curated), operator toggles via env |
 | `NetworkAccessList` | Per harness/agent/session, agent-authored URLs | Users/agents |
 | Future Egress Gateway | Network component owning outbound policy | Deployment |
 

--- a/specs/utility-llm.md
+++ b/specs/utility-llm.md
@@ -28,8 +28,11 @@ endpoint.
 - `PlatformDefinition` carries the active service as part of the platform
   profile.
 - Runtime tool execution threads the service into `ToolContext`.
-- Concrete implementations must use `EgressService` for provider HTTP once
-  migrated; the utility LLM service remains the capability-facing typed API.
+- Concrete implementations use direct provider HTTP clients; the utility LLM
+  service remains the capability-facing typed API.
+- Utility LLM provider transport is host-owned. It does not route through
+  `EgressService` and is not governed by tenant/agent egress policy such as
+  `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED`.
 
 The model is hardcoded to `gpt-5.5`. Requests do not expose tools, tool search,
 previous response IDs, model overrides, or provider credentials. By default the


### PR DESCRIPTION
## What
Keep host-owned services outside the tenant/agent `EgressService` boundary:

- Resend system email now uses a direct provider HTTP client instead of injected egress.
- Runtime egress constructors are named for tenant/agent traffic and used by server, worker, plugin fetch, direct-worker fallback, and MCP service wiring.
- System allowlist and egress specs now define the boundary as tenant/agent runtime egress only.
- LLM provider, utility LLM, system email, and Daytona/provider APIs are documented as host-owned direct transports.

## Why
`EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` is intended to constrain tenant/agent egress, not deployment-owned system transports. The SaaS signup incident showed that routing Resend through runtime egress blocked transactional email even though Resend never received the message.

## How
- Removed `SystemEmailConfig::into_sender_with_egress` and `ResendEmailSender`'s `EgressService` dependency.
- Added `ResendEmailSender::with_http_client(...)` for embedders/tests that need custom host-owned HTTP transport.
- Kept `DirectEgressService` allowlist enforcement strict for anything routed through runtime egress.
- Added a regression proving Resend succeeds against an endpoint outside the runtime system allowlist.
- Disabled redirects on the direct Resend client during security review.

## Risk
- Medium: changes outbound transport boundaries and email delivery plumbing.
- Main risk is accidentally weakening tenant/agent egress. Mitigated by keeping `DirectEgressService` strict and preserving allowlist regression coverage for runtime egress.
- Email provider base URL remains deployment/test configuration, not agent/user input.

## Security
- Threat categories reviewed: TM-AGENT (runtime egress / allowlist), TM-LLM (provider credential boundary), TM-API (HTTP client behavior / redirect handling), TM-AUTH (signup/recovery email side effects), TM-DOS (timeouts/resource bounds).
- Findings and resolutions:
  - Preserved tenant/agent system-allowlist enforcement for all traffic that uses `EgressService`.
  - Moved system email outside `EgressService` as a host-owned transport, matching LLM/Daytona direct-provider behavior.
  - Added a 30s client timeout and disabled redirects on the direct Resend HTTP client.
  - No new dependencies and no secret logging introduced.
- Threat model update: not required; existing threat categories still apply, and durable boundary intent was updated in specs.

## Evidence
- `cargo test -p everruns-core email::resend::tests::resend_sender`
- `cargo test -p everruns-core egress::tests`
- `cargo check -p everruns-server -p everruns-worker`
- `PORT_PREFIX=271 DEV_MODE=true DEPLOYMENT_GRADE=dev AUTH_MODE=none OTEL_SDK_DISABLED=true SECRETS_ENCRYPTION_KEY=... ./scripts/lib/services.sh server`, then `curl http://127.0.0.1:27101/health` returned `200 OK`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

