### PR TITLE
test(llm-tests): repin Fireworks live case to llama-v3p3-70b

### DIFF
--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -37,7 +37,7 @@ use everruns_core::traits::ResolvedModel;
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
 #[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
-#[case::fireworks_gpt_oss(FIREWORKS_GPT_OSS)]
+#[case::fireworks_llama33(FIREWORKS_LLAMA33)]
 #[tokio::test]
 async fn test_basic_completion(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {
@@ -73,7 +73,7 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
 #[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
-#[case::fireworks_gpt_oss(FIREWORKS_GPT_OSS)]
+#[case::fireworks_llama33(FIREWORKS_LLAMA33)]
 #[tokio::test]
 async fn test_tool_call(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -135,11 +135,16 @@ pub const OPENROUTER_GPT4O_MINI: ProviderModelConfig = ProviderModelConfig::new(
 );
 
 // Fireworks AI serves open models via an OpenAI-compatible Chat Completions
-// API. gpt-oss-120b is a chat + tool-calling model. Exercises the Chat
-// Completions streaming path against a third (non-OpenAI/Azure) host.
-pub const FIREWORKS_GPT_OSS: ProviderModelConfig = ProviderModelConfig::new(
+// API. The point of this case is to exercise our OpenAI-protocol driver's
+// streaming + tool-calling path against a third (non-OpenAI/Azure) host — not
+// to probe a model's intelligence — so the model must call tools reliably for
+// the `test_tool_call` assertion to be deterministic. Llama 3.3 70B Instruct is
+// a dependable tool-caller; the previous `gpt-oss-120b` (an open reasoning
+// model) inconsistently emitted tool calls and flaked the "must call tool"
+// assert (see the #2550/#2556 live-matrix history).
+pub const FIREWORKS_LLAMA33: ProviderModelConfig = ProviderModelConfig::new(
     DriverId::Fireworks,
-    "accounts/fireworks/models/gpt-oss-120b",
+    "accounts/fireworks/models/llama-v3p3-70b-instruct",
     "FIREWORKS_API_KEY",
 );
 


### PR DESCRIPTION
## What
Repin the Fireworks live-matrix case from `gpt-oss-120b` to `accounts/fireworks/models/llama-v3p3-70b-instruct` (Llama 3.3 70B Instruct). Renames the matrix constant `FIREWORKS_GPT_OSS` → `FIREWORKS_LLAMA33` and the two rstest case labels.

## Why
The Fireworks case exists to exercise **our OpenAI-protocol driver's streaming + tool-calling path against a third (non-OpenAI/Azure) host** — not to probe a model's intelligence. `test_tool_call` asserts the model actually calls a tool (`tool_calls_count > 0`, `iterations > 1`), so the pinned model must do that deterministically.

`gpt-oss-120b` (an open reasoning model, pinned in `e852e6b`) inconsistently emits tool calls and flaked that assertion with `Should have called get_current_time`. That's independent live-model non-determinism — unrelated to the streaming-transport flake fixed in #2594, and never masked by the reverted skip logic (it isn't a transport signature). Llama 3.3 70B Instruct is a dependable tool-caller, so the integration case becomes deterministic while keeping the exact same coverage. **No test is ignored.**

## How
Const + comment update in `crates/llm-tests/tests/llm_test_matrix/mod.rs`; two `#[case::…]` label/constant updates in `crates/llm-tests/tests/agent_run_basic.rs`.

## Risk
- **Very low.** Test-only; changes which live Fireworks model the matrix pins. No product code touched.

## Security
- No security-relevant code changes — test-only model-id change in `crates/llm-tests/`.

## Follow-ups
- No follow-ups.

## Validation
- `cargo test -p everruns-llm-tests --features llm-tests --no-run` compiles; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean on the crate.
- These are push-only live tests (skipped on PRs — no secrets), so the live tool-call behavior of the new model is verified by CI's LLM matrix on push-to-main. Model choice confirmed as a reliable tool-caller.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)