### PR TITLE
test(llm-tests): repin Fireworks live case to served Kimi K2 model

### DIFF
--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -3,7 +3,7 @@
 //! Exercises a real streamed chat completion through `FireworksChatDriver` plus
 //! live `/models` discovery and profile mapping. These are the live counterparts
 //! to the wiremock unit tests. (Live tool-calling is covered by the shared
-//! `everruns-llm-tests` matrix via the `FIREWORKS_GPT_OSS` case.)
+//! `everruns-llm-tests` matrix via the `FIREWORKS_KIMI_K2` case.)
 //!
 //! Ignored by default (requires network + `FIREWORKS_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-fireworks --test chat_live -- --ignored --nocapture`

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -37,7 +37,7 @@ use everruns_core::traits::ResolvedModel;
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
 #[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
-#[case::fireworks_llama33(FIREWORKS_LLAMA33)]
+#[case::fireworks_kimi_k2(FIREWORKS_KIMI_K2)]
 #[tokio::test]
 async fn test_basic_completion(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {
@@ -73,7 +73,7 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
 #[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
-#[case::fireworks_llama33(FIREWORKS_LLAMA33)]
+#[case::fireworks_kimi_k2(FIREWORKS_KIMI_K2)]
 #[tokio::test]
 async fn test_tool_call(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -138,13 +138,15 @@ pub const OPENROUTER_GPT4O_MINI: ProviderModelConfig = ProviderModelConfig::new(
 // API. The point of this case is to exercise our OpenAI-protocol driver's
 // streaming + tool-calling path against a third (non-OpenAI/Azure) host — not
 // to probe a model's intelligence — so the model must call tools reliably for
-// the `test_tool_call` assertion to be deterministic. Llama 3.3 70B Instruct is
-// a dependable tool-caller; the previous `gpt-oss-120b` (an open reasoning
-// model) inconsistently emitted tool calls and flaked the "must call tool"
-// assert (see the #2550/#2556 live-matrix history).
-pub const FIREWORKS_LLAMA33: ProviderModelConfig = ProviderModelConfig::new(
+// the `test_tool_call` assertion to be deterministic. Kimi K2 is purpose-built
+// for agentic tool use and calls tools deterministically. Fireworks has
+// churned its serverless catalog repeatedly: `gpt-oss-120b` flaked the "must
+// call tool" assert (#2550/#2556), and `llama-v3p3-70b-instruct` (#2597) was
+// then de-listed from the account entirely ("Model not available"). Kimi K2 is
+// a current, dependable tool-caller in the served catalog.
+pub const FIREWORKS_KIMI_K2: ProviderModelConfig = ProviderModelConfig::new(
     DriverId::Fireworks,
-    "accounts/fireworks/models/llama-v3p3-70b-instruct",
+    "accounts/fireworks/models/kimi-k2p6",
     "FIREWORKS_API_KEY",
 );
 


### PR DESCRIPTION
## What
Repin the Fireworks live-matrix case from `accounts/fireworks/models/llama-v3p3-70b-instruct` to `accounts/fireworks/models/kimi-k2p6`. Rename the matrix constant `FIREWORKS_LLAMA33` → `FIREWORKS_KIMI_K2`, update the two rstest case labels, and refresh the `chat_live` doc comment.

## Why
Main CI has been red since #2597. The Fireworks push-only live tests (`test_basic_completion::case_6_fireworks_llama33`, `test_tool_call::case_6_fireworks_llama33`) fail with:

```
Turn should succeed: Some("Model not available: accounts/fireworks/models/llama-v3p3-70b-instruct")
```

Fireworks has churned its serverless catalog and **de-listed** `llama-v3p3-70b-instruct` from the account. Querying the account's live `/v1/models` shows only these tool-capable models remain: `gpt-oss-120b`, `glm-5p1`, `glm-5p2`, `deepseek-v4-pro`, `kimi-k2p5`, `kimi-k2p6`. The previous pin `gpt-oss-120b` flaked the "must call tool" assertion (#2550/#2556).

## How
`kimi-k2p6` (Kimi K2) is purpose-built for agentic tool use. I verified against the account with the case's own `get_current_time` tool-call request at `temperature=0`: `kimi-k2p6` emitted a tool call **3/3** times (`deepseek-v4-pro` and `glm-5p2` also 3/3; `kimi-k2p5` returned HTTP 500s and was rejected). This keeps the exact same coverage — exercising our OpenAI-protocol driver's streaming + tool-calling path against a third (non-OpenAI/Azure) host — while making the case deterministic again. No test is ignored.

## Risk
- **Low.** Test-only; changes which live Fireworks model the matrix pins. No product code touched.

## Security
- Threat categories reviewed: No security-relevant code changes — test-only model-id change under `crates/llm-tests/` and a doc-comment update under `crates/fireworks/`.
- Findings and resolutions: none.

## Follow-ups
- Fireworks keeps de-listing serverless models, forcing recurring repins (gpt-oss-120b → llama-v3p3-70b → kimi-k2p6). A more durable fix would resolve the live case's model from the account's `/models` catalog at test time (pick the first tool-capable served model) instead of a hard-coded id. Deferred: out of scope for this red-CI hotfix and needs its own design. Otherwise, no follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czg367PJjx79WBtSdhuB5D)_