### PR TITLE
feat(handoff): give agent handoffs a dedicated task kind

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -10,8 +10,8 @@ use super::util::{get_platform_store, require_str_nonblank as require_str};
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SystemPromptContext};
 use crate::session::SubagentStatus;
 use crate::session_task::{
-    CreateSessionTask, SessionTaskFilter, SessionTaskState, SessionTaskUpdate, TASK_KIND_SUBAGENT,
-    TaskError, TaskLinks, TaskWakePolicy,
+    CreateSessionTask, SessionTaskFilter, SessionTaskState, SessionTaskUpdate,
+    TASK_KIND_AGENT_HANDOFF, TaskError, TaskLinks, TaskWakePolicy,
 };
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
@@ -522,7 +522,7 @@ impl Tool for StartAgentHandoffTool {
                     .create(CreateSessionTask {
                         session_id: context.session_id,
                         id: None,
-                        kind: TASK_KIND_SUBAGENT.to_string(),
+                        kind: TASK_KIND_AGENT_HANDOFF.to_string(),
                         display_name: target.name.clone(),
                         spec: json!({
                             "target_id": &target.id,
@@ -698,7 +698,7 @@ impl Tool for GetAgentHandoffsTool {
             .list(
                 context.session_id,
                 Some(&SessionTaskFilter {
-                    kind: Some(TASK_KIND_SUBAGENT.to_string()),
+                    kind: Some(TASK_KIND_AGENT_HANDOFF.to_string()),
                     state: None,
                 }),
             )
@@ -711,10 +711,10 @@ impl Tool for GetAgentHandoffsTool {
         let handoffs = tasks
             .into_iter()
             .filter_map(|task| {
-                // Subagent-kind tasks cover both spawn_subagent and handoffs;
-                // only handoff tasks carry `target_id`/`external_agent_id` in
-                // their spec (set by start_agent_handoff), so use that to
-                // exclude plain subagents.
+                // Handoff tasks are their own kind (`agent_handoff`), so the
+                // registry filter above already excludes plain `subagent` tasks.
+                // Every handoff task carries `target_id`/`external_agent_id` in
+                // its spec (set by start_agent_handoff); read it for the output.
                 let target_id = task.spec.get("target_id").and_then(Value::as_str)?;
                 let child_session_id = task.links.child_session_id?;
                 let handoff_id_str = child_session_id.to_string();
@@ -857,7 +857,9 @@ mod tests {
     use crate::Result;
     use crate::capabilities::session_tasks::tests::InMemorySessionTaskRegistry;
     use crate::platform_store::tests::MockPlatformStore;
-    use crate::session_task::{CreateSessionTask, SessionTaskRegistry, TaskLinks};
+    use crate::session_task::{
+        CreateSessionTask, SessionTaskRegistry, TASK_KIND_SUBAGENT, TaskLinks,
+    };
     use crate::tools::{Tool, ToolExecutionResult};
     use crate::traits::UserConnectionResolver;
     use crate::typed_id::SessionId;
@@ -1165,11 +1167,10 @@ mod tests {
             .create(CreateSessionTask {
                 session_id: parent_id,
                 id: None,
-                kind: TASK_KIND_SUBAGENT.to_string(),
+                kind: TASK_KIND_AGENT_HANDOFF.to_string(),
                 display_name: "AWS Operator".to_string(),
-                // Handoff tasks carry target_id/external_agent_id in spec;
-                // get_agent_handoffs filters on target_id to exclude plain
-                // spawn_subagent tasks.
+                // Handoff tasks use the dedicated `agent_handoff` kind and carry
+                // target_id/external_agent_id in spec.
                 spec: json!({ "target_id": "aws", "external_agent_id": "agent_aws" }),
                 state: SessionTaskState::Succeeded,
                 links: TaskLinks {
@@ -1200,8 +1201,9 @@ mod tests {
 
     #[tokio::test]
     async fn get_handoffs_excludes_plain_subagent_tasks() {
-        // A subagent-kind task without target_id in spec is a plain
-        // spawn_subagent, not a handoff — it must not be listed.
+        // A `subagent`-kind task is a plain spawn_subagent, not a handoff
+        // (which now uses the dedicated `agent_handoff` kind) — it must not be
+        // listed by get_agent_handoffs.
         let parent_id = SessionId::new();
         let child_id = SessionId::new();
         let store = Arc::new(MockPlatformStore::new());

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -498,10 +498,11 @@ pub use session_sqldb::{
 };
 pub use session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
-    SessionTaskState, SessionTaskUpdate, TASK_KIND_BACKGROUND_TOOL, TASK_KIND_EXTERNAL_AGENT,
-    TASK_KIND_MONITOR, TASK_KIND_SUBAGENT, TaskArtifact, TaskError, TaskExecutor,
-    TaskExecutorPlugin, TaskInputRequest, TaskLinks, TaskMessage, TaskMessageDirection,
-    TaskMessagePart, TaskProgress, TaskSink, TaskWakePolicy, apply_task_update, find_task_executor,
+    SessionTaskState, SessionTaskUpdate, TASK_KIND_AGENT_HANDOFF, TASK_KIND_BACKGROUND_TOOL,
+    TASK_KIND_EXTERNAL_AGENT, TASK_KIND_MONITOR, TASK_KIND_SUBAGENT, TaskArtifact, TaskError,
+    TaskExecutor, TaskExecutorPlugin, TaskInputRequest, TaskLinks, TaskMessage,
+    TaskMessageDirection, TaskMessagePart, TaskProgress, TaskSink, TaskWakePolicy,
+    apply_task_update, find_task_executor,
 };
 pub use skill::{
     ParsedSkillMd, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus, SkillUsage,

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -29,6 +29,11 @@ pub type TaskProgress = crate::background::BackgroundProgress;
 /// Well-known task kinds. Kind stays a free-form string; these constants
 /// cover the built-in executors.
 pub const TASK_KIND_SUBAGENT: &str = "subagent";
+/// Cross-agent handoff to a different configured Agent in the same harness.
+/// Distinct from `subagent` so `list_tasks(kind="subagent")` returns only
+/// same-agent subagents and not handoffs (they share the spawn shape but are a
+/// different target). Matches the historical `session_resources.kind`.
+pub const TASK_KIND_AGENT_HANDOFF: &str = "agent_handoff";
 pub const TASK_KIND_EXTERNAL_AGENT: &str = "external_agent";
 pub const TASK_KIND_BACKGROUND_TOOL: &str = "background_tool";
 /// Long-lived monitor task linked to a session schedule. Stays `running`

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -3,8 +3,8 @@ use crate::domains::common::*;
 use crate::domains::sessions::{SESSION_MANAGE, SESSION_VIEW};
 use everruns_core::SessionTask;
 use everruns_core::session_task::{
-    NewTaskMessage, SessionTaskFilter, SessionTaskRegistry, SessionTaskState, TASK_KIND_SUBAGENT,
-    TaskMessage, TaskMessagePart, find_task_executor,
+    NewTaskMessage, SessionTaskFilter, SessionTaskRegistry, SessionTaskState,
+    TASK_KIND_AGENT_HANDOFF, TASK_KIND_SUBAGENT, TaskMessage, TaskMessagePart, find_task_executor,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -264,10 +264,10 @@ impl Command for PostSessionTaskMessage {
             .await?
             .ok_or_else(|| CommandError::not_found("Session task"))?;
 
-        if task.kind == TASK_KIND_SUBAGENT {
+        if task.kind == TASK_KIND_SUBAGENT || task.kind == TASK_KIND_AGENT_HANDOFF {
             return Err(CommandError::bad_request(
-                "Subagent tasks are steered by their parent agent via the message_task tool; \
-                 HTTP message delivery is not supported for this task kind.",
+                "Subagent and agent-handoff tasks are steered by their parent agent via the \
+                 message_task tool; HTTP message delivery is not supported for this task kind.",
             ));
         }
 
@@ -445,8 +445,8 @@ mod tests {
     use everruns_core::network_access::NetworkAccessList;
     use everruns_core::session_task::{
         CreateSessionTask, NewTaskMessage, SessionTaskRegistry, SessionTaskState,
-        TASK_KIND_BACKGROUND_TOOL, TASK_KIND_MONITOR, TASK_KIND_SUBAGENT, TaskLinks,
-        TaskMessagePart, TaskWakePolicy,
+        TASK_KIND_AGENT_HANDOFF, TASK_KIND_BACKGROUND_TOOL, TASK_KIND_MONITOR, TASK_KIND_SUBAGENT,
+        TaskLinks, TaskMessagePart, TaskWakePolicy,
     };
     use everruns_core::{Caller, DEFAULT_ORG_ID, HarnessId, PrincipalId};
     use std::sync::Arc;
@@ -822,6 +822,57 @@ mod tests {
         assert!(
             messages.is_empty(),
             "no message must be persisted for subagent tasks"
+        );
+    }
+
+    /// Handoff tasks are also parent-steered (via message_agent_handoff), so the
+    /// HTTP message endpoint must reject them exactly like subagent tasks.
+    #[tokio::test]
+    async fn post_message_to_agent_handoff_task_returns_bad_request() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let session_id = create_session(&db).await;
+        let ctx = test_ctx(db.clone());
+
+        let registry = q::registry_for_ctx(&ctx);
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TASK_KIND_AGENT_HANDOFF.to_string(),
+                display_name: "AWS Operator".to_string(),
+                spec: serde_json::json!({ "target_id": "aws", "external_agent_id": "agent_aws" }),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        let result = PostSessionTaskMessage {
+            session_id: session_id.to_string(),
+            task_id: task.id.clone(),
+            text: Some("steer me".to_string()),
+            content: None,
+            in_reply_to: None,
+        }
+        .execute(&ctx)
+        .await;
+
+        assert!(result.is_err(), "handoff task message must be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err.kind, CommandErrorKind::BadRequest(_)),
+            "must be a BadRequest error, got: {:?}",
+            err.kind
+        );
+
+        let messages = registry
+            .list_messages(session_id, &task.id, Some(10), None)
+            .await
+            .unwrap();
+        assert!(
+            messages.is_empty(),
+            "no message must be persisted for agent-handoff tasks"
         );
     }
 

--- a/specs/agent-handoff.md
+++ b/specs/agent-handoff.md
@@ -69,15 +69,21 @@ Behavior:
 3. If a connection is missing, return `connection_required(provider)`.
 4. Create a child session with the target `agent_id`.
 5. Persist parent/child metadata through the existing subagent session fields.
-6. Register a `session_resources.kind = "agent_handoff"` entry.
+6. Create a `session_tasks` row of kind `agent_handoff` (distinct from
+   `subagent`) with `links.child_session_id` set and `spec` carrying
+   `target_id`/`external_agent_id`/`mode`.
 7. Send the task to the child session.
 8. Block until the child session idles and return its last assistant message.
 
 ### `get_agent_handoffs`
 
-Lists handoff resources for the current session. When the session resource
-registry is available, this uses `session_resources`; otherwise it falls back to
-child-session metadata.
+Lists handoffs for the current session by reading the session task registry for
+tasks of kind `agent_handoff`. Because handoffs have their own kind,
+`list_tasks(kind="subagent")` and this listing are disjoint — plain
+`spawn_subagent` tasks are never reported as handoffs. Each task's
+`display_name`/`state` supply the handoff name/status,
+`links.child_session_id` the child session, and `spec.target_id`/
+`external_agent_id` the target.
 
 ### `message_agent_handoff`
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -50,7 +50,7 @@ IDs use the `task_` prefix per `specs/id-schema.md`.
 |---|---|
 | `id` | `task_*` public ID |
 | `session_id` | Owning session; `ON DELETE CASCADE` |
-| `kind` | `subagent`, `external_agent`, `background_tool`, `monitor`, … |
+| `kind` | `subagent`, `agent_handoff`, `external_agent`, `background_tool`, `monitor`, … |
 | `display_name` | Human label ("Test Runner") |
 | `spec` | Kind-specific input (instructions, tool args, external agent id) |
 | `state` | See state machine below |
@@ -337,9 +337,10 @@ session's effective network ACL (harness chain → agent → session overlay fol
 if the ACL cannot be computed the executor call is skipped with a `warn`.
 
 Specifically:
-- `POST …/messages`: rejected with 400 for `subagent`-kind tasks — subagent
-  steering is done exclusively by the parent agent via the `message_task` tool;
-  `links.child_session_id` exposes the child session for direct addressing. For
+- `POST …/messages`: rejected with 400 for `subagent`- and `agent_handoff`-kind
+  tasks — both are steered exclusively by the parent agent (via the
+  `message_task` / `message_agent_handoff` tools); `links.child_session_id`
+  exposes the child session for direct addressing. For
   all other kinds the message is recorded durably, the task is re-fetched (it
   may have transitioned to `running` if the message answered an input request),
   and `executor.deliver` is called. For kinds without a registered executor the


### PR DESCRIPTION
## What
Introduce a dedicated `TASK_KIND_AGENT_HANDOFF` (`"agent_handoff"`) session-task kind and use it for cross-agent handoffs, instead of sharing `TASK_KIND_SUBAGENT` with same-agent subagents.

First slice of **EVE-677** (unify agent delegation behind a single `spawn_agent` tool). It delivers acceptance criterion #3 ("Handoff tasks have their own kind — `list_tasks(kind="subagent")` no longer returns handoffs; new kind constant exported from `everruns-core`") independently, ahead of the tool unification.

## Why
`start_agent_handoff` created its session task with `TASK_KIND_SUBAGENT`, and `get_agent_handoffs` then re-filtered on the presence of `spec.target_id` to exclude plain `spawn_subagent` tasks. Consequences:
- `list_tasks(kind="subagent")` mixed same-agent subagents with cross-agent handoffs.
- Handoff identification relied on a spec-field heuristic rather than the task's kind.

Handoffs are a distinct target, so they should be a distinct kind — matching the historical `session_resources.kind = "agent_handoff"`.

## How
- Add `TASK_KIND_AGENT_HANDOFF` in `session_task.rs`; re-export from `everruns-core`.
- `agent_handoff.rs`: create handoff tasks with the new kind; filter `get_agent_handoffs` by kind (the `spec.target_id` read stays only to populate output, no longer for exclusion).
- `crates/server/.../session_tasks/commands.rs`: extend the `POST …/messages` gate so `agent_handoff` tasks are rejected exactly like `subagent` tasks (both are parent-steered — via `message_task` / `message_agent_handoff` — not the HTTP endpoint). Preserves existing behavior for handoffs, which were previously covered by the shared kind.
- Specs: `session-tasks.md` (kind list + messages-rejection rule) and `agent-handoff.md` (task kind + `get_agent_handoffs` semantics).

No migrations. No product behavior change beyond the kind value: handoffs still can't be messaged over HTTP; plain subagents are still excluded from the handoff listing (now by kind).

## Risk
- **Low.** Internal tool wiring; no backward-compat guarantees for internal task kinds (mirrors prior retirements). No schema/migration changes. In-memory task filtering only.

## Security
- Threat categories reviewed: TM-AUTHZ / TM-API (the `POST …/messages` gate). The change *widens* the rejection to also cover `agent_handoff`, preserving the "parent-steered only" boundary — it does not open any new inbound path. Credential-handling in handoffs is untouched.
- Findings and resolutions: none.

## Follow-ups
- Remaining EVE-677 work (the unified `spawn_agent` tool with a `target` discriminator, background handoff mode, retiring `spawn_subagent`/`start_agent_handoff`) lands in subsequent PRs of the epic. This PR is intentionally scoped to the task-kind separation so it is independently reviewable and shippable.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czg367PJjx79WBtSdhuB5D)_