### PR TITLE
test(llm-tests): retry live tool-call case to absorb model non-determinism

### DIFF
--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -76,33 +76,59 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 #[case::fireworks_kimi_k2(FIREWORKS_KIMI_K2)]
 #[tokio::test]
 async fn test_tool_call(#[case] config: ProviderModelConfig) {
-    let Some(model) = config.model() else {
+    if config.model().is_none() {
         eprintln!("Skipping: {} not set", config.label());
         return;
-    };
+    }
 
-    let runner = InMemoryAgenticLoop::builder()
-        .agent_name("Time Agent")
-        .system_prompt("When asked about time, use get_current_time tool first.")
-        .model(model)
-        .driver_registry(all_providers_registry())
-        .capability(CurrentTimeCapability)
-        .max_iterations(5)
-        .build()
-        .await
-        .unwrap();
+    // Live models are occasionally non-deterministic about emitting a tool call
+    // for this borderline prompt: the "Should have called get_current_time"
+    // assertion has flaked across successive pinned models (gpt-oss-120b, then
+    // Anthropic Haiku on main). This case verifies the driver's tool-calling
+    // *path* end-to-end against each provider — not single-shot model
+    // determinism — so retry a few times and require the model to call the tool
+    // (and iterate reason -> act -> reason) on at least one attempt. Genuine
+    // turn failures still fail fast; only a successful turn that skipped the
+    // tool triggers a retry.
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut last = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let model = config.model().expect("model set (checked above)");
+        let runner = InMemoryAgenticLoop::builder()
+            .agent_name("Time Agent")
+            .system_prompt("When asked about time, use get_current_time tool first.")
+            .model(model)
+            .driver_registry(all_providers_registry())
+            .capability(CurrentTimeCapability)
+            .max_iterations(5)
+            .build()
+            .await
+            .unwrap();
 
-    let result = runner.run_turn("What time is it?").await.unwrap();
+        let result = runner.run_turn("What time is it?").await.unwrap();
 
-    skip_if_quota!(result, config.label());
-    assert!(result.success, "Turn should succeed: {:?}", result.error);
-    assert!(
-        result.tool_calls_count > 0,
-        "Should have called get_current_time"
-    );
-    assert!(
-        result.iterations > 1,
-        "Should have multiple iterations (reason -> act -> reason)"
+        skip_if_quota!(result, config.label());
+        assert!(result.success, "Turn should succeed: {:?}", result.error);
+
+        if result.tool_calls_count > 0 && result.iterations > 1 {
+            return;
+        }
+
+        eprintln!(
+            "{}: attempt {attempt}/{MAX_ATTEMPTS} did not exercise the tool path \
+             (tool_calls_count={}, iterations={}); retrying",
+            config.label(),
+            result.tool_calls_count,
+            result.iterations
+        );
+        last = Some(result);
+    }
+
+    let result = last.expect("at least one attempt ran");
+    panic!(
+        "Should have called get_current_time and iterated (reason -> act -> reason) \
+         within {MAX_ATTEMPTS} attempts; last: tool_calls_count={}, iterations={}",
+        result.tool_calls_count, result.iterations
     );
 }
 


### PR DESCRIPTION
## What
Make the live-matrix `test_tool_call` case retry up to 3 times, requiring the model to call `get_current_time` (and iterate reason → act → reason) on at least one attempt, instead of asserting it on a single live turn.

## Why
The push-only Fireworks/Anthropic/OpenAI/… live matrix asserts a single live turn emits a tool call. Live models are occasionally non-deterministic about calling a tool for the borderline `"What time is it?"` prompt, and the `Should have called get_current_time` assertion has flaked on main across successive pinned models:
- `gpt-oss-120b` (documented in #2597),
- **Anthropic Haiku** — flaked `test_tool_call::case_1_anthropic_haiku` on the `main` push run for merge `a16d43a5` (`Should have called get_current_time`), turning main CI red even though the change under test was unrelated.

This case exists to verify our driver's tool-calling *path* end-to-end against each provider, not to probe single-shot model determinism. A bounded retry keeps that coverage while removing the recurring flake, which currently forces model repins and red main CI whenever a served model gets slightly less eager to call the tool.

## How
- Loop up to `MAX_ATTEMPTS = 3`: rebuild the runner (re-resolving the model from env), run the turn, and return on the first attempt where `tool_calls_count > 0 && iterations > 1`.
- **Genuine turn failures still fail fast** — the `assert!(result.success, …)` runs each attempt, so a real error (e.g. a de-listed model like the earlier `Model not available`) surfaces immediately rather than being retried away. Only a *successful* turn that skipped the tool triggers a retry.
- `skip_if_quota!` still short-circuits on quota exhaustion. On exhausting all attempts, panic with the last attempt's counts.

Test-only; no product code touched. `test_basic_completion` and the other cases are unchanged.

## Risk
- **Low.** Test-only change to a push-only live test. Worst case it masks a *consistent* (3/3) failure to call the tool — but that would be a real regression the assertion still catches; it only tolerates transient single-shot misses.

## Security
- Threat categories reviewed: No security-relevant code changes — test-only retry logic under `crates/llm-tests/`.
- Findings and resolutions: none.

## Follow-ups
- If `test_basic_completion` or other live cases start flaking on transient non-determinism, apply the same bounded-retry pattern. Not done here to keep the change minimal and because tool-call emission is the only assertion with observed flakes. Otherwise, no follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czg367PJjx79WBtSdhuB5D)_