### PR TITLE
feat(subagents): expose spawn_agent subagent target

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -324,7 +324,7 @@ pub use skills_scoped::{
 pub use stateless_todo_list::{
     STATELESS_TODO_LIST_CAPABILITY_ID, StatelessTodoListCapability, WriteTodosTool,
 };
-pub use subagents::{SUBAGENTS_CAPABILITY_ID, SubagentCapability};
+pub use subagents::{SUBAGENTS_CAPABILITY_ID, SpawnSubagentAsAgentTool, SubagentCapability};
 // Blueprint types are exported directly from the trait definitions above
 pub use bashkit_shell::{
     BASHKIT_SHELL_CAPABILITY_ID, BashTool, BashkitShellCapability, SessionFileSystemAdapter,
@@ -2523,6 +2523,22 @@ pub async fn collect_capabilities_with_configs(
         }
     }
 
+    // EVE-677 migration slice: subagent-only sessions should expose the new
+    // unified delegation surface without colliding with existing `spawn_agent`
+    // providers (currently external A2A). Once all providers share one
+    // dispatcher, this conditional adapter can retire with `spawn_subagent`.
+    if applied_ids.iter().any(|id| id == SUBAGENTS_CAPABILITY_ID)
+        && !tools.iter().any(|tool| tool.name() == "spawn_agent")
+    {
+        let tool = SpawnSubagentAsAgentTool;
+        let def = tool
+            .to_definition()
+            .with_category("Core")
+            .with_capability_attribution(SUBAGENTS_CAPABILITY_ID, Some("Subagents"));
+        tools.push(Box::new(tool));
+        tool_definitions.push(def);
+    }
+
     // Auto-activate `background_execution` whenever any collected tool
     // declares background support via `ToolHints::supports_background`.
     //
@@ -4695,6 +4711,118 @@ mod tests {
             "background_execution must not appear in applied_ids when no \
              background-capable tool is present; got: {:?}",
             collected.applied_ids
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subagents_collect_unified_spawn_agent_adapter() {
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(
+            &[SUBAGENTS_CAPABILITY_ID.to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+
+        assert!(
+            collected
+                .tools
+                .iter()
+                .any(|tool| tool.name() == "spawn_agent"),
+            "subagent-only sessions should get the unified spawn_agent adapter"
+        );
+        let spawn_agent = collected
+            .tool_definitions
+            .iter()
+            .find(|tool| tool.name() == "spawn_agent")
+            .expect("spawn_agent definition");
+        assert_eq!(
+            spawn_agent.parameters()["properties"]["target"]["properties"]["type"]["enum"],
+            serde_json::json!(["subagent"])
+        );
+    }
+
+    struct ExistingSpawnAgentCapability;
+
+    impl Capability for ExistingSpawnAgentCapability {
+        fn id(&self) -> &str {
+            "existing_spawn_agent"
+        }
+
+        fn name(&self) -> &str {
+            "Existing Spawn Agent"
+        }
+
+        fn description(&self) -> &str {
+            "Test capability that already owns spawn_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn Tool>> {
+            vec![Box::new(ExistingSpawnAgentTool)]
+        }
+    }
+
+    struct ExistingSpawnAgentTool;
+
+    #[async_trait]
+    impl Tool for ExistingSpawnAgentTool {
+        fn name(&self) -> &str {
+            "spawn_agent"
+        }
+
+        fn description(&self) -> &str {
+            "Existing spawn_agent test tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "object",
+                        "properties": {
+                            "type": {"type": "string", "enum": ["external_a2a"]}
+                        },
+                        "required": ["type"]
+                    }
+                },
+                "required": ["target"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            _arguments: serde_json::Value,
+        ) -> crate::tools::ToolExecutionResult {
+            crate::tools::ToolExecutionResult::success(serde_json::json!({"ok": true}))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_subagents_do_not_shadow_existing_spawn_agent_provider() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(SubagentCapability);
+        registry.register(ExistingSpawnAgentCapability);
+
+        let collected = collect_capabilities(
+            &[
+                SUBAGENTS_CAPABILITY_ID.to_string(),
+                "existing_spawn_agent".to_string(),
+            ],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+
+        let spawn_agent_defs: Vec<_> = collected
+            .tool_definitions
+            .iter()
+            .filter(|tool| tool.name() == "spawn_agent")
+            .collect();
+        assert_eq!(spawn_agent_defs.len(), 1);
+        assert_eq!(
+            spawn_agent_defs[0].parameters()["properties"]["target"]["properties"]["type"]["enum"],
+            serde_json::json!(["external_a2a"])
         );
     }
 

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -319,6 +319,114 @@ impl Tool for SpawnSubagentTool {
     }
 }
 
+/// Unified delegation wrapper for the subagent target of `spawn_agent`.
+///
+/// This is injected by capability collection for subagent-only sessions so the
+/// new unified tool surface can ship before all delegation providers are merged
+/// into one dispatcher. `spawn_subagent` remains available during the migration.
+pub struct SpawnSubagentAsAgentTool;
+
+#[async_trait]
+impl Tool for SpawnSubagentAsAgentTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_spawn_subagent(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
+    fn name(&self) -> &str {
+        "spawn_agent"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Spawn Agent")
+    }
+
+    fn description(&self) -> &str {
+        "Delegate a task to a subagent in its own context window. Set target.type to \"subagent\". Runs in the background by default and returns a task_id immediately; set mode to \"foreground\" to block until it completes."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable name for the subagent (e.g. 'Test Runner', 'Auth Explorer'). Must be unique within this session."
+                },
+                "instructions": {
+                    "type": "string",
+                    "description": "Instructions for the subagent — what it should do."
+                },
+                "target": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["subagent"],
+                            "description": "Delegation target type. Use \"subagent\" for a same-agent child session."
+                        }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["background", "foreground"],
+                    "description": "Execution mode. \"background\" (default) returns immediately with a task_id — monitor with get_task/wait_task; the session is notified when the subagent finishes. \"foreground\" blocks until the subagent completes and returns its result inline."
+                },
+                "blueprint": {
+                    "type": "string",
+                    "description": "Blueprint ID to spawn a specialist agent with its own tools and model. Omit to inherit parent's configuration."
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Blueprint-specific configuration. Only valid when `blueprint` is set. Validated against the blueprint's config schema."
+                }
+            },
+            "required": ["name", "instructions", "target"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "spawn_agent requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let target = arguments.get("target").unwrap_or(&Value::Null);
+        if target.get("type").and_then(Value::as_str) != Some("subagent") {
+            return ToolExecutionResult::tool_error(
+                "spawn_agent target.type must be \"subagent\" for the subagents capability",
+            );
+        }
+        spawn_subagent_impl(arguments, context)
+            .await
+            .unwrap_or_else(|e| e)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
 /// Resolve the effective spawn mode from the `mode` argument.
 ///
 /// Background needs a session task registry (it is the only surface through
@@ -1274,6 +1382,20 @@ mod tests {
         assert!(!required.contains(&json!("mode")));
     }
 
+    #[test]
+    fn spawn_agent_subagent_schema_advertises_only_subagent_target() {
+        let tool = SpawnSubagentAsAgentTool;
+        let schema = tool.parameters_schema();
+        assert_eq!(
+            schema["properties"]["target"]["properties"]["type"]["enum"],
+            json!(["subagent"])
+        );
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("target")));
+        assert!(required.contains(&json!("name")));
+        assert!(required.contains(&json!("instructions")));
+    }
+
     #[tokio::test]
     async fn spawn_subagent_without_context_returns_error() {
         let tool = SpawnSubagentTool;
@@ -1415,6 +1537,57 @@ mod tests {
             panic!("expected ToolError, got {result:?}");
         };
         assert!(msg.contains("Invalid mode"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_subagent_rejects_other_target_types() {
+        let context = ToolContext::new(crate::typed_id::SessionId::new());
+        let result = SpawnSubagentAsAgentTool
+            .execute_with_context(
+                json!({
+                    "name": "Runner",
+                    "instructions": "go",
+                    "target": {"type": "external_a2a"}
+                }),
+                &context,
+            )
+            .await;
+        let ToolExecutionResult::ToolError(msg) = result else {
+            panic!("expected ToolError, got {result:?}");
+        };
+        assert!(msg.contains("subagent"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_subagent_creates_subagent_task() {
+        let store = Arc::new(MockPlatformStore::new());
+        *store.wait_for_idle_status.lock().unwrap() = "completed".to_string();
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let context = spawn_context(&store, Some(registry.clone()));
+
+        let result = SpawnSubagentAsAgentTool
+            .execute_with_context(
+                json!({
+                    "name": "Runner",
+                    "instructions": "go",
+                    "target": {"type": "subagent"},
+                    "mode": "foreground"
+                }),
+                &context,
+            )
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        let task_id = value["task_id"].as_str().expect("task_id");
+        let task = registry
+            .get(context.session_id, task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.kind, TASK_KIND_SUBAGENT);
+        assert_eq!(task.spec["mode"], "foreground");
+        assert!(task.links.child_session_id.is_some());
     }
 
     #[tokio::test]

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -14,6 +14,14 @@ Spawn subagents for parallel task execution. Each subagent runs in its own isola
 
 ## Tools
 
+### `spawn_agent`
+
+Subagent-only sessions also expose the unified delegation tool with
+`target.type: "subagent"`. It follows the same lifecycle as `spawn_subagent`:
+background by default, `foreground` when requested, and a returned `task_id` for
+the generic session task tools. This is the migration path toward one delegation
+surface across subagents, first-party agent handoffs, and external A2A agents.
+
 ### `spawn_subagent`
 
 Create and start a new subagent. By default the subagent runs in the background: the tool returns immediately with a `task_id`, the parent agent keeps working, and the session is notified when the subagent finishes. Use the `task_id` with the generic session task tools to monitor, message, or cancel the subagent.

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -269,11 +269,14 @@ cancel_task             — sets cancel intent
 wait_task               — generic foreground wait; subsumes wait_agent
 ```
 
-Spawning stays per-capability (`spawn_subagent`, `spawn_agent`,
-`spawn_background`) because input schemas genuinely differ — but every spawn
-creates a task and returns its `task_id`. Blocking (foreground) spawns also
-create task records: same object, and the UI shows it live while the parent
-turn waits; background is a mode, not a different entity.
+Spawning is converging on the unified `spawn_agent` surface while some legacy
+per-capability entry points remain during migration. Subagent-only sessions now
+advertise `spawn_agent(target.type = "subagent")`; external A2A continues to use
+`spawn_agent(target.type = "external_a2a")`; `spawn_subagent` remains available
+until the migration completes. Every spawn creates a task and returns its
+`task_id`. Blocking (foreground) spawns also create task records: same object,
+and the UI shows it live while the parent turn waits; background is a mode, not
+a different entity.
 
 Naming cleanup: `task` parameters that carry instruction text
 (`subagent_task`, `spawn_subagent(task:)`) have been renamed to `instructions` so

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -81,6 +81,19 @@ See `crates/server/migrations/009_subagents.sql` for schema changes.
 
 ## Tools
 
+### spawn_agent (`target.type = "subagent"`)
+
+During the unified delegation migration, sessions with `subagents` enabled and
+no other `spawn_agent` provider advertise `spawn_agent` with a single supported
+target type: `subagent`. The wrapper uses the same behavior as
+`spawn_subagent`: it creates a child session with `parent_session_id` set,
+creates a `TASK_KIND_SUBAGENT` task, defaults to background mode, and supports
+`mode: "foreground"` for blocking execution.
+
+This adapter is conditional so it does not shadow other current `spawn_agent`
+providers such as external A2A. Once all delegation targets share one dispatcher,
+`spawn_subagent` can retire.
+
 ### spawn_subagent
 
 Creates a child session and sends the instructions as the first user message. Runs in the background by default and returns immediately; `mode: "foreground"` blocks until the child idles. Returns a `task_id` that can be used with the generic session task tools.
@@ -117,7 +130,8 @@ Creates a child session and sends the instructions as the first user message. Ru
 
 ### Monitoring and steering subagents
 
-Use the generic `session_tasks` tools after spawning. The `task_id` is returned by `spawn_subagent`.
+Use the generic `session_tasks` tools after spawning. The `task_id` is returned
+by `spawn_agent(target.type = "subagent")` and by `spawn_subagent`.
 
 | Tool | Description |
 |------|-------------|


### PR DESCRIPTION
## What
Expose a transitional unified `spawn_agent` adapter for subagent-only sessions.

## Why
EVE-677 is moving delegation toward a single `spawn_agent` surface. Subagents can take the first safe slice without colliding with the existing external A2A `spawn_agent` provider.

## How
- Adds `SpawnSubagentAsAgentTool`, a `spawn_agent` wrapper that accepts `target.type = "subagent"` and delegates to the existing subagent implementation.
- Injects the adapter during capability collection only when `subagents` is active and no other collected tool already owns `spawn_agent`.
- Covers schema, execution, and collision behavior with focused tests.
- Updates subagent/session-task specs and public docs for the migration state.

## Risk
- Low / Medium
- Main risk is model-visible tool-schema confusion. The adapter is only added when no existing `spawn_agent` provider is present, and it reuses the existing `spawn_subagent` execution path, nesting guard, task kind, and task registry behavior.

## Security
- Threat categories reviewed: TM-TOOL, TM-AGENT, TM-DOS.
- Findings and resolutions: no new execution authority is introduced. The new tool is a schema/dispatch adapter over the existing subagent path, so current mitigations for registered-tool dispatch, session scoping, nesting prevention, org inheritance, and task-resource bounds remain in force. No threat-model update needed.

## Validation
- `cargo fmt --check`
- `cargo test -p everruns-core subagent -- --nocapture`
- `cargo test -p everruns-core test_subagents_collect_unified_spawn_agent_adapter -- --nocapture`
- `cargo test -p everruns-core test_subagents_do_not_shadow_existing_spawn_agent_provider -- --nocapture`
- `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings`
- `npx --yes pnpm@10.33.0 run check` in `apps/docs`
- `npx --yes pnpm@10.33.0 run build` in `apps/docs`
- `cargo test -p everruns-core spawn_agent_subagent_creates_subagent_task -- --nocapture` as the focused smoke for the changed flow
- `PORT_PREFIX=271 just start-dev --no-watch` attempted for full-stack smoke, but local environment is missing `caddy` (`just init` prerequisite)
- `just pre-push`

## Follow-ups
- Continue EVE-677 by merging first-party agent handoff and external A2A into a shared `spawn_agent` dispatcher, then retire `spawn_subagent` and `start_agent_handoff`. Safe to defer because this PR deliberately avoids provider collisions and preserves legacy tools during migration.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-677