### PR TITLE
chore: standardize PR descriptions on functional change + before/after

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,15 @@
-## What
-Clear description of the change.
+## What changed
+Describe the change functionally — what behavior changes and its impact on users
+or callers. Lead with outcomes; don't walk through code locations, the diff shows
+where and how. Keep any code-level notes short and specific.
 
 ## Why
 Problem or motivation.
 
-## How
-High-level approach.
+## Before / After
+Show the effect with evidence. Include before and after whenever behavior changes —
+CLI/API output, logs, metrics, or screenshots for UI (attach working screenshots
+when possible). For changes with no observable behavior (pure refactor, docs), say so.
 
 ## Risk
 - Low / Medium / High

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,10 @@ Commit attribution must be the real human user.
 ### PRs and CI
 
 - Use `.github/pull_request_template.md`.
+- PR descriptions center on functional change and impact, not a code-location
+  walkthrough (the diff shows that). Keep code-level notes short and specific, and
+  add a Before / After with proof — output, logs, metrics, or screenshots for UI —
+  whenever behavior changes.
 - PR titles must be Conventional Commits and under 70 characters.
 - Squash and Merge.
 - GitHub Actions is the CI source of truth; check with `gh`.


### PR DESCRIPTION
## What changed

PR descriptions now center on **functional change and impact** instead of a code-location walkthrough, and the PR template gains a **Before / After** section that asks for proof — output, logs, metrics, or screenshots for UI. The same standard is applied to both `.github/pull_request_template.md` and the `AGENTS.md` PR guidance, so humans and coding agents write PRs the same way. The template's Security and Follow-ups sections are unchanged.

## Why

The diff already shows *where* and *how* code changed. A description should add what the diff can't: the behavior that changed, who it affects, and evidence it works — shifting effort from restating code to demonstrating impact.

## Before / After

Docs/templates only — no runtime behavior changes.

- **Before:** `## What` ("Clear description of the change") + `## How` ("High-level approach").
- **After:** `## What changed` (functional summary + impact, short code notes) + `## Before / After` (proof: output/logs/metrics, screenshots for UI when possible).

## Risk

- Low
- Documentation and PR-template only; no source, config, or CI logic touched.

## Security

- Threat categories reviewed: No security-relevant code changes (Markdown docs/templates only).
- Findings and resolutions: None.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — N/A (docs/templates only)
- [x] Backward compatibility considered — no code paths affected
- [x] Security review performed against relevant threat model categories — no security-relevant changes
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_