### PR TITLE
feat(agent-handoff): expose spawn_agent target

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -23,6 +23,10 @@ use serde_json::{Value, json};
 
 pub const AGENT_HANDOFF_CAPABILITY_ID: &str = "agent_handoff";
 const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
+const BACKGROUND_WAIT_SLICE_SECS: u64 = 300;
+const BACKGROUND_MAX_WAIT_SECS: u64 = 6 * 60 * 60;
+const BACKGROUND_HEARTBEAT_INTERVAL_SECS: u64 = 15;
+const BACKGROUND_POLL_BACKOFF_SECS: u64 = 5;
 
 fn terminal_handoff_status(wait_status: &str) -> Option<SubagentStatus> {
     match wait_status {
@@ -351,6 +355,45 @@ impl AgentHandoffMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum SpawnAgentHandoffMode {
+    Background,
+    Foreground,
+}
+
+impl SpawnAgentHandoffMode {
+    fn parse(value: Option<&str>, context: &ToolContext) -> std::result::Result<Self, String> {
+        let explicit = match value.map(str::trim).filter(|s| !s.is_empty()) {
+            None => None,
+            Some("background") => Some(Self::Background),
+            Some("foreground") => Some(Self::Foreground),
+            Some(other) => {
+                return Err(format!(
+                    "Invalid mode: \"{other}\". Valid modes: background, foreground."
+                ));
+            }
+        };
+        let has_registry = context.session_task_registry.is_some();
+        match explicit {
+            Some(Self::Background) if !has_registry => Err(
+                "Background mode requires a session task registry, which is not available in this environment. Use mode: \"foreground\" instead."
+                    .to_string(),
+            ),
+            Some(mode) => Ok(mode),
+            None if has_registry => Ok(Self::Background),
+            None => Ok(Self::Foreground),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Background => "background",
+            Self::Foreground => "foreground",
+        }
+    }
+}
+
 fn child_task(task: &str, public_context: Option<&Value>) -> String {
     let Some(public_context) = public_context else {
         return task.to_string();
@@ -366,6 +409,208 @@ fn last_agent_message(messages: &[crate::platform_store::PlatformMessage]) -> Op
         .iter()
         .rfind(|message| message.role == "agent" || message.role == "assistant")
         .map(|message| message.content.clone())
+}
+
+async fn finish_handoff_task(
+    context: &ToolContext,
+    task_id: Option<&str>,
+    state: SessionTaskState,
+    summary: Option<String>,
+    error: Option<TaskError>,
+    expected_attempt: Option<i32>,
+) {
+    let (Some(registry), Some(task_id)) = (context.session_task_registry.as_ref(), task_id) else {
+        return;
+    };
+    let _ = registry
+        .update(
+            context.session_id,
+            task_id,
+            SessionTaskUpdate {
+                state: Some(state),
+                summary,
+                error,
+                expected_attempt,
+                ..Default::default()
+            },
+        )
+        .await;
+}
+
+fn handoff_task_state(status: &SubagentStatus) -> SessionTaskState {
+    match status {
+        SubagentStatus::Completed => SessionTaskState::Succeeded,
+        SubagentStatus::Cancelled => SessionTaskState::Canceled,
+        SubagentStatus::Failed | SubagentStatus::MaxIterationsReached | SubagentStatus::Sealed => {
+            SessionTaskState::Failed
+        }
+        SubagentStatus::Running | SubagentStatus::Spawning => SessionTaskState::Running,
+    }
+}
+
+fn handoff_error(status: &str, state: SessionTaskState) -> Option<TaskError> {
+    (state == SessionTaskState::Failed).then(|| TaskError {
+        kind: "handoff_failed".to_string(),
+        message: format!("Handoff ended with status: {status}"),
+    })
+}
+
+async fn handoff_result(
+    store: &dyn crate::platform_store::PlatformStore,
+    child_session_id: crate::typed_id::SessionId,
+    status: &str,
+) -> Result<String, ToolExecutionResult> {
+    let messages = store
+        .get_messages(child_session_id, Some(5))
+        .await
+        .map_err(ToolExecutionResult::internal_error)?;
+    Ok(last_agent_message(&messages)
+        .unwrap_or_else(|| format!("Handoff completed with status: {status}")))
+}
+
+fn spawn_handoff_background_watcher(
+    context: &ToolContext,
+    child_session_id: crate::typed_id::SessionId,
+    first_message: String,
+    task_id: String,
+    task_attempt: i32,
+) {
+    let context = context.clone();
+    tokio::spawn(async move {
+        let Some(store) = context.platform_store.clone() else {
+            return;
+        };
+
+        if let Err(error) = store.send_message(child_session_id, &first_message).await {
+            finish_handoff_task(
+                &context,
+                Some(&task_id),
+                SessionTaskState::Failed,
+                None,
+                Some(TaskError {
+                    kind: "handoff_failed".to_string(),
+                    message: error.to_string(),
+                }),
+                Some(task_attempt),
+            )
+            .await;
+            return;
+        }
+
+        let heartbeat = async {
+            let Some(registry) = context.session_task_registry.clone() else {
+                return std::future::pending::<()>().await;
+            };
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    BACKGROUND_HEARTBEAT_INTERVAL_SECS,
+                ))
+                .await;
+                let _ = registry
+                    .update(
+                        context.session_id,
+                        &task_id,
+                        SessionTaskUpdate {
+                            heartbeat_at: Some(chrono::Utc::now()),
+                            expected_attempt: Some(task_attempt),
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+            }
+        };
+
+        let wait_and_settle = async {
+            let started = tokio::time::Instant::now();
+            loop {
+                let status = match store
+                    .wait_for_idle(child_session_id, Some(BACKGROUND_WAIT_SLICE_SECS))
+                    .await
+                {
+                    Ok(status) => status,
+                    Err(error) => {
+                        finish_handoff_task(
+                            &context,
+                            Some(&task_id),
+                            SessionTaskState::Failed,
+                            None,
+                            Some(TaskError {
+                                kind: "handoff_failed".to_string(),
+                                message: error.to_string(),
+                            }),
+                            Some(task_attempt),
+                        )
+                        .await;
+                        return;
+                    }
+                };
+
+                if let Some(terminal) = terminal_handoff_status(&status) {
+                    let state = handoff_task_state(&terminal);
+                    let result = handoff_result(store.as_ref(), child_session_id, &status)
+                        .await
+                        .ok();
+                    let error = handoff_error(&status, state);
+                    finish_handoff_task(
+                        &context,
+                        Some(&task_id),
+                        state,
+                        result,
+                        error,
+                        Some(task_attempt),
+                    )
+                    .await;
+                    return;
+                }
+
+                if started.elapsed().as_secs() >= BACKGROUND_MAX_WAIT_SECS {
+                    finish_handoff_task(
+                        &context,
+                        Some(&task_id),
+                        SessionTaskState::Failed,
+                        None,
+                        Some(TaskError {
+                            kind: "timeout".to_string(),
+                            message: format!(
+                                "Background agent handoff did not finish within {BACKGROUND_MAX_WAIT_SECS}s (last status: {status})"
+                            ),
+                        }),
+                        Some(task_attempt),
+                    )
+                    .await;
+                    return;
+                }
+
+                if let Some(registry) = context.session_task_registry.as_ref() {
+                    let _ = registry
+                        .update(
+                            context.session_id,
+                            &task_id,
+                            SessionTaskUpdate {
+                                state_detail: Some(format!(
+                                    "waiting for agent handoff ({}s elapsed, last status: {status})",
+                                    started.elapsed().as_secs()
+                                )),
+                                expected_attempt: Some(task_attempt),
+                                ..Default::default()
+                            },
+                        )
+                        .await;
+                }
+                if !status.starts_with("timeout") {
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        BACKGROUND_POLL_BACKOFF_SECS,
+                    ))
+                    .await;
+                }
+            }
+        };
+
+        tokio::select! {
+            () = wait_and_settle => {}
+            () = heartbeat => {}
+        }
+    });
 }
 
 async fn require_connections(
@@ -645,6 +890,316 @@ impl Tool for StartAgentHandoffTool {
     }
 }
 
+pub struct SpawnAgentHandoffTool {
+    config: AgentHandoffConfig,
+}
+
+impl SpawnAgentHandoffTool {
+    pub fn new(config: &Value) -> Self {
+        Self {
+            config: AgentHandoffConfig::from_value(config).unwrap_or_default(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for SpawnAgentHandoffTool {
+    fn name(&self) -> &str {
+        "spawn_agent"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Spawn Agent")
+    }
+
+    fn description(&self) -> &str {
+        "Delegate work to a configured first-party target agent. Set target.type to \"agent\" and target.id to a configured handoff target id. Runs in the background by default when task tracking is available; set mode to \"foreground\" to block for the result."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable name for this delegated run."
+                },
+                "instructions": {
+                    "type": "string",
+                    "description": "Instructions for the target agent. Do not include credentials or bearer tokens."
+                },
+                "target": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["agent"],
+                            "description": "Delegation target type. Use \"agent\" for a configured first-party Agent handoff."
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": "Configured handoff target id."
+                        }
+                    },
+                    "required": ["type", "id"],
+                    "additionalProperties": false
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["background", "foreground"],
+                    "description": "Execution mode. \"background\" (default when task tracking is available) returns immediately with a task_id; \"foreground\" blocks until the handoff completes."
+                },
+                "public_context": {
+                    "type": "object",
+                    "description": "Non-secret structured context to include with the instructions."
+                }
+            },
+            "required": ["name", "instructions", "target"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "spawn_agent requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(store) => store,
+            Err(error) => return error,
+        };
+
+        let target = arguments.get("target").unwrap_or(&Value::Null);
+        if target.get("type").and_then(Value::as_str) != Some("agent") {
+            return ToolExecutionResult::tool_error(
+                "spawn_agent target.type must be \"agent\" for the agent_handoff capability",
+            );
+        }
+        let target_id = match target
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(id) => id,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: target.id");
+            }
+        };
+        let name = match require_str(&arguments, "name") {
+            Ok(value) => value.trim().to_string(),
+            Err(error) => return error,
+        };
+        let instructions = match require_str(&arguments, "instructions") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let mode = match SpawnAgentHandoffMode::parse(
+            arguments.get("mode").and_then(Value::as_str),
+            context,
+        ) {
+            Ok(mode) => mode,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+
+        let Some(target) = self.config.target(target_id) else {
+            return ToolExecutionResult::tool_error(format!(
+                "Unknown handoff target: \"{target_id}\". Check configured targets."
+            ));
+        };
+
+        if let Err(error) = require_connections(context, target).await {
+            return error;
+        }
+
+        let parent_session = match store.get_session_by_id(context.session_id).await {
+            Ok(Some(session)) => session,
+            Ok(None) => return ToolExecutionResult::tool_error("Current session not found"),
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+
+        if parent_session.parent_session_id.is_some() {
+            return ToolExecutionResult::tool_error(
+                "Agent handoffs cannot be started from child sessions.",
+            );
+        }
+
+        let child_session = match store
+            .create_session(
+                target.harness_id,
+                Some(target.agent_id),
+                Some(&name),
+                parent_session.locale.as_deref(),
+                None,
+                None,
+                Some(context.session_id),
+            )
+            .await
+        {
+            Ok(session) => session,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+
+        let handoff_task = child_task(instructions, arguments.get("public_context"));
+        let mut task_id = None;
+        let mut task_attempt = 1;
+        if let Some(task_registry) = &context.session_task_registry {
+            match task_registry
+                .create(CreateSessionTask {
+                    session_id: context.session_id,
+                    id: None,
+                    kind: TASK_KIND_AGENT_HANDOFF.to_string(),
+                    display_name: name.clone(),
+                    spec: json!({
+                        "target_id": &target.id,
+                        "external_agent_id": target.agent_id,
+                        "instructions": instructions,
+                        "mode": mode.as_str(),
+                    }),
+                    state: SessionTaskState::Running,
+                    links: TaskLinks {
+                        child_session_id: Some(child_session.id),
+                        ..Default::default()
+                    },
+                    wake_policy: match mode {
+                        SpawnAgentHandoffMode::Background => TaskWakePolicy::OnTerminal,
+                        SpawnAgentHandoffMode::Foreground => TaskWakePolicy::Silent,
+                    },
+                })
+                .await
+            {
+                Ok(task) => {
+                    task_attempt = task.attempt;
+                    task_id = Some(task.id);
+                }
+                Err(error) if mode == SpawnAgentHandoffMode::Background => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Background spawn_agent could not create its session task, so the handoff was not started: {error}"
+                    ));
+                }
+                Err(_) => {}
+            }
+        }
+
+        match mode {
+            SpawnAgentHandoffMode::Background => {
+                let Some(task_id) = task_id else {
+                    return ToolExecutionResult::tool_error(
+                        "Background spawn_agent requires session_task_registry context so the handoff can be controlled with wait_task/message_task/cancel_task",
+                    );
+                };
+                spawn_handoff_background_watcher(
+                    context,
+                    child_session.id,
+                    handoff_task,
+                    task_id.clone(),
+                    task_attempt,
+                );
+                ToolExecutionResult::success(json!({
+                    "task_id": task_id,
+                    "handoff_id": child_session.id.to_string(),
+                    "target": target.id,
+                    "target_agent_id": target.agent_id,
+                    "name": name,
+                    "status": "running",
+                    "mode": "background",
+                }))
+            }
+            SpawnAgentHandoffMode::Foreground => {
+                if let Err(error) = store.send_message(child_session.id, &handoff_task).await {
+                    finish_handoff_task(
+                        context,
+                        task_id.as_deref(),
+                        SessionTaskState::Failed,
+                        None,
+                        Some(TaskError {
+                            kind: "handoff_failed".to_string(),
+                            message: error.to_string(),
+                        }),
+                        None,
+                    )
+                    .await;
+                    return ToolExecutionResult::internal_error(error);
+                }
+
+                let status = match store
+                    .wait_for_idle(child_session.id, Some(DEFAULT_WAIT_TIMEOUT_SECS))
+                    .await
+                {
+                    Ok(status) => status,
+                    Err(error) => {
+                        finish_handoff_task(
+                            context,
+                            task_id.as_deref(),
+                            SessionTaskState::Failed,
+                            None,
+                            Some(TaskError {
+                                kind: "handoff_failed".to_string(),
+                                message: error.to_string(),
+                            }),
+                            None,
+                        )
+                        .await;
+                        return ToolExecutionResult::success(json!({
+                            "task_id": task_id,
+                            "handoff_id": child_session.id.to_string(),
+                            "target": target.id,
+                            "target_agent_id": target.agent_id,
+                            "name": name,
+                            "status": "failed",
+                            "error": error.to_string(),
+                            "mode": "foreground",
+                        }));
+                    }
+                };
+
+                let result = match handoff_result(store, child_session.id, &status).await {
+                    Ok(result) => result,
+                    Err(error) => return error,
+                };
+                if let Some(terminal) = terminal_handoff_status(&status) {
+                    let state = handoff_task_state(&terminal);
+                    let error = handoff_error(&status, state);
+                    finish_handoff_task(
+                        context,
+                        task_id.as_deref(),
+                        state,
+                        Some(result.clone()),
+                        error,
+                        None,
+                    )
+                    .await;
+                }
+
+                ToolExecutionResult::success(json!({
+                    "task_id": task_id,
+                    "handoff_id": child_session.id.to_string(),
+                    "target": target.id,
+                    "target_agent_id": target.agent_id,
+                    "name": name,
+                    "status": status,
+                    "result": result,
+                    "mode": "foreground",
+                }))
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
 pub struct GetAgentHandoffsTool;
 
 #[async_trait]
@@ -911,6 +1466,10 @@ mod tests {
             .expect("message_agent_handoff tool")
     }
 
+    fn spawn_agent_tool(config: &Value) -> Box<dyn Tool> {
+        Box::new(SpawnAgentHandoffTool::new(config))
+    }
+
     struct TestConnectionResolver {
         providers: HashSet<String>,
     }
@@ -1014,6 +1573,24 @@ mod tests {
         assert!(error.contains("Duplicate handoff target id"));
     }
 
+    #[test]
+    fn spawn_agent_schema_advertises_only_agent_target() {
+        let tool = SpawnAgentHandoffTool::new(&json!({}));
+        let schema = tool.parameters_schema();
+        assert_eq!(
+            schema["properties"]["target"]["properties"]["type"]["enum"],
+            json!(["agent"])
+        );
+        assert_eq!(
+            schema["properties"]["target"]["required"],
+            json!(["type", "id"])
+        );
+        assert_eq!(
+            schema["required"],
+            json!(["name", "instructions", "target"])
+        );
+    }
+
     #[tokio::test]
     async fn start_handoff_requires_configured_connection() {
         let store = Arc::new(MockPlatformStore::new());
@@ -1042,6 +1619,162 @@ mod tests {
             result,
             ToolExecutionResult::ConnectionRequired { provider } if provider == "fake_aws"
         ));
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_requires_configured_connection() {
+        let store = Arc::new(MockPlatformStore::new());
+        let config = target_config(
+            store.agent.public_id,
+            store.session.harness_id,
+            vec!["fake_aws"],
+        );
+        let tool = spawn_agent_tool(&config);
+        let resolver = Arc::new(TestConnectionResolver {
+            providers: HashSet::new(),
+        });
+        let context = context(store, Some(resolver));
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "AWS Operator",
+                    "instructions": "Create an RDS database named app-db",
+                    "target": { "type": "agent", "id": "aws_operator" },
+                    "mode": "foreground"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            ToolExecutionResult::ConnectionRequired { provider } if provider == "fake_aws"
+        ));
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_rejects_other_target_types() {
+        let store = Arc::new(MockPlatformStore::new());
+        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let tool = spawn_agent_tool(&config);
+        let context = context(store, None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "Wrong Target",
+                    "instructions": "Do work",
+                    "target": { "type": "subagent" }
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(message) if message.contains("target.type must be \"agent\""))
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_creates_agent_handoff_task() {
+        let store = Arc::new(MockPlatformStore::new());
+        let resolver = Arc::new(TestConnectionResolver {
+            providers: HashSet::from(["fake_aws".to_string()]),
+        });
+        let config = target_config(
+            store.agent.public_id,
+            store.session.harness_id,
+            vec!["fake_aws"],
+        );
+        let tool = spawn_agent_tool(&config);
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let mut context = context(store.clone(), Some(resolver));
+        context.session_task_registry = Some(registry.clone());
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "AWS Operator Run",
+                    "instructions": "Create an RDS database named app-db",
+                    "target": { "type": "agent", "id": "aws_operator" },
+                    "mode": "foreground",
+                    "public_context": { "region": "us-east-1" }
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        let task_id = value["task_id"].as_str().expect("task_id");
+        let task = registry
+            .get(store.session.id, task_id)
+            .await
+            .expect("task lookup")
+            .expect("task");
+        assert_eq!(value["mode"], "foreground");
+        assert_eq!(value["target"], "aws_operator");
+        assert_eq!(task.kind, TASK_KIND_AGENT_HANDOFF);
+        assert_eq!(task.display_name, "AWS Operator Run");
+        assert_eq!(task.state, SessionTaskState::Succeeded);
+        assert_eq!(task.spec["target_id"], "aws_operator");
+        assert_eq!(task.spec["mode"], "foreground");
+        assert!(task.links.child_session_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_background_returns_task_handle() {
+        let store = Arc::new(MockPlatformStore::new());
+        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let tool = spawn_agent_tool(&config);
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let mut context = context(store.clone(), None);
+        context.session_task_registry = Some(registry.clone());
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "AWS Operator Background",
+                    "instructions": "List RDS databases",
+                    "target": { "type": "agent", "id": "aws_operator" },
+                    "mode": "background"
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        let task_id = value["task_id"].as_str().expect("task_id");
+        assert_eq!(value["status"], "running");
+        assert_eq!(value["mode"], "background");
+
+        let mut task = registry
+            .get(store.session.id, task_id)
+            .await
+            .expect("task lookup")
+            .expect("task");
+        assert_eq!(task.kind, TASK_KIND_AGENT_HANDOFF);
+        assert_eq!(task.wake_policy, TaskWakePolicy::OnTerminal);
+        assert_eq!(task.spec["mode"], "background");
+
+        for _ in 0..20 {
+            if task.state.is_terminal() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            task = registry
+                .get(store.session.id, task_id)
+                .await
+                .expect("task lookup")
+                .expect("task");
+        }
+
+        assert_eq!(task.state, SessionTaskState::Succeeded);
+        assert_eq!(task.summary.as_deref(), Some("Hi!"));
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -169,7 +169,7 @@ pub use a2a_delegation::{A2aAgentDelegationCapability, SpawnAgentTool};
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};
 pub use agent_handoff::{
     AGENT_HANDOFF_CAPABILITY_ID, AgentHandoffCapability, GetAgentHandoffsTool,
-    MessageAgentHandoffTool, StartAgentHandoffTool,
+    MessageAgentHandoffTool, SpawnAgentHandoffTool, StartAgentHandoffTool,
 };
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
@@ -2323,6 +2323,7 @@ pub async fn collect_capabilities_with_configs(
     let mut has_dynamic_facts = false;
     let facts_ctx = FactsContext::new(ctx.session_id);
     let compaction_on = compaction_is_enabled(capability_configs, registry);
+    let mut agent_handoff_spawn_config: Option<serde_json::Value> = None;
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -2392,6 +2393,9 @@ pub async fn collect_capabilities_with_configs(
                     None => capability.as_ref(),
                 };
             let effective_id = effective.id();
+            if cap_id == AGENT_HANDOFF_CAPABILITY_ID {
+                agent_handoff_spawn_config = Some(cap_config.config.clone());
+            }
 
             // Collect dynamic system prompt contribution (config-aware, may read from filesystem)
             if let Some(contribution) = effective
@@ -2523,18 +2527,28 @@ pub async fn collect_capabilities_with_configs(
         }
     }
 
-    // EVE-677 migration slice: subagent-only sessions should expose the new
-    // unified delegation surface without colliding with existing `spawn_agent`
-    // providers (currently external A2A). Once all providers share one
-    // dispatcher, this conditional adapter can retire with `spawn_subagent`.
-    if applied_ids.iter().any(|id| id == SUBAGENTS_CAPABILITY_ID)
-        && !tools.iter().any(|tool| tool.name() == "spawn_agent")
+    // EVE-677 migration slices: expose the new unified delegation surface for
+    // single-provider sessions without colliding with existing `spawn_agent`
+    // owners (currently external A2A). Once all providers share one dispatcher,
+    // these conditional adapters can retire with the legacy spawn tools.
+    if !tools.iter().any(|tool| tool.name() == "spawn_agent")
+        && applied_ids.iter().any(|id| id == SUBAGENTS_CAPABILITY_ID)
     {
         let tool = SpawnSubagentAsAgentTool;
         let def = tool
             .to_definition()
             .with_category("Core")
             .with_capability_attribution(SUBAGENTS_CAPABILITY_ID, Some("Subagents"));
+        tools.push(Box::new(tool));
+        tool_definitions.push(def);
+    } else if !tools.iter().any(|tool| tool.name() == "spawn_agent")
+        && let Some(config) = agent_handoff_spawn_config.as_ref()
+    {
+        let tool = SpawnAgentHandoffTool::new(config);
+        let def = tool
+            .to_definition()
+            .with_category("Orchestration")
+            .with_capability_attribution(AGENT_HANDOFF_CAPABILITY_ID, Some("Agent Handoff"));
         tools.push(Box::new(tool));
         tool_definitions.push(def);
     }
@@ -4742,6 +4756,43 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_agent_handoff_collects_unified_spawn_agent_adapter() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(AgentHandoffCapability);
+        let agent_id = crate::typed_id::AgentId::new();
+        let harness_id = crate::typed_id::HarnessId::new();
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new(AGENT_HANDOFF_CAPABILITY_ID),
+            config: serde_json::json!({
+                "targets": [{
+                    "id": "aws_operator",
+                    "name": "AWS Operator",
+                    "agent_id": agent_id,
+                    "harness_id": harness_id
+                }]
+            }),
+        }];
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        assert!(
+            collected
+                .tools
+                .iter()
+                .any(|tool| tool.name() == "spawn_agent"),
+            "agent_handoff-only sessions should get the unified spawn_agent adapter"
+        );
+        let spawn_agent = collected
+            .tool_definitions
+            .iter()
+            .find(|tool| tool.name() == "spawn_agent")
+            .expect("spawn_agent definition");
+        assert_eq!(
+            spawn_agent.parameters()["properties"]["target"]["properties"]["type"]["enum"],
+            serde_json::json!(["agent"])
+        );
+    }
+
     struct ExistingSpawnAgentCapability;
 
     impl Capability for ExistingSpawnAgentCapability {
@@ -4813,6 +4864,46 @@ mod tests {
             &test_ctx(),
         )
         .await;
+
+        let spawn_agent_defs: Vec<_> = collected
+            .tool_definitions
+            .iter()
+            .filter(|tool| tool.name() == "spawn_agent")
+            .collect();
+        assert_eq!(spawn_agent_defs.len(), 1);
+        assert_eq!(
+            spawn_agent_defs[0].parameters()["properties"]["target"]["properties"]["type"]["enum"],
+            serde_json::json!(["external_a2a"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_agent_handoff_does_not_shadow_existing_spawn_agent_provider() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(AgentHandoffCapability);
+        registry.register(ExistingSpawnAgentCapability);
+
+        let agent_id = crate::typed_id::AgentId::new();
+        let harness_id = crate::typed_id::HarnessId::new();
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(AGENT_HANDOFF_CAPABILITY_ID),
+                config: serde_json::json!({
+                    "targets": [{
+                        "id": "aws_operator",
+                        "name": "AWS Operator",
+                        "agent_id": agent_id,
+                        "harness_id": harness_id
+                    }]
+                }),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("existing_spawn_agent"),
+                config: serde_json::json!({}),
+            },
+        ];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
 
         let spawn_agent_defs: Vec<_> = collected
             .tool_definitions

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -16,11 +16,11 @@ Spawn subagents for parallel task execution. Each subagent runs in its own isola
 
 ### `spawn_agent`
 
-Subagent-only sessions also expose the unified delegation tool with
-`target.type: "subagent"`. It follows the same lifecycle as `spawn_subagent`:
-background by default, `foreground` when requested, and a returned `task_id` for
-the generic session task tools. This is the migration path toward one delegation
-surface across subagents, first-party agent handoffs, and external A2A agents.
+Subagent-only sessions expose the unified delegation tool with
+`target.type: "subagent"`. Handoff-only sessions expose the same tool with
+`target.type: "agent"`. These migration adapters return a `task_id` for the
+generic session task tools and move Everruns toward one delegation surface
+across subagents, first-party agent handoffs, and external A2A agents.
 
 ### `spawn_subagent`
 

--- a/specs/agent-handoff.md
+++ b/specs/agent-handoff.md
@@ -49,6 +49,32 @@ before performing external writes.
 
 ## Tools
 
+### `spawn_agent` (`target.type = "agent"`)
+
+Handoff-only sessions also expose the unified delegation tool with
+`target.type = "agent"` when no other `spawn_agent` provider is active. This is
+the migration path toward the single delegation surface described in
+`specs/session-tasks.md`.
+
+Parameters:
+
+| Field | Required | Description |
+|---|---:|---|
+| `name` | yes | Human-readable label for this delegated run and task. |
+| `instructions` | yes | Work request for the target agent. Must not contain credentials. |
+| `target.type` | yes | Must be `agent`. |
+| `target.id` | yes | Target key from capability config. |
+| `mode` | no | `background` by default when task tracking is available; `foreground` blocks for the result. |
+| `public_context` | no | Non-secret structured context appended to the child task. |
+
+Behavior matches `start_agent_handoff` for authorization, child-session
+creation, task kind, and result handling. Background mode creates an
+`agent_handoff` task with `wake_policy = on_terminal`, sends the initial
+instructions from a detached watcher, heartbeats the task while waiting, and
+settles the task with the child session's terminal status and last assistant
+message. If task tracking is unavailable, an omitted mode degrades to
+`foreground`; explicit `background` is rejected.
+
 ### `start_agent_handoff`
 
 Starts a child session using the configured target Agent.
@@ -74,6 +100,8 @@ Behavior:
    `target_id`/`external_agent_id`/`mode`.
 7. Send the task to the child session.
 8. Block until the child session idles and return its last assistant message.
+
+`start_agent_handoff` remains during the EVE-677 migration and is wait-only.
 
 ### `get_agent_handoffs`
 
@@ -136,12 +164,12 @@ Create an RDS database named app-db in us-east-1.
 5. Add a Fake AWS connection in Settings → Connections. Any non-empty key is
    accepted by the fake provider for local testing.
 6. Retry the user request. The welcome agent should call
-   `start_agent_handoff`, and the child AWS Operator session should receive the
-   task and use its own fake AWS tools.
+   `spawn_agent` with `target.type = "agent"` (or legacy
+   `start_agent_handoff` during migration), and the child AWS Operator session
+   should receive the task and use its own fake AWS tools.
 
-Background mode is intentionally not exposed until there is a durable lifecycle
-updater that can move handoff resources from `active` to a terminal status after
-the parent turn has returned.
+Background mode is available through `spawn_agent`; legacy
+`start_agent_handoff` remains wait-only during migration.
 
 Focused verification:
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -270,13 +270,14 @@ wait_task               — generic foreground wait; subsumes wait_agent
 ```
 
 Spawning is converging on the unified `spawn_agent` surface while some legacy
-per-capability entry points remain during migration. Subagent-only sessions now
-advertise `spawn_agent(target.type = "subagent")`; external A2A continues to use
-`spawn_agent(target.type = "external_a2a")`; `spawn_subagent` remains available
-until the migration completes. Every spawn creates a task and returns its
-`task_id`. Blocking (foreground) spawns also create task records: same object,
-and the UI shows it live while the parent turn waits; background is a mode, not
-a different entity.
+per-capability entry points remain during migration. Subagent-only sessions
+advertise `spawn_agent(target.type = "subagent")`; handoff-only sessions
+advertise `spawn_agent(target.type = "agent")`; external A2A continues to use
+`spawn_agent(target.type = "external_a2a")`. Legacy `spawn_subagent` and
+`start_agent_handoff` remain available until the migration completes. Every
+spawn creates a task and returns its `task_id`. Blocking (foreground) spawns
+also create task records: same object, and the UI shows it live while the parent
+turn waits; background is a mode, not a different entity.
 
 Naming cleanup: `task` parameters that carry instruction text
 (`subagent_task`, `spawn_subagent(task:)`) have been renamed to `instructions` so

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -468,7 +468,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update (static) and re-validated at execution time with DNS resolution via `validate_url_dns_pinned`; every resolved IP is checked against the blocked ranges, closing the DNS-rebinding gap | MITIGATED |
 | TM-TOOL-019 | MCP `query`/`execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
 | TM-TOOL-020 | Skill `` !`command` `` activation RCE on worker host | High | `ActivateSkillFromVfsTool::execute_with_context` never invokes `preprocess_command_injections` — the trust gate is forced off because no non-user-spoofable provenance signal exists on `SessionFile` today. Expansion is also capped at `MAX_COMMAND_PLACEHOLDERS_PER_SKILL` (32) with concurrency ≤ 4 in the expansion function itself. See EVE-388. | MITIGATED |
-| TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/resource metadata, records only non-secret provider/scope labels in `session_resources`, and rejects follow-up messages unless the child session belongs to the current parent session. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
+| TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids through `spawn_agent(target.type="agent")` or legacy `start_agent_handoff`, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/task metadata, records only non-secret target/provider/scope labels in `session_tasks`, and rejects follow-up messages unless the child session belongs to the current parent session. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
 | TM-TOOL-022 | Cross-tenant MCP credential reach via guardrail `mcp` check | High | The guardrails `mcp` check (specs/guardrails.md) names a `server`/`tool` to call over the scoped-MCP client. The check resolves connections through the host's per-session `McpConnectionResolver`, which only resolves servers scoped to the current session/org; a tenant's guardrail config can only reach that tenant's servers and never another tenant's MCP credentials. A misconfigured/unknown server fails open (allow) rather than blocking. The verdict parser reads only `verdict`/`reason`, so a poisoned endpoint response cannot widen behavior beyond the fail-open baseline. | MITIGATED |
 
 ### Mitigation Details
@@ -508,9 +508,10 @@ to keep authority explicit and non-secret:
 1. Source agents can only target ids listed in their `agent_handoff` config.
 2. Required provider connections are resolved server-side through
    `UserConnectionResolver`; bearer tokens are never accepted in tool arguments,
-   capability config, system prompt context, or session resource metadata.
-3. Handoff resources store only non-secret target id, target agent id, provider
-   ids, scope labels, and mode. Full task text and credentials are excluded.
+   capability config, system prompt context, or session task metadata.
+3. Handoff task records store only non-secret target id, target agent id,
+   provider ids, scope labels, mode, and lifecycle metadata. Full credentials
+   are excluded.
 4. `message_agent_handoff` verifies the child session's `parent_session_id`
    matches the current session before sending follow-up input.
 5. This gate proves the user has the required connection before delegation.


### PR DESCRIPTION
## What
Expose `spawn_agent(target.type = "agent")` for handoff-only sessions as the next EVE-677 migration slice.

## Why
EVE-677 is moving all delegation toward one `spawn_agent` surface. PR #2604 covered subagents; this PR covers first-party agent handoffs without colliding with external A2A's existing `spawn_agent` provider.

## How
- Adds `SpawnAgentHandoffTool`, a `spawn_agent` adapter for configured `agent_handoff` targets.
- Supports foreground and background modes. Background returns a task handle, sends the initial handoff from a detached watcher, heartbeats the task, and settles it on terminal child status.
- Injects the adapter only when `agent_handoff` is active and no collected tool already owns `spawn_agent`.
- Preserves legacy `start_agent_handoff`, `get_agent_handoffs`, and `message_agent_handoff` during migration.
- Updates handoff/session-task specs, public delegation docs, and TM-TOOL-021 threat-model text.

## Risk
- Medium
- Main risk is widening cross-agent delegation semantics. The new tool reuses the existing target allowlist, parent/child ownership checks, and server-side connection gate. Background mode is task-backed and uses `OnTerminal` wake policy so the parent can observe completion through generic task tools.

## Security
- Threat categories reviewed: TM-TOOL-021, TM-AGENT, TM-DOS.
- Findings and resolutions: no credentials are accepted in tool args/config/task metadata; required connections are still resolved server-side before child-session creation; only configured target ids can be used; child sessions retain `parent_session_id` ownership checks; background handoffs heartbeat and settle through `session_tasks` to avoid unbounded running tasks. Threat model updated for the new `spawn_agent(target.type="agent")` path.

## Validation
- `cargo fmt --check`
- `cargo test -p everruns-core agent_handoff -- --nocapture`
- `cargo test -p everruns-core spawn_agent_subagent -- --nocapture`
- `cargo test -p everruns-core test_subagents_collect_unified_spawn_agent_adapter -- --nocapture`
- `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings`
- `npx --yes pnpm@10.33.0 run check` in `apps/docs`
- `npx --yes pnpm@10.33.0 run build` in `apps/docs`
- `cargo test -p everruns-core agent_handoff -- --nocapture` includes the focused smoke for background handoff task settling
- `PORT_PREFIX=271 just start-dev --no-watch` attempted for full-stack smoke, but local environment is missing `caddy` (`just init` prerequisite)
- `just pre-push`

## Follow-ups
- Continue EVE-677 by merging first-party subagent + handoff + external A2A into one shared dispatcher for multi-provider sessions, then retire `spawn_subagent` and `start_agent_handoff` once no legacy references remain.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-677