### PR TITLE
feat(capabilities): dispatch spawn_agent targets

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -29,8 +29,8 @@ use crate::message::Message;
 use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::{ToolCall, ToolDefinition};
-use crate::tools::{Tool, ToolRegistry};
-use crate::traits::SessionFileSystem;
+use crate::tools::{Tool, ToolExecutionResult, ToolRegistry};
+use crate::traits::{SessionFileSystem, ToolContext};
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -1688,6 +1688,208 @@ impl CollectedCapabilities {
     }
 }
 
+struct SpawnAgentTargetProvider {
+    target_type: &'static str,
+    tool: Box<dyn Tool>,
+}
+
+struct UnifiedSpawnAgentTool {
+    providers: Vec<SpawnAgentTargetProvider>,
+}
+
+impl UnifiedSpawnAgentTool {
+    fn new(providers: Vec<SpawnAgentTargetProvider>) -> Self {
+        Self { providers }
+    }
+
+    fn provider_for(&self, target_type: &str) -> Option<&dyn Tool> {
+        self.providers
+            .iter()
+            .find(|provider| provider.target_type == target_type)
+            .map(|provider| provider.tool.as_ref())
+    }
+
+    fn target_types(&self) -> Vec<&'static str> {
+        ["subagent", "agent", "external_a2a"]
+            .into_iter()
+            .filter(|target_type| {
+                self.providers
+                    .iter()
+                    .any(|provider| provider.target_type == *target_type)
+            })
+            .collect()
+    }
+
+    fn normalize_arguments(&self, mut arguments: serde_json::Value) -> serde_json::Value {
+        let target_type = arguments
+            .get("target")
+            .and_then(|target| target.get("type"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+
+        if target_type == "external_a2a" {
+            if let Some(target) = arguments
+                .get_mut("target")
+                .and_then(serde_json::Value::as_object_mut)
+                && !target.contains_key("external_agent_id")
+                && let Some(id) = target.get("id").cloned()
+            {
+                target.insert("external_agent_id".to_string(), id);
+            }
+            if arguments.get("mode").and_then(serde_json::Value::as_str) == Some("foreground") {
+                arguments["mode"] = serde_json::Value::String("wait".to_string());
+            }
+        } else if matches!(target_type, "subagent" | "agent")
+            && arguments.get("mode").and_then(serde_json::Value::as_str) == Some("wait")
+        {
+            arguments["mode"] = serde_json::Value::String("foreground".to_string());
+        }
+
+        arguments
+    }
+}
+
+#[async_trait]
+impl Tool for UnifiedSpawnAgentTool {
+    fn narrate(
+        &self,
+        tool_call: &ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        let target_type = tool_call
+            .arguments
+            .get("target")
+            .and_then(|target| target.get("type"))
+            .and_then(serde_json::Value::as_str)?;
+        self.provider_for(target_type)
+            .and_then(|tool| tool.narrate(tool_call, phase, locale))
+    }
+
+    fn name(&self) -> &str {
+        "spawn_agent"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Spawn Agent")
+    }
+
+    fn description(&self) -> &str {
+        "Delegate work to another agent target. Set target.type to one of the advertised target types; background returns a task_id for generic task tools, and foreground waits for the result."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable name for local subagent or first-party handoff runs. Optional for external A2A targets."
+                },
+                "instructions": {
+                    "type": "string",
+                    "description": "Instructions for the delegated agent. Do not include credentials or bearer tokens."
+                },
+                "target": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": self.target_types(),
+                            "description": "Delegation target type. Use subagent for same-agent child sessions, agent for configured first-party handoffs, or external_a2a for configured remote A2A agents."
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": "Configured first-party handoff target id. Also accepted as an alias for external_a2a target.external_agent_id."
+                        },
+                        "external_agent_id": {
+                            "type": "string",
+                            "description": "Configured external A2A agent id."
+                        }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["background", "foreground", "wait"],
+                    "description": "Execution mode. Use background to return immediately with a task_id. Use foreground to block for local targets; external_a2a also accepts legacy wait."
+                },
+                "blueprint": {
+                    "type": "string",
+                    "description": "Subagent-only blueprint ID to spawn a specialist agent with its own tools and model."
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Subagent-only blueprint configuration. Only valid when blueprint is set."
+                },
+                "public_context": {
+                    "type": "object",
+                    "description": "Agent-handoff-only non-secret structured context to include with the instructions."
+                },
+                "wait_timeout_secs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 86400,
+                    "description": "External-A2A-only foreground/wait timeout."
+                },
+                "wake_on_completion": {
+                    "type": "boolean",
+                    "description": "External-A2A-only control for background completion wake-ups."
+                }
+            },
+            "required": ["instructions", "target"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> crate::tool_types::ToolHints {
+        let mut hints = crate::tool_types::ToolHints::default().with_long_running(true);
+        if self.provider_for("external_a2a").is_some() {
+            hints = hints.with_open_world(true);
+        }
+        hints
+    }
+
+    async fn execute(&self, _arguments: serde_json::Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "spawn_agent requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: serde_json::Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let target_type = match arguments
+            .get("target")
+            .and_then(|target| target.get("type"))
+            .and_then(serde_json::Value::as_str)
+        {
+            Some(target_type) => target_type,
+            None => {
+                return ToolExecutionResult::tool_error("Missing required parameter: target.type");
+            }
+        };
+
+        let Some(provider) = self.provider_for(target_type) else {
+            let supported = self.target_types().join(", ");
+            return ToolExecutionResult::tool_error(format!(
+                "Unsupported spawn_agent target.type: \"{target_type}\". Supported target types: {supported}"
+            ));
+        };
+
+        provider
+            .execute_with_context(self.normalize_arguments(arguments), context)
+            .await
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
 /// Compose the model-visible system prompt from the stable base prompt and
 /// collected capability contributions. Keep the base prompt first so changes in
 /// dynamic capabilities (for example AGENTS.md reads or environment context)
@@ -2324,6 +2526,7 @@ pub async fn collect_capabilities_with_configs(
     let facts_ctx = FactsContext::new(ctx.session_id);
     let compaction_on = compaction_is_enabled(capability_configs, registry);
     let mut agent_handoff_spawn_config: Option<serde_json::Value> = None;
+    let mut spawn_agent_providers: Vec<SpawnAgentTargetProvider> = Vec::new();
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -2421,7 +2624,16 @@ pub async fn collect_capabilities_with_configs(
             }
 
             // Collect tools and hooks (config-aware: capabilities can adapt based on per-agent config)
-            tools.extend(effective.tools_with_config(&cap_config.config));
+            for tool in effective.tools_with_config(&cap_config.config) {
+                if cap_id == A2A_AGENT_DELEGATION_CAPABILITY_ID && tool.name() == "spawn_agent" {
+                    spawn_agent_providers.push(SpawnAgentTargetProvider {
+                        target_type: "external_a2a",
+                        tool,
+                    });
+                } else {
+                    tools.push(tool);
+                }
+            }
             tool_definition_hooks
                 .extend(effective.tool_definition_hooks_with_context(ctx, &cap_config.config));
             tool_call_hooks.extend(effective.tool_call_hooks());
@@ -2433,6 +2645,9 @@ pub async fn collect_capabilities_with_configs(
             // Collect tool definitions, propagating capability category if not already set
             let cap_category = effective.category();
             for def in effective.tool_definitions() {
+                if cap_id == A2A_AGENT_DELEGATION_CAPABILITY_ID && def.name() == "spawn_agent" {
+                    continue;
+                }
                 let def = match (def.category(), cap_category) {
                     (None, Some(cat)) => def.with_category(cat),
                     _ => def,
@@ -2527,28 +2742,28 @@ pub async fn collect_capabilities_with_configs(
         }
     }
 
-    // EVE-677 migration slices: expose the new unified delegation surface for
-    // single-provider sessions without colliding with existing `spawn_agent`
-    // owners (currently external A2A). Once all providers share one dispatcher,
-    // these conditional adapters can retire with the legacy spawn tools.
-    if !tools.iter().any(|tool| tool.name() == "spawn_agent")
-        && applied_ids.iter().any(|id| id == SUBAGENTS_CAPABILITY_ID)
-    {
-        let tool = SpawnSubagentAsAgentTool;
-        let def = tool
-            .to_definition()
-            .with_category("Core")
-            .with_capability_attribution(SUBAGENTS_CAPABILITY_ID, Some("Subagents"));
-        tools.push(Box::new(tool));
-        tool_definitions.push(def);
-    } else if !tools.iter().any(|tool| tool.name() == "spawn_agent")
-        && let Some(config) = agent_handoff_spawn_config.as_ref()
-    {
-        let tool = SpawnAgentHandoffTool::new(config);
+    // EVE-677 migration: known delegation providers now share one model-facing
+    // `spawn_agent` dispatcher so subagents, first-party handoffs, and external
+    // A2A agents can coexist in the same session. Unknown third-party
+    // `spawn_agent` owners still win to avoid changing their contract.
+    if applied_ids.iter().any(|id| id == SUBAGENTS_CAPABILITY_ID) {
+        spawn_agent_providers.push(SpawnAgentTargetProvider {
+            target_type: "subagent",
+            tool: Box::new(SpawnSubagentAsAgentTool),
+        });
+    }
+    if let Some(config) = agent_handoff_spawn_config.as_ref() {
+        spawn_agent_providers.push(SpawnAgentTargetProvider {
+            target_type: "agent",
+            tool: Box::new(SpawnAgentHandoffTool::new(config)),
+        });
+    }
+    if !tools.iter().any(|tool| tool.name() == "spawn_agent") && !spawn_agent_providers.is_empty() {
+        let tool = UnifiedSpawnAgentTool::new(spawn_agent_providers);
         let def = tool
             .to_definition()
             .with_category("Orchestration")
-            .with_capability_attribution(AGENT_HANDOFF_CAPABILITY_ID, Some("Agent Handoff"));
+            .with_capability_attribution("agent_delegation", Some("Agent Delegation"));
         tools.push(Box::new(tool));
         tool_definitions.push(def);
     }
@@ -4790,6 +5005,84 @@ mod tests {
         assert_eq!(
             spawn_agent.parameters()["properties"]["target"]["properties"]["type"]["enum"],
             serde_json::json!(["agent"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_agent_dispatcher_combines_known_target_providers() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(SubagentCapability);
+        registry.register(AgentHandoffCapability);
+
+        let agent_id = crate::typed_id::AgentId::new();
+        let harness_id = crate::typed_id::HarnessId::new();
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(SUBAGENTS_CAPABILITY_ID),
+                config: serde_json::json!({}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(AGENT_HANDOFF_CAPABILITY_ID),
+                config: serde_json::json!({
+                    "targets": [{
+                        "id": "aws_operator",
+                        "name": "AWS Operator",
+                        "agent_id": agent_id,
+                        "harness_id": harness_id
+                    }]
+                }),
+            },
+        ];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+        let spawn_agent_defs: Vec<_> = collected
+            .tool_definitions
+            .iter()
+            .filter(|tool| tool.name() == "spawn_agent")
+            .collect();
+
+        assert_eq!(spawn_agent_defs.len(), 1);
+        assert_eq!(
+            spawn_agent_defs[0].parameters()["properties"]["target"]["properties"]["type"]["enum"],
+            serde_json::json!(["subagent", "agent"])
+        );
+    }
+
+    #[cfg(feature = "a2a")]
+    #[tokio::test]
+    async fn test_spawn_agent_dispatcher_includes_external_a2a_provider() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(SubagentCapability);
+        registry.register(A2aAgentDelegationCapability);
+
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(SUBAGENTS_CAPABILITY_ID),
+                config: serde_json::json!({}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(A2A_AGENT_DELEGATION_CAPABILITY_ID),
+                config: serde_json::json!({
+                    "agents": [{
+                        "id": "local_app",
+                        "name": "Local App",
+                        "base_url": "https://example.com"
+                    }]
+                }),
+            },
+        ];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+        let spawn_agent_defs: Vec<_> = collected
+            .tool_definitions
+            .iter()
+            .filter(|tool| tool.name() == "spawn_agent")
+            .collect();
+
+        assert_eq!(spawn_agent_defs.len(), 1);
+        assert_eq!(
+            spawn_agent_defs[0].parameters()["properties"]["target"]["properties"]["type"]["enum"],
+            serde_json::json!(["subagent", "external_a2a"])
         );
     }
 

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -16,11 +16,12 @@ Spawn subagents for parallel task execution. Each subagent runs in its own isola
 
 ### `spawn_agent`
 
-Subagent-only sessions expose the unified delegation tool with
-`target.type: "subagent"`. Handoff-only sessions expose the same tool with
-`target.type: "agent"`. These migration adapters return a `task_id` for the
-generic session task tools and move Everruns toward one delegation surface
-across subagents, first-party agent handoffs, and external A2A agents.
+Sessions with `subagents` expose `target.type: "subagent"` in the shared
+`spawn_agent` dispatcher. If first-party handoffs or external A2A delegation are
+also active, the same tool advertises those target types too. The dispatcher
+returns a `task_id` for the generic session task tools and moves Everruns toward
+one delegation surface across subagents, first-party agent handoffs, and
+external A2A agents.
 
 ### `spawn_subagent`
 

--- a/specs/a2a-capability.md
+++ b/specs/a2a-capability.md
@@ -105,13 +105,17 @@ agent runs via the `ExternalAgentTaskExecutor`.
 ### `spawn_agent`
 
 Creates an external A2A run. Returns an `agent_run_id` and `task_id`.
+When other known delegation providers are active, external A2A is advertised as
+the `external_a2a` target in the shared `spawn_agent` dispatcher rather than as
+a competing tool definition.
 
 Parameters:
 
 - `instructions` required
 - `target.type = external_a2a`
 - `target.external_agent_id`
-- `mode = wait | background`
+- `mode = wait | background`; the shared dispatcher also accepts `foreground`
+  as an alias for `wait`.
 - `wait_timeout_secs`
 - `wake_on_completion`
 

--- a/specs/agent-handoff.md
+++ b/specs/agent-handoff.md
@@ -51,10 +51,11 @@ before performing external writes.
 
 ### `spawn_agent` (`target.type = "agent"`)
 
-Handoff-only sessions also expose the unified delegation tool with
-`target.type = "agent"` when no other `spawn_agent` provider is active. This is
-the migration path toward the single delegation surface described in
-`specs/session-tasks.md`.
+Sessions with `agent_handoff` enabled advertise `agent` in the shared
+`spawn_agent` dispatcher's `target.type` enum. The dispatcher can advertise
+other active known delegation providers alongside `agent` (for example
+subagents or external A2A), which is the migration path toward the single
+delegation surface described in `specs/session-tasks.md`.
 
 Parameters:
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -270,14 +270,13 @@ wait_task               — generic foreground wait; subsumes wait_agent
 ```
 
 Spawning is converging on the unified `spawn_agent` surface while some legacy
-per-capability entry points remain during migration. Subagent-only sessions
-advertise `spawn_agent(target.type = "subagent")`; handoff-only sessions
-advertise `spawn_agent(target.type = "agent")`; external A2A continues to use
-`spawn_agent(target.type = "external_a2a")`. Legacy `spawn_subagent` and
-`start_agent_handoff` remain available until the migration completes. Every
-spawn creates a task and returns its `task_id`. Blocking (foreground) spawns
-also create task records: same object, and the UI shows it live while the parent
-turn waits; background is a mode, not a different entity.
+per-capability entry points remain during migration. Known delegation providers
+now share one `spawn_agent` dispatcher; its `target.type` enum reflects the
+active providers (`subagent`, `agent`, and/or `external_a2a`). Legacy
+`spawn_subagent` and `start_agent_handoff` remain available until the migration
+completes. Every spawn creates a task and returns its `task_id`. Blocking
+(foreground) spawns also create task records: same object, and the UI shows it
+live while the parent turn waits; background is a mode, not a different entity.
 
 Naming cleanup: `task` parameters that carry instruction text
 (`subagent_task`, `spawn_subagent(task:)`) have been renamed to `instructions` so

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -83,16 +83,16 @@ See `crates/server/migrations/009_subagents.sql` for schema changes.
 
 ### spawn_agent (`target.type = "subagent"`)
 
-During the unified delegation migration, sessions with `subagents` enabled and
-no other `spawn_agent` provider advertise `spawn_agent` with a single supported
-target type: `subagent`. The wrapper uses the same behavior as
-`spawn_subagent`: it creates a child session with `parent_session_id` set,
-creates a `TASK_KIND_SUBAGENT` task, defaults to background mode, and supports
-`mode: "foreground"` for blocking execution.
+During the unified delegation migration, sessions with `subagents` enabled
+advertise `subagent` in the shared `spawn_agent` dispatcher's `target.type`
+enum. The dispatcher routes to the same behavior as `spawn_subagent`: it creates
+a child session with `parent_session_id` set, creates a `TASK_KIND_SUBAGENT`
+task, defaults to background mode, and supports `mode: "foreground"` for
+blocking execution.
 
-This adapter is conditional so it does not shadow other current `spawn_agent`
-providers such as external A2A. Once all delegation targets share one dispatcher,
-`spawn_subagent` can retire.
+The dispatcher can advertise other active known delegation providers alongside
+`subagent` (for example first-party handoff or external A2A). Once all legacy
+references are migrated, `spawn_subagent` can retire.
 
 ### spawn_subagent
 


### PR DESCRIPTION
## What changed
Known delegation providers now share one model-facing `spawn_agent` dispatcher. Sessions can advertise `target.type` values for active providers together (`subagent`, `agent`, and/or `external_a2a`) instead of choosing a single-provider adapter.

The dispatcher routes each call to the existing target-specific implementation, preserves unknown third-party `spawn_agent` owners, and keeps A2A compatibility by accepting legacy `wait` plus unified `foreground` as a wait-mode alias.

## Why
EVE-677 is converging subagents, first-party handoffs, and external A2A delegation onto one `spawn_agent` surface. The previous migration slices worked for single-provider sessions; this slice allows multi-provider sessions to expose one combined tool.

## Before / After
Before: capability collection only injected `spawn_agent(target.type="subagent")` or `spawn_agent(target.type="agent")` when no other `spawn_agent` provider existed; external A2A owned its own separate `spawn_agent` definition.

After: capability collection with multiple known providers emits one `spawn_agent` definition whose target enum reflects the active providers, for example `["subagent", "agent"]` or `["subagent", "external_a2a"]`.

Evidence:
- Added collection tests for combined subagent + handoff and subagent + external A2A target enums.
- Existing target-specific tools continue to pass their focused tests.

## Risk
- Medium
- Main risk is changing model-visible tool schema/collection for sessions with multiple delegation providers. Runtime execution still delegates to existing provider tools, and unknown third-party `spawn_agent` owners still take precedence to avoid contract changes.

## Security
- Threat categories reviewed: TM-TOOL-021, TM-AGENT, TM-DOS.
- Findings and resolutions: no new credentials are accepted or persisted; dispatcher only selects an already-active provider by `target.type`; each provider keeps its existing authorization, target allowlist, task registry, nesting, URL safety, and connection checks. No threat-model text change needed for this routing-only slice.

## Follow-ups
Continue EVE-677 by retiring legacy `spawn_subagent` and `start_agent_handoff` after prompts/specs/tests no longer reference them.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-677