### PR TITLE
feat(ui): ATIF session export with limit alerts

### DIFF
--- a/apps/ui/src/__tests__/session-export.test.tsx
+++ b/apps/ui/src/__tests__/session-export.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * Session export: format selection on SessionCard and the ATIF limit alerts
+ * (413 size cap -> error toast, X-Atif-Images-Omitted -> info toast) in the
+ * shared download flow. The default JSONL path must stay unchanged.
+ */
+
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SessionCard } from "@/components/session/session-card";
+import { downloadSessionExport } from "@/lib/session-export";
+import type { Session } from "@/lib/api/types";
+
+// Mock next/link - using span with data-href to avoid linting issues
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <span data-testid="session-link" data-href={href}>
+      {children}
+    </span>
+  ),
+}));
+
+// base-ui menus do not open in jsdom; render all parts as passthrough elements
+// (same approach as dropdown-menu.test.tsx) so menu items are clickable.
+jest.mock("@base-ui/react/menu", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  type PassthroughProps = React.HTMLAttributes<HTMLElement> & {
+    children?: React.ReactNode;
+    sideOffset?: number;
+    align?: string;
+  };
+
+  const divPassthrough = ReactActual.forwardRef<HTMLElement, PassthroughProps>(
+    function DivPassthrough({ children, sideOffset, align, ...props }, ref) {
+      return (
+        <div
+          ref={ref as React.Ref<HTMLDivElement>}
+          data-side-offset={sideOffset}
+          data-align={align}
+          {...props}
+        >
+          {children}
+        </div>
+      );
+    },
+  );
+
+  const buttonPassthrough = ReactActual.forwardRef<
+    HTMLButtonElement,
+    React.ButtonHTMLAttributes<HTMLButtonElement>
+  >(function ButtonPassthrough({ children, ...props }, ref) {
+    return (
+      <button ref={ref} type="button" {...props}>
+        {children}
+      </button>
+    );
+  });
+
+  return {
+    Menu: {
+      Root: divPassthrough,
+      Portal: divPassthrough,
+      Trigger: buttonPassthrough,
+      Positioner: divPassthrough,
+      Popup: divPassthrough,
+      Group: divPassthrough,
+      Item: divPassthrough,
+      CheckboxItem: divPassthrough,
+      CheckboxItemIndicator: divPassthrough,
+      RadioGroup: divPassthrough,
+      RadioItem: divPassthrough,
+      RadioItemIndicator: divPassthrough,
+      GroupLabel: divPassthrough,
+      Separator: divPassthrough,
+      SubmenuRoot: divPassthrough,
+      SubmenuTrigger: buttonPassthrough,
+    },
+  };
+});
+
+const SESSION_ID = "session_0d9f3a91b24e48d6a0e91f3b7c4d2e85";
+
+const mockSession: Session = {
+  id: SESSION_ID,
+  organization_id: "org_default",
+  harness_id: "harness-default",
+  agent_id: "agent-1",
+  owner_principal_id: "principal-1",
+  title: "Test Session",
+  tags: [],
+  model_id: null,
+  status: "idle",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:02Z",
+  started_at: "2025-01-01T00:00:01Z",
+  finished_at: null,
+};
+
+describe("SessionCard export menu", () => {
+  it("offers JSONL and ATIF export options", () => {
+    const onExport = jest.fn();
+    render(<SessionCard session={mockSession} onExport={onExport} />);
+
+    expect(screen.getByLabelText("Export session")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Export JSONL"));
+    expect(onExport).toHaveBeenCalledWith(SESSION_ID, "jsonl");
+
+    fireEvent.click(screen.getByText("Export ATIF"));
+    expect(onExport).toHaveBeenCalledWith(SESSION_ID, "atif");
+  });
+
+  it("does not render the export menu without onExport", () => {
+    render(<SessionCard session={mockSession} />);
+    expect(screen.queryByLabelText("Export session")).not.toBeInTheDocument();
+  });
+});
+
+type MockResponseOptions = {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  body?: string;
+};
+
+function mockResponse({
+  ok = true,
+  status = 200,
+  statusText = "OK",
+  headers = {},
+  body = "",
+}: MockResponseOptions = {}) {
+  return {
+    ok,
+    status,
+    statusText,
+    headers: { get: (name: string) => headers[name] ?? null },
+    blob: async () => new Blob([body]),
+    text: async () => body,
+  } as unknown as Response;
+}
+
+describe("downloadSessionExport", () => {
+  const fetchMock = jest.fn();
+  let downloads: string[] = [];
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    downloads = [];
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    URL.createObjectURL = jest.fn(() => "blob:mock");
+    URL.revokeObjectURL = jest.fn();
+    jest
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloads.push(this.download);
+      });
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("downloads JSONL by default without any toast", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse());
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "jsonl", "en", notify);
+
+    expect(fetchMock).toHaveBeenCalledWith(`/api/v1/sessions/${SESSION_ID}/export`, {
+      credentials: "include",
+    });
+    expect(downloads).toEqual([`${SESSION_ID}.jsonl`]);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("downloads ATIF via ?format=atif as {sessionId}.atif.json", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse());
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(fetchMock).toHaveBeenCalledWith(`/api/v1/sessions/${SESSION_ID}/export?format=atif`, {
+      credentials: "include",
+    });
+    expect(downloads).toEqual([`${SESSION_ID}.atif.json`]);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("shows the server message as an error toast on 413", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 413,
+        statusText: "Payload Too Large",
+        body: JSON.stringify({ detail: "ATIF document exceeds the 10 MiB export cap" }),
+      }),
+    );
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(downloads).toEqual([]);
+    expect(notify).toHaveBeenCalledWith({
+      title: "ATIF export failed",
+      body: "ATIF document exceeds the 10 MiB export cap",
+    });
+  });
+
+  it("falls back to a clear message when the 413 body is not parseable", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 413, statusText: "Payload Too Large" }),
+    );
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(downloads).toEqual([]);
+    expect(notify).toHaveBeenCalledWith({
+      title: "ATIF export failed",
+      body: "This session is too large for ATIF export.",
+    });
+  });
+
+  it("still downloads and shows an info toast when images were omitted", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ headers: { "X-Atif-Images-Omitted": "3" } }));
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(downloads).toEqual([`${SESSION_ID}.atif.json`]);
+    expect(notify).toHaveBeenCalledWith({
+      title: "ATIF export",
+      body: "3 images were omitted from the ATIF export",
+    });
+  });
+
+  it("uses the singular form for one omitted image", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ headers: { "X-Atif-Images-Omitted": "1" } }));
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(notify).toHaveBeenCalledWith({
+      title: "ATIF export",
+      body: "1 image was omitted from the ATIF export",
+    });
+  });
+
+  it("keeps the legacy console-only behavior for non-413 errors", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 500, statusText: "Internal Server Error" }),
+    );
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(downloads).toEqual([]);
+    expect(notify).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
+++ b/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
@@ -29,7 +29,10 @@ import { AgentFilterMenu } from "@/components/agent/agent-filter-menu";
 import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
-import { exportSessionJsonl } from "@/lib/api/sessions";
+import { downloadSessionExport } from "@/lib/session-export";
+import { useOptionalNotificationsContext } from "@/providers/notifications-provider";
+import { useLocale } from "@/providers/locale-provider";
+import type { SessionExportFormat } from "@/lib/api/sessions";
 import type { ModelWithProvider, Agent } from "@/lib/api/types";
 import { getDisplayName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
@@ -48,6 +51,8 @@ const PAGE_SIZE = 20;
 
 export default function SessionsPageClient() {
   const router = useRouter();
+  const { locale } = useLocale();
+  const notificationsContext = useOptionalNotificationsContext();
   const [page, setPage] = useState(0);
   const [selectedAgentId, setSelectedAgentId] = useState<string>("");
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
@@ -140,10 +145,8 @@ export default function SessionsPageClient() {
     }
   };
 
-  const handleExport = (sessionId: string) => {
-    exportSessionJsonl(sessionId).catch((err) => {
-      console.error("Failed to export session:", err);
-    });
+  const handleExport = (sessionId: string, format: SessionExportFormat) => {
+    void downloadSessionExport(sessionId, format, locale, notificationsContext?.notify);
   };
 
   const filterLabel = selectedAgentId

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -14,10 +14,19 @@ import { Badge } from "@/components/ui/badge";
 import { EntityCard } from "@/components/ui/entity-card";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuPositioner,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { cn, shortenId } from "@/lib/utils";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
 import { CopyButton } from "@/components/ui/copy-button";
+import { useLocale } from "@/providers/locale-provider";
 import type { Session, SessionStatus, ModelWithProvider, TokenUsage } from "@/lib/api/types";
+import type { SessionExportFormat } from "@/lib/api/sessions";
 import { getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { joinTags } from "@/lib/tags";
 
@@ -44,8 +53,8 @@ export interface SessionCardProps {
   onDelete?: (sessionId: string, sessionTitle: string) => void;
   /** Callback to toggle pin state */
   onTogglePin?: (sessionId: string, pinned: boolean) => void;
-  /** Callback to export session as JSONL */
-  onExport?: (sessionId: string) => void;
+  /** Callback to export the session in the chosen format */
+  onExport?: (sessionId: string, format: SessionExportFormat) => void;
 }
 
 /**
@@ -148,6 +157,7 @@ export function SessionCard({
   onTogglePin,
   onExport,
 }: SessionCardProps) {
+  const { t } = useLocale();
   const statusInfo = getStatusInfo(session.status);
   const displayTitle = session.title || `Session ${shortenId(session.id)}`;
   // Show preview from session (first user message), explicit summary prop, or nothing
@@ -198,19 +208,27 @@ export function SessionCard({
             </Badge>
           )}
           {onExport && (
-            <Tooltip>
-              <TooltipTrigger
+            <DropdownMenu>
+              <DropdownMenuTrigger
                 className={cn(
                   "p-0.5 rounded transition-colors flex-shrink-0",
                   "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
                 )}
-                aria-label="Export session as JSONL"
-                onClick={() => onExport(session.id)}
+                aria-label={t("export_session")}
               >
                 <Download className="w-3.5 h-3.5" />
-              </TooltipTrigger>
-              <TooltipContent>Export JSONL</TooltipContent>
-            </Tooltip>
+              </DropdownMenuTrigger>
+              <DropdownMenuPositioner align="end">
+                <DropdownMenuContent>
+                  <DropdownMenuItem onClick={() => onExport(session.id, "jsonl")}>
+                    {t("export_jsonl")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => onExport(session.id, "atif")}>
+                    {t("export_atif")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenuPositioner>
+            </DropdownMenu>
           )}
           {onTogglePin && (
             <Tooltip>

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -1,7 +1,7 @@
 // Session API functions
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api } from "./client";
+import { api, throwApiError } from "./client";
 import type {
   Session,
   SessionStats,
@@ -113,23 +113,48 @@ export async function unpinSession(sessionId: string): Promise<void> {
 // Session Export
 // ============================================
 
-/** Export session messages as JSONL file and trigger browser download */
-export async function exportSessionJsonl(sessionId: string): Promise<void> {
-  const response = await fetch(`/api/v1/sessions/${sessionId}/export`, {
+export type SessionExportFormat = "jsonl" | "atif";
+
+export interface SessionExportResult {
+  /**
+   * Number of image parts the server omitted from an ATIF document
+   * (`X-Atif-Images-Omitted` header). 0 when the header is absent (JSONL
+   * exports, or servers without ATIF support).
+   */
+  imagesOmitted: number;
+}
+
+/**
+ * Export session messages and trigger a browser download.
+ * `jsonl` (default) downloads `{sessionId}.jsonl`; `atif` downloads the
+ * ATIF-v1.7 trajectory document as `{sessionId}.atif.json`.
+ *
+ * Throws `ApiError` on failure — notably status 413 when the ATIF document
+ * exceeds the server's size cap.
+ */
+export async function exportSession(
+  sessionId: string,
+  format: SessionExportFormat = "jsonl",
+): Promise<SessionExportResult> {
+  const query = format === "atif" ? "?format=atif" : "";
+  const response = await fetch(`/api/v1/sessions/${sessionId}/export${query}`, {
     credentials: "include",
   });
   if (!response.ok) {
-    throw new Error(`Export failed: ${response.status} ${response.statusText}`);
+    await throwApiError(response);
   }
+  const omittedHeader = response.headers.get("X-Atif-Images-Omitted");
+  const omitted = omittedHeader ? Number.parseInt(omittedHeader, 10) : 0;
   const blob = await response.blob();
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `${sessionId}.jsonl`;
+  a.download = format === "atif" ? `${sessionId}.atif.json` : `${sessionId}.jsonl`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+  return { imagesOmitted: Number.isFinite(omitted) && omitted > 0 ? omitted : 0 };
 }
 
 // ============================================

--- a/apps/ui/src/lib/i18n.ts
+++ b/apps/ui/src/lib/i18n.ts
@@ -192,6 +192,15 @@ const messages = {
     mount_path_trailing_slash: "Path must not end with a trailing slash",
     mount_path_duplicate: "Duplicate mount path '{value}'",
     mount_path_overlap: "Path '{value}' overlaps with '{other}'",
+    export_session: "Export session",
+    export_jsonl: "Export JSONL",
+    export_atif: "Export ATIF",
+    atif_export_title: "ATIF export",
+    atif_export_failed_title: "ATIF export failed",
+    atif_export_too_large: "This session is too large for ATIF export.",
+    atif_images_omitted_one: "{count} image was omitted from the ATIF export",
+    atif_images_omitted_few: "{count} images were omitted from the ATIF export",
+    atif_images_omitted_many: "{count} images were omitted from the ATIF export",
   },
   uk: {
     thinking: "думаю",
@@ -379,6 +388,15 @@ const messages = {
     mount_path_trailing_slash: "Шлях не може закінчуватися символом '/'",
     mount_path_duplicate: "Повторюваний шлях монтування '{value}'",
     mount_path_overlap: "Шлях '{value}' перетинається з '{other}'",
+    export_session: "Експортувати сесію",
+    export_jsonl: "Експортувати JSONL",
+    export_atif: "Експортувати ATIF",
+    atif_export_title: "Експорт ATIF",
+    atif_export_failed_title: "Не вдалося експортувати ATIF",
+    atif_export_too_large: "Ця сесія завелика для експорту ATIF.",
+    atif_images_omitted_one: "{count} зображення пропущено під час експорту ATIF",
+    atif_images_omitted_few: "{count} зображення пропущено під час експорту ATIF",
+    atif_images_omitted_many: "{count} зображень пропущено під час експорту ATIF",
   },
 } as const;
 
@@ -445,6 +463,27 @@ export function formatImageCount(locale: SupportedLocale, count: number): string
   }
 
   return formatMessage(locale, count === 1 ? "image_count_one" : "image_count_many", { count });
+}
+
+export function formatAtifImagesOmitted(locale: SupportedLocale, count: number): string {
+  if (locale === "uk") {
+    const form = getUkrainianPluralForm(count);
+    if (form === "one") {
+      return formatMessage(locale, "atif_images_omitted_one", { count });
+    }
+    if (form === "few") {
+      return formatMessage(locale, "atif_images_omitted_few", { count });
+    }
+    return formatMessage(locale, "atif_images_omitted_many", { count });
+  }
+
+  return formatMessage(
+    locale,
+    count === 1 ? "atif_images_omitted_one" : "atif_images_omitted_many",
+    {
+      count,
+    },
+  );
 }
 
 export function formatEditCount(locale: SupportedLocale, count: number): string {

--- a/apps/ui/src/lib/session-export.ts
+++ b/apps/ui/src/lib/session-export.ts
@@ -1,0 +1,51 @@
+// Session export download flow shared by session lists.
+//
+// Decisions:
+// - ATIF limit signals are user-facing: 413 (document over the server size
+//   cap) becomes an error toast and `X-Atif-Images-Omitted` becomes an info
+//   toast. Everything else keeps the pre-ATIF behavior (console.error only),
+//   so the flow degrades gracefully against servers without ATIF support.
+
+import { exportSession, type SessionExportFormat } from "@/lib/api/sessions";
+import { ApiError } from "@/lib/api/client";
+import { formatAtifImagesOmitted, formatMessage, type SupportedLocale } from "@/lib/i18n";
+
+export interface SessionExportToast {
+  title: string;
+  body: string;
+}
+
+/**
+ * Download a session export and surface ATIF limit alerts via `notify`.
+ * `notify` is optional so callers outside the notifications provider keep the
+ * plain download behavior.
+ */
+export async function downloadSessionExport(
+  sessionId: string,
+  format: SessionExportFormat,
+  locale: SupportedLocale,
+  notify?: (toast: SessionExportToast) => void,
+): Promise<void> {
+  try {
+    const result = await exportSession(sessionId, format);
+    if (format === "atif" && result.imagesOmitted > 0) {
+      notify?.({
+        title: formatMessage(locale, "atif_export_title"),
+        body: formatAtifImagesOmitted(locale, result.imagesOmitted),
+      });
+    }
+  } catch (error) {
+    if (format === "atif" && error instanceof ApiError && error.status === 413) {
+      // ApiError falls back to "API Error: <status> <statusText>" when the
+      // response body had no parseable message; prefer the localized fallback.
+      const genericMessage = `API Error: ${error.status} ${error.statusText}`;
+      const body =
+        error.message && error.message !== genericMessage
+          ? error.message
+          : formatMessage(locale, "atif_export_too_large");
+      notify?.({ title: formatMessage(locale, "atif_export_failed_title"), body });
+      return;
+    }
+    console.error("Failed to export session:", error);
+  }
+}

--- a/apps/ui/src/providers/notifications-provider.tsx
+++ b/apps/ui/src/providers/notifications-provider.tsx
@@ -41,12 +41,23 @@ type NotificationState = {
 
 type ToastNotification = Notification & { toast_id: string };
 
+export interface LocalToastInput {
+  title: string;
+  body: string;
+}
+
 interface NotificationsContextValue {
   notifications: Notification[];
   unviewedCount: number;
   isEnabled: boolean;
   markViewed: (notificationId: string) => Promise<void>;
   openNotification: (notification: Notification) => void;
+  /**
+   * Show a client-local toast on the shared toast surface. Local toasts are
+   * ephemeral: they never enter the durable notification list or bell count,
+   * and never call the server.
+   */
+  notify: (input: LocalToastInput) => void;
 }
 
 const NotificationsContext = createContext<NotificationsContextValue | undefined>(undefined);
@@ -187,6 +198,29 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       setToastQueue((prev) => prev.filter((item) => item.toast_id !== toast_id));
     }, 5000);
   }, []);
+
+  const localToastSeqRef = useRef(0);
+  const notify = useCallback(
+    (input: LocalToastInput) => {
+      localToastSeqRef.current += 1;
+      const now = new Date().toISOString();
+      // viewed_at is pre-set so a click never triggers markViewed (there is no
+      // server-side notification behind a local toast), and href is absent so
+      // the click is a no-op beyond dismissing.
+      enqueueToast({
+        id: `local-${localToastSeqRef.current}`,
+        kind: "local",
+        title: input.title,
+        body: input.body,
+        payload: {},
+        occurrence_count: 1,
+        viewed_at: now,
+        created_at: now,
+        updated_at: now,
+      });
+    },
+    [enqueueToast],
+  );
 
   const markViewed = useCallback(async (notificationId: string) => {
     setState((prev) => updateViewedInState(prev, notificationId));
@@ -335,8 +369,9 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       isEnabled,
       markViewed,
       openNotification,
+      notify,
     }),
-    [isEnabled, markViewed, notifications, openNotification, unviewedCount],
+    [isEnabled, markViewed, notifications, notify, openNotification, unviewedCount],
   );
 
   return (

--- a/specs/session-export.md
+++ b/specs/session-export.md
@@ -54,5 +54,12 @@ Same as `GET /v1/sessions/{session_id}` — requires `SESSION_VIEW`.
 
 ## UI
 
-Download button on the `SessionCard` component (sessions list page). Icon: `Download` from lucide-react.
-Clicking triggers a browser download of the JSONL file via `fetch` + blob URL.
+Download menu on the `SessionCard` component (sessions list page). Icon: `Download` from lucide-react.
+The menu offers "Export JSONL" (default, `{session_id}.jsonl`) and "Export ATIF"
+(`{session_id}.atif.json`); both download via `fetch` + blob URL.
+
+ATIF limit alerts surface on the shared toast surface (notifications provider):
+HTTP 413 (document over the server size cap) shows an error toast with the
+server message when parseable, and a non-zero `X-Atif-Images-Omitted` response
+header still downloads but shows an informational toast. Both signals are
+optional — against servers without them the flow behaves like JSONL export.


### PR DESCRIPTION
## What changed
The export affordance on session cards (sessions list page) is now a small dropdown menu with two items: "Export JSONL" (default, unchanged: downloads `{sessionId}.jsonl`) and "Export ATIF" (fetches `?format=atif`, downloads `{sessionId}.atif.json`).

ATIF limit signals from the server are now user-facing on the shared toast surface:
- HTTP 413 (ATIF document over the server size cap) shows an error toast with the server's message when the error body is parseable, otherwise a clear localized fallback.
- A non-zero `X-Atif-Images-Omitted` response header still downloads the document and shows an informational toast ("N image(s) were omitted from the ATIF export", pluralized per locale).

Both signals are optional: against a server without the ATIF sibling PR deployed, absent headers and non-413 errors behave exactly as the existing export flow does today (download, or console-only error). The notifications provider gained a client-local `notify` API that reuses the existing toast surface without touching the durable notification list, bell count, or server. New UI strings are localized in both supported locales (en, uk).

## Why
The API supports `GET /v1/sessions/{id}/export?format=atif` (ATIF-v1.7 trajectory document), but the UI only exposed JSONL export. The ATIF format also has server-side limits (size cap, omitted image parts) that users need to see rather than silently losing data or getting a console-only failure.

## Before / After
Before: single download icon on SessionCard, JSONL only; any export failure was console-only.
After: download icon opens a two-item menu (Export JSONL / Export ATIF). ATIF 413 shows an error toast; omitted-image exports still download and show an info toast. Covered by component/unit tests (9 new tests: menu wiring, atif URL + filename, 413 error toast with body message and with fallback, images-omitted info toast singular/plural, default JSONL path unchanged, non-413 legacy behavior).

## Risk
- Low
- The `onExport` SessionCard prop signature changed to include the format; the sessions list page is its only caller and was updated. The JSONL path and non-ATIF error handling are behavior-identical.

## Security
- Threat categories reviewed: TM-WEB, TM-API, TM-DOS. UI-only change; no new endpoints, auth, or data exposure. The `X-Atif-Images-Omitted` header carries a non-sensitive count and is validated with `parseInt` + finite/positive clamp before display. Server-provided 413 error text is rendered as React text nodes (auto-escaped), so no XSS surface. Export requests keep the same credentialed same-origin fetch as before.
- Findings and resolutions: none. The UI degrades gracefully when the server PR adding the 413/header contract is not deployed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)