### PR TITLE
fix(runtime): default to runtime-safe capabilities

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1260,6 +1260,62 @@ impl CapabilityRegistry {
         Self::with_builtins_for_grade(DeploymentGrade::from_env())
     }
 
+    /// Create a registry with capabilities that are usable in the public
+    /// in-process runtime with its default host services.
+    ///
+    /// This intentionally excludes hosted Everruns product capabilities,
+    /// demos/tests, and capabilities whose tools require optional host backends
+    /// such as `platform_store`, `session_task_registry`, `schedule_store`, SQL
+    /// databases, provider credentials, or knowledge stores. Embedders can
+    /// still opt into those capabilities by supplying an explicit
+    /// [`PlatformDefinition`](crate::PlatformDefinition) with the required
+    /// backends.
+    pub fn runtime_builtins() -> Self {
+        let mut registry = Self::new();
+
+        registry.register(AgentInstructionsCapability);
+        registry.register(HumanIntentCapability);
+        registry.register(NoopCapability);
+        registry.register(CurrentTimeCapability);
+        registry.register(MessageMetadataCapability);
+        registry.register(FileSystemCapability);
+        registry.register(SessionStorageCapability);
+        registry.register(SessionCapability);
+        registry.register(StatelessTodoListCapability);
+        #[cfg(feature = "web-fetch")]
+        registry.register(WebFetchCapability::from_env());
+        registry.register(BashkitShellCapability);
+        registry.register(BtwCapability);
+        registry.register(InfinityContextCapability);
+        registry.register(budgeting::BudgetingCapability);
+        registry.register(SelfBudgetCapability);
+        registry.register(CompactionCapability);
+        registry.register(ErrorDisclosureCapability);
+        registry.register(OpenAiToolSearchCapability::new());
+        registry.register(ClaudeToolSearchCapability::new());
+        registry.register(ToolSearchCapability::new());
+        registry.register(AutoToolSearchCapability::new());
+        registry.register(PromptCachingCapability::new());
+        registry.register(ParallelToolCallsCapability);
+        registry.register(SkillsCapability);
+        registry.register(SystemCommandsCapability);
+        registry.register(tool_output_persistence::ToolOutputPersistenceCapability);
+        registry.register(tool_output_distillation::ToolOutputDistillationCapability);
+        registry.register(LoopDetectionCapability);
+        registry.register(ToolCallRepairCapability);
+        registry.register(PromptCanaryGuardrailCapability);
+        registry.register(GuardrailsCapability);
+        registry.register(user_hooks::UserHooksCapability);
+
+        let internal_flags = crate::InternalFeatureFlags::from_env();
+        if internal_flags.lua {
+            registry.register(LuaCapability);
+            registry.register(LuaCodeModeCapability);
+        }
+
+        registry
+    }
+
     /// Create a registry with built-in capabilities for a specific deployment grade
     ///
     /// Experimental capabilities are included via integration plugins in dev environments.
@@ -3037,6 +3093,49 @@ mod tests {
         ids
     }
 
+    /// Capabilities present in the default in-process runtime registry.
+    fn expected_runtime_builtin_ids() -> BTreeSet<&'static str> {
+        let mut ids = [
+            "agent_instructions",
+            "human_intent",
+            "budgeting",
+            "self_budget",
+            "noop",
+            "current_time",
+            "session_file_system",
+            "session_storage",
+            "session",
+            "stateless_todo_list",
+            "bashkit_shell",
+            "btw",
+            "infinity_context",
+            "compaction",
+            "message_metadata",
+            "openai_tool_search",
+            "claude_tool_search",
+            "tool_search",
+            "auto_tool_search",
+            "prompt_caching",
+            "parallel_tool_calls",
+            "skills",
+            "system_commands",
+            "tool_output_persistence",
+            "tool_output_distillation",
+            "loop_detection",
+            "tool_call_repair",
+            "error_disclosure",
+            "prompt_canary_guardrail",
+            "guardrails",
+            "user_hooks",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+        if cfg!(feature = "web-fetch") {
+            ids.insert("web_fetch");
+        }
+        ids
+    }
+
     /// Full set for dev: base + experimental delegation capabilities.
     fn expected_dev_builtin_ids() -> BTreeSet<&'static str> {
         let mut ids = expected_core_builtin_ids();
@@ -3080,6 +3179,46 @@ mod tests {
         assert!(!registry.has("docker_container"));
         assert!(!registry.has("agent_handoff"));
         assert!(!registry.has("a2a_agent_delegation"));
+    }
+
+    #[test]
+    fn test_capability_registry_runtime_builtins() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_LUA") };
+        let registry = CapabilityRegistry::runtime_builtins();
+        assert_eq!(registry_ids(&registry), expected_runtime_builtin_ids());
+        assert!(registry.has("session_file_system"));
+        #[cfg(feature = "web-fetch")]
+        assert!(registry.has("web_fetch"));
+        assert!(registry.has("bashkit_shell"));
+
+        for platform_only in [
+            "platform_management",
+            "model_scout",
+            "openrouter_workspace",
+            "openrouter_server_tools",
+            "session_tasks",
+            "session_schedule",
+            "subagents",
+            "background_execution",
+            "session_sql_database",
+            "knowledge_base",
+            "knowledge_index",
+            "sample_data",
+            "data_knowledge",
+            "fake_aws",
+            "fake_crm",
+            "fake_financial",
+            "fake_warehouse",
+            "test_math",
+            "test_weather",
+            "research",
+        ] {
+            assert!(
+                !registry.has(platform_only),
+                "`{platform_only}` should not be in the runtime default registry"
+            );
+        }
     }
 
     #[test]

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -66,6 +66,11 @@ no API key. Swap in a real provider (for example
 [`everruns-openai`](https://crates.io/crates/everruns-openai)) to talk to a
 hosted model.
 
+`InProcessRuntimeBuilder::new()` starts with a runtime-safe built-in capability
+registry. If you call `.platform_definition(...)`, that platform becomes
+authoritative; start from `CapabilityRegistry::runtime_builtins()` when you want
+the default runtime catalog plus your own additions.
+
 Runnable examples ship with the crate:
 
 ```text

--- a/crates/runtime/examples/in_process_runtime.rs
+++ b/crates/runtime/examples/in_process_runtime.rs
@@ -9,6 +9,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(TestMathCapability);
 
+    // Supplying a PlatformDefinition replaces the runtime default capability
+    // registry, so register every capability this embedded host will reference.
     let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
 
     // Per-type builders are useful when an embedder needs stable ids or

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,6 +15,11 @@
 //! - reuse runtime-owned host phase execution from durable or server-backed hosts
 //! - map `plan_next_host_turn(...)` onto their own queue, retry, or in-memory host
 //!
+//! `InProcessRuntimeBuilder::new()` starts from a runtime-safe built-in
+//! capability registry. Hosted Everruns product capabilities and capabilities
+//! that require optional host backends can still be enabled by supplying an
+//! explicit [`PlatformDefinition`](everruns_core::PlatformDefinition).
+//!
 //! For a runnable example, see:
 //!
 //! ```text

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -209,7 +209,8 @@ impl Default for InProcessRuntimeBuilder {
 }
 
 impl InProcessRuntimeBuilder {
-    /// Create a builder with built-in capabilities and no implicit LLM driver.
+    /// Create a builder with runtime-safe built-in capabilities and no implicit
+    /// LLM driver.
     ///
     /// Embedders must either:
     /// - call [`Self::llm_sim`] for deterministic local examples/tests, or
@@ -218,7 +219,7 @@ impl InProcessRuntimeBuilder {
     pub fn new() -> Self {
         Self {
             platform_definition: PlatformDefinition::builder()
-                .capability_registry(CapabilityRegistry::with_builtins())
+                .capability_registry(CapabilityRegistry::runtime_builtins())
                 .driver_registry(DriverRegistry::new())
                 .session_file_system_factory(Arc::new(InMemorySessionFileSystemFactory))
                 .build(),

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -105,6 +105,58 @@ fn per_type_builders_accept_explicit_timestamps() {
 }
 
 #[tokio::test]
+async fn default_runtime_uses_runtime_safe_capability_preset() {
+    let runtime = InProcessRuntimeBuilder::new()
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .single_session(|s| {
+            s.harness("time", "You know the current time.")
+                .with_capability("current_time")
+                .agent("time-agent", "Use tools when helpful.")
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let session_id = runtime.default_session_id().expect("default session id");
+    let context = runtime.load_context(session_id).await.unwrap();
+    assert!(
+        context
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "get_current_time"),
+        "default runtime should expose runtime-backed built-in capabilities",
+    );
+
+    let platform_only_runtime = InProcessRuntimeBuilder::new()
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .single_session(|s| {
+            s.harness("platform", "You manage the platform.")
+                .with_capability("platform_management")
+                .agent("platform-agent", "Use tools when helpful.")
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let platform_session_id = platform_only_runtime
+        .default_session_id()
+        .expect("default session id");
+    let platform_context = platform_only_runtime
+        .load_context(platform_session_id)
+        .await
+        .unwrap();
+    assert!(
+        platform_context.resolved_capability_configs.is_empty(),
+        "platform-only capability should not resolve from runtime defaults"
+    );
+    assert!(
+        platform_context.runtime_agent.tools.is_empty(),
+        "unresolved platform-only capability should not contribute tools"
+    );
+}
+
+#[tokio::test]
 async fn runtime_executes_tool_loop_and_persists_messages() {
     let harness_id = "harness_00000000000000000000000000000021".parse().unwrap();
     let agent_id = "agent_00000000000000000000000000000021".parse().unwrap();

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -131,6 +131,12 @@ fn platform() -> PlatformDefinition {
 
 When you build from scratch, only the components you register exist. Seeded providers, models, harnesses, and agents are filtered against that definition.
 
+For in-process hosts, `InProcessRuntimeBuilder::new()` already starts with
+`CapabilityRegistry::runtime_builtins()`. Supplying a custom
+`PlatformDefinition` replaces that default. Use `runtime_builtins()` as your
+base registry when you want the standard embedded-runtime capability surface and
+then add or remove capabilities for your host.
+
 ## Custom LLM Provider Drivers
 
 Built-in providers are registered with their crate's `register_driver`

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -68,6 +68,32 @@ let runtime = InProcessRuntimeBuilder::new()
 
 The quickstart uses the built-in `llmsim` driver for deterministic, offline runs. To talk to a live provider, register that provider's driver and point `default_model` at it — see [Talk to OpenAI](#talk-to-openai) below.
 
+## Capability registry
+
+`InProcessRuntimeBuilder::new()` includes a runtime-safe built-in capability
+registry by default. That registry contains capabilities that work with the
+runtime's in-process services, such as session files, session storage, egress,
+prompt helpers, guardrails, and tool-search helpers.
+
+When you call `.platform_definition(platform)`, the supplied platform replaces
+that default. Use `CapabilityRegistry::runtime_builtins()` as the starting point
+when you want the default runtime catalog plus custom capabilities:
+
+```rust
+use everruns_core::{CapabilityRegistry, DriverRegistry, PlatformDefinition};
+
+let mut capabilities = CapabilityRegistry::runtime_builtins();
+capabilities.register(MyCapability);
+
+let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+```
+
+Hosted Everruns product capabilities and capabilities that require optional host
+services, such as platform management, session tasks, schedules, session SQL
+databases, provider credentials, or knowledge stores, are not in the runtime
+default. Register them explicitly only when your host provides the required
+services.
+
 ## Talk to OpenAI
 
 A real provider needs two things, not one: the provider's **driver must be registered** in the `DriverRegistry`, *and* `default_model` must select it. Setting `default_model` alone is not enough — the runtime resolves `provider_type` against the registry, so an unregistered driver fails at turn time.

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -911,10 +911,23 @@ See `crates/server/migrations/001_base_schema.sql` for the `agent_capabilities` 
 1. Implement the `Capability` trait (see `crates/core/src/capabilities/mod.rs` for trait definition)
 2. Declare `pub const <SCREAMING_SNAKE>_CAPABILITY_ID: &str = "<id>";` in the module and return it from `fn id()` (see **Built-in Capability ID Constants** above)
 3. Re-export the constant and the struct from `crates/core/src/capabilities/mod.rs`
-4. Register in `CapabilityRegistry::with_builtins()` (same file)
+4. Choose the registry preset deliberately:
+   - Register in `CapabilityRegistry::runtime_builtins()` only when the capability is usable with `everruns-runtime`'s default in-process host services.
+   - Register in `CapabilityRegistry::with_builtins_for_grade()` when the capability is part of the hosted Everruns platform catalog, a product/demo capability, or requires optional host services not present in the runtime default.
+   - Register in both only when both statements are true.
+   - Use integration inventory registration for external integration crates that should appear only when their crate is linked.
 5. Add tool implementations if needed (implement `Tool` trait from `crates/core/src/tools.rs`)
 6. No database migration required — capability ID validated at runtime
-7. Update documentation at `docs/capabilities/` — add a page for the new capability and update the overview table in `docs/capabilities/index.md`
+7. Add or update registry tests that prove the capability appears in the intended preset(s) and is absent from inappropriate preset(s)
+8. Update documentation at `docs/capabilities/` — add a page for the new capability and update the overview table in `docs/capabilities/index.md`
+
+Runtime-default eligibility is based on host services, not risk level. A high-risk
+capability may be runtime-usable when it runs entirely through runtime-provided
+services such as the session filesystem or egress service. A low-risk capability
+must still stay out of `runtime_builtins()` if its tools need optional services
+such as `platform_store`, `session_task_registry`, `schedule_store`, session SQL
+databases, provider credentials, or knowledge stores. See `specs/runtime.md` for
+the embedded runtime contract.
 
 ### Capability Mount Points
 

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -289,6 +289,16 @@ embedded-turn coverage.
 
 Capabilities continue to live in `everruns-core`.
 
+`InProcessRuntimeBuilder::new()` starts from
+`CapabilityRegistry::runtime_builtins()`, a curated registry containing only
+capabilities usable with the runtime's default in-process host services. The
+default registry intentionally excludes hosted Everruns product capabilities,
+demos/tests, and capabilities whose tools require optional host backends such as
+`platform_store`, `session_task_registry`, `schedule_store`, SQL databases,
+provider credentials, or knowledge stores. Embedders that provide those
+services can still build an explicit `PlatformDefinition` and register the
+larger platform capability set or any selected capability manually.
+
 `everruns-runtime` must provide the supporting stores those capabilities expect
 through `ToolContext`, including:
 


### PR DESCRIPTION
## What changed
`everruns-runtime` now starts from a curated runtime-safe capability registry instead of the full hosted Everruns built-in catalog. The default runtime keeps capabilities that are usable with the in-process host services and excludes hosted product/demo capabilities plus tools that need optional platform backends such as platform management, session tasks, schedules, session SQL databases, provider credentials, and knowledge stores.

Docs, examples, and specs now describe how to place future capabilities in the runtime preset, hosted platform catalog, integration inventory, or multiple registries.

## Why
The embedded runtime should not expose capabilities that cannot execute with its default host services. This makes runtime behavior easier to reason about and prevents hosted-only capabilities from appearing to be available in a runtime-only embed.

## Before / After
Before: `InProcessRuntimeBuilder::new()` used `CapabilityRegistry::with_builtins()`, so a harness could name hosted-only capabilities such as `platform_management` even though the default runtime did not provide their required platform services.

After: the default runtime uses `CapabilityRegistry::runtime_builtins()`. Local proof:

```text
cargo test -p everruns-runtime default_runtime_uses_runtime_safe_capability_preset
# platform_management does not resolve or contribute tools under the default runtime
```

Runtime smoke proof:

```text
cargo run -p everruns-runtime --example in_process_runtime
success: true
iterations: 2
response: Let me calculate that.
```

## Risk
Medium. This intentionally tightens the default embedded runtime catalog. Embedders that relied on the default runtime builder while referencing hosted-only capabilities will need to supply an explicit `PlatformDefinition` with the required capabilities and host services.

## Security
- Threat categories reviewed: TM-TOOL, TM-AGENT, TM-BASH, TM-FS, TM-DOS, TM-LLM.
- Findings and resolutions: no new tool execution path, persistence path, credential flow, or outbound network path is added. The change narrows the default runtime registry; existing mitigations for registered runtime tools remain unchanged.

## Follow-ups
Physical extraction of hosted-only capabilities into a separate crate remains possible later; this PR establishes the runtime/hosted placement contract first and prevents default runtime exposure now.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo test -p everruns-core test_capability_registry_runtime_builtins`
- `cargo test -p everruns-runtime`
- `cargo run -p everruns-runtime --example in_process_runtime`
- `npm exec --package=pnpm@10.33.0 -- pnpm run check`
- `npm exec --package=pnpm@10.33.0 -- pnpm run build`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`