### PR TITLE
feat(core): add subagent progress schema

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -324,7 +324,8 @@ pub use stateless_todo_list::{
     STATELESS_TODO_LIST_CAPABILITY_ID, StatelessTodoListCapability, WriteTodosTool,
 };
 pub use subagents::{
-    ReportResultTool, SUBAGENTS_CAPABILITY_ID, SpawnSubagentAsAgentTool, SubagentCapability,
+    ReportProgressTool, ReportResultTool, SUBAGENTS_CAPABILITY_ID, SpawnSubagentAsAgentTool,
+    SubagentCapability, report_progress_tool_for_child_session,
     report_result_tool_for_child_session,
 };
 // Blueprint types are exported directly from the trait definitions above
@@ -1885,6 +1886,10 @@ impl Tool for UnifiedSpawnAgentTool {
                 "result_schema": {
                     "type": "object",
                     "description": "Subagent-only JSON Schema for the child agent's final structured result. When set, the child must call report_result before the task can succeed."
+                },
+                "message_schema": {
+                    "type": "object",
+                    "description": "Subagent-only JSON Schema for structured progress messages. When set, the child receives report_progress and valid calls post data messages to the task thread."
                 },
                 "public_context": {
                     "type": "object",

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -22,9 +22,10 @@
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 use crate::platform_store::PlatformStore;
 use crate::session_task::{
-    CreateSessionTask, SessionTask, SessionTaskFilter, SessionTaskState, SessionTaskUpdate,
-    TASK_KIND_SUBAGENT, TaskError, TaskExecutor, TaskExecutorPlugin, TaskLinks, TaskMessage,
-    TaskWakePolicy, task_message_text, task_result_path,
+    CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskState,
+    SessionTaskUpdate, TASK_KIND_SUBAGENT, TaskError, TaskExecutor, TaskExecutorPlugin, TaskLinks,
+    TaskMessage, TaskMessageDirection, TaskMessagePart, TaskWakePolicy, task_message_text,
+    task_result_path,
 };
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
@@ -87,6 +88,7 @@ impl Capability for SubagentCapability {
 
 const SUBAGENT_SYSTEM_PROMPT: &str = "Spawn subagents only for independent workstreams that benefit from parallelism or a separate context window; do not delegate immediate sequential steps. Spawns are background by default: you get a task_id, keep working, and are notified on completion (monitor with get_task/wait_task). Use mode \"foreground\" only when you cannot proceed without the result. No nested subagents. Use blueprints for specialist agents with their own tools and model.";
 const RESULT_SCHEMA_SPEC_KEY: &str = "result_schema";
+const MESSAGE_SCHEMA_SPEC_KEY: &str = "message_schema";
 
 /// Execution mode for subagent delegation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,19 +154,33 @@ fn declared_result_schema(task: &SessionTask) -> Option<&Value> {
         .filter(|schema| schema.is_object())
 }
 
-fn normalize_result_schema(arguments: &Value) -> Result<Option<Value>, ToolExecutionResult> {
-    let Some(schema) = arguments
-        .get(RESULT_SCHEMA_SPEC_KEY)
-        .filter(|v| !v.is_null())
-    else {
+fn declared_message_schema(task: &SessionTask) -> Option<&Value> {
+    task.spec
+        .get(MESSAGE_SCHEMA_SPEC_KEY)
+        .filter(|schema| schema.is_object())
+}
+
+fn normalize_optional_schema(
+    arguments: &Value,
+    key: &str,
+) -> Result<Option<Value>, ToolExecutionResult> {
+    let Some(schema) = arguments.get(key).filter(|v| !v.is_null()) else {
         return Ok(None);
     };
     if !schema.is_object() {
-        return Err(ToolExecutionResult::tool_error(
-            "result_schema must be a JSON Schema object when provided.",
-        ));
+        return Err(ToolExecutionResult::tool_error(format!(
+            "{key} must be a JSON Schema object when provided.",
+        )));
     }
     Ok(Some(schema.clone()))
+}
+
+fn normalize_result_schema(arguments: &Value) -> Result<Option<Value>, ToolExecutionResult> {
+    normalize_optional_schema(arguments, RESULT_SCHEMA_SPEC_KEY)
+}
+
+fn normalize_message_schema(arguments: &Value) -> Result<Option<Value>, ToolExecutionResult> {
+    normalize_optional_schema(arguments, MESSAGE_SCHEMA_SPEC_KEY)
 }
 
 fn json_schema_type_matches(expected: &str, value: &Value) -> bool {
@@ -180,12 +196,7 @@ fn json_schema_type_matches(expected: &str, value: &Value) -> bool {
     }
 }
 
-fn validate_against_result_schema(
-    schema: &Value,
-    value: &Value,
-    path: &str,
-    errors: &mut Vec<String>,
-) {
+fn validate_against_schema(schema: &Value, value: &Value, path: &str, errors: &mut Vec<String>) {
     if let Some(enum_values) = schema.get("enum").and_then(Value::as_array)
         && !enum_values.iter().any(|candidate| candidate == value)
     {
@@ -235,7 +246,7 @@ fn validate_against_result_schema(
 
         for (key, property_schema) in properties {
             if let Some(property_value) = object.get(key) {
-                validate_against_result_schema(
+                validate_against_schema(
                     property_schema,
                     property_value,
                     &format!("{path}.{key}"),
@@ -247,14 +258,14 @@ fn validate_against_result_schema(
 
     if let (Some(array), Some(item_schema)) = (value.as_array(), schema.get("items")) {
         for (index, item) in array.iter().enumerate() {
-            validate_against_result_schema(item_schema, item, &format!("{path}[{index}]"), errors);
+            validate_against_schema(item_schema, item, &format!("{path}[{index}]"), errors);
         }
     }
 }
 
-fn result_schema_validation_errors(schema: &Value, value: &Value) -> Vec<String> {
+fn schema_validation_errors(schema: &Value, value: &Value) -> Vec<String> {
     let mut errors = Vec::new();
-    validate_against_result_schema(schema, value, "$", &mut errors);
+    validate_against_schema(schema, value, "$", &mut errors);
     errors
 }
 
@@ -416,7 +427,7 @@ impl Tool for ReportResultTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let errors = result_schema_validation_errors(&self.result_schema, &arguments);
+        let errors = schema_validation_errors(&self.result_schema, &arguments);
         if !errors.is_empty() {
             return ToolExecutionResult::tool_error(format!(
                 "report_result arguments do not match result_schema: {}",
@@ -473,6 +484,95 @@ impl Tool for ReportResultTool {
     }
 }
 
+/// Context-bound tool injected into a child subagent when its parent task
+/// declares `message_schema`.
+pub struct ReportProgressTool {
+    parent_session_id: SessionId,
+    task_id: String,
+    message_schema: Value,
+}
+
+impl ReportProgressTool {
+    pub fn new(parent_session_id: SessionId, task_id: String, message_schema: Value) -> Self {
+        Self {
+            parent_session_id,
+            task_id,
+            message_schema,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ReportProgressTool {
+    fn name(&self) -> &str {
+        "report_progress"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Report Progress")
+    }
+
+    fn description(&self) -> &str {
+        "Post a structured progress message for this subagent task. The call arguments must match the declared message schema."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        self.message_schema.clone()
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "report_progress requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let errors = schema_validation_errors(&self.message_schema, &arguments);
+        if !errors.is_empty() {
+            return ToolExecutionResult::tool_error(format!(
+                "report_progress arguments do not match message_schema: {}",
+                errors.join("; ")
+            ));
+        }
+
+        let Some(registry) = context.session_task_registry.as_ref() else {
+            return ToolExecutionResult::tool_error(
+                "report_progress requires session_task_registry context",
+            );
+        };
+
+        let message = NewTaskMessage {
+            direction: TaskMessageDirection::Outbound,
+            content: vec![TaskMessagePart::Data {
+                data: arguments.clone(),
+            }],
+            in_reply_to: None,
+            expected_attempt: None,
+        };
+        let stored = match registry
+            .record_message(self.parent_session_id, &self.task_id, message)
+            .await
+        {
+            Ok(stored) => stored,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+
+        ToolExecutionResult::success(json!({
+            "status": "posted",
+            "task_id": self.task_id,
+            "message_id": stored.id,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
 pub async fn report_result_tool_for_child_session(
     child_session_id: SessionId,
     session_store: &dyn SessionStore,
@@ -511,6 +611,45 @@ pub async fn report_result_tool_for_child_session(
     Ok(Some(ReportResultTool::new(
         parent_session_id,
         parent.workspace_id,
+        task.id.clone(),
+        schema.clone(),
+    )))
+}
+
+pub async fn report_progress_tool_for_child_session(
+    child_session_id: SessionId,
+    session_store: &dyn SessionStore,
+    task_registry: &dyn crate::session_task::SessionTaskRegistry,
+) -> crate::error::Result<Option<ReportProgressTool>> {
+    let Some(child) = session_store.get_session(child_session_id).await? else {
+        return Ok(None);
+    };
+    let Some(parent_session_id) = child.parent_session_id else {
+        return Ok(None);
+    };
+
+    let tasks = task_registry
+        .list(
+            parent_session_id,
+            Some(&SessionTaskFilter {
+                kind: Some(TASK_KIND_SUBAGENT.to_string()),
+                state: None,
+            }),
+        )
+        .await?;
+
+    let Some(task) = tasks
+        .into_iter()
+        .find(|task| task.links.child_session_id == Some(child_session_id))
+    else {
+        return Ok(None);
+    };
+    let Some(schema) = declared_message_schema(&task) else {
+        return Ok(None);
+    };
+
+    Ok(Some(ReportProgressTool::new(
+        parent_session_id,
         task.id.clone(),
         schema.clone(),
     )))
@@ -587,6 +726,10 @@ impl Tool for SpawnSubagentAsAgentTool {
                 "result_schema": {
                     "type": "object",
                     "description": "Optional JSON Schema for the subagent's final structured result. When set, the child receives report_result and must call it before the task can succeed."
+                },
+                "message_schema": {
+                    "type": "object",
+                    "description": "Optional JSON Schema for structured progress messages. When set, the child receives report_progress and valid calls post data messages to the task thread."
                 }
             },
             "required": ["name", "instructions", "target"],
@@ -679,6 +822,7 @@ async fn spawn_agent_subagent_impl(
         .map(|s| s.to_string());
     let config_param = arguments.get("config").filter(|v| !v.is_null()).cloned();
     let result_schema = normalize_result_schema(&arguments)?;
+    let message_schema = normalize_message_schema(&arguments)?;
 
     // Reject config without blueprint
     if config_param.is_some() && blueprint_param.is_none() {
@@ -864,6 +1008,7 @@ async fn spawn_agent_subagent_impl(
                     &blueprint_param,
                     &config_param,
                     &result_schema,
+                    &message_schema,
                     mode,
                     Some((
                         spawn_store.as_ref(),
@@ -887,6 +1032,7 @@ async fn spawn_agent_subagent_impl(
         &blueprint_param,
         &config_param,
         &result_schema,
+        &message_schema,
         mode,
         None,
     )
@@ -933,6 +1079,7 @@ async fn spawn_create_and_wait(
     blueprint_param: &Option<String>,
     config_param: &Option<Value>,
     result_schema: &Option<Value>,
+    message_schema: &Option<Value>,
     mode: SpawnMode,
     settle_ctx: Option<(
         &dyn crate::traits::SubagentSpawnStore,
@@ -977,6 +1124,11 @@ async fn spawn_create_and_wait(
     {
         spec.insert(RESULT_SCHEMA_SPEC_KEY.to_string(), schema.clone());
     }
+    if let Some(schema) = message_schema
+        && let Some(spec) = task_spec.as_object_mut()
+    {
+        spec.insert(MESSAGE_SCHEMA_SPEC_KEY.to_string(), schema.clone());
+    }
 
     if let Some(ref task_registry) = context.session_task_registry
         && let Ok(created) = task_registry
@@ -991,9 +1143,10 @@ async fn spawn_create_and_wait(
                     child_session_id: Some(child_session.id),
                     ..Default::default()
                 },
-                wake_policy: match mode {
-                    SpawnMode::Background => TaskWakePolicy::OnTerminal,
-                    SpawnMode::Foreground => TaskWakePolicy::Silent,
+                wake_policy: match (mode, message_schema.is_some()) {
+                    (SpawnMode::Background, true) => TaskWakePolicy::OnActivity,
+                    (SpawnMode::Background, false) => TaskWakePolicy::OnTerminal,
+                    (SpawnMode::Foreground, _) => TaskWakePolicy::Silent,
                 },
             })
             .await
@@ -1599,6 +1752,7 @@ mod tests {
         assert!(props.contains_key("blueprint"));
         assert!(props.contains_key("config"));
         assert!(props.contains_key("result_schema"));
+        assert!(props.contains_key("message_schema"));
         assert!(!required.contains(&json!("blueprint")));
         assert!(!required.contains(&json!("config")));
         assert_eq!(
@@ -2062,6 +2216,125 @@ mod tests {
             panic!("expected validation error, got {result:?}");
         };
         assert!(message.contains("$.answer is required"), "got: {message}");
+        assert!(message.contains("$.extra is not allowed"), "got: {message}");
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_subagent_stores_message_schema_and_wakes_on_activity() {
+        let store = Arc::new(MockPlatformStore::new());
+        *store.wait_for_idle_status.lock().unwrap() = "completed".to_string();
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let context = spawn_context(&store, Some(registry.clone()));
+
+        let result = SpawnSubagentAsAgentTool
+            .execute_with_context(
+                json!({
+                    "name": "Runner",
+                    "instructions": "go",
+                    "target": {"type": "subagent"},
+                    "message_schema": {
+                        "type": "object",
+                        "properties": {"step": {"type": "string"}},
+                        "required": ["step"],
+                        "additionalProperties": false
+                    }
+                }),
+                &context,
+            )
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        let task_id = value["task_id"].as_str().expect("task_id");
+        let task = registry
+            .get(context.session_id, task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.spec["message_schema"]["required"], json!(["step"]));
+        assert_eq!(task.wake_policy, TaskWakePolicy::OnActivity);
+    }
+
+    #[tokio::test]
+    async fn report_progress_posts_structured_outbound_message() {
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let parent_session_id = crate::typed_id::SessionId::new();
+        let task = registry
+            .create(CreateSessionTask {
+                session_id: parent_session_id,
+                id: None,
+                kind: TASK_KIND_SUBAGENT.to_string(),
+                display_name: "Runner".to_string(),
+                spec: json!({
+                    "message_schema": {
+                        "type": "object",
+                        "properties": {"step": {"type": "string"}},
+                        "required": ["step"],
+                        "additionalProperties": false
+                    }
+                }),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::OnActivity,
+            })
+            .await
+            .unwrap();
+
+        let tool = ReportProgressTool::new(
+            parent_session_id,
+            task.id.clone(),
+            task.spec["message_schema"].clone(),
+        );
+        let mut context = ToolContext::new(crate::typed_id::SessionId::new());
+        context.session_task_registry = Some(registry.clone());
+
+        let result = tool
+            .execute_with_context(json!({"step": "tests-running"}), &context)
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        assert_eq!(value["status"], "posted");
+
+        let messages = registry
+            .list_messages(parent_session_id, &task.id, None, None)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].direction, TaskMessageDirection::Outbound);
+        assert_eq!(
+            messages[0].content,
+            vec![TaskMessagePart::Data {
+                data: json!({"step": "tests-running"})
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn report_progress_rejects_invalid_message_schema_payload() {
+        let tool = ReportProgressTool::new(
+            crate::typed_id::SessionId::new(),
+            "task_test".to_string(),
+            json!({
+                "type": "object",
+                "properties": {"step": {"type": "string"}},
+                "required": ["step"],
+                "additionalProperties": false
+            }),
+        );
+        let result = tool
+            .execute_with_context(
+                json!({"step": 42, "extra": true}),
+                &ToolContext::new(SessionId::new()),
+            )
+            .await;
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("expected validation error, got {result:?}");
+        };
+        assert!(
+            message.contains("$.step has the wrong JSON type"),
+            "got: {message}"
+        );
         assert!(message.contains("$.extra is not allowed"), "got: {message}");
     }
 

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -8,7 +8,8 @@ use everruns_core::atoms::{
     ReasonInput, ReasonResult,
 };
 use everruns_core::capabilities::{
-    SystemPromptContext, collect_capabilities_with_configs, report_result_tool_for_child_session,
+    SystemPromptContext, collect_capabilities_with_configs, report_progress_tool_for_child_session,
+    report_result_tool_for_child_session,
 };
 use everruns_core::events::{
     EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
@@ -1210,6 +1211,20 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
         .await?
     {
         tool_registry.register_boxed(Box::new(tool.with_file_store(adapter.file_store())));
+    }
+    if input
+        .tool_definitions
+        .iter()
+        .any(|definition| definition.name() == "report_progress")
+        && let Some(registry) = adapter.session_task_registry()
+        && let Some(tool) = report_progress_tool_for_child_session(
+            input.context.session_id,
+            adapter.session_store(org_id).as_ref(),
+            registry.as_ref(),
+        )
+        .await?
+    {
+        tool_registry.register_boxed(Box::new(tool));
     }
 
     // Register the session's MCP tools as first-class registry tools, so they

--- a/crates/server/src/storage/session_task_store.rs
+++ b/crates/server/src/storage/session_task_store.rs
@@ -188,6 +188,11 @@ impl DbSessionTaskRegistry {
         if task.wake_policy != TaskWakePolicy::OnActivity {
             return;
         }
+        let message_text = if message_text.trim().is_empty() {
+            "structured progress update"
+        } else {
+            message_text
+        };
         let text = format!(
             "Task \"{}\" ({}) sent a message: {}",
             task.display_name, task.id, message_text
@@ -445,7 +450,9 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::session_task::{TaskInputRequest, TaskLinks, TaskWakePolicy};
+    use everruns_core::session_task::{
+        TaskInputRequest, TaskLinks, TaskMessagePart, TaskWakePolicy,
+    };
     use std::sync::Mutex;
 
     // -------------------------------------------------------------------------
@@ -915,6 +922,26 @@ mod tests {
         assert_eq!(calls.len(), 1, "Should wake on outbound message");
         assert!(calls[0].1.contains("task says hi"));
 
+        // Data-only outbound messages still get a readable wake prompt.
+        registry
+            .record_message(
+                session_id,
+                &task.id,
+                NewTaskMessage {
+                    direction: TaskMessageDirection::Outbound,
+                    content: vec![TaskMessagePart::Data {
+                        data: serde_json::json!({"step": "halfway"}),
+                    }],
+                    in_reply_to: None,
+                    expected_attempt: None,
+                },
+            )
+            .await
+            .unwrap();
+        let calls = waker.recorded();
+        assert_eq!(calls.len(), 2, "Should wake on data-only outbound message");
+        assert!(calls[1].1.contains("structured progress update"));
+
         // Awaiting input: another wake.
         registry
             .update(
@@ -932,8 +959,8 @@ mod tests {
             .await
             .unwrap();
         let calls = waker.recorded();
-        assert_eq!(calls.len(), 2, "Should wake on awaiting_input transition");
-        assert!(calls[1].1.contains("Approve?"));
+        assert_eq!(calls.len(), 3, "Should wake on awaiting_input transition");
+        assert!(calls[2].1.contains("Approve?"));
 
         // Second awaiting_input update (idempotent input_request churn from
         // polling): no extra wake because state is already awaiting_input.
@@ -954,7 +981,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             waker.recorded().len(),
-            2,
+            3,
             "No duplicate wake for repeated awaiting_input"
         );
 
@@ -979,7 +1006,7 @@ mod tests {
         let calls = waker.recorded();
         assert_eq!(
             calls.len(),
-            3,
+            4,
             "Should also wake on terminal for OnActivity"
         );
     }

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -3,7 +3,9 @@
 // the public everruns-runtime host contract.
 
 use async_trait::async_trait;
-use everruns_core::capabilities::report_result_tool_for_child_session;
+use everruns_core::capabilities::{
+    report_progress_tool_for_child_session, report_result_tool_for_child_session,
+};
 use everruns_core::error::Result;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver, PaymentAuthority,
@@ -140,6 +142,15 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
             let session_store: Arc<dyn SessionStore> =
                 Arc::new(AdapterSessionStore::new(self.adapters.clone(), org_id));
             if let Some(tool) = report_result_tool_for_child_session(
+                session_id,
+                session_store.as_ref(),
+                registry.as_ref(),
+            )
+            .await?
+            {
+                mcp_tool_definitions.push(tool.to_definition());
+            }
+            if let Some(tool) = report_progress_tool_for_child_session(
                 session_id,
                 session_store.as_ref(),
                 registry.as_ref(),

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -114,6 +114,10 @@ TaskMessage {
 - For subagents the channel carries only cross-boundary messages — the child
   transcript is not mirrored; `links.child_session_id` points at the full
   conversation.
+- Schema-bound subagents can post structured progress with a child-only
+  `report_progress` tool. Valid calls append outbound messages containing a
+  single `data` part; invalid payloads return a validation error so the child
+  can retry.
 
 ## Contracts
 
@@ -205,6 +209,11 @@ to `result_path`, and updates the task record. If a schema-bound subagent
 reaches a successful terminal child status without a recorded `result_path`, the
 task settles as `failed` with `error.kind = "no_result"`. Tasks without
 `spec.result_schema` keep their existing summary-only behavior.
+
+Subagent tasks may also declare `spec.message_schema` as a JSON Schema. That
+schema injects a child-only `report_progress` tool; valid calls are recorded as
+outbound task messages with `data` content, and background tasks use
+`wake_policy: on_activity` so those messages wake the parent session.
 
 ### Retention (TTL)
 

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -101,6 +101,7 @@ The retired direct creation entry point is no longer advertised to models.
 | `blueprint` | string | No | Optional blueprint ID for a specialist child agent. |
 | `config` | object | No | Blueprint-specific configuration. Only valid with `blueprint`. |
 | `result_schema` | object | No | JSON Schema for the child session's final machine result. |
+| `message_schema` | object | No | JSON Schema for structured progress messages from the child session. |
 
 **Returns (background):** `task_id` and `status: "running"` immediately; the final result lands on the task record (`summary`) and the parent is woken on the terminal transition.
 
@@ -115,6 +116,13 @@ successful terminal status without reporting the result settles the task as
 JSON object inline; without `result_schema`, foreground spawns keep returning
 the last assistant message.
 
+When `message_schema` is present, the child session receives a
+`report_progress` tool whose parameters are the declared schema. A valid
+`report_progress` call appends an outbound task message with a `data` part to
+the parent task's message thread. Background subagent tasks with
+`message_schema` use `wake_policy: on_activity` so progress messages wake the
+parent; tasks without `message_schema` keep completion-only wake-ups.
+
 **Behavior (both modes):**
 1. Creates child session with `parent_session_id` set to current session
 2. Inherits the parent session locale when present
@@ -128,7 +136,7 @@ the last assistant message.
 
 **Background:**
 4. Detaches a watcher (same pattern as `spawn_background` runs) and returns immediately; the watcher sends `instructions` as the first user message — deferred so local hosts, where `send_message` runs the child turn synchronously, do not block the spawn call
-5. The task is created with `wake_policy: on_terminal`; the watcher heartbeats the task registry (attempt-fenced) so the session task reaper can fail an orphaned watcher after worker loss
+5. The task is created with `wake_policy: on_terminal`, or `on_activity` when `message_schema` is present; the watcher heartbeats the task registry (attempt-fenced) so the session task reaper can fail an orphaned watcher after worker loss
 6. The watcher waits in slices until the child reaches a terminal turn status (overall cap 6 h), then settles the task and the durable spawn handle; the registry-level wake policy delivers the completion message to the parent (specs/session-tasks.md, Wake-ups)
 7. Local/embedded hosts (everruns-runtime) may report a bare `idle` after their synchronous turn — the watcher settles it as `completed`; hosted adapters never return bare `idle`
 8. `SubagentTaskExecutor::reconcile` (invoked from `wait_task`'s poll loop) probes the child's terminal turn status and settles the task if the watcher died, so `wait_task` converges even after worker loss


### PR DESCRIPTION
## What changed
Added `message_schema` for `spawn_agent(target.type = "subagent")`. Schema-bound child sessions now receive a child-only `report_progress` tool that validates its arguments and posts structured outbound task messages as `data` parts. Background subagent tasks with `message_schema` wake the parent on activity, and data-only wake messages now have readable fallback text.

## Why
EVE-678 needs deterministic machine-readable subagent progress, not just final summaries or transcript text. This gives parent sessions a typed progress channel while keeping existing subagent behavior unchanged when no schema is provided.

## Before / After
Before: `spawn_agent` supported `result_schema`, but there was no schema-bound progress tool and background subagents only woke on terminal completion.

After:
- `message_schema` is advertised on subagent spawn surfaces.
- Child turns with `message_schema` can call `report_progress`.
- Valid progress payloads append outbound task messages with `data` content.
- Invalid progress payloads return validation errors for retry.
- Background schema-bound progress tasks use `wake_policy: on_activity`.

Evidence:
- `cargo test -p everruns-core capabilities::subagents --all-features`
- `cargo test -p everruns-server storage::session_task_store::tests::on_activity_wakes_on_awaiting_input_and_outbound_message --all-features`
- `cargo fmt --all --check`
- `cargo check -p everruns-runtime -p everruns-worker --all-features`
- `cargo clippy -p everruns-core -p everruns-runtime -p everruns-worker -p everruns-server --all-targets --all-features -- -D warnings`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push` after rebase onto `origin/main`
- Full-stack smoke with `PORT_PREFIX=273 just start-dev --no-watch` through Caddy: `/health` 200, `/api-doc/openapi.json` 200, `/dashboard` 200, `/api/v1/capabilities` shows `subagents` and `session_tasks` available.

## Risk
- Medium
- Touches model-visible tool schemas and child-session tool injection. Existing callers without `message_schema` keep the old completion-only behavior; validation uses the same bounded JSON Schema subset as `report_result`.

## Security
- Threat categories reviewed: TM-TOOL, TM-TENANT, TM-API, TM-DOS.
- Findings and resolutions: `report_progress` is only injected for child sessions linked to a parent subagent task with `spec.message_schema`; the tool records messages against the captured parent session/task, not caller-supplied ids. Payloads are schema-validated before persistence. No new external input surface, secrets, filesystem path, SQL query, or network call was introduced. No threat-model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
