### PR TITLE
feat(sessions): denormalize root_session_id for delegation trees

### DIFF
--- a/crates/server/migrations/094_root_session_id.sql
+++ b/crates/server/migrations/094_root_session_id.sql
@@ -1,0 +1,57 @@
+-- Denormalize `root_session_id` onto `sessions` and `session_tasks`.
+--
+-- EVE-680 (governed subagent nesting) makes a delegation tree — coordinator →
+-- area owner → worker — a first-class object: the whole tree shares one root
+-- session, which (in later PRs) owns the shared budget pool and anchors
+-- tree-level observability. This migration lands only the denormalized column
+-- and its backfill; depth caps, breadth caps, and the shared budget arrive in
+-- follow-up PRs.
+--
+-- Semantics: a top-level session (`parent_session_id IS NULL`) is its own root;
+-- a child (subagent) session inherits its parent's root. Denormalizing the root
+-- turns "give me the whole tree" into one indexed lookup instead of a per-row
+-- walk up `parent_session_id`. `session_tasks.root_session_id` mirrors the root
+-- of the task's owning session so `GET /v1/tasks?root_session_id=…` filters a
+-- whole tree's work with a local column and no join.
+--
+-- The column is a self-referential FK with ON DELETE CASCADE, matching
+-- `parent_session_id` (007_v0.8.6): deleting a root already cascades the subtree
+-- via the parent chain, so the denormalized pointer never dangles.
+
+ALTER TABLE sessions
+    ADD COLUMN root_session_id UUID REFERENCES sessions(id) ON DELETE CASCADE;
+
+ALTER TABLE session_tasks
+    ADD COLUMN root_session_id UUID;
+
+-- Backfill sessions: walk each session's parent chain to its top-level ancestor.
+-- Anchored at NULL-parent roots (root_session_id = self), then propagated down.
+WITH RECURSIVE session_roots AS (
+    SELECT id, id AS root_id
+    FROM sessions
+    WHERE parent_session_id IS NULL
+  UNION ALL
+    SELECT s.id, r.root_id
+    FROM sessions s
+    JOIN session_roots r ON s.parent_session_id = r.id
+)
+UPDATE sessions s
+SET root_session_id = session_roots.root_id
+FROM session_roots
+WHERE session_roots.id = s.id;
+
+-- Any session not reachable from a NULL-parent root (e.g. a parent row already
+-- gone) falls back to being its own root, so the column is never NULL after
+-- backfill for existing rows.
+UPDATE sessions
+SET root_session_id = id
+WHERE root_session_id IS NULL;
+
+-- Backfill tasks from their owning session's (now-populated) root.
+UPDATE session_tasks t
+SET root_session_id = s.root_session_id
+FROM sessions s
+WHERE s.id = t.session_id;
+
+CREATE INDEX sessions_root_session_id_idx ON sessions (root_session_id);
+CREATE INDEX session_tasks_root_session_id_idx ON session_tasks (root_session_id);

--- a/crates/server/src/api/session_tasks.rs
+++ b/crates/server/src/api/session_tasks.rs
@@ -77,6 +77,7 @@ pub struct ListOrgTasksQuery {
     pub state: Option<String>,
     pub kind: Option<String>,
     pub created_after: Option<String>,
+    pub root_session_id: Option<String>,
     pub limit: Option<u32>,
 }
 
@@ -88,6 +89,7 @@ pub struct ListOrgTasksQuery {
         ("state" = Option<String>, Query, description = "Filter by state"),
         ("kind" = Option<String>, Query, description = "Filter by kind"),
         ("created_after" = Option<String>, Query, description = "Only tasks created at/after this RFC3339 timestamp"),
+        ("root_session_id" = Option<String>, Query, description = "Only tasks whose owning session's delegation-tree root is this session"),
         ("limit" = Option<u32>, Query, description = "Max tasks, newest first (default 100, max 500)"),
     ),
     responses(
@@ -105,6 +107,7 @@ pub async fn list_org_tasks(
             state: query.state,
             kind: query.kind,
             created_after: query.created_after,
+            root_session_id: query.root_session_id,
             limit: query.limit,
         }
         .run(&state.ctx(&org))

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -93,6 +93,11 @@ pub struct ListOrgTasks {
     /// Optional age filter: only tasks created at or after this RFC3339 timestamp.
     #[serde(default)]
     pub created_after: Option<String>,
+    /// Optional delegation-tree filter (EVE-680): only tasks whose owning
+    /// session's root is this session's prefixed public id. Returns a whole
+    /// subagent tree's work in one query.
+    #[serde(default)]
+    pub root_session_id: Option<String>,
     /// Max tasks to return, newest first. Defaults to 100, capped at 500.
     #[serde(default)]
     pub limit: Option<u32>,
@@ -141,6 +146,10 @@ impl Command for ListOrgTasks {
             ),
             None => None,
         };
+        let root_session_id = match self.root_session_id.as_deref().filter(|s| !s.is_empty()) {
+            Some(raw) => Some(q::parse_session_id(raw)?),
+            None => None,
+        };
         let limit = self.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT) as i64;
         let state = state.map(|s| s.to_string());
 
@@ -151,6 +160,7 @@ impl Command for ListOrgTasks {
                 kind.as_deref(),
                 state.as_deref(),
                 created_after,
+                root_session_id,
                 limit,
             )
             .await
@@ -573,9 +583,131 @@ mod tests {
         .id
     }
 
+    /// Create a subagent child session whose `parent_session_id` is `parent`,
+    /// returning its ID. Used to build a delegation tree in tests.
+    async fn create_child_session(
+        db: &Arc<StorageBackend>,
+        parent: everruns_core::SessionId,
+    ) -> everruns_core::SessionId {
+        db.create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            title: Some("child session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: Some(parent),
+            workspace_id: None,
+        })
+        .await
+        .unwrap()
+        .id
+    }
+
     // -------------------------------------------------------------------------
     // ListOrgTasks — cross-session, org-scoped listing (EVE-583)
     // -------------------------------------------------------------------------
+
+    /// EVE-680: a subagent child inherits its parent's `root_session_id`, and
+    /// `ListOrgTasks { root_session_id }` returns exactly one delegation tree's
+    /// tasks — the root's own plus every descendant's — and nothing from a
+    /// sibling tree.
+    #[tokio::test]
+    async fn list_org_tasks_filters_by_root_session() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = test_ctx(db.clone());
+        let registry = q::registry_for_ctx(&ctx);
+
+        // Tree 1: root A → child B (a subagent). B must inherit A as its root.
+        let sess_a = create_session(&db).await;
+        let sess_b = create_child_session(&db, sess_a).await;
+        let child = db
+            .get_session(DEFAULT_ORG_ID, sess_b)
+            .await
+            .unwrap()
+            .expect("child session exists");
+        assert_eq!(
+            child.root_session_id,
+            Some(sess_a),
+            "subagent child must inherit its parent's tree root"
+        );
+        let root = db
+            .get_session(DEFAULT_ORG_ID, sess_a)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            root.root_session_id,
+            Some(sess_a),
+            "a top-level session is its own root"
+        );
+
+        // Tree 2: an independent root C — its tasks must not appear when
+        // filtering on tree 1's root.
+        let sess_c = create_session(&db).await;
+
+        for (sess, name) in [(sess_a, "A-root"), (sess_b, "B-child"), (sess_c, "C-root")] {
+            registry
+                .create(CreateSessionTask {
+                    session_id: sess,
+                    id: None,
+                    kind: TASK_KIND_SUBAGENT.to_string(),
+                    display_name: name.to_string(),
+                    spec: serde_json::json!({}),
+                    state: SessionTaskState::Running,
+                    links: TaskLinks::default(),
+                    wake_policy: TaskWakePolicy::Silent,
+                })
+                .await
+                .unwrap();
+        }
+
+        // Filter on tree 1's root: the root's task and the child's task, never C.
+        let tree1 = ListOrgTasks {
+            root_session_id: Some(sess_a.to_string()),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await
+        .unwrap();
+        let names: std::collections::HashSet<_> =
+            tree1.iter().map(|t| t.display_name.clone()).collect();
+        assert_eq!(
+            names,
+            ["A-root".to_string(), "B-child".to_string()]
+                .into_iter()
+                .collect(),
+            "root filter must return the whole tree (root + descendants) and only that tree"
+        );
+
+        // An invalid session id is a bad request, mirroring other id filters.
+        let bad = ListOrgTasks {
+            root_session_id: Some("not-a-session".to_string()),
+            ..Default::default()
+        }
+        .execute(&ctx)
+        .await;
+        assert!(
+            matches!(bad.unwrap_err().kind, CommandErrorKind::BadRequest(_)),
+            "invalid root_session_id must be a bad request"
+        );
+    }
 
     /// Org-scoped listing must return every task across the caller's org while
     /// never leaking tasks owned by another org, and must honor kind/state/limit

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3352,12 +3352,14 @@ impl StorageBackend {
     /// optional kind/state/age filters and a bounded limit. Org scoping is the
     /// authoritative multitenancy boundary (a semijoin on `sessions.org_id`):
     /// a task is only returned when its owning session belongs to the org.
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_org_session_tasks(
         &self,
         org_id: i64,
         kind: Option<&str>,
         state: Option<&str>,
         created_after: Option<DateTime<Utc>>,
+        root_session_id: Option<SessionId>,
         limit: i64,
     ) -> Result<Vec<SessionTaskRow>> {
         dispatch!(
@@ -3367,6 +3369,7 @@ impl StorageBackend {
             kind,
             state,
             created_after,
+            root_session_id,
             limit
         )
     }

--- a/crates/server/src/storage/memory/session_tasks.rs
+++ b/crates/server/src/storage/memory/session_tasks.rs
@@ -13,7 +13,15 @@ impl InMemoryDatabase {
     /// Insert a task. Idempotent on `id`: when the row already exists it is
     /// returned unchanged and the `bool` is false.
     pub async fn create_session_task(&self, task: &SessionTask) -> Result<(SessionTaskRow, bool)> {
-        let row = SessionTaskRow::from_task(task)?;
+        let mut row = SessionTaskRow::from_task(task)?;
+        // EVE-680: denormalize the owning session's tree root onto the task,
+        // mirroring the Postgres subquery. Read sessions before locking tasks to
+        // keep a consistent lock order.
+        row.root_session_id = self
+            .sessions
+            .read()
+            .get(&task.session_id)
+            .and_then(|s| s.root_session_id);
         let mut tasks = self.session_tasks.write();
         if let Some(existing) = tasks.get(&row.id) {
             // Idempotency is scoped to the owning session: an id that exists
@@ -67,12 +75,14 @@ impl InMemoryDatabase {
     /// PostgreSQL repository: org scoping is the authoritative multitenancy
     /// boundary — a task is only returned when its owning session belongs to
     /// the org.
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_org_session_tasks(
         &self,
         org_id: i64,
         kind: Option<&str>,
         state: Option<&str>,
         created_after: Option<chrono::DateTime<chrono::Utc>>,
+        root_session_id: Option<SessionId>,
         limit: i64,
     ) -> Result<Vec<SessionTaskRow>> {
         // Sessions owned by the org — the multitenancy boundary, mirroring the
@@ -93,6 +103,7 @@ impl InMemoryDatabase {
                     && kind.is_none_or(|k| row.kind == k)
                     && state.is_none_or(|s| row.state == s)
                     && created_after.is_none_or(|c| row.created_at >= c)
+                    && root_session_id.is_none_or(|r| row.root_session_id == Some(r))
             })
             .cloned()
             .collect();
@@ -356,6 +367,7 @@ mod tests {
         let row = SessionTaskRow {
             id: id.to_string(),
             session_id,
+            root_session_id: Some(session_id),
             kind: "background_tool".to_string(),
             display_name: "t".to_string(),
             spec: serde_json::json!({}),

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -45,6 +45,19 @@ impl InMemoryDatabase {
                 },
             );
         }
+        // EVE-680: root of this session's delegation tree. A top-level session
+        // is its own root; a subagent child inherits its parent's root. Mirrors
+        // the Postgres path; the read guard is released before the insert below.
+        let root_session_id = match input.parent_session_id {
+            Some(parent) => self
+                .sessions
+                .read()
+                .get(&parent)
+                .and_then(|p| p.root_session_id)
+                .unwrap_or(parent),
+            None => id,
+        };
+
         let row = SessionRow {
             id,
             org_id: input.org_id,
@@ -83,6 +96,7 @@ impl InMemoryDatabase {
             total_estimated_cost_usd: 0.0,
             total_cost_usd: 0.0,
             parent_session_id: input.parent_session_id,
+            root_session_id: Some(root_session_id),
             forked_from_session_id: None,
             forked_from_sequence: None,
             blueprint_id: input.blueprint_id,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -744,6 +744,12 @@ pub struct SessionRow {
     // -- Subagent nesting fields --
     #[sqlx(default)]
     pub parent_session_id: Option<SessionId>,
+    /// Root of this session's delegation tree (EVE-680). A top-level session is
+    /// its own root; a subagent child inherits its parent's root. Denormalized
+    /// so a whole tree is one indexed query. Set by the storage layer at
+    /// creation; `#[sqlx(default)]` because most SELECTs don't project it.
+    #[sqlx(default)]
+    pub root_session_id: Option<SessionId>,
     // -- Fork lineage fields (specs/forking-sessions.md) --
     #[sqlx(default)]
     pub forked_from_session_id: Option<SessionId>,
@@ -2163,6 +2169,12 @@ pub struct UpsertSessionResourceRow {
 pub struct SessionTaskRow {
     pub id: String,
     pub session_id: SessionId,
+    /// Root of the owning session's delegation tree (EVE-680). Denormalized
+    /// from `sessions.root_session_id` at insert so `GET /v1/tasks` can filter a
+    /// whole tree's work by a local column. DB-only — not part of the core
+    /// `SessionTask`; `#[sqlx(default)]` so queries that omit it still map.
+    #[sqlx(default)]
+    pub root_session_id: Option<SessionId>,
     pub kind: String,
     pub display_name: String,
     pub spec: serde_json::Value,
@@ -2192,6 +2204,9 @@ impl SessionTaskRow {
         Ok(Self {
             id: task.id.clone(),
             session_id: task.session_id,
+            // Populated at the storage insert from the owning session's root;
+            // the core task carries no root, so default to None here.
+            root_session_id: None,
             kind: task.kind.clone(),
             display_name: task.display_name.clone(),
             spec: task.spec.clone(),

--- a/crates/server/src/storage/repositories/session_tasks.rs
+++ b/crates/server/src/storage/repositories/session_tasks.rs
@@ -10,10 +10,10 @@ use anyhow::Result;
 use everruns_core::SessionId;
 use everruns_core::session_task::{SessionTask, SessionTaskUpdate, apply_task_update};
 
-const TASK_COLUMNS: &str = "id, session_id, kind, display_name, spec, state, state_detail, \
-     progress, input_request, cancel_requested_at, summary, result_path, artifacts, error, \
-     attempt, worker_id, heartbeat_at, links, wake_policy, created_at, started_at, finished_at, \
-     updated_at";
+const TASK_COLUMNS: &str = "id, session_id, root_session_id, kind, display_name, spec, state, \
+     state_detail, progress, input_request, cancel_requested_at, summary, result_path, artifacts, \
+     error, attempt, worker_id, heartbeat_at, links, wake_policy, created_at, started_at, \
+     finished_at, updated_at";
 
 const MESSAGE_COLUMNS: &str =
     "id, task_id, session_id, direction, content, in_reply_to, created_at";
@@ -29,10 +29,14 @@ impl Database {
                 id, session_id, kind, display_name, spec, state, state_detail,
                 progress, input_request, cancel_requested_at, summary, result_path,
                 artifacts, error, attempt, worker_id, heartbeat_at, links,
-                wake_policy, created_at, started_at, finished_at, updated_at
+                wake_policy, created_at, started_at, finished_at, updated_at,
+                root_session_id
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
-                    $15, $16, $17, $18, $19, $20, $21, $22, $23)
+                    $15, $16, $17, $18, $19, $20, $21, $22, $23,
+                    -- EVE-680: denormalize the owning session's tree root so the
+                    -- org task list can filter a whole tree by a local column.
+                    (SELECT root_session_id FROM sessions WHERE id = $2))
             ON CONFLICT (id) DO NOTHING
             RETURNING {TASK_COLUMNS}
             "#
@@ -128,12 +132,14 @@ impl Database {
     /// optional kind/state/age filters and a bounded limit. The org boundary is
     /// a semijoin on `sessions.org_id` — the authoritative multitenancy scope —
     /// so a task only appears when its owning session belongs to the org.
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_org_session_tasks(
         &self,
         org_id: i64,
         kind: Option<&str>,
         state: Option<&str>,
         created_after: Option<chrono::DateTime<chrono::Utc>>,
+        root_session_id: Option<SessionId>,
         limit: i64,
     ) -> Result<Vec<SessionTaskRow>> {
         let rows = sqlx::query_as::<_, SessionTaskRow>(sqlx::AssertSqlSafe(format!(
@@ -144,14 +150,16 @@ impl Database {
               AND ($2::text IS NULL OR kind = $2)
               AND ($3::text IS NULL OR state = $3)
               AND ($4::timestamptz IS NULL OR created_at >= $4)
+              AND ($5::uuid IS NULL OR root_session_id = $5)
             ORDER BY created_at DESC, id DESC
-            LIMIT $5
+            LIMIT $6
             "#
         )))
         .bind(org_id)
         .bind(kind)
         .bind(state)
         .bind(created_after)
+        .bind(root_session_id.map(|id| id.uuid()))
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -51,12 +51,30 @@ impl Database {
             .await?;
         }
 
+        // EVE-680: resolve this session's delegation-tree root. A top-level
+        // session (no parent) is its own root; a subagent child inherits its
+        // parent's root. Looked up within the same tx so the denormalized
+        // pointer stays consistent with the parent chain. The parent row is
+        // guaranteed to exist (parent_session_id is itself an FK) and to carry a
+        // root post-migration; the fallbacks are defensive.
+        let root_session_id: uuid::Uuid = match input.parent_session_id {
+            Some(parent) => sqlx::query_scalar::<_, Option<uuid::Uuid>>(
+                "SELECT root_session_id FROM sessions WHERE id = $1",
+            )
+            .bind(parent.uuid())
+            .fetch_optional(&mut *tx)
+            .await?
+            .flatten()
+            .unwrap_or_else(|| parent.uuid()),
+            None => session_id,
+        };
+
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            INSERT INTO sessions (id, org_id, app_id, harness_id, agent_id, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, blueprint_id, blueprint_config, parent_session_id, workspace_id, parallel_tool_calls, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, 'started')
+            INSERT INTO sessions (id, org_id, app_id, harness_id, agent_id, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, blueprint_id, blueprint_config, parent_session_id, workspace_id, parallel_tool_calls, root_session_id, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, 'started')
             RETURNING id, org_id, workspace_id, app_id, harness_id, agent_id, agent_version_id, agent_config_hash, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, parallel_tool_calls, status, created_at, updated_at, started_at, finished_at,
-                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd, parent_session_id,
+                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd, parent_session_id, root_session_id,
                       blueprint_id, blueprint_config
             "#,
         )
@@ -85,6 +103,7 @@ impl Database {
         .bind(input.parent_session_id.map(|id| id.uuid()))
         .bind(workspace_id)
         .bind(input.parallel_tool_calls)
+        .bind(root_session_id)
         .fetch_one(&mut *tx)
         .await?;
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -3163,7 +3163,7 @@ async fn list_org_session_tasks_pg() {
 
     // Org A listing: contains both A tasks, never the B task.
     let a_all = backend
-        .list_org_session_tasks(TEST_ORG_ID, None, None, None, 500)
+        .list_org_session_tasks(TEST_ORG_ID, None, None, None, None, 500)
         .await
         .expect("list org A");
     let a_all_ids = ids(&a_all);
@@ -3176,7 +3176,7 @@ async fn list_org_session_tasks_pg() {
 
     // Org B listing: contains only the B task, never A's.
     let b_all = backend
-        .list_org_session_tasks(org_b, None, None, None, 500)
+        .list_org_session_tasks(org_b, None, None, None, None, 500)
         .await
         .expect("list org B");
     let b_all_ids = ids(&b_all);
@@ -3185,7 +3185,7 @@ async fn list_org_session_tasks_pg() {
 
     // Kind filter (org A): only the subagent task.
     let a_subs = backend
-        .list_org_session_tasks(TEST_ORG_ID, Some("subagent"), None, None, 500)
+        .list_org_session_tasks(TEST_ORG_ID, Some("subagent"), None, None, None, 500)
         .await
         .expect("list org A subagents");
     let a_subs_ids = ids(&a_subs);
@@ -3194,7 +3194,7 @@ async fn list_org_session_tasks_pg() {
 
     // State filter (org A): only the queued task.
     let a_queued = backend
-        .list_org_session_tasks(TEST_ORG_ID, None, Some("queued"), None, 500)
+        .list_org_session_tasks(TEST_ORG_ID, None, Some("queued"), None, None, 500)
         .await
         .expect("list org A queued");
     let a_queued_ids = ids(&a_queued);
@@ -3204,7 +3204,7 @@ async fn list_org_session_tasks_pg() {
     // created_after in the future excludes our just-created tasks.
     let future = Utc::now() + chrono::Duration::hours(1);
     let a_future = backend
-        .list_org_session_tasks(TEST_ORG_ID, None, None, Some(future), 500)
+        .list_org_session_tasks(TEST_ORG_ID, None, None, Some(future), None, 500)
         .await
         .expect("list org A future");
     let a_future_ids = ids(&a_future);
@@ -3212,8 +3212,25 @@ async fn list_org_session_tasks_pg() {
 
     // Limit is honored.
     let a_limited = backend
-        .list_org_session_tasks(TEST_ORG_ID, None, None, None, 1)
+        .list_org_session_tasks(TEST_ORG_ID, None, None, None, None, 1)
         .await
         .expect("list org A limited");
     assert!(a_limited.len() <= 1, "limit must bound the result set");
+
+    // root_session_id filter (EVE-680): session_a is its own root (no parent),
+    // so filtering on it returns exactly A's two tasks and never B's — and the
+    // org boundary still applies alongside the root filter.
+    let a_root = backend
+        .list_org_session_tasks(TEST_ORG_ID, None, None, None, Some(session_a), 500)
+        .await
+        .expect("list org A by root");
+    let a_root_ids = ids(&a_root);
+    assert!(
+        a_root_ids.contains(&a_sub) && a_root_ids.contains(&a_bg),
+        "root filter must return the whole tree's tasks"
+    );
+    assert!(
+        !a_root_ids.contains(&b_sub),
+        "root filter must never cross the org boundary"
+    );
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13606,6 +13606,15 @@
             }
           },
           {
+            "name": "root_session_id",
+            "in": "query",
+            "description": "Only tasks whose owning session's delegation-tree root is this session",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "Max tasks, newest first (default 100, max 500)",

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -330,7 +330,7 @@ a registry policy rather than per-capability cleanup.
 ## API
 
 ```
-GET  /v1/tasks                                  — org-scoped list (state/kind/created_after, newest-first, bounded limit)
+GET  /v1/tasks                                  — org-scoped list (state/kind/created_after/root_session_id, newest-first, bounded limit)
 GET  /v1/sessions/{session_id}/tasks            — list (filter by state/kind)
 GET  /v1/sessions/{session_id}/tasks/{task_id}  — snapshot + recent thread
 POST /v1/sessions/{session_id}/tasks/{task_id}/messages — inbound message
@@ -344,6 +344,15 @@ filters and a bounded `limit` (default 100, max 500). The org is taken from the
 authenticated caller, never from input; scoping is a semijoin on
 `sessions.org_id` (the authoritative tenant boundary), backed by the
 `session_tasks (created_at DESC)` index.
+
+The optional `root_session_id` filter (EVE-680) narrows the list to a single
+delegation tree — the root session's own tasks plus every descendant's. A
+session's tree root is denormalized onto `sessions.root_session_id` (a top-level
+session is its own root; a subagent child inherits its parent's root, set at
+session creation and backfilled by migration 093) and mirrored onto
+`session_tasks.root_session_id` at task creation, so the whole tree is one
+indexed lookup with no parent-chain walk. The filter parses to a session id and
+stays inside the org semijoin, so it never crosses the tenant boundary.
 
 Message posts and cancels both invoke the kind's `TaskExecutor` best-effort
 after the durable registry write: the message is recorded and the cancel intent

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -349,7 +349,7 @@ The optional `root_session_id` filter (EVE-680) narrows the list to a single
 delegation tree — the root session's own tasks plus every descendant's. A
 session's tree root is denormalized onto `sessions.root_session_id` (a top-level
 session is its own root; a subagent child inherits its parent's root, set at
-session creation and backfilled by migration 093) and mirrored onto
+session creation and backfilled by migration 094) and mirrored onto
 `session_tasks.root_session_id` at task creation, so the whole tree is one
 indexed lookup with no parent-chain walk. The filter parses to a session id and
 stays inside the org semijoin, so it never crosses the tenant boundary.

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -45,6 +45,7 @@ The `Session` entity is extended with a subagent nesting guard:
 | Field | Type | Description |
 |-------|------|-------------|
 | `parent_session_id` | SessionId? | Parent session (null for top-level sessions) |
+| `root_session_id` | SessionId? | Root of this session's delegation tree (EVE-680). A top-level session is its own root; a subagent child inherits its parent's root. Denormalized (migration 094) so a whole tree is one indexed query; mirrored onto `session_tasks.root_session_id` and filterable via `GET /v1/tasks?root_session_id=`. Tree-observability groundwork; does not change the current nesting guard. |
 
 `subagent_name`, `subagent_task`, and `subagent_status` were retired in
 migration 059. Lifecycle state is now tracked via `SessionTask` records


### PR DESCRIPTION
## What changed

Every session now carries a `root_session_id` identifying the root of its delegation tree, and `GET /v1/tasks` gains a `root_session_id` filter that returns a whole tree's work (root + every descendant) in one query.

- A top-level session (no parent) is its own root; a subagent child inherits its parent's root, resolved and stored at session creation in both storage backends.
- Each `session_tasks` row mirrors its owning session's root, so the org task list can filter a tree by a local indexed column with no parent-chain walk.
- `GET /v1/tasks?root_session_id=…` narrows to one tree while staying inside the existing org semijoin, so it never crosses the tenant boundary.

This is the first, foundational step of **EVE-680 (governed subagent nesting)**. The denormalized root is what later PRs hang depth/breadth caps, a shared root budget, and tree-level observability on. **This PR does not change the nesting guard** — nesting is still blocked exactly as before; only the tree identity is added.

## Why

Making the delegation tree a first-class object answers `spawn_subagent`'s debuggability concern and gives the shared-budget work (next PRs) a stable anchor. Denormalizing the root turns "give me the whole tree" into one indexed lookup instead of recursively walking `parent_session_id`.

## Before / After

Before: a subagent tree could only be reconstructed by walking `parent_session_id` per session; `GET /v1/tasks` could not scope to a tree.

After: `sessions.root_session_id` / `session_tasks.root_session_id` populated for new rows and backfilled for existing ones (migration 093); `GET /v1/tasks?root_session_id=<root>` returns the root's own tasks plus all descendants', and nothing from a sibling tree — proven by a unit test (child inherits parent's root; tree-scoped listing) and an integration test (SQL root filter under org scoping).

## Risk

- Low–Medium. Additive nullable column + backfill; no behavior change to session creation or nesting. The backfill uses a recursive CTE anchored at NULL-parent roots with a self-root fallback for any unreachable row, so the column is never NULL for existing data. The self-referential FK uses `ON DELETE CASCADE`, matching `parent_session_id`, so the denormalized pointer can't dangle. Both storage backends and the OpenAPI spec were updated together.

## Security

- Threat categories reviewed: TM-TENANT, TM-AUTHZ. The new `root_session_id` filter is applied **inside** the existing `sessions.org_id` semijoin in both backends, so passing another tenant's root id can only ever return tasks already owned by the caller's org — no cross-tenant enumeration. Same `SESSION_VIEW` policy; no new authz surface.
- Findings and resolutions: none. (The TM-DOS "nesting bomb" / budget-bypass concerns in EVE-680 belong to the depth/breadth-cap and shared-budget PRs, which this one deliberately does not include.)

## Follow-ups

- Depth cap + config resolution (platform/org/agent), breadth/total caps per root, and the shared root budget pool — the remaining EVE-680 PRs, all of which build on this column.

## Checklist

- [x] Tests added or updated — unit (root inheritance + tree filter) and integration (SQL root filter)
- [x] Backward compatibility considered — additive column + backfill; nesting guard unchanged
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)