### PR TITLE
test(auth): manual reachability cases for the auth state machine

### DIFF
--- a/test_cases/ui/full_auth/README.md
+++ b/test_cases/ui/full_auth/README.md
@@ -1,0 +1,26 @@
+# Full Auth — State-Machine Coverage Map
+
+These cases exercise the auth flow whose reachability contract is modelled in
+`apps/ui/src/lib/auth-flow/machine.ts` and enforced by `machine.test.ts`
+(structural reachability + no-misleading-remediation, ratcheted in CI). The
+diagram of that model lives in `specs/authentication.md` § Flow Reachability.
+
+`machine.test.ts` is the **automated** guard on the model itself; the cases
+below are the **manual** walk-throughs of the same flows against a running
+`AUTH_MODE=full` stack. Keep them aligned: when an auth screen's affordances
+change, update `machine.ts`, keep `machine.test.ts` green, and update the case
+here that walks that path.
+
+| State-machine scenario (machine.ts) | Case |
+|---|---|
+| Brand-new user creates an account → verify link → authenticated | `TC001_user_signup.md`, `TC006_email_verification_flow.md` |
+| Verified user signs in / signs out | `TC002_signout_after_signin.md`, `TC003_login_signout_flow.md` |
+| Failed login (wrong/unknown credentials) | `TC004_failed_login_random_user.md` |
+| Verified user who forgot their password recovers | `TC005_password_reset_flow.md` |
+| Unverified user verifies (pending / resend / wrong-address / expired) | `TC006_email_verification_flow.md` |
+| OAuth rejection categories land on the login door, never a dead end | `TC007_oauth_error_paths.md` |
+| **Closed traps + gated-verify recovery** (no path silently no-ops) | `TC008_reachability_dead_end_recovery.md` |
+
+Account states referenced across the suite (see `machine.ts`):
+**S0** `none` · **S1** `local_unverified` · **S2** `local_verified` ·
+**S3** `oauth_only`.

--- a/test_cases/ui/full_auth/TC008_reachability_dead_end_recovery.md
+++ b/test_cases/ui/full_auth/TC008_reachability_dead_end_recovery.md
@@ -1,0 +1,80 @@
+# TC008: Full Auth - Reachability Dead-End & Trap Recovery
+
+## Description
+
+Walk the scenarios the reachability model (`apps/ui/src/lib/auth-flow/machine.ts`)
+exists to protect: situations where a screen historically offered a way forward
+that silently no-ops or dead-ends for a particular hidden account state. Each
+must now surface a path that actually works. These are the manual counterpart to
+the `machine.test.ts` invariants (structural reachability + no misleading
+remediation).
+
+Account states: **S1** `local_unverified`, **S2** `local_verified`,
+**S3** `oauth_only`.
+
+## Preconditions
+
+- `AUTH_MODE=full`; email delivery configured (`EMAIL_PROVIDER`) or read links
+  from the dev mailbox/server logs
+- Google and/or GitHub OAuth configured (scenarios A, B)
+- Accounts available:
+  - an **S3 oauth_only** account (created via "Continue with Google", never given
+    a password)
+  - an **S2 local_verified** account bound to a password
+  - an **S1 local_unverified** account with an org membership (accept an invite,
+    or let verification lapse) for scenario C
+
+## Steps
+
+### Scenario A — oauth_only user typed a password, then reached for reset (closed trap #1)
+
+1. `/login` → enter the **S3 oauth_only** account's email → "Continue with email".
+2. On `login.password`, type any password → "Continue". Verify the submit
+   **fails** (no usable password on this account).
+3. Verify the credential-failure alert names the **OAuth alternative** — copy
+   shown to everyone, e.g. "Signed up with Google or GitHub? Go back and use
+   that instead" — and does **not** present password reset as the only way out.
+   (A reset request for an oauth_only account produces no email, so offering
+   only reset would strand the user.)
+4. Follow it: "Back" → `login.email` → "Continue with Google" → **authenticated**.
+
+### Scenario B — permanent OAuth link-refusal (closed trap #2)
+
+1. Ensure the target verified email already has an account bound to a different
+   method (e.g. a local password account for that address).
+2. `/login` → "Continue with <provider>" and complete consent with that email so
+   the server refuses to link.
+3. Verify the outcome is the **permanent** category: `409 → oauth_account_exists`,
+   landing on the login door with copy that **names the way through** ("sign in
+   with your original method"), not the transient "didn't complete, try again".
+4. Sign in via the original method from the same door → **authenticated**.
+
+### Scenario C — signed-in but unverified, blocked by a verification gate (app.gated_on_verify)
+
+1. Sign in as the **S1 local_unverified** account that already belongs to an org
+   (so onboarding's zero-org verify gate does not apply).
+2. Trigger a verification-gated action (e.g. accept an org invite / hit
+   `TM-AUTH-023`). Verify it is blocked pending verification.
+3. Verify a **persistent verify-email banner** is present on the authenticated
+   screens with a working **Resend**. Click it.
+4. Click the emailed link → email verified → retry the gated action → it now
+   **succeeds**.
+
+### Scenario D — expired verification link with no email param (verify.failed_no_email)
+
+1. Open `/verify-email?token=garbage` (no `email=` param).
+2. Verify the failed state does **not** dead-end on "sign in to request a new
+   verification email". It accepts an email and **resends in place**.
+3. Enter the S1 account's address → resend → a fresh verification email arrives →
+   click it → **email verified**.
+
+## Expected Result
+
+- Every scenario reaches its goal (authenticated / email_verified) via an
+  affordance that genuinely works for that account state — no silent no-op, no
+  dead end, no raw JSON page.
+- Recovery copy stays enumeration-safe: generic copy shown to everyone
+  (scenario A alt), an action on the user's own authenticated account
+  (scenario C banner), or addressed to a caller who already proved mailbox
+  ownership (scenario B `oauth_account_exists`).
+- `machine.test.ts` remains green — `findDeadEnds()` and `findTraps()` both empty.


### PR DESCRIPTION
## What & why
The auth reachability model (`apps/ui/src/lib/auth-flow/machine.ts`) is guarded automatically by `machine.test.ts`, but the manual `full_auth/` suite had no case for the specific dead-ends/traps the model exists to protect, and no explicit tie between the suite and the model. This adds both.

- **`full_auth/TC008_reachability_dead_end_recovery.md`** — walks the four scenarios the model protects:
  - **A** — `oauth_only` account types a password then reaches for reset: the credential-failure alert names the OAuth alternative (shown to everyone, enumeration-safe) instead of offering only a reset that silently produces no email.
  - **B** — permanent OAuth link-refusal returns `409 → oauth_account_exists` with copy naming the original method, not the transient "try again".
  - **C** — signed-in but unverified user behind a verification gate reaches the persistent verify-email banner's working Resend (`app.gated_on_verify`).
  - **D** — a dead `/verify-email` link with no `email=` param resends in place instead of dead-ending.
- **`full_auth/README.md`** — maps the whole suite (TC001–TC008) to the `machine.ts` scenarios and points at `machine.test.ts` + the diagram in `specs/authentication.md`.

## Relationship to the automated model
`machine.test.ts` stays the source of truth for the reachability invariants (`findDeadEnds()` / `findTraps()` both empty); these manual cases are the human-run counterpart against a live `AUTH_MODE=full` stack.

Docs/test-cases only; no code or behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9cKZdLQcBjLxfDQJSRFzG)_