### PR TITLE
test(subagents): cover nested reaper orphan handling

### DIFF
--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -526,8 +526,8 @@ mod tests {
     use async_trait::async_trait;
     use everruns_core::session_task::{
         CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
-        SessionTaskState, TaskExecutor, TaskLinks, TaskMessage, TaskWakePolicy, apply_task_update,
-        new_session_task,
+        SessionTaskState, TASK_KIND_SUBAGENT, TaskExecutor, TaskLinks, TaskMessage, TaskWakePolicy,
+        apply_task_update, new_session_task,
     };
     use everruns_core::{Result as CoreResult, SessionId};
     use std::collections::HashMap;
@@ -936,6 +936,84 @@ mod tests {
             updated.attempt, 2,
             "orphan reap must supersede the executor's attempt"
         );
+    }
+
+    #[tokio::test]
+    async fn reaper_fails_orphaned_depth_two_subagent_task() {
+        let registry = Arc::new(MockRegistry::default());
+        let root_session_id = SessionId::new();
+        let child_session_id = SessionId::new();
+        let grandchild_session_id = SessionId::new();
+
+        let parent_task = registry
+            .create(CreateSessionTask {
+                session_id: root_session_id,
+                id: None,
+                kind: TASK_KIND_SUBAGENT.to_string(),
+                display_name: "Child".to_string(),
+                spec: serde_json::json!({"mode": "background"}),
+                state: SessionTaskState::Running,
+                links: TaskLinks {
+                    child_session_id: Some(child_session_id),
+                    ..Default::default()
+                },
+                wake_policy: TaskWakePolicy::OnTerminal,
+            })
+            .await
+            .unwrap();
+
+        let grandchild_task = registry
+            .create(CreateSessionTask {
+                session_id: child_session_id,
+                id: None,
+                kind: TASK_KIND_SUBAGENT.to_string(),
+                display_name: "Grandchild".to_string(),
+                spec: serde_json::json!({"mode": "background"}),
+                state: SessionTaskState::Running,
+                links: TaskLinks {
+                    child_session_id: Some(grandchild_session_id),
+                    ..Default::default()
+                },
+                wake_policy: TaskWakePolicy::OnTerminal,
+            })
+            .await
+            .unwrap();
+
+        // Simulate the nested background watcher disappearing after it had
+        // heartbeated. The storage query that detects stale heartbeats is
+        // covered elsewhere; this proves the depth-2 subagent task goes through
+        // the same terminal update path as any other orphan.
+        let orphans = vec![(child_session_id, grandchild_task.id.clone())];
+        let input = SessionTaskReaperInput::default();
+        let result = run_reaper(orphans, registry.clone(), &input).await;
+
+        assert_eq!(result["reaped"], 1);
+        assert_eq!(result["reattached"], 0);
+        assert_eq!(result["skipped"], 0);
+
+        let updated_grandchild = registry
+            .get(child_session_id, &grandchild_task.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_grandchild.kind, TASK_KIND_SUBAGENT);
+        assert_eq!(updated_grandchild.state, SessionTaskState::Failed);
+        assert_eq!(
+            updated_grandchild.error.as_ref().map(|e| e.kind.as_str()),
+            Some("orphaned")
+        );
+        assert_eq!(
+            updated_grandchild.attempt, 2,
+            "orphan reap must fence the stale nested watcher attempt"
+        );
+
+        let unchanged_parent = registry
+            .get(root_session_id, &parent_task.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(unchanged_parent.state, SessionTaskState::Running);
+        assert_eq!(unchanged_parent.attempt, 1);
     }
 
     #[tokio::test]

--- a/specs/load-testing.md
+++ b/specs/load-testing.md
@@ -114,6 +114,7 @@ Named benches distinguish different test scenarios. Comparisons only match runs 
 | `history-depth` | Message history scaling | 1 session, 200+ messages |
 | `horizontal-scale` | Worker scaling | Fixed load, vary workers |
 | `burst` | Burst capacity | High concurrency, low messages |
+| `subagent-fanout` | Governed subagent tree fan-out: root sessions spawn background child tasks, selected children spawn grandchildren, and all tasks settle or fail through the session-task registry. Track root turn latency, task terminal latency, orphan/reaper counts, and cap-rejection rate. | Small tree first (for example 10 roots x 4 children x 2 grandchildren), then scale breadth until `max_active_descendant_tasks` is approached |
 
 ## Justfile Profiles
 


### PR DESCRIPTION
## What changed
Added regression coverage for the EVE-680 depth-2 watcher/reaper path: a root subagent task remains running while an orphaned grandchild subagent task is failed by the session-task reaper with `error.kind = "orphaned"` and a bumped attempt fence.

Added the `subagent-fanout` load-test scenario note so tree fan-out behavior has a named benchmark target covering task terminal latency, orphan/reaper counts, and cap rejection rate.

## Why
The remaining EVE-680 proof needed to show that nested background subagent watchers at depth >= 2 are settled by the existing session task reaper path, and that load testing has an explicit tree fan-out scenario.

## Before / After
Before: reaper tests covered generic stale tasks and reattach behavior, but not the nested subagent task shape. The load testing spec did not name a tree fan-out scenario.

After: focused worker test proves a child-owned grandchild subagent task is reaped as orphaned without mutating the parent task. The load testing spec now names `subagent-fanout` with the metrics to watch.

Evidence:
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p everruns-worker session_task_reaper --lib --all-features` (14 passed)
- `cargo test -p everruns-core capabilities::subagents --lib --all-features` (30 passed)
- `cargo test -p everruns-server session_task_store --lib --all-features` (12 passed)
- `cargo clippy -p everruns-worker --all-targets --all-features -- -D warnings`
- `bash scripts/lib/check-migration-ordering.sh` (`migrations sequential (001..094)`)
- `git diff --check`
- `just pre-push` (10/10 passed)
- Caddy smoke on `PORT_PREFIX=280 CARGO_INCREMENTAL=0 just start-dev --no-watch`: proxy `/health` 200, `/api/v1/tasks?kind=subagent&limit=5` 200, `/api-doc/openapi.json` 200 (`openapi=3.1.0`, `paths=202`), `/login` 200.

## Risk
- Low
- Test/spec-only change; risk is limited to inaccurate coverage or documentation wording.

## Security
- Threat categories reviewed: No security-relevant code changes. This PR changes a worker unit test and load-testing spec text only.
- Findings and resolutions: No findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
