### PR TITLE
feat(ui): segmented ATIF export for large sessions

### DIFF
--- a/apps/ui/src/__tests__/session-export.test.tsx
+++ b/apps/ui/src/__tests__/session-export.test.tsx
@@ -142,6 +142,33 @@ function mockResponse({
   } as unknown as Response;
 }
 
+// A standalone ATIF segment document. When `cursor` is provided, it carries a
+// root `continued_trajectory_ref` pointing at the next segment (mirroring the
+// server contract); the final segment omits it.
+function atifSegment(cursor?: string): string {
+  const doc: Record<string, unknown> = { atif_version: "1.7", messages: [] };
+  if (cursor) {
+    doc.continued_trajectory_ref = `/v1/sessions/${SESSION_ID}/export?format=atif&segmented=true&cursor=${cursor}`;
+  }
+  return JSON.stringify(doc);
+}
+
+// A 413 whose RFC-9457 detail advertises segmentation (new server).
+function tooLargeSegmentedResponse() {
+  return mockResponse({
+    ok: false,
+    status: 413,
+    statusText: "Payload Too Large",
+    body: JSON.stringify({
+      title: "Payload Too Large",
+      status: 413,
+      code: "atif_export_too_large",
+      detail:
+        "ATIF document is over the 10485760-byte limit; use &segmented=true to download it in parts",
+    }),
+  });
+}
+
 describe("downloadSessionExport", () => {
   const fetchMock = jest.fn();
   let downloads: string[] = [];
@@ -262,5 +289,127 @@ describe("downloadSessionExport", () => {
     expect(downloads).toEqual([]);
     expect(notify).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("offers a segmented download on a segmentation-capable 413 and walks all parts", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tooLargeSegmentedResponse())
+      .mockResolvedValueOnce(mockResponse({ body: atifSegment("c1") }))
+      .mockResolvedValueOnce(mockResponse({ body: atifSegment("c2") }))
+      .mockResolvedValueOnce(mockResponse({ body: atifSegment() }));
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    // The offer is a single toast with an action; nothing downloads yet.
+    expect(downloads).toEqual([]);
+    expect(notify).toHaveBeenCalledTimes(1);
+    const offer = notify.mock.calls[0][0];
+    expect(offer.title).toBe("ATIF export");
+    expect(offer.body).toBe(
+      "This session is too large for a single ATIF file. Download it in parts instead?",
+    );
+    expect(offer.action.label).toBe("Download in parts");
+
+    // Confirm → the segmented walk runs.
+    await offer.action.onClick();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `/api/v1/sessions/${SESSION_ID}/export?format=atif&segmented=true`,
+      { credentials: "include" },
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      `/api/v1/sessions/${SESSION_ID}/export?format=atif&segmented=true&cursor=c1`,
+      { credentials: "include" },
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      `/api/v1/sessions/${SESSION_ID}/export?format=atif&segmented=true&cursor=c2`,
+      { credentials: "include" },
+    );
+    expect(downloads).toEqual([
+      `${SESSION_ID}.atif.part1.json`,
+      `${SESSION_ID}.atif.part2.json`,
+      `${SESSION_ID}.atif.part3.json`,
+    ]);
+    expect(notify).toHaveBeenLastCalledWith({
+      title: "ATIF export",
+      body: "Exported 3 ATIF parts",
+    });
+  });
+
+  it("aggregates omitted images across segments into one info toast", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tooLargeSegmentedResponse())
+      .mockResolvedValueOnce(
+        mockResponse({ headers: { "X-Atif-Images-Omitted": "2" }, body: atifSegment("c1") }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ headers: { "X-Atif-Images-Omitted": "3" }, body: atifSegment() }),
+      );
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+    await notify.mock.calls[0][0].action.onClick();
+
+    expect(downloads).toEqual([`${SESSION_ID}.atif.part1.json`, `${SESSION_ID}.atif.part2.json`]);
+    expect(notify).toHaveBeenCalledWith({ title: "ATIF export", body: "Exported 2 ATIF parts" });
+    expect(notify).toHaveBeenLastCalledWith({
+      title: "ATIF export",
+      body: "5 images were omitted from the ATIF export",
+    });
+  });
+
+  it("stops with an error toast when a mid-walk segment returns a bad cursor (400)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tooLargeSegmentedResponse())
+      .mockResolvedValueOnce(mockResponse({ body: atifSegment("c1") }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: "Bad Request",
+          body: JSON.stringify({ code: "atif_cursor_invalid", detail: "invalid cursor" }),
+        }),
+      );
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+    await notify.mock.calls[0][0].action.onClick();
+
+    // First part saved, then the walk halts on the bad cursor.
+    expect(downloads).toEqual([`${SESSION_ID}.atif.part1.json`]);
+    expect(notify).toHaveBeenLastCalledWith({
+      title: "ATIF export failed",
+      body: "ATIF export stopped after 1 part",
+    });
+  });
+
+  it("falls back to a plain error toast when a 413 does not advertise segmentation", async () => {
+    // Old server: same too-large `code`, but the detail does not mention
+    // segmentation, so no "Download in parts" offer is made.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 413,
+        statusText: "Payload Too Large",
+        body: JSON.stringify({
+          code: "atif_export_too_large",
+          detail: "ATIF document exceeds the 10 MiB export cap",
+        }),
+      }),
+    );
+    const notify = jest.fn();
+
+    await downloadSessionExport(SESSION_ID, "atif", "en", notify);
+
+    expect(downloads).toEqual([]);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith({
+      title: "ATIF export failed",
+      body: "ATIF document exceeds the 10 MiB export cap",
+    });
   });
 });

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -12,6 +12,10 @@ export class ApiError extends Error {
     public status: number,
     public statusText: string,
     message?: string,
+    // RFC 9457 `code` from the Problem Details body, when present. Lets callers
+    // branch on a stable machine string (e.g. `atif_export_too_large`) rather
+    // than parsing the human-facing message.
+    public code?: string,
   ) {
     super(message || `API Error: ${status} ${statusText}`);
     this.name = "ApiError";
@@ -118,6 +122,7 @@ export const api = {
  */
 export async function throwApiError(response: Response): Promise<never> {
   let errorMessage: string | undefined;
+  let errorCode: string | undefined;
   try {
     // Read body as text first to avoid consuming the stream with response.json()
     const text = await response.text();
@@ -132,6 +137,9 @@ export async function throwApiError(response: Response): Promise<never> {
           errorBody.error ||
           errorBody.message ||
           JSON.stringify(errorBody);
+        if (typeof errorBody.code === "string") {
+          errorCode = errorBody.code;
+        }
       } catch {
         // Not JSON — use the raw text as the error message
         errorMessage = text;
@@ -140,7 +148,7 @@ export async function throwApiError(response: Response): Promise<never> {
   } catch {
     // No body at all
   }
-  throw new ApiError(response.status, response.statusText, errorMessage);
+  throw new ApiError(response.status, response.statusText, errorMessage, errorCode);
 }
 
 export function getApiBaseUrl(): string {

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -3923,6 +3923,11 @@ export interface components {
        */
       forked_from_version_id?: string | null;
       /**
+       * @description Harness that supplies the base execution environment for this agent.
+       * @example harness_01933b5a00007000800000000000001
+       */
+      harness_id: string;
+      /**
        * @description External identifier (agent_<32-hex>). Shown as "id" in API.
        *     Client-supplied or auto-generated.
        * @example agent_01933b5a000070008000000000000001
@@ -5115,6 +5120,17 @@ export interface components {
        * @example Customer Support Agent
        */
       display_name?: string | null;
+      /**
+       * @description Harness ID used as this agent's base execution environment. If omitted,
+       *     the org's built-in `generic` harness is used.
+       * @example harness_01933b5a00007000800000000000001
+       */
+      harness_id?: string | null;
+      /**
+       * @description Addressable harness name. Alternative to `harness_id`.
+       * @example generic
+       */
+      harness_name?: string | null;
       /**
        * @description Client-supplied agent ID (format: agent_{32-hex}).
        *     If not provided, one is auto-generated.
@@ -8211,6 +8227,11 @@ export interface components {
          */
         forked_from_version_id?: string | null;
         /**
+         * @description Harness that supplies the base execution environment for this agent.
+         * @example harness_01933b5a00007000800000000000001
+         */
+        harness_id: string;
+        /**
          * @description External identifier (agent_<32-hex>). Shown as "id" in API.
          *     Client-supplied or auto-generated.
          * @example agent_01933b5a000070008000000000000001
@@ -11269,7 +11290,7 @@ export interface components {
         parallel_tool_calls?: boolean | null;
         /**
          * @description Parent session that spawned this subagent. NULL for top-level sessions.
-         *     Used as the subagent nesting guard.
+         *     Used to compute governed subagent delegation depth.
          */
         parent_session_id?: string | null;
         /**
@@ -11578,6 +11599,11 @@ export interface components {
          */
         forked_from_version_id?: string | null;
         /**
+         * @description Harness that supplies the base execution environment for this agent.
+         * @example harness_01933b5a00007000800000000000001
+         */
+        harness_id: string;
+        /**
          * @description External identifier (agent_<32-hex>). Shown as "id" in API.
          *     Client-supplied or auto-generated.
          * @example agent_01933b5a000070008000000000000001
@@ -11851,7 +11877,7 @@ export interface components {
         parallel_tool_calls?: boolean | null;
         /**
          * @description Parent session that spawned this subagent. NULL for top-level sessions.
-         *     Used as the subagent nesting guard.
+         *     Used to compute governed subagent delegation depth.
          */
         parent_session_id?: string | null;
         /**
@@ -13505,7 +13531,7 @@ export interface components {
       parallel_tool_calls?: boolean | null;
       /**
        * @description Parent session that spawned this subagent. NULL for top-level sessions.
-       *     Used as the subagent nesting guard.
+       *     Used to compute governed subagent delegation depth.
        */
       parent_session_id?: string | null;
       /**
@@ -14699,6 +14725,16 @@ export interface components {
        */
       display_name?: string | null;
       /**
+       * @description Harness ID used as this agent's base execution environment. Omit to leave unchanged.
+       * @example harness_01933b5a00007000800000000000001
+       */
+      harness_id?: string | null;
+      /**
+       * @description Addressable harness name. Alternative to `harness_id`; omit to leave unchanged.
+       * @example generic
+       */
+      harness_name?: string | null;
+      /**
        * @description Starter files copied into each new session for this agent.
        * @example [
        *       {
@@ -15667,6 +15703,11 @@ export interface components {
        */
       forked_from_version_id?: string | null;
       /**
+       * @description Harness that supplies the base execution environment for this agent.
+       * @example harness_01933b5a00007000800000000000001
+       */
+      harness_id: string;
+      /**
        * @description External identifier (agent_<32-hex>). Shown as "id" in API.
        *     Client-supplied or auto-generated.
        * @example agent_01933b5a000070008000000000000001
@@ -16556,6 +16597,11 @@ export interface components {
        */
       forked_from_version_id?: string | null;
       /**
+       * @description Harness that supplies the base execution environment for this agent.
+       * @example harness_01933b5a00007000800000000000001
+       */
+      harness_id: string;
+      /**
        * @description External identifier (agent_<32-hex>). Shown as "id" in API.
        *     Client-supplied or auto-generated.
        * @example agent_01933b5a000070008000000000000001
@@ -16955,7 +17001,7 @@ export interface components {
       parallel_tool_calls?: boolean | null;
       /**
        * @description Parent session that spawned this subagent. NULL for top-level sessions.
-       *     Used as the subagent nesting guard.
+       *     Used to compute governed subagent delegation depth.
        */
       parent_session_id?: string | null;
       /**
@@ -26464,6 +26510,10 @@ export interface operations {
       query?: {
         /** @description Output format: jsonl (default) or atif */
         format?: string;
+        /** @description ATIF only: return byte-bounded segments linked by continued_trajectory_ref instead of one document */
+        segmented?: boolean;
+        /** @description ATIF segmented export: opaque continuation cursor from the previous segment */
+        cursor?: string;
       };
       header?: never;
       path: {
@@ -26474,7 +26524,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description JSONL file with one message per line, or one ATIF trajectory JSON document (with X-Atif-Images-Omitted header when image parts were flattened to markers) */
+      /** @description JSONL file with one message per line, or one ATIF trajectory JSON document (with X-Atif-Images-Omitted header when image parts were flattened to markers). With segmented=true, one ATIF segment linked forward by continued_trajectory_ref. */
       200: {
         headers: {
           [name: string]: unknown;
@@ -26483,7 +26533,7 @@ export interface operations {
           "application/x-ndjson": unknown;
         };
       };
-      /** @description Invalid ID format */
+      /** @description Invalid ID format, or malformed/foreign segmented-export cursor */
       400: {
         headers: {
           [name: string]: unknown;
@@ -26504,7 +26554,7 @@ export interface operations {
         };
         content?: never;
       };
-      /** @description ATIF document exceeds the 50 MiB export cap; segmented export is a planned follow-up */
+      /** @description ATIF document exceeds the 50 MiB export cap; retry with segmented=true for a recoverable chunked export */
       413: {
         headers: {
           [name: string]: unknown;
@@ -28140,6 +28190,8 @@ export interface operations {
         kind?: string;
         /** @description Only tasks created at/after this RFC3339 timestamp */
         created_after?: string;
+        /** @description Only tasks whose owning session's delegation-tree root is this session */
+        root_session_id?: string;
         /** @description Max tasks, newest first (default 100, max 500) */
         limit?: number;
       };

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -143,18 +143,172 @@ export async function exportSession(
   if (!response.ok) {
     await throwApiError(response);
   }
-  const omittedHeader = response.headers.get("X-Atif-Images-Omitted");
-  const omitted = omittedHeader ? Number.parseInt(omittedHeader, 10) : 0;
+  const omitted = parseImagesOmitted(response.headers.get("X-Atif-Images-Omitted"));
   const blob = await response.blob();
+  triggerBlobDownload(format === "atif" ? `${sessionId}.atif.json` : `${sessionId}.jsonl`, blob);
+  return { imagesOmitted: omitted };
+}
+
+// ============================================
+// Segmented ATIF Export
+// ============================================
+
+/**
+ * Safety cap on the segmented walk. A server that never stops emitting
+ * `continued_trajectory_ref` (bug, or hostile) must not loop forever or fill
+ * the disk. 10k segments is far beyond any legitimate session.
+ */
+export const MAX_ATIF_SEGMENTS = 10_000;
+
+export interface SegmentedExportResult {
+  /** Number of segment files saved to disk. */
+  partsSaved: number;
+  /** Total images omitted across all segments (summed `X-Atif-Images-Omitted`). */
+  imagesOmitted: number;
+}
+
+/**
+ * Thrown when the segmented walk aborts. Carries how many parts were saved
+ * before the failure so callers can say "stopped after N parts".
+ */
+export class SegmentedExportError extends Error {
+  constructor(
+    message: string,
+    public partsSaved: number,
+    /** `http`: a segment request failed. `limit`: hit `MAX_ATIF_SEGMENTS`. */
+    public reason: "http" | "limit",
+    public apiError?: unknown,
+  ) {
+    super(message);
+    this.name = "SegmentedExportError";
+  }
+}
+
+function parseImagesOmitted(header: string | null): number {
+  const n = header ? Number.parseInt(header, 10) : 0;
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function triggerBlobDownload(filename: string, blob: Blob): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = format === "atif" ? `${sessionId}.atif.json` : `${sessionId}.jsonl`;
+  a.download = filename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
-  return { imagesOmitted: Number.isFinite(omitted) && omitted > 0 ? omitted : 0 };
+}
+
+/**
+ * Extract the opaque `cursor` from a server-provided next-segment reference.
+ *
+ * Security: the server returns a full-path `continued_trajectory_ref` URL, but
+ * we deliberately trust only its `cursor` query value and always re-fetch our
+ * own same-origin `/api` export endpoint. This prevents following the returned
+ * ref to an arbitrary path/origin. The cursor stays opaque server state.
+ */
+function cursorFromRef(ref: string | null | undefined): string | null {
+  if (!ref) return null;
+  try {
+    // Parse against a dummy base so relative refs still expose their query.
+    return new URL(ref, "http://ref.invalid").searchParams.get("cursor");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The `X-Atif-Next-Cursor` header may carry either a full ref URL or the raw
+ * cursor value; accept both, still opaquely.
+ */
+function cursorFromHeader(value: string | null): string | null {
+  if (!value) return null;
+  const fromUrl = cursorFromRef(value);
+  if (fromUrl) return fromUrl;
+  // A bare token (no query/path syntax) is the raw cursor.
+  return value.includes("=") || value.includes("/") ? null : value.trim() || null;
+}
+
+function nextSegmentUrl(sessionId: string, cursor: string | null): string {
+  const params = new URLSearchParams({ format: "atif", segmented: "true" });
+  if (cursor) params.set("cursor", cursor);
+  return `/api/v1/sessions/${sessionId}/export?${params.toString()}`;
+}
+
+/**
+ * Walk the segmented ATIF export, saving each segment as a separate file
+ * (`{sessionId}.atif.part{n}.json`, 1-based). Follows `continued_trajectory_ref`
+ * (via its opaque cursor) until a segment omits it. Recoverable path for
+ * sessions too large for a single ATIF document (HTTP 413).
+ */
+export async function exportSessionSegmented(sessionId: string): Promise<SegmentedExportResult> {
+  let cursor: string | null = null;
+  let partsSaved = 0;
+  let imagesOmitted = 0;
+
+  for (;;) {
+    let response: Response;
+    try {
+      response = await fetch(nextSegmentUrl(sessionId, cursor), { credentials: "include" });
+    } catch (err) {
+      throw new SegmentedExportError(
+        `Segmented ATIF export failed after ${partsSaved} part(s)`,
+        partsSaved,
+        "http",
+        err,
+      );
+    }
+
+    if (!response.ok) {
+      let apiError: unknown;
+      try {
+        await throwApiError(response);
+      } catch (err) {
+        apiError = err;
+      }
+      throw new SegmentedExportError(
+        `Segmented ATIF export failed after ${partsSaved} part(s)`,
+        partsSaved,
+        "http",
+        apiError,
+      );
+    }
+
+    imagesOmitted += parseImagesOmitted(response.headers.get("X-Atif-Images-Omitted"));
+    const text = await response.text();
+    triggerBlobDownload(
+      `${sessionId}.atif.part${partsSaved + 1}.json`,
+      new Blob([text], { type: "application/json" }),
+    );
+    partsSaved += 1;
+
+    // Primary continuation signal is the body's root `continued_trajectory_ref`;
+    // the `X-Atif-Next-Cursor` header is a fallback. The final segment omits both.
+    let bodyRef: string | null = null;
+    try {
+      const doc = JSON.parse(text) as { continued_trajectory_ref?: unknown };
+      if (typeof doc.continued_trajectory_ref === "string") {
+        bodyRef = doc.continued_trajectory_ref;
+      }
+    } catch {
+      // Non-JSON body: rely on the header fallback below.
+    }
+
+    const nextCursor =
+      cursorFromRef(bodyRef) ?? cursorFromHeader(response.headers.get("X-Atif-Next-Cursor"));
+    if (!nextCursor) {
+      return { partsSaved, imagesOmitted };
+    }
+    if (partsSaved >= MAX_ATIF_SEGMENTS) {
+      throw new SegmentedExportError(
+        `Segmented ATIF export exceeded ${MAX_ATIF_SEGMENTS} parts`,
+        partsSaved,
+        "limit",
+      );
+    }
+    cursor = nextCursor;
+  }
 }
 
 // ============================================

--- a/apps/ui/src/lib/i18n.ts
+++ b/apps/ui/src/lib/i18n.ts
@@ -198,6 +198,17 @@ const messages = {
     atif_export_title: "ATIF export",
     atif_export_failed_title: "ATIF export failed",
     atif_export_too_large: "This session is too large for ATIF export.",
+    atif_export_segmented_prompt:
+      "This session is too large for a single ATIF file. Download it in parts instead?",
+    atif_export_download_parts: "Download in parts",
+    atif_export_segmented_limit:
+      "ATIF export stopped at the {count}-part safety limit; the session is unexpectedly large.",
+    atif_parts_exported_one: "Exported {count} ATIF part",
+    atif_parts_exported_few: "Exported {count} ATIF parts",
+    atif_parts_exported_many: "Exported {count} ATIF parts",
+    atif_export_stopped_one: "ATIF export stopped after {count} part",
+    atif_export_stopped_few: "ATIF export stopped after {count} parts",
+    atif_export_stopped_many: "ATIF export stopped after {count} parts",
     atif_images_omitted_one: "{count} image was omitted from the ATIF export",
     atif_images_omitted_few: "{count} images were omitted from the ATIF export",
     atif_images_omitted_many: "{count} images were omitted from the ATIF export",
@@ -394,6 +405,17 @@ const messages = {
     atif_export_title: "Експорт ATIF",
     atif_export_failed_title: "Не вдалося експортувати ATIF",
     atif_export_too_large: "Ця сесія завелика для експорту ATIF.",
+    atif_export_segmented_prompt:
+      "Ця сесія завелика для одного файлу ATIF. Завантажити її частинами?",
+    atif_export_download_parts: "Завантажити частинами",
+    atif_export_segmented_limit:
+      "Експорт ATIF зупинено на межі безпеки в {count} частин; сесія неочікувано велика.",
+    atif_parts_exported_one: "Експортовано {count} частину ATIF",
+    atif_parts_exported_few: "Експортовано {count} частини ATIF",
+    atif_parts_exported_many: "Експортовано {count} частин ATIF",
+    atif_export_stopped_one: "Експорт ATIF зупинено після {count} частини",
+    atif_export_stopped_few: "Експорт ATIF зупинено після {count} частин",
+    atif_export_stopped_many: "Експорт ATIF зупинено після {count} частин",
     atif_images_omitted_one: "{count} зображення пропущено під час експорту ATIF",
     atif_images_omitted_few: "{count} зображення пропущено під час експорту ATIF",
     atif_images_omitted_many: "{count} зображень пропущено під час експорту ATIF",
@@ -483,6 +505,44 @@ export function formatAtifImagesOmitted(locale: SupportedLocale, count: number):
     {
       count,
     },
+  );
+}
+
+export function formatAtifPartsExported(locale: SupportedLocale, count: number): string {
+  if (locale === "uk") {
+    const form = getUkrainianPluralForm(count);
+    if (form === "one") {
+      return formatMessage(locale, "atif_parts_exported_one", { count });
+    }
+    if (form === "few") {
+      return formatMessage(locale, "atif_parts_exported_few", { count });
+    }
+    return formatMessage(locale, "atif_parts_exported_many", { count });
+  }
+
+  return formatMessage(
+    locale,
+    count === 1 ? "atif_parts_exported_one" : "atif_parts_exported_many",
+    { count },
+  );
+}
+
+export function formatAtifExportStopped(locale: SupportedLocale, count: number): string {
+  if (locale === "uk") {
+    const form = getUkrainianPluralForm(count);
+    if (form === "one") {
+      return formatMessage(locale, "atif_export_stopped_one", { count });
+    }
+    if (form === "few") {
+      return formatMessage(locale, "atif_export_stopped_few", { count });
+    }
+    return formatMessage(locale, "atif_export_stopped_many", { count });
+  }
+
+  return formatMessage(
+    locale,
+    count === 1 ? "atif_export_stopped_one" : "atif_export_stopped_many",
+    { count },
   );
 }
 

--- a/apps/ui/src/lib/session-export.ts
+++ b/apps/ui/src/lib/session-export.ts
@@ -2,17 +2,82 @@
 //
 // Decisions:
 // - ATIF limit signals are user-facing: 413 (document over the server size
-//   cap) becomes an error toast and `X-Atif-Images-Omitted` becomes an info
-//   toast. Everything else keeps the pre-ATIF behavior (console.error only),
-//   so the flow degrades gracefully against servers without ATIF support.
+//   cap) and `X-Atif-Images-Omitted` become toasts. Everything else keeps the
+//   pre-ATIF behavior (console.error only), so the flow degrades gracefully
+//   against servers without ATIF support.
+// - When the server advertises SEGMENTED export in its 413 (the RFC-9457
+//   `detail` names `segmented=true`), the too-large case becomes recoverable:
+//   we offer a "Download in parts" action that walks the segmented export and
+//   saves each segment as a separate file. Against an older server whose 413
+//   does not mention segmentation, we fall back to today's plain error toast.
 
-import { exportSession, type SessionExportFormat } from "@/lib/api/sessions";
+import {
+  exportSession,
+  exportSessionSegmented,
+  MAX_ATIF_SEGMENTS,
+  SegmentedExportError,
+  type SessionExportFormat,
+} from "@/lib/api/sessions";
 import { ApiError } from "@/lib/api/client";
-import { formatAtifImagesOmitted, formatMessage, type SupportedLocale } from "@/lib/i18n";
+import {
+  formatAtifExportStopped,
+  formatAtifImagesOmitted,
+  formatAtifPartsExported,
+  formatMessage,
+  type SupportedLocale,
+} from "@/lib/i18n";
 
 export interface SessionExportToast {
   title: string;
   body: string;
+  action?: { label: string; onClick: () => void | Promise<void> };
+}
+
+/** True when a 413 body indicates the server supports segmented export. */
+function serverOffersSegmentation(error: ApiError): boolean {
+  // The new server's 413 `detail` names `segmented=true`; an old server's does
+  // not. The detail text is the only reliable discriminator — the `code` is
+  // `atif_export_too_large` on both old and new servers, so it cannot gate the
+  // offer (offering against an old server would only 400/404 on the walk).
+  return /segmented/i.test(error.message ?? "");
+}
+
+/**
+ * Walk the segmented ATIF export, saving each segment as its own file, and
+ * surface progress/completion/failure via `notify`.
+ */
+async function runSegmentedExport(
+  sessionId: string,
+  locale: SupportedLocale,
+  notify: (toast: SessionExportToast) => void,
+): Promise<void> {
+  try {
+    const { partsSaved, imagesOmitted } = await exportSessionSegmented(sessionId);
+    notify({
+      title: formatMessage(locale, "atif_export_title"),
+      body: formatAtifPartsExported(locale, partsSaved),
+    });
+    if (imagesOmitted > 0) {
+      notify({
+        title: formatMessage(locale, "atif_export_title"),
+        body: formatAtifImagesOmitted(locale, imagesOmitted),
+      });
+    }
+  } catch (error) {
+    if (error instanceof SegmentedExportError) {
+      const body =
+        error.reason === "limit"
+          ? formatMessage(locale, "atif_export_segmented_limit", { count: MAX_ATIF_SEGMENTS })
+          : formatAtifExportStopped(locale, error.partsSaved);
+      notify({ title: formatMessage(locale, "atif_export_failed_title"), body });
+      return;
+    }
+    console.error("Failed to export session in segments:", error);
+    notify({
+      title: formatMessage(locale, "atif_export_failed_title"),
+      body: formatMessage(locale, "atif_export_too_large"),
+    });
+  }
 }
 
 /**
@@ -36,6 +101,20 @@ export async function downloadSessionExport(
     }
   } catch (error) {
     if (format === "atif" && error instanceof ApiError && error.status === 413) {
+      // Recoverable path: offer a segmented download when the server supports
+      // it and we can drive the walk (needs `notify` to confirm + report).
+      if (notify && serverOffersSegmentation(error)) {
+        notify({
+          title: formatMessage(locale, "atif_export_title"),
+          body: formatMessage(locale, "atif_export_segmented_prompt"),
+          action: {
+            label: formatMessage(locale, "atif_export_download_parts"),
+            onClick: () => runSegmentedExport(sessionId, locale, notify),
+          },
+        });
+        return;
+      }
+      // Old server (no segmentation) or no notify: plain error toast.
       // ApiError falls back to "API Error: <status> <statusText>" when the
       // response body had no parseable message; prefer the localized fallback.
       const genericMessage = `API Error: ${error.status} ${error.statusText}`;

--- a/apps/ui/src/providers/notifications-provider.tsx
+++ b/apps/ui/src/providers/notifications-provider.tsx
@@ -39,11 +39,22 @@ type NotificationState = {
   initialized: boolean;
 };
 
-type ToastNotification = Notification & { toast_id: string };
+export interface LocalToastAction {
+  label: string;
+  /** May be async; the toast dismisses immediately, work continues in the background. */
+  onClick: () => void | Promise<void>;
+}
+
+type ToastNotification = Notification & { toast_id: string; action?: LocalToastAction };
 
 export interface LocalToastInput {
   title: string;
   body: string;
+  /**
+   * Optional action button. Toasts with an action persist (no auto-dismiss) so
+   * the user has time to decide; they clear on action or manual dismiss.
+   */
+  action?: LocalToastAction;
 }
 
 interface NotificationsContextValue {
@@ -189,15 +200,20 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   isVisibleRef.current = isVisible;
   isFocusedRef.current = isFocused;
 
-  const enqueueToast = useCallback((notification: Notification) => {
-    if (toastIdsRef.current.has(notification.id)) return;
-    toastIdsRef.current.add(notification.id);
-    const toast_id = `${notification.id}:${Date.now()}`;
-    setToastQueue((prev) => [...prev, { ...notification, toast_id }]);
-    window.setTimeout(() => {
-      setToastQueue((prev) => prev.filter((item) => item.toast_id !== toast_id));
-    }, 5000);
-  }, []);
+  const enqueueToast = useCallback(
+    (notification: Notification, options?: { action?: LocalToastAction; persist?: boolean }) => {
+      if (toastIdsRef.current.has(notification.id)) return;
+      toastIdsRef.current.add(notification.id);
+      const toast_id = `${notification.id}:${Date.now()}`;
+      setToastQueue((prev) => [...prev, { ...notification, toast_id, action: options?.action }]);
+      if (!options?.persist) {
+        window.setTimeout(() => {
+          setToastQueue((prev) => prev.filter((item) => item.toast_id !== toast_id));
+        }, 5000);
+      }
+    },
+    [],
+  );
 
   const localToastSeqRef = useRef(0);
   const notify = useCallback(
@@ -207,17 +223,20 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       // viewed_at is pre-set so a click never triggers markViewed (there is no
       // server-side notification behind a local toast), and href is absent so
       // the click is a no-op beyond dismissing.
-      enqueueToast({
-        id: `local-${localToastSeqRef.current}`,
-        kind: "local",
-        title: input.title,
-        body: input.body,
-        payload: {},
-        occurrence_count: 1,
-        viewed_at: now,
-        created_at: now,
-        updated_at: now,
-      });
+      enqueueToast(
+        {
+          id: `local-${localToastSeqRef.current}`,
+          kind: "local",
+          title: input.title,
+          body: input.body,
+          payload: {},
+          occurrence_count: 1,
+          viewed_at: now,
+          created_at: now,
+          updated_at: now,
+        },
+        input.action ? { action: input.action, persist: true } : undefined,
+      );
     },
     [enqueueToast],
   );
@@ -404,6 +423,22 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
                   <X className="h-4 w-4" />
                 </button>
               </div>
+              {toast.action && (
+                <div className="mt-2 flex justify-end">
+                  <button
+                    type="button"
+                    className="inline-flex h-7 items-center px-2.5 text-sm font-medium text-primary underline-offset-4 hover:underline"
+                    onClick={() => {
+                      void toast.action?.onClick();
+                      setToastQueue((prev) =>
+                        prev.filter((item) => item.toast_id !== toast.toast_id),
+                      );
+                    }}
+                  >
+                    {toast.action.label}
+                  </button>
+                </div>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## What changed
Makes the "session too large for a single ATIF file" case recoverable in the UI. When an ATIF export returns HTTP 413 and the server advertises segmentation in its RFC-9457 detail, the export no longer dead-ends on an error toast. Instead it offers a "Download in parts" action. On confirm, the UI walks the segmented export and saves each segment as its own file `{sessionId}.atif.part{N}.json` (1-based), then reports "Exported N parts". Omitted-image counts are summed across segments into the existing info toast.

Failure handling: a bad cursor (400 `atif_cursor_invalid`) or any mid-walk failure stops the walk and surfaces "ATIF export stopped after N parts" (already-saved parts are kept). The walk is capped at 10,000 segments as a safety stop, with a distinct message if hit.

Graceful degradation: against an older server whose 413 does not mention segmentation, the flow falls back to today's plain error toast — no offer, no crash. All new strings are localized in both `en` and `uk`, including Ukrainian-plural forms for the "N parts" and "stopped after N parts" messages, mirroring the existing `formatAtifImagesOmitted` pattern.

Implementation notes: the segmented walk lives in `lib/api/sessions.ts` (`exportSessionSegmented`, `SegmentedExportError`, `MAX_ATIF_SEGMENTS`); orchestration/toasts in `lib/session-export.ts`; the local-toast surface in `providers/notifications-provider.tsx` gains an optional action button (persists until acted on/dismissed). `ApiError` now also captures the RFC-9457 `code`.

## Why
An over-cap ATIF export was unrecoverable — the only outcome was an error toast telling the user the session was too large, with no way to get the data out. The server (PR #2626) added segmented export; this wires the UI to use it.

## Before / After
- Before: ATIF export of an over-cap session → HTTP 413 → error toast "This session is too large for ATIF export." Dead end.
- After: same 413 (segmentation-capable server) → toast "This session is too large for a single ATIF file. Download it in parts instead?" with a "Download in parts" action → on confirm, N segment files download and an "Exported N parts" toast appears. A 3-segment export produces 3 files.

Evidence (in `apps/ui`):
- `pnpm run format:check` — clean
- `pnpm run lint` — clean (exit 0)
- `pnpm run typecheck` — clean (exit 0)
- `pnpm run test` (jest) — 124 suites, 1089 tests passed, including new `session-export` cases: offer-then-walk-3-segments, cross-segment image aggregation, bad-cursor-mid-walk "stopped after 1 part", and old-server no-segmentation fallback
- `pnpm run build` — Compiled successfully

## Risk
- Low
- UI-only. Worst case: the segment walk mishandles an unexpected server response; it is bounded (10k cap), converts failures into a "stopped after N parts" toast, and never crashes the page.

## Security
- Threat categories reviewed: TM-WEB, TM-API, TM-DOS.
- Findings and resolutions:
  - SSRF / open-redirect via `continued_trajectory_ref`: the server returns a full-path ref, but the UI trusts only its opaque `cursor` query value and always re-fetches its own same-origin `/api/v1/sessions/{id}/export` endpoint (never follows the ref's path/origin). The dummy parse base is used solely to read the query string, never to fetch.
  - DOS / unbounded walk: capped at `MAX_ATIF_SEGMENTS` (10,000) so a server that never stops emitting a next cursor cannot loop forever or fill the disk.
  - No new data exposure: same export endpoint, same auth cookie (`credentials: "include"`), cursor is opaque server state. Toast content is React-escaped text (no `dangerouslySetInnerHTML`).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)