### PR TITLE
feat(sessions): add participant model

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -487,7 +487,10 @@ pub use payment::{
 };
 pub use principal::{Principal, PrincipalKind, PrincipalStatus, PrincipalSummary};
 pub use provider::{Provider, ProviderStatus, ProviderTraceConfig};
-pub use session::{Session, SessionStatus, SubagentStatus};
+pub use session::{
+    Session, SessionParticipant, SessionParticipantKind, SessionParticipantRole, SessionStatus,
+    SubagentStatus,
+};
 pub use session_file::{FileInfo, FileStat, GrepMatch, GrepResult, InitialFile, SessionFile};
 pub use session_resource::{
     RegisterSessionResource, SessionResourceEntry, SessionResourceFilter, SessionResourceStatus,
@@ -514,7 +517,7 @@ pub use typed_id::{
     IdParseError, ImageId, KnowledgeBaseId, KnowledgeEntryId, LeasedResourceId, McpServerId,
     MemoryId, MessageId, ModelId, NotificationId, OrgId, PaymentAccountId, PaymentAttemptId,
     PaymentPolicyId, PluginInstallId, PluginMarketplaceId, PrincipalId, ProviderId, ScheduleId,
-    SessionId, SkillId, TurnId, TypedId, WorkspaceId,
+    SessionId, SessionParticipantId, SkillId, TurnId, TypedId, WorkspaceId,
 };
 
 // Audit logging re-exports

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -14,7 +14,7 @@ use crate::principal::PrincipalSummary;
 use crate::tool_types::ToolDefinition;
 use crate::typed_id::{
     AgentId, AgentIdentityId, AgentVersionId, HarnessId, ModelId, PrincipalId, SessionId,
-    WorkspaceId,
+    SessionParticipantId, WorkspaceId,
 };
 
 #[cfg(feature = "openapi")]
@@ -114,6 +114,120 @@ impl From<&str> for SessionStatus {
             _ => SessionStatus::Started,
         }
     }
+}
+
+/// Kind of actor participating in a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionParticipantKind {
+    Agent,
+    User,
+}
+
+impl std::fmt::Display for SessionParticipantKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionParticipantKind::Agent => write!(f, "agent"),
+            SessionParticipantKind::User => write!(f, "user"),
+        }
+    }
+}
+
+impl From<&str> for SessionParticipantKind {
+    fn from(s: &str) -> Self {
+        match s {
+            "agent" => SessionParticipantKind::Agent,
+            "user" => SessionParticipantKind::User,
+            _ => SessionParticipantKind::User,
+        }
+    }
+}
+
+/// Role a participant has inside a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionParticipantRole {
+    Host,
+    Member,
+}
+
+impl std::fmt::Display for SessionParticipantRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionParticipantRole::Host => write!(f, "host"),
+            SessionParticipantRole::Member => write!(f, "member"),
+        }
+    }
+}
+
+impl From<&str> for SessionParticipantRole {
+    fn from(s: &str) -> Self {
+        match s {
+            "host" => SessionParticipantRole::Host,
+            "member" => SessionParticipantRole::Member,
+            _ => SessionParticipantRole::Member,
+        }
+    }
+}
+
+/// Session participant - an agent or user that has joined a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct SessionParticipant {
+    /// Unique identifier for the participant row (format: part_{32-hex}).
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = String,
+            example = "part_01933b5a00007000800000000000001"
+        )
+    )]
+    pub id: SessionParticipantId,
+    /// Session this participant belongs to.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = String,
+            example = "session_01933b5a00007000800000000000001"
+        )
+    )]
+    pub session_id: SessionId,
+    pub kind: SessionParticipantKind,
+    /// Present for agent participants.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = Option<String>,
+            example = "agent_01933b5a00007000800000000000001"
+        )
+    )]
+    pub agent_id: Option<AgentId>,
+    /// Immutable agent version captured for an agent participant when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = Option<String>,
+            example = "agentver_01933b5a00007000800000000000001"
+        )
+    )]
+    pub agent_version_id: Option<AgentVersionId>,
+    /// Principal that joined the session.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = String,
+            example = "principal_01933b5a000070008000000000000001"
+        )
+    )]
+    pub principal_id: PrincipalId,
+    pub role: SessionParticipantRole,
+    pub joined_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left_at: Option<DateTime<Utc>>,
 }
 
 /// Session - instance of agentic loop execution.

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -336,6 +336,13 @@ impl IdMarker for SessionIdMarker {
     const PREFIX: &'static str = "session";
 }
 
+/// Marker for Session Participant IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SessionParticipantIdMarker;
+impl IdMarker for SessionParticipantIdMarker {
+    const PREFIX: &'static str = "part";
+}
+
 /// Marker for Message IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct MessageIdMarker;
@@ -621,6 +628,8 @@ pub type AgentIdentityId = TypedId<AgentIdentityIdMarker>;
 pub type PrincipalId = TypedId<PrincipalIdMarker>;
 /// Session ID
 pub type SessionId = TypedId<SessionIdMarker>;
+/// Session Participant ID
+pub type SessionParticipantId = TypedId<SessionParticipantIdMarker>;
 /// Message ID
 pub type MessageId = TypedId<MessageIdMarker>;
 /// Event ID

--- a/crates/server/migrations/095_session_participants.sql
+++ b/crates/server/migrations/095_session_participants.sql
@@ -1,0 +1,97 @@
+-- Session participants: durable membership model for agent/user collaboration.
+--
+-- `sessions.agent_id` remains the denormalized host-agent pointer for existing
+-- reads. This table is the canonical participant set used by the follow-on
+-- API/runtime slices.
+
+CREATE TABLE session_participants (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id) ON DELETE CASCADE,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('agent', 'user')),
+    agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+    agent_version_id UUID REFERENCES agent_versions(id) ON DELETE SET NULL,
+    principal_id UUID NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+    role TEXT NOT NULL CHECK (role IN ('host', 'member')),
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    left_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT session_participants_agent_shape CHECK (
+        (kind = 'agent' AND agent_id IS NOT NULL)
+        OR (kind = 'user' AND agent_id IS NULL AND agent_version_id IS NULL)
+    ),
+    CONSTRAINT session_participants_host_agent CHECK (
+        role <> 'host' OR kind = 'agent'
+    ),
+    CONSTRAINT session_participants_interval CHECK (
+        left_at IS NULL OR left_at >= joined_at
+    )
+);
+
+CREATE UNIQUE INDEX session_participants_one_active_host_idx
+    ON session_participants(session_id)
+    WHERE kind = 'agent' AND role = 'host' AND left_at IS NULL;
+
+CREATE INDEX idx_session_participants_org_session
+    ON session_participants(org_id, session_id, joined_at);
+
+CREATE INDEX idx_session_participants_agent
+    ON session_participants(org_id, agent_id)
+    WHERE agent_id IS NOT NULL;
+
+CREATE INDEX idx_session_participants_principal
+    ON session_participants(org_id, principal_id);
+
+CREATE INDEX idx_session_participants_session_left_at
+    ON session_participants(session_id, left_at);
+
+CREATE TRIGGER update_session_participants_updated_at BEFORE UPDATE ON session_participants
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+INSERT INTO session_participants (
+    id, org_id, session_id, kind, agent_id, agent_version_id,
+    principal_id, role, joined_at, created_at, updated_at
+)
+SELECT
+    uuidv7(),
+    org_id,
+    id,
+    'agent',
+    agent_id,
+    agent_version_id,
+    owner_principal_id,
+    'host',
+    created_at,
+    created_at,
+    updated_at
+FROM sessions
+WHERE agent_id IS NOT NULL;
+
+INSERT INTO session_participants (
+    id, org_id, session_id, kind, agent_id, agent_version_id,
+    principal_id, role, joined_at, created_at, updated_at
+)
+SELECT
+    uuidv7(),
+    org_id,
+    id,
+    'user',
+    NULL,
+    NULL,
+    owner_principal_id,
+    'member',
+    created_at,
+    created_at,
+    updated_at
+FROM sessions;
+
+COMMENT ON TABLE session_participants IS
+    'Durable membership rows for users and agents participating in a session.';
+COMMENT ON COLUMN session_participants.kind IS
+    'Participant actor kind: agent or user.';
+COMMENT ON COLUMN session_participants.role IS
+    'Participant role within the session. Host is reserved for the active agent.';
+COMMENT ON COLUMN session_participants.agent_version_id IS
+    'Immutable agent version captured for agent participants when known.';

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -767,6 +767,21 @@ impl StorageBackend {
         dispatch!(self, create_session, input)
     }
 
+    pub async fn create_session_participant(
+        &self,
+        input: CreateSessionParticipantRow,
+    ) -> Result<SessionParticipantRow> {
+        dispatch!(self, create_session_participant, input)
+    }
+
+    pub async fn list_session_participants(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+    ) -> Result<Vec<SessionParticipantRow>> {
+        dispatch!(self, list_session_participants, org_id, session_id)
+    }
+
     pub async fn list_reporting_outbox(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -37,6 +37,7 @@ mod reporting;
 mod schedules;
 mod session_files;
 mod session_git;
+mod session_participants;
 mod session_resources;
 mod session_storage;
 mod session_tasks;
@@ -55,7 +56,8 @@ use chrono::{DateTime, Utc};
 use everruns_core::{
     AgentId, AgentIdentityId, AgentVersionId, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, EventId,
     HarnessId, ImageId, LeasedResourceId, McpServerId, MessageId, ModelId, NotificationId,
-    PluginMarketplaceId, PrincipalId, ProviderId, ScheduleId, SessionId, SkillId,
+    PluginMarketplaceId, PrincipalId, ProviderId, ScheduleId, SessionId, SessionParticipantId,
+    SkillId,
 };
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -103,6 +105,7 @@ pub struct InMemoryDatabase {
     agents: RwLock<HashMap<AgentId, AgentRow>>,
     agent_versions: RwLock<HashMap<AgentVersionId, AgentVersionRow>>,
     sessions: RwLock<HashMap<SessionId, SessionRow>>,
+    session_participants: RwLock<HashMap<SessionParticipantId, SessionParticipantRow>>,
     events: RwLock<HashMap<EventId, EventRow>>,
     providers: RwLock<HashMap<ProviderId, ProviderRow>>,
     models: RwLock<HashMap<ModelId, ModelRow>>,
@@ -259,6 +262,7 @@ impl Default for InMemoryDatabase {
             agents: RwLock::new(HashMap::new()),
             agent_versions: RwLock::new(HashMap::new()),
             sessions: RwLock::new(HashMap::new()),
+            session_participants: RwLock::new(HashMap::new()),
             events: RwLock::new(HashMap::new()),
             providers: RwLock::new(HashMap::new()),
             models: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory/session_participants.rs
+++ b/crates/server/src/storage/memory/session_participants.rs
@@ -1,0 +1,149 @@
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::{Result, bail};
+use everruns_core::{
+    SessionId, SessionParticipantId, SessionParticipantKind, SessionParticipantRole,
+};
+
+impl InMemoryDatabase {
+    pub(crate) async fn insert_initial_session_participants(
+        &self,
+        session: &SessionRow,
+    ) -> Result<()> {
+        if let Some(agent_id) = session.agent_id {
+            self.insert_session_participant_unchecked(SessionParticipantRow {
+                id: SessionParticipantId::new(),
+                org_id: session.org_id,
+                session_id: session.id,
+                kind: SessionParticipantKind::Agent.to_string(),
+                agent_id: Some(agent_id),
+                agent_version_id: session.agent_version_id,
+                principal_id: session.owner_principal_id,
+                role: SessionParticipantRole::Host.to_string(),
+                joined_at: session.created_at,
+                left_at: None,
+                created_at: session.created_at,
+                updated_at: session.created_at,
+            })?;
+        }
+
+        self.insert_session_participant_unchecked(SessionParticipantRow {
+            id: SessionParticipantId::new(),
+            org_id: session.org_id,
+            session_id: session.id,
+            kind: SessionParticipantKind::User.to_string(),
+            agent_id: None,
+            agent_version_id: None,
+            principal_id: session.owner_principal_id,
+            role: SessionParticipantRole::Member.to_string(),
+            joined_at: session.created_at,
+            left_at: None,
+            created_at: session.created_at,
+            updated_at: session.created_at,
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn create_session_participant(
+        &self,
+        input: CreateSessionParticipantRow,
+    ) -> Result<SessionParticipantRow> {
+        self.validate_session_participant(&input)?;
+
+        let now = Self::now();
+        let joined_at = input.joined_at.unwrap_or(now);
+        let row = SessionParticipantRow {
+            id: SessionParticipantId::new(),
+            org_id: input.org_id,
+            session_id: input.session_id,
+            kind: input.kind.to_string(),
+            agent_id: input.agent_id,
+            agent_version_id: input.agent_version_id,
+            principal_id: input.principal_id,
+            role: input.role.to_string(),
+            joined_at,
+            left_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        self.insert_session_participant_unchecked(row.clone())?;
+        Ok(row)
+    }
+
+    pub async fn list_session_participants(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+    ) -> Result<Vec<SessionParticipantRow>> {
+        let mut rows: Vec<_> = self
+            .session_participants
+            .read()
+            .values()
+            .filter(|row| row.org_id == org_id && row.session_id == session_id)
+            .cloned()
+            .collect();
+        rows.sort_by_key(|row| (row.joined_at, row.created_at, row.id.uuid()));
+        Ok(rows)
+    }
+
+    fn validate_session_participant(&self, input: &CreateSessionParticipantRow) -> Result<()> {
+        let session = self
+            .sessions
+            .read()
+            .get(&input.session_id)
+            .cloned()
+            .filter(|session| session.org_id == input.org_id);
+        if session.is_none() {
+            bail!("session not found");
+        }
+
+        match input.kind {
+            SessionParticipantKind::Agent if input.agent_id.is_none() => {
+                bail!("agent participants require agent_id")
+            }
+            SessionParticipantKind::User
+                if input.agent_id.is_some() || input.agent_version_id.is_some() =>
+            {
+                bail!("user participants cannot reference an agent")
+            }
+            _ => {}
+        }
+
+        if input.role == SessionParticipantRole::Host && input.kind != SessionParticipantKind::Agent
+        {
+            bail!("host participants must be agents");
+        }
+
+        if input.role == SessionParticipantRole::Host {
+            let has_active_host = self.session_participants.read().values().any(|row| {
+                row.session_id == input.session_id
+                    && row.kind == "agent"
+                    && row.role == "host"
+                    && row.left_at.is_none()
+            });
+            if has_active_host {
+                bail!("session already has an active host participant");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert_session_participant_unchecked(&self, row: SessionParticipantRow) -> Result<()> {
+        if row.role == "host" {
+            let has_active_host = self.session_participants.read().values().any(|existing| {
+                existing.session_id == row.session_id
+                    && existing.kind == "agent"
+                    && existing.role == "host"
+                    && existing.left_at.is_none()
+            });
+            if has_active_host {
+                bail!("session already has an active host participant");
+            }
+        }
+        self.session_participants.write().insert(row.id, row);
+        Ok(())
+    }
+}

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -103,6 +103,7 @@ impl InMemoryDatabase {
             blueprint_config: input.blueprint_config,
         };
         self.sessions.write().insert(id, row.clone());
+        self.insert_initial_session_participants(&row).await?;
         self.enqueue_reporting_outbox(
             row.org_id,
             "session",

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -3,7 +3,10 @@ use super::*;
 use crate::api::common::Pagination;
 use chrono::Utc;
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
-use everruns_core::{AgentId, DEFAULT_ORG_ID, HarnessId, SessionId};
+use everruns_core::{
+    AgentId, DEFAULT_ORG_ID, HarnessId, PrincipalId, SessionId, SessionParticipantKind,
+    SessionParticipantRole,
+};
 
 /// Default pagination for tests (large enough to not truncate).
 fn default_pagination() -> Pagination {
@@ -12,6 +15,35 @@ fn default_pagination() -> Pagination {
 
 fn test_harness_id() -> HarnessId {
     HarnessId::from_uuid(uuid::Uuid::nil())
+}
+
+fn test_session_input(agent_id: Option<AgentId>) -> CreateSessionRow {
+    CreateSessionRow {
+        workspace_id: None,
+        org_id: DEFAULT_ORG_ID,
+        app_id: None,
+        harness_id: None,
+        agent_id,
+        agent_identity_id: None,
+        owner_principal_id: PrincipalId::from_seed(1),
+        resolved_owner_user_id: None,
+        title: None,
+        locale: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: serde_json::json!([]),
+        tools: serde_json::json!([]),
+        mcp_servers: serde_json::json!({}),
+        system_prompt: None,
+        initial_files: serde_json::Value::Array(vec![]),
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        parallel_tool_calls: None,
+        blueprint_id: None,
+        blueprint_config: None,
+        parent_session_id: None,
+    }
 }
 
 #[tokio::test]
@@ -233,6 +265,89 @@ async fn test_set_session_fork_lineage_roundtrip() {
         .unwrap()
         .unwrap();
     assert_eq!(reloaded_parent.forked_from_session_id, None);
+}
+
+#[tokio::test]
+async fn test_create_session_seeds_agent_and_user_participants() {
+    let db = InMemoryDatabase::new();
+    let agent_id = AgentId::new();
+
+    let session = db
+        .create_session(test_session_input(Some(agent_id)))
+        .await
+        .unwrap();
+    let participants = db
+        .list_session_participants(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap();
+
+    assert_eq!(participants.len(), 2);
+    assert_eq!(session.agent_id, Some(agent_id));
+
+    let host = participants
+        .iter()
+        .map(SessionParticipantRow::to_core)
+        .find(|participant| participant.role == SessionParticipantRole::Host)
+        .unwrap();
+    assert_eq!(host.kind, SessionParticipantKind::Agent);
+    assert_eq!(host.agent_id, Some(agent_id));
+    assert_eq!(host.principal_id, PrincipalId::from_seed(1));
+
+    let user = participants
+        .iter()
+        .map(SessionParticipantRow::to_core)
+        .find(|participant| participant.kind == SessionParticipantKind::User)
+        .unwrap();
+    assert_eq!(user.role, SessionParticipantRole::Member);
+    assert_eq!(user.agent_id, None);
+    assert_eq!(user.principal_id, PrincipalId::from_seed(1));
+}
+
+#[tokio::test]
+async fn test_create_session_without_agent_seeds_user_participant_only() {
+    let db = InMemoryDatabase::new();
+
+    let session = db.create_session(test_session_input(None)).await.unwrap();
+    let participants = db
+        .list_session_participants(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap();
+
+    assert_eq!(participants.len(), 1);
+    let participant = participants[0].to_core();
+    assert_eq!(participant.kind, SessionParticipantKind::User);
+    assert_eq!(participant.role, SessionParticipantRole::Member);
+    assert_eq!(participant.agent_id, None);
+}
+
+#[tokio::test]
+async fn test_create_session_participant_rejects_second_active_host() {
+    let db = InMemoryDatabase::new();
+    let agent_id = AgentId::new();
+
+    let session = db
+        .create_session(test_session_input(Some(agent_id)))
+        .await
+        .unwrap();
+
+    let err = db
+        .create_session_participant(CreateSessionParticipantRow {
+            org_id: DEFAULT_ORG_ID,
+            session_id: session.id,
+            kind: SessionParticipantKind::Agent,
+            agent_id: Some(AgentId::new()),
+            agent_version_id: None,
+            principal_id: PrincipalId::from_seed(1),
+            role: SessionParticipantRole::Host,
+            joined_at: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("session already has an active host participant")
+    );
 }
 
 #[tokio::test]

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -4,7 +4,8 @@ use chrono::{DateTime, Utc};
 use everruns_core::{
     AgentId, AgentIdentityId, EventId, HarnessId, ImageId, LeasedResourceId, McpServerId,
     MessageId, ModelId, NotificationId, PrincipalId, ProviderId, ScheduleId, ServiceKind,
-    SessionId, SkillId,
+    SessionId, SessionParticipant, SessionParticipantId, SessionParticipantKind,
+    SessionParticipantRole, SkillId,
 };
 use everruns_durable::UpdateField;
 use sqlx::FromRow;
@@ -825,6 +826,50 @@ pub struct CreateSessionRow {
     /// equals the new session id (the equality invariant). When `Some`, the
     /// session attaches to that workspace and no new workspace is created.
     pub workspace_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionParticipantRow {
+    pub id: SessionParticipantId,
+    pub org_id: i64,
+    pub session_id: SessionId,
+    pub kind: String,
+    pub agent_id: Option<AgentId>,
+    pub agent_version_id: Option<everruns_core::AgentVersionId>,
+    pub principal_id: PrincipalId,
+    pub role: String,
+    pub joined_at: DateTime<Utc>,
+    pub left_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl SessionParticipantRow {
+    pub fn to_core(&self) -> SessionParticipant {
+        SessionParticipant {
+            id: self.id,
+            session_id: self.session_id,
+            kind: SessionParticipantKind::from(self.kind.as_str()),
+            agent_id: self.agent_id,
+            agent_version_id: self.agent_version_id,
+            principal_id: self.principal_id,
+            role: SessionParticipantRole::from(self.role.as_str()),
+            joined_at: self.joined_at,
+            left_at: self.left_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSessionParticipantRow {
+    pub org_id: i64,
+    pub session_id: SessionId,
+    pub kind: SessionParticipantKind,
+    pub agent_id: Option<AgentId>,
+    pub agent_version_id: Option<everruns_core::AgentVersionId>,
+    pub principal_id: PrincipalId,
+    pub role: SessionParticipantRole,
+    pub joined_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -32,6 +32,7 @@ mod reporting;
 mod schedules;
 mod session_files;
 mod session_git;
+mod session_participants;
 mod session_resources;
 mod session_storage;
 mod session_tasks;

--- a/crates/server/src/storage/repositories/session_participants.rs
+++ b/crates/server/src/storage/repositories/session_participants.rs
@@ -1,0 +1,56 @@
+use super::super::models::*;
+use super::Database;
+use anyhow::Result;
+
+impl Database {
+    pub async fn create_session_participant(
+        &self,
+        input: CreateSessionParticipantRow,
+    ) -> Result<SessionParticipantRow> {
+        let joined_at = input.joined_at.unwrap_or_else(chrono::Utc::now);
+
+        sqlx::query_as::<_, SessionParticipantRow>(
+            r#"
+            INSERT INTO session_participants (
+                id, org_id, session_id, kind, agent_id, agent_version_id,
+                principal_id, role, joined_at
+            )
+            VALUES (uuidv7(), $1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id, org_id, session_id, kind, agent_id, agent_version_id,
+                      principal_id, role, joined_at, left_at, created_at, updated_at
+            "#,
+        )
+        .bind(input.org_id)
+        .bind(input.session_id.uuid())
+        .bind(input.kind.to_string())
+        .bind(input.agent_id.map(|id| id.uuid()))
+        .bind(input.agent_version_id.map(|id| id.uuid()))
+        .bind(input.principal_id)
+        .bind(input.role.to_string())
+        .bind(joined_at)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn list_session_participants(
+        &self,
+        org_id: i64,
+        session_id: everruns_core::SessionId,
+    ) -> Result<Vec<SessionParticipantRow>> {
+        sqlx::query_as::<_, SessionParticipantRow>(
+            r#"
+            SELECT id, org_id, session_id, kind, agent_id, agent_version_id,
+                   principal_id, role, joined_at, left_at, created_at, updated_at
+            FROM session_participants
+            WHERE org_id = $1 AND session_id = $2
+            ORDER BY joined_at ASC, created_at ASC, id ASC
+            "#,
+        )
+        .bind(org_id)
+        .bind(session_id.uuid())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+}

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -107,6 +107,42 @@ impl Database {
         .fetch_one(&mut *tx)
         .await?;
 
+        if let Some(agent_id) = row.agent_id {
+            sqlx::query(
+                r#"
+                INSERT INTO session_participants (
+                    id, org_id, session_id, kind, agent_id, agent_version_id,
+                    principal_id, role, joined_at
+                )
+                VALUES (uuidv7(), $1, $2, 'agent', $3, $4, $5, 'host', $6)
+                "#,
+            )
+            .bind(row.org_id)
+            .bind(row.id.uuid())
+            .bind(agent_id.uuid())
+            .bind(row.agent_version_id.map(|id| id.uuid()))
+            .bind(row.owner_principal_id)
+            .bind(row.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO session_participants (
+                id, org_id, session_id, kind, agent_id, agent_version_id,
+                principal_id, role, joined_at
+            )
+            VALUES (uuidv7(), $1, $2, 'user', NULL, NULL, $3, 'member', $4)
+            "#,
+        )
+        .bind(row.org_id)
+        .bind(row.id.uuid())
+        .bind(row.owner_principal_id)
+        .bind(row.created_at)
+        .execute(&mut *tx)
+        .await?;
+
         tx.commit().await?;
 
         // Reporting outbox enqueue is best-effort (see specs/reporting.md).

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -62,7 +62,10 @@ Working instance of an agentic loop. Configured by its harness and situationally
 
 - Many sessions in the system
 - Each session has an assigned harness
-- Agent is optional and can change over the session's lifetime
+- Agent is optional and can change over the session's lifetime. `session.agent_id`
+  is the denormalized pointer to the active host agent.
+- Session participants record the agents and users attached to a session. At
+  most one active agent participant may have the `host` role.
 - Sessions can have own capabilities, additive to agent capabilities
 - Sessions can override the LLM model
 - Status: `started` → `active` → `idle` (sessions work indefinitely)

--- a/specs/models.md
+++ b/specs/models.md
@@ -52,14 +52,16 @@ Last-resort validation limits to guard against abuse. API returns generic `400 B
 
 ### Session
 
-An instance of agentic loop execution. Sessions are top-level entities under organizations, with an agent assigned to work in each session.
+An instance of agentic loop execution. Sessions are top-level entities under organizations, with an optional host agent assigned to work in each session.
 
 See `crates/core/src/session.rs` for full field definitions.
 
 See `specs/localization.md` for locale/timezone resolution and durable preference rules.
 
 Key design points:
-- Sessions are direct children of organizations (not agents). The `agent_id` specifies which agent is assigned.
+- Sessions are direct children of organizations (not agents). The `agent_id` column is a denormalized pointer to the active host agent for existing reads.
+- `session_participants` records the users and agents associated with the session. Existing sessions are backfilled with an owner user participant and, when `agent_id` is present, a host agent participant.
+- The database enforces at most one active host agent participant per session.
 - `agent_version_id` captures the immutable AgentVersion used for runtime execution when agent versions are enabled.
 - `app_id` is a nullable internal backreference set only when the server creates a session from an App channel. User/API, MCP, and platform-management session creation paths cannot set it.
 - `locale` is an optional session-level BCP 47 tag (for example `uk-UA`). The worker carries it through turn loading and prompt construction so scheduled runs, resumed runs, and subagents can inherit localized behavior.


### PR DESCRIPTION
## What changed
Adds the first EVE-692 session participant slice: sessions now get durable participant rows for the owner user and, when present, the host agent while preserving existing `sessions.agent_id` reads. The database enforces participant shape and at most one active host agent per session; in-memory storage mirrors the behavior for OSS dev mode.

## Why
EVE-692 needs a durable model for multi-participant sessions before API/runtime slices can expose agent + user collaboration safely.

## Before / After
Before: session membership was implicit in `sessions.agent_id` and owner fields only.

After: creating a session seeds participant rows automatically. Existing sessions are backfilled by migration `095_session_participants.sql`.

Evidence:
- `cargo test -p everruns-server test_create_session_ --lib --all-features` -> 12 passed
- `cargo test -p everruns-server participants --lib --all-features` -> participant seed test passed
- `cargo test -p everruns-server test_create_session_participant_rejects_second_active_host --lib --all-features` -> duplicate-host guard passed
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` -> passed
- `bash scripts/lib/check-migration-ordering.sh` -> migrations sequential (001..095)
- `just pre-push` -> all 10 checks passed after rebase
- Caddy smoke on `PORT_PREFIX=281`: `/health` 200, `/api-doc/openapi.json` 3.1.0 with 202 paths, `/login` 200, created `session_019f4818398f7ec3a9c685edc2a6c715`, session chat route 200

## Risk
Medium. This adds a migration and changes the session-create write path; mistakes could affect new session creation or migration rollout. The public API shape is unchanged.

## Security
- Threat categories reviewed: TM-TENANT, TM-AUTHZ, TM-SQL
- Findings and resolutions: participant rows carry `org_id` and list paths are org-scoped; DB constraints enforce host/user shape and one active host; no new external endpoint, auth behavior, secret handling, or network access is introduced.

## Follow-ups
Remaining EVE-692 slices: participant API, runtime routing/addressing, UI affordances, task/participant attribution, and docs/test-cases for the public behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

