### PR TITLE
feat(models): add GPT-5.6 Sol, Terra, and Luna profiles

### DIFF
--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -92,7 +92,7 @@ fn reasoning_effort_gpt52() -> ReasoningEffortConfig {
     }
 }
 
-/// Reasoning effort for gpt-5.5
+/// Reasoning effort for gpt-5.5 and the gpt-5.6 series (Sol, Terra, Luna)
 /// Default: medium, supports: none, low, medium, high, xhigh
 fn reasoning_effort_gpt55() -> ReasoningEffortConfig {
     ReasoningEffortConfig {
@@ -283,6 +283,10 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["gpt-5.4-pro"], ModelVendor::OpenAi, OPENAI),
     md(&["gpt-5.5"], ModelVendor::OpenAi, OPENAI),
     md(&["gpt-5.5-pro"], ModelVendor::OpenAi, OPENAI),
+    // GPT-5.6 series: Sol (flagship), Terra (balanced), Luna (fast/cheap).
+    md(&["gpt-5.6-sol"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.6-terra"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.6-luna"], ModelVendor::OpenAi, OPENAI),
     // Anthropic
     md(&["claude-fable-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-8"], ModelVendor::Anthropic, ANTHROPIC),
@@ -1416,7 +1420,137 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
             supports_phases: false,
         }),
 
-        // GPT-5.5 family: latest flagship reasoning models. Released 2026-04-23.
+        // GPT-5.6 series: current flagship family, publicly released 2026-07-09.
+        // The version (5.6) names the generation; Sol/Terra/Luna are durable
+        // capability tiers (intelligence / balanced / fast-and-cheap) that can
+        // advance on their own cadence. All three share a 1.05M context, 128K
+        // output, a 2026-02-16 knowledge cutoff, and none/low/medium/high/xhigh
+        // reasoning effort (default medium). Pricing is tiered: prompts over
+        // 272K input tokens bill at 2x input and 1.5x output for the whole
+        // request. Source: developers.openai.com/api/docs/models/gpt-5.6-{sol,
+        // terra,luna} and openai.com/index/gpt-5-6/ (models.dev did not yet list
+        // these variants at the time of addition; refresh once it catches up).
+        "gpt-5.6-sol" => Some(ModelProfile {
+            name: "GPT-5.6 Sol".into(),
+            family: "gpt-5.6-sol".into(),
+            description: Some("Flagship model of the GPT-5.6 series. Deepest reasoning for complex agentic coding, science, and multi-step analysis.".into()),
+            release_date: Some("2026-07-09".into()),
+            last_updated: Some("2026-07-09".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: Some("2026-02-16".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 5.00,
+                output: 30.00,
+                cache_read: Some(0.50),
+                cost_tiers: vec![CostTier {
+                    above_tokens: 272_000,
+                    input: 10.00,
+                    output: 45.00,
+                    cache_read: Some(1.00),
+                }],
+            }),
+            limits: Some(ModelLimits {
+                context: 1_050_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt55()),
+            tool_search: true,
+            supported_parameters: Vec::new(),
+            supports_phases: true,
+        }),
+
+        "gpt-5.6-terra" => Some(ModelProfile {
+            name: "GPT-5.6 Terra".into(),
+            family: "gpt-5.6-terra".into(),
+            description: Some("Balanced GPT-5.6 tier for everyday work. Performance competitive with GPT-5.5 at roughly half the cost.".into()),
+            release_date: Some("2026-07-09".into()),
+            last_updated: Some("2026-07-09".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: Some("2026-02-16".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 2.50,
+                output: 15.00,
+                cache_read: Some(0.25),
+                cost_tiers: vec![CostTier {
+                    above_tokens: 272_000,
+                    input: 5.00,
+                    output: 22.50,
+                    cache_read: Some(0.50),
+                }],
+            }),
+            limits: Some(ModelLimits {
+                context: 1_050_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt55()),
+            tool_search: true,
+            supported_parameters: Vec::new(),
+            supports_phases: true,
+        }),
+
+        "gpt-5.6-luna" => Some(ModelProfile {
+            name: "GPT-5.6 Luna".into(),
+            family: "gpt-5.6-luna".into(),
+            description: Some("Fastest, most cost-efficient GPT-5.6 tier. Built for high-volume, latency-sensitive work: classification, extraction, routing, and first-pass drafting.".into()),
+            release_date: Some("2026-07-09".into()),
+            last_updated: Some("2026-07-09".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: Some("2026-02-16".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 1.00,
+                output: 6.00,
+                cache_read: Some(0.10),
+                cost_tiers: vec![CostTier {
+                    above_tokens: 272_000,
+                    input: 2.00,
+                    output: 9.00,
+                    cache_read: Some(0.20),
+                }],
+            }),
+            limits: Some(ModelLimits {
+                context: 1_050_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_gpt55()),
+            tool_search: true,
+            supported_parameters: Vec::new(),
+            supports_phases: true,
+        }),
+
+        // GPT-5.5 family: flagship reasoning models. Released 2026-04-23.
         // Flat pricing (no 200K context tiers, unlike 5.4).
         // Source: developers.openai.com/api/docs/models/gpt-5.5 and .../gpt-5.5-pro
         // (models.dev did not yet list these variants at the time of addition;
@@ -1424,7 +1558,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
         "gpt-5.5" => Some(ModelProfile {
             name: "GPT-5.5".into(),
             family: "gpt-5.5".into(),
-            description: Some("Latest flagship reasoning model. Best for complex multi-step tasks, code generation, and deep analysis.".into()),
+            description: Some("Flagship reasoning model. Best for complex multi-step tasks, code generation, and deep analysis.".into()),
             release_date: Some("2026-04-23".into()),
             last_updated: Some("2026-04-23".into()),
             attachment: true,
@@ -3245,6 +3379,9 @@ mod tests {
         (DriverId::OpenAI, "gpt-5.4-pro"),
         (DriverId::OpenAI, "gpt-5.5"),
         (DriverId::OpenAI, "gpt-5.5-pro"),
+        (DriverId::OpenAI, "gpt-5.6-sol"),
+        (DriverId::OpenAI, "gpt-5.6-terra"),
+        (DriverId::OpenAI, "gpt-5.6-luna"),
         // Anthropic
         (DriverId::Anthropic, "claude-fable-5"),
         (DriverId::Anthropic, "claude-opus-4-8"),
@@ -3680,6 +3817,88 @@ mod tests {
         assert_eq!(normalize_model_id("gpt-5.5-2026-04-23"), "gpt-5.5");
         assert_eq!(normalize_model_id("gpt-5.5-pro"), "gpt-5.5-pro");
         assert_eq!(normalize_model_id("gpt-5.5-pro-2026-04-23"), "gpt-5.5-pro");
+    }
+
+    #[test]
+    fn test_gpt56_profiles() {
+        // Sol, Terra, Luna share the same shape: 1.05M context, 128K output,
+        // 2026-02-16 knowledge cutoff, tool_search + native phases, and a
+        // >272K-token pricing tier (2x input, 1.5x output).
+        for (id, name, family, input, output, cache, tier_input, tier_output, tier_cache) in [
+            (
+                "gpt-5.6-sol",
+                "GPT-5.6 Sol",
+                "gpt-5.6-sol",
+                5.00,
+                30.00,
+                0.50,
+                10.00,
+                45.00,
+                1.00,
+            ),
+            (
+                "gpt-5.6-terra",
+                "GPT-5.6 Terra",
+                "gpt-5.6-terra",
+                2.50,
+                15.00,
+                0.25,
+                5.00,
+                22.50,
+                0.50,
+            ),
+            (
+                "gpt-5.6-luna",
+                "GPT-5.6 Luna",
+                "gpt-5.6-luna",
+                1.00,
+                6.00,
+                0.10,
+                2.00,
+                9.00,
+                0.20,
+            ),
+        ] {
+            let profile = get_model_profile(&DriverId::OpenAI, id).unwrap();
+            assert_eq!(profile.name, name);
+            assert_eq!(profile.family, family);
+            assert!(profile.reasoning);
+            assert!(!profile.temperature);
+            assert!(profile.tool_call);
+            assert!(profile.structured_output);
+            assert!(profile.tool_search);
+            assert!(profile.supports_phases);
+            assert_eq!(profile.knowledge.as_deref(), Some("2026-02-16"));
+
+            let limits = profile.limits.unwrap();
+            assert_eq!(limits.context, 1_050_000);
+            assert_eq!(limits.output, 128_000);
+
+            let cost = profile.cost.unwrap();
+            assert!((cost.input - input).abs() < f64::EPSILON);
+            assert!((cost.output - output).abs() < f64::EPSILON);
+            assert!((cost.cache_read.unwrap() - cache).abs() < f64::EPSILON);
+            assert_eq!(cost.cost_tiers.len(), 1);
+            let tier = &cost.cost_tiers[0];
+            assert_eq!(tier.above_tokens, 272_000);
+            assert!((tier.input - tier_input).abs() < f64::EPSILON);
+            assert!((tier.output - tier_output).abs() < f64::EPSILON);
+            assert!((tier.cache_read.unwrap() - tier_cache).abs() < f64::EPSILON);
+
+            // Series default: medium, supports none/low/medium/high/xhigh.
+            let effort = profile.reasoning_effort.unwrap();
+            assert_eq!(effort.default, ReasoningEffort::Medium);
+            assert_eq!(effort.values.len(), 5);
+        }
+    }
+
+    #[test]
+    fn test_gpt56_versioned() {
+        // Dated wire ids resolve to the canonical profile via the "<id>-" prefix.
+        let sol = get_model_profile(&DriverId::OpenAI, "gpt-5.6-sol-2026-07-09").unwrap();
+        assert_eq!(sol.name, "GPT-5.6 Sol");
+        assert_eq!(normalize_model_id("gpt-5.6-sol-2026-07-09"), "gpt-5.6-sol");
+        assert_eq!(normalize_model_id("gpt-5.6-luna"), "gpt-5.6-luna");
     }
 
     #[test]

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -118,6 +118,9 @@ mod seed_ids {
     pub const GPT_5_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000223);
     pub const GPT_5_5_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000224);
     pub const GPT_REALTIME_2: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000225);
+    pub const GPT_5_6_SOL: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000226);
+    pub const GPT_5_6_TERRA: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000227);
+    pub const GPT_5_6_LUNA: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000228);
     pub const O1_PREVIEW: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021e);
 
     // Anthropic Models (0x300-0x3FF)
@@ -1699,6 +1702,31 @@ const SEED_MODELS: &[SeedModel] = &[
         model_id: "gpt-realtime-2",
         display_name: "GPT Realtime 2",
         enabled: false,
+        is_favorite: false,
+    },
+    // OpenAI GPT-5.6 series (Sol / Terra / Luna)
+    SeedModel {
+        id: seed_ids::GPT_5_6_SOL,
+        provider_id: seed_ids::OPENAI_PROVIDER,
+        model_id: "gpt-5.6-sol",
+        display_name: "GPT-5.6 Sol",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        id: seed_ids::GPT_5_6_TERRA,
+        provider_id: seed_ids::OPENAI_PROVIDER,
+        model_id: "gpt-5.6-terra",
+        display_name: "GPT-5.6 Terra",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        id: seed_ids::GPT_5_6_LUNA,
+        provider_id: seed_ids::OPENAI_PROVIDER,
+        model_id: "gpt-5.6-luna",
+        display_name: "GPT-5.6 Luna",
+        enabled: true, // Enabled by default
         is_favorite: false,
     },
     // OpenAI GPT-5.5 series


### PR DESCRIPTION
## What changed

Adds model profiles and seed entries for the **GPT-5.6 series** — OpenAI's current flagship family, publicly released 2026-07-09. The version (5.6) names the generation; **Sol**, **Terra**, and **Luna** are durable capability tiers:

| Model | Tier | Input / Output ($/1M) | Cached input | >272K tier (in/out/cache) |
|---|---|---|---|---|
| GPT-5.6 Sol | Flagship — deepest reasoning | 5.00 / 30.00 | 0.50 | 10.00 / 45.00 / 1.00 |
| GPT-5.6 Terra | Balanced everyday work | 2.50 / 15.00 | 0.25 | 5.00 / 22.50 / 0.50 |
| GPT-5.6 Luna | Fast, cost-efficient | 1.00 / 6.00 | 0.10 | 2.00 / 9.00 / 0.20 |

All three share: 1.05M context, 128K max output, `2026-02-16` knowledge cutoff, text+image input / text output, `tool_search` + native phases, and `none/low/medium/high/xhigh` reasoning effort (default `medium`). Pricing is tiered — prompts over 272K input tokens bill at 2× input / 1.5× output for the whole request. All three are seeded enabled (Sol/Terra favorited).

Impact: the three models now appear in pickers and resolve to correct pricing/limits/capabilities for cost estimation and reasoning-effort UI.

## Why

Fills the gap for the newly released GPT-5.6 family so agents/sessions can select them and cost/limit metadata is accurate.

## Before / After

Before: `gpt-5.6-sol/terra/luna` had no profile (unknown model → no cost estimate, not in pickers).

After — verified end-to-end against a running dev server (`GET /api/v1/models`):

```
gpt-5.6-luna   name=GPT-5.6 Luna   in=1.0 out=6.0  cache=0.1  ctx=1050000 maxout=128000 knowledge=2026-02-16 tiers=1 enabled=True
gpt-5.6-sol    name=GPT-5.6 Sol    in=5.0 out=30.0 cache=0.5  ctx=1050000 maxout=128000 knowledge=2026-02-16 tiers=1 enabled=True
gpt-5.6-terra  name=GPT-5.6 Terra  in=2.5 out=15.0 cache=0.25 ctx=1050000 maxout=128000 knowledge=2026-02-16 tiers=1 enabled=True

sol tier: above_tokens=272000 input=10.0 output=45.0 cache_read=1.0
sol reasoning: default=medium values=[none, low, medium, high, xhigh]  tool_search=True supports_phases=True temperature=False
```

All values grounded in the OpenAI model cards (`developers.openai.com/api/docs/models/gpt-5.6-{sol,terra,luna}`) and the GPT-5.6 launch blog (`openai.com/index/gpt-5-6/`), per the module's "never guess profile data" rule. models.dev did not yet list these variants; noted in a source comment to refresh later.

## Risk

- **Low.** Additive static metadata (profile constants + 3 seed rows with fresh well-known UUIDs `…226/227/228`). No schema, API-shape, or control-flow changes. Seeding is idempotent.

## Security

- Threat categories reviewed: **TM-LLM** (model parameters/pricing metadata). No auth, endpoints, queries, inputs, tool paths, or dependencies changed. No `THREAT` comments in touched files. No new threat surface — no threat-model update needed.
- Findings: none.

## Follow-ups

No follow-ups. (Refreshing the source comment once models.dev lists these variants is captured inline, not a blocker.)

## Checklist
- [x] Tests added or updated (`test_gpt56_profiles`, `test_gpt56_versioned`; registry-consistency invariant covers the new ids)
- [x] Backward compatibility considered (additive only)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKjqukHXEYQv55Jsdg4AfH)_