### PR TITLE
fix(auth): gate default-org auto-join behind opt-in flag

### DIFF
--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -201,6 +201,15 @@ pub struct AuthConfig {
     /// — never an on-screen signal). Requires a configured email sender;
     /// self-host default is off, keeping instant-session signup.
     pub signup_email_confirm: bool,
+    /// When true, a newly registered / first-time-OAuth user is auto-added to
+    /// `DEFAULT_ORG_ID` as a member. This is the single-tenant convenience
+    /// (one shared org for a single-binary / small self-host). It MUST stay off
+    /// for any multi-tenant deployment: there a fresh signup must own no org so
+    /// the zero-org onboarding flow creates the user's own org — otherwise every
+    /// tenant lands in the same shared organization. Default off; opt in with
+    /// `AUTH_AUTO_JOIN_DEFAULT_ORG=true`. Does not affect the admin-mode
+    /// bootstrap owner, which always seeds the default org.
+    pub auto_join_default_org: bool,
 }
 
 /// Cloudflare Turnstile keys for the auth surface.
@@ -228,6 +237,7 @@ impl Default for AuthConfig {
             session_max_age: Duration::from_secs(30 * 24 * 60 * 60), // 30 days
             turnstile: None,
             signup_email_confirm: false,
+            auto_join_default_org: false,
         }
     }
 }
@@ -400,6 +410,12 @@ impl AuthConfig {
             .map(|s| s.to_lowercase() == "true" || s == "1")
             .unwrap_or(false);
 
+        // Off by default: multi-tenant-safe. Single-binary / small self-host
+        // opts in to the shared default org via AUTH_AUTO_JOIN_DEFAULT_ORG=true.
+        let auto_join_default_org = std::env::var("AUTH_AUTO_JOIN_DEFAULT_ORG")
+            .map(|s| s.to_lowercase() == "true" || s == "1")
+            .unwrap_or(false);
+
         let session_max_age = std::env::var("AUTH_SESSION_MAX_AGE")
             .ok()
             .and_then(|s| s.parse().ok())
@@ -435,6 +451,7 @@ impl AuthConfig {
             session_max_age,
             turnstile,
             signup_email_confirm,
+            auto_join_default_org,
         };
 
         // Fail fast on conflicting auth-config combinations so operators see

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -819,33 +819,39 @@ pub async fn register(
             AuthError::unauthorized(GENERIC_REGISTRATION_FAILED)
         })?;
 
-    // Add user to default organization
-    let _ = state
-        .db
-        .add_organization_member(DEFAULT_ORG_ID, user.id, "member")
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to add user to default org: {}", e);
-            // Continue anyway - user is created, they just might not have org membership
-        });
+    // Add user to the default organization — single-tenant convenience only.
+    // Gated on `auto_join_default_org` (off by default): in a multi-tenant
+    // deployment a fresh signup must own no org so the zero-org onboarding flow
+    // creates the user's own org, instead of every tenant landing in the shared
+    // default organization. See `specs/authentication.md`.
+    if state.config.auto_join_default_org {
+        let _ = state
+            .db
+            .add_organization_member(DEFAULT_ORG_ID, user.id, "member")
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to add user to default org: {}", e);
+                // Continue anyway - user is created, they just might not have org membership
+            });
 
-    // Harness-seed safety net: the async seed task (500 ms delay, see
-    // `seed::spawn_seed_task_with_platform_definition`) may not have
-    // provisioned DEFAULT_ORG_ID's built-in harnesses yet when a user
-    // registers immediately after server startup. Re-run the provisioner
-    // using the *platform definition*'s harness set (NOT the OSS default)
-    // so a custom `PlatformDefinition` is never overridden — that was the
-    // security concern addressed by PR #1462. The call is idempotent: if
-    // seeding has already completed, every harness is "unchanged". See
-    // EVE-390 and `specs/authentication.md`.
-    if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
-        &state.db,
-        DEFAULT_ORG_ID,
-        state.platform_definition.built_in_harnesses(),
-    )
-    .await
-    {
-        tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+        // Harness-seed safety net: the async seed task (500 ms delay, see
+        // `seed::spawn_seed_task_with_platform_definition`) may not have
+        // provisioned DEFAULT_ORG_ID's built-in harnesses yet when a user
+        // registers immediately after server startup. Re-run the provisioner
+        // using the *platform definition*'s harness set (NOT the OSS default)
+        // so a custom `PlatformDefinition` is never overridden — that was the
+        // security concern addressed by PR #1462. The call is idempotent: if
+        // seeding has already completed, every harness is "unchanged". See
+        // EVE-390 and `specs/authentication.md`.
+        if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
+            &state.db,
+            DEFAULT_ORG_ID,
+            state.platform_definition.built_in_harnesses(),
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+        }
     }
 
     // Email verification: on successful signup, issue a single-use verification
@@ -1405,28 +1411,34 @@ async fn oauth_callback_inner(
                     AuthError::unauthorized("OAuth authentication failed")
                 })?;
 
-            // Add newly created user to default organization
-            let _ = state
-                .db
-                .add_organization_member(DEFAULT_ORG_ID, created_user.id, "member")
-                .await
-                .map_err(|e| {
-                    tracing::error!("Failed to add OAuth user to default org: {}", e);
-                    // Continue anyway
-                });
+            // Add newly created user to the default organization — single-tenant
+            // convenience only, gated on `auto_join_default_org` (off by default).
+            // In a multi-tenant deployment a first-time-OAuth user must own no org
+            // so zero-org onboarding creates their own. See `register` and
+            // `specs/authentication.md`.
+            if state.config.auto_join_default_org {
+                let _ = state
+                    .db
+                    .add_organization_member(DEFAULT_ORG_ID, created_user.id, "member")
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("Failed to add OAuth user to default org: {}", e);
+                        // Continue anyway
+                    });
 
-            // Harness-seed safety net (see equivalent comment in `register` and
-            // EVE-390). Drive the provisioner from `platform_definition`, not
-            // `oss_built_in_harnesses()`, so a custom platform definition is
-            // never overridden on OAuth signup.
-            if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
-                &state.db,
-                DEFAULT_ORG_ID,
-                state.platform_definition.built_in_harnesses(),
-            )
-            .await
-            {
-                tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+                // Harness-seed safety net (see equivalent comment in `register` and
+                // EVE-390). Drive the provisioner from `platform_definition`, not
+                // `oss_built_in_harnesses()`, so a custom platform definition is
+                // never overridden on OAuth signup.
+                if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
+                    &state.db,
+                    DEFAULT_ORG_ID,
+                    state.platform_definition.built_in_harnesses(),
+                )
+                .await
+                {
+                    tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+                }
             }
 
             created_user
@@ -2487,6 +2499,93 @@ mod oauth_state_tests {
             .unwrap()
             .expect("user created");
         assert_eq!(user.name, "Ada Lovelace");
+    }
+
+    // Multi-tenant safety: with auto_join_default_org off (the default), a fresh
+    // signup owns NO org, so zero-org onboarding creates the user's own org
+    // instead of dumping every tenant into the shared default organization.
+    #[tokio::test]
+    async fn register_does_not_join_default_org_by_default() {
+        let state = full_mode_backend();
+        let db = state.db.clone();
+        register(
+            State(state.clone()),
+            HeaderMap::new(),
+            CookieJar::new(),
+            Json(RegisterRequest {
+                email: "solo@example.com".to_string(),
+                password: "password12345".to_string(),
+                name: None,
+                captcha_token: None,
+            }),
+        )
+        .await
+        .expect("register should succeed");
+
+        let user = db
+            .get_user_by_email("solo@example.com")
+            .await
+            .unwrap()
+            .expect("user created");
+        let orgs = db.list_user_organizations(user.id).await.unwrap();
+        assert!(
+            orgs.is_empty(),
+            "fresh signup must have zero org memberships by default, got {orgs:?}"
+        );
+    }
+
+    // Single-tenant opt-in: AUTH_AUTO_JOIN_DEFAULT_ORG=true restores the shared
+    // default-org membership for a single-binary / small self-host.
+    #[tokio::test]
+    async fn register_joins_default_org_when_opted_in() {
+        use crate::storage::models::CreateOrganizationRow;
+        let config = AuthConfig {
+            mode: AuthMode::Full,
+            auto_join_default_org: true,
+            ..Default::default()
+        };
+        let db = Arc::new(StorageBackend::in_memory());
+        // Membership can only attach if the default org exists.
+        db.create_organization_with_id(
+            DEFAULT_ORG_ID,
+            CreateOrganizationRow {
+                public_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+                name: "Default Organization".to_string(),
+                created_by: None,
+            },
+        )
+        .await
+        .expect("seed default org");
+        let state = BuiltinAuthBackend::new(
+            config,
+            db.clone(),
+            Arc::new(crate::platform::oss_platform_definition()),
+        );
+        register(
+            State(state.clone()),
+            HeaderMap::new(),
+            CookieJar::new(),
+            Json(RegisterRequest {
+                email: "joiner@example.com".to_string(),
+                password: "password12345".to_string(),
+                name: None,
+                captcha_token: None,
+            }),
+        )
+        .await
+        .expect("register should succeed");
+
+        let user = db
+            .get_user_by_email("joiner@example.com")
+            .await
+            .unwrap()
+            .expect("user created");
+        assert!(
+            db.is_organization_member(DEFAULT_ORG_ID, user.id)
+                .await
+                .unwrap(),
+            "opted-in signup should join the default org"
+        );
     }
 
     async fn seed_local_user(db: &StorageBackend, email: &str, password: &str) -> Uuid {

--- a/crates/server/tests/auth_integration_test.rs
+++ b/crates/server/tests/auth_integration_test.rs
@@ -776,6 +776,10 @@ async fn custom_platform_auth_router(
 
     let config = AuthConfig {
         mode: AuthMode::Full,
+        // These tests exercise the default-org membership + harness safety net,
+        // which is now opt-in (single-tenant). Enable it so `register` joins the
+        // default org and provisions its harnesses.
+        auto_join_default_org: true,
         jwt: JwtConfig {
             secret: "test-secret-for-auth-integration-tests".to_string(),
             access_token_lifetime: Duration::from_secs(900),

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -432,11 +432,15 @@ See `crates/server/migrations/001_base_schema.sql` for `users`, `personal_access
 
 For `auth=none` mode, a well-known anonymous user is seeded via `crates/server/src/seed.rs`. Constants in `crates/core/src/organization.rs`: `ANONYMOUS_USER_ID`, `ANONYMOUS_USER_EMAIL`, `ANONYMOUS_USER_NAME`. The anonymous user has admin role and belongs to the default organization.
 
+#### Default-Org Membership (single-tenant only)
+
+`register` and `oauth_callback` add a brand-new user to `DEFAULT_ORG_ID` **only when `AuthConfig.auto_join_default_org` is set** (`AUTH_AUTO_JOIN_DEFAULT_ORG=true`). It is **off by default**, because auto-joining the shared default org is a single-tenant convenience (single-binary / small self-host where everyone shares one org). In any multi-tenant deployment it MUST stay off: a fresh signup must own **no** org so the zero-org onboarding flow creates the user's *own* org — otherwise every tenant lands in `DEFAULT_ORG_ID` together (a tenant-isolation failure). The admin-mode bootstrap owner is unaffected: `login` always seeds the admin into the default org regardless of this flag.
+
 #### Default-Org Harness-Seed Guarantee
 
 The server's background seed task (`seed::spawn_seed_task_with_platform_definition`) provisions the platform-defined built-in harnesses for every organization — including `DEFAULT_ORG_ID` — using the active `PlatformDefinition`. The task runs asynchronously with a 500 ms initial delay, so there is a window on cold boot where a user could register via `register` or `oauth_callback` before `DEFAULT_ORG_ID` has its harnesses.
 
-To close that window, both handlers re-run `initialize_org_harnesses_with_definitions(db, DEFAULT_ORG_ID, platform_definition.built_in_harnesses())` as a safety net after adding the user to the default org. Invariants:
+When default-org auto-join is enabled (above), both handlers re-run `initialize_org_harnesses_with_definitions(db, DEFAULT_ORG_ID, platform_definition.built_in_harnesses())` as a safety net after adding the user to the default org (the re-run is gated together with the membership). Invariants:
 
 - **Correctness**: every newly-signed-up user lands in an org that has built-in harnesses, even if the async seed task has not completed. The provisioner is idempotent (upsert keyed on harness name), so the second call is a no-op once seeding is done.
 - **No operator override**: the safety net drives from `state.platform_definition.built_in_harnesses()` (the operator-configured set), **not** from `oss_built_in_harnesses()`. This preserves the fix from PR #1462 — public signup cannot reintroduce OSS harnesses that a custom `PlatformDefinition` removed. Tracked as threat-model entry `TM-AUTH-016` in `specs/threat-model.md` and originally surfaced in EVE-390.


### PR DESCRIPTION
## What & why
`register` and `oauth_callback` unconditionally added every new user to `DEFAULT_ORG_ID` as a member. That's correct for single-tenant (one shared org), but in a **multi-tenant** deployment it means every public signup lands in the *same* shared organization — a tenant-isolation failure — and it silently bypasses zero-org onboarding (the user already has an org, so the onboarding redirect never fires).

This gates the default-org membership behind a new `AuthConfig.auto_join_default_org` (`AUTH_AUTO_JOIN_DEFAULT_ORG`), **off by default**:
- **Off (default, multi-tenant-safe):** a fresh signup owns no org, so zero-org onboarding creates the user's own org.
- **On (single-binary / small self-host):** restores the previous shared-default-org convenience.

The harness-seed safety net is gated together with the membership (pointless when the user isn't joining the org). The **admin-mode bootstrap owner** is intentionally unaffected — `login` still seeds the admin into the default org.

## Behavior change
Self-host `full`-mode deployments that relied on new users auto-joining the default org must now set `AUTH_AUTO_JOIN_DEFAULT_ORG=true`. This is deliberate: multi-tenant-safe by default.

## Tests
- `register_does_not_join_default_org_by_default` — fresh signup has **zero** org memberships (the regression guard for the isolation bug).
- `register_joins_default_org_when_opted_in` — with the flag on, the signup joins `DEFAULT_ORG_ID`.

Both green (`cargo test -p everruns-server`). Existing register tests unaffected.

## Note
Discovered on the SaaS multi-tenant deployment, where a fresh signup came back with `organizations: [org_…0001 "Default Organization"]`. The SaaS side will adopt this (submodule bump; it needs no config since the default is now off) and add a zero-org assertion to its signup smoke test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9cKZdLQcBjLxfDQJSRFzG)_