### PR TITLE
feat(sessions): route addressed participant turns

### DIFF
--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -471,6 +471,7 @@ pub(crate) async fn run_app_agent_stream(
                     role: ApiMessageRole::User,
                     content: trigger_parts,
                 },
+                addressed_participant_id: None,
                 controls: None,
                 metadata: Some(ag_ui_message_metadata(&app, thread_tag, run_tag)),
                 tags: None,

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -407,6 +407,7 @@ pub async fn message(
                     role: ApiMessageRole::User,
                     content: vec![InputContentPart::text(user_text)],
                 },
+                addressed_participant_id: None,
                 controls: None,
                 metadata: Some(fcp_message_metadata(&context.app)),
                 tags: None,

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -23,7 +23,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::{DateTime, Utc};
-use everruns_core::typed_id::{MessageId, SessionId};
+use everruns_core::typed_id::{MessageId, SessionId, SessionParticipantId};
 
 use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
 use everruns_worker::AgentRunner;
@@ -129,6 +129,14 @@ fn default_user_role() -> MessageRole {
 pub struct CreateMessageRequest {
     /// The message to create. Example shape is defined on `InputMessage`.
     pub message: InputMessage,
+    /// Optional active agent participant to address for this turn. When omitted,
+    /// the session host remains the responder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(
+        value_type = Option<String>,
+        example = "part_01933b5a00007000800000000000001"
+    )]
+    pub addressed_participant_id: Option<SessionParticipantId>,
     /// Runtime controls (model, reasoning, etc.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controls: Option<Controls>,
@@ -155,6 +163,7 @@ impl CreateMessageRequest {
                 role: MessageRole::User,
                 content: vec![InputContentPart::text(text)],
             },
+            addressed_participant_id: None,
             controls: None,
             metadata: None,
             tags: None,
@@ -271,6 +280,7 @@ pub async fn create_message(
     let message = CreateMessage {
         session_id,
         message: req.message,
+        addressed_participant_id: req.addressed_participant_id,
         controls: req.controls,
         metadata: req.metadata,
         tags: req.tags,

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -767,6 +767,7 @@ async fn process_slack_message(
             role: MessageRole::User,
             content,
         },
+        addressed_participant_id: None,
         controls: None,
         metadata: Some(slack_message_metadata(app, event)),
         tags: None,

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -1432,6 +1432,7 @@ fn build_voice_message_command(session_id: SessionId, data: &VoiceTranscriptData
             role: MessageRole::User,
             content: vec![InputContentPart::text(data.accumulated.trim().to_string())],
         },
+        addressed_participant_id: None,
         controls: None,
         metadata: Some(metadata),
         tags: Some(vec!["voice".to_string()]),

--- a/crates/server/src/domains/agents/health_check/runner.rs
+++ b/crates/server/src/domains/agents/health_check/runner.rs
@@ -287,6 +287,7 @@ async fn run_turn(
             role: crate::api::messages::MessageRole::User,
             content: vec![everruns_core::InputContentPart::text(content)],
         },
+        addressed_participant_id: None,
         controls: None,
         metadata: None,
         tags: None,

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -1463,6 +1463,7 @@ async fn dispatch_invocation_message(
                     role: MessageRole::User,
                     content: vec![InputContentPart::text(rendered_message)],
                 },
+                addressed_participant_id: None,
                 controls: None,
                 metadata,
                 tags: None,

--- a/crates/server/src/domains/evals/runner.rs
+++ b/crates/server/src/domains/evals/runner.rs
@@ -514,6 +514,7 @@ async fn send_message_and_wait(
             role: crate::api::messages::MessageRole::User,
             content: vec![everruns_core::InputContentPart::text(content)],
         },
+        addressed_participant_id: None,
         controls: None,
         metadata: None,
         tags: None,

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -1,7 +1,9 @@
 use super::queries as q;
-use crate::api::messages::Message;
+use crate::api::messages::{Message, MessageRole};
 use crate::domains::common::*;
 use crate::domains::messages::CreateMessageContext;
+use everruns_core::typed_id::{AgentId, SessionId, SessionParticipantId};
+use everruns_core::{SessionParticipantKind, SessionParticipantRole};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -10,6 +12,8 @@ pub struct CreateMessage {
     /// Session's prefixed public identifier.
     pub session_id: String,
     pub message: crate::api::messages::InputMessage,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub addressed_participant_id: Option<SessionParticipantId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controls: Option<everruns_core::Controls>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -42,8 +46,15 @@ impl Command for CreateMessage {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Message, CommandError> {
+        if self.message.role != MessageRole::User {
+            return Err(CommandError::bad_request(
+                "Only user messages can be created through this endpoint",
+            ));
+        }
+
         let mut req = crate::api::messages::CreateMessageRequest {
             message: self.message,
+            addressed_participant_id: self.addressed_participant_id,
             controls: self.controls,
             metadata: self.metadata,
             tags: self.tags,
@@ -58,6 +69,19 @@ impl Command for CreateMessage {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("Session"))?;
+        let session_row = ctx
+            .db
+            .get_session(ctx.org_id(), session_id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Session"))?;
+        let responder_agent_id = resolve_responder_agent_id(
+            ctx,
+            session_id,
+            session_row.agent_id,
+            req.addressed_participant_id,
+        )
+        .await?;
 
         q::message_service(ctx)?
             .create(
@@ -65,7 +89,7 @@ impl Command for CreateMessage {
                     org_id: ctx.org_id(),
                     user_id: ctx.caller.user_id,
                     harness_id: session.harness_id.uuid(),
-                    agent_id: session.agent_id.map(|id| id.uuid()),
+                    agent_id: responder_agent_id.map(|id| id.uuid()),
                     session_id: session_id.uuid(),
                     event_metadata: None,
                     request_id: self.request_id,
@@ -78,6 +102,52 @@ impl Command for CreateMessage {
 }
 
 inventory::submit! { CommandDescriptor::of::<CreateMessage>() }
+
+async fn resolve_responder_agent_id(
+    ctx: &Ctx,
+    session_id: SessionId,
+    default_agent_id: Option<AgentId>,
+    addressed_participant_id: Option<SessionParticipantId>,
+) -> Result<Option<AgentId>, CommandError> {
+    let Some(participant_id) = addressed_participant_id else {
+        return Ok(default_agent_id);
+    };
+
+    let participants = ctx
+        .db
+        .list_session_participants(ctx.org_id(), session_id)
+        .await
+        .map_err(classify_anyhow)?;
+    let participant = participants
+        .iter()
+        .find(|row| row.id == participant_id)
+        .ok_or_else(|| CommandError::not_found("Participant"))?;
+
+    if participant.left_at.is_some() {
+        return Err(CommandError::conflict(
+            "Addressed participant is no longer active",
+        ));
+    }
+    if participant.kind != SessionParticipantKind::Agent.to_string() {
+        return Err(CommandError::bad_request(
+            "Addressed participant must be an agent",
+        ));
+    }
+
+    let agent_id = participant.agent_id.ok_or_else(|| {
+        CommandError::internal(anyhow::anyhow!("agent participant missing agent_id"))
+    })?;
+
+    if participant.role != SessionParticipantRole::Host.to_string()
+        && participant.role != SessionParticipantRole::Member.to_string()
+    {
+        return Err(CommandError::bad_request(
+            "Addressed participant has an unsupported role",
+        ));
+    }
+
+    Ok(Some(agent_id))
+}
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListMessages {
@@ -288,4 +358,311 @@ pub async fn export_session_segment(
         next_cursor: segment.next_cursor,
         segment_index: segment.segment_index,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::messages::{InputContentPart, InputMessage};
+    use crate::domains::sessions::SessionService;
+    use crate::event_delivery::EventDelivery;
+    use crate::storage::StorageBackend;
+    use crate::storage::models::{
+        AgentRow, CreateAgentRow, CreateHarnessRow, CreateSessionParticipantRow, CreateSessionRow,
+        SessionParticipantRow, SessionRow,
+    };
+    use async_trait::async_trait;
+    use everruns_core::typed_id::{HarnessId, MessageId};
+    use everruns_core::{Caller, DEFAULT_ORG_ID, PrincipalId};
+    use everruns_worker::AgentRunner;
+    use std::sync::{Arc, Mutex};
+    use tokio::time::{Duration, sleep};
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        calls: Mutex<Vec<Option<AgentId>>>,
+    }
+
+    impl RecordingRunner {
+        fn calls(&self) -> Vec<Option<AgentId>> {
+            self.calls.lock().expect("runner calls lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl AgentRunner for RecordingRunner {
+        async fn start_run(
+            &self,
+            _org_id: i64,
+            _session_id: SessionId,
+            _harness_id: HarnessId,
+            agent_id: Option<AgentId>,
+            _input_message_id: MessageId,
+            _request_id: Option<String>,
+        ) -> anyhow::Result<()> {
+            self.calls.lock().expect("runner calls lock").push(agent_id);
+            Ok(())
+        }
+
+        async fn resume_after_tool_results(&self, _session_id: SessionId) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn cancel_run(&self, _session_id: SessionId) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn is_running(&self, _session_id: SessionId) -> bool {
+            false
+        }
+
+        async fn active_count(&self) -> usize {
+            self.calls.lock().expect("runner calls lock").len()
+        }
+    }
+
+    struct RoutingFixture {
+        ctx: Ctx,
+        runner: Arc<RecordingRunner>,
+        host_agent: AgentRow,
+        guest_agent: AgentRow,
+        session: SessionRow,
+        guest_participant: SessionParticipantRow,
+        user_participant: SessionParticipantRow,
+    }
+
+    async fn setup_routing_fixture() -> RoutingFixture {
+        let db = Arc::new(StorageBackend::in_memory());
+        let harness = db
+            .create_harness(
+                DEFAULT_ORG_ID,
+                CreateHarnessRow {
+                    name: "routing-harness".to_string(),
+                    display_name: None,
+                    description: None,
+                    system_prompt: Some("You are helpful.".to_string()),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec![],
+                    initial_files: serde_json::json!([]),
+                    mcp_servers: serde_json::json!({}),
+                    network_access: None,
+                    embedder_metadata: serde_json::json!({}),
+                    is_built_in: false,
+                },
+            )
+            .await
+            .expect("create harness");
+
+        let host_agent = seed_agent(&db, harness.id, "routing-host").await;
+        let guest_agent = seed_agent(&db, harness.id, "routing-guest").await;
+        let session = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                app_id: None,
+                harness_id: Some(harness.id),
+                agent_id: Some(host_agent.id),
+                agent_identity_id: None,
+                owner_principal_id: PrincipalId::from_seed(DEFAULT_ORG_ID as u128),
+                resolved_owner_user_id: None,
+                title: Some("Routing session".to_string()),
+                locale: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                system_prompt: None,
+                initial_files: serde_json::json!([]),
+                hints: None,
+                network_access: None,
+                max_iterations: None,
+                parallel_tool_calls: None,
+                blueprint_id: None,
+                blueprint_config: None,
+                parent_session_id: None,
+                workspace_id: None,
+            })
+            .await
+            .expect("create session");
+        let guest_participant = db
+            .create_session_participant(CreateSessionParticipantRow {
+                org_id: DEFAULT_ORG_ID,
+                session_id: session.id,
+                kind: SessionParticipantKind::Agent,
+                agent_id: Some(guest_agent.id),
+                agent_version_id: None,
+                principal_id: session.owner_principal_id,
+                role: SessionParticipantRole::Member,
+                joined_at: None,
+            })
+            .await
+            .expect("create guest participant");
+        let user_participant = db
+            .list_session_participants(DEFAULT_ORG_ID, session.id)
+            .await
+            .expect("list participants")
+            .into_iter()
+            .find(|row| row.kind == SessionParticipantKind::User.to_string())
+            .expect("user participant");
+
+        let runner = Arc::new(RecordingRunner::default());
+        let runner_trait: Arc<dyn AgentRunner> = runner.clone();
+        let message_service = Arc::new(crate::domains::messages::MessageService::new(
+            db.clone(),
+            runner_trait,
+            false,
+            EventDelivery::in_memory(),
+        ));
+        let ctx = Ctx::minimal_for_test(Caller::internal(DEFAULT_ORG_ID), db.clone(), None)
+            .with_session_service(Arc::new(SessionService::new(db)))
+            .with_message_service(message_service);
+
+        RoutingFixture {
+            ctx,
+            runner,
+            host_agent,
+            guest_agent,
+            session,
+            guest_participant,
+            user_participant,
+        }
+    }
+
+    async fn seed_agent(db: &StorageBackend, harness_id: HarnessId, name: &str) -> AgentRow {
+        db.create_agent(
+            DEFAULT_ORG_ID,
+            CreateAgentRow {
+                public_id: AgentId::new().to_string(),
+                name: name.to_string(),
+                display_name: None,
+                description: None,
+                system_prompt: format!("You are {name}."),
+                default_model_id: None,
+                harness_id,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: None,
+                max_iterations: None,
+                parallel_tool_calls: None,
+            },
+        )
+        .await
+        .expect("create agent")
+    }
+
+    fn user_input(text: &str) -> InputMessage {
+        InputMessage {
+            role: MessageRole::User,
+            content: vec![InputContentPart::text(text)],
+        }
+    }
+
+    fn create_message_command(
+        session_id: SessionId,
+        addressed_participant_id: Option<SessionParticipantId>,
+    ) -> CreateMessage {
+        CreateMessage {
+            session_id: session_id.to_string(),
+            message: user_input("hello"),
+            addressed_participant_id,
+            controls: None,
+            metadata: None,
+            tags: None,
+            external_actor: None,
+            request_id: None,
+        }
+    }
+
+    async fn wait_for_runner_calls(runner: &RecordingRunner, expected_len: usize) {
+        for _ in 0..20 {
+            if runner.calls().len() >= expected_len {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!(
+            "runner recorded {} calls, expected at least {expected_len}",
+            runner.calls().len()
+        );
+    }
+
+    #[tokio::test]
+    async fn unaddressed_turn_routes_to_host_agent() {
+        let fixture = setup_routing_fixture().await;
+
+        create_message_command(fixture.session.id, None)
+            .execute(&fixture.ctx)
+            .await
+            .expect("create message");
+
+        wait_for_runner_calls(&fixture.runner, 1).await;
+        assert_eq!(fixture.runner.calls(), vec![Some(fixture.host_agent.id)]);
+    }
+
+    #[tokio::test]
+    async fn addressed_turn_routes_to_guest_agent() {
+        let fixture = setup_routing_fixture().await;
+
+        create_message_command(fixture.session.id, Some(fixture.guest_participant.id))
+            .execute(&fixture.ctx)
+            .await
+            .expect("create message");
+
+        wait_for_runner_calls(&fixture.runner, 1).await;
+        assert_eq!(fixture.runner.calls(), vec![Some(fixture.guest_agent.id)]);
+    }
+
+    #[tokio::test]
+    async fn addressed_user_participant_is_rejected() {
+        let fixture = setup_routing_fixture().await;
+
+        let err = create_message_command(fixture.session.id, Some(fixture.user_participant.id))
+            .execute(&fixture.ctx)
+            .await
+            .expect_err("user participant cannot be addressed for agent routing");
+
+        assert_eq!(err.status().as_u16(), 400);
+        assert!(fixture.runner.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn left_guest_participant_is_rejected() {
+        let fixture = setup_routing_fixture().await;
+        fixture
+            .ctx
+            .db
+            .leave_session_participant(
+                DEFAULT_ORG_ID,
+                fixture.session.id,
+                fixture.guest_participant.id,
+            )
+            .await
+            .expect("leave guest");
+
+        let err = create_message_command(fixture.session.id, Some(fixture.guest_participant.id))
+            .execute(&fixture.ctx)
+            .await
+            .expect_err("left participant cannot be addressed");
+
+        assert_eq!(err.status().as_u16(), 409);
+        assert!(fixture.runner.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_role_input_is_rejected_before_turn_starts() {
+        let fixture = setup_routing_fixture().await;
+        let mut command = create_message_command(fixture.session.id, None);
+        command.message.role = MessageRole::Agent;
+
+        let err = command
+            .execute(&fixture.ctx)
+            .await
+            .expect_err("agent input role cannot create a user turn");
+
+        assert_eq!(err.status().as_u16(), 400);
+        assert!(fixture.runner.calls().is_empty());
+    }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -18029,6 +18029,14 @@
           "message"
         ],
         "properties": {
+          "addressed_participant_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional active agent participant to address for this turn. When omitted,\nthe session host remains the responder.",
+            "example": "part_01933b5a00007000800000000000001"
+          },
           "controls": {
             "oneOf": [
               {


### PR DESCRIPTION
## What changed
Message creation now accepts an optional `addressed_participant_id`. When it is omitted, user turns still route to the session host. When it names an active agent participant in the same session, the turn is enqueued for that guest agent. User participants, left participants, and non-user message roles are rejected before a turn starts.

Internal message creators set the new field to `None`, preserving their existing host/default routing behavior. OpenAPI is regenerated with the new request field.

## Why
EVE-692 slice C needs host semantics plus V1 turn routing: guests should respond only when explicitly addressed, and API-created agent-role messages should not create agent-to-agent loops.

## Before / After
Before:
- `POST /v1/sessions/{id}/messages` always routed through the session host path; there was no API-level way to address a guest participant.
- Non-user message roles were documented as unsupported but not rejected at the command boundary.

After:
- Host-only and unaddressed turns route to the host.
- Addressed active agent participants route to that guest.
- Addressing a user participant returns 400.
- Addressing a left guest returns 409.
- API-created `agent` role input returns 400 before turn enqueue.

Local evidence:
- `cargo test -p everruns-server messages::commands::tests --lib --all-features` — 5 passed.
- `cargo test -p everruns-server participant --lib --all-features` — 7 passed.
- `cargo clippy -p everruns-server --lib --all-features -- -D warnings` — passed.
- `./scripts/export-openapi.sh` — OpenAPI 0.2.0, 204 endpoints.
- `just pre-push` — all 10 checks passed.
- `bash scripts/lib/check-migration-ordering.sh` — migrations sequential (001..095).
- Caddy smoke on `PORT_PREFIX=284 CARGO_INCREMENTAL=0 just start-dev --no-watch`:
  ```json
  {
    "host_id": "agent_019f4956fd8c7ff0977bdd19791d0ef0",
    "guest_id": "agent_019f4956fd9b78219946c14714e0208b",
    "session_id": "session_019f4956fdbb79a09243bec8f93177f1",
    "host_participant": "part_019f4956fdbb79a09243bed4d2ef418e",
    "user_participant": "part_019f4956fdbb79a09243bee360f6cf87",
    "guest_participant": "part_019f4956fdf6790089fa76ad5d8bcaef",
    "unaddressed_status": "201",
    "addressed_status": "201",
    "user_address_status": "400",
    "left_status": "409",
    "agent_role_status": "400",
    "chat_status": "200 39184"
  }
  ```
  Provider execution logged expected missing-key warnings in local no-secret dev mode after the turns were accepted; the routing API behavior completed before provider execution.

## Risk
- Medium: message creation is a hot API path and this changes request validation/routing.
- Main risk is rejecting a client that incorrectly sent `role: agent`; this matches the documented contract that only user messages can be created via this endpoint.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-DOS.
- Findings and resolutions:
  - TM-API: `addressed_participant_id` is a typed participant id and invalid/non-agent/left targets are rejected.
  - TM-AUTHZ: the existing `SESSION_MANAGE` policy still gates message creation; no new unauthenticated path.
  - TM-TENANT: participant resolution lists rows through `ctx.org_id()` and the already-resolved session id, so cross-org or foreign-session participants are not accepted.
  - TM-DOS: each user request still enqueues at most one turn; agent-role input is rejected before enqueue to guard the V1 path against agent-to-agent loops.
  - No threat-model update needed; existing mitigations cover this changed surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
