### PR TITLE
perf(ui): reduce Settings prefetches (EVE-694)

### DIFF
--- a/apps/ui/e2e/navigation-prefetch.spec.ts
+++ b/apps/ui/e2e/navigation-prefetch.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page, type Request } from "@playwright/test";
+
+const DEFAULT_ORG_ID = "org_00000000000000000000000000000001";
+const SETTINGS_CHILD_ROUTES = [
+  "/settings/organization",
+  "/settings/providers",
+  "/settings/members",
+  "/settings/features",
+  "/settings/payments",
+  "/settings/profile",
+  "/settings/connections",
+  "/settings/personal-access-tokens",
+];
+
+async function mockAppApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    let json: unknown;
+
+    if (pathname === "/api/v1/auth/config") {
+      json = {
+        mode: "none",
+        password_auth_enabled: false,
+        oauth_providers: [],
+        signup_enabled: false,
+      };
+    } else if (pathname === "/api/v1/auth/me") {
+      json = {
+        id: "user-1",
+        email: "dev@example.com",
+        name: "Dev User",
+        roles: [],
+        email_verified: true,
+        organizations: [{ public_id: DEFAULT_ORG_ID, name: "Default", role: "owner" }],
+      };
+    } else if (pathname.endsWith("/feature-flags")) {
+      json = {
+        global_chat: false,
+        notifications: false,
+        evals: false,
+        app_budgets: false,
+        agent_versions: false,
+        voice: false,
+        agent_delegation: false,
+        observers: false,
+        public_chat: false,
+      };
+    } else if (pathname.endsWith("/switch-org")) {
+      json = { success: true, org_id: DEFAULT_ORG_ID };
+    } else if (pathname.endsWith("/config")) {
+      json = { policies: {} };
+    } else {
+      json = { data: [], has_more: false, total: 0 };
+    }
+
+    await route.fulfill({ json });
+  });
+}
+
+function isSettingsRscRequest(request: Request) {
+  const url = new URL(request.url());
+  return request.headers().rsc === "1" && url.pathname.startsWith("/settings");
+}
+
+test.describe("Settings navigation prefetch", () => {
+  test.use({ viewport: { width: 1440, height: 2000 } });
+
+  test.beforeEach(async ({ context, page, baseURL }) => {
+    const origin = new URL(baseURL ?? "http://localhost:9100");
+    await context.addCookies([
+      {
+        name: "access_token",
+        value: "e2e-only",
+        domain: origin.hostname,
+        path: "/",
+      },
+    ]);
+    await mockAppApi(page);
+  });
+
+  test("normal pages and Settings navigation avoid Settings route fan-out", async ({ page }) => {
+    const settingsRequests: Request[] = [];
+    page.on("request", (request) => {
+      if (isSettingsRscRequest(request)) settingsRequests.push(request);
+    });
+
+    await page.goto("/dashboard");
+    await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    expect(settingsRequests).toHaveLength(0);
+
+    settingsRequests.length = 0;
+    await page.getByRole("link", { name: "Settings" }).click();
+    await expect(page).toHaveURL(/\/settings\/organization$/);
+    await page.waitForLoadState("networkidle");
+
+    const eagerChildRequests = settingsRequests.filter((request) => {
+      const pathname = new URL(request.url()).pathname;
+      return pathname !== "/settings/organization" && SETTINGS_CHILD_ROUTES.includes(pathname);
+    });
+    expect(eagerChildRequests).toHaveLength(0);
+  });
+});

--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -1,6 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import SettingsLayout from "@/app/(main)/settings/layout";
 
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    prefetch,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { prefetch?: boolean }) => (
+    <a {...props} data-prefetch={prefetch === undefined ? undefined : String(prefetch)}>
+      {children}
+    </a>
+  ),
+}));
+
 // Mock next/navigation
 const mockPathname = jest.fn();
 jest.mock("next/navigation", () => ({
@@ -74,6 +87,19 @@ describe("SettingsLayout", () => {
     expect(profileLink).toHaveAttribute("href", "/settings/profile");
     expect(connectionsLink).toHaveAttribute("href", "/settings/connections");
     expect(apiKeysLink).toHaveAttribute("href", "/settings/personal-access-tokens");
+  });
+
+  it("disables automatic prefetch for every Settings navigation link", () => {
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    expect(screen.getAllByRole("link")).toHaveLength(8);
+    for (const link of screen.getAllByRole("link")) {
+      expect(link).toHaveAttribute("data-prefetch", "false");
+    }
   });
 
   it("highlights the active navigation item for providers", () => {

--- a/apps/ui/src/__tests__/settings-redirect.test.tsx
+++ b/apps/ui/src/__tests__/settings-redirect.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import SettingsPage from "@/app/(main)/settings/page";
+
+const mockRedirect = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+    mockReplace.mockClear();
+  });
+
+  it("redirects to the canonical Settings route during server rendering", () => {
+    render(<SettingsPage />);
+
+    expect(mockRedirect).toHaveBeenCalledWith("/settings/organization");
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -4,6 +4,19 @@ import type { SidebarConfig, NavigationSection } from "@/components/layout/sideb
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Settings, Zap } from "lucide-react";
 
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    prefetch,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { prefetch?: boolean }) => (
+    <a {...props} data-prefetch={prefetch === undefined ? undefined : String(prefetch)}>
+      {children}
+    </a>
+  ),
+}));
+
 // Mock next/navigation
 const mockPathname = jest.fn();
 const mockPush = jest.fn();
@@ -208,7 +221,22 @@ describe("Sidebar", () => {
     expect(memoryLink).toHaveAttribute("href", "/memory");
     expect(modelsLink).toHaveAttribute("href", "/models");
     expect(capabilitiesLink).toHaveAttribute("href", "/capabilities");
-    expect(settingsLink).toHaveAttribute("href", "/settings");
+    expect(settingsLink).toHaveAttribute("href", "/settings/organization");
+  });
+
+  it("disables prefetch only for the top-level Settings link", () => {
+    render(<Sidebar />);
+
+    const navigation = screen.getByRole("navigation");
+    const links = within(navigation).getAllByRole("link");
+    const settingsLink = within(navigation).getByRole("link", { name: "Settings" });
+
+    expect(settingsLink).toHaveAttribute("data-prefetch", "false");
+    for (const link of links) {
+      if (link !== settingsLink) {
+        expect(link).not.toHaveAttribute("data-prefetch");
+      }
+    }
   });
 
   it("does not render legacy navigation items", () => {
@@ -233,6 +261,22 @@ describe("Sidebar", () => {
     const agentsLink = screen.getByRole("link", { name: /agents/i });
     expect(agentsLink).toHaveClass("border-l-primary");
     expect(agentsLink).toHaveClass("bg-card");
+  });
+
+  it.each([
+    "/settings/organization",
+    "/settings/providers",
+    "/settings/members",
+    "/settings/features",
+    "/settings/payments",
+    "/settings/profile",
+    "/settings/connections",
+    "/settings/personal-access-tokens",
+  ])("keeps Settings active on %s", (pathname) => {
+    mockPathname.mockReturnValue(pathname);
+    render(<Sidebar />);
+
+    expect(screen.getByRole("link", { name: "Settings" })).toHaveClass("border-l-primary");
   });
 
   it("renders version in footer", () => {

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -123,6 +123,7 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
                       <Link
                         key={item.name}
                         href={item.href}
+                        prefetch={false}
                         className={cn(
                           "flex items-center gap-3 px-3 py-2 text-sm transition-colors border-l-2",
                           isActive

--- a/apps/ui/src/app/(main)/settings/page.tsx
+++ b/apps/ui/src/app/(main)/settings/page.tsx
@@ -1,14 +1,5 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { redirect } from "next/navigation";
 
 export default function SettingsPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace("/settings/organization");
-  }, [router]);
-
-  return null;
+  return redirect("/settings/organization");
 }

--- a/apps/ui/src/components/layout/sidebar-navigation.tsx
+++ b/apps/ui/src/components/layout/sidebar-navigation.tsx
@@ -27,13 +27,15 @@ function NavLink({
 }) {
   if (item.flag && !featureFlags[item.flag]) return null;
 
+  const activePath = item.activePrefix ?? item.href;
   const isActive = item.exact
-    ? pathname === item.href
-    : pathname === item.href || pathname.startsWith(`${item.href}/`);
+    ? pathname === activePath
+    : pathname === activePath || pathname.startsWith(`${activePath}/`);
 
   return (
     <Link
       href={item.href}
+      prefetch={item.prefetch}
       className={cn(
         "flex items-center gap-2.5 border-l-2 px-3 py-1.5 text-[13px] font-semibold leading-5 transition-colors",
         isActive

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -61,6 +61,8 @@ export type NavigationItem = {
   name: string;
   href: string;
   icon: React.ComponentType<{ className?: string }>;
+  activePrefix?: string;
+  prefetch?: boolean;
   flag?: keyof FeatureFlags;
   exact?: boolean;
   experimental?: boolean;
@@ -115,7 +117,13 @@ export const defaultBuildingBlocksNavigation: NavigationItem[] = [
 ];
 
 export const defaultBottomNavigation: NavigationItem[] = [
-  { name: "Settings", href: "/settings", icon: Settings },
+  {
+    name: "Settings",
+    href: "/settings/organization",
+    icon: Settings,
+    activePrefix: "/settings",
+    prefetch: false,
+  },
 ];
 
 export const defaultDurableNavigation: NavigationItem[] = [


### PR DESCRIPTION
## What changed
Settings navigation now opts out of automatic route prefetch only where it was creating unnecessary fan-out:
- the main Settings sidebar link points canonically to `/settings/organization`, disables prefetch, and remains active for every `/settings/*` route
- all eight Settings layout links disable automatic prefetch
- `/settings` redirects during server rendering instead of rendering blank and redirecting from a client effect

Dashboard, Sessions, Agents, other top-level navigation items, and entity-card links keep their existing prefetch behavior.

## Why
Opening Settings was inexpensive in wall time but wasteful on the network. The main Settings entry prefetched an intermediate route, then the Settings layout eagerly prefetched every child page. The client-effect redirect also added a blank-render waterfall.

Linear: [EVE-694](https://linear.app/everruns/issue/EVE-694/perfui-scope-settings-navigation-prefetch)

## Before / After
Repeatable production benchmark:

```sh
cd apps/ui
pnpm run build
PORT=9127 HOSTNAME=127.0.0.1 node .next/standalone/server.js
PLAYWRIGHT_BASE_URL=http://127.0.0.1:9127 \
  PLAYWRIGHT_CHROMIUM_PATH=/path/to/chromium \
  pnpm exec playwright test e2e/navigation-prefetch.spec.ts --project=chromium
```

With a 1440×2000 viewport so the full sidebar is eligible for automatic prefetch:

| Flow | Before | After |
| --- | --- | --- |
| Load Dashboard | 2 Settings RSC prefetches | 0 Settings RSC requests |
| Enter Settings | 17 Settings RSC requests; 15 prefetches spanning all 8 children | 1 canonical `/settings/organization` navigation; 0 prefetches |

The production-mode Playwright regression failed before the implementation with 2 unexpected Settings prefetches and passes after it.

## Risk
- Low
- Risk is limited to Settings navigation targeting, active-route matching, and Next.js prefetch configuration.
- Keyboard activation, responsive layout classes, direct deep links, and child-page active styling are preserved and tested.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: no new input handling, rendering of untrusted content, authentication/authorization logic, data access, dependency, or external navigation surface. Links remain same-origin React links and the redirect target is a fixed same-origin path. No threat-model update required.

## Follow-ups
No follow-ups.

## Validation
- Regression-first proof: 3 focused suites failed before the fix, then 53 focused tests passed
- `pnpm exec jest --runInBand`: 125 suites, 1,100 tests passed
- UI format, lint, typecheck, and production build passed with repository-pinned pnpm 10.33.0
- Production-mode and default dev-server Playwright navigation-prefetch E2E passed
- Agent-browser production smoke passed: keyboard navigation, active styling, canonical Settings landing, and direct `/settings` redirect
- `just pre-push`: all 10 checks passed after rebase onto current `origin/main`
- Pre-PR equivalent passed: all-feature workspace Rust tests excluding the unavailable Turbopuffer live package, Turbopuffer's 11 non-live tests, OpenAPI freshness, migration ordering, UI build/tests, and docs check/build with valid links
- Local `just pre-pr` cannot run the single `turbopuffer-live-tests` case because `TURBOPUFFER_API_KEY` is absent from the configured Doppler dev project; GitHub Actions remains the source of truth for that secret-backed check

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)