### PR TITLE
fix(reporting): bound event projection repair (EVE-696)

### DIFF
--- a/crates/server/migrations/096_reporting_event_repair_cursor.sql
+++ b/crates/server/migrations/096_reporting_event_repair_cursor.sql
@@ -1,0 +1,31 @@
+-- Bound periodic reporting repair to an indexed slice of supported events.
+-- Full historical reconciliation remains available through the admin backfill.
+
+CREATE TABLE reporting_event_repair_cursor (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    last_event_created_at TIMESTAMPTZ,
+    last_event_id UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (
+        (last_event_created_at IS NULL AND last_event_id IS NULL)
+        OR (last_event_created_at IS NOT NULL AND last_event_id IS NOT NULL)
+    )
+);
+
+INSERT INTO reporting_event_repair_cursor (singleton) VALUES (TRUE);
+
+CREATE INDEX idx_events_reporting_repair
+    ON events(created_at, id)
+    WHERE event_type IN (
+        'tool.completed',
+        'capability.usage',
+        'output.message.replaced',
+        'turn.completed',
+        'turn.failed',
+        'turn.cancelled'
+    );
+
+COMMENT ON TABLE reporting_event_repair_cursor IS
+    'Global watermark for bounded, cyclic verification of reporting event projections';
+COMMENT ON INDEX idx_events_reporting_repair IS
+    'Partial ordered index for bounded reporting event projection repair';

--- a/crates/server/src/domains/reporting/background.rs
+++ b/crates/server/src/domains/reporting/background.rs
@@ -7,30 +7,37 @@ use crate::storage::StorageBackend;
 
 const DEFAULT_PROJECTOR_INTERVAL_SECS: u64 = 5;
 const DEFAULT_PROJECTOR_LIMIT: i64 = 500;
-const DEFAULT_BACKFILL_INTERVAL_SECS: u64 = 300;
-const DEFAULT_BACKFILL_LIMIT: i64 = 1_000;
+const DEFAULT_REPAIR_INTERVAL_SECS: u64 = 300;
+const DEFAULT_REPAIR_LIMIT: i64 = 1_000;
 
 #[derive(Debug, Clone)]
 struct ReportingBackgroundConfig {
     projector_interval: Duration,
     projector_limit: i64,
-    backfill_interval: Duration,
-    backfill_limit: i64,
+    repair_interval: Duration,
+    repair_limit: i64,
 }
 
 impl ReportingBackgroundConfig {
     fn from_env() -> Self {
+        Self::from_lookup(|name| std::env::var(name).ok())
+    }
+
+    fn from_lookup(mut lookup: impl FnMut(&str) -> Option<String>) -> Self {
         Self {
-            projector_interval: Duration::from_secs(env_u64(
-                "REPORTING_PROJECTOR_INTERVAL_SECS",
+            projector_interval: Duration::from_secs(value_u64(
+                lookup("REPORTING_PROJECTOR_INTERVAL_SECS"),
                 DEFAULT_PROJECTOR_INTERVAL_SECS,
             )),
-            projector_limit: env_i64("REPORTING_PROJECTOR_LIMIT", DEFAULT_PROJECTOR_LIMIT),
-            backfill_interval: Duration::from_secs(env_u64(
-                "REPORTING_BACKFILL_INTERVAL_SECS",
-                DEFAULT_BACKFILL_INTERVAL_SECS,
+            projector_limit: value_i64(
+                lookup("REPORTING_PROJECTOR_LIMIT"),
+                DEFAULT_PROJECTOR_LIMIT,
+            ),
+            repair_interval: Duration::from_secs(value_u64(
+                lookup("REPORTING_REPAIR_INTERVAL_SECS"),
+                DEFAULT_REPAIR_INTERVAL_SECS,
             )),
-            backfill_limit: env_i64("REPORTING_BACKFILL_LIMIT", DEFAULT_BACKFILL_LIMIT),
+            repair_limit: value_i64(lookup("REPORTING_REPAIR_LIMIT"), DEFAULT_REPAIR_LIMIT),
         }
     }
 }
@@ -47,7 +54,7 @@ pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) -> Vec<JoinHandl
     }
 
     let config = ReportingBackgroundConfig::from_env();
-    if config.projector_interval.is_zero() && config.backfill_interval.is_zero() {
+    if config.projector_interval.is_zero() && config.repair_interval.is_zero() {
         tracing::info!("Reporting background task disabled by zero intervals");
         return Vec::new();
     }
@@ -85,34 +92,30 @@ pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) -> Vec<JoinHandl
         }));
     }
 
-    if !config.backfill_interval.is_zero() {
+    if !config.repair_interval.is_zero() {
         let service = ReportingService::new(db);
-        let interval_secs = config.backfill_interval.as_secs();
-        let limit = config.backfill_limit;
+        let interval_secs = config.repair_interval.as_secs();
+        let limit = config.repair_limit;
         handles.push(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
             tracing::info!(
                 interval_secs,
                 limit,
-                "Started reporting backfill background task"
+                "Started bounded reporting event repair background task"
             );
 
             loop {
                 interval.tick().await;
-                match service.backfill_missing(None, limit).await {
-                    Ok(result) if result.enqueued > 0 => {
+                match service.repair_missing_event_projections(limit).await {
+                    Ok(enqueued) if enqueued > 0 => {
                         tracing::info!(
-                            enqueued = result.enqueued,
-                            events = result.events,
-                            sessions = result.sessions,
-                            llm_generations = result.llm_generations,
-                            usage_ledger = result.usage_ledger,
-                            "Reporting backfill enqueued missing projection work"
+                            enqueued,
+                            "Reporting event repair enqueued missing projection work"
                         );
                     }
                     Ok(_) => {}
                     Err(error) => {
-                        tracing::error!(%error, "Reporting backfill failed");
+                        tracing::error!(%error, "Reporting event repair failed");
                     }
                 }
             }
@@ -133,16 +136,48 @@ fn env_bool(name: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
-fn env_u64(name: &str, default: u64) -> u64 {
-    std::env::var(name)
-        .ok()
+fn value_u64(value: Option<String>, default: u64) -> u64 {
+    value
         .and_then(|value| value.parse().ok())
         .unwrap_or(default)
 }
 
-fn env_i64(name: &str, default: i64) -> i64 {
-    std::env::var(name)
-        .ok()
+fn value_i64(value: Option<String>, default: i64) -> i64 {
+    value
         .and_then(|value| value.parse().ok())
         .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_schedule_bounded_repair_not_full_backfill() {
+        let mut requested = Vec::new();
+        let config = ReportingBackgroundConfig::from_lookup(|name| {
+            requested.push(name.to_string());
+            None
+        });
+
+        assert_eq!(config.projector_interval, Duration::from_secs(5));
+        assert_eq!(config.projector_limit, 500);
+        assert_eq!(config.repair_interval, Duration::from_secs(300));
+        assert_eq!(config.repair_limit, 1_000);
+        assert!(requested.contains(&"REPORTING_REPAIR_INTERVAL_SECS".to_string()));
+        assert!(requested.contains(&"REPORTING_REPAIR_LIMIT".to_string()));
+        assert!(!requested.iter().any(|name| name.contains("BACKFILL")));
+    }
+
+    #[test]
+    fn bounded_repair_schedule_can_be_disabled() {
+        let config = ReportingBackgroundConfig::from_lookup(|name| match name {
+            "REPORTING_REPAIR_INTERVAL_SECS" => Some("0".to_string()),
+            "REPORTING_REPAIR_LIMIT" => Some("42".to_string()),
+            _ => None,
+        });
+
+        assert!(config.repair_interval.is_zero());
+        assert_eq!(config.repair_limit, 42);
+    }
 }

--- a/crates/server/src/domains/reporting/service.rs
+++ b/crates/server/src/domains/reporting/service.rs
@@ -398,6 +398,16 @@ impl ReportingService {
         }
     }
 
+    pub async fn repair_missing_event_projections(&self, limit: i64) -> Result<i64, CommandError> {
+        match self.db.as_ref() {
+            StorageBackend::Postgres(db) => PostgresReportingProjector::new(db.pool().clone())
+                .repair_missing_event_projections(limit)
+                .await
+                .map_err(classify_anyhow),
+            StorageBackend::InMemory(_) => Ok(0),
+        }
+    }
+
     pub async fn backfill_missing(
         &self,
         org_id: Option<i64>,

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -184,6 +184,179 @@ impl PostgresReportingProjector {
         Ok(acquired.then_some(connection))
     }
 
+    /// Verify one indexed event slice and transactionally advance the global cursor.
+    ///
+    /// A completed outbox row is reset only when one of its exact projected fact
+    /// keys is absent. Events whose best-effort outbox enqueue never succeeded
+    /// are inserted. The cursor wraps after reaching the current tail, so old
+    /// projections are still rechecked without a hot full-table scan.
+    pub async fn repair_missing_event_projections(&self, limit: i64) -> Result<i64> {
+        let Some(mut lock) = self.try_acquire_global_backfill_lock().await? else {
+            return Ok(0);
+        };
+        let (last_event_created_at, last_event_id) =
+            sqlx::query_as::<_, (Option<chrono::DateTime<chrono::Utc>>, Option<Uuid>)>(
+                r#"
+            SELECT last_event_created_at, last_event_id
+              FROM reporting_event_repair_cursor
+             WHERE singleton
+            "#,
+            )
+            .fetch_one(&mut *lock)
+            .await?;
+        let result = sqlx::query_scalar::<_, i64>(
+            r#"
+            WITH candidates AS MATERIALIZED (
+                SELECT sliced.*
+                  FROM (
+                      (
+                          SELECT e.id, e.session_id, e.event_type, e.data, e.created_at
+                            FROM events e
+                           WHERE $2::TIMESTAMPTZ IS NULL
+                             AND e.event_type IN (
+                                 'tool.completed',
+                                 'capability.usage',
+                                 'output.message.replaced',
+                                 'turn.completed',
+                                 'turn.failed',
+                                 'turn.cancelled'
+                             )
+                           ORDER BY e.created_at, e.id
+                           LIMIT $1
+                      )
+                      UNION ALL
+                      (
+                          SELECT e.id, e.session_id, e.event_type, e.data, e.created_at
+                            FROM events e
+                           WHERE $2::TIMESTAMPTZ IS NOT NULL
+                             AND (e.created_at, e.id) > ($2::TIMESTAMPTZ, $3::UUID)
+                             AND e.event_type IN (
+                                 'tool.completed',
+                                 'capability.usage',
+                                 'output.message.replaced',
+                                 'turn.completed',
+                                 'turn.failed',
+                                 'turn.cancelled'
+                             )
+                           ORDER BY e.created_at, e.id
+                           LIMIT $1
+                      )
+                  ) sliced
+                 LIMIT $1
+            ),
+            scoped AS MATERIALIZED (
+                SELECT s.org_id, candidates.*
+                  FROM candidates
+                  JOIN sessions s ON s.id = candidates.session_id
+            ),
+            missing AS MATERIALIZED (
+                SELECT scoped.org_id, scoped.id
+                  FROM scoped
+                 WHERE CASE
+                       WHEN scoped.event_type = 'tool.completed' THEN
+                           NOT EXISTS (
+                               SELECT 1
+                                 FROM fact_tool_call fact
+                                WHERE fact.org_id = scoped.org_id
+                                  AND fact.source_key = 'event:' || scoped.id::TEXT
+                           )
+                           OR (
+                               scoped.data ? 'capability_id'
+                               AND NOT EXISTS (
+                                   SELECT 1
+                                     FROM fact_capability_usage fact
+                                    WHERE fact.org_id = scoped.org_id
+                                      AND fact.source_key = 'event:' || scoped.id::TEXT || ':invoked'
+                               )
+                           )
+                       WHEN scoped.event_type = 'capability.usage' THEN EXISTS (
+                           SELECT 1
+                             FROM jsonb_array_elements(
+                                  COALESCE(scoped.data->'records', '[]'::jsonb)
+                             ) WITH ORDINALITY AS usage(record, ordinality)
+                            WHERE usage.record ? 'capability_id'
+                              AND usage.record ? 'usage_kind'
+                              AND NOT EXISTS (
+                                  SELECT 1
+                                    FROM fact_capability_usage fact
+                                   WHERE fact.org_id = scoped.org_id
+                                     AND fact.source_key =
+                                         'event:' || scoped.id::TEXT
+                                         || ':capability_usage:' || usage.ordinality::TEXT
+                              )
+                       )
+                       WHEN scoped.event_type = 'output.message.replaced' THEN
+                           scoped.data ? 'guardrail_capability_id'
+                           AND NOT EXISTS (
+                               SELECT 1
+                                 FROM fact_capability_usage fact
+                                WHERE fact.org_id = scoped.org_id
+                                  AND fact.source_key = 'event:' || scoped.id::TEXT || ':effect_ran'
+                           )
+                       ELSE NOT EXISTS (
+                           SELECT 1
+                             FROM fact_turn fact
+                            WHERE fact.org_id = scoped.org_id
+                              AND fact.source_key = 'event:' || scoped.id::TEXT
+                       )
+                   END
+            ),
+            enqueued AS (
+                INSERT INTO reporting_outbox (
+                    org_id, source_type, source_id, source_version,
+                    reason, status, next_attempt_at
+                )
+                SELECT org_id, 'event', id::TEXT, id::TEXT,
+                       'event_projection', 'pending', NOW()
+                  FROM missing
+                ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+                DO UPDATE SET
+                    status = 'pending',
+                    next_attempt_at = NOW(),
+                    updated_at = NOW()
+                WHERE reporting_outbox.status = 'completed'
+                RETURNING 1
+            ),
+            advanced AS (
+                UPDATE reporting_event_repair_cursor repair_cursor
+                   SET last_event_created_at = tail.created_at,
+                       last_event_id = tail.id,
+                       updated_at = NOW()
+                  FROM (
+                      SELECT created_at, id
+                        FROM candidates
+                       ORDER BY created_at DESC, id DESC
+                       LIMIT 1
+                  ) tail
+                 WHERE repair_cursor.singleton
+                RETURNING 1
+            ),
+            reset AS (
+                UPDATE reporting_event_repair_cursor repair_cursor
+                   SET last_event_created_at = NULL,
+                       last_event_id = NULL,
+                       updated_at = NOW()
+                 WHERE repair_cursor.singleton
+                   AND NOT EXISTS (SELECT 1 FROM candidates)
+                RETURNING 1
+            )
+            SELECT COUNT(*)::BIGINT FROM enqueued
+            "#,
+        )
+        .bind(limit.clamp(1, 10_000))
+        .bind(last_event_created_at)
+        .bind(last_event_id)
+        .fetch_one(&mut *lock)
+        .await;
+
+        sqlx::query("SELECT pg_advisory_unlock($1)")
+            .bind(GLOBAL_BACKFILL_LOCK_KEY)
+            .execute(&mut *lock)
+            .await?;
+
+        result.map_err(Into::into)
+    }
+
     async fn backfill_events(&self, org_id: Option<i64>, limit: i64) -> Result<i64> {
         if limit == 0 {
             return Ok(0);
@@ -203,21 +376,42 @@ impl PostgresReportingProjector {
                        'turn.cancelled'
                  )
                    AND CASE
-                       WHEN e.event_type = 'tool.completed' THEN NOT EXISTS (
-                           SELECT 1 FROM fact_tool_call fact
-                            WHERE fact.org_id = s.org_id
-                              AND fact.source_key = 'event:' || e.id::TEXT
+                       WHEN e.event_type = 'tool.completed' THEN
+                           NOT EXISTS (
+                               SELECT 1 FROM fact_tool_call fact
+                                WHERE fact.org_id = s.org_id
+                                  AND fact.source_key = 'event:' || e.id::TEXT
+                           )
+                           OR (
+                               e.data ? 'capability_id'
+                               AND NOT EXISTS (
+                                   SELECT 1 FROM fact_capability_usage fact
+                                    WHERE fact.org_id = s.org_id
+                                      AND fact.source_key = 'event:' || e.id::TEXT || ':invoked'
+                               )
+                           )
+                       WHEN e.event_type = 'capability.usage' THEN EXISTS (
+                           SELECT 1
+                             FROM jsonb_array_elements(
+                                  COALESCE(e.data->'records', '[]'::jsonb)
+                             ) WITH ORDINALITY AS usage(record, ordinality)
+                            WHERE usage.record ? 'capability_id'
+                              AND usage.record ? 'usage_kind'
+                              AND NOT EXISTS (
+                                  SELECT 1 FROM fact_capability_usage fact
+                                   WHERE fact.org_id = s.org_id
+                                     AND fact.source_key =
+                                         'event:' || e.id::TEXT
+                                         || ':capability_usage:' || usage.ordinality::TEXT
+                              )
                        )
-                       WHEN e.event_type = 'capability.usage' THEN NOT EXISTS (
-                           SELECT 1 FROM fact_capability_usage fact
-                            WHERE fact.org_id = s.org_id
-                              AND fact.source_key LIKE ('event:' || e.id::TEXT || ':capability_usage:%')
-                       )
-                       WHEN e.event_type = 'output.message.replaced' THEN NOT EXISTS (
-                           SELECT 1 FROM fact_capability_usage fact
-                            WHERE fact.org_id = s.org_id
-                              AND fact.source_key = 'event:' || e.id::TEXT || ':effect_ran'
-                       )
+                       WHEN e.event_type = 'output.message.replaced' THEN
+                           e.data ? 'guardrail_capability_id'
+                           AND NOT EXISTS (
+                               SELECT 1 FROM fact_capability_usage fact
+                                WHERE fact.org_id = s.org_id
+                                  AND fact.source_key = 'event:' || e.id::TEXT || ':effect_ran'
+                           )
                        ELSE NOT EXISTS (
                            SELECT 1 FROM fact_turn fact
                             WHERE fact.org_id = s.org_id

--- a/crates/server/tests/reporting_integration_test.rs
+++ b/crates/server/tests/reporting_integration_test.rs
@@ -4,6 +4,9 @@ mod test_harness;
 
 use axum::http::StatusCode;
 use chrono::{Duration, Utc};
+use everruns_server::storage::{
+    CreateOrganizationRow, CreatePrincipalRow, reporting::PostgresReportingProjector,
+};
 use serde_json::{Value, json};
 use test_harness::TestServer;
 use uuid::Uuid;
@@ -245,5 +248,469 @@ async fn reporting_backfill_enqueues_missing_postgres_session_fact() {
     assert_eq!(
         row.0,
         updated_at.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
+    );
+}
+
+async fn create_reporting_repair_session(server: &TestServer, org_id: i64, suffix: &str) -> Uuid {
+    let principal = server
+        .db
+        .create_principal(CreatePrincipalRow {
+            id: everruns_core::PrincipalId::new(),
+            org_id,
+            kind: "system".to_string(),
+            subject_id: Some(Uuid::now_v7()),
+            parent_principal_id: None,
+            resolved_user_id: None,
+            metadata: json!({ "source": "reporting_repair_test" }),
+        })
+        .await
+        .expect("create repair test principal");
+    let workspace_id = Uuid::now_v7();
+    sqlx::query(
+        r#"
+        INSERT INTO workspaces (id, org_id, public_id, name, status)
+        VALUES ($1, $2, $3, $4, 'active')
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(org_id)
+    .bind(format!("wsp_{}", workspace_id.simple()))
+    .bind(format!("reporting-repair-{suffix}-{workspace_id}"))
+    .execute(&server.pool)
+    .await
+    .expect("insert repair test workspace");
+
+    sqlx::query_scalar(
+        r#"
+        INSERT INTO sessions (org_id, title, status, owner_principal_id, workspace_id)
+        VALUES ($1, $2, 'started', $3, $4)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(format!("reporting-repair-{suffix}-{}", Uuid::now_v7()))
+    .bind(principal.id.uuid())
+    .bind(workspace_id)
+    .fetch_one(&server.pool)
+    .await
+    .expect("insert repair test session")
+}
+
+#[tokio::test]
+async fn bounded_event_repair_enqueues_only_missing_projections() {
+    let server = TestServer::new().await;
+    let other_org = server
+        .db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: format!("Reporting repair org {}", Uuid::now_v7()),
+            created_by: None,
+        })
+        .await
+        .expect("create second repair org");
+    let primary_session = create_reporting_repair_session(&server, 1, "primary").await;
+    let other_session = create_reporting_repair_session(&server, other_org.org_id, "other").await;
+
+    let base_time = Utc::now() + Duration::days(30);
+    let tool = Uuid::now_v7();
+    let tool_missing = Uuid::now_v7();
+    let capability_partial = Uuid::now_v7();
+    let capability_complete = Uuid::now_v7();
+    let guardrail = Uuid::now_v7();
+    let guardrail_missing = Uuid::now_v7();
+    let turn_completed = Uuid::now_v7();
+    let turn_failed = Uuid::now_v7();
+    let turn_cancelled = Uuid::now_v7();
+    let ignored = Uuid::now_v7();
+    let events = [
+        (
+            tool,
+            primary_session,
+            1,
+            "tool.completed",
+            json!({ "capability_id": "cap-tool", "tool_name": "search" }),
+        ),
+        (
+            tool_missing,
+            primary_session,
+            2,
+            "tool.completed",
+            json!({ "capability_id": "cap-tool-missing", "tool_name": "fetch" }),
+        ),
+        (
+            capability_partial,
+            primary_session,
+            3,
+            "capability.usage",
+            json!({ "records": [
+                { "capability_id": "cap-a", "usage_kind": "resolved" },
+                { "capability_id": "cap-b", "usage_kind": "exposed" }
+            ] }),
+        ),
+        (
+            guardrail,
+            primary_session,
+            4,
+            "output.message.replaced",
+            json!({ "guardrail_capability_id": "guardrail-a" }),
+        ),
+        (
+            guardrail_missing,
+            primary_session,
+            5,
+            "output.message.replaced",
+            json!({ "guardrail_capability_id": "guardrail-missing" }),
+        ),
+        (
+            turn_completed,
+            primary_session,
+            6,
+            "turn.completed",
+            json!({ "turn_id": "turn-completed" }),
+        ),
+        (
+            turn_failed,
+            primary_session,
+            7,
+            "turn.failed",
+            json!({ "turn_id": "turn-failed" }),
+        ),
+        (
+            capability_complete,
+            other_session,
+            1,
+            "capability.usage",
+            json!({ "records": [
+                { "capability_id": "cap-c", "usage_kind": "configured" },
+                { "capability_id": "cap-d", "usage_kind": "invoked" }
+            ] }),
+        ),
+        (
+            turn_cancelled,
+            other_session,
+            2,
+            "turn.cancelled",
+            json!({ "turn_id": "turn-cancelled" }),
+        ),
+        (
+            ignored,
+            other_session,
+            3,
+            "output.message.delta",
+            json!({ "delta": "ignored" }),
+        ),
+    ];
+    for (id, session_id, sequence, event_type, data) in &events {
+        sqlx::query(
+            r#"
+            INSERT INTO events (
+                id, session_id, sequence, event_type, data, context, ts, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, $6, $6)
+            "#,
+        )
+        .bind(id)
+        .bind(session_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(data)
+        .bind(base_time)
+        .execute(&server.pool)
+        .await
+        .expect("insert repair test event");
+    }
+
+    for (org_id, id) in [
+        (1, tool),
+        (1, tool_missing),
+        (1, capability_partial),
+        (1, guardrail),
+        (1, guardrail_missing),
+        (1, turn_completed),
+        (1, turn_failed),
+        (other_org.org_id, capability_complete),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            VALUES ($1, 'event', $2, $2, 'event_projection', 'completed', NOW())
+            "#,
+        )
+        .bind(org_id)
+        .bind(id.to_string())
+        .execute(&server.pool)
+        .await
+        .expect("insert completed repair outbox row");
+    }
+
+    sqlx::query(
+        r#"
+        INSERT INTO fact_tool_call (org_id, source_key, created_at, time_bucket_day)
+        VALUES (1, $1, $2, ($2 AT TIME ZONE 'UTC')::DATE)
+        "#,
+    )
+    .bind(format!("event:{tool}"))
+    .bind(base_time)
+    .execute(&server.pool)
+    .await
+    .expect("insert completed tool fact");
+
+    for (org_id, source_key, capability_id, usage_kind) in [
+        (1, format!("event:{tool}:invoked"), "cap-tool", "invoked"),
+        (
+            1,
+            format!("event:{capability_partial}:capability_usage:1"),
+            "cap-a",
+            "resolved",
+        ),
+        (
+            1,
+            format!("event:{guardrail}:effect_ran"),
+            "guardrail-a",
+            "effect_ran",
+        ),
+        (
+            other_org.org_id,
+            format!("event:{capability_complete}:capability_usage:1"),
+            "cap-c",
+            "configured",
+        ),
+        (
+            other_org.org_id,
+            format!("event:{capability_complete}:capability_usage:2"),
+            "cap-d",
+            "invoked",
+        ),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO fact_capability_usage (
+                org_id, source_key, created_at, time_bucket_day,
+                capability_id, capability_usage_kind
+            )
+            VALUES ($1, $2, $3, ($3 AT TIME ZONE 'UTC')::DATE, $4, $5)
+            "#,
+        )
+        .bind(org_id)
+        .bind(source_key)
+        .bind(base_time)
+        .bind(capability_id)
+        .bind(usage_kind)
+        .execute(&server.pool)
+        .await
+        .expect("insert completed capability fact");
+    }
+
+    sqlx::query(
+        r#"
+        INSERT INTO fact_turn (
+            org_id, source_key, created_at, time_bucket_day, turn_status
+        )
+        VALUES (1, $1, $2, ($2 AT TIME ZONE 'UTC')::DATE, 'failed')
+        "#,
+    )
+    .bind(format!("event:{turn_failed}"))
+    .bind(base_time)
+    .execute(&server.pool)
+    .await
+    .expect("insert completed turn fact");
+
+    sqlx::query(
+        r#"
+        UPDATE reporting_event_repair_cursor
+           SET last_event_created_at = $1,
+               last_event_id = '00000000-0000-0000-0000-000000000000'
+         WHERE singleton
+        "#,
+    )
+    .bind(base_time - Duration::seconds(1))
+    .execute(&server.pool)
+    .await
+    .expect("position repair cursor before fixture");
+
+    let first = PostgresReportingProjector::new(server.pool.clone());
+    let second = PostgresReportingProjector::new(server.pool.clone());
+    let (first_count, second_count) = tokio::join!(
+        first.repair_missing_event_projections(100),
+        second.repair_missing_event_projections(100)
+    );
+    assert_eq!(first_count.unwrap() + second_count.unwrap(), 5);
+
+    let rows: Vec<(i64, String, String)> = sqlx::query_as(
+        r#"
+        SELECT org_id, source_id, status
+          FROM reporting_outbox
+         WHERE source_type = 'event'
+           AND source_id = ANY($1)
+         ORDER BY org_id, source_id
+        "#,
+    )
+    .bind(vec![
+        tool.to_string(),
+        tool_missing.to_string(),
+        capability_partial.to_string(),
+        capability_complete.to_string(),
+        guardrail.to_string(),
+        guardrail_missing.to_string(),
+        turn_completed.to_string(),
+        turn_failed.to_string(),
+        turn_cancelled.to_string(),
+        ignored.to_string(),
+    ])
+    .fetch_all(&server.pool)
+    .await
+    .expect("load repaired outbox rows");
+    let pending: Vec<_> = rows
+        .iter()
+        .filter(|(_, _, status)| status == "pending")
+        .map(|(org_id, source_id, _)| (*org_id, source_id.clone()))
+        .collect();
+    let mut expected_pending = vec![
+        (1, capability_partial.to_string()),
+        (1, guardrail_missing.to_string()),
+        (1, tool_missing.to_string()),
+        (1, turn_completed.to_string()),
+        (other_org.org_id, turn_cancelled.to_string()),
+    ];
+    expected_pending.sort();
+    assert_eq!(pending, expected_pending);
+    assert_eq!(rows.len(), 9, "unsupported events must not be enqueued");
+
+    sqlx::query(
+        r#"
+        UPDATE reporting_event_repair_cursor
+           SET last_event_created_at = $1,
+               last_event_id = '00000000-0000-0000-0000-000000000000'
+         WHERE singleton
+        "#,
+    )
+    .bind(base_time - Duration::seconds(1))
+    .execute(&server.pool)
+    .await
+    .expect("rewind repair cursor for idempotence check");
+    assert_eq!(
+        PostgresReportingProjector::new(server.pool.clone())
+            .repair_missing_event_projections(100)
+            .await
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+#[ignore = "benchmark: seeds 60k events and 180k capability facts"]
+async fn reporting_event_repair_benchmark() {
+    let server = TestServer::new().await;
+    let session_id = create_reporting_repair_session(&server, 1, "benchmark").await;
+    let base_time = Utc::now() + Duration::days(60);
+
+    let (event_count, fact_count, outbox_count): (i64, i64, i64) = sqlx::query_as(
+        r#"
+        WITH inserted_events AS (
+            INSERT INTO events (
+                id, session_id, sequence, event_type, data, context, ts, created_at
+            )
+            SELECT uuidv7(), $1, n, 'capability.usage',
+                   jsonb_build_object('records', jsonb_build_array(
+                       jsonb_build_object(
+                           'capability_id', 'cap-a', 'usage_kind', 'configured'
+                       ),
+                       jsonb_build_object(
+                           'capability_id', 'cap-b', 'usage_kind', 'resolved'
+                       ),
+                       jsonb_build_object(
+                           'capability_id', 'cap-c', 'usage_kind', 'exposed'
+                       )
+                   )),
+                   '{}'::jsonb,
+                   $2 + n * INTERVAL '1 microsecond',
+                   $2 + n * INTERVAL '1 microsecond'
+              FROM generate_series(1, 60000) n
+            RETURNING id, session_id, created_at
+        ),
+        inserted_facts AS (
+            INSERT INTO fact_capability_usage (
+                org_id, source_key, session_id, created_at, time_bucket_day,
+                capability_id, capability_usage_kind
+            )
+            SELECT 1,
+                   'event:' || inserted_events.id::TEXT
+                       || ':capability_usage:' || ordinal::TEXT,
+                   inserted_events.session_id,
+                   inserted_events.created_at,
+                   (inserted_events.created_at AT TIME ZONE 'UTC')::DATE,
+                   'cap-' || ordinal::TEXT,
+                   CASE ordinal
+                       WHEN 1 THEN 'configured'
+                       WHEN 2 THEN 'resolved'
+                       ELSE 'exposed'
+                   END
+              FROM inserted_events
+             CROSS JOIN generate_series(1, 3) ordinal
+            RETURNING 1
+        ),
+        inserted_outbox AS (
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version,
+                reason, status, next_attempt_at
+            )
+            SELECT 1, 'event', id::TEXT, id::TEXT,
+                   'event_projection', 'completed', NOW()
+              FROM inserted_events
+            RETURNING 1
+        )
+        SELECT (SELECT COUNT(*) FROM inserted_events),
+               (SELECT COUNT(*) FROM inserted_facts),
+               (SELECT COUNT(*) FROM inserted_outbox)
+        "#,
+    )
+    .bind(session_id)
+    .bind(base_time)
+    .fetch_one(&server.pool)
+    .await
+    .expect("seed reporting repair benchmark");
+    assert_eq!(
+        (event_count, fact_count, outbox_count),
+        (60_000, 180_000, 60_000)
+    );
+
+    sqlx::query(
+        r#"
+        UPDATE reporting_event_repair_cursor
+           SET last_event_created_at = $1,
+               last_event_id = '00000000-0000-0000-0000-000000000000'
+         WHERE singleton
+        "#,
+    )
+    .bind(base_time)
+    .execute(&server.pool)
+    .await
+    .expect("position benchmark cursor");
+    sqlx::query("ANALYZE events")
+        .execute(&server.pool)
+        .await
+        .expect("analyze benchmark events");
+    sqlx::query("ANALYZE fact_capability_usage")
+        .execute(&server.pool)
+        .await
+        .expect("analyze benchmark facts");
+
+    let started = std::time::Instant::now();
+    let enqueued = PostgresReportingProjector::new(server.pool.clone())
+        .repair_missing_event_projections(1_000)
+        .await
+        .expect("run reporting repair benchmark");
+    let elapsed = started.elapsed();
+
+    assert_eq!(enqueued, 0);
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "no-work repair took {elapsed:?}"
+    );
+    eprintln!(
+        "reporting repair benchmark: {event_count} events, {fact_count} facts, {} ms",
+        elapsed.as_millis()
     );
 }

--- a/specs/reporting.md
+++ b/specs/reporting.md
@@ -137,7 +137,11 @@ the correctness mechanism.
 The server runs a built-in reporting background task for PostgreSQL storage. It
 is controlled by `REPORTING_BACKGROUND_ENABLED`,
 `REPORTING_PROJECTOR_INTERVAL_SECS`, `REPORTING_PROJECTOR_LIMIT`,
-`REPORTING_BACKFILL_INTERVAL_SECS`, and `REPORTING_BACKFILL_LIMIT`.
+`REPORTING_REPAIR_INTERVAL_SECS`, and `REPORTING_REPAIR_LIMIT`. Periodic repair
+walks supported event sources in bounded, indexed slices behind a durable
+watermark, checks exact fact source keys, and wraps after reaching the current
+tail. It does not run a full historical backfill. Full backfill remains an
+explicit admin operation.
 
 ## Idempotency
 
@@ -459,8 +463,9 @@ Backfills:
 - Backfills are idempotent and resumable.
 - Backfills must be rate-limited per org and globally.
 - The initial backfill/reconciler enqueues missing event, session,
-  LLM-generation, and usage-ledger work from canonical tables. It is available
-  as an admin operation and also runs periodically in the background.
+  LLM-generation, and usage-ledger work from canonical tables. Full historical
+  reconciliation is available as an admin operation. The background task only
+  performs bounded event repair using its durable cursor.
 
 Retention:
 


### PR DESCRIPTION
## What changed

The default reporting maintenance loop now repairs event projections in bounded, indexed slices instead of globally rescanning historical events every five minutes.

- A durable cyclic cursor walks supported event sources in `(created_at, id)` order under the existing advisory lock.
- Missing facts are verified with exact `(org_id, source_key)` probes, including every ordinal in multi-record `capability.usage` events.
- Missing or previously completed outbox work is enqueued idempotently; pending/failed retry state remains untouched.
- Full historical reconciliation remains available through the admin backfill, but is no longer the hot background default.
- Background configuration moves to `REPORTING_REPAIR_INTERVAL_SECS` / `REPORTING_REPAIR_LIMIT` (defaults: 300 seconds / 1,000 rows).

Linear: [EVE-696](https://linear.app/everruns/issue/EVE-696/bound-periodic-reporting-projection-repair)

## Why

The former five-minute global backfill took 81–89 seconds on development data (~57,952 events, ~168,343 capability facts, ~57,001 outbox rows). Its `capability.usage` branch used a correlated prefix `LIKE` probe that scanned capability facts by org for every event candidate, creating database contention and unrelated API latency.

## Before / After

Representative local fixture: 60,000 supported events, 180,000 capability facts, and 60,000 completed outbox rows with no missing work.

- Before query shape: exceeded a 120-second `statement_timeout` on the fixture.
- After, actual Rust repair path: **16 ms** for a 1,000-row no-work slice.
- `EXPLAIN (ANALYZE, BUFFERS)`: **7.68 ms** execution; `idx_events_reporting_repair` used with the watermark in `Index Cond`; 2,997 capability probes used `fact_capability_usage_pkey`; no full events scan and no org-wide capability scan per candidate.

Repeatable benchmark:

```bash
DATABASE_URL=postgres://everruns:everruns@localhost:37932/everruns_test \
  cargo test -p everruns-server --test reporting_integration_test \
  reporting_event_repair_benchmark -- --ignored --nocapture
```

Observed output:

```text
reporting repair benchmark: 60000 events, 180000 facts, 16 ms
```

## Risk

- Medium: changes background scheduling and adds migration 096 (singleton repair cursor plus a partial ordered events index).
- The cursor and enqueue happen atomically in one statement; the existing global advisory lock prevents overlapping global repair/backfill runs.
- The admin full backfill remains available for operator-triggered historical repair.
- Compatibility was considered: periodic full backfill environment controls are intentionally replaced by bounded repair controls; the admin API is unchanged.

## Security

- Threat categories reviewed: TM-TENANT, TM-SQL, TM-DOS.
- Tenant isolation: org scope is derived from each event's owning session and carried through exact fact/outbox keys; the PostgreSQL fixture covers multiple orgs.
- SQL safety: cursor and limit values are bound, the limit is clamped, and no dynamic SQL is constructed.
- Resource exhaustion: work is bounded, index-ranged, and advisory-locked. The old broad prefix scan is removed from both periodic repair and operator backfill verification.
- No new trust boundary or materially new threat was introduced, so `specs/threat-model.md` does not require a new entry.

## Validation

- `cargo fmt --check`
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings`
- PostgreSQL reporting integration suite: 6 passed, 1 ignored benchmark
- Benchmark above: 16 ms at 60k events / 180k facts
- Full all-feature server library suite: 1,867 passed
- Standard PostgreSQL server integration binaries, including reporting/repository conformance: passed
- `just pre-push`: passed all 10 checks after rebasing to `e9c2b2cd`
- Migration ordering: sequential 001..096
- Migration immutability: passed
- UI format/lint/build and OpenAPI freshness: passed during `just pre-pr`

Local environment-only limitations:

- Live Slack and Turbopuffer tests could not run because this worktree has no configured Doppler project/fallback and the required live secrets are absent. GitHub Actions is the authority for those Doppler-backed checks.
- The bundled pnpm v11 runtime does not honor the repositories' pnpm 10 package-level build allowlist; docs check had 0 errors, while the local docs build hit the existing notebook `/llms-full.txt` runtime failure. No docs or pnpm files are changed by this PR; CI will validate with its pinned environment.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)