### PR TITLE
perf(sessions): add org created-at index (EVE-697)

### DIFF
--- a/crates/server/migrations/097_sessions_org_created_at_index.sql
+++ b/crates/server/migrations/097_sessions_org_created_at_index.sql
@@ -1,0 +1,5 @@
+-- no-transaction
+-- Session listing is scoped to one organization and ordered newest-first.
+-- Build concurrently so applying this migration does not block session writes.
+CREATE INDEX CONCURRENTLY idx_sessions_org_created_at
+    ON sessions (org_id, created_at DESC);

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -798,6 +798,31 @@ async fn test_session_crud() {
         .unwrap();
 }
 
+#[tokio::test]
+async fn test_sessions_list_has_org_created_at_index() {
+    let pool = create_test_pool().await;
+    let index_definition: Option<String> = sqlx::query_scalar(
+        r#"
+        SELECT indexdef
+        FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND tablename = 'sessions'
+          AND indexname = 'idx_sessions_org_created_at'
+        "#,
+    )
+    .fetch_optional(&pool)
+    .await
+    .expect("Failed to inspect sessions indexes");
+
+    let index_definition = index_definition.expect(
+        "sessions listing needs an org_id/created_at index to avoid scanning other tenants",
+    );
+    assert!(
+        index_definition.ends_with("USING btree (org_id, created_at DESC)"),
+        "unexpected sessions list index definition: {index_definition}"
+    );
+}
+
 // ============================================
 // Event Repository Tests
 // ============================================


### PR DESCRIPTION
## What changed

Session listing now has a PostgreSQL index matching its tenant-scoped newest-first access pattern: `sessions(org_id, created_at DESC)`.

Migration 097 builds the index concurrently so production session writes are not blocked. Existing indexes remain in place. A schema regression test locks the index name and column order to the query contract.

## Why

The list query filters `WHERE org_id = ?` and orders `created_at DESC`. With only separate indexes, PostgreSQL chose the global `idx_sessions_created_at` index and filtered other organizations while walking it. On a multi-org fixture, the first page discarded 1,439 unrelated rows for 8 results; offset 40 discarded 8,639.

## Before / After

Fixture: 900,000 rows for another organization plus 5,000 rows for the target organization. Target rows are interleaved every 180 seconds so the global recency index must cross tenant boundaries. Measurements are warm-cache `EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)` runs.

| Variant | Plan before → after | Rows removed by filter before → after | Planning ms before → after | Execution ms before → after | Buffers before → after |
| --- | --- | ---: | ---: | ---: | ---: |
| First page, limit 8 / offset 0 | `idx_sessions_created_at` → `idx_sessions_org_created_at` | 1,439 → 0 | 0.091 → 0.106 | 0.104 → 0.014 | 65 → 4 |
| Non-zero offset, limit 8 / offset 40 | `idx_sessions_created_at` → `idx_sessions_org_created_at` | 8,639 → 0 | 0.034 → 0.036 | 0.759 → 0.027 | 383 → 6 |
| Agent filter | `idx_sessions_org_agent_id` → same | 0 → 0 | 0.056 → 0.043 | 1.904 → 1.823 | 154 → 154 |
| Search filter | `idx_sessions_org_id` → same | 4,500 title-filtered target-org rows → 4,500 | 0.057 → 0.073 | 0.813 → 0.779 | 154 → 154 |

The filtered variants retain their prior indexes and timing; no speculative filtered indexes were added.

The concurrent build completed in 607 ms on the 905,000-row fixture. Final sequencing validation also applied 096 → 097 in 1.24 ms on an existing empty-schema database, and a fresh database applied migrations 001–097 successfully.

<details>
<summary>Repeatable benchmark command</summary>

Start isolated PostgreSQL and migrate a disposable database through 096:

```bash
PORT_PREFIX=297 just start-infra
DB=postgres://everruns:everruns@localhost:29732/everruns_sessions_index_bench
PGPASSWORD=everruns psql -h localhost -p 29732 -U everruns -d postgres \
  -c "DROP DATABASE IF EXISTS everruns_sessions_index_bench WITH (FORCE)" \
  -c "CREATE DATABASE everruns_sessions_index_bench"
cargo sqlx migrate run --source crates/server/migrations \
  --database-url "$DB" --target-version 96
```

Load the deterministic multi-org fixture:

```bash
psql "$DB" -v ON_ERROR_STOP=1 <<'SQL'
SET session_replication_role = replica;
INSERT INTO sessions (
  org_id, agent_id, title, owner_principal_id, workspace_id, created_at, updated_at
)
SELECT 2, NULL, 'other-org',
       '00000000-0000-0000-0000-000000000001',
       '00000000-0000-0000-0000-000000000002',
       TIMESTAMPTZ '2026-01-01 00:00:00+00' - n * INTERVAL '1 second',
       TIMESTAMPTZ '2026-01-01 00:00:00+00'
FROM generate_series(1, 900000) AS n;

INSERT INTO sessions (
  org_id, agent_id, title, owner_principal_id, workspace_id, created_at, updated_at
)
SELECT 1, '00000000-0000-0000-0000-000000000003',
       CASE WHEN n % 10 = 0 THEN 'needle target' ELSE 'target' END,
       '00000000-0000-0000-0000-000000000001',
       '00000000-0000-0000-0000-000000000002',
       TIMESTAMPTZ '2026-01-01 00:00:00+00' - n * INTERVAL '180 seconds',
       TIMESTAMPTZ '2026-01-01 00:00:00+00'
FROM generate_series(1, 5000) AS n;
SET session_replication_role = origin;
ANALYZE sessions;
SQL
```

Run these warm-cache statements twice before migration 097 and twice after it:

```sql
EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)
SELECT id FROM sessions
WHERE org_id = 1
ORDER BY created_at DESC LIMIT 8 OFFSET 0;

EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)
SELECT id FROM sessions
WHERE org_id = 1
ORDER BY created_at DESC LIMIT 8 OFFSET 40;

EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)
SELECT id FROM sessions
WHERE org_id = 1
  AND agent_id = '00000000-0000-0000-0000-000000000003'
ORDER BY created_at DESC LIMIT 8 OFFSET 0;

EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)
SELECT id FROM sessions
WHERE org_id = 1
  AND LOWER(COALESCE(title, '')) LIKE '%needle%' ESCAPE '\'
ORDER BY created_at DESC LIMIT 8 OFFSET 0;
```

Apply the index between the before/after runs:

```bash
cargo sqlx migrate run --source crates/server/migrations \
  --database-url "$DB" --target-version 97
```

</details>

Offset pagination still walks `offset + limit` entries within the selected organization, so deep offsets remain linear in that organization's history. Keyset pagination is intentionally outside this focused index change.

## Risk

- **Low.**
- The new index adds normal storage and write-maintenance overhead.
- `CREATE INDEX CONCURRENTLY` avoids blocking session writes during rollout.
- Query semantics, API shape, and existing indexes are unchanged.

## Security

- Threat categories reviewed: TM-TENANT, TM-SQL, TM-DOS.
- The leading `org_id` key preserves tenant isolation and removes cross-tenant scan amplification.
- The migration is static DDL with no user-controlled input or data mutation.
- Remaining offset cost is bounded to rows in the selected organization.
- No trust boundary or threat-model contract changes.

## Follow-ups

- Deep offset pagination remains linear within one organization; replacing it with keyset pagination is a separate API behavior change and intentionally out of scope.

## Validation

- Regression test was written first and failed before migration 097 because the composite index was absent.
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p everruns-server --test repository_integration_test` — 31 passed
- Focused index regression on both 096 → 097 upgrade and fresh 001 → 097 databases
- `cargo test -p everruns-server --test migration_history_test`
- `bash scripts/lib/check-migration-ordering.sh`
- `bash scripts/lib/check-migration-immutability.sh`
- `just pre-push` — all 10 checks passed
- API smoke: `GET /api/v1/sessions?limit=8&offset=0` and `offset=40` returned the expected pagination envelopes against a live local stack
- Full local `just pre-pr` completed ordinary Rust tests, UI format/lint/build, OpenAPI freshness, and migration checks. The only unavailable local gates were the credentialed live Turbopuffer test and an existing docs notebook-manifest route failure; final GitHub CI is authoritative.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

