### PR TITLE
feat(sessions): record user participant provenance

### DIFF
--- a/crates/server/migrations/098_session_participant_user_identity.sql
+++ b/crates/server/migrations/098_session_participant_user_identity.sql
@@ -1,0 +1,28 @@
+-- Session participant identity: one active user row per principal in a session.
+--
+-- Slack and other channel speakers become explicit user participants keyed by
+-- their durable external-actor principal. Historical leave/rejoin intervals stay
+-- possible because the uniqueness only applies while `left_at` is NULL.
+
+WITH ranked_active_users AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY session_id, principal_id
+            ORDER BY joined_at ASC, created_at ASC, id ASC
+        ) AS duplicate_rank
+    FROM session_participants
+    WHERE kind = 'user' AND left_at IS NULL
+)
+UPDATE session_participants
+SET left_at = NOW(),
+    updated_at = NOW()
+WHERE id IN (
+    SELECT id
+    FROM ranked_active_users
+    WHERE duplicate_rank > 1
+);
+
+CREATE UNIQUE INDEX session_participants_one_active_user_principal_idx
+    ON session_participants(session_id, principal_id)
+    WHERE kind = 'user' AND left_at IS NULL;

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -31,7 +31,10 @@ use everruns_core::channel::{
 };
 use everruns_core::progress_reporting::sync_slack_reply_mode_tags;
 use everruns_core::validate_safe_url;
-use everruns_core::{App, AppStatus, Caller, SessionStrategy, SlackChannelConfig, SlackReplyMode};
+use everruns_core::{
+    App, AppStatus, Caller, SessionParticipantKind, SessionParticipantRole, SessionStrategy,
+    SlackChannelConfig, SlackReplyMode,
+};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, KeyInit, Mac};
 use moka::sync::Cache;
@@ -46,10 +49,10 @@ use crate::domains::messages::{CreateMessageContext, MessageService};
 use crate::domains::sessions::SessionService;
 use crate::execution_metadata;
 use crate::middleware::RequestId;
-use crate::services::EventService;
+use crate::services::{EventService, PrincipalService};
 use crate::slack_delivery::SlackDeliveryDispatcher;
 use crate::storage::StorageBackend;
-use crate::storage::models::UpdateSession;
+use crate::storage::models::{CreateSessionParticipantRow, SessionParticipantRow, UpdateSession};
 
 use super::common::ErrorResponse;
 
@@ -704,6 +707,11 @@ async fn process_slack_message(
         }
     }
 
+    let speaker_participant = match external_actor.as_ref() {
+        Some(actor) => Some(ensure_slack_user_participant(state, org_id, session.id, actor).await?),
+        None => None,
+    };
+
     // Inject thread context: when joining an existing thread mid-conversation,
     // fetch prior messages from Slack and inject them as context so the agent
     // sees the full conversation history.
@@ -769,10 +777,27 @@ async fn process_slack_message(
         },
         addressed_participant_id: None,
         controls: None,
-        metadata: Some(slack_message_metadata(app, event)),
+        metadata: Some(slack_message_metadata(
+            app,
+            event,
+            speaker_participant.as_ref(),
+        )),
         tags: None,
         external_actor,
     };
+    let mut event_metadata = execution_metadata::app_message_metadata(
+        app.public_id,
+        app.owner_principal_id,
+        app.agent_identity_id,
+    );
+    if let Some(participant) = &speaker_participant
+        && let Some(map) = event_metadata.as_object_mut()
+    {
+        map.insert(
+            "participant_id".to_string(),
+            serde_json::Value::String(participant.id.to_string()),
+        );
+    }
 
     let message = state
         .message_service
@@ -783,11 +808,7 @@ async fn process_slack_message(
                 harness_id: app.harness_id.uuid(),
                 agent_id: app.agent_id.map(|agent_id| agent_id.uuid()),
                 session_id: session.id.uuid(),
-                event_metadata: Some(execution_metadata::app_message_metadata(
-                    app.public_id,
-                    app.owner_principal_id,
-                    app.agent_identity_id,
-                )),
+                event_metadata: Some(event_metadata),
                 request_id,
             },
             create_msg,
@@ -860,8 +881,36 @@ async fn process_slack_message(
     Ok(())
 }
 
-fn slack_message_metadata(app: &App, event: &SlackEvent) -> HashMap<String, serde_json::Value> {
-    [
+async fn ensure_slack_user_participant(
+    state: &SlackState,
+    org_id: i64,
+    session_id: everruns_core::typed_id::SessionId,
+    actor: &everruns_core::ExternalActor,
+) -> anyhow::Result<SessionParticipantRow> {
+    let principal = PrincipalService::new(state.db.clone())
+        .ensure_external_actor_principal(org_id, actor)
+        .await?;
+    state
+        .db
+        .ensure_active_user_session_participant(CreateSessionParticipantRow {
+            org_id,
+            session_id,
+            kind: SessionParticipantKind::User,
+            agent_id: None,
+            agent_version_id: None,
+            principal_id: principal.id,
+            role: SessionParticipantRole::Member,
+            joined_at: None,
+        })
+        .await
+}
+
+fn slack_message_metadata(
+    app: &App,
+    event: &SlackEvent,
+    participant: Option<&SessionParticipantRow>,
+) -> HashMap<String, serde_json::Value> {
+    let mut metadata: HashMap<String, serde_json::Value> = [
         (
             "_app_id".to_string(),
             serde_json::Value::String(app.public_id.to_string()),
@@ -876,7 +925,14 @@ fn slack_message_metadata(app: &App, event: &SlackEvent) -> HashMap<String, serd
         ),
     ]
     .into_iter()
-    .collect()
+    .collect();
+    if let Some(participant) = participant {
+        metadata.insert(
+            "participant_id".to_string(),
+            serde_json::Value::String(participant.id.to_string()),
+        );
+    }
+    metadata
 }
 
 /// Supported image MIME types for Slack file attachments.
@@ -2087,7 +2143,7 @@ mod tests {
         let app = test_app();
         let event = test_event("C123", Some("1234.5678"), None);
 
-        let metadata = slack_message_metadata(&app, &event);
+        let metadata = slack_message_metadata(&app, &event, None);
 
         assert_eq!(
             metadata.get("_app_id"),

--- a/crates/server/src/domains/messages/service.rs
+++ b/crates/server/src/domains/messages/service.rs
@@ -21,6 +21,7 @@ use everruns_core::events::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_worker::AgentRunner;
+use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -168,7 +169,8 @@ impl MessageService {
                 };
                 execution_metadata::interactive_user_metadata(Some(user_id), principal_id)
             } else {
-                None
+                self.session_owner_message_metadata(ctx.org_id, session_id_typed)
+                    .await
             };
             let mut event_request = EventRequest::new(
                 session_id_typed,
@@ -272,6 +274,33 @@ impl MessageService {
     /// need to emit lifecycle events outside of `MessageService::create`.
     pub fn event_service(&self) -> &EventService {
         &self.event_service
+    }
+
+    async fn session_owner_message_metadata(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+    ) -> Option<serde_json::Value> {
+        let session = match self.db.get_session_unscoped(session_id).await {
+            Ok(Some(session)) if session.org_id == org_id => session,
+            Ok(_) => return None,
+            Err(err) => {
+                tracing::warn!(
+                    org_id,
+                    session_id = %session_id,
+                    error = %err,
+                    "Failed to resolve session owner for message metadata"
+                );
+                return None;
+            }
+        };
+
+        Some(json!({
+            "initiator": { "type": "api_key" },
+            "acting_principal": { "type": "api_key" },
+            "initiator_principal_id": session.owner_principal_id,
+            "acting_principal_id": session.owner_principal_id,
+        }))
     }
 
     pub async fn list(&self, session_id: Uuid) -> Result<Vec<Message>> {
@@ -542,6 +571,70 @@ mod tests {
         assert!(
             err.to_string().contains("Too many active turns"),
             "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_message_without_user_id_uses_session_owner_participant_metadata() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let runner: Arc<dyn AgentRunner> = Arc::new(NoopRunner);
+        let delivery = crate::event_delivery::EventDelivery::in_memory();
+
+        let svc = MessageService::new(db.clone(), runner, false, delivery).with_caps(OrgCaps {
+            max_concurrent_sessions: 10_000,
+            max_active_turns: 10_000,
+        });
+
+        let session = create_test_session(&db, 1).await;
+        let owner_participant = db
+            .list_session_participants(1, session.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|row| {
+                row.kind == "user"
+                    && row.principal_id == session.owner_principal_id
+                    && row.left_at.is_none()
+            })
+            .expect("session owner user participant");
+
+        let message = svc
+            .create(
+                CreateMessageContext {
+                    org_id: 1,
+                    user_id: None,
+                    harness_id: session.id.uuid(),
+                    agent_id: None,
+                    session_id: session.id.uuid(),
+                    event_metadata: None,
+                    request_id: None,
+                },
+                CreateMessageRequest::user("owner provenance"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(message.session_id, session.id);
+
+        let events = db
+            .list_message_events_limited(session.id, None)
+            .await
+            .unwrap();
+        let input = events
+            .into_iter()
+            .find(|row| row.event_type == "input.message")
+            .expect("input message event");
+        let metadata = input.metadata.expect("input message metadata");
+        assert_eq!(
+            metadata
+                .get("initiator_principal_id")
+                .and_then(|value| value.as_str()),
+            Some(session.owner_principal_id.to_string().as_str())
+        );
+        assert_eq!(
+            metadata
+                .get("participant_id")
+                .and_then(|value| value.as_str()),
+            Some(owner_participant.id.to_string().as_str())
         );
     }
 

--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -25,8 +25,9 @@ use crate::storage::{
     models::{CreateEventRow, EventsSummary as EventsSummaryRow, ListEventsParams},
 };
 use anyhow::{Result, bail};
-use everruns_core::typed_id::{AgentId, AgentVersionId, EventId, SessionId};
-use everruns_core::{Event, EventListener, EventRequest, FeatureFlags};
+use everruns_core::events::{INPUT_MESSAGE, OUTPUT_MESSAGE_COMPLETED};
+use everruns_core::typed_id::{AgentId, AgentVersionId, EventId, PrincipalId, SessionId};
+use everruns_core::{Event, EventListener, EventRequest, FeatureFlags, SessionParticipantKind};
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -167,6 +168,7 @@ impl EventService {
     /// Returns an error if event_type doesn't match the data type.
     pub async fn emit(&self, mut request: EventRequest) -> Result<Event> {
         self.attach_agent_version_metadata(&mut request).await;
+        self.attach_session_participant_metadata(&mut request).await;
         Self::validate_event_type_consistency(&request)?;
 
         // Only skip PG for delta events when the delivery backend supports it
@@ -229,6 +231,94 @@ impl EventService {
                 .or_insert_with(|| serde_json::Value::String(hash));
         }
         request.metadata = Some(serde_json::Value::Object(metadata));
+    }
+
+    async fn attach_session_participant_metadata(&self, request: &mut EventRequest) {
+        if request.event_type != INPUT_MESSAGE && request.event_type != OUTPUT_MESSAGE_COMPLETED {
+            return;
+        }
+
+        let mut metadata = match request.metadata.take() {
+            Some(serde_json::Value::Object(map)) => map,
+            Some(other) => {
+                request.metadata = Some(other);
+                return;
+            }
+            None => return,
+        };
+
+        if metadata.contains_key("participant_id") {
+            request.metadata = Some(serde_json::Value::Object(metadata));
+            return;
+        }
+
+        let participant = match request.event_type.as_str() {
+            INPUT_MESSAGE => {
+                let principal_id = metadata
+                    .get("initiator_principal_id")
+                    .and_then(|value| value.as_str())
+                    .and_then(|value| value.parse::<PrincipalId>().ok());
+                match principal_id {
+                    Some(principal_id) => {
+                        self.find_active_participant(request.session_id, |row| {
+                            row.kind == SessionParticipantKind::User.to_string()
+                                && row.principal_id == principal_id
+                        })
+                        .await
+                    }
+                    None => None,
+                }
+            }
+            OUTPUT_MESSAGE_COMPLETED => {
+                let agent_id = metadata
+                    .get("agent_id")
+                    .and_then(|value| value.as_str())
+                    .and_then(|value| value.parse::<AgentId>().ok());
+                match agent_id {
+                    Some(agent_id) => {
+                        self.find_active_participant(request.session_id, |row| {
+                            row.kind == SessionParticipantKind::Agent.to_string()
+                                && row.agent_id == Some(agent_id)
+                        })
+                        .await
+                    }
+                    None => None,
+                }
+            }
+            _ => None,
+        };
+
+        if let Some(participant_id) = participant {
+            metadata.insert(
+                "participant_id".to_string(),
+                serde_json::Value::String(participant_id.to_string()),
+            );
+        }
+
+        request.metadata = Some(serde_json::Value::Object(metadata));
+    }
+
+    async fn find_active_participant<F>(
+        &self,
+        session_id: SessionId,
+        matches_participant: F,
+    ) -> Option<everruns_core::SessionParticipantId>
+    where
+        F: Fn(&crate::storage::models::SessionParticipantRow) -> bool,
+    {
+        let session = self
+            .db
+            .get_session_unscoped(session_id)
+            .await
+            .ok()
+            .flatten()?;
+        self.db
+            .list_session_participants(session.org_id, session_id)
+            .await
+            .ok()?
+            .into_iter()
+            .find(|row| row.left_at.is_none() && matches_participant(row))
+            .map(|row| row.id)
     }
 
     /// Emit an ephemeral event (skip PG, deliver via EventDelivery only).
@@ -469,6 +559,13 @@ impl everruns_core::traits::EventEmitter for EventService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event_delivery::EventDelivery;
+    use crate::storage::StorageBackend;
+    use crate::storage::models::{CreateSessionParticipantRow, CreateSessionRow};
+    use everruns_core::events::{EventContext, InputMessageData, OutputMessageCompletedData};
+    use everruns_core::{DEFAULT_ORG_ID, HarnessId, Message, PrincipalId, SessionParticipantRole};
+    use everruns_core::{SessionParticipantKind, typed_id::AgentId};
+    use std::sync::Arc;
 
     fn sample_metadata() -> AgentVersionEventMetadata {
         AgentVersionEventMetadata {
@@ -508,5 +605,110 @@ mod tests {
         cache.insert(id, sample_metadata()).await;
         assert!(cache.get(&id).await.is_some());
         assert!(cache.get(&SessionId::new()).await.is_none());
+    }
+
+    fn test_session_input(agent_id: AgentId) -> CreateSessionRow {
+        CreateSessionRow {
+            workspace_id: None,
+            org_id: DEFAULT_ORG_ID,
+            app_id: None,
+            harness_id: Some(HarnessId::from_uuid(Uuid::nil())),
+            agent_id: Some(agent_id),
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn message_events_attach_active_participant_metadata() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let event_service = EventService::new(db.clone(), EventDelivery::in_memory());
+        let host_agent_id = AgentId::new();
+        let guest_agent_id = AgentId::new();
+        let session = db
+            .create_session(test_session_input(host_agent_id))
+            .await
+            .unwrap();
+        let guest = db
+            .create_session_participant(CreateSessionParticipantRow {
+                org_id: DEFAULT_ORG_ID,
+                session_id: session.id,
+                kind: SessionParticipantKind::Agent,
+                agent_id: Some(guest_agent_id),
+                agent_version_id: None,
+                principal_id: PrincipalId::from_seed(2),
+                role: SessionParticipantRole::Member,
+                joined_at: None,
+            })
+            .await
+            .unwrap();
+        let owner_user = db
+            .list_session_participants(DEFAULT_ORG_ID, session.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|row| row.kind == "user" && row.principal_id == PrincipalId::from_seed(1))
+            .unwrap();
+
+        let input = event_service
+            .emit(
+                EventRequest::new(
+                    session.id,
+                    EventContext::empty(),
+                    InputMessageData::new(Message::user("hello")),
+                )
+                .with_metadata(serde_json::json!({
+                    "initiator_principal_id": PrincipalId::from_seed(1).to_string()
+                })),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            input
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("participant_id"))
+                .and_then(|value| value.as_str()),
+            Some(owner_user.id.to_string().as_str())
+        );
+
+        let output = event_service
+            .emit(
+                EventRequest::new(
+                    session.id,
+                    EventContext::empty(),
+                    OutputMessageCompletedData::new(Message::assistant("hi")),
+                )
+                .with_metadata(serde_json::json!({
+                    "agent_id": guest_agent_id.to_string()
+                })),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            output
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("participant_id"))
+                .and_then(|value| value.as_str()),
+            Some(guest.id.to_string().as_str())
+        );
     }
 }

--- a/crates/server/src/services/principal.rs
+++ b/crates/server/src/services/principal.rs
@@ -5,8 +5,8 @@
 
 use anyhow::{Result, anyhow};
 use everruns_core::{
-    ANONYMOUS_USER_ID, Caller, Principal, PrincipalId, PrincipalKind, PrincipalStatus,
-    PrincipalSummary, org_public_id_from_internal,
+    ANONYMOUS_USER_ID, Caller, ExternalActor, Principal, PrincipalId, PrincipalKind,
+    PrincipalStatus, PrincipalSummary, org_public_id_from_internal,
 };
 use everruns_durable::UpdateField;
 use serde_json::json;
@@ -71,6 +71,37 @@ impl PrincipalService {
                     "email": user.email,
                     "avatar_url": user.avatar_url,
                     "source": "user",
+                }),
+            })
+            .await
+    }
+
+    pub async fn ensure_external_actor_principal(
+        &self,
+        org_id: i64,
+        actor: &ExternalActor,
+    ) -> Result<PrincipalRow> {
+        let subject_key = format!("{}:{}", actor.source, actor.actor_id);
+        let subject_id = Uuid::new_v5(
+            &Uuid::NAMESPACE_URL,
+            format!("everruns:external_actor:{subject_key}").as_bytes(),
+        );
+
+        self.db
+            .create_principal(CreatePrincipalRow {
+                id: PrincipalId::new(),
+                org_id,
+                kind: "user".to_string(),
+                subject_id: Some(subject_id),
+                parent_principal_id: None,
+                resolved_user_id: None,
+                metadata: json!({
+                    "name": actor.display_label(),
+                    "source": "external_actor",
+                    "external_source": actor.source,
+                    "external_actor_id": actor.actor_id,
+                    "external_actor_name": actor.actor_name,
+                    "external_actor_metadata": actor.metadata,
                 }),
             })
             .await

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -850,6 +850,13 @@ impl StorageBackend {
         dispatch!(self, create_session_participant, input)
     }
 
+    pub async fn ensure_active_user_session_participant(
+        &self,
+        input: CreateSessionParticipantRow,
+    ) -> Result<SessionParticipantRow> {
+        dispatch!(self, ensure_active_user_session_participant, input)
+    }
+
     pub async fn list_session_participants(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/session_participants.rs
+++ b/crates/server/src/storage/memory/session_participants.rs
@@ -72,6 +72,57 @@ impl InMemoryDatabase {
         Ok(row)
     }
 
+    pub async fn ensure_active_user_session_participant(
+        &self,
+        input: CreateSessionParticipantRow,
+    ) -> Result<SessionParticipantRow> {
+        if input.kind != SessionParticipantKind::User
+            || input.role != SessionParticipantRole::Member
+            || input.agent_id.is_some()
+            || input.agent_version_id.is_some()
+        {
+            bail!("active user participant upsert requires a user member shape");
+        }
+
+        if let Some(existing) = self
+            .session_participants
+            .read()
+            .values()
+            .find(|row| {
+                row.org_id == input.org_id
+                    && row.session_id == input.session_id
+                    && row.kind == SessionParticipantKind::User.to_string()
+                    && row.principal_id == input.principal_id
+                    && row.left_at.is_none()
+            })
+            .cloned()
+        {
+            return Ok(existing);
+        }
+
+        self.validate_session_participant(&input)?;
+
+        let now = Self::now();
+        let joined_at = input.joined_at.unwrap_or(now);
+        let row = SessionParticipantRow {
+            id: SessionParticipantId::new(),
+            org_id: input.org_id,
+            session_id: input.session_id,
+            kind: SessionParticipantKind::User.to_string(),
+            agent_id: None,
+            agent_version_id: None,
+            principal_id: input.principal_id,
+            role: SessionParticipantRole::Member.to_string(),
+            joined_at,
+            left_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        self.insert_session_participant_unchecked(row.clone())?;
+        Ok(row)
+    }
+
     pub async fn list_session_participants(
         &self,
         org_id: i64,
@@ -150,6 +201,18 @@ impl InMemoryDatabase {
             }
         }
 
+        if input.kind == SessionParticipantKind::User {
+            let has_active_user = self.session_participants.read().values().any(|row| {
+                row.session_id == input.session_id
+                    && row.kind == "user"
+                    && row.principal_id == input.principal_id
+                    && row.left_at.is_none()
+            });
+            if has_active_user {
+                bail!("session already has an active user participant for this principal");
+            }
+        }
+
         Ok(())
     }
 
@@ -163,6 +226,17 @@ impl InMemoryDatabase {
             });
             if has_active_host {
                 bail!("session already has an active host participant");
+            }
+        }
+        if row.kind == "user" {
+            let has_active_user = self.session_participants.read().values().any(|existing| {
+                existing.session_id == row.session_id
+                    && existing.kind == "user"
+                    && existing.principal_id == row.principal_id
+                    && existing.left_at.is_none()
+            });
+            if has_active_user {
+                bail!("session already has an active user participant for this principal");
             }
         }
         self.session_participants.write().insert(row.id, row);

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -351,6 +351,44 @@ async fn test_create_session_participant_rejects_second_active_host() {
 }
 
 #[tokio::test]
+async fn test_ensure_active_user_session_participant_is_idempotent() {
+    let db = InMemoryDatabase::new();
+    let session = db.create_session(test_session_input(None)).await.unwrap();
+    let principal_id = PrincipalId::from_seed(42);
+
+    let input = CreateSessionParticipantRow {
+        org_id: DEFAULT_ORG_ID,
+        session_id: session.id,
+        kind: SessionParticipantKind::User,
+        agent_id: None,
+        agent_version_id: None,
+        principal_id,
+        role: SessionParticipantRole::Member,
+        joined_at: None,
+    };
+    let first = db
+        .ensure_active_user_session_participant(input.clone())
+        .await
+        .unwrap();
+    let second = db
+        .ensure_active_user_session_participant(input)
+        .await
+        .unwrap();
+
+    assert_eq!(first.id, second.id);
+    let active_for_principal = db
+        .list_session_participants(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|row| {
+            row.kind == "user" && row.principal_id == principal_id && row.left_at.is_none()
+        })
+        .count();
+    assert_eq!(active_for_principal, 1);
+}
+
+#[tokio::test]
 async fn test_leave_session_participant_preserves_history() {
     let db = InMemoryDatabase::new();
     let session = db.create_session(test_session_input(None)).await.unwrap();

--- a/crates/server/src/storage/repositories/session_participants.rs
+++ b/crates/server/src/storage/repositories/session_participants.rs
@@ -1,7 +1,9 @@
 use super::super::models::*;
 use super::Database;
-use anyhow::Result;
-use everruns_core::{SessionId, SessionParticipantId};
+use anyhow::{Result, bail};
+use everruns_core::{
+    SessionId, SessionParticipantId, SessionParticipantKind, SessionParticipantRole,
+};
 
 impl Database {
     pub async fn create_session_participant(
@@ -28,6 +30,43 @@ impl Database {
         .bind(input.agent_version_id.map(|id| id.uuid()))
         .bind(input.principal_id)
         .bind(input.role.to_string())
+        .bind(joined_at)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    pub async fn ensure_active_user_session_participant(
+        &self,
+        input: CreateSessionParticipantRow,
+    ) -> Result<SessionParticipantRow> {
+        if input.kind != SessionParticipantKind::User
+            || input.role != SessionParticipantRole::Member
+            || input.agent_id.is_some()
+            || input.agent_version_id.is_some()
+        {
+            bail!("active user participant upsert requires a user member shape");
+        }
+
+        let joined_at = input.joined_at.unwrap_or_else(chrono::Utc::now);
+
+        sqlx::query_as::<_, SessionParticipantRow>(
+            r#"
+            INSERT INTO session_participants (
+                id, org_id, session_id, kind, agent_id, agent_version_id,
+                principal_id, role, joined_at
+            )
+            VALUES (uuidv7(), $1, $2, 'user', NULL, NULL, $3, 'member', $4)
+            ON CONFLICT (session_id, principal_id)
+                WHERE kind = 'user' AND left_at IS NULL
+            DO UPDATE SET updated_at = NOW()
+            RETURNING id, org_id, session_id, kind, agent_id, agent_version_id,
+                      principal_id, role, joined_at, left_at, created_at, updated_at
+            "#,
+        )
+        .bind(input.org_id)
+        .bind(input.session_id.uuid())
+        .bind(input.principal_id)
         .bind(joined_at)
         .fetch_one(&self.pool)
         .await

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -99,11 +99,25 @@ impl<A: WorkerAdapters> McpConnectionResolver for WorkerMcpResolver<A> {
 #[derive(Clone)]
 pub struct WorkerRuntimeHost<A: WorkerAdapters> {
     adapters: A,
+    event_metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl<A: WorkerAdapters> WorkerRuntimeHost<A> {
     pub fn new(adapters: A) -> Self {
-        Self { adapters }
+        Self {
+            adapters,
+            event_metadata: None,
+        }
+    }
+
+    pub fn with_event_metadata(
+        adapters: A,
+        metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Self {
+        Self {
+            adapters,
+            event_metadata: metadata,
+        }
     }
 }
 
@@ -202,7 +216,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
     }
 
     fn event_emitter(&self) -> Arc<dyn EventEmitter> {
-        Arc::new(AdapterEventEmitter::new(self.adapters.clone()))
+        Arc::new(
+            AdapterEventEmitter::new(self.adapters.clone())
+                .with_event_metadata(self.event_metadata.clone()),
+        )
     }
 
     fn file_store(&self) -> Arc<dyn SessionFileSystem> {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -1243,8 +1243,16 @@ async fn execute_reason_activity<A: WorkerAdapters>(
         iteration: input.iteration,
     };
 
+    let event_metadata = input.agent_id.map(|agent_id| {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            "agent_id".to_string(),
+            serde_json::Value::String(agent_id.to_string()),
+        );
+        metadata
+    });
     let result = runtime_execute_reason_activity(
-        &WorkerRuntimeHost::new(adapters.clone()),
+        &WorkerRuntimeHost::with_event_metadata(adapters.clone(), event_metadata),
         input.org_id,
         reason_input,
     )

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -462,11 +462,23 @@ pub struct TurnContext {
 /// Implements: MessageRetriever, EventEmitter, SessionFileSystem.
 pub struct SessionAdapter<A: WorkerAdapters> {
     adapters: A,
+    event_metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl<A: WorkerAdapters> SessionAdapter<A> {
     pub fn new(adapters: A) -> Self {
-        Self { adapters }
+        Self {
+            adapters,
+            event_metadata: None,
+        }
+    }
+
+    pub fn with_event_metadata(
+        mut self,
+        metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Self {
+        self.event_metadata = metadata;
+        self
     }
 }
 
@@ -573,7 +585,18 @@ impl<A: WorkerAdapters> everruns_core::MessageRetriever for SessionAdapter<A> {
 
 #[async_trait]
 impl<A: WorkerAdapters> everruns_core::traits::EventEmitter for SessionAdapter<A> {
-    async fn emit(&self, request: EventRequest) -> Result<Event> {
+    async fn emit(&self, mut request: EventRequest) -> Result<Event> {
+        if let Some(extra) = &self.event_metadata {
+            let mut metadata = request
+                .metadata
+                .take()
+                .and_then(|value| value.as_object().cloned())
+                .unwrap_or_default();
+            for (key, value) in extra {
+                metadata.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+            request.metadata = Some(serde_json::Value::Object(metadata));
+        }
         self.adapters.emit_event(request).await
     }
 }


### PR DESCRIPTION
## What changed
Session messages now carry participant provenance for both human speakers and agent responders.

Slack ingress ensures each external Slack speaker has an active user participant keyed by a durable external-actor principal, then stamps that participant on the created message/event metadata. API-key/no-user message creation falls back to the session owner principal so input events can still resolve to the active user participant.

Agent output events now preserve the acting agent id from the worker runtime so addressed participant turns can resolve output provenance to the correct agent participant.

## Why
EVE-692 Slice D: multi-user channel sessions need explicit user participants, and session events need enough provenance to show which participant produced each message without relying on `external_actor` as identity.

## Before / After
Before:
- API-created `input.message` events in dev/no-user mode only carried `agent_id`, so participant provenance could not be attached.
- Slack speaker identity lived as message `external_actor` metadata instead of an explicit session participant.
- Addressed worker output events could fall back to session-host metadata rather than the addressed agent participant.

After:
- Caddy smoke on `PORT_PREFIX=285`:
  ```json
  {
    "host_msg_status": "201",
    "guest_msg_status": "201",
    "active_user_count": 1,
    "input_events_with_user_participant": 2,
    "guest_input_events_with_user_participant": 1
  }
  ```
- Follow-up local event check after provider-key failure:
  ```json
  {
    "total_events": 10,
    "output_events_with_host_participant": 1,
    "terminal_events": 1
  }
  ```
- Guest output did not drain in the local no-key smoke before the bounded timeout; focused event and worker tests cover the addressed-agent metadata path.

Validation:
- `cargo test -p everruns-server create_message_without_user_id_uses_session_owner_participant_metadata --lib --all-features`
- `cargo test -p everruns-server message_events_attach_active_participant_metadata --lib --all-features`
- `cargo test -p everruns-server session_participant --lib --all-features`
- `cargo test -p everruns-server slack_message_metadata_includes_system_app_id --lib --all-features`
- `cargo test -p everruns-worker --lib --all-features`
- `cargo clippy -p everruns-server -p everruns-worker --lib --all-features -- -D warnings`
- `cargo fmt --check`
- `bash scripts/lib/check-migration-ordering.sh`
- `git diff --check`
- `just pre-push`

## Risk
- Medium
- Touches shared message/event metadata and participant storage paths. Main risk is incorrect provenance stamping or duplicate participant handling; mitigated with a partial unique index/upsert and focused coverage for user idempotency, no-user API messages, Slack metadata, event participant resolution, and worker metadata propagation.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-SLACK, TM-DOS.
- Findings and resolutions: Slack still passes through the existing signed app webhook path before participant creation. External actor principals are org-scoped and deterministic; they grant no auth. Event participant lookup is session/org scoped. The new unique index bounds active user participant duplication per principal/session. No threat model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
