### PR TITLE
chore(release): prepare v0.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.6] - 2026-07-10
+
+### Highlights
+
+- **ATIF session/eval export** — Export sessions and eval datasets to ATIF, segmented for large sessions with image refs, size guards, and CLI (`--format atif`) support ([#2591](https://github.com/everruns/everruns/pull/2591), [#2609](https://github.com/everruns/everruns/pull/2609), [#2610](https://github.com/everruns/everruns/pull/2610), [#2619](https://github.com/everruns/everruns/pull/2619), [#2626](https://github.com/everruns/everruns/pull/2626), [#2627](https://github.com/everruns/everruns/pull/2627), [#2596](https://github.com/everruns/everruns/pull/2596)).
+- **New model profiles** — Added GPT-5.6 Sol, Terra, and Luna ([#2631](https://github.com/everruns/everruns/pull/2631)).
+- **Streaming reliability** — LLM streaming responses now reconnect automatically on transport failure ([#2594](https://github.com/everruns/everruns/pull/2594)).
+- **Auth fixes** — Closed reachability dead-ends across the auth flow, added OAuth password-reset links, and improved the signup path ([#2606](https://github.com/everruns/everruns/pull/2606), [#2603](https://github.com/everruns/everruns/pull/2603), [#2592](https://github.com/everruns/everruns/pull/2592)).
+
+### What's Changed
+
+- feat(email): add logo to branded template by [@chaliy](https://github.com/chaliy)
+- feat(sessions): record user participant provenance ([#2639](https://github.com/everruns/everruns/pull/2639)) by [@chaliy](https://github.com/chaliy)
+- perf(sessions): add org created-at index (EVE-697) by [@chaliy](https://github.com/chaliy)
+- perf(sessions): eliminate list N+1 queries (EVE-695) ([#2637](https://github.com/everruns/everruns/pull/2637)) by [@chaliy](https://github.com/chaliy)
+- fix(reporting): bound event projection repair (EVE-696) by [@chaliy](https://github.com/chaliy)
+- chore: deep maintenance — refresh UI deps, fix specs drift ([#2617](https://github.com/everruns/everruns/pull/2617)) by [@chaliy](https://github.com/chaliy)
+- feat(models): add GPT-5.6 Sol, Terra, and Luna profiles ([#2631](https://github.com/everruns/everruns/pull/2631)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): route addressed participant turns ([#2634](https://github.com/everruns/everruns/pull/2634)) by [@chaliy](https://github.com/chaliy)
+- perf(ui): reduce Settings prefetches (EVE-694) ([#2635](https://github.com/everruns/everruns/pull/2635)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): gate default-org auto-join behind opt-in flag ([#2632](https://github.com/everruns/everruns/pull/2632)) by [@chaliy](https://github.com/chaliy)
+- fix(openapi): add sdk model metadata ([#2633](https://github.com/everruns/everruns/pull/2633)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): add participant API by [@chaliy](https://github.com/chaliy)
+- feat(sessions): agent-first session creation (EVE-686 B–F) by [@chaliy](https://github.com/chaliy)
+- feat(ui): segmented ATIF export for large sessions ([#2627](https://github.com/everruns/everruns/pull/2627)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): add participant model ([#2629](https://github.com/everruns/everruns/pull/2629)) by [@chaliy](https://github.com/chaliy)
+- feat(export): segmented ATIF export for large sessions ([#2626](https://github.com/everruns/everruns/pull/2626)) by [@chaliy](https://github.com/chaliy)
+- test(subagents): cover nested reaper orphan handling ([#2625](https://github.com/everruns/everruns/pull/2625)) by [@chaliy](https://github.com/chaliy)
+- feat(subagents): cap root task fanout ([#2624](https://github.com/everruns/everruns/pull/2624)) by [@chaliy](https://github.com/chaliy)
+- feat(budgets): share root session budgets with subagents ([#2623](https://github.com/everruns/everruns/pull/2623)) by [@chaliy](https://github.com/chaliy)
+- test(auth): manual reachability cases for the auth state machine ([#2622](https://github.com/everruns/everruns/pull/2622)) by [@chaliy](https://github.com/chaliy)
+- feat(subagents): enforce governed nesting depth ([#2621](https://github.com/everruns/everruns/pull/2621)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): denormalize root_session_id for delegation trees ([#2620](https://github.com/everruns/everruns/pull/2620)) by [@chaliy](https://github.com/chaliy)
+- feat(agents): persist agent harness ownership ([#2618](https://github.com/everruns/everruns/pull/2618)) by [@chaliy](https://github.com/chaliy)
+- feat(cli): add --format atif to sessions export ([#2619](https://github.com/everruns/everruns/pull/2619)) by [@chaliy](https://github.com/chaliy)
+- chore(specs): add auth flow-reachability state diagram ([#2616](https://github.com/everruns/everruns/pull/2616)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add subagent progress schema by [@chaliy](https://github.com/chaliy)
+- chore(ui): typecheck on the native TypeScript 7 compiler ([#2612](https://github.com/everruns/everruns/pull/2612)) by [@chaliy](https://github.com/chaliy)
+- feat(subagents): report schema-bound task results by [@chaliy](https://github.com/chaliy)
+- fix(runtime): default to runtime-safe capabilities by [@chaliy](https://github.com/chaliy)
+- feat(export): ATIF export image refs and size guard ([#2610](https://github.com/everruns/everruns/pull/2610)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): retire legacy delegation tools by [@chaliy](https://github.com/chaliy)
+- feat(ui): ATIF session export with limit alerts ([#2609](https://github.com/everruns/everruns/pull/2609)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): dispatch spawn_agent targets by [@chaliy](https://github.com/chaliy)
+- fix(auth): close reachability dead-ends across the auth flow ([#2606](https://github.com/everruns/everruns/pull/2606)) by [@chaliy](https://github.com/chaliy)
+- feat(agent-handoff): expose spawn_agent target by [@chaliy](https://github.com/chaliy)
+- chore: standardize PR descriptions on functional change + before/after ([#2605](https://github.com/everruns/everruns/pull/2605)) by [@chaliy](https://github.com/chaliy)
+- feat(subagents): expose spawn_agent subagent target by [@chaliy](https://github.com/chaliy)
+- fix(auth): send reset links for oauth accounts ([#2603](https://github.com/everruns/everruns/pull/2603)) by [@chaliy](https://github.com/chaliy)
+- test(llm-tests): extend live-turn resilience to the thinking matrix ([#2602](https://github.com/everruns/everruns/pull/2602)) by [@chaliy](https://github.com/chaliy)
+- test(llm-tests): make live agent-run matrix resilient to transient flakes ([#2601](https://github.com/everruns/everruns/pull/2601)) by [@chaliy](https://github.com/chaliy)
+- test(llm-tests): retry live tool-call case to absorb model non-determinism ([#2600](https://github.com/everruns/everruns/pull/2600)) by [@chaliy](https://github.com/chaliy)
+- feat(handoff): give agent handoffs a dedicated task kind ([#2599](https://github.com/everruns/everruns/pull/2599)) by [@chaliy](https://github.com/chaliy)
+- test(llm-tests): repin Fireworks live case to served Kimi K2 model ([#2598](https://github.com/everruns/everruns/pull/2598)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): add ATIF dataset export and case import ([#2596](https://github.com/everruns/everruns/pull/2596)) by [@chaliy](https://github.com/chaliy)
+- test(llm-tests): repin Fireworks live case to llama-v3p3-70b ([#2597](https://github.com/everruns/everruns/pull/2597)) by [@chaliy](https://github.com/chaliy)
+- fix(egress): keep host transports outside runtime policy ([#2595](https://github.com/everruns/everruns/pull/2595)) by [@chaliy](https://github.com/chaliy)
+- feat(drivers): reconnect streaming LLM responses on transport failure ([#2594](https://github.com/everruns/everruns/pull/2594)) by [@chaliy](https://github.com/chaliy)
+- feat(export): add ATIF session export ([#2591](https://github.com/everruns/everruns/pull/2591)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): signup path from password screen + prefill + copy space ([#2592](https://github.com/everruns/everruns/pull/2592)) by [@chaliy](https://github.com/chaliy)
+- test(llm-tests): revert "skip live matrix on transient transport errors" ([#2556](https://github.com/everruns/everruns/pull/2556)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.5] - 2026-07-08
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,11 +2470,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.5"
+version = "0.17.6"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3052,11 +3052,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.5"
+version = "0.17.6"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.5"
+version = "0.17.6"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -149,11 +149,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.10"
-everruns-core = { path = "crates/core", version = "0.17.5" }
+everruns-core = { path = "crates/core", version = "0.17.6" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.5" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.6" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.5" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.6" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -5722,6 +5722,12 @@ export interface components {
         });
     /** @description Request to create a message */
     CreateMessageRequest: {
+      /**
+       * @description Optional active agent participant to address for this turn. When omitted,
+       *     the session host remains the responder.
+       * @example part_01933b5a00007000800000000000001
+       */
+      addressed_participant_id?: string | null;
       controls?: null | components["schemas"]["Controls"];
       external_actor?: null | components["schemas"]["ExternalActor"];
       /** @description The message to create. Example shape is defined on `InputMessage`. */

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.5", default-features = false }
+everruns-core = { path = "../core", version = "0.17.6", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.5", default-features = false }
+everruns-core = { path = "../core", version = "0.17.6", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.5", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.6", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.5", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.6", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.5", default-features = false }
+everruns-core = { path = "../core", version = "0.17.6", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.5", default-features = false }
+everruns-core = { path = "../core", version = "0.17.6", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.5", default-features = false }
+everruns-core = { path = "../core", version = "0.17.6", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What changed
Prepares the v0.17.6 patch release: bumps workspace/UI version to 0.17.6, syncs path-dependency pins, regenerates Cargo.lock for the bumped internal crates, and adds the CHANGELOG.md entry for changes since v0.17.5.

## Why
Ship the accumulated changes since v0.17.5 as a patch release. No new migrations or breaking changes.

## Before / After
No behavior change — version metadata and changelog only.
- `Cargo.toml` workspace version: 0.17.5 → 0.17.6
- `apps/ui/package.json` version: 0.17.5 → 0.17.6
- `Cargo.lock`: internal `everruns-*` crate entries bumped to 0.17.6 (no transitive dependency changes)

## Risk
- Low
- Merging triggers the release workflow (tag `v0.17.6`, GitHub Release, Docker image build). If the CHANGELOG entry has an error it can be fixed post-tag on the GitHub Release notes.

## Security
- No security-relevant code changes (version bump and changelog only).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (no code change)
- [x] Backward compatibility considered — N/A (no code change)
- [x] Security review performed against relevant threat model categories — N/A (no code change)
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.17.6`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
