### PR TITLE
fix(sessions): reject harnesses requiring unavailable capabilities

### DIFF
--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -34,7 +34,7 @@ use everruns_core::{
         MEMORY_CAPABILITY_ID, RiskLevel, SystemPromptContext, collect_capabilities_with_configs,
         compute_features, resolve_capability_configs,
     },
-    is_declarative_capability,
+    is_declarative_capability, is_mcp_capability, is_plugin_capability, is_skill_capability,
     memory::{MemoryConfig, MemoryMountAccess},
     merge_capabilities, merge_initial_files, normalize_initial_file_path,
     parse_declarative_capability_id,
@@ -532,6 +532,21 @@ impl SessionService {
             &session_capabilities,
         )
         .await?;
+
+        // EVE-709: reject sessions whose harness/agent/session require a built-in
+        // capability that is not available in this deployment (e.g. a feature-gated
+        // `container_sandbox` when `FEATURE_CONTAINER_SANDBOX` is off). Without this
+        // gate the missing capability's tools are silently dropped and the session
+        // degrades into a different execution environment (e.g. bash), so the user
+        // believes isolated work ran when it did not. Fail clearly instead.
+        self.require_available_capabilities(
+            org_id,
+            harness_id.uuid(),
+            agent_id.map(|id| id.uuid()),
+            &session_capabilities,
+        )
+        .await?;
+
         let mut scoped_mcp_layers = vec![&effective_harness.mcp_servers];
         if let Some(ref agent_mcp_servers) = agent_mcp_servers {
             scoped_mcp_layers.push(agent_mcp_servers);
@@ -1916,6 +1931,56 @@ impl SessionService {
         }
 
         Ok(mounts)
+    }
+
+    /// EVE-709: reject session creation when a required built-in capability is not
+    /// available in this deployment.
+    ///
+    /// The effective capability set (harness chain + agent + session) may name
+    /// built-in capabilities that are feature-gated (e.g. `container_sandbox`
+    /// behind `FEATURE_CONTAINER_SANDBOX`). When such a capability is disabled it
+    /// is absent from the registry, its tools never register, and the session
+    /// silently runs without them — degrading into a different execution
+    /// environment. Rather than degrade silently, fail with a clear error naming
+    /// the unavailable capabilities.
+    ///
+    /// Only plain built-in references are checked. Namespaced refs
+    /// (`declarative:`, `plugin:`, `skill:`, `mcp:`) resolve from org data rather
+    /// than the registry, so their absence from the registry is expected and is
+    /// validated separately by `validate_capability_refs`.
+    async fn require_available_capabilities(
+        &self,
+        org_id: i64,
+        harness_id: Uuid,
+        agent_id: Option<Uuid>,
+        session_capabilities: &[AgentCapabilityConfig],
+    ) -> Result<()> {
+        let capability_ids = self
+            .collect_session_capability_ids(org_id, harness_id, agent_id, session_capabilities)
+            .await?;
+
+        let mut missing: Vec<String> = capability_ids
+            .into_iter()
+            .filter(|id| {
+                !is_declarative_capability(id)
+                    && !is_plugin_capability(id)
+                    && !is_skill_capability(id)
+                    && !is_mcp_capability(id)
+                    && !self.capability_registry.has(id)
+            })
+            .collect();
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        missing.sort();
+        missing.dedup();
+        Err(BadRequestError::new(format!(
+            "Harness requires capabilities unavailable in this deployment: {}",
+            missing.join(", ")
+        ))
+        .into())
     }
 
     async fn require_admin_for_high_risk_session_capabilities(
@@ -3568,6 +3633,66 @@ mod tests {
         fn risk_level(&self) -> RiskLevel {
             RiskLevel::High
         }
+    }
+
+    // EVE-709: a harness declaring a built-in capability that is not registered in
+    // this deployment (e.g. feature-gated `container_sandbox`) must fail session
+    // creation with a clear error rather than silently dropping the capability's
+    // tools and degrading into a different execution environment.
+    #[tokio::test]
+    async fn create_rejects_harness_with_unavailable_builtin_capability() {
+        let db = Arc::new(StorageBackend::in_memory());
+        // Empty registry stands in for a deployment where `container_sandbox` is
+        // feature-gated off, so it is absent from the capability registry.
+        let registry = CapabilityRegistry::new();
+        let session_service = SessionService::with_registry(db.clone(), registry);
+        let owner = Caller::internal(DEFAULT_ORG_ID);
+
+        let harness = db
+            .create_harness(
+                owner.org_id,
+                CreateHarnessRow {
+                    name: "coding-container".to_string(),
+                    display_name: Some("Coding (Container)".to_string()),
+                    description: None,
+                    system_prompt: Some("coding".to_string()),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec![],
+                    initial_files: serde_json::json!([]),
+                    mcp_servers: serde_json::json!({}),
+                    network_access: None,
+                    embedder_metadata: serde_json::json!({}),
+                    is_built_in: false,
+                },
+            )
+            .await
+            .unwrap();
+        db.set_harness_capabilities(
+            harness.id.uuid(),
+            vec![("container_sandbox".to_string(), 0, serde_json::json!({}))],
+        )
+        .await
+        .unwrap();
+
+        // Owner (admin) so the high-risk capability gate does not fire first.
+        let err = session_service
+            .create(
+                &owner,
+                harness.id.uuid(),
+                None,
+                None,
+                build_create_request(harness.id, None, None),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("capabilities unavailable in this deployment")
+                && err.to_string().contains("container_sandbox"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -137,6 +137,19 @@ Capabilities are defined in **everruns-core** and resolved at the **API layer**:
 - The Agent Loop remains focused on execution
 - RuntimeAgent is built with merged system prompt and tools from capabilities
 
+#### Deployment Availability (session creation)
+
+Some built-in capabilities are feature-gated (e.g. `container_sandbox` behind
+`FEATURE_CONTAINER_SANDBOX`). When a gate is off the capability is absent from
+the registry and its tools never register. Session creation therefore rejects
+requests whose effective capability set (harness chain + agent + session) names
+a **built-in** capability that is not available in this deployment, rather than
+silently dropping its tools and degrading into a different execution environment
+(e.g. a `coding-container` session quietly running in the bash workspace). The
+check runs in `SessionService::create` and only applies to plain built-in
+references; namespaced refs (`declarative:`, `plugin:`, `skill:`, `mcp:`) resolve
+from org data and are validated separately.
+
 ### Data Model
 
 #### Capability (Public DTO)


### PR DESCRIPTION
## What changed

Session creation now fails clearly when the requested harness (or its agent/session capability layers) requires a **built-in capability that is not available in this deployment**. Previously such a session was created anyway: the missing capability's tools never registered and the run silently degraded into a different execution environment.

Concretely, a `coding-container` session created while `container_sandbox` is feature-gated off (`FEATURE_CONTAINER_SANDBOX` unset) used to succeed and quietly run in the ordinary bash workspace — no `sandbox_create`/`sandbox_exec`, no leased sandbox — while looking successful to the user. It now returns `400` with `Harness requires capabilities unavailable in this deployment: container_sandbox`.

Only plain built-in capability references are checked. Namespaced refs (`declarative:`, `plugin:`, `skill:`, `mcp:`) resolve from org data and are validated separately, so they are skipped here. The check reuses the existing effective-capability collection (harness inheritance chain + agent + session) and the registry's alias-aware `has()`.

## Why

EVE-709: a harness whose required capability is unavailable must not silently degrade into a different execution environment — that produces misleading functional and isolation semantics (a user believes code ran in an isolated sandbox when it ran in the session workspace). This is the OSS hardening called for in the issue's "Expected" contract. (Deployment-side cleanup of stale legacy `coding-container` rows and the SaaS sandbox test-case prerequisites remains a separate SaaS concern — see Follow-ups.)

## Before / After

Session created with `harness_name: "coding-container"` while `container_sandbox` is gated off:

- **Before:** `201 Created`; run replies successfully; tool trace contains only `bash` from `bashkit_shell`; no sandbox resource created.
- **After:** `400 Bad Request` — `Harness requires capabilities unavailable in this deployment: container_sandbox`.

Evidence (targeted tests, `everruns-server`):

```
running 3 tests
test ...::create_rejects_harness_with_unavailable_builtin_capability ... ok
test ...::create_rejects_high_risk_harness_capabilities_for_members ... ok
test ...::create_rejects_declarative_capability_with_high_risk_dependency_for_members ... ok
test result: ok. 3 passed; 0 failed
```

`cargo check -p everruns-server --all-features` and `cargo fmt --check` pass.

## Risk

- Low
- Fail-closed hardening that adds a rejection; it relaxes no existing check and adds no new input, endpoint, or query. The only behavior change is that sessions which previously degraded silently now error. Base/generic harness capabilities are all unconditionally registered, so ordinary sessions are unaffected; the check runs after the authz (high-risk) gate so it cannot force expensive work pre-authorization.

## Security

- Threat categories reviewed: **TM-AUTHZ** (session creation authorization order preserved — the new check runs after `require_admin_for_high_risk_session_capabilities`), **TM-TENANT** (no change to org scoping; uses the existing org-scoped effective-capability collection). No injection, data-exposure, or resource surface added; the error message names only capability IDs, which are already public via `GET /v1/capabilities`.
- Findings and resolutions: none.

## Follow-ups

- SaaS deployment: remove/disable stale `coding-container` rows from legacy orgs and update the SaaS container-sandbox test-case/spec prerequisites (deployment + DB data cleanup, out of scope for this OSS repo). Tracked by EVE-709's SaaS side.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal API; intended behavior change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSjP9mKoqSKshTZSXL4rqZ)_