### PR TITLE
fix(sessions): settle session to idle when a turn is cancelled

### DIFF
--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -5,8 +5,8 @@ use super::types::{
 };
 use crate::domains::common::*;
 use everruns_core::events::{
-    EventContext, EventData, EventRequest, InputMessageData, LLM_GENERATION, TurnCancelledData,
-    deserialize_event_data,
+    EventContext, EventData, EventRequest, InputMessageData, LLM_GENERATION, SessionIdledData,
+    TurnCancelledData, deserialize_event_data,
 };
 use everruns_core::model_profiles::get_model_profile;
 use everruns_core::provider::DriverId;
@@ -785,6 +785,85 @@ mod tests {
         .id
     }
 
+    // Minimal runner whose `cancel_run` succeeds without a real durable backend,
+    // so `CancelSession` can be exercised against the in-memory store.
+    struct CancelTestRunner;
+
+    #[async_trait::async_trait]
+    impl everruns_worker::AgentRunner for CancelTestRunner {
+        async fn start_run(
+            &self,
+            _org_id: i64,
+            _session_id: SessionId,
+            _harness_id: HarnessId,
+            _agent_id: Option<AgentId>,
+            _input_message_id: MessageId,
+            _request_id: Option<String>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn resume_after_tool_results(&self, _session_id: SessionId) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn cancel_run(&self, _session_id: SessionId) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn is_running(&self, _session_id: SessionId) -> bool {
+            false
+        }
+
+        async fn active_count(&self) -> usize {
+            0
+        }
+    }
+
+    // EVE-708: cancelling an active turn must settle the session back to `idle`.
+    // The durable workflow is marked cancelled and the worker short-circuits before
+    // the runtime's idle transition, so `CancelSession` itself must idle the session
+    // or it stays `active` forever, blocking clean follow-up turns.
+    #[tokio::test]
+    async fn cancel_active_session_transitions_to_idle() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = test_ctx(db.clone(), 100).with_runner(Arc::new(CancelTestRunner));
+        let harness_id = seed_harness(&ctx).await;
+
+        let session = CreateSession(create_request(harness_id))
+            .execute(&ctx)
+            .await
+            .expect("create session");
+
+        // Simulate an in-flight turn.
+        q::session_service(&ctx)
+            .unwrap()
+            .update_status(&ctx.caller, session.id.uuid(), "active".to_string())
+            .await
+            .expect("mark active");
+
+        let response = CancelSession {
+            session_id: session.id.to_string(),
+        }
+        .execute(&ctx)
+        .await
+        .expect("cancel");
+        assert!(
+            matches!(response.status, CancelStatus::Cancelled),
+            "expected an active cancel, got {:?}",
+            response.status
+        );
+
+        let after = q::get_session(&ctx, session.id, None)
+            .await
+            .expect("reload session");
+        assert_eq!(
+            after.status,
+            everruns_core::SessionStatus::Idle,
+            "cancelled session must settle to idle"
+        );
+    }
+
     #[tokio::test]
     async fn session_creation_rejected_at_limit_and_allowed_below() {
         let db = Arc::new(StorageBackend::in_memory());
@@ -1363,6 +1442,36 @@ impl Command for CancelSession {
             if let Err(error) = event_service.emit(user_message_event).await {
                 tracing::warn!(session_id = %session_id, error = %error, "Failed to emit user cancellation message");
             }
+
+            // EVE-708: emit the `session.idled` lifecycle event for parity with the
+            // normal turn-completion path. The cancelled workflow short-circuits in
+            // the worker before the runtime reaches its `session.idled` emission, so
+            // without this the lifecycle would silently stop at `turn.cancelled`.
+            let idled_event = EventRequest::new(
+                session_id,
+                EventContext::turn(turn_id, input_message_id),
+                SessionIdledData {
+                    turn_id,
+                    iterations: None,
+                    usage: None,
+                },
+            );
+            if let Err(error) = event_service.emit(idled_event).await {
+                tracing::warn!(session_id = %session_id, error = %error, "Failed to emit session.idled event");
+            }
+        }
+
+        // EVE-708: settle the session status. Cancelling marks the durable workflow
+        // `Cancelled`, which makes the worker fail the task and return early — so the
+        // runtime turn loop never reaches `TurnAction::Complete` and never transitions
+        // the session back to `idle`. Session status is a stored column that is not
+        // derived from events, so we must set it here or the session stays `active`
+        // indefinitely, blocking clean follow-up turns.
+        if let Err(error) = q::session_service(ctx)?
+            .update_status(&ctx.caller, session_id.uuid(), "idle".to_string())
+            .await
+        {
+            tracing::warn!(session_id = %session_id, error = %error, "Failed to set session idle after cancel");
         }
 
         Ok(CancelTurnResponse {

--- a/test_cases/api/sessions/TC006_cancel_active_turn.md
+++ b/test_cases/api/sessions/TC006_cancel_active_turn.md
@@ -67,3 +67,4 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 | Step 4: HTTP status | 200 |
 | Step 5: session `status` | `"idle"` |
 | Events contain cancellation | `turn.cancelled` or `turn.completed` event |
+| Events contain lifecycle settle | `session.idled` event emitted after `turn.cancelled` |


### PR DESCRIPTION
## What changed

Cancelling an active turn now deterministically returns the session to `idle`. Previously the cancel endpoint returned `200` and emitted `turn.cancelled`, but the session stayed `active` indefinitely — blocking clean follow-up turns and misreporting a cancelled session as still running.

`CancelSession` now, after cancelling the workflow and emitting `turn.cancelled` + the user cancellation message, also:
- emits `session.idled` for lifecycle parity with the normal turn-completion path, and
- sets the session status to `idle`.

## Why

EVE-708. Session status is a **stored column**, not derived from events. On cancel, the durable workflow is marked `Cancelled`, so the worker fails the task and returns early — the runtime turn loop never reaches its `TurnAction::Complete` → `emit_session_idled` path that normally idles the session. Emitting `turn.cancelled` alone therefore could never change status, so the session was stuck `active`. (A `SessionLifecycle::cancelled()` method exists in the worker but is dead code — never instantiated — so it never ran.)

## Before / After

Send a long prompt, then immediately `POST /v1/sessions/{id}/cancel`, then poll `GET /v1/sessions/{id}`:

- **Before:** cancel returns `200`, `turn.cancelled` emitted, but session `status` stays `"active"` for 70+ seconds (indefinitely); no `session.idled` event.
- **After:** cancel returns `200`, emits `turn.cancelled` then `session.idled`, and session `status` becomes `"idle"` promptly.

Evidence (deterministic command-level regression test, `everruns-server`):

```
running 1 test
test domains::sessions::commands::tests::cancel_active_session_transitions_to_idle ... ok
test result: ok. 1 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy --all-targets --all-features -D warnings` pass on `everruns-server`. TC006 updated to assert the `session.idled` event.

## Risk

- Low
- The cancel endpoint is already `SESSION_MANAGE`-gated and org-scoped; this adds an org-scoped status write plus one event on a path that already emits events. No new endpoint, input, or query. Setting `idle` on cancel is the intended terminal state; the only behavior change is that a previously-stuck-`active` session now settles. Status writes on cancel don't race the worker, which does not touch session status on the cancelled path.

## Security

- Threat categories reviewed: **TM-AUTHZ** (no change to the existing `SESSION_MANAGE` authorization on cancel), **TM-TENANT** (status update uses the caller's org-scoped `update_status`; no cross-tenant surface). No injection, data-exposure, or resource surface introduced.
- Findings and resolutions: none.

## Follow-ups

- The A2A/app cancel paths (`api/app_api.rs`, `api/app_a2a.rs`) share the same gap for their own session rows; they track task state separately and are out of scope for TC006. Left as a follow-up to keep this PR focused on the documented session-status regression.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (intended terminal-state fix)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSjP9mKoqSKshTZSXL4rqZ)_