### PR TITLE
fix(auth): reject unsupported personal access token scopes at creation

### DIFF
--- a/crates/server/src/auth/personal_access_token_routes.rs
+++ b/crates/server/src/auth/personal_access_token_routes.rs
@@ -75,6 +75,10 @@ pub struct PersonalAccessTokenListItem {
 pub struct CreatePersonalAccessTokenRequest {
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
+    /// Token scopes. Scopes are not yet enforced on the request path, so only a
+    /// full-access token is supported: omit this field or pass `["*"]`. Any other
+    /// value is rejected (`unsupported_pat_scopes`) rather than silently granting
+    /// full access under a narrower-looking label. See EVE-701.
     #[serde(default)]
     pub scopes: Vec<String>,
     /// Expiration in days (optional)
@@ -128,6 +132,30 @@ async fn list_personal_access_tokens(
     Ok(Json(ListResponse::new(items)))
 }
 
+/// EVE-701: validate and normalize requested PAT scopes.
+///
+/// PAT scopes are not yet enforced on the request path — a validated token
+/// authenticates with the owning user's full authority regardless of stored
+/// scopes. Accepting a narrower scope would advertise a security control we do
+/// not honor: a user pasting a "read-only" token into CI would believe they had
+/// limited blast radius, while a leak of that token is still equivalent to full
+/// account compromise. Until per-request enforcement exists, only the full-access
+/// wildcard is accepted (empty ⇒ `["*"]`); any other scope is rejected so the API
+/// never mints a token whose advertised scopes lie.
+fn normalize_pat_scopes(requested: &[String]) -> Result<Vec<String>, AuthError> {
+    if requested.is_empty() || requested.iter().all(|s| s == "*") {
+        Ok(vec!["*".to_string()])
+    } else {
+        Err(AuthError {
+            error: "Custom personal access token scopes are not yet supported. \
+                    Omit `scopes` or pass [\"*\"] to create a full-access token."
+                .to_string(),
+            status: StatusCode::BAD_REQUEST,
+            code: Some("unsupported_pat_scopes"),
+        })
+    }
+}
+
 /// POST /v1/auth/personal-access-tokens - Create a new personal access token
 ///
 /// Personal access tokens are user-scoped (not org-scoped). The token inherits
@@ -172,11 +200,7 @@ async fn create_personal_access_token(
 
     let generated = generate_personal_access_token();
 
-    let scopes = if req.scopes.is_empty() {
-        vec!["*".to_string()]
-    } else {
-        req.scopes
-    };
+    let scopes = normalize_pat_scopes(&req.scopes)?;
 
     const PAT_EXPIRES_MIN_DAYS: i64 = 1;
     const PAT_EXPIRES_MAX_DAYS: i64 = 3650;
@@ -288,5 +312,41 @@ async fn delete_personal_access_token(
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(AuthError::not_found("Personal access token not found"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_scopes_default_to_full_access() {
+        assert_eq!(normalize_pat_scopes(&[]).unwrap(), vec!["*".to_string()]);
+    }
+
+    #[test]
+    fn wildcard_scope_accepted() {
+        assert_eq!(
+            normalize_pat_scopes(&["*".to_string()]).unwrap(),
+            vec!["*".to_string()]
+        );
+        // Redundant wildcards normalize to a single full-access scope.
+        assert_eq!(
+            normalize_pat_scopes(&["*".to_string(), "*".to_string()]).unwrap(),
+            vec!["*".to_string()]
+        );
+    }
+
+    #[test]
+    fn narrow_scope_rejected_until_enforced() {
+        let err = normalize_pat_scopes(&["read".to_string()]).unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.code, Some("unsupported_pat_scopes"));
+    }
+
+    #[test]
+    fn mixed_wildcard_and_narrow_scope_rejected() {
+        // A narrower scope alongside the wildcard must not be silently accepted.
+        assert!(normalize_pat_scopes(&["*".to_string(), "read".to_string()]).is_err());
     }
 }

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -43,7 +43,12 @@ Authorization: Bearer <personal_access_token>
 - Personal access tokens are prefixed with `evr_pat_` for identification — the prefix distinguishes them from JWTs within the `Bearer` scheme
 - Auth scheme matching is case-insensitive per RFC 7235 (`bearer`, `BEARER`, `Bearer` all accepted)
 - Full token shown only at creation, stored hashed (SHA-256)
-- Supports scopes and expiration
+- Expiration is supported and enforced. Scopes are **not yet enforced** on the
+  request path — a validated token authenticates with the owning user's full
+  authority regardless of stored scopes. To avoid advertising a control that is
+  not honored, token creation only accepts the full-access wildcard (`scopes`
+  omitted or `["*"]`); any narrower scope is rejected with `unsupported_pat_scopes`
+  until per-request scope enforcement exists. See EVE-701.
 - Used for programmatic access
 - Non-`Bearer` formats (`Authorization: evr_pat_...`, `Authorization: ApiKey evr_pat_...`) are also accepted for non-Bearer clients
 - `metadata` JSONB column stores creation context: `source` (cli_login, web_ui, api), `hostname`, `os`, `ip`


### PR DESCRIPTION
## What changed

Creating a personal access token (PAT) now rejects any scope other than full access. `POST /v1/auth/personal-access-tokens` accepts `scopes` omitted or `["*"]` (full-access token); any narrower value returns `400` with code `unsupported_pat_scopes`.

## Why

EVE-701 (High, security). PAT `scopes` were accepted, stored, and echoed back, but **never consulted on the request path**: a validated PAT authenticates with the owning user's full account authority regardless of its scopes (they are read from the DB only for the expiry check, then dropped). So a token created with `scopes: ["read"]` had full write/delete authority across every org the user belongs to.

That is a misleading security control: a user pasting a "read-only" PAT into CI or a third-party tool believes they've limited blast radius, when a leak of that token is equivalent to full account compromise. Rather than silently mint a token whose advertised scopes lie, the API now refuses to create one until real per-request enforcement exists. This matches the current documented posture (`specs/authentication.md`: a PAT equals the user's full access).

## Before / After

`POST /v1/auth/personal-access-tokens {"name":"read-only ci","scopes":["read"]}`:

- **Before:** `201 Created` — token returned with `scopes:["read"]`, but usable against any mutating endpoint (create/delete agents, rotate provider keys, mint more tokens).
- **After:** `400 Bad Request` — `{"error":"Custom personal access token scopes are not yet supported. Omit \`scopes\` or pass [\"*\"] to create a full-access token.","code":"unsupported_pat_scopes"}`. Omitting `scopes` or passing `["*"]` still succeeds and yields a full-access token (unchanged).

Evidence (unit tests, `everruns-server`):

```
running 4 tests
test ...::empty_scopes_default_to_full_access ... ok
test ...::wildcard_scope_accepted ... ok
test ...::narrow_scope_rejected_until_enforced ... ok
test ...::mixed_wildcard_and_narrow_scope_rejected ... ok
test result: ok. 4 passed; 0 failed
```

`cargo fmt --check` passes; clippy clean locally.

## Risk

- Low
- Tightens input validation on token creation only; the auth/validation path and existing full-access tokens are unchanged. Existing clients that omit `scopes` or send `["*"]` are unaffected. Only clients that were sending narrower scopes (which never actually limited anything) now get a clear `400` instead of a false sense of security.

## Security

- Threat categories reviewed: **TM-AUTH** (token issuance), **TM-AUTHZ** (this closes an authorization/least-privilege gap where scopes were advertised but not enforced). No new endpoint, query, or data exposure; the error message contains no sensitive data.
- Findings and resolutions: the underlying gap (scopes not enforced per request) is closed for the *misleading-control* aspect by refusing to issue narrowed tokens. Actually honoring narrow scopes is a larger change — see Follow-ups.

## Follow-ups

- **Full per-request scope enforcement (deferred, larger):** thread PAT scopes through `AuthUser → ResolvedOrg → Caller` and enforce in the central authorization chokepoint (`Policy::evaluate_with` in `crates/core/src/permissions.rs`), classifying each `Permission` as read vs write (the enum already splits `*View` vs `*Manage`/`*Dangerous`). This also requires pinning a scope vocabulary in `specs/authentication.md` and wiring up the currently-dead `ValidatedPersonalAccessToken::has_scope`. Deferred because it modifies the core authorization path for every request and warrants its own focused review; this PR removes the misleading control safely in the meantime. Recommend a follow-up Linear issue (OSS, EVE).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (full-access tokens unchanged; only unenforced narrow scopes rejected)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSjP9mKoqSKshTZSXL4rqZ)_