### PR TITLE
fix(auth): derive rate-limit client IP from trusted proxy hops, not leftmost XFF

### DIFF
--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -270,16 +270,44 @@ impl From<RateLimitError> for Response {
     }
 }
 
-fn extract_forwarded_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
-    if let Some(forwarded) = headers.get("x-forwarded-for")
-        && let Ok(val) = forwarded.to_str()
-        && let Some(first) = val.split(',').next()
-        && let Ok(ip) = first.trim().parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
+/// Number of trusted reverse-proxy hops directly in front of the server.
+///
+/// Each trusted proxy *appends* the peer IP it observed to the RIGHT of
+/// `X-Forwarded-For`, so the real client IP is the entry `hops`-from-the-right.
+/// Everything further left is client-supplied and MUST NOT be trusted. Default
+/// is 1 (a single reverse proxy — the documented deployment topology, e.g.
+/// Caddy). Operators who stack additional proxies (a CDN/LB in front of the
+/// reverse proxy) set `TRUSTED_PROXY_HOPS` to that count.
+fn trusted_proxy_hops() -> usize {
+    static HOPS: std::sync::LazyLock<usize> = std::sync::LazyLock::new(|| {
+        everruns_core::config::env_or("TRUSTED_PROXY_HOPS", 1usize).max(1)
+    });
+    *HOPS
+}
 
-    None
+/// Extract the real client IP from `X-Forwarded-For`, honoring `trusted_hops`
+/// trusted reverse-proxy hops.
+///
+/// TM-AUTH-001 / TM-DOS: a standard reverse proxy *appends* the peer IP it saw
+/// to the right of any client-supplied `X-Forwarded-For`. Taking the leftmost
+/// entry therefore returns a fully attacker-controlled value, letting one client
+/// mint unlimited distinct rate-limit keys. The real client IP is the entry
+/// `hops`-from-the-right; entries further left are never used. Returns `None`
+/// when the header is absent, empty, unparseable, or shorter than the configured
+/// hop count (a misconfiguration / spoofing attempt — the caller then falls back
+/// to the trusted peer IP).
+fn extract_forwarded_ip_from_headers(headers: &HeaderMap, trusted_hops: usize) -> Option<IpAddr> {
+    let forwarded = headers.get("x-forwarded-for")?.to_str().ok()?;
+    let entries: Vec<&str> = forwarded
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    let hops = trusted_hops.max(1);
+    // The rightmost `hops` entries were appended by trusted proxies; the client
+    // IP is the entry immediately to their left.
+    let idx = entries.len().checked_sub(hops)?;
+    entries.get(idx)?.parse::<IpAddr>().ok()
 }
 
 fn extract_real_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
@@ -324,7 +352,7 @@ pub fn extract_client_ip_from_parts(peer: Option<SocketAddr>, headers: &HeaderMa
         let peer_ip = peer.ip();
 
         if is_trusted_proxy_ip(peer_ip) {
-            if let Some(ip) = extract_forwarded_ip_from_headers(headers) {
+            if let Some(ip) = extract_forwarded_ip_from_headers(headers, trusted_proxy_hops()) {
                 return ip;
             }
             if let Some(ip) = extract_real_ip_from_headers(headers) {
@@ -758,6 +786,9 @@ mod tests {
 
     #[test]
     fn test_extract_ip_from_x_forwarded_for_from_trusted_proxy() {
+        // With one trusted proxy hop (default), the client IP is the RIGHTMOST
+        // X-Forwarded-For entry — the one the trusted proxy appended. The left
+        // entry is client-supplied and must not be used.
         let mut req = Request::builder()
             .header("x-forwarded-for", "203.0.113.50, 70.41.3.18")
             .body(Body::empty())
@@ -768,7 +799,54 @@ mod tests {
                 443,
             ))));
         let ip = extract_client_ip(&req);
-        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(70, 41, 3, 18)));
+    }
+
+    // TM-AUTH-001 / TM-DOS regression: a spoofed leftmost X-Forwarded-For entry
+    // must not change the derived client IP, so an attacker rotating the left
+    // value cannot mint distinct rate-limit keys.
+    #[test]
+    fn test_spoofed_leftmost_xff_does_not_change_client_ip() {
+        let client_ip = |xff: &str| {
+            let mut req = Request::builder()
+                .header("x-forwarded-for", xff)
+                .body(Body::empty())
+                .unwrap();
+            req.extensions_mut()
+                .insert(ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    443,
+                ))));
+            extract_client_ip(&req)
+        };
+        // The real (rightmost, proxy-appended) IP is identical; only the spoofed
+        // leftmost value differs. Both must resolve to the same real client IP.
+        let real = IpAddr::V4(Ipv4Addr::new(70, 41, 3, 18));
+        assert_eq!(client_ip("1.1.1.1, 70.41.3.18"), real);
+        assert_eq!(client_ip("2.2.2.2, 70.41.3.18"), real);
+        assert_eq!(client_ip("9.9.9.9, 8.8.8.8, 70.41.3.18"), real);
+    }
+
+    #[test]
+    fn test_extract_forwarded_ip_selects_hops_from_right() {
+        use axum::http::HeaderValue;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("1.1.1.1, 2.2.2.2, 3.3.3.3"),
+        );
+        // One hop: rightmost entry.
+        assert_eq!(
+            extract_forwarded_ip_from_headers(&headers, 1),
+            Some(IpAddr::V4(Ipv4Addr::new(3, 3, 3, 3)))
+        );
+        // Two hops: second from the right.
+        assert_eq!(
+            extract_forwarded_ip_from_headers(&headers, 2),
+            Some(IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2)))
+        );
+        // Chain shorter than the hop count is not trusted.
+        assert_eq!(extract_forwarded_ip_from_headers(&headers, 5), None);
     }
 
     #[test]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -129,7 +129,8 @@ Per-IP rate limiting implemented on all auth endpoints via `AuthRateLimiter` (`c
 - Register: 5 requests/min per IP
 - Refresh: 30 requests/min per IP
 - **Dual backend**: In-memory (governor crate, per-instance) when `VALKEY_URL` not set; Valkey distributed sliding-window counter when set. Fail-open on Valkey errors (availability > strictness).
-- **Residual risk**: Without Valkey, rate limits are per-instance. With N instances behind a load balancer, an attacker gets N× the budget. Set `VALKEY_URL` for coordinated limits in multi-instance deployments.
+- **Client IP (anti-spoofing)**: The rate-limit key is the real client IP, derived by peeling trusted reverse-proxy hops off the **right** of `X-Forwarded-For`, not the leftmost (client-supplied, spoofable) entry. Forwarding headers are honored only when the immediate peer is a trusted proxy, and only the entry `TRUSTED_PROXY_HOPS`-from-the-right is used (default 1 — a single reverse proxy, the documented topology). Set `TRUSTED_PROXY_HOPS` to the number of trusted proxies in front when stacking a CDN/LB. This closes the bypass where a client rotated a forged leftmost `X-Forwarded-For` to mint unlimited distinct rate-limit keys (EVE-700).
+- **Residual risk**: Without Valkey, rate limits are per-instance. With N instances behind a load balancer, an attacker gets N× the budget. Set `VALKEY_URL` for coordinated limits in multi-instance deployments. Forensic audit logging (`audit.client_ip`) still records the leftmost `X-Forwarded-For` entry and does not gate on the trusted peer — attribution-only, not a rate-limit control; hardening it is tracked separately.
 
 **TM-AUTH-002 — JWT Secret:**
 ```


### PR DESCRIPTION
## What changed

Per-IP rate limiting now keys on the **real** client IP. The client IP is derived from `X-Forwarded-For` by peeling trusted reverse-proxy hops off the **right** (the entry `TRUSTED_PROXY_HOPS`-from-the-right, default 1), instead of taking the leftmost entry. A new `TRUSTED_PROXY_HOPS` env var (default 1) lets operators who stack a CDN/LB in front of the reverse proxy set the correct hop count. The existing "forwarding headers are honored only when the immediate peer is a trusted proxy" gate is retained.

## Why

EVE-700 (High, security). A standard reverse proxy **appends** the peer IP it observed to the right of any client-supplied `X-Forwarded-For`, so the header arriving at the server is `<client-supplied>, <real-client-ip>`. The rate limiter took `.split(',').next()` — the **leftmost**, fully attacker-controlled value. A single client could rotate that left value (`1.2.3.4`, `1.2.3.5`, …) to mint unlimited distinct rate-limit keys, defeating the login (10/min), register (5/min), and refresh (30/min) limiters (TM-AUTH-001) and the global API DoS limiter (TM-DOS). Password spraying, mass registration, and DoS-limiter bypass all followed.

## Before / After

Request through the trusted proxy with `X-Forwarded-For: <spoofed>, <real>`:

- **Before:** rate-limit key = `<spoofed>` (leftmost). Rotating the spoofed value produced unlimited fresh buckets → limits never bind one client. (The old test `test_extract_ip_from_x_forwarded_for_from_trusted_proxy` even asserted the leftmost `203.0.113.50` was returned.)
- **After:** rate-limit key = `<real>` (rightmost, proxy-appended). `"1.1.1.1, 70.41.3.18"` and `"2.2.2.2, 70.41.3.18"` both resolve to `70.41.3.18`, so spoofed left entries cannot create distinct keys.

Evidence (unit tests, `everruns-server`):

```
running 6 tests
test ...::test_extract_ip_from_x_forwarded_for_from_trusted_proxy ... ok   # now expects rightmost
test ...::test_spoofed_leftmost_xff_does_not_change_client_ip ... ok        # new regression
test ...::test_extract_forwarded_ip_selects_hops_from_right ... ok          # new (1 & 2 hop, short chain)
test ...::test_extract_ip_from_x_real_ip_from_trusted_proxy ... ok
test ...::test_extract_ip_ignores_forwarded_for_from_untrusted_peer ... ok
test ...::test_extract_ip_fallback_to_loopback ... ok
test result: ok. 6 passed; 0 failed
```

`cargo fmt --check` passes; clippy clean locally.

## Risk

- Low–Medium
- Changes which `X-Forwarded-For` entry becomes the rate-limit key. For the documented single-reverse-proxy topology (`TRUSTED_PROXY_HOPS=1`, the default), the correct client IP is the rightmost entry the proxy appended. Deployments with additional proxies in front must set `TRUSTED_PROXY_HOPS` to the true hop count, otherwise a proxy IP (not the client) could become the key — a stricter, not weaker, failure mode. The trusted-peer gate and X-Real-IP fallback are unchanged; direct (untrusted-peer) clients still can't influence the key.

## Security

- Threat categories reviewed: **TM-AUTH** (TM-AUTH-001 rate limiting — this closes the XFF-spoofing bypass), **TM-DOS** (global API limiter keyed on the same IP). No new endpoint or data exposure; `TRUSTED_PROXY_HOPS` is read once from env.
- Findings and resolutions: threat model updated (TM-AUTH-001 mitigation details now document the rightmost/trusted-hop derivation). Related lower-severity items from the report are deferred — see Follow-ups.

## Follow-ups

- **Audit-log IP (`audit::client_ip`)** still reads the leftmost `X-Forwarded-For` with no trusted-peer gate, so `auth.*` audit rows can log a spoofed IP. It is attribution-only (not a rate-limit control), and fixing it cleanly needs the peer/trust context threaded into the audit helper. Deferred; noted in the threat model residual-risk note.
- **Over-broad trusted-proxy set** (`is_trusted_proxy_ip` trusts all loopback/RFC1918/link-local peers with no configurable allowlist) and **unbounded in-memory rate-limit key growth** (governor `DashMapStateStore` without TTL) are separate lower-severity hardening items from the same report; recommend follow-up Linear issues (OSS, EVE).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (`TRUSTED_PROXY_HOPS` default 1 matches documented topology)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSjP9mKoqSKshTZSXL4rqZ)_