### PR TITLE
fix(auth): preserve invite return_to through signup

### DIFF
--- a/apps/ui/src/__tests__/auth-redirect.test.ts
+++ b/apps/ui/src/__tests__/auth-redirect.test.ts
@@ -1,4 +1,12 @@
-import { getLoginRedirectPath, sanitizeReturnTo } from "@/lib/auth-redirect";
+import {
+  buildLoginHref,
+  buildSignupHref,
+  consumeReturnTo,
+  getLoginRedirectPath,
+  persistReturnTo,
+  RETURN_TO_STORAGE_KEY,
+  sanitizeReturnTo,
+} from "@/lib/auth-redirect";
 
 describe("getLoginRedirectPath", () => {
   it("preserves the current path and query in return_to", () => {
@@ -55,5 +63,44 @@ describe("sanitizeReturnTo", () => {
     expect(sanitizeReturnTo(null)).toBeNull();
     expect(sanitizeReturnTo(undefined)).toBeNull();
     expect(sanitizeReturnTo("")).toBeNull();
+  });
+});
+
+describe("buildSignupHref", () => {
+  it("includes sanitized return_to and email when provided", () => {
+    expect(buildSignupHref("/invite/abc123", "new@example.com")).toBe(
+      "/signup?email=new%40example.com&return_to=%2Finvite%2Fabc123",
+    );
+  });
+
+  it("omits unsafe return_to values", () => {
+    expect(buildSignupHref("https://evil.com", "new@example.com")).toBe(
+      "/signup?email=new%40example.com",
+    );
+  });
+});
+
+describe("buildLoginHref", () => {
+  it("includes sanitized return_to when provided", () => {
+    expect(buildLoginHref("/invite/abc123")).toBe("/login?return_to=%2Finvite%2Fabc123");
+  });
+});
+
+describe("return_to session storage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("persists and consumes sanitized return_to values", () => {
+    persistReturnTo("/invite/token123");
+    expect(sessionStorage.getItem(RETURN_TO_STORAGE_KEY)).toBe("/invite/token123");
+    expect(consumeReturnTo()).toBe("/invite/token123");
+    expect(sessionStorage.getItem(RETURN_TO_STORAGE_KEY)).toBeNull();
+  });
+
+  it("ignores unsafe return_to values", () => {
+    persistReturnTo("//evil.com");
+    expect(sessionStorage.getItem(RETURN_TO_STORAGE_KEY)).toBeNull();
+    expect(consumeReturnTo()).toBeNull();
   });
 });

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -20,11 +20,14 @@ import { useAuthConfig, useLogin } from "@/hooks/use-auth";
 import { usePageTitle } from "@/hooks";
 import { ApiError } from "@/lib/api/client";
 import { getOAuthUrl, login } from "@/lib/api/auth";
-import { isBackendNavigationPath, sanitizeReturnTo } from "@/lib/auth-redirect";
+import {
+  isBackendNavigationPath,
+  sanitizeReturnTo,
+  buildSignupHref,
+  RETURN_TO_STORAGE_KEY,
+  persistReturnTo,
+} from "@/lib/auth-redirect";
 import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
-
-// Session storage key for preserving return_to across OAuth redirects
-const RETURN_TO_KEY = "everruns_return_to";
 
 // OAuth provider display names (logos come from OAuthProviderIcon)
 const oauthProviders: Record<string, { name: string }> = {
@@ -99,8 +102,8 @@ export default function LoginPage() {
   const getRedirectTarget = (): string => {
     // Check URL param first, then sessionStorage (for OAuth flow).
     // Both are sanitized so a poisoned sessionStorage can't redirect off-origin.
-    const stored = sanitizeReturnTo(sessionStorage.getItem(RETURN_TO_KEY));
-    sessionStorage.removeItem(RETURN_TO_KEY);
+    const stored = sanitizeReturnTo(sessionStorage.getItem(RETURN_TO_STORAGE_KEY));
+    sessionStorage.removeItem(RETURN_TO_STORAGE_KEY);
     return returnTo || stored || "/dashboard";
   };
 
@@ -170,9 +173,9 @@ export default function LoginPage() {
     if (oauthPending) return;
     setOauthPending(true);
     // Persist return_to in sessionStorage so it survives the OAuth redirect chain
-    const target = returnTo || sessionStorage.getItem(RETURN_TO_KEY);
+    const target = returnTo || sessionStorage.getItem(RETURN_TO_STORAGE_KEY);
     if (target) {
-      sessionStorage.setItem(RETURN_TO_KEY, target);
+      persistReturnTo(target);
     }
     window.location.assign(getOAuthUrl(provider));
   };
@@ -288,7 +291,7 @@ export default function LoginPage() {
           <p className="mt-5 text-[13px] text-muted-foreground">
             New to Everruns?{" "}
             <Link
-              href={`/signup?email=${encodeURIComponent(email)}`}
+              href={buildSignupHref(returnTo, email)}
               className="font-medium text-primary hover:underline"
             >
               Create an account
@@ -315,7 +318,10 @@ export default function LoginPage() {
           <>
             {" "}
             New to Everruns?{" "}
-            <Link href="/signup" className="font-medium text-primary hover:underline">
+            <Link
+              href={buildSignupHref(returnTo)}
+              className="font-medium text-primary hover:underline"
+            >
               Create an account
             </Link>
           </>

--- a/apps/ui/src/app/(auth)/signup/page.tsx
+++ b/apps/ui/src/app/(auth)/signup/page.tsx
@@ -8,7 +8,7 @@
 // the email itself, never on-screen). Without confirm mode (self-host, no
 // email sender) signup keeps the instant session.
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,13 @@ import { OAuthProviderIcon } from "@/components/auth/oauth-provider-icon";
 import { TurnstileWidget } from "@/components/auth/turnstile-widget";
 import { useAuthConfig, useRegister } from "@/hooks/use-auth";
 import { getOAuthUrl } from "@/lib/api/auth";
+import {
+  buildLoginHref,
+  consumeReturnTo,
+  isBackendNavigationPath,
+  persistReturnTo,
+  sanitizeReturnTo,
+} from "@/lib/auth-redirect";
 import { usePageTitle } from "@/hooks";
 import { Check, Loader2, Mail } from "lucide-react";
 
@@ -44,6 +51,24 @@ export default function SignupPage() {
   const [oauthPending, setOauthPending] = useState(false);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
 
+  const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
+
+  useEffect(() => {
+    persistReturnTo(returnTo);
+  }, [returnTo]);
+
+  const getPostAuthTarget = (): string => {
+    return returnTo || consumeReturnTo() || "/dashboard";
+  };
+
+  const navigateAfterAuth = (target: string) => {
+    if (isBackendNavigationPath(target)) {
+      window.location.assign(target);
+      return;
+    }
+    router.push(target);
+  };
+
   const handleCaptchaVerify = useCallback((token: string) => setCaptchaToken(token), []);
   const handleCaptchaReset = useCallback(() => setCaptchaToken(null), []);
 
@@ -53,6 +78,7 @@ export default function SignupPage() {
   const handleOAuth = (provider: string) => {
     if (oauthPending) return;
     setOauthPending(true);
+    persistReturnTo(returnTo);
     window.location.assign(getOAuthUrl(provider));
   };
 
@@ -68,13 +94,14 @@ export default function SignupPage() {
       return;
     }
     const captcha_token = captchaToken ?? undefined;
+    persistReturnTo(returnTo);
     try {
       await registerMutation.mutateAsync({ email, password, captcha_token });
       if (config?.signup_email_confirm) {
         // Confirm mode: no session yet — the emailed link signs you in.
         setSubmittedEmail(email);
       } else {
-        router.push("/dashboard");
+        navigateAfterAuth(getPostAuthTarget());
       }
     } catch {
       if (config?.signup_email_confirm) {
@@ -114,7 +141,10 @@ export default function SignupPage() {
         </p>
         <p className="mt-2 text-[13px] text-muted-foreground">
           Already have an account?{" "}
-          <Link href="/login" className="font-medium text-primary hover:underline">
+          <Link
+            href={buildLoginHref(returnTo)}
+            className="font-medium text-primary hover:underline"
+          >
             Log in
           </Link>
         </p>
@@ -142,7 +172,10 @@ export default function SignupPage() {
           New registrations are currently disabled on this deployment.
         </p>
         <p className="mt-6 text-sm text-muted-foreground">
-          <Link href="/login" className="font-medium text-primary hover:underline">
+          <Link
+            href={buildLoginHref(returnTo)}
+            className="font-medium text-primary hover:underline"
+          >
             Back to log in
           </Link>
         </p>
@@ -163,7 +196,7 @@ export default function SignupPage() {
       </h1>
       <p className="mt-[10px] text-sm text-muted-foreground">
         Already have one?{" "}
-        <Link href="/login" className="font-medium text-primary hover:underline">
+        <Link href={buildLoginHref(returnTo)} className="font-medium text-primary hover:underline">
           Log in
         </Link>
       </p>

--- a/apps/ui/src/app/(auth)/verify-email/page.tsx
+++ b/apps/ui/src/app/(auth)/verify-email/page.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthShell } from "@/components/auth/auth-shell";
 import { useVerifyEmail, useResendVerification } from "@/hooks/use-auth";
+import { consumeReturnTo, isBackendNavigationPath } from "@/lib/auth-redirect";
 import { usePageTitle } from "@/hooks";
 import { Check, Loader2, Mail } from "lucide-react";
 
@@ -165,9 +166,19 @@ export default function VerifyEmailPage() {
         <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
           Thanks for confirming your email address. You can pick up right where you left off.
         </p>
-        {/* In a browser without a session, /dashboard bounces to /login with
-            return_to — so this works in both the original and a fresh browser. */}
-        <Button className="mt-7" onClick={() => router.push("/dashboard")}>
+        {/* Resume a stored invite/deep-link target when present; otherwise fall
+            back to dashboard (which may continue onboarding for zero-org users). */}
+        <Button
+          className="mt-7"
+          onClick={() => {
+            const target = consumeReturnTo() || "/dashboard";
+            if (isBackendNavigationPath(target)) {
+              window.location.assign(target);
+              return;
+            }
+            router.push(target);
+          }}
+        >
           Continue
         </Button>
       </AuthShell>

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -13,6 +13,7 @@ import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-comma
 import {
   getLoginRedirectPath,
   isBackendNavigationPath,
+  RETURN_TO_STORAGE_KEY,
   sanitizeReturnTo,
 } from "@/lib/auth-redirect";
 import { useAuth } from "@/providers/auth-provider";
@@ -65,8 +66,8 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   // After OAuth login, check sessionStorage for a pending return_to redirect
   useEffect(() => {
     if (!authLoading && !authUnavailable && isAuthenticated) {
-      const pendingReturnTo = sanitizeReturnTo(sessionStorage.getItem("everruns_return_to"));
-      sessionStorage.removeItem("everruns_return_to");
+      const pendingReturnTo = sanitizeReturnTo(sessionStorage.getItem(RETURN_TO_STORAGE_KEY));
+      sessionStorage.removeItem(RETURN_TO_STORAGE_KEY);
       if (pendingReturnTo) {
         // Backend paths (e.g. /oauth/authorize, /api/v1/auth/cli/callback,
         // or /v1/... when frontend and backend share an origin) need a

--- a/apps/ui/src/lib/auth-redirect.ts
+++ b/apps/ui/src/lib/auth-redirect.ts
@@ -3,6 +3,9 @@
 // `return_to` is the single public login-page contract for auth resume — see
 // specs/authentication.md. Paths must be relative to the frontend origin.
 
+/** Session storage key for preserving return_to across OAuth and signup flows. */
+export const RETURN_TO_STORAGE_KEY = "everruns_return_to";
+
 type SearchInput = URLSearchParams | string | null | undefined;
 
 function getSearchString(search: SearchInput): string {
@@ -63,4 +66,53 @@ const BACKEND_PATH_PREFIXES = ["/oauth/", "/api/", "/v1/"] as const;
 
 export function isBackendNavigationPath(path: string): boolean {
   return BACKEND_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function buildAuthPath(
+  basePath: "/login" | "/signup",
+  returnTo: string | null | undefined,
+  email?: string | null,
+): string {
+  const params = new URLSearchParams();
+  if (email) {
+    params.set("email", email);
+  }
+  const sanitized = sanitizeReturnTo(returnTo);
+  if (sanitized) {
+    params.set("return_to", sanitized);
+  }
+  const query = params.toString();
+  return query ? `${basePath}?${query}` : basePath;
+}
+
+/** Build a signup href that preserves a sanitized return_to and optional email. */
+export function buildSignupHref(
+  returnTo: string | null | undefined,
+  email?: string | null,
+): string {
+  return buildAuthPath("/signup", returnTo, email);
+}
+
+/** Build a login href that preserves a sanitized return_to and optional email. */
+export function buildLoginHref(returnTo: string | null | undefined, email?: string | null): string {
+  return buildAuthPath("/login", returnTo, email);
+}
+
+/** Persist a sanitized return_to in sessionStorage for post-auth resume. */
+export function persistReturnTo(value: string | null | undefined): void {
+  const sanitized = sanitizeReturnTo(value);
+  if (!sanitized || typeof sessionStorage === "undefined") {
+    return;
+  }
+  sessionStorage.setItem(RETURN_TO_STORAGE_KEY, sanitized);
+}
+
+/** Read and clear a stored return_to from sessionStorage. */
+export function consumeReturnTo(): string | null {
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+  const stored = sanitizeReturnTo(sessionStorage.getItem(RETURN_TO_STORAGE_KEY));
+  sessionStorage.removeItem(RETURN_TO_STORAGE_KEY);
+  return stored;
 }

--- a/test_cases/ui/full_auth/TC009_invited_user_signup_resume.md
+++ b/test_cases/ui/full_auth/TC009_invited_user_signup_resume.md
@@ -1,0 +1,38 @@
+# TC009 — Invited user signs up and accepts invitation
+
+## Description
+
+Verifies that an organization invite link preserves its target through the
+login → signup → email verification path and resumes invitation acceptance for a
+brand-new user.
+
+## Preconditions
+
+- `AUTH_MODE=full`, signup enabled, password auth enabled
+- `AUTH_SIGNUP_EMAIL_CONFIRM=true` with working email delivery (or AgentMail in dev)
+- An org owner account can send invitations
+- Clean browser session (no existing Everruns cookies)
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Invitee email | `everruns-testing+<unique>@agentmail.to` |
+| Password | `ValidPass123` (12+ chars with a number) |
+
+## Steps
+
+1. Sign in as an org owner and invite the invitee email.
+2. Open the emailed `/invite/<token>` link in the clean browser.
+3. Confirm redirect to `/login?return_to=%2Finvite%2F<token>`.
+4. Click **Create an account** on the login page.
+5. Confirm the signup URL includes `return_to=%2Finvite%2F<token>`.
+6. Complete signup with the invitee email and password.
+7. Open the verification link from email.
+8. Click **Continue** on the verified-email screen.
+
+## Expected Result
+
+- Step 4–5: signup retains the sanitized invite `return_to`.
+- Step 8: the browser resumes `/invite/<token>` (not plain `/onboarding`).
+- Invitation acceptance succeeds and the invitee lands in the invited org.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Invite links now keep their `return_to` target when an unauthenticated user switches from login to signup, completes email verification, and resumes invitation acceptance.

## Why

Organization invite links correctly redirected to `/login?return_to=/invite/<token>`, but the login page's **Create an account** links dropped `return_to`. New invited users lost the invite continuation and could not accept the membership after signup.

Fixes EVE-717.

## Before / After

**Before:** `/login?return_to=%2Finvite%2F<token>` → **Create an account** → `/signup` (no `return_to`) → verify → dashboard/onboarding; invite never accepted.

**After:** Both login phases link to `/signup?return_to=%2Finvite%2F<token>`; signup persists the target in `sessionStorage`; verification **Continue** resumes `/invite/<token>` and acceptance proceeds.

**Evidence:**
- `pnpm test src/__tests__/auth-redirect.test.ts` — 15 passed
- `pnpm test src/__tests__/main-layout-auth.test.tsx` — 4 passed
- `pnpm run format:check && pnpm run lint` — clean

## Risk

- Low — UI-only auth navigation; reuses existing `sanitizeReturnTo` open-redirect guards.

## Security

- Threat categories reviewed: TM-WEB (open redirect via `return_to`)
- All `return_to` values pass through `sanitizeReturnTo` before URL embedding or `sessionStorage` persistence; unsafe absolute/protocol-relative paths are rejected.
- No new trust boundaries introduced.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96d6f3a3-7d97-4625-8edd-0132e6b7b95f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96d6f3a3-7d97-4625-8edd-0132e6b7b95f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

