### PR TITLE
feat(sessions): invite handoff agents

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -8,6 +8,8 @@
 
 use super::util::{get_platform_store, require_str_nonblank as require_str};
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SystemPromptContext};
+use crate::config_layer::{AgentConfigOverlay, normalize_initial_file_path};
+use crate::harness::Harness;
 use crate::session::SubagentStatus;
 use crate::session_task::{
     CreateSessionTask, SessionTask, SessionTaskState, SessionTaskUpdate, TASK_KIND_AGENT_HANDOFF,
@@ -337,6 +339,7 @@ impl AgentHandoffTargetConfig {
 enum SpawnAgentHandoffMode {
     Background,
     Foreground,
+    Invite,
 }
 
 impl SpawnAgentHandoffMode {
@@ -345,9 +348,10 @@ impl SpawnAgentHandoffMode {
             None => None,
             Some("background") => Some(Self::Background),
             Some("foreground") => Some(Self::Foreground),
+            Some("invite") => Some(Self::Invite),
             Some(other) => {
                 return Err(format!(
-                    "Invalid mode: \"{other}\". Valid modes: background, foreground."
+                    "Invalid mode: \"{other}\". Valid modes: background, foreground, invite."
                 ));
             }
         };
@@ -367,8 +371,118 @@ impl SpawnAgentHandoffMode {
         match self {
             Self::Background => "background",
             Self::Foreground => "foreground",
+            Self::Invite => "invite",
         }
     }
+}
+
+fn capability_conflict_message(
+    host: &AgentConfigOverlay,
+    guest: &AgentConfigOverlay,
+) -> Option<String> {
+    guest.capabilities.iter().find_map(|guest_cap| {
+        host.capabilities
+            .iter()
+            .find(|host_cap| host_cap.capability_id() == guest_cap.capability_id())
+            .and_then(|host_cap| {
+                (host_cap.config != guest_cap.config).then(|| {
+                    format!(
+                        "capability `{}` has different host and guest configuration",
+                        guest_cap.capability_id()
+                    )
+                })
+            })
+    })
+}
+
+fn initial_file_conflict_message(
+    host: &AgentConfigOverlay,
+    guest: &AgentConfigOverlay,
+) -> Option<String> {
+    guest.initial_files.iter().find_map(|guest_file| {
+        let guest_path = normalize_initial_file_path(&guest_file.path);
+        host.initial_files
+            .iter()
+            .find(|host_file| normalize_initial_file_path(&host_file.path) == guest_path)
+            .and_then(|host_file| {
+                (host_file != guest_file)
+                    .then(|| format!("mount `{guest_path}` has different host and guest contents"))
+            })
+    })
+}
+
+fn mcp_conflict_message(host: &AgentConfigOverlay, guest: &AgentConfigOverlay) -> Option<String> {
+    guest.mcp_servers.iter().find_map(|(name, guest_server)| {
+        host.mcp_servers.get(name).and_then(|host_server| {
+            (host_server != guest_server)
+                .then(|| format!("MCP server `{name}` has different host and guest configuration"))
+        })
+    })
+}
+
+fn invite_conflict_message(
+    host: &AgentConfigOverlay,
+    guest: &AgentConfigOverlay,
+) -> Option<String> {
+    capability_conflict_message(host, guest)
+        .or_else(|| initial_file_conflict_message(host, guest))
+        .or_else(|| mcp_conflict_message(host, guest))
+}
+
+async fn harness_overlay(
+    store: &dyn crate::platform_store::PlatformStore,
+    harness_id: HarnessId,
+) -> Result<AgentConfigOverlay, ToolExecutionResult> {
+    let harness = store
+        .get_harness(harness_id)
+        .await
+        .map_err(ToolExecutionResult::internal_error)?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Harness not found: {harness_id}"))
+        })?;
+    Ok(AgentConfigOverlay::from(&harness))
+}
+
+async fn invite_mode_overlays(
+    store: &dyn crate::platform_store::PlatformStore,
+    parent_session: &crate::session::Session,
+    target: &AgentHandoffTargetConfig,
+) -> Result<(AgentConfigOverlay, AgentConfigOverlay), ToolExecutionResult> {
+    let mut host_layers = vec![harness_overlay(store, parent_session.harness_id).await?];
+    if let Some(agent_id) = parent_session.agent_id {
+        let host_agent = store
+            .get_agent_by_id(agent_id)
+            .await
+            .map_err(ToolExecutionResult::internal_error)?
+            .ok_or_else(|| {
+                ToolExecutionResult::tool_error(format!("Host agent not found: {agent_id}"))
+            })?;
+        host_layers.push(AgentConfigOverlay::from(&host_agent));
+    }
+    host_layers.push(AgentConfigOverlay::from(parent_session));
+
+    let target_harness: Harness = store
+        .get_harness(target.harness_id)
+        .await
+        .map_err(ToolExecutionResult::internal_error)?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Harness not found: {}", target.harness_id))
+        })?;
+    let target_agent = store
+        .get_agent_by_id(target.agent_id)
+        .await
+        .map_err(ToolExecutionResult::internal_error)?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Target agent not found: {}", target.agent_id))
+        })?;
+
+    Ok((
+        AgentConfigOverlay::fold(host_layers),
+        AgentConfigOverlay::fold([
+            AgentConfigOverlay::from(&target_harness),
+            AgentConfigOverlay::from(&target_agent),
+        ]),
+    ))
 }
 
 fn child_task(task: &str, public_context: Option<&Value>) -> String {
@@ -640,7 +754,7 @@ impl Tool for SpawnAgentHandoffTool {
     }
 
     fn description(&self) -> &str {
-        "Delegate work to a configured first-party target agent. Set target.type to \"agent\" and target.id to a configured handoff target id. Runs in the background by default when task tracking is available; set mode to \"foreground\" to block for the result."
+        "Delegate work to a configured first-party target agent. Set target.type to \"agent\" and target.id to a configured handoff target id. Runs in the background by default when task tracking is available; set mode to \"foreground\" to block for the result or \"invite\" to add the target as a member of the current session."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -673,8 +787,8 @@ impl Tool for SpawnAgentHandoffTool {
                 },
                 "mode": {
                     "type": "string",
-                    "enum": ["background", "foreground"],
-                    "description": "Execution mode. \"background\" (default when task tracking is available) returns immediately with a task_id; \"foreground\" blocks until the handoff completes."
+                    "enum": ["background", "foreground", "invite"],
+                    "description": "Execution mode. \"background\" (default when task tracking is available) returns immediately with a task_id; \"foreground\" blocks until the handoff completes; \"invite\" adds the target agent as a member participant in this session."
                 },
                 "public_context": {
                     "type": "object",
@@ -761,6 +875,38 @@ impl Tool for SpawnAgentHandoffTool {
             );
         }
 
+        if mode == SpawnAgentHandoffMode::Invite {
+            let (host_overlay, guest_overlay) =
+                match invite_mode_overlays(store, &parent_session, target).await {
+                    Ok(overlays) => overlays,
+                    Err(error) => return error,
+                };
+            if let Some(conflict) = invite_conflict_message(&host_overlay, &guest_overlay) {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invite-mode handoff cannot join target \"{}\": {conflict}. Use background or foreground mode for targets that need their own environment.",
+                    target.id
+                ));
+            }
+
+            let participant = match store
+                .add_agent_session_participant(context.session_id, target.agent_id)
+                .await
+            {
+                Ok(participant) => participant,
+                Err(error) => return ToolExecutionResult::internal_error(error),
+            };
+
+            return ToolExecutionResult::success(json!({
+                "participant_id": participant.id,
+                "target": target.id,
+                "target_agent_id": target.agent_id,
+                "name": name,
+                "status": "joined",
+                "mode": "invite",
+                "message": "Target agent joined this session and can respond when addressed.",
+            }));
+        }
+
         let child_session = match store
             .create_session(
                 target.harness_id,
@@ -801,6 +947,9 @@ impl Tool for SpawnAgentHandoffTool {
                     wake_policy: match mode {
                         SpawnAgentHandoffMode::Background => TaskWakePolicy::OnTerminal,
                         SpawnAgentHandoffMode::Foreground => TaskWakePolicy::Silent,
+                        SpawnAgentHandoffMode::Invite => {
+                            unreachable!("invite mode returns before child-session task creation")
+                        }
                     },
                 })
                 .await
@@ -918,6 +1067,9 @@ impl Tool for SpawnAgentHandoffTool {
                     "result": result,
                     "mode": "foreground",
                 }))
+            }
+            SpawnAgentHandoffMode::Invite => {
+                unreachable!("invite mode returns before child-session execution")
             }
         }
     }
@@ -1167,6 +1319,10 @@ mod tests {
             json!(["type", "id"])
         );
         assert_eq!(
+            schema["properties"]["mode"]["enum"],
+            json!(["background", "foreground", "invite"])
+        );
+        assert_eq!(
             schema["required"],
             json!(["name", "instructions", "target"])
         );
@@ -1326,6 +1482,96 @@ mod tests {
 
         assert_eq!(task.state, SessionTaskState::Succeeded);
         assert_eq!(task.summary.as_deref(), Some("Hi!"));
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_invite_adds_member_participant() {
+        let store = Arc::new(MockPlatformStore::new());
+        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let tool = spawn_agent_tool(&config);
+        let context = context(store.clone(), None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "AWS Operator Invite",
+                    "instructions": "Join this incident session",
+                    "target": { "type": "agent", "id": "aws_operator" },
+                    "mode": "invite"
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        assert_eq!(value["mode"], "invite");
+        assert_eq!(value["status"], "joined");
+        assert_eq!(value["target"], "aws_operator");
+        assert!(value["participant_id"].as_str().is_some());
+
+        assert!(
+            store
+                .created_session_harness_ids
+                .lock()
+                .expect("recorder lock")
+                .is_empty(),
+            "invite mode must not create a child session"
+        );
+        let participants = store
+            .joined_participants
+            .lock()
+            .expect("participants lock")
+            .clone();
+        assert_eq!(participants.len(), 1);
+        assert_eq!(participants[0].agent_id, Some(store.agent.public_id));
+        assert_eq!(
+            participants[0].role,
+            crate::session::SessionParticipantRole::Member
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_invite_rejects_capability_conflict() {
+        let mut store_value = MockPlatformStore::new();
+        store_value.session.capabilities = vec![crate::AgentCapabilityConfig::with_config(
+            "web_fetch",
+            json!({"max_bytes": 1024}),
+        )];
+        store_value.agent.capabilities = vec![crate::AgentCapabilityConfig::with_config(
+            "web_fetch",
+            json!({"max_bytes": 2048}),
+        )];
+        let store = Arc::new(store_value);
+        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let tool = spawn_agent_tool(&config);
+        let context = context(store.clone(), None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "AWS Operator Invite",
+                    "instructions": "Join this incident session",
+                    "target": { "type": "agent", "id": "aws_operator" },
+                    "mode": "invite"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(matches!(result, ToolExecutionResult::ToolError(message)
+                if message.contains("Invite-mode handoff cannot join target")
+                    && message.contains("capability `web_fetch`")
+                    && message.contains("Use background or foreground mode")));
+        assert!(
+            store
+                .joined_participants
+                .lock()
+                .expect("participants lock")
+                .is_empty(),
+            "conflicting invite must not join the participant"
+        );
     }
 
     /// Regression for the confused-deputy issue this PR fixes: the child

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -11,7 +11,7 @@ use crate::app::{App, AppChannel, ChannelType};
 use crate::capability_dto::CapabilityInfo;
 use crate::error::Result;
 use crate::harness::Harness;
-use crate::session::Session;
+use crate::session::{Session, SessionParticipant};
 use crate::typed_id::{AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -209,6 +209,13 @@ pub trait PlatformStore: Send + Sync {
     /// Get a session by ID.
     async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>>;
 
+    /// Add an agent as a member participant in an existing session.
+    async fn add_agent_session_participant(
+        &self,
+        session_id: SessionId,
+        agent_id: AgentId,
+    ) -> Result<SessionParticipant>;
+
     /// Get the latest estimated context breakdown for a session.
     async fn get_session_context_report(&self, id: SessionId) -> Result<SessionContextReport>;
 
@@ -283,6 +290,7 @@ pub mod tests {
         pub app_channel: AppChannel,
         pub session: Session,
         pub extra_sessions: std::sync::Mutex<std::collections::HashMap<SessionId, Session>>,
+        pub joined_participants: std::sync::Mutex<Vec<SessionParticipant>>,
         /// Records the `harness_id` argument of every `create_session`
         /// call so tests can assert which harness a child session was
         /// created against. See `start_handoff_uses_target_harness_not_parent`.
@@ -435,6 +443,7 @@ pub mod tests {
                     }
                 },
                 extra_sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
+                joined_participants: std::sync::Mutex::new(Vec::new()),
                 created_session_harness_ids: std::sync::Mutex::new(Vec::new()),
                 wait_for_idle_status: std::sync::Mutex::new("idle".to_string()),
             }
@@ -714,6 +723,27 @@ pub mod tests {
                 return Ok(Some(session));
             }
             Ok(Some(self.session.clone()))
+        }
+        async fn add_agent_session_participant(
+            &self,
+            session_id: SessionId,
+            agent_id: AgentId,
+        ) -> Result<SessionParticipant> {
+            let participant = SessionParticipant {
+                id: crate::typed_id::SessionParticipantId::new(),
+                session_id,
+                kind: crate::session::SessionParticipantKind::Agent,
+                agent_id: Some(agent_id),
+                agent_version_id: self.agent.default_version_id,
+                principal_id: self.session.owner_principal_id,
+                role: crate::session::SessionParticipantRole::Member,
+                joined_at: chrono::Utc::now(),
+                left_at: None,
+            };
+            if let Ok(mut participants) = self.joined_participants.lock() {
+                participants.push(participant.clone());
+            }
+            Ok(participant)
         }
         async fn get_session_context_report(&self, id: SessionId) -> Result<SessionContextReport> {
             Ok(SessionContextReport {

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -2574,6 +2574,13 @@ mod tests {
         async fn get_session_by_id(&self, _id: SessionId) -> crate::Result<Option<crate::Session>> {
             Ok(None)
         }
+        async fn add_agent_session_participant(
+            &self,
+            _session_id: SessionId,
+            _agent_id: AgentId,
+        ) -> crate::Result<crate::SessionParticipant> {
+            unreachable!()
+        }
         async fn get_session_context_report(
             &self,
             id: SessionId,

--- a/crates/local/src/platform_store.rs
+++ b/crates/local/src/platform_store.rs
@@ -17,7 +17,7 @@ use everruns_core::capability_dto::CapabilityInfo;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::harness::Harness;
 use everruns_core::platform_store::{PlatformMessage, PlatformStore};
-use everruns_core::session::Session;
+use everruns_core::session::{Session, SessionParticipant};
 use everruns_core::typed_id::{
     AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
 };
@@ -111,6 +111,14 @@ impl PlatformStore for LocalPlatformStore {
 
     async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>> {
         self.runner.get_session(id).await
+    }
+
+    async fn add_agent_session_participant(
+        &self,
+        _session_id: SessionId,
+        _agent_id: AgentId,
+    ) -> Result<SessionParticipant> {
+        Err(unsupported("add_agent_session_participant"))
     }
 
     async fn list_sessions(

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -22,8 +22,8 @@ use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverId, DriverRegistry, EgressRequest,
     EgressRequestKind, EgressService, EventData, Harness, HarnessStatus, Message, MessageRole,
-    Session, SessionStatus, ToolDefinition, ToolResultContentPart, UtilityLlmService,
-    merge_harness,
+    Session, SessionParticipant, SessionStatus, ToolDefinition, ToolResultContentPart,
+    UtilityLlmService, merge_harness,
 };
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
@@ -2988,6 +2988,22 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         self.execute_domain_lookup(
             "get_session",
             serde_json::json!({ "session_id": id.to_string() }),
+        )
+        .await
+    }
+
+    async fn add_agent_session_participant(
+        &self,
+        session_id: SessionId,
+        agent_id: AgentId,
+    ) -> everruns_core::error::Result<SessionParticipant> {
+        self.execute_domain_command(
+            "add_session_participant",
+            serde_json::json!({
+                "session_id": session_id.to_string(),
+                "kind": "agent",
+                "agent_id": agent_id.to_string(),
+            }),
         )
         .await
     }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -22,7 +22,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, LeasedResourceId, MessageId, ModelId, SessionId};
 use everruns_core::{
-    Agent, Harness, HarnessStatus, Message, MessageFilter, MessageRole, Session, SessionStatus,
+    Agent, Harness, HarnessStatus, Message, MessageFilter, MessageRole, Session,
+    SessionParticipant, SessionStatus,
 };
 use everruns_internal_protocol::proto;
 use everruns_internal_protocol::{
@@ -3257,6 +3258,22 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
         self.execute_platform_lookup(
             "get_session",
             serde_json::json!({ "session_id": id.to_string() }),
+        )
+        .await
+    }
+
+    async fn add_agent_session_participant(
+        &self,
+        session_id: SessionId,
+        agent_id: AgentId,
+    ) -> Result<SessionParticipant> {
+        self.execute_platform_command(
+            "add_session_participant",
+            serde_json::json!({
+                "session_id": session_id.to_string(),
+                "kind": "agent",
+                "agent_id": agent_id.to_string(),
+            }),
         )
         .await
     }

--- a/specs/agent-handoff.md
+++ b/specs/agent-handoff.md
@@ -65,16 +65,24 @@ Parameters:
 | `instructions` | yes | Work request for the target agent. Must not contain credentials. |
 | `target.type` | yes | Must be `agent`. |
 | `target.id` | yes | Target key from capability config. |
-| `mode` | no | `background` by default when task tracking is available; `foreground` blocks for the result. |
+| `mode` | no | `background` by default when task tracking is available; `foreground` blocks for the child-session result; `invite` joins the target to the current session. |
 | `public_context` | no | Non-secret structured context appended to the child task. |
 
 Authorization, child-session creation, task kind, and result handling match the
-original handoff contract. Background mode creates an
+original handoff contract for `background` and `foreground`. Background mode creates an
 `agent_handoff` task with `wake_policy = on_terminal`, sends the initial
 instructions from a detached watcher, heartbeats the task while waiting, and
 settles the task with the child session's terminal status and last assistant
 message. If task tracking is unavailable, an omitted mode degrades to
 `foreground`; explicit `background` is rejected.
+
+Invite mode is for targets that can collaborate inside the host session's
+environment. It adds the configured target Agent as a member participant in the
+current session instead of creating a child session. Addressed user messages can
+then route a turn to that participant. The target contributes only behavioral
+agent overlay during addressed turns: prompt, capabilities, model defaults, and
+client tools are folded on top of the host session environment. The target's
+own harness stays reserved for child-session modes.
 
 Behavior:
 
@@ -82,13 +90,17 @@ Behavior:
 2. Resolve required provider connections server-side through
    `UserConnectionResolver`.
 3. If a connection is missing, return `connection_required(provider)`.
-4. Create a child session with the target `agent_id`.
-5. Persist parent/child metadata through the existing subagent session fields.
-6. Create a `session_tasks` row of kind `agent_handoff` (distinct from
+4. For `invite`, reject duplicate capability or mounted-resource conflicts with
+   a clear error and add the target Agent as a member participant in the current
+   session.
+5. For `background` or `foreground`, create a child session with the target
+   `agent_id`.
+6. Persist parent/child metadata through the existing subagent session fields.
+7. Create a `session_tasks` row of kind `agent_handoff` (distinct from
    `subagent`) with `links.child_session_id` set and `spec` carrying
    `target_id`/`external_agent_id`/`mode`.
-7. Send the task to the child session.
-8. In foreground mode, block until the child session idles and return its last assistant message.
+8. Send the task to the child session.
+9. In foreground mode, block until the child session idles and return its last assistant message.
 
 ### Monitoring and Steering
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -470,7 +470,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update (static) and re-validated at execution time with DNS resolution via `validate_url_dns_pinned`; every resolved IP is checked against the blocked ranges, closing the DNS-rebinding gap | MITIGATED |
 | TM-TOOL-019 | MCP `query`/`execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
 | TM-TOOL-020 | Skill `` !`command` `` activation RCE on worker host | High | `ActivateSkillFromVfsTool::execute_with_context` never invokes `preprocess_command_injections` — the trust gate is forced off because no non-user-spoofable provenance signal exists on `SessionFile` today. Expansion is also capped at `MAX_COMMAND_PLACEHOLDERS_PER_SKILL` (32) with concurrency ≤ 4 in the expansion function itself. See EVE-388. | MITIGATED |
-| TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids through `spawn_agent(target.type="agent")`, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/task metadata, records only non-secret target/provider/scope labels in `session_tasks`, and routes follow-up control through `message_task` for the parent-owned task. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
+| TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids through `spawn_agent(target.type="agent")`, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/task metadata, records only non-secret target/provider/scope labels in `session_tasks`, and keeps invite-mode joins in the current session behind duplicate capability/mount conflict checks. Child-session follow-up control routes through `message_task` for the parent-owned task. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
 | TM-TOOL-022 | Cross-tenant MCP credential reach via guardrail `mcp` check | High | The guardrails `mcp` check (specs/guardrails.md) names a `server`/`tool` to call over the scoped-MCP client. The check resolves connections through the host's per-session `McpConnectionResolver`, which only resolves servers scoped to the current session/org; a tenant's guardrail config can only reach that tenant's servers and never another tenant's MCP credentials. A misconfigured/unknown server fails open (allow) rather than blocking. The verdict parser reads only `verdict`/`reason`, so a poisoned endpoint response cannot widen behavior beyond the fail-open baseline. | MITIGATED |
 
 ### Mitigation Details
@@ -504,8 +504,9 @@ Follow-up work (tracked on EVE-388): (a) add a platform-controlled provenance fi
 
 **TM-TOOL-021 — Agent Handoff Delegation Gate:**
 `agent_handoff` is a high-risk orchestration tool because one agent can start a
-child session using another configured Agent's tools and data. The mitigation is
-to keep authority explicit and non-secret:
+child session using another configured Agent's tools and data, or invite another
+configured Agent to respond inside the current session. The mitigation is to
+keep authority explicit and non-secret:
 
 1. Source agents can only target ids listed in their `agent_handoff` config.
 2. Required provider connections are resolved server-side through
@@ -516,7 +517,11 @@ to keep authority explicit and non-secret:
    are excluded.
 4. Follow-up control uses `message_task` against the parent-owned
    `agent_handoff` task, whose `links.child_session_id` is set by the server.
-5. This gate proves the user has the required connection before delegation.
+5. Invite mode adds the target as a current-session member participant instead
+   of creating a task. Before joining, it rejects duplicate capability
+   configuration and mounted-resource conflicts so the shared environment is
+   not silently overwritten.
+6. This gate proves the user has the required connection before delegation.
    Real provider write tools still need scoped grant enforcement before mutating
    external infrastructure.
 


### PR DESCRIPTION
## What changed
`spawn_agent(target.type="agent")` now supports `mode: "invite"` for configured first-party handoff targets. Invite mode adds the target Agent as a member participant in the current session instead of creating a child session, and returns the joined participant id so clients can address the guest in-session.

Child-session `background` and `foreground` handoff modes remain unchanged. Invite joins reject duplicate capability or mounted-resource conflicts before adding the member, with a clear fallback to child-session modes for targets that need their own environment.

## Why
EVE-692 Slice E needs same-session multi-agent collaboration without forcing every handoff into a child session. The source agent should be able to invite compatible configured agents into the active session while preserving the host environment.

## Before / After
Before: `spawn_agent` for first-party handoff accepted only `background` and `foreground`; both created child sessions.

After: `mode: "invite"` joins the target as a current-session member participant and leaves child-session modes intact.

Evidence:
- `cargo test -p everruns-core agent_handoff --lib --all-features`: 17 passed, including invite join and conflict rejection.
- `cargo test -p everruns-server participant_commands_list_add_and_leave_history --lib --all-features`: passed.
- `cargo test -p everruns-server addressed_turn_routes_to_guest_agent --lib --all-features`: passed.
- Smoke via `PORT_PREFIX=286 just start-dev --no-watch`: created host/guest agents, configured host `agent_handoff`, created a session, added guest participant, then sent an addressed message. Participants changed from 2 to 3; guest participant was `kind=agent`, `role=member`; addressed message was accepted. The subsequent local model call reported missing provider API key, expected for this no-secret dev smoke.
- `cargo check -p everruns-server -p everruns-worker --all-features`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `just pre-push`: passed.

## Risk
- Medium
- Changes the high-risk orchestration tool surface and extends the shared `PlatformStore` trait. Main risk is an adapter missing the new participant join behavior or invite mode allowing an incompatible target into a shared session; tests cover the new trait path and conflict rejection, and the local platform store explicitly rejects unsupported participant joins.

## Security
- Threat categories reviewed: TM-TOOL, TM-AUTHZ, TM-TENANT, TM-API, TM-DOS.
- Findings and resolutions: invite mode keeps the configured-target gate and server-side connection resolution, never accepts credentials in arguments, and rejects duplicate capability/mount conflicts before joining the target. `specs/threat-model.md` was updated for the new invite-mode surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
