### PR TITLE
fix(core): strip echoed [time] annotations from assistant replies

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -2779,7 +2779,11 @@ impl ReasonAtom {
             );
         }
 
-        // 18. Store and emit output.message.completed event with metadata and usage
+        // 18. Store and emit output.message.completed event with metadata and usage.
+        // Strip any synthetic `[time …]` annotation the model echoed from the
+        // message_metadata model view before persisting/returning it (EVE-710),
+        // so exact-output replies are not polluted by the injected prefix.
+        let text = crate::capabilities::strip_leading_timestamp_annotations(&text);
         let has_tool_calls = !tool_calls.is_empty();
         let mut assistant_message = if has_tool_calls {
             Message::assistant_with_tools(&text, tool_calls.clone())
@@ -2885,6 +2889,8 @@ impl ReasonAtom {
             .await;
 
         // Build the assistant message from accumulated text and persist via event.
+        // Strip any echoed `[time …]` annotation the model produced (EVE-710).
+        let accumulated = crate::capabilities::strip_leading_timestamp_annotations(&accumulated);
         let assistant_message = Message::assistant(&accumulated);
         let output_message_id = assistant_message.id;
         self.event_emitter

--- a/crates/core/src/capabilities/message_metadata.rs
+++ b/crates/core/src/capabilities/message_metadata.rs
@@ -205,6 +205,40 @@ impl ModelViewProvider for MessageMetadataModelViewProvider {
     }
 }
 
+/// Strip synthetic leading `[time <RFC3339 UTC>]` annotations from generated
+/// assistant text before it is persisted.
+///
+/// The model view prepends `[time …]` to messages so the model can reason about
+/// timing, with a system-prompt instruction never to emit it. Models
+/// nevertheless echo the annotation into their replies (EVE-710); the echoed
+/// text is then stored and shown to the user, breaking exact-output prompts.
+/// This removes only the exact synthetic pattern — one or more leading
+/// `[time <timestamp>]` segments, each followed by an optional single space —
+/// validating the bracket contents as a real RFC3339 timestamp so legitimate
+/// user-authored text like `[time to go]` is left untouched. Only leading
+/// occurrences are removed; a bracketed timestamp later in the text is treated
+/// as authored content and preserved.
+pub fn strip_leading_timestamp_annotations(text: &str) -> String {
+    let mut rest = text;
+    while let Some(after) = strip_one_timestamp_annotation(rest) {
+        rest = after;
+    }
+    rest.to_string()
+}
+
+/// Strip a single leading `[time <rfc3339>]` (plus one optional following space)
+/// from `text`, returning the remainder when it matches the synthetic format.
+fn strip_one_timestamp_annotation(text: &str) -> Option<&str> {
+    const PREFIX: &str = "[time ";
+    let rest = text.strip_prefix(PREFIX)?;
+    let close = rest.find(']')?;
+    // Only strip when the bracket holds a real RFC3339 timestamp — the exact
+    // synthetic format produced by `MessageMetadataField::Timestamp::render`.
+    chrono::DateTime::parse_from_rfc3339(&rest[..close]).ok()?;
+    let after = &rest[close + 1..];
+    Some(after.strip_prefix(' ').unwrap_or(after))
+}
+
 /// Render the combined metadata annotation for a message, e.g.
 /// `[time 2026-06-11T09:15:42Z]`. Returns `None` when no field yields a value.
 pub fn render_annotation(msg: &Message, fields: &[MessageMetadataField]) -> Option<String> {
@@ -346,6 +380,73 @@ mod tests {
         let text = out[0].text().unwrap();
         assert!(text.starts_with("[time 2"), "got: {text}");
         assert!(text.contains("Z] hello"), "got: {text}");
+    }
+
+    // EVE-710: models echo the synthetic `[time …]` prefix into their replies;
+    // it must be stripped before the assistant text is persisted.
+    #[test]
+    fn strip_removes_single_leading_annotation() {
+        assert_eq!(
+            strip_leading_timestamp_annotations("[time 2026-07-10T05:38:28Z] cobalt"),
+            "cobalt"
+        );
+    }
+
+    // EVE-710: duplicated prefixes (observed in the wild) are all removed.
+    #[test]
+    fn strip_removes_repeated_leading_annotations() {
+        assert_eq!(
+            strip_leading_timestamp_annotations(
+                "[time 2026-07-10T05:38:21Z] [time 2026-07-10T05:38:21Z] Understood"
+            ),
+            "Understood"
+        );
+    }
+
+    // EVE-710: an annotation with no following space still strips cleanly.
+    #[test]
+    fn strip_handles_annotation_without_trailing_space() {
+        assert_eq!(
+            strip_leading_timestamp_annotations("[time 2026-07-10T05:38:28Z]hi"),
+            "hi"
+        );
+    }
+
+    // EVE-710: legitimate user-authored bracket text that is not a timestamp is
+    // preserved.
+    #[test]
+    fn strip_preserves_non_timestamp_bracket_text() {
+        assert_eq!(
+            strip_leading_timestamp_annotations("[time to go] home"),
+            "[time to go] home"
+        );
+        assert_eq!(
+            strip_leading_timestamp_annotations("hello world"),
+            "hello world"
+        );
+    }
+
+    // EVE-710: a real timestamp appearing later in the text is authored content,
+    // not the synthetic leading prefix, and is kept.
+    #[test]
+    fn strip_only_touches_leading_annotation() {
+        assert_eq!(
+            strip_leading_timestamp_annotations("see [time 2026-07-10T05:38:28Z]"),
+            "see [time 2026-07-10T05:38:28Z]"
+        );
+    }
+
+    // EVE-710: stripping is the inverse of the model-view annotation, so an
+    // agent reply that merely echoed the injected prefix round-trips to the
+    // author's original text.
+    #[test]
+    fn strip_inverts_render_annotation() {
+        let agent = Message::assistant("the answer");
+        let annotated = format!("{} the answer", time_annotation(&agent));
+        assert_eq!(
+            strip_leading_timestamp_annotations(&annotated),
+            "the answer"
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -257,7 +257,7 @@ pub use mcp::{
 pub use memory::{MEMORY_CAPABILITY_ID, MemoryCapability};
 pub use message_metadata::{
     MESSAGE_METADATA_CAPABILITY_ID, MessageMetadataCapability, MessageMetadataConfig,
-    MessageMetadataField, render_annotation,
+    MessageMetadataField, render_annotation, strip_leading_timestamp_annotations,
 };
 pub use model_scout::{
     MODEL_SCOUT_CAPABILITY_ID, ModelRanking, ModelScoutCapability, ProbeResult, ProbeTask,


### PR DESCRIPTION
## What changed
Assistant replies are no longer polluted by the synthetic `[time <RFC3339>]` prefix. The `message_metadata` model view injects that prefix so the model can reason about timing, but models echo it back into their output; the echoed text was persisted and rendered. Generated assistant text is now cleaned of any leading `[time …]` annotation before it is stored, at both the normal-completion and partial-stream finalize seams in `ReasonAtom`.

Impact: exact-output requests ("Reply with only the code word") return exactly the intended text, and normal replies are no longer prefixed with a timestamp.

## Why
The system prompt already instructs the model never to emit the annotation, but instruction alone is unreliable — the bug reproduced on `gpt-4.1-mini`/`gpt-4o-mini`, including a duplicated `[time …] [time …]` prefix. A deterministic strip at the persistence boundary is the robust fix (Fixes EVE-710).

## Before / After
- **Before:** stored assistant text `[time 2026-07-10T05:38:28Z] cobalt`.
- **After:** stored assistant text `cobalt`.
- **Preserved:** user-authored bracket text that is not a timestamp, e.g. `[time to go] home`, and a real timestamp appearing later in the text, are left untouched — bracket contents are validated as RFC3339 before stripping.

Evidence (local): 16/16 `capabilities::message_metadata` tests pass, including new cases for single/repeated/space-less prefixes, non-timestamp bracket preservation, leading-only scoping, and a render→strip round-trip. `cargo fmt --check` and `cargo clippy --all-targets --all-features -D warnings` clean for `everruns-core`.

## Risk
- Low. The strip runs at the single provider-agnostic persistence seam in `ReasonAtom`, so both OpenAI Responses and Chat Completions paths are covered. Only an exact leading `[time <valid RFC3339>]` is removed; non-timestamp brackets and mid-text timestamps are preserved.

## Security
- Threat categories reviewed: TM-LLM (assistant output handling). No security-relevant surface changed: this trims a synthetic prefix from model output before storage; no auth, input-trust, injection, or resource-limit behavior is affected.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---