### PR TITLE
fix(test-cases): align TC010 disabled-chat copy with Platform Chat rebrand

### DIFF
--- a/test_cases/ui/global_chat/TC010_chat_disabled_feature_flag.md
+++ b/test_cases/ui/global_chat/TC010_chat_disabled_feature_flag.md
@@ -26,7 +26,7 @@ None.
 | Check | Expected |
 |-------|----------|
 | Sidebar | "Chat" entry hidden or not present |
-| `/chat` page | Shows "Global Chat is not enabled" message |
+| `/chat` page | Shows "Platform Chat is not enabled" message |
 | Sub-message | Shows "This feature is currently disabled." |
 | No session created | No `POST /v1/sessions/chat` call made |
 | No errors | No console errors or unhandled exceptions |


### PR DESCRIPTION
## What changed
`test_cases/ui/global_chat/TC010` now expects the `/chat` disabled empty state to read "Platform Chat is not enabled" (matching the shipped rebrand) instead of the stale "Global Chat is not enabled".

## Why
EVE-713 reported the disabled `/chat` route rendering a blank dead end (observed on 0.17.5). On current `main` the OSS route already renders the documented explanatory empty state — heading "Platform Chat is not enabled", sub-message "This feature is currently disabled." — and does not create a session. That behavior is implemented in `apps/ui/src/app/(main)/chat/page.tsx` and covered by `apps/ui/src/__tests__/global-chat-page.test.tsx`, which asserts the empty state renders when the flag is off and that the `useGlobalChat` session hook is never invoked. The only remaining drift was TC010 still documenting the pre-rebrand heading, so the manual test would spuriously fail. Fixes EVE-713.

## Before / After
- **Before:** TC010 expected "Global Chat is not enabled" — mismatched the shipped UI copy.
- **After:** TC010 expects "Platform Chat is not enabled" — matches the rendered empty state and the existing jest assertion.

Acceptance mapping: disabled route renders the documented empty state (implemented, now documented consistently); regression coverage for direct-nav-with-flag-off exists in `global-chat-page.test.tsx` (empty state + no session hook call); hidden sidebar behavior and no-session-POST are preserved.

## Risk
- Low. Documentation/test-case only; no runtime code changed.

## Security
- No security-relevant code changes — this edits a manual UI test-case document only.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (behavior covered by existing `global-chat-page.test.tsx`; TC010 doc aligned)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---