### PR TITLE
fix(members-ui): hide owner-only controls from org admins, show errors

### DIFF
--- a/apps/ui/src/__tests__/settings-members.test.tsx
+++ b/apps/ui/src/__tests__/settings-members.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import MembersPage from "@/app/(main)/settings/members/page";
 
-// Mock members data
+// Mock members data: an owner, an admin, and a plain member.
 const mockMembers = [
   {
     user_id: "user-1",
@@ -12,6 +12,14 @@ const mockMembers = [
     avatar_url: "https://example.com/avatar1.jpg",
     role: "owner" as const,
     joined_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    user_id: "user-3",
+    email: "admin@example.com",
+    name: "Admin User",
+    avatar_url: null,
+    role: "admin" as const,
+    joined_at: "2024-02-01T00:00:00Z",
   },
   {
     user_id: "user-2",
@@ -43,6 +51,22 @@ jest.mock("@/providers/org-provider", () => ({
   useOrg: () => mockUseOrg(),
 }));
 
+const ROLE_LEVELS: Record<string, number> = { owner: 3, admin: 2, member: 1 };
+
+/** Build a useOrg() mock whose hasRole mirrors the real role hierarchy. */
+function orgMock(role: "owner" | "admin" | "member") {
+  return {
+    currentOrg: { public_id: "org-123", name: "Test Org", role },
+    hasRole: (required: string) => (ROLE_LEVELS[role] ?? 0) >= (ROLE_LEVELS[required] ?? 0),
+    isLoading: false,
+  };
+}
+
+/** Locate the member card row containing the given display name. */
+function cardFor(name: string): HTMLElement {
+  return screen.getByText(name).closest(".border") as HTMLElement;
+}
+
 describe("MembersPage", () => {
   let queryClient: QueryClient;
 
@@ -58,19 +82,13 @@ describe("MembersPage", () => {
       },
     });
 
+    // Default: viewer is the owner (user-1).
     mockUseAuth.mockReturnValue({
       user: { id: "user-1" },
       requiresAuth: true,
     });
 
-    mockUseOrg.mockReturnValue({
-      currentOrg: { public_id: "org-123", name: "Test Org", role: "owner" },
-      hasRole: (role: string) => {
-        const levels: Record<string, number> = { owner: 3, admin: 2, member: 1 };
-        return (levels["owner"] ?? 0) >= (levels[role] ?? 0);
-      },
-      isLoading: false,
-    });
+    mockUseOrg.mockReturnValue(orgMock("owner"));
 
     mockUseMembers.mockReturnValue({
       data: mockMembers,
@@ -81,11 +99,15 @@ describe("MembersPage", () => {
     mockUseUpdateMemberRole.mockReturnValue({
       mutateAsync: jest.fn(),
       isPending: false,
+      isError: false,
+      error: null,
     });
 
     mockUseRemoveMember.mockReturnValue({
       mutateAsync: jest.fn(),
       isPending: false,
+      isError: false,
+      error: null,
     });
   });
 
@@ -108,10 +130,10 @@ describe("MembersPage", () => {
   it("shows role badge for current user (self)", () => {
     render(<MembersPage />, { wrapper });
 
-    // Current user (user-1) should have Owner badge (not a dropdown)
-    expect(screen.getByText("Owner")).toBeInTheDocument();
-    // And "You" badge
-    expect(screen.getByText("You")).toBeInTheDocument();
+    // Current user (user-1) should show its own role as a badge, not a dropdown.
+    const ownerCard = cardFor("Owner User");
+    expect(within(ownerCard).getByText("Owner")).toBeInTheDocument();
+    expect(within(ownerCard).getByText("You")).toBeInTheDocument();
   });
 
   it("shows loading skeleton when loading", () => {
@@ -154,47 +176,116 @@ describe("MembersPage", () => {
   it("shows member count", () => {
     render(<MembersPage />, { wrapper });
 
-    expect(screen.getByText("2 members")).toBeInTheDocument();
+    expect(screen.getByText("3 members")).toBeInTheDocument();
   });
 
   it("shows joined date for members", () => {
     render(<MembersPage />, { wrapper });
 
     const joinedDates = screen.getAllByText(/Joined/);
-    expect(joinedDates.length).toBe(2);
-  });
-
-  it("shows remove button for non-self members when user can manage", () => {
-    render(<MembersPage />, { wrapper });
-
-    // Remove button should exist for the non-self member
-    expect(screen.getByTitle("Remove member")).toBeInTheDocument();
-  });
-
-  it("hides role editing when user lacks admin role", () => {
-    mockUseOrg.mockReturnValue({
-      currentOrg: { public_id: "org-123", name: "Test Org", role: "member" },
-      hasRole: () => false,
-      isLoading: false,
-    });
-
-    mockUseAuth.mockReturnValue({
-      user: { id: "user-2" },
-      requiresAuth: true,
-    });
-
-    render(<MembersPage />, { wrapper });
-
-    // Should show badges for all members, not dropdowns
-    expect(screen.getByText("Owner")).toBeInTheDocument();
-    expect(screen.getByText("Member")).toBeInTheDocument();
-    // No remove button
-    expect(screen.queryByTitle("Remove member")).not.toBeInTheDocument();
+    expect(joinedDates.length).toBe(3);
   });
 
   it("shows org name in subtitle", () => {
     render(<MembersPage />, { wrapper });
 
     expect(screen.getByText("Test Org")).toBeInTheDocument();
+  });
+
+  describe("owner viewer", () => {
+    it("can change any member's role and offers the Owner option", () => {
+      render(<MembersPage />, { wrapper });
+
+      // Non-self admin + member cards render role dropdowns (2 comboboxes).
+      const comboboxes = screen.getAllByRole("combobox");
+      expect(comboboxes.length).toBe(2);
+      // Owner promotion is available to an owner viewer.
+      expect(screen.getAllByText("Owner").length).toBeGreaterThan(0);
+    });
+
+    it("shows remove buttons for other members", () => {
+      render(<MembersPage />, { wrapper });
+
+      // Owner may remove the admin and the member (not self).
+      expect(screen.getAllByTitle("Remove member").length).toBe(2);
+    });
+  });
+
+  describe("admin viewer", () => {
+    beforeEach(() => {
+      // Viewer is the admin (user-3).
+      mockUseAuth.mockReturnValue({ user: { id: "user-3" }, requiresAuth: true });
+      mockUseOrg.mockReturnValue(orgMock("admin"));
+    });
+
+    it("cannot demote the owner: shows a badge, not a dropdown", () => {
+      render(<MembersPage />, { wrapper });
+
+      const ownerCard = cardFor("Owner User");
+      // Owner card renders a role badge, never a role combobox for an admin.
+      expect(within(ownerCard).queryByRole("combobox")).not.toBeInTheDocument();
+      expect(within(ownerCard).getByText("Owner")).toBeInTheDocument();
+    });
+
+    it("never shows any remove controls (owners-only)", () => {
+      render(<MembersPage />, { wrapper });
+
+      expect(screen.queryByTitle("Remove member")).not.toBeInTheDocument();
+    });
+
+    it("can re-role a non-owner member but is not offered the Owner option", () => {
+      render(<MembersPage />, { wrapper });
+
+      const memberCard = cardFor("Regular Member");
+      const combobox = within(memberCard).getByRole("combobox");
+      expect(combobox).toBeInTheDocument();
+      // The Owner option must not be present for an admin viewer.
+      expect(within(memberCard).queryByText("Owner")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("member viewer", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({ user: { id: "user-2" }, requiresAuth: true });
+      mockUseOrg.mockReturnValue(orgMock("member"));
+    });
+
+    it("shows only badges and no management controls", () => {
+      render(<MembersPage />, { wrapper });
+
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+      expect(screen.queryByTitle("Remove member")).not.toBeInTheDocument();
+      // Role badges are still rendered.
+      const ownerCard = cardFor("Owner User");
+      expect(within(ownerCard).getByText("Owner")).toBeInTheDocument();
+    });
+  });
+
+  describe("mutation error surfacing", () => {
+    it("renders a visible inline error when removing a member fails", () => {
+      mockUseRemoveMember.mockReturnValue({
+        mutateAsync: jest.fn(),
+        isPending: false,
+        isError: true,
+        error: new Error("Only owners can remove members"),
+      });
+
+      render(<MembersPage />, { wrapper });
+
+      expect(screen.getAllByText("Only owners can remove members").length).toBeGreaterThan(0);
+    });
+
+    it("renders a visible inline error when a role change fails", () => {
+      mockUseUpdateMemberRole.mockReturnValue({
+        mutateAsync: jest.fn(),
+        isPending: false,
+        isError: true,
+        error: new Error("Only owners can change owner roles"),
+      });
+
+      render(<MembersPage />, { wrapper });
+
+      expect(screen.getAllByText("Only owners can change owner roles").length).toBeGreaterThan(0);
+    });
   });
 });

--- a/apps/ui/src/app/(main)/settings/members/page.tsx
+++ b/apps/ui/src/app/(main)/settings/members/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Notice, NoticeDescription } from "@/components/ui/notice";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -71,29 +72,48 @@ const ROLE_BADGE_VARIANT: Record<OrgRole, "default" | "secondary" | "outline"> =
   member: "outline",
 };
 
+/** Extract a human-facing message from a mutation error (ApiError carries the
+ *  backend 403/400 message), falling back to a generic string. */
+function mutationErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
 function MemberCard({
   member,
   currentUserId,
-  canManage,
-  isOwner,
+  viewerIsAdmin,
+  viewerIsOwner,
 }: {
   member: OrgMember;
   currentUserId: string;
-  canManage: boolean;
-  isOwner: boolean;
+  /** Viewer has admin (or higher) role in the current org. */
+  viewerIsAdmin: boolean;
+  /** Viewer has owner role in the current org. */
+  viewerIsOwner: boolean;
 }) {
   const updateRole = useUpdateMemberRole();
   const removeMember = useRemoveMember();
   const [pendingRole, setPendingRole] = useState<string | null>(null);
   const isSelf = member.user_id === currentUserId;
+  const targetIsOwner = member.role === "owner";
   const RoleIcon = ROLE_ICONS[member.role];
+
+  // Mirror backend owner/admin rules (crates/server/src/api/organizations.rs):
+  // - Changing any role that involves an owner (target is owner, or promoting
+  //   to owner) requires the viewer to be an owner. Admins may only re-role
+  //   non-owner members between admin/member.
+  // - Removing another member requires the viewer to be an owner; admins and
+  //   members cannot remove others. Self-removal is not offered here.
+  const canChangeRole = viewerIsAdmin && !isSelf && (viewerIsOwner || !targetIsOwner);
+  const canRemove = viewerIsOwner && !isSelf;
 
   const handleRoleChange = async (newRole: string) => {
     setPendingRole(newRole);
     try {
       await updateRole.mutateAsync({ userId: member.user_id, role: newRole as OrgRole });
     } catch {
-      // Error handled by mutation
+      // Surfaced inline below via updateRole.error
     } finally {
       setPendingRole(null);
     }
@@ -104,76 +124,93 @@ function MemberCard({
     try {
       await removeMember.mutateAsync(member.user_id);
     } catch {
-      // Error handled by mutation
+      // Surfaced inline below via removeMember.error
     }
   };
 
-  return (
-    <div className="flex items-center justify-between p-4 border">
-      <div className="flex items-center gap-4">
-        <Avatar className="h-10 w-10">
-          {member.avatar_url && <AvatarImage src={member.avatar_url} alt={member.name} />}
-          <AvatarFallback>{getInitials(member.name)}</AvatarFallback>
-        </Avatar>
-        <div>
-          <div className="font-medium flex items-center gap-2">
-            {member.name}
-            {isSelf && (
-              <Badge variant="outline" className="text-xs">
-                You
-              </Badge>
-            )}
-          </div>
-          <div className="text-sm text-muted-foreground">{member.email}</div>
-        </div>
-      </div>
-      <div className="flex items-center gap-3">
-        <span className="text-xs text-muted-foreground hidden sm:inline">
-          Joined {formatDate(member.joined_at)}
-        </span>
+  const errorMessage = removeMember.isError
+    ? mutationErrorMessage(removeMember.error, "Failed to remove member.")
+    : updateRole.isError
+      ? mutationErrorMessage(updateRole.error, "Failed to update member role.")
+      : null;
 
-        {canManage && !isSelf ? (
-          <Select
-            value={pendingRole ?? member.role}
-            onValueChange={handleRoleChange}
-            disabled={updateRole.isPending}
-          >
-            <SelectTrigger className="w-[120px]">
-              {updateRole.isPending ? (
+  return (
+    <div className="border">
+      <div className="flex items-center justify-between p-4">
+        <div className="flex items-center gap-4">
+          <Avatar className="h-10 w-10">
+            {member.avatar_url && <AvatarImage src={member.avatar_url} alt={member.name} />}
+            <AvatarFallback>{getInitials(member.name)}</AvatarFallback>
+          </Avatar>
+          <div>
+            <div className="font-medium flex items-center gap-2">
+              {member.name}
+              {isSelf && (
+                <Badge variant="outline" className="text-xs">
+                  You
+                </Badge>
+              )}
+            </div>
+            <div className="text-sm text-muted-foreground">{member.email}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-muted-foreground hidden sm:inline">
+            Joined {formatDate(member.joined_at)}
+          </span>
+
+          {canChangeRole ? (
+            <Select
+              value={pendingRole ?? member.role}
+              onValueChange={handleRoleChange}
+              disabled={updateRole.isPending}
+            >
+              <SelectTrigger className="w-[120px]">
+                {updateRole.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <SelectValue>{ROLE_LABELS[(pendingRole ?? member.role) as OrgRole]}</SelectValue>
+                )}
+              </SelectTrigger>
+              <SelectContent>
+                {/* Only owners can promote to owner. */}
+                {viewerIsOwner && <SelectItem value="owner">Owner</SelectItem>}
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="member">Member</SelectItem>
+              </SelectContent>
+            </Select>
+          ) : (
+            <Badge variant={ROLE_BADGE_VARIANT[member.role]} className="gap-1">
+              <RoleIcon className="h-3 w-3" />
+              {ROLE_LABELS[member.role]}
+            </Badge>
+          )}
+
+          {canRemove && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleRemove}
+              disabled={removeMember.isPending}
+              title="Remove member"
+            >
+              {removeMember.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                <SelectValue>{ROLE_LABELS[(pendingRole ?? member.role) as OrgRole]}</SelectValue>
+                <UserMinus className="h-4 w-4 text-muted-foreground" />
               )}
-            </SelectTrigger>
-            <SelectContent>
-              {isOwner && <SelectItem value="owner">Owner</SelectItem>}
-              <SelectItem value="admin">Admin</SelectItem>
-              <SelectItem value="member">Member</SelectItem>
-            </SelectContent>
-          </Select>
-        ) : (
-          <Badge variant={ROLE_BADGE_VARIANT[member.role]} className="gap-1">
-            <RoleIcon className="h-3 w-3" />
-            {ROLE_LABELS[member.role]}
-          </Badge>
-        )}
-
-        {canManage && !isSelf && (
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleRemove}
-            disabled={removeMember.isPending}
-            title="Remove member"
-          >
-            {removeMember.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <UserMinus className="h-4 w-4 text-muted-foreground" />
-            )}
-          </Button>
-        )}
+            </Button>
+          )}
+        </div>
       </div>
+
+      {errorMessage && (
+        <div className="px-4 pb-4">
+          <Notice variant="destructive" role="alert">
+            <NoticeDescription>{errorMessage}</NoticeDescription>
+          </Notice>
+        </div>
+      )}
     </div>
   );
 }
@@ -334,8 +371,8 @@ export default function MembersPage() {
                   key={member.user_id}
                   member={member}
                   currentUserId={currentUserId}
-                  canManage={canManage}
-                  isOwner={isOwner}
+                  viewerIsAdmin={canManage}
+                  viewerIsOwner={isOwner}
                 />
               ))}
             </div>


### PR DESCRIPTION
## What changed
On `/settings/members`, member management controls now mirror the backend's owner/admin rules per target member and per action, instead of gating everything on a single `hasRole("admin")` check:

- The role selector is shown only when the viewer may actually change that member's role. Admins no longer see an owner's role selector (owner demotion) and are no longer offered the "Owner" option (owner promotion) — both are owner-only on the backend. Admins can still re-role non-owner members between Admin/Member.
- The Remove button is shown only to owners for other members, matching the backend rule that only owners can remove other users. Admins and members no longer see remove controls they cannot use.
- Failed role-change and remove mutations now surface a visible inline `Notice` (destructive) carrying the backend message, instead of being silently swallowed.

## Why
Admins were shown controls the backend reserves for owners. Prohibited role changes silently reverted (the backend returns 403 for `PATCH`/`DELETE` on `/v1/orgs/<org>/members/<owner>`), and mutation failures rendered no feedback — a confusing, misleading affordance (EVE-718).

## Before / After
- **Before:** Admin viewing the owner sees a role dropdown offering Admin/Member and a Remove button; selecting either silently reverts with no message.
- **After:** Admin sees the owner's role as a read-only badge with no Remove button; non-owner members show a dropdown without the Owner option; any failed mutation renders an inline error Notice with the server message.

Verified via unit tests: owner/admin/member viewers each assert the correct controls, plus two tests asserting inline errors render on failed remove / role-change mutations. Full UI suite: 125 suites / 1112 tests green; lint, typecheck, and format clean.

## Risk
- Low
- Only affects control visibility and error display on the members settings page; backend enforcement is unchanged and remains the source of truth.

## Security
- Threat categories reviewed: TM-WEB / authorization-UI. This is defense-in-depth UI gating that mirrors server-side checks in `crates/server/src/api/organizations.rs` (`update_member_role`, `remove_member`); the backend continues to enforce all rules, so hiding controls cannot be bypassed for actual mutations.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)