### PR TITLE
fix(auth): return fresh user name after profile updates

### DIFF
--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -270,10 +270,15 @@ impl BuiltinAuthBackend {
         })?;
         let is_platform_user = platform_user_from_roles(&roles);
 
+        // EVE-715: derive identity fields (name, email) from the freshly-loaded DB
+        // user row rather than the JWT claims. Profile updates write the DB but do
+        // not mint a new token, so claim-sourced values go stale until re-login.
+        // The PAT and caller-resolution paths already read fresh; this keeps the
+        // JWT/MCP paths consistent (and complements EVE-703's DB-sourced roles).
         Ok(AuthUser {
             id: user_id,
-            email: claims.email,
-            name: claims.name,
+            email: user.email,
+            name: user.name,
             roles,
             is_platform_user,
             auth_method,
@@ -793,6 +798,112 @@ mod tests {
             assert!(
                 !user.is_platform_user,
                 "MCP platform access must be derived from DB roles, not JWT roles"
+            );
+        }
+    }
+
+    // EVE-715: profile-name updates must surface on the next request within the
+    // same access-token session. `/v1/auth/me` builds `UserInfoResponse.name` from
+    // `AuthUser.name`, which comes from `auth_user_from_claims`. Because profile
+    // updates write the DB but do not mint a new token, the name must be sourced
+    // from the freshly-loaded DB user row, not the (now stale) JWT claim.
+    mod jwt_fresh_profile_name {
+        use super::super::super::backend::AuthBackend;
+        use super::super::*;
+        use crate::storage::StorageBackend;
+        use crate::storage::models::{CreateUserRow, UpdateUser};
+
+        const MCP_RESOURCE: &str = "https://app.example.com/mcp";
+
+        async fn backend_with_named_user(name: &str) -> (BuiltinAuthBackend, uuid::Uuid) {
+            let db = Arc::new(StorageBackend::in_memory());
+            let backend = BuiltinAuthBackend::new(
+                AuthConfig::default(),
+                db.clone(),
+                Arc::new(crate::platform::oss_platform_definition()),
+            );
+            let user = db
+                .create_user(CreateUserRow {
+                    email: "profile@example.com".to_string(),
+                    name: name.to_string(),
+                    avatar_url: None,
+                    roles: vec!["user".to_string()],
+                    password_hash: None,
+                    email_verified: true,
+                    auth_provider: None,
+                    auth_provider_id: None,
+                    external_id: None,
+                })
+                .await
+                .expect("create user");
+            (backend, user.id)
+        }
+
+        #[tokio::test]
+        async fn access_token_reflects_db_name_after_profile_update() {
+            let (backend, user_id) = backend_with_named_user("Original Name").await;
+            // Token minted with the original name; a profile rename does not reissue it.
+            let token = backend
+                .jwt_service
+                .generate_access_token(user_id, "profile@example.com", "Original Name", &[])
+                .expect("generate token");
+
+            let before = backend.validate_token(&token).await.expect("validate");
+            assert_eq!(before.name, "Original Name");
+
+            backend
+                .db
+                .update_user(
+                    user_id,
+                    UpdateUser {
+                        name: Some("Updated Name".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("rename user");
+
+            // Same access token, next request: name must reflect the DB write.
+            let after = backend.validate_token(&token).await.expect("validate");
+            assert_eq!(
+                after.name, "Updated Name",
+                "auth_user_from_claims must source name from the fresh DB user row"
+            );
+        }
+
+        #[tokio::test]
+        async fn mcp_token_reflects_db_name_after_profile_update() {
+            let (backend, user_id) = backend_with_named_user("Original Name").await;
+            let token = backend
+                .jwt_service
+                .generate_mcp_access_token(
+                    user_id,
+                    "profile@example.com",
+                    "Original Name",
+                    &[],
+                    MCP_RESOURCE,
+                )
+                .expect("generate mcp token");
+
+            backend
+                .db
+                .update_user(
+                    user_id,
+                    UpdateUser {
+                        name: Some("Updated Name".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("rename user");
+
+            let after = backend
+                .validate_mcp_token(&token, MCP_RESOURCE)
+                .await
+                .expect("validate mcp");
+            assert_eq!(
+                after.name, "Updated Name",
+                "MCP path must also source name from the fresh DB user row"
             );
         }
     }

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -575,6 +575,8 @@ See `crates/server/src/auth/backend.rs` for the `AuthBackend` trait. Key methods
 
 See `crates/server/src/auth/builtin.rs`. Wraps JWT + password + personal access token logic. Auth route handlers use `BuiltinAuthBackend` as axum state directly with `FromRef<BuiltinAuthBackend> for AuthState`.
 
+Token validation is a fresh-state boundary: `auth_user_from_claims` reloads the subject's DB user row (already required to reject deleted subjects) and derives the resolved identity — `name`, `email`, `roles`, and `is_platform_user` — from that row, not from the JWT claim payload. JWT claims still carry these fields for the token's lifetime, but they never drive request-time authorization or the profile shown by `/v1/auth/me`. So a profile rename (or role/email change) surfaces on the next request within the same access-token session, with no re-login and no token reissue (roles: EVE-703; name/email: EVE-715). The personal-access-token path reads the same DB row per request for the same reason.
+
 ### AuthState
 
 `AuthState` holds `Arc<dyn AuthBackend>`. The `extract_auth_user()` middleware delegates to `backend.validate_token()` and `backend.validate_personal_access_token()`. OSS convenience: `AuthState::builtin(config, db)`.


### PR DESCRIPTION
## What changed
`auth_user_from_claims` now sources the user's `name` and `email` from the freshly-loaded database user row instead of the JWT claims. The row is already loaded in this function (EVE-703 introduced it to derive `roles`/`is_platform_user` fresh); this extends the same freshness to the remaining identity fields.

## Why
A profile-name update writes the database but does not mint a new access token, so `GET /v1/auth/me` — which builds `UserInfoResponse.name` from `AuthUser.name` — kept returning the stale claim-sourced name until the user signed out and back in. This is the functional-identity counterpart of EVE-703 (stale roles from JWT claims). Sourcing name/email from the DB row makes the JWT and MCP paths consistent with the PAT and caller-resolution paths, which already read fresh. (Fixes EVE-715)

## Before / After
- **Before:** After renaming the profile, `/v1/auth/me` returns the old name from the JWT claim until re-login.
- **After:** `/v1/auth/me` reflects the database-backed current name on the next request within the same access-token session.

Evidence: two new regression tests assert that, after `update_user(name=...)`, validating the same unchanged access token (and MCP token) returns the updated name:
- `jwt_fresh_profile_name::access_token_reflects_db_name_after_profile_update`
- `jwt_fresh_profile_name::mcp_token_reflects_db_name_after_profile_update`

## Risk
- Low. Narrow change at one function; name/email now follow the DB (the same source already used for roles). No schema or API-shape change.

## Security
- Threat categories reviewed: TM-AUTH (identity freshness). Strengthens revocation/consistency posture alongside EVE-703; no new input-trust, injection, or authorization surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)