### PR TITLE
feat(llm): add speed selector mapped to OpenAI service_tier

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1803,6 +1803,7 @@ impl AnthropicModelInfo {
             limits,
             modalities,
             reasoning_effort,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,

--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -21,6 +21,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/anthropic/tests/parallel_tool_calls_live.rs
+++ b/crates/anthropic/tests/parallel_tool_calls_live.rs
@@ -42,6 +42,7 @@ fn tool(name: &str, description: &str) -> ToolDefinition {
 
 fn config_with(parallel: Option<bool>) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: LIVE_MODEL.to_string(),
         temperature: Some(0.0),
         max_tokens: Some(1024),

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1328,6 +1328,35 @@ impl ReasonAtom {
             }
         });
 
+        // Resolve the speed (service tier) from the latest user message's
+        // `controls.speed`, gated the same way: a model whose profile has no
+        // speed config never gets a `service_tier` (sending flex/priority to
+        // an unsupported model is a 400). Unknown models pass through — let
+        // the API decide.
+        let speed = messages
+            .iter()
+            .rev()
+            .find(|m| m.role == MessageRole::User)
+            .and_then(|m| m.controls.as_ref())
+            .and_then(|c| c.speed.clone())
+            .filter(|speed| {
+                let profile = crate::model_profiles::get_model_profile(
+                    &model_with_provider.provider_type,
+                    &model_with_provider.model,
+                );
+                match profile {
+                    Some(p) if p.speed.is_none() => {
+                        tracing::warn!(
+                            model = %model_with_provider.model,
+                            speed = %speed,
+                            "Stripping speed: model does not support service tiers"
+                        );
+                        false
+                    }
+                    _ => true,
+                }
+            });
+
         // 9. Check for an in-flight partial assistant stream from a previous worker (EVE-532).
         // If found, apply the ContinuePartial recovery policy: finalize from accumulated
         // text (if non-empty) or restart clean (if empty/usable partial only).
@@ -1494,6 +1523,9 @@ impl ReasonAtom {
         let mut llm_config_builder = LlmCallConfigBuilder::from(&runtime_agent);
         if let Some(effort) = reasoning_effort.clone() {
             llm_config_builder = llm_config_builder.reasoning_effort(effort);
+        }
+        if let Some(speed) = speed {
+            llm_config_builder = llm_config_builder.speed(speed);
         }
 
         // Inject embedder metadata first; system keys added below take precedence
@@ -2019,6 +2051,7 @@ impl ReasonAtom {
                             ];
 
                             let summary_config = crate::driver_registry::LlmCallConfig {
+                                speed: None,
                                 model: config
                                     .summarization
                                     .model
@@ -3600,6 +3633,7 @@ mod tests {
     #[test]
     fn test_build_request_options_for_openai_prompt_cache() {
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.4".to_string(),
             temperature: None,
             max_tokens: None,
@@ -3634,6 +3668,7 @@ mod tests {
     #[test]
     fn test_build_request_options_for_gemini_explicit_cache() {
         let config = LlmCallConfig {
+            speed: None,
             model: "gemini-2.5-pro".to_string(),
             temperature: None,
             max_tokens: None,
@@ -3668,6 +3703,7 @@ mod tests {
     #[test]
     fn test_build_request_options_omits_gemini_cache_flag_when_disabled() {
         let config = LlmCallConfig {
+            speed: None,
             model: "gemini-2.5-pro".to_string(),
             temperature: None,
             max_tokens: None,

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -1173,6 +1173,10 @@ pub struct LlmCallConfig {
     pub tools: Vec<ToolDefinition>,
     /// Reasoning effort level (for models that support it: low, medium, high)
     pub reasoning_effort: Option<String>,
+    /// Speed (service tier) for this call: "flex", "default", or "priority".
+    /// Serialized as OpenAI `service_tier`; omitted when `None` so the
+    /// provider keeps its default ("auto") routing.
+    pub speed: Option<String>,
     /// Metadata to send with the API request for tracking and debugging.
     /// Keys and values are strings. Both OpenAI and Anthropic support metadata fields.
     /// Typically includes: session_id, agent_id, org_id, turn_id, exec_id.
@@ -1232,6 +1236,7 @@ impl From<&RuntimeAgent> for LlmCallConfig {
             max_tokens: runtime_agent.max_tokens,
             tools: runtime_agent.tools.clone(),
             reasoning_effort: None, // Set by ReasonAtom from user message controls
+            speed: None,            // Set by ReasonAtom from user message controls
             metadata: HashMap::new(), // Set by ReasonAtom with session/agent context
             previous_response_id: None,
             tool_search: runtime_agent.tool_search.clone(),
@@ -1288,6 +1293,12 @@ impl LlmCallConfigBuilder {
     /// Set reasoning effort level (for models that support it: low, medium, high)
     pub fn reasoning_effort(mut self, effort: impl Into<String>) -> Self {
         self.config.reasoning_effort = Some(effort.into());
+        self
+    }
+
+    /// Set speed (service tier): "flex", "default", or "priority"
+    pub fn speed(mut self, speed: impl Into<String>) -> Self {
+        self.config.speed = Some(speed.into());
         self
     }
 

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -995,6 +995,7 @@ mod tests {
 
     fn make_config() -> LlmCallConfig {
         LlmCallConfig {
+            speed: None,
             model: "test-model".to_string(),
             temperature: None,
             max_tokens: None,

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -203,6 +203,12 @@ pub struct Controls {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
 
+    /// Speed (service tier) for this message turn: "flex", "default", or
+    /// "priority". Only sent to providers whose model profile advertises a
+    /// speed config (OpenAI `service_tier`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<String>,
+
     /// Error disclosure override for this turn: "generic", "standard", or
     /// "detailed". Clamped to at most the mode allowed by the agent's
     /// `error_disclosure` capability (capability absent => "standard"), so a

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -249,6 +249,40 @@ pub struct ReasoningEffortConfig {
     pub default: ReasoningEffort,
 }
 
+/// Speed level for models that expose a latency/price service tier.
+/// Wire values map 1:1 to the OpenAI `service_tier` request parameter:
+/// `flex` (slower, cheaper), `default` (standard), `priority` (faster,
+/// premium). `auto` is deliberately not offered — omitting the field
+/// preserves the provider's default routing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Speed {
+    Flex,
+    Default,
+    Priority,
+}
+
+/// Named speed value for UI display
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct SpeedValue {
+    /// The API value (e.g., "flex", "priority")
+    pub value: Speed,
+    /// Display name (e.g., "Flex", "Fast")
+    pub name: String,
+}
+
+/// Speed configuration for a model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct SpeedConfig {
+    /// Available speed values for this model
+    pub values: Vec<SpeedValue>,
+    /// Default speed for this model
+    pub default: Speed,
+}
+
 /// Vendor / brand that authored a model. Independent of the provider type
 /// that serves it (the same model may be offered by several providers or
 /// gateways). Primarily drives UI iconography.
@@ -339,6 +373,10 @@ pub struct ModelProfile {
     /// Reasoning effort configuration (for reasoning models)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffortConfig>,
+    /// Speed (service tier) configuration, for models served with
+    /// selectable latency/price tiers (OpenAI `service_tier`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<SpeedConfig>,
     /// Whether the model supports tool_search (deferred tool loading).
     /// When true, the driver can use namespaces and defer_loading to reduce
     /// token usage for large tool sets. Currently supported by GPT-5.4 and newer.

--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -17,7 +17,8 @@
 use crate::driver_registry::ServiceKind;
 use crate::model::{
     CostTier, DriverId, Modality, ModelCost, ModelLimits, ModelModalities, ModelProfile,
-    ModelVendor, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
+    ModelVendor, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue, Speed, SpeedConfig,
+    SpeedValue,
 };
 
 // Helper functions for creating reasoning effort configurations
@@ -161,6 +162,59 @@ fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
             effort(ReasoningEffort::Xhigh, "Max"),
         ],
         default: ReasoningEffort::High,
+    }
+}
+
+// Helper functions for creating speed (service tier) configurations.
+//
+// Availability is sourced from the tier tables on the official pricing page
+// (developers.openai.com/api/docs/pricing): a model gets a speed config only
+// when it has a Flex and/or Priority pricing row. Codex-family, chat-latest,
+// and deep-research models have no tier rows and therefore no speed config.
+// Display names follow Codex's speed selector ("Fast" for priority).
+
+fn speed(value: Speed, name: &str) -> SpeedValue {
+    SpeedValue {
+        value,
+        name: name.into(),
+    }
+}
+
+/// Speed for models with both flex and priority pricing rows
+/// (gpt-5, gpt-5-mini, gpt-5.1, gpt-5.2, gpt-5.4, gpt-5.4-mini, gpt-5.5,
+/// gpt-5.6 series, o3, o4-mini).
+fn speed_flex_priority() -> SpeedConfig {
+    SpeedConfig {
+        values: vec![
+            speed(Speed::Flex, "Flex"),
+            speed(Speed::Default, "Standard"),
+            speed(Speed::Priority, "Fast"),
+        ],
+        default: Speed::Default,
+    }
+}
+
+/// Speed for models with only a flex pricing row
+/// (gpt-5-nano, gpt-5.4-nano, gpt-5.4-pro, gpt-5.5-pro).
+fn speed_flex_only() -> SpeedConfig {
+    SpeedConfig {
+        values: vec![
+            speed(Speed::Flex, "Flex"),
+            speed(Speed::Default, "Standard"),
+        ],
+        default: Speed::Default,
+    }
+}
+
+/// Speed for models with only a priority pricing row
+/// (gpt-4o, gpt-4o-mini, gpt-4.1 family).
+fn speed_priority_only() -> SpeedConfig {
+    SpeedConfig {
+        values: vec![
+            speed(Speed::Default, "Standard"),
+            speed(Speed::Priority, "Fast"),
+        ],
+        default: Speed::Default,
     }
 }
 
@@ -423,6 +477,12 @@ pub fn get_model_profile(provider_type: &DriverId, model_id: &str) -> Option<Mod
     if !matches!(provider_type, DriverId::OpenAI | DriverId::Anthropic) {
         profile.tool_search = false;
     }
+    // Speed (service tier) is an OpenAI-platform billing feature. Azure has
+    // its own capacity model and gateways (OpenRouter) do their own routing,
+    // so only the first-party OpenAI surface keeps the selector.
+    if !matches!(provider_type, DriverId::OpenAI) {
+        profile.speed = None;
+    }
     Some(profile)
 }
 
@@ -533,6 +593,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text, Modality::Audio],
             }),
             reasoning_effort: Some(reasoning_effort_realtime()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -568,6 +629,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text, Modality::Audio],
             }),
             reasoning_effort: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -603,6 +665,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -638,6 +701,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -673,6 +737,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -708,6 +773,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -743,6 +809,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -778,6 +845,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: Some(speed_flex_priority()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -813,6 +881,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -848,6 +917,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: Some(speed_flex_priority()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -884,6 +954,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -919,6 +990,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -954,6 +1026,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -991,6 +1064,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            speed: Some(speed_flex_priority()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1026,6 +1100,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            speed: Some(speed_flex_priority()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1061,6 +1136,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            speed: Some(speed_flex_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1096,6 +1172,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1131,6 +1208,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1167,6 +1245,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            speed: Some(speed_flex_priority()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1202,6 +1281,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1237,6 +1317,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1273,6 +1354,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1309,6 +1391,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: Some(speed_flex_priority()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1344,6 +1427,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1379,6 +1463,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1415,6 +1500,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1465,6 +1551,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
+            speed: Some(speed_flex_priority()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1505,6 +1592,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
+            speed: Some(speed_flex_priority()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1545,6 +1633,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
+            speed: Some(speed_flex_priority()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1585,6 +1674,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
+            speed: Some(speed_flex_priority()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1620,6 +1710,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
+            speed: Some(speed_flex_only()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1663,6 +1754,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: Some(speed_flex_priority()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1698,6 +1790,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: Some(speed_flex_priority()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1733,6 +1826,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: Some(speed_flex_only()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1773,6 +1867,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
+            speed: Some(speed_flex_only()),
             tool_search: true,
             supported_parameters: Vec::new(),
             supports_phases: true,
@@ -1809,6 +1904,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1844,6 +1940,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1879,6 +1976,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1915,6 +2013,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1950,6 +2049,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1985,6 +2085,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2040,6 +2141,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2077,6 +2179,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2108,6 +2211,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2141,6 +2245,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2178,6 +2283,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2215,6 +2321,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2257,6 +2364,7 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2364,6 +2472,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2406,6 +2515,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2446,6 +2556,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2483,6 +2594,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2543,6 +2655,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2578,6 +2691,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2614,6 +2728,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2649,6 +2764,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2684,6 +2800,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2720,6 +2837,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2756,6 +2874,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2791,6 +2910,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2827,6 +2947,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2863,6 +2984,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2898,6 +3020,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2933,6 +3056,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -2968,6 +3092,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3003,6 +3128,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3060,6 +3186,7 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3100,6 +3227,7 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3140,6 +3268,7 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3180,6 +3309,7 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text, Modality::Image],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3220,6 +3350,7 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3260,6 +3391,7 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3303,6 +3435,7 @@ fn llmsim_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()), // Same as GPT-5.2
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3484,6 +3617,28 @@ mod tests {
                     effort.default
                 );
             }
+
+            if let Some(speed) = &p.speed {
+                assert!(!speed.values.is_empty(), "{id}: empty speed set");
+                let mut seen: Vec<&Speed> = Vec::new();
+                for v in &speed.values {
+                    assert!(
+                        !v.name.trim().is_empty(),
+                        "{id}: speed value with empty display name"
+                    );
+                    assert!(
+                        !seen.contains(&&v.value),
+                        "{id}: duplicate speed value {:?}",
+                        v.value
+                    );
+                    seen.push(&v.value);
+                }
+                assert!(
+                    speed.values.iter().any(|v| v.value == speed.default),
+                    "{id}: speed default {:?} is not among its values",
+                    speed.default
+                );
+            }
         }
     }
 
@@ -3595,6 +3750,62 @@ mod tests {
         let profile = get_model_profile(&DriverId::AzureOpenAI, "gpt-4o");
         assert!(profile.is_some());
         assert_eq!(profile.unwrap().name, "GPT-4o");
+    }
+
+    // Speed (service tier) availability follows the tier tables on the
+    // official pricing page; see the speed_* helper docs.
+
+    #[test]
+    fn test_speed_config_matches_pricing_tiers() {
+        let speeds = |model: &str| -> Vec<Speed> {
+            get_model_profile(&DriverId::OpenAI, model)
+                .unwrap()
+                .speed
+                .map(|s| s.values.into_iter().map(|v| v.value).collect())
+                .unwrap_or_default()
+        };
+        use Speed::*;
+        // Flex + priority pricing rows.
+        for model in ["gpt-5.2", "gpt-5.6-sol", "gpt-5.4", "o3", "o4-mini"] {
+            assert_eq!(speeds(model), vec![Flex, Default, Priority], "{model}");
+        }
+        // Flex-only pricing rows.
+        for model in ["gpt-5-nano", "gpt-5.4-pro", "gpt-5.5-pro"] {
+            assert_eq!(speeds(model), vec![Flex, Default], "{model}");
+        }
+        // Priority-only pricing rows (legacy priority launch set).
+        for model in ["gpt-4o", "gpt-4.1"] {
+            assert_eq!(speeds(model), vec![Default, Priority], "{model}");
+        }
+        // No tier rows: codex family, chat-latest, most pro/o1 models.
+        for model in ["gpt-5.2-codex", "gpt-5-chat-latest", "gpt-5-pro", "o1"] {
+            assert_eq!(speeds(model), vec![], "{model}");
+        }
+    }
+
+    #[test]
+    fn test_speed_masked_for_non_openai_surfaces() {
+        assert!(
+            get_model_profile(&DriverId::OpenAI, "gpt-5.2")
+                .unwrap()
+                .speed
+                .is_some()
+        );
+        // Service tiers are OpenAI-platform billing; other surfaces reaching
+        // the same model must not advertise the selector.
+        for provider in [
+            DriverId::AzureOpenAI,
+            DriverId::OpenRouter,
+            DriverId::OpenAICompletions,
+        ] {
+            assert!(
+                get_model_profile(&provider, "gpt-5.2")
+                    .unwrap()
+                    .speed
+                    .is_none(),
+                "{provider:?}"
+            );
+        }
     }
 
     // GPT-5 model tests

--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -167,11 +167,12 @@ fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
 
 // Helper functions for creating speed (service tier) configurations.
 //
-// Availability is sourced from the tier tables on the official pricing page
-// (developers.openai.com/api/docs/pricing): a model gets a speed config only
-// when it has a Flex and/or Priority pricing row. Codex-family, chat-latest,
-// and deep-research models have no tier rows and therefore no speed config.
-// Display names follow Codex's speed selector ("Fast" for priority).
+// Availability is sourced from OpenAI's official tier tables: the API pricing
+// page for Flex, the Priority processing page for first-party priority models,
+// and the specialized pricing table for Codex priority. A model gets a speed
+// config only when it has a Flex and/or Priority row. Chat-latest,
+// deep-research, and unlisted variants have no speed config. Display names
+// follow Codex's speed selector ("Fast" for priority).
 
 fn speed(value: Speed, name: &str) -> SpeedValue {
     SpeedValue {
@@ -181,8 +182,7 @@ fn speed(value: Speed, name: &str) -> SpeedValue {
 }
 
 /// Speed for models with both flex and priority pricing rows
-/// (gpt-5, gpt-5-mini, gpt-5.1, gpt-5.2, gpt-5.4, gpt-5.4-mini, gpt-5.5,
-/// gpt-5.6 series, o3, o4-mini).
+/// (gpt-5.4, gpt-5.4-mini, gpt-5.5, gpt-5.6 series).
 fn speed_flex_priority() -> SpeedConfig {
     SpeedConfig {
         values: vec![
@@ -195,7 +195,7 @@ fn speed_flex_priority() -> SpeedConfig {
 }
 
 /// Speed for models with only a flex pricing row
-/// (gpt-5-nano, gpt-5.4-nano, gpt-5.4-pro, gpt-5.5-pro).
+/// (gpt-5.4-nano, gpt-5.4-pro, gpt-5.5-pro).
 fn speed_flex_only() -> SpeedConfig {
     SpeedConfig {
         values: vec![
@@ -207,7 +207,9 @@ fn speed_flex_only() -> SpeedConfig {
 }
 
 /// Speed for models with only a priority pricing row
-/// (gpt-4o, gpt-4o-mini, gpt-4.1 family).
+/// (gpt-4o, gpt-4o-mini, gpt-4.1 family, gpt-5/gpt-5-mini,
+/// gpt-5-codex, gpt-5.1/gpt-5.1-codex, gpt-5.2, gpt-5.3-codex,
+/// o3, o4-mini).
 fn speed_priority_only() -> SpeedConfig {
     SpeedConfig {
         values: vec![
@@ -845,7 +847,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
-            speed: Some(speed_flex_priority()),
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -917,7 +919,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
-            speed: Some(speed_flex_priority()),
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1064,7 +1066,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
-            speed: Some(speed_flex_priority()),
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1100,7 +1102,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
-            speed: Some(speed_flex_priority()),
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1136,7 +1138,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
-            speed: Some(speed_flex_only()),
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1208,7 +1210,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
-            speed: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1245,7 +1247,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
-            speed: Some(speed_flex_priority()),
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1281,7 +1283,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
-            speed: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1391,7 +1393,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
-            speed: Some(speed_flex_priority()),
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -1500,7 +1502,7 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
-            speed: None,
+            speed: Some(speed_priority_only()),
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,
@@ -3752,8 +3754,8 @@ mod tests {
         assert_eq!(profile.unwrap().name, "GPT-4o");
     }
 
-    // Speed (service tier) availability follows the tier tables on the
-    // official pricing page; see the speed_* helper docs.
+    // Speed (service tier) availability follows OpenAI's official tier tables;
+    // see the speed_* helper docs.
 
     #[test]
     fn test_speed_config_matches_pricing_tiers() {
@@ -3766,19 +3768,51 @@ mod tests {
         };
         use Speed::*;
         // Flex + priority pricing rows.
-        for model in ["gpt-5.2", "gpt-5.6-sol", "gpt-5.4", "o3", "o4-mini"] {
+        for model in [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+        ] {
             assert_eq!(speeds(model), vec![Flex, Default, Priority], "{model}");
         }
         // Flex-only pricing rows.
-        for model in ["gpt-5-nano", "gpt-5.4-pro", "gpt-5.5-pro"] {
+        for model in ["gpt-5.5-pro", "gpt-5.4-nano", "gpt-5.4-pro"] {
             assert_eq!(speeds(model), vec![Flex, Default], "{model}");
         }
-        // Priority-only pricing rows (legacy priority launch set).
-        for model in ["gpt-4o", "gpt-4.1"] {
+        // Priority-only pricing rows.
+        for model in [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4.1-nano",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-codex",
+            "gpt-5.1",
+            "gpt-5.1-codex",
+            "gpt-5.2",
+            "gpt-5.3-codex",
+            "o3",
+            "o4-mini",
+        ] {
             assert_eq!(speeds(model), vec![Default, Priority], "{model}");
         }
-        // No tier rows: codex family, chat-latest, most pro/o1 models.
-        for model in ["gpt-5.2-codex", "gpt-5-chat-latest", "gpt-5-pro", "o1"] {
+        // No tier rows: unlisted variants, chat-latest, deep research, and o1.
+        for model in [
+            "gpt-5-nano",
+            "gpt-5-pro",
+            "gpt-5.1-codex-mini",
+            "gpt-5.1-codex-max",
+            "gpt-5.2-pro",
+            "gpt-5.2-codex",
+            "gpt-5-chat-latest",
+            "o3-deep-research",
+            "o1",
+        ] {
             assert_eq!(speeds(model), vec![], "{model}");
         }
     }

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -543,6 +543,7 @@ impl ChatDriver for OpenAIProtocolChatDriver {
                 .as_ref()
                 .filter(|e| !e.eq_ignore_ascii_case("none"))
                 .cloned(),
+            service_tier: config.speed.clone(),
             metadata,
         };
 
@@ -835,6 +836,10 @@ struct OpenAiRequest {
     parallel_tool_calls: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<String>,
+    /// Speed selector: OpenAI service tier ("flex", "default", "priority").
+    /// Omitted when `None` so the provider keeps its default ("auto") routing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<String>,
     /// Metadata for tracking API usage (up to 16 key-value pairs).
     /// Useful for correlating requests with session_id, agent_id, org_id, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1135,6 +1140,7 @@ mod tests {
         // OpenAI streaming API requires stream_options.include_usage=true
         // to return token usage in the response
         let request = OpenAiRequest {
+            service_tier: None,
             model: "gpt-4o".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
@@ -1167,6 +1173,7 @@ mod tests {
         metadata.insert("agent_id".to_string(), "agent_xyz789".to_string());
 
         let request = OpenAiRequest {
+            service_tier: None,
             model: "gpt-4o".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
@@ -1467,6 +1474,7 @@ mod tests {
         // When reasoning_effort is "none", it should be filtered out
         // to avoid "Unrecognized request argument" errors on non-thinking models
         let request = OpenAiRequest {
+            service_tier: None,
             model: "gpt-4o-mini".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
@@ -1497,6 +1505,7 @@ mod tests {
     #[test]
     fn test_reasoning_effort_high_is_included() {
         let request = OpenAiRequest {
+            service_tier: None,
             model: "o3-mini".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
@@ -1528,6 +1537,7 @@ mod tests {
     fn test_request_serializes_parallel_tool_calls() {
         fn build(flag: Option<bool>) -> serde_json::Value {
             let request = OpenAiRequest {
+                service_tier: None,
                 model: "gpt-4o-mini".to_string(),
                 messages: vec![OpenAiMessage {
                     role: "user".to_string(),
@@ -1552,6 +1562,37 @@ mod tests {
         // Present and preserved for Some(_).
         assert_eq!(build(Some(true))["parallel_tool_calls"], true);
         assert_eq!(build(Some(false))["parallel_tool_calls"], false);
+    }
+
+    /// The speed selector serializes as `service_tier` only when set, so the
+    /// provider's default ("auto") routing applies when unset.
+    #[test]
+    fn test_request_serializes_service_tier() {
+        fn build(tier: Option<&str>) -> serde_json::Value {
+            let request = OpenAiRequest {
+                service_tier: tier.map(str::to_string),
+                model: "gpt-4o-mini".to_string(),
+                messages: vec![OpenAiMessage {
+                    role: "user".to_string(),
+                    content: Some(OpenAiContent::Text("Hello".to_string())),
+                    tool_calls: None,
+                    tool_call_id: None,
+                }],
+                temperature: None,
+                max_tokens: None,
+                stream: true,
+                stream_options: None,
+                tools: None,
+                parallel_tool_calls: None,
+                reasoning_effort: None,
+                metadata: None,
+            };
+            serde_json::to_value(&request).unwrap()
+        }
+
+        assert!(build(None).get("service_tier").is_none());
+        assert_eq!(build(Some("flex"))["service_tier"], "flex");
+        assert_eq!(build(Some("priority"))["service_tier"], "priority");
     }
 
     // ------------------------------------------------------------------

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -1071,6 +1071,7 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             prompt_cache_key,
             parallel_tool_calls: config
                 .resolved_parallel_tool_calls(self.supports_parallel_tool_calls(&config.model)),
+            service_tier: config.speed.clone(),
         };
 
         // Log request details for debugging LLM errors.
@@ -2032,6 +2033,10 @@ struct ResponsesRequest {
     /// `None` to preserve the provider default.
     #[serde(skip_serializing_if = "Option::is_none")]
     parallel_tool_calls: Option<bool>,
+    /// Speed selector: OpenAI service tier ("flex", "default", "priority").
+    /// Omitted when `None` so the provider keeps its default ("auto") routing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2166,6 +2171,7 @@ mod tests {
     #[test]
     fn test_request_serialization() {
         let request = ResponsesRequest {
+            service_tier: None,
             model: "gpt-4o".to_string(),
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
@@ -2195,6 +2201,7 @@ mod tests {
     #[test]
     fn test_request_with_reasoning() {
         let request = ResponsesRequest {
+            service_tier: None,
             model: "o3".to_string(),
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
@@ -2229,6 +2236,7 @@ mod tests {
         metadata.insert("agent_id".to_string(), "agent_xyz789".to_string());
 
         let request = ResponsesRequest {
+            service_tier: None,
             model: "gpt-4o".to_string(),
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
@@ -2258,6 +2266,7 @@ mod tests {
     #[test]
     fn test_request_serializes_parallel_tool_calls() {
         let make = |flag: Option<bool>| ResponsesRequest {
+            service_tier: None,
             model: "gpt-5.4".to_string(),
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
@@ -2290,11 +2299,47 @@ mod tests {
         assert_eq!(json["parallel_tool_calls"], false);
     }
 
+    /// The speed selector serializes as `service_tier` only when set,
+    /// preserving the provider's default ("auto") routing when `None`.
+    #[test]
+    fn test_request_serializes_service_tier() {
+        let make = |tier: Option<&str>| ResponsesRequest {
+            service_tier: tier.map(str::to_string),
+            model: "gpt-5.4".to_string(),
+            input: vec![ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("Hello".to_string()),
+                phase: None,
+            }],
+            instructions: None,
+            previous_response_id: None,
+            temperature: None,
+            max_output_tokens: None,
+            stream: true,
+            tools: None,
+            reasoning: None,
+            metadata: None,
+            prompt_cache_key: None,
+            parallel_tool_calls: None,
+        };
+
+        let json = serde_json::to_value(make(None)).unwrap();
+        assert!(json.get("service_tier").is_none());
+
+        let json = serde_json::to_value(make(Some("priority"))).unwrap();
+        assert_eq!(json["service_tier"], "priority");
+
+        let json = serde_json::to_value(make(Some("flex"))).unwrap();
+        assert_eq!(json["service_tier"], "flex");
+    }
+
     #[test]
     fn test_build_prompt_cache_key_when_enabled() {
         let mut metadata = std::collections::HashMap::new();
         metadata.insert("session_id".to_string(), "session_abc123".to_string());
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.4".to_string(),
             temperature: None,
             max_tokens: None,
@@ -2335,6 +2380,7 @@ mod tests {
         let mut metadata = std::collections::HashMap::new();
         metadata.insert("session_id".to_string(), "session_abc123".to_string());
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.4".to_string(),
             temperature: None,
             max_tokens: None,
@@ -2388,6 +2434,7 @@ mod tests {
         let mut second_metadata = std::collections::HashMap::new();
         second_metadata.insert("session_id".to_string(), "session_xyz789".to_string());
         let make_config = |metadata| LlmCallConfig {
+            speed: None,
             model: "gpt-5.4".to_string(),
             temperature: None,
             max_tokens: None,
@@ -2431,6 +2478,7 @@ mod tests {
     #[test]
     fn test_build_prompt_cache_key_stays_within_openai_limit() {
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.5".to_string(),
             temperature: None,
             max_tokens: None,
@@ -3306,6 +3354,7 @@ mod tests {
         ];
 
         let config = LlmCallConfig {
+            speed: None,
             model: "some/model".to_string(),
             temperature: None,
             max_tokens: None,
@@ -3391,6 +3440,7 @@ mod tests {
             .collect();
 
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.4".to_string(),
             temperature: None,
             max_tokens: None,
@@ -3451,6 +3501,7 @@ mod tests {
         let mut metadata = std::collections::HashMap::new();
         metadata.insert("session_id".to_string(), "session_abc123".to_string());
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5-mini".to_string(),
             temperature: None,
             max_tokens: None,
@@ -3516,6 +3567,7 @@ mod tests {
         let api_url = format!("{}/v1/responses", server.uri());
         let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
         let config = LlmCallConfig {
+            speed: None,
             model: "openai/gpt-4o-mini".to_string(),
             temperature: None,
             max_tokens: None,
@@ -4109,6 +4161,7 @@ mod tests {
         // When reasoning effort is "none", the reasoning field should be omitted
         // to avoid API errors on models that don't support reasoning params
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.2".to_string(),
             temperature: None,
             max_tokens: None,
@@ -4143,6 +4196,7 @@ mod tests {
     fn test_request_reasoning_high_is_included() {
         // When reasoning effort is "high", the reasoning field should be present
         let config = LlmCallConfig {
+            speed: None,
             model: "gpt-5.2".to_string(),
             temperature: None,
             max_tokens: None,
@@ -4726,6 +4780,7 @@ mod tests {
     /// Minimal `LlmCallConfig` for wire tests.
     fn auth_test_config() -> LlmCallConfig {
         LlmCallConfig {
+            speed: None,
             model: "gpt-5.4".to_string(),
             temperature: None,
             max_tokens: None,

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -567,6 +567,7 @@ mod tests {
         let message_store = InMemoryMessageRetriever::new();
         let mut input = InputMessage::user("What is 2 * 3?");
         input.controls = Some(Controls {
+            speed: None,
             model_id: None,
             reasoning: None,
             locale: Some("fr-FR".into()),

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -87,6 +87,7 @@ impl UtilityLlmRequest {
         }
 
         let config = LlmCallConfig {
+            speed: None,
             model: UTILITY_LLM_MODEL.to_string(),
             temperature: self.temperature,
             max_tokens: self.max_tokens,

--- a/crates/core/tests/openai_protocol_wire.rs
+++ b/crates/core/tests/openai_protocol_wire.rs
@@ -20,6 +20,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/core/tests/openai_reconnect_wire.rs
+++ b/crates/core/tests/openai_reconnect_wire.rs
@@ -23,6 +23,7 @@ use tokio::net::TcpListener;
 
 fn config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/core/tests/openresponses_protocol_wire.rs
+++ b/crates/core/tests/openresponses_protocol_wire.rs
@@ -22,6 +22,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1127,6 +1127,7 @@ async fn test_driver_registry_integration() {
 
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "Hello")];
     let call_config = LlmCallConfig {
+        speed: None,
         model: "test".to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/fireworks/src/driver.rs
+++ b/crates/fireworks/src/driver.rs
@@ -277,6 +277,7 @@ impl FireworksModelInfo {
             limits,
             modalities,
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,

--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -27,6 +27,7 @@ async fn fireworks_chat_streams_response() {
     let driver = FireworksChatDriver::new(api_key());
 
     let config = LlmCallConfig {
+        speed: None,
         model: LIVE_MODEL.to_string(),
         temperature: Some(0.0),
         // Generous budget: reasoning models can spend tokens on

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -22,6 +22,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -67,6 +67,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
                 "How many trailing zeros does 2024! (factorial) have? Work it out carefully, then state the final count as a plain number.",
             )],
             controls: Some(Controls {
+                speed: None,
                 model_id: None,
                 locale: None,
                 reasoning: Some(ReasoningConfig {
@@ -203,6 +204,7 @@ async fn test_thinking_with_tool_call(#[case] config: ProviderModelConfig) {
                 role: MessageRole::User,
                 content: vec![ContentPart::text("What's the current time in UTC?")],
                 controls: Some(Controls {
+                    speed: None,
                     model_id: None,
                     locale: None,
                     reasoning: Some(ReasoningConfig {

--- a/crates/llm-tests/tests/gpt_comparison_bench.rs
+++ b/crates/llm-tests/tests/gpt_comparison_bench.rs
@@ -223,6 +223,7 @@ async fn test_gpt52_vs_gpt54_reasoning() {
                 "A farmer has 17 chickens. All but 9 die. How many are left? Think step by step.",
             )],
             controls: Some(Controls {
+                speed: None,
                 model_id: None,
                 locale: None,
                 reasoning: Some(ReasoningConfig {

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -564,6 +564,7 @@ mod tests {
 
     fn dummy_config() -> LlmCallConfig {
         LlmCallConfig {
+            speed: None,
             model: "mai-code-1-flash".into(),
             temperature: None,
             max_tokens: None,

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -22,6 +22,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/openai/tests/parallel_tool_calls_live.rs
+++ b/crates/openai/tests/parallel_tool_calls_live.rs
@@ -41,6 +41,7 @@ fn tool(name: &str, description: &str) -> ToolDefinition {
 
 fn config_with(parallel: Option<bool>) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: LIVE_MODEL.to_string(),
         temperature: Some(0.0),
         max_tokens: Some(512),

--- a/crates/openrouter/src/types.rs
+++ b/crates/openrouter/src/types.rs
@@ -193,6 +193,7 @@ impl OpenRouterModelInfo {
             limits,
             modalities,
             reasoning_effort,
+            speed: None,
             tool_search: false,
             supported_parameters: self.supported_parameters.clone(),
             supports_phases: false,

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -28,6 +28,7 @@ async fn openrouter_chat_with_session_id_and_routing_succeeds() {
     metadata.insert("session_id".to_string(), "session_live_smoke".to_string());
 
     let config = LlmCallConfig {
+        speed: None,
         model: "openai/gpt-4o-mini".to_string(),
         temperature: Some(0.0),
         max_tokens: Some(16),

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -20,6 +20,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn base_config(model: &str) -> LlmCallConfig {
     LlmCallConfig {
+        speed: None,
         model: model.to_string(),
         temperature: None,
         max_tokens: None,

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -436,6 +436,7 @@ mod tests {
             model_id: None,
             locale: Some("uk_UA".to_string()),
             reasoning: None,
+            speed: None,
             error_disclosure: None,
             hints: None,
         };

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -229,7 +229,23 @@ pub fn normalize_controls_locale(
         return Ok(None);
     };
     controls.locale = normalize_locale(controls.locale)?;
+    validate_controls_speed(controls.speed.as_deref())?;
     Ok(Some(controls))
+}
+
+/// Validate a speed (service tier) override inside message controls.
+///
+/// THREAT[TM-API-002]: `controls.speed` is client input that is persisted and
+/// forwarded verbatim to the provider as `service_tier`; reject anything
+/// outside the closed value set at the trust boundary.
+pub fn validate_controls_speed(speed: Option<&str>) -> Result<(), ValidationError> {
+    match speed {
+        None | Some("flex") | Some("default") | Some("priority") => Ok(()),
+        Some(other) => {
+            tracing::warn!("Invalid controls.speed value: {:?}", other);
+            Err(ValidationError)
+        }
+    }
 }
 
 /// Validate starter files collection and per-file shape.
@@ -443,6 +459,37 @@ mod tests {
 
         let normalized = normalize_controls_locale(Some(controls)).unwrap().unwrap();
         assert_eq!(normalized.locale.as_deref(), Some("uk-UA"));
+    }
+
+    #[test]
+    fn test_controls_speed_accepts_known_tiers_and_rejects_others() {
+        assert!(validate_controls_speed(None).is_ok());
+        for tier in ["flex", "default", "priority"] {
+            assert!(validate_controls_speed(Some(tier)).is_ok(), "{tier}");
+        }
+        for bad in [
+            "fast",
+            "auto",
+            "scale",
+            "PRIORITY",
+            "",
+            "x".repeat(64).as_str(),
+        ] {
+            assert!(validate_controls_speed(Some(bad)).is_err(), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn test_normalize_controls_rejects_invalid_speed() {
+        let controls = everruns_core::Controls {
+            model_id: None,
+            locale: None,
+            reasoning: None,
+            speed: Some("fast".to_string()),
+            error_disclosure: None,
+            hints: None,
+        };
+        assert!(normalize_controls_locale(Some(controls)).is_err());
     }
 
     #[test]

--- a/crates/server/src/domains/models/service.rs
+++ b/crates/server/src/domains/models/service.rs
@@ -436,6 +436,7 @@ impl ModelService {
             limits: hardcoded.limits.or(discovered.limits),
             modalities: hardcoded.modalities.or(discovered.modalities),
             reasoning_effort: hardcoded.reasoning_effort.or(discovered.reasoning_effort),
+            speed: hardcoded.speed.or(discovered.speed),
             tool_search: hardcoded.tool_search,
             supported_parameters: if hardcoded.supported_parameters.is_empty() {
                 discovered.supported_parameters
@@ -596,6 +597,7 @@ mod tests {
             limits: None,
             modalities: None,
             reasoning_effort: None,
+            speed: None,
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: false,

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -206,6 +206,7 @@ impl JudgeClient for LlmJudgeClient {
             LlmMessage::text(LlmMessageRole::User, user),
         ];
         let config = LlmCallConfig {
+            speed: None,
             model: resolved.model_id,
             temperature: Some(0.0),
             max_tokens: Some(700),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -17463,6 +17463,13 @@
                 "description": "Reasoning configuration"
               }
             ]
+          },
+          "speed": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Speed (service tier) for this message turn: \"flex\", \"default\", or\n\"priority\". Only sent to providers whose model profile advertises a\nspeed config (OpenAI `service_tier`)."
           }
         }
       },
@@ -27881,6 +27888,17 @@
             ],
             "description": "Release date (YYYY-MM-DD format)"
           },
+          "speed": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SpeedConfig",
+                "description": "Speed (service tier) configuration, for models served with\nselectable latency/price tiers (OpenAI `service_tier`)."
+              }
+            ]
+          },
           "structured_output": {
             "type": "boolean",
             "description": "Whether the model supports structured output (JSON mode)"
@@ -33179,6 +33197,54 @@
               "type": "string"
             },
             "description": "Non-fatal warnings (style, deprecated patterns, optional fields missing). Emitted alongside a `valid` result."
+          }
+        }
+      },
+      "Speed": {
+        "type": "string",
+        "description": "Speed level for models that expose a latency/price service tier.\nWire values map 1:1 to the OpenAI `service_tier` request parameter:\n`flex` (slower, cheaper), `default` (standard), `priority` (faster,\npremium). `auto` is deliberately not offered — omitting the field\npreserves the provider's default routing.",
+        "enum": [
+          "flex",
+          "default",
+          "priority"
+        ]
+      },
+      "SpeedConfig": {
+        "type": "object",
+        "description": "Speed configuration for a model",
+        "required": [
+          "values",
+          "default"
+        ],
+        "properties": {
+          "default": {
+            "$ref": "#/components/schemas/Speed",
+            "description": "Default speed for this model"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpeedValue"
+            },
+            "description": "Available speed values for this model"
+          }
+        }
+      },
+      "SpeedValue": {
+        "type": "object",
+        "description": "Named speed value for UI display",
+        "required": [
+          "value",
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name (e.g., \"Flex\", \"Fast\")"
+          },
+          "value": {
+            "$ref": "#/components/schemas/Speed",
+            "description": "The API value (e.g., \"flex\", \"priority\")"
           }
         }
       },

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -201,7 +201,7 @@ The UI also prevents setting reasoning on non-thinking models (checks `profile.r
 
 The speed selector maps to OpenAI's `service_tier` request parameter: `flex` trades latency for batch-rate pricing, `priority` buys faster and more consistent latency at a premium, `default` pins the standard tier. The API rejects values outside the closed set at message creation. It is resolved per turn from the latest user message's `controls.speed` and guarded like reasoning effort: ReasonAtom strips the value (with a warning log) when the model profile carries no `speed` config, and unknown models pass through. When unset, the field is omitted so the provider keeps its default (`auto`) routing.
 
-Per-model availability lives in the model profile's `speed` config, sourced from the tier tables on OpenAI's pricing page (models without a flex/priority pricing row get no config). Profiles mask the config for every provider surface except first-party OpenAI — Azure and gateways have their own capacity models. Both OpenAI drivers (Responses and Chat Completions) serialize the value verbatim as `service_tier`; other drivers ignore it.
+Per-model availability lives in the model profile's `speed` config, sourced from OpenAI's official tier tables — the API pricing page for Flex, the Priority-processing docs for first-party priority models, and the specialized Codex priority table (models without a tier row get no config). Profiles mask the config for every provider surface except first-party OpenAI — Azure and gateways have their own capacity models. Both OpenAI drivers (Responses and Chat Completions) serialize the value verbatim as `service_tier`; other drivers ignore it.
 
 ### Completion Metadata
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -116,6 +116,7 @@ construction, streaming parse logic, retry classification, and error mapping.
    - `max_tokens`: Optional token limit
    - `tools`: Tool definitions
    - `reasoning_effort`: Optional reasoning level (low, medium, high)
+   - `speed`: Optional speed selector (flex, default, priority), sent as OpenAI `service_tier`
    - `metadata`: Optional request metadata for provider-side correlation
    - `previous_response_id`: Optional OpenAI Responses continuation handle
    - `tool_search`: Optional deferred tool-loading config
@@ -195,6 +196,12 @@ Reasoning parameters are validated at two levels to prevent API errors from non-
    on; the API rejects them with a 400).
 
 The UI also prevents setting reasoning on non-thinking models (checks `profile.reasoning` and `profile.reasoning_effort`).
+
+### Speed (Service Tier)
+
+The speed selector maps to OpenAI's `service_tier` request parameter: `flex` trades latency for batch-rate pricing, `priority` buys faster and more consistent latency at a premium, `default` pins the standard tier. It is resolved per turn from the latest user message's `controls.speed` and guarded like reasoning effort: ReasonAtom strips the value (with a warning log) when the model profile carries no `speed` config, and unknown models pass through. When unset, the field is omitted so the provider keeps its default (`auto`) routing.
+
+Per-model availability lives in the model profile's `speed` config, sourced from the tier tables on OpenAI's pricing page (models without a flex/priority pricing row get no config). Profiles mask the config for every provider surface except first-party OpenAI — Azure and gateways have their own capacity models. Both OpenAI drivers (Responses and Chat Completions) serialize the value verbatim as `service_tier`; other drivers ignore it.
 
 ### Completion Metadata
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -199,7 +199,7 @@ The UI also prevents setting reasoning on non-thinking models (checks `profile.r
 
 ### Speed (Service Tier)
 
-The speed selector maps to OpenAI's `service_tier` request parameter: `flex` trades latency for batch-rate pricing, `priority` buys faster and more consistent latency at a premium, `default` pins the standard tier. It is resolved per turn from the latest user message's `controls.speed` and guarded like reasoning effort: ReasonAtom strips the value (with a warning log) when the model profile carries no `speed` config, and unknown models pass through. When unset, the field is omitted so the provider keeps its default (`auto`) routing.
+The speed selector maps to OpenAI's `service_tier` request parameter: `flex` trades latency for batch-rate pricing, `priority` buys faster and more consistent latency at a premium, `default` pins the standard tier. The API rejects values outside the closed set at message creation. It is resolved per turn from the latest user message's `controls.speed` and guarded like reasoning effort: ReasonAtom strips the value (with a warning log) when the model profile carries no `speed` config, and unknown models pass through. When unset, the field is omitted so the provider keeps its default (`auto`) routing.
 
 Per-model availability lives in the model profile's `speed` config, sourced from the tier tables on OpenAI's pricing page (models without a flex/priority pricing row get no config). Profiles mask the config for every provider surface except first-party OpenAI — Azure and gateways have their own capacity models. Both OpenAI drivers (Responses and Chat Completions) serialize the value verbatim as `service_tier`; other drivers ignore it.
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -124,7 +124,11 @@ See `specs/localization.md` for precedence rules.
 
 **Controls:**
 
-Optional per-message overrides for model selection and reasoning configuration.
+Optional per-message overrides for model selection, reasoning configuration, and speed (service tier).
+
+**Speed (Service Tier):**
+
+When `controls.speed` is set (`flex`, `default`, or `priority`), OpenAI requests carry the matching `service_tier`; see [LLM Drivers spec](llm-drivers.md).
 
 **Extended Thinking:**
 

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -143,7 +143,7 @@ The model's identity, promoted from a runtime-computed shadow type to a first-cl
 
 - **Stable key**: `"{vendor}/{model}"` (e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-5.5`, `openai/text-embedding-3-large`).
 - **Service kind**: which service this model belongs to (`chat`, `embeddings`, `realtime`, ...). Pickers filter on it — chat pickers never show `gpt-realtime-2`; embedding configuration only shows embedding profiles. This removes the per-model special-casing the voice spec required.
-- **Metadata**: vendor, default display name, capabilities (tools, vision, reasoning, structured output), limits, cost, modalities, reasoning-effort config — everything `LlmModelProfile` carries today (`crates/core/src/model.rs`), still sourced from models.dev cross-referenced with official provider docs (sourcing rules in `specs/models.md` apply unchanged).
+- **Metadata**: vendor, default display name, capabilities (tools, vision, reasoning, structured output), limits, cost, modalities, reasoning-effort config, speed (service-tier) config — everything `LlmModelProfile` carries today (`crates/core/src/model.rs`), still sourced from models.dev cross-referenced with official provider docs (sourcing rules in `specs/models.md` apply unchanged).
 - **Sources**: built-in code registry (as today) plus discovered profiles persisted from provider metadata (the OpenRouter `supported_parameters` path). Org-custom profiles are out of scope until self-hosted models need them.
 - **Invariant**: every model row has a profile. Discovery that cannot match a known profile creates a minimal one (key derived from the wire id, service `chat`, no cost/limits data — never guessed).
 


### PR DESCRIPTION
## What changed
Backend support for a per-message **speed selector** on OpenAI models, mapped to the `service_tier` request parameter (`flex` = slower/batch-rate pricing, `default` = standard, `priority` = faster/premium — the same knob Codex exposes as its "Fast" selector):

- Clients can set `controls.speed` on `POST /v1/sessions/{id}/messages`; the value is validated against the closed set (`flex`/`default`/`priority`, else 400).
- Model profiles gain a `speed` config (available values + default) exposed through the models API and OpenAPI schema, so the UI can render per-model options. Availability is sourced from OpenAI's official tier tables (API pricing page for Flex, Priority-processing docs, Codex priority table): flex+priority (gpt-5.4, 5.4-mini, 5.5, 5.6 family), flex-only (gpt-5.4-nano, 5.4-pro, 5.5-pro), priority-only (gpt-4o/4o-mini, gpt-4.1 family, gpt-5/5-mini, gpt-5-codex, 5.1/5.1-codex, 5.2, 5.3-codex, o3, o4-mini). Chat-latest, deep-research, and unlisted variants get none.
- ReasonAtom resolves speed from the latest user message and strips it (warn log) when the model profile has no speed config, mirroring the reasoning-effort guard. Profiles mask the config for every surface except first-party OpenAI (Azure/OpenRouter have their own capacity models).
- Both OpenAI wire protocols (Responses + Chat Completions) serialize the value as `service_tier`; omitted when unset so the provider keeps its default `auto` routing.

Frontend selector is intentionally a separate change; this PR ships the whole backend contract.

## Why
Users want to trade latency vs cost per request on OpenAI models (Codex-style "Fast" mode / flex processing). Reasoning effort was already wired end to end; `service_tier` was defined in our OpenResponses schema copy but never sent.

## Before / After
Before: `controls` accepted only model/reasoning/locale; no request ever carried `service_tier`.

After (smoke-tested live on the in-memory dev stack):
- `POST .../messages` with `"controls":{"speed":"fast"}` → `400 Bad Request` (`Invalid controls.speed value: "fast"` in logs).
- `"controls":{"speed":"priority"}` → `201`, persisted on the message (`"controls": {"speed": "priority"}` on read-back).
- Turn on a non-tier model (llmsim) with `"speed":"flex"` → completes normally with the guard firing: `WARN Stripping speed: model does not support service tiers model=llmsim-default speed=flex`.
- `GET /v1/models` for gpt-5.4 → `profile.speed = {values: [flex "Flex", default "Standard", priority "Fast"], default: "default"}`.
- Unit tests pin the wire shape: `service_tier` omitted when unset, `"flex"`/`"priority"` serialized verbatim on both protocols.

Not exercised live: a real OpenAI API call with a tier (no provider key in this environment); the serialization path is covered by protocol unit tests.

## Risk
- Low
- Worst case: a tier value reaches a model OpenAI rejects (400 on that turn only). Guarded three ways: API validation (closed set), profile gating in ReasonAtom, and profile data sourced from the official tier tables. Unset speed changes nothing — field omitted, identical requests to today.

## Security
- Threat categories reviewed: TM-API (new client-supplied `controls.speed` field), TM-LLM (new provider request parameter).
- Findings and resolutions: `controls.speed` is persisted and forwarded verbatim to the provider, so unbounded/garbage input was rejected at the trust boundary with a closed-set validator (`THREAT[TM-API-002]` comment at the validation site). No injection surface (serialized as a JSON string via serde), no secrets/logging exposure (value is one of three known tokens), no new dependencies. Existing threat-model entries cover this; no new threat-model rows needed.

## Follow-ups
- Session- and agent-level default speed (the `parallel_tool_calls`-style migration + columns) — deferred: per-message controls matches how reasoning effort ships today and is all the frontend needs; defaults can be added when a concrete need appears.
- Frontend speed selector — explicitly out of scope per the request; the API contract (`profile.speed`, `controls.speed`) is ready.
- Anthropic `service_tier` (`auto`/`standard_only`) mapping — deferred: different semantics (no priority tier on Messages API), needs its own sourcing pass.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
