### PR TITLE
feat(mcp-ui): edit MCP server name, description, and URL

### DIFF
--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
 import McpServersPage from "@/app/(main)/mcp-servers/page";
 
 const mockUseMcpServers = jest.fn();
@@ -50,7 +50,9 @@ describe("McpServersPage", () => {
 
     mockUseUpdateMcpServer.mockReturnValue({
       mutateAsync: jest.fn(),
+      reset: jest.fn(),
       isPending: false,
+      error: null,
     });
 
     mockUseDeleteMcpServer.mockReturnValue({
@@ -167,5 +169,94 @@ describe("McpServersPage", () => {
 
     expect(await screen.findByText("URL must be a valid absolute URL")).toBeInTheDocument();
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("opens the edit dialog prefilled with the server's current values", () => {
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Edit MCP Server")).toBeInTheDocument();
+    expect(within(dialog).getByLabelText("Name")).toHaveValue("microsoft_learn");
+    expect(within(dialog).getByLabelText("URL")).toHaveValue("https://learn.microsoft.com/api/mcp");
+    expect(within(dialog).getByLabelText("Description (optional)")).toHaveValue(
+      "Microsoft Learn documentation MCP server",
+    );
+  });
+
+  it("submits updated name, description, and URL through the update hook", async () => {
+    const mockMutateAsync = jest.fn().mockResolvedValue({});
+    mockUseUpdateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      reset: jest.fn(),
+      isPending: false,
+      error: null,
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "updated-mcp-server" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("Description (optional)"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.change(within(dialog).getByLabelText("URL"), {
+      target: { value: "https://new.mcp.com/v1/mcp" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        name: "updated-mcp-server",
+        description: "Updated description",
+        url: "https://new.mcp.com/v1/mcp",
+        protocol_mode: "auto",
+      }),
+    );
+  });
+
+  it("shows a validation error for invalid URLs when editing", async () => {
+    const mockMutateAsync = jest.fn();
+    mockUseUpdateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      reset: jest.fn(),
+      isPending: false,
+      error: null,
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("URL"), { target: { value: "not-a-url" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("URL must be a valid absolute URL")).toBeInTheDocument();
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an update failure in the edit dialog", async () => {
+    const mockMutateAsync = jest.fn().mockRejectedValue(new Error("name already exists"));
+    mockUseUpdateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      reset: jest.fn(),
+      isPending: false,
+      error: new Error("name already exists"),
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(await within(dialog).findByText(/name already exists/)).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -40,7 +40,7 @@ import {
 } from "@/hooks/use-mcp-servers";
 import { usePolicies } from "@/hooks/use-policies";
 import { usePageTitle } from "@/hooks";
-import { Plus, Trash2, Key, X } from "lucide-react";
+import { Plus, Trash2, Key, X, Pencil } from "lucide-react";
 import type {
   McpServer,
   CreateMcpServerRequest,
@@ -50,6 +50,7 @@ import type {
 import {
   apiKeySecretSchema,
   getFieldErrors,
+  mcpServerEditFormSchema,
   mcpServerFormSchema,
   type FieldErrors,
 } from "@/lib/form-validation";
@@ -94,6 +95,7 @@ function protocolModeLabel(mode?: McpProtocolMode): string {
 function McpServerRow({
   server,
   canDestroy,
+  onEdit,
   onDelete,
   onArchive,
   onSetApiKey,
@@ -101,6 +103,7 @@ function McpServerRow({
 }: {
   server: McpServer;
   canDestroy: boolean;
+  onEdit: (server: McpServer) => void;
   onDelete: (server: McpServer) => void;
   onArchive: (server: McpServer) => void;
   onSetApiKey: (server: McpServer) => void;
@@ -141,6 +144,12 @@ function McpServerRow({
             <Button variant="outline" size="sm" onClick={() => onSetApiKey(server)}>
               <Key className="h-4 w-4 mr-1" />
               {server.api_key_set ? "Update Key" : "Set Key"}
+            </Button>
+          )}
+          {!isArchived && !isDeleted && (
+            <Button variant="outline" size="sm" onClick={() => onEdit(server)}>
+              <Pencil className="h-4 w-4 mr-1" />
+              Edit
             </Button>
           )}
           {!isArchived && !isDeleted && (
@@ -429,6 +438,161 @@ function AddMcpServerDialog({
               }
             >
               {createServer.isPending ? "Creating..." : "Create Server"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditMcpServerDialog({
+  server,
+  open,
+  onOpenChange,
+}: {
+  server: McpServer | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [url, setUrl] = useState("");
+  const [protocolMode, setProtocolMode] = useState<McpProtocolMode>("auto");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+
+  const updateServer = useUpdateMcpServer(server?.id ?? "");
+
+  // Prefill the form with the current values whenever the dialog opens.
+  useEffect(() => {
+    if (!open || !server) return;
+    setName(server.name);
+    setDescription(server.description ?? "");
+    setUrl(server.url);
+    setProtocolMode(server.protocol_mode ?? "auto");
+    setFieldErrors({});
+    updateServer.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, server]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!server) return;
+
+    const parsed = mcpServerEditFormSchema.safeParse({
+      name,
+      description,
+      url,
+      protocol_mode: protocolMode,
+    });
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
+    setFieldErrors({});
+
+    try {
+      await updateServer.mutateAsync({
+        name: parsed.data.name,
+        // Send the trimmed string (may be empty) so clearing the field persists;
+        // the backend treats an omitted field as "no change".
+        description: description.trim(),
+        url: parsed.data.url,
+        protocol_mode: parsed.data.protocol_mode,
+      });
+      onOpenChange(false);
+    } catch {
+      // Error is surfaced below via updateServer.error.
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit MCP Server</DialogTitle>
+          <DialogDescription>
+            Update the name, description, URL, and protocol compatibility for this MCP server.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="edit-name">Name</Label>
+            <Input
+              id="edit-name"
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setName(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, name: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.name}
+              placeholder="atlassian-mcp-server"
+              required
+            />
+            {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-description">Description (optional)</Label>
+            <Textarea
+              id="edit-description"
+              value={description}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                setDescription(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, description: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.description}
+              placeholder="Atlassian MCP Server for Jira and Confluence"
+              rows={2}
+            />
+            {fieldErrors.description && (
+              <p className="text-xs text-destructive">{fieldErrors.description}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-url">URL</Label>
+            <Input
+              id="edit-url"
+              value={url}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setUrl(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, url: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.url}
+              placeholder="https://mcp.atlassian.com/v1/mcp"
+              required
+            />
+            {fieldErrors.url && <p className="text-xs text-destructive">{fieldErrors.url}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-protocol-mode">Protocol compatibility</Label>
+            <Select
+              value={protocolMode}
+              onValueChange={(value) => setProtocolMode(value as McpProtocolMode)}
+            >
+              <SelectTrigger id="edit-protocol-mode">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Auto (negotiate)</SelectItem>
+                <SelectItem value="rc">RC 2026 — stateless</SelectItem>
+                <SelectItem value="stable">Stable 2025-06-18</SelectItem>
+                <SelectItem value="legacy">Legacy 2025-03-26</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Authentication ({server?.auth_mode ?? "none"}) is managed separately. Use the Set Key
+            action to update an API key.
+          </p>
+          {updateServer.error && (
+            <p className="text-sm text-destructive">Error: {updateServer.error.message}</p>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={updateServer.isPending || !name || !url}>
+              {updateServer.isPending ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </form>
@@ -743,6 +907,7 @@ export default function McpServersPage() {
   const [search, setSearch] = useState("");
   const [statusTab, setStatusTab] = useState<StatusTab>("active");
   const [addServerOpen, setAddServerOpen] = useState(false);
+  const [editServer, setEditServer] = useState<McpServer | null>(null);
   const [apiKeyServer, setApiKeyServer] = useState<McpServer | null>(null);
   const [headersServer, setHeadersServer] = useState<McpServer | null>(null);
   const [pendingDeleteServer, setPendingDeleteServer] = useState<McpServer | null>(null);
@@ -891,6 +1056,7 @@ export default function McpServersPage() {
                         key={server.id}
                         server={server}
                         canDestroy={canDestroy}
+                        onEdit={setEditServer}
                         onDelete={setPendingDeleteServer}
                         onArchive={setPendingArchiveServer}
                         onSetApiKey={setApiKeyServer}
@@ -957,6 +1123,11 @@ export default function McpServersPage() {
 
       {/* Dialogs */}
       <AddMcpServerDialog open={addServerOpen} onOpenChange={setAddServerOpen} />
+      <EditMcpServerDialog
+        server={editServer}
+        open={editServer !== null}
+        onOpenChange={(open) => !open && setEditServer(null)}
+      />
       <ManageHeadersDialog
         server={headersServer}
         open={headersServer !== null}

--- a/apps/ui/src/lib/form-validation.ts
+++ b/apps/ui/src/lib/form-validation.ts
@@ -103,6 +103,21 @@ export const mcpServerFormSchema = z
     }
   });
 
+/**
+ * Edit schema for an existing MCP server. Covers the mutable identity fields
+ * (name, description, url) plus protocol compatibility. Auth mode and the API
+ * key are managed via their own dedicated flows and are intentionally omitted.
+ */
+export const mcpServerEditFormSchema = z.object({
+  name: requiredString("Name"),
+  description: optionalString(),
+  url: requiredString("URL").refine(
+    (value) => z.url().safeParse(value).success,
+    "URL must be a valid absolute URL",
+  ),
+  protocol_mode: z.enum(["auto", "legacy", "stable", "rc"]),
+});
+
 export const apiKeySecretSchema = z.object({
   api_key: requiredString("API key"),
 });

--- a/test_cases/ui/mcp_servers/TC005_update_mcp_server.md
+++ b/test_cases/ui/mcp_servers/TC005_update_mcp_server.md
@@ -2,12 +2,12 @@
 
 ## Description
 
-Verify that an existing MCP server can be updated.
+Verify that an existing MCP server's name, description, and URL can be edited from the MCP Servers list.
 
 ## Preconditions
 
 - API server is running
-- An MCP server exists with name "test-mcp-server"
+- An active MCP server exists with name "test-mcp-server"
 
 ## Test Data
 
@@ -19,16 +19,23 @@ Verify that an existing MCP server can be updated.
 
 ## Steps
 
-1. Navigate to Settings > MCP Servers
-2. Find the server "test-mcp-server"
-3. Click "Edit" button
-4. Update name to: `updated-mcp-server`
-5. Update description to: `Updated description`
+1. Navigate to Building blocks > MCP Servers
+2. Find the row for the server "test-mcp-server"
+3. Click the "Edit" button in that row
+4. In the "Edit MCP Server" dialog, update Name to: `updated-mcp-server`
+5. Update Description to: `Updated description`
 6. Update URL to: `https://new.mcp.com/v1/mcp`
-7. Click "Save" button
+7. Click the "Save" button
 
 ## Expected Result
 
-- MCP server is updated successfully
-- List shows updated values
-- updated_at timestamp is updated
+- The dialog closes and the MCP server is updated successfully
+- The list row shows the updated name, and the updated description/URL appear in the row subtitle
+- `updated_at` timestamp is updated
+- Submitting an invalid URL keeps the dialog open and shows "URL must be a valid absolute URL"
+- A backend failure (e.g. a duplicate name) keeps the dialog open and surfaces the error message inline
+
+## Notes
+
+- Authentication mode is managed separately: use the "Set Key" action to update an API key. The Edit dialog does not change auth mode.
+</content>


### PR DESCRIPTION
## What changed
The MCP Servers list now has an **Edit** action on each active server that opens a dialog to change the server's **name, description, URL, and protocol compatibility**, wired to the existing `useUpdateMcpServer` update API. Previously only the API key and custom headers were editable, so fixing a typo or migrating an endpoint required archive + recreate.

- New `EditMcpServerDialog` prefills the current values, validates via a new `mcpServerEditFormSchema`, and submits through the existing update hook.
- Mutation failures are surfaced visibly instead of being swallowed.
- The description field sends its trimmed value so clearing it persists.

## Why
`test_cases/ui/mcp_servers/TC005_update_mcp_server.md` documents editable base configuration, and the update API/hook already existed — only the UI affordance was missing (EVE-721).

## Before / After
- **Before:** An active MCP server row exposed only Headers, Archive, and (for API-key auth) Set/Update Key. No way to change name/description/URL/protocol.
- **After:** An **Edit** button opens a dialog to update name, description, URL, and protocol compatibility, with inline validation and visible error feedback. TC005 is aligned to the shipped flow.

## Risk
- Low. Client-only surface on the MCP Servers page; the change reuses the existing update mutation and design-system dialog/inputs. Backend validation remains authoritative.

## Security
- Threat categories reviewed: TM-WEB. Inputs render as React text (auto-escaped); no new server/auth surface. The update flows through the same authenticated API hook as existing mutations.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)