### PR TITLE
fix(subagents): rename interim tool to report_task_progress

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -324,9 +324,9 @@ pub use stateless_todo_list::{
     STATELESS_TODO_LIST_CAPABILITY_ID, StatelessTodoListCapability, WriteTodosTool,
 };
 pub use subagents::{
-    ReportProgressTool, ReportResultTool, SUBAGENTS_CAPABILITY_ID, SpawnSubagentAsAgentTool,
-    SubagentCapability, report_progress_tool_for_child_session,
-    report_result_tool_for_child_session,
+    ReportResultTool, ReportTaskProgressTool, SUBAGENTS_CAPABILITY_ID, SpawnSubagentAsAgentTool,
+    SubagentCapability, report_result_tool_for_child_session,
+    report_task_progress_tool_for_child_session,
 };
 // Blueprint types are exported directly from the trait definitions above
 pub use bashkit_shell::{
@@ -1889,7 +1889,7 @@ impl Tool for UnifiedSpawnAgentTool {
                 },
                 "message_schema": {
                     "type": "object",
-                    "description": "Subagent-only JSON Schema for structured progress messages. When set, the child receives report_progress and valid calls post data messages to the task thread."
+                    "description": "Subagent-only JSON Schema for structured progress messages. When set, the child receives report_task_progress and valid calls post data messages to the task thread."
                 },
                 "public_context": {
                     "type": "object",

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -727,13 +727,17 @@ impl Tool for ReportResultTool {
 
 /// Context-bound tool injected into a child subagent when its parent task
 /// declares `message_schema`.
-pub struct ReportProgressTool {
+///
+/// Named `report_task_progress` on the wire to avoid colliding with the
+/// channel-facing `report_progress` tool (`progress_reporting::REPORT_PROGRESS_TOOL_NAME`),
+/// which has different semantics and input schema (EVE-727).
+pub struct ReportTaskProgressTool {
     parent_session_id: SessionId,
     task_id: String,
     message_schema: Value,
 }
 
-impl ReportProgressTool {
+impl ReportTaskProgressTool {
     pub fn new(parent_session_id: SessionId, task_id: String, message_schema: Value) -> Self {
         Self {
             parent_session_id,
@@ -744,13 +748,13 @@ impl ReportProgressTool {
 }
 
 #[async_trait]
-impl Tool for ReportProgressTool {
+impl Tool for ReportTaskProgressTool {
     fn name(&self) -> &str {
-        "report_progress"
+        "report_task_progress"
     }
 
     fn display_name(&self) -> Option<&str> {
-        Some("Report Progress")
+        Some("Report Task Progress")
     }
 
     fn description(&self) -> &str {
@@ -763,7 +767,7 @@ impl Tool for ReportProgressTool {
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
-            "report_progress requires context. This tool must be executed with session context.",
+            "report_task_progress requires context. This tool must be executed with session context.",
         )
     }
 
@@ -775,14 +779,14 @@ impl Tool for ReportProgressTool {
         let errors = schema_validation_errors(&self.message_schema, &arguments);
         if !errors.is_empty() {
             return ToolExecutionResult::tool_error(format!(
-                "report_progress arguments do not match message_schema: {}",
+                "report_task_progress arguments do not match message_schema: {}",
                 errors.join("; ")
             ));
         }
 
         let Some(registry) = context.session_task_registry.as_ref() else {
             return ToolExecutionResult::tool_error(
-                "report_progress requires session_task_registry context",
+                "report_task_progress requires session_task_registry context",
             );
         };
 
@@ -857,11 +861,11 @@ pub async fn report_result_tool_for_child_session(
     )))
 }
 
-pub async fn report_progress_tool_for_child_session(
+pub async fn report_task_progress_tool_for_child_session(
     child_session_id: SessionId,
     session_store: &dyn SessionStore,
     task_registry: &dyn crate::session_task::SessionTaskRegistry,
-) -> crate::error::Result<Option<ReportProgressTool>> {
+) -> crate::error::Result<Option<ReportTaskProgressTool>> {
     let Some(child) = session_store.get_session(child_session_id).await? else {
         return Ok(None);
     };
@@ -889,7 +893,7 @@ pub async fn report_progress_tool_for_child_session(
         return Ok(None);
     };
 
-    Ok(Some(ReportProgressTool::new(
+    Ok(Some(ReportTaskProgressTool::new(
         parent_session_id,
         task.id.clone(),
         schema.clone(),
@@ -970,7 +974,7 @@ impl Tool for SpawnSubagentAsAgentTool {
                 },
                 "message_schema": {
                     "type": "object",
-                    "description": "Optional JSON Schema for structured progress messages. When set, the child receives report_progress and valid calls post data messages to the task thread."
+                    "description": "Optional JSON Schema for structured progress messages. When set, the child receives report_task_progress and valid calls post data messages to the task thread."
                 }
             },
             "required": ["name", "instructions", "target"],
@@ -2758,7 +2762,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn report_progress_posts_structured_outbound_message() {
+    async fn report_task_progress_posts_structured_outbound_message() {
         let registry = Arc::new(InMemorySessionTaskRegistry::default());
         let parent_session_id = crate::typed_id::SessionId::new();
         let task = registry
@@ -2782,11 +2786,12 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ReportProgressTool::new(
+        let tool = ReportTaskProgressTool::new(
             parent_session_id,
             task.id.clone(),
             task.spec["message_schema"].clone(),
         );
+        assert_eq!(tool.name(), "report_task_progress");
         let mut context = ToolContext::new(crate::typed_id::SessionId::new());
         context.session_task_registry = Some(registry.clone());
 
@@ -2813,8 +2818,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn report_progress_rejects_invalid_message_schema_payload() {
-        let tool = ReportProgressTool::new(
+    async fn report_task_progress_rejects_invalid_message_schema_payload() {
+        let tool = ReportTaskProgressTool::new(
             crate::typed_id::SessionId::new(),
             "task_test".to_string(),
             json!({
@@ -2838,6 +2843,39 @@ mod tests {
             "got: {message}"
         );
         assert!(message.contains("$.extra is not allowed"), "got: {message}");
+    }
+
+    #[test]
+    fn subagent_and_channel_progress_tools_have_distinct_names() {
+        // EVE-727: the subagent interim-progress tool must not share a wire name
+        // with the channel-facing `report_progress` tool. `ToolRegistry` is keyed
+        // by name, so a collision would silently drop one tool. This guards the
+        // rename against regressions: both tools must coexist in one registry.
+        use crate::progress_reporting::{
+            REPORT_PROGRESS_TOOL_NAME, ReportProgressTool as ChannelReportProgressTool,
+        };
+        use crate::tools::ToolRegistry;
+
+        let subagent = ReportTaskProgressTool::new(
+            crate::typed_id::SessionId::new(),
+            "task_test".to_string(),
+            json!({"type": "object"}),
+        );
+        assert_eq!(subagent.name(), "report_task_progress");
+        assert_eq!(REPORT_PROGRESS_TOOL_NAME, "report_progress");
+        assert_ne!(subagent.name(), REPORT_PROGRESS_TOOL_NAME);
+
+        let mut registry = ToolRegistry::new();
+        registry.register(ChannelReportProgressTool);
+        registry.register(subagent);
+        assert!(
+            registry.has("report_progress"),
+            "channel report_progress tool must survive"
+        );
+        assert!(
+            registry.has("report_task_progress"),
+            "subagent report_task_progress tool must survive"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -8,8 +8,8 @@ use everruns_core::atoms::{
     ReasonInput, ReasonResult,
 };
 use everruns_core::capabilities::{
-    SystemPromptContext, collect_capabilities_with_configs, report_progress_tool_for_child_session,
-    report_result_tool_for_child_session,
+    SystemPromptContext, collect_capabilities_with_configs, report_result_tool_for_child_session,
+    report_task_progress_tool_for_child_session,
 };
 use everruns_core::events::{
     EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
@@ -1255,9 +1255,9 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     if input
         .tool_definitions
         .iter()
-        .any(|definition| definition.name() == "report_progress")
+        .any(|definition| definition.name() == "report_task_progress")
         && let Some(registry) = adapter.session_task_registry()
-        && let Some(tool) = report_progress_tool_for_child_session(
+        && let Some(tool) = report_task_progress_tool_for_child_session(
             input.context.session_id,
             adapter.session_store(org_id).as_ref(),
             registry.as_ref(),

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use everruns_core::capabilities::{
-    report_progress_tool_for_child_session, report_result_tool_for_child_session,
+    report_result_tool_for_child_session, report_task_progress_tool_for_child_session,
 };
 use everruns_core::error::Result;
 use everruns_core::traits::{
@@ -164,7 +164,7 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
             {
                 mcp_tool_definitions.push(tool.to_definition());
             }
-            if let Some(tool) = report_progress_tool_for_child_session(
+            if let Some(tool) = report_task_progress_tool_for_child_session(
                 session_id,
                 session_store.as_ref(),
                 registry.as_ref(),

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -115,7 +115,7 @@ TaskMessage {
   transcript is not mirrored; `links.child_session_id` points at the full
   conversation.
 - Schema-bound subagents can post structured progress with a child-only
-  `report_progress` tool. Valid calls append outbound messages containing a
+  `report_task_progress` tool. Valid calls append outbound messages containing a
   single `data` part; invalid payloads return a validation error so the child
   can retry.
 
@@ -211,7 +211,7 @@ task settles as `failed` with `error.kind = "no_result"`. Tasks without
 `spec.result_schema` keep their existing summary-only behavior.
 
 Subagent tasks may also declare `spec.message_schema` as a JSON Schema. That
-schema injects a child-only `report_progress` tool; valid calls are recorded as
+schema injects a child-only `report_task_progress` tool; valid calls are recorded as
 outbound task messages with `data` content, and background tasks use
 `wake_policy: on_activity` so those messages wake the parent session.
 

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -120,9 +120,11 @@ JSON object inline; without `result_schema`, foreground spawns keep returning
 the last assistant message.
 
 When `message_schema` is present, the child session receives a
-`report_progress` tool whose parameters are the declared schema. A valid
-`report_progress` call appends an outbound task message with a `data` part to
-the parent task's message thread. Background subagent tasks with
+`report_task_progress` tool whose parameters are the declared schema. A valid
+`report_task_progress` call appends an outbound task message with a `data` part to
+the parent task's message thread. The name is deliberately distinct from the
+channel-facing `report_progress` tool (progress-reporting reply mode) so the two
+never collide in a single session toolset. Background subagent tasks with
 `message_schema` use `wake_policy: on_activity` so progress messages wake the
 parent; tasks without `message_schema` keep completion-only wake-ups.
 


### PR DESCRIPTION
## What changed
The child-subagent interim-progress tool is renamed on the wire from `report_progress` to `report_task_progress`. The unrelated channel-facing `report_progress` tool (progress-reporting reply mode) is unchanged. No behavior change for either tool beyond the subagent tool's name; no external/back-compat concern (internal tool name, per AGENTS.md).

## Why
Both tools shipped the same wire name `report_progress` with different input schemas and semantics (channel: free-form user update; subagent: `message_schema`-validated task→host data part). `ToolRegistry` is keyed by tool name (`HashMap<String, _>`), so if both were ever contributed to a single session toolset — e.g. a subagent spawned inside a channel-reply-mode session via tag propagation — one would silently overwrite the other. Latent footgun, not a live outage today. Fixes EVE-727.

## Before / After
- **Before:** `subagents::ReportProgressTool::name()` → `"report_progress"`; host injection gated on `definition.name() == "report_progress"`.
- **After:** `ReportTaskProgressTool::name()` → `"report_task_progress"`; the injection gate in `crates/runtime/src/host.rs` moves in lockstep. New guard test registers both the channel and subagent tools in one `ToolRegistry` and asserts both names survive (proving no collision), plus asserts the names differ.

Unit tests: `cargo test -p everruns-core --lib capabilities::subagents` → 31 passed (incl. the delivery test exercising `execute_with_context` and the new coexistence guard).

## Risk
- Low
- The only runtime coupling is the host injection gate string, moved together with the tool name. The subagent tool definition (built from `name()`) and the gate now match. Covered by the delivery unit test and the worker/runtime paths.

## Security
- Threat categories reviewed: No security-relevant code changes — pure internal tool rename; no auth, tenancy, egress, or input-trust surface touched. Schema validation of `report_task_progress` payloads is unchanged.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal tool name; no external contract)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Closes EVE-727

https://claude.ai/code/session_01VkY5d4PDpuVYh99QDu8ryZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkY5d4PDpuVYh99QDu8ryZ)_