### PR TITLE
fix(fs): present persisted output paths via file store

### DIFF
--- a/crates/core/src/capabilities/tool_output_distillation.rs
+++ b/crates/core/src/capabilities/tool_output_distillation.rs
@@ -194,7 +194,8 @@ impl PostToolExecHook for DistillOutputHook {
             return;
         };
 
-        inject_pointer(result_value, &stdout_path, original_len);
+        let display_path = file_store.display_path(&stdout_path);
+        inject_pointer(result_value, &display_path, original_len);
     }
 }
 
@@ -375,17 +376,16 @@ fn head_tail(text: &str, max_bytes: usize) -> String {
 
 /// Inject the recovery pointer fields into a distilled result value, mirroring
 /// the contract of `tool_output_persistence` (`output_files` / `full_output`).
-fn inject_pointer(result_value: &mut Value, stdout_path: &str, original_len: usize) {
+fn inject_pointer(result_value: &mut Value, display_path: &str, original_len: usize) {
     let note = annotate_truncated_output(
         "Tool output was distilled to fit the context window.",
-        stdout_path,
+        display_path,
         original_len,
     );
-    let pointer = format!("/workspace{stdout_path}");
 
     if let Some(obj) = result_value.as_object_mut() {
-        obj.insert("output_files".to_string(), json!([pointer]));
-        obj.insert("full_output".to_string(), json!(stdout_path));
+        obj.insert("output_files".to_string(), json!([display_path]));
+        obj.insert("full_output".to_string(), json!(display_path));
         obj.insert("distilled".to_string(), json!(true));
         obj.insert("distill_note".to_string(), json!(note));
     } else {
@@ -394,8 +394,8 @@ fn inject_pointer(result_value: &mut Value, stdout_path: &str, original_len: usi
         let distilled = std::mem::replace(result_value, Value::Null);
         *result_value = json!({
             "distilled_output": distilled,
-            "output_files": [pointer],
-            "full_output": stdout_path,
+            "output_files": [display_path],
+            "full_output": display_path,
             "distilled": true,
             "distill_note": note,
         });
@@ -517,12 +517,12 @@ mod tests {
     #[test]
     fn test_inject_pointer_into_object() {
         let mut value = json!({ "content": "distilled" });
-        inject_pointer(&mut value, "/outputs/abc.stdout", 50 * 1024);
+        inject_pointer(&mut value, "/workspace/outputs/abc.stdout", 50 * 1024);
         assert_eq!(
             value["output_files"],
             json!(["/workspace/outputs/abc.stdout"])
         );
-        assert_eq!(value["full_output"], json!("/outputs/abc.stdout"));
+        assert_eq!(value["full_output"], json!("/workspace/outputs/abc.stdout"));
         assert_eq!(value["distilled"], json!(true));
         assert!(
             value["distill_note"]
@@ -535,10 +535,10 @@ mod tests {
     #[test]
     fn test_inject_pointer_wraps_non_object() {
         let mut value = json!(["a", "b"]);
-        inject_pointer(&mut value, "/outputs/x.stdout", 1024);
+        inject_pointer(&mut value, "/workspace/outputs/x.stdout", 1024);
         assert!(value.is_object());
         assert_eq!(value["distilled_output"], json!(["a", "b"]));
-        assert_eq!(value["full_output"], json!("/outputs/x.stdout"));
+        assert_eq!(value["full_output"], json!("/workspace/outputs/x.stdout"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -147,7 +147,7 @@ fn truncate_for_persistence(text: &str, max_bytes: usize) -> String {
 pub fn annotate_truncated_output(truncated: &str, file_path: &str, full_size: usize) -> String {
     let size_kb = full_size / 1024;
     format!(
-        "{truncated}\n\n[full output saved to /workspace{file_path} ({size_kb} KiB) — use read_file with offset/limit]"
+        "{truncated}\n\n[full output saved to {file_path} ({size_kb} KiB) — use read_file with offset/limit]"
     )
 }
 
@@ -323,16 +323,17 @@ impl PostToolExecHook for PersistOutputHook {
                 let mut output_files = Vec::new();
 
                 if let Some(ref path) = persist_result.stdout_path {
+                    let display_path = file_store.display_path(path);
                     // Compact inline stdout/output to the success/failure budget and
                     // append the file-reference pointer. Explicit modes (verbose, full,
                     // normal) cannot produce unbounded model-facing output after
                     // persistence succeeds — full content is in /outputs/.
-                    compact_persisted_result_for_model(obj, path, stdout.len());
+                    compact_persisted_result_for_model(obj, &display_path, stdout.len());
 
-                    output_files.push(format!("/workspace{path}"));
+                    output_files.push(display_path.clone());
                     // full_output points to the stdout file only; stderr (if persisted)
                     // is available via the output_files array
-                    obj.insert("full_output".to_string(), json!(path));
+                    obj.insert("full_output".to_string(), json!(display_path));
                     obj.insert(
                         "total_lines".to_string(),
                         json!(persist_result.stdout_total_lines),
@@ -340,7 +341,7 @@ impl PostToolExecHook for PersistOutputHook {
                 }
 
                 if let Some(ref path) = persist_result.stderr_path {
-                    output_files.push(format!("/workspace{path}"));
+                    output_files.push(file_store.display_path(path));
                     // Compact stderr inline when stdout was not persisted (if stdout was
                     // persisted, compact_persisted_result_for_model already handled this).
                     if persist_result.stdout_path.is_none() {
@@ -498,8 +499,11 @@ mod tests {
 
     #[test]
     fn test_annotate_truncated_output() {
-        let annotated =
-            annotate_truncated_output("truncated text...", "/outputs/abc.stdout", 50 * 1024);
+        let annotated = annotate_truncated_output(
+            "truncated text...",
+            "/workspace/outputs/abc.stdout",
+            50 * 1024,
+        );
         assert!(annotated.contains("truncated text..."));
         assert!(annotated.contains("/workspace/outputs/abc.stdout"));
         assert!(annotated.contains("50 KiB"));
@@ -508,7 +512,7 @@ mod tests {
 
     #[test]
     fn test_annotate_truncated_output_small() {
-        let annotated = annotate_truncated_output("short", "/outputs/x.stdout", 1024);
+        let annotated = annotate_truncated_output("short", "/workspace/outputs/x.stdout", 1024);
         assert!(annotated.contains("1 KiB"));
         assert!(annotated.contains("read_file with offset/limit"));
     }

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -35,7 +35,7 @@ pub const VERBOSE_BUDGET: usize = 16 * 1024;
 /// model can `read_file` the persisted log when it needs more detail.
 ///
 /// Sized so that even after the `PersistOutputHook` appends its
-/// `[full output saved to /workspace/outputs/... (NN KiB) — use read_file ...]`
+/// `[full output saved to <display path> (NN KiB) — use read_file ...]`
 /// pointer (~120 bytes), the full inline `stdout` field stays ≤ ~512 bytes.
 pub const AUTO_SUCCESS_BUDGET: usize = 384;
 

--- a/crates/runtime/tests/workspace_paths_conformance_test.rs
+++ b/crates/runtime/tests/workspace_paths_conformance_test.rs
@@ -7,11 +7,15 @@
 // cwd-relative resolution all agree on the same root — and that repointing the
 // host root (the worktree-switch scenario) moves every surface together.
 
-use everruns_core::capabilities::BashTool;
+use everruns_core::atoms::PostToolExecHook;
+use everruns_core::capabilities::{BashTool, DistillOutputHook, PersistOutputHook};
+use everruns_core::tool_types::{
+    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResult,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use everruns_core::{MountFs, SessionFileSystem, SessionId, WorkspaceRootSet};
-use everruns_runtime::{RealDiskFileStore, multi_root_file_system};
+use everruns_runtime::{InMemorySessionFileStore, RealDiskFileStore, multi_root_file_system};
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -29,6 +33,135 @@ async fn bash_pwd(ctx: &ToolContext) -> String {
             .to_string(),
         other => panic!("bash pwd did not succeed: {other:?}"),
     }
+}
+
+fn output_tool_def(persist_output: bool) -> ToolDefinition {
+    let hints = if persist_output {
+        ToolHints::default().with_persist_output(true)
+    } else {
+        ToolHints::default()
+    };
+    ToolDefinition::Builtin(BuiltinTool {
+        name: "test_output".to_string(),
+        display_name: None,
+        description: "test output".to_string(),
+        parameters: json!({}),
+        policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
+        hints,
+        full_parameters: None,
+    })
+}
+
+fn output_tool_call() -> ToolCall {
+    ToolCall {
+        id: "call_paths".to_string(),
+        name: "test_output".to_string(),
+        arguments: json!({}),
+    }
+}
+
+async fn assert_output_pointers_follow_store(store: Arc<dyn SessionFileSystem>) {
+    let session = SessionId::from_seed(662);
+    let context = ToolContext::with_file_store(session, store.clone());
+    let root = store.display_root();
+    let stdout_path = format!("{root}/outputs/call_paths.stdout");
+    let stderr_path = format!("{root}/outputs/call_paths.stderr");
+    let mut result = ToolResult {
+        tool_call_id: "call_paths".to_string(),
+        result: Some(json!({
+            "stdout": "stdout body",
+            "stderr": "stderr body",
+            "exit_code": 0,
+        })),
+        images: None,
+        error: None,
+        connection_required: None,
+        raw_output: Some("stdout body\n--- stderr ---\nstderr body".to_string()),
+    };
+
+    PersistOutputHook
+        .after_exec(
+            &output_tool_call(),
+            &output_tool_def(true),
+            &mut result,
+            &context,
+        )
+        .await;
+
+    let value = result.result.as_ref().unwrap();
+    assert_eq!(value["full_output"], json!(stdout_path));
+    assert_eq!(value["output_files"], json!([stdout_path, stderr_path]));
+    for pointer in value["output_files"].as_array().unwrap() {
+        assert!(
+            store
+                .read_file(session, pointer.as_str().unwrap())
+                .await
+                .unwrap()
+                .is_some(),
+            "model-visible output pointer must be readable by file tools"
+        );
+    }
+    assert!(
+        value["stdout"]
+            .as_str()
+            .unwrap()
+            .contains(&store.display_path("/outputs/call_paths.stdout"))
+    );
+}
+
+async fn assert_distillation_pointer_follows_store(store: Arc<dyn SessionFileSystem>) {
+    let session = SessionId::from_seed(663);
+    let context = ToolContext::with_file_store(session, store.clone());
+    let rows: Vec<_> = (0..2000)
+        .map(|i| json!({"id": i, "name": format!("row-{i}")}))
+        .collect();
+    let mut result = ToolResult {
+        tool_call_id: "call_paths".to_string(),
+        result: Some(json!({"rows": rows})),
+        images: None,
+        error: None,
+        connection_required: None,
+        raw_output: None,
+    };
+
+    DistillOutputHook
+        .after_exec(
+            &output_tool_call(),
+            &output_tool_def(false),
+            &mut result,
+            &context,
+        )
+        .await;
+
+    let expected = store.display_path("/outputs/call_paths.stdout");
+    let value = result.result.as_ref().unwrap();
+    assert_eq!(value["full_output"], json!(expected));
+    assert_eq!(value["output_files"], json!([expected]));
+    assert!(value["distill_note"].as_str().unwrap().contains(&expected));
+    assert!(store.read_file(session, &expected).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn persisted_output_paths_follow_real_disk_mount_and_vfs_identity() {
+    let direct_root = TempDir::new().unwrap();
+    let direct: Arc<dyn SessionFileSystem> =
+        Arc::new(RealDiskFileStore::new(direct_root.path()).unwrap());
+    assert_output_pointers_follow_store(direct.clone()).await;
+    assert_distillation_pointer_follows_store(direct).await;
+
+    let mounted_root = TempDir::new().unwrap();
+    let mounted = MountFs::wrap(Arc::new(
+        RealDiskFileStore::new(mounted_root.path()).unwrap(),
+    ));
+    assert_output_pointers_follow_store(mounted.clone()).await;
+    assert_distillation_pointer_follows_store(mounted).await;
+
+    let memory: Arc<dyn SessionFileSystem> = Arc::new(InMemorySessionFileStore::new());
+    assert_eq!(memory.display_root(), "/workspace");
+    assert_output_pointers_follow_store(memory.clone()).await;
+    assert_distillation_pointer_follows_store(memory).await;
 }
 
 #[tokio::test]

--- a/docs/advanced/tool-output-pipeline.md
+++ b/docs/advanced/tool-output-pipeline.md
@@ -24,7 +24,7 @@ raw output ───────────────────────
 2. Capability hooks                                        │
   │   • Tool Output Distillation  (non-exec tools)         │
   ▼                                                        ▼
-3. Final infrastructure hooks                      /workspace/outputs/
+3. Final infrastructure hooks                      <display-root>/outputs/
   │   • Persist Output  (exec tools → VFS)         {tool_call_id}.stdout
   │   • Output Hard Limit  (64 KiB ceiling)        {tool_call_id}.stderr
   ▼                                                  ▲
@@ -76,8 +76,8 @@ Two infrastructure hooks always run last, in order:
 Everything the pipeline elides is recoverable from the **session filesystem**:
 
 ```
-/workspace/outputs/{tool_call_id}.stdout    ← full standard output
-/workspace/outputs/{tool_call_id}.stderr    ← full standard error (when present)
+<display-root>/outputs/{tool_call_id}.stdout    ← full standard output
+<display-root>/outputs/{tool_call_id}.stderr    ← full standard error (when present)
 ```
 
 The inline result carries the pointer in `output_files` and `full_output`, plus a human-readable note telling the model to use `read_file` (with `offset`/`limit`) when it needs detail it can't see inline. Persisted streams are capped at 1 MiB each. Deleting the session cascades and removes them.
@@ -101,8 +101,8 @@ Together: the pipeline controls per-result size, compaction controls total-histo
 | Stage | Applies to | Effect | Destination of full output |
 |-------|-----------|--------|----------------------------|
 | Verbosity budget | exec/sandbox | Compact summary on success, diagnostic window on failure | `raw_output` → persisted in Stage 3 |
-| Distillation | MCP / web fetch / non-exec | Content-aware compact view | `/workspace/outputs/{id}.stdout` |
-| Persist Output | `persist_output` tools | Lossless write + pointer | `/workspace/outputs/{id}.{stdout,stderr}` |
+| Distillation | MCP / web fetch / non-exec | Content-aware compact view | `<display-root>/outputs/{id}.stdout` |
+| Persist Output | `persist_output` tools | Lossless write + pointer | `<display-root>/outputs/{id}.{stdout,stderr}` |
 | Output Hard Limit | all | 64 KiB ceiling backstop | (already persisted) |
 
 The agent always sees a lean view and can always recover the full original with `read_file`.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -165,7 +165,7 @@ All exec tools accept an `output` parameter controlling how much output is retur
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation — when the LLM needs every line |
 
-Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET` so the model relies on the persisted log; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. `AUTO_SUCCESS_BUDGET` is intentionally sized so the inline `stdout` field — including the `[full output saved to /workspace/outputs/... — use read_file ...]` pointer that `PersistOutputHook` appends — stays around 512 bytes total. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. Explicit `silent`/`concise`/`normal`/`verbose`/`full` are opt-ins for a fixed inline window and continue to behave exactly as before — they ignore exit code.
+Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET` so the model relies on the persisted log; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. `AUTO_SUCCESS_BUDGET` is intentionally sized so the inline `stdout` field — including the `[full output saved to ... — use read_file ...]` pointer that `PersistOutputHook` appends — stays around 512 bytes total. The pointer uses the session filesystem's display identity. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. Explicit `silent`/`concise`/`normal`/`verbose`/`full` are opt-ins for a fixed inline window and continue to behave exactly as before — they ignore exit code.
 
 Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and the files are readable with `read_file`. The persisted files are the source of truth for full logs; the inline payload is sized for next-step reasoning. See `crates/core/src/tool_output_sanitizer.rs` for budget constants, `output_verbosity_budget()`, and `resolve_auto_mode()`.
 
@@ -192,8 +192,8 @@ Human-facing exec tools should return a structured result instead of a single co
 | `hint` | string | Short diagnostic hint for signal exits or common recovery advice |
 | `truncated` | boolean | Whether stdout or stderr was truncated for the inline result |
 | `total_lines` | integer | Total stdout line count before truncation |
-| `output_files` | string[] | Session VFS files containing full persisted output |
-| `full_output` | string | Canonical stdout path in session VFS when persisted |
+| `output_files` | string[] | Model-visible, file-tool-readable paths containing full persisted output |
+| `full_output` | string | Model-visible, file-tool-readable stdout path when persisted |
 
 **Legacy compatibility:** Tools may continue to carry a combined pre-truncation string in `ToolResult.raw_output` for persistence hooks and logging, but the user-visible JSON contract should use `stdout`/`stderr`.
 

--- a/specs/tool-output-distillation.md
+++ b/specs/tool-output-distillation.md
@@ -59,7 +59,7 @@ Constants (no per-agent config in v1): `MIN_DISTILL_BYTES = 8 KiB`, `MAX_FIELD_B
 
 ## Recovery Contract
 
-The full original is written to `/outputs/{tool_call_id}.stdout` in the session VFS (same convention and helper as `tool_output_persistence`), readable with `read_file`. The distilled inline result carries `output_files` and `full_output` pointing at it, plus a `distill_note` instructing the model to `read_file` the full output when it needs detail it cannot see. This is the reversibility headroom builds via a separate CCR store; Everruns reuses the session VFS it already has.
+The full original is written to `/outputs/{tool_call_id}.stdout` in the session VFS (same convention and helper as `tool_output_persistence`). Model-visible `output_files`, `full_output`, and `distill_note` pointers are rendered through `SessionFileSystem::display_path`, so VFS stores expose `/workspace/...` while real-disk stores expose their host-absolute root. Every emitted pointer is accepted directly by `read_file`. This is the reversibility headroom builds via a separate CCR store; Everruns reuses the session VFS it already has.
 
 ## Configuration
 


### PR DESCRIPTION
## What changed
Persisted tool-output pointers now use the active SessionFileSystem display contract. output_files, full_output, inline full-output annotations, and distillation notes expose host-absolute paths for real-disk sessions while in-memory/VFS sessions retain /workspace. Every emitted pointer can be passed directly back to read_file.

## Why
Tool output persistence still hardcoded /workspace after MountFs became path-transparent. Real-disk agents therefore received output pointers that disagreed with their shell, file tools, repo map, LSP, and checkout path identity.

## Before / After
Before: a real-disk session rooted at /repo emitted /workspace/outputs/call.stdout while persisting under the real checkout. full_output and distillation metadata also exposed inconsistent session-key paths.

After: the same session emits /repo/outputs/call.stdout everywhere. In-memory stores still emit /workspace/outputs/call.stdout. Direct real-disk, mounted real-disk, and VFS conformance tests read every emitted pointer back through the file store.

## Risk
- Low
- Consumers of model-visible full_output now receive the same presented path as output_files instead of an internal session key. Both forms remain accepted by the underlying file stores, but the visible contract is now consistent.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL
- Findings and resolutions: persistence still sanitizes tool-call IDs, writes session-scoped /outputs keys, enforces the existing 1 MiB stream cap, and relies on backend containment. Rendering through display_path does not expand routing or host access, and regression tests prove emitted real-disk pointers round-trip through read_file. No dependencies, authorization boundaries, or new threat surface were introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)