### PR TITLE
test(sessions): refresh API contract cases

### DIFF
--- a/test_cases/api/sessions/TC001_create_session_for_agent.md
+++ b/test_cases/api/sessions/TC001_create_session_for_agent.md
@@ -6,7 +6,9 @@ Verify that a session can be created for an existing agent and starts in the cor
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
 - An agent exists (create one first)
 
 ## Test Data
@@ -21,7 +23,7 @@ Verify that a session can be created for an existing agent and starts in the cor
 
 1. Create agent:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
        "name": "chat-agent",
@@ -33,7 +35,7 @@ Verify that a session can be created for an existing agent and starts in the cor
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -41,7 +43,7 @@ Verify that a session can be created for an existing agent and starts in the cor
 
 3. Fetch session:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}"
    ```
 
 ## Expected Result
@@ -54,7 +56,7 @@ Verify that a session can be created for an existing agent and starts in the cor
 | `status` | `"started"` |
 | `preview` | `null` (no messages yet) |
 | `output_preview` | `null` |
-| `usage` | All counters at 0 |
+| `usage` | `null` before the first turn |
 
 ## Validation Commands
 

--- a/test_cases/api/sessions/TC002_send_message_and_get_response.md
+++ b/test_cases/api/sessions/TC002_send_message_and_get_response.md
@@ -6,14 +6,16 @@ Verify that sending a user message to a session triggers a turn, the agent respo
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
 - LLM API keys configured
 
 ## Test Data
 
 | Field | Value |
 |-------|-------|
-| Agent Name | Simple Chat Agent |
+| Agent Name | simple-chat-agent |
 | Agent Prompt | You are a helpful assistant. Answer concisely. |
 | User Message | What is 2 + 2? |
 
@@ -21,10 +23,10 @@ Verify that sending a user message to a session triggers a turn, the agent respo
 
 1. Create agent:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Simple Chat Agent",
+       "name": "simple-chat-agent",
        "system_prompt": "You are a helpful assistant. Answer concisely."
      }'
    ```
@@ -32,7 +34,7 @@ Verify that sending a user message to a session triggers a turn, the agent respo
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -40,7 +42,7 @@ Verify that sending a user message to a session triggers a turn, the agent respo
 
 3. Send user message:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -54,17 +56,22 @@ Verify that sending a user message to a session triggers a turn, the agent respo
 
 5. Get session events:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/events"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}/events"
    ```
 
 6. Get messages:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/messages"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}/messages"
    ```
 
 7. Check session status:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}"
+   ```
+
+8. List sessions and find `session_id` in the response:
+   ```bash
+   curl -s "${BASE_URL}/api/v1/sessions"
    ```
 
 ## Expected Result
@@ -95,8 +102,9 @@ Verify that sending a user message to a session triggers a turn, the agent respo
 | Check | Expected |
 |-------|----------|
 | `status` | `"idle"` |
-| `preview` | Contains `"What is 2 + 2?"` |
-| `output_preview` | Non-empty |
+| Detail `preview` and `output_preview` | May remain `null`; detail is not the preview-hydration contract |
+| List row `preview` | Contains `"What is 2 + 2?"` |
+| List row `output_preview` | Non-empty |
 | `usage.total_tokens` | > 0 |
 
 ## Validation Commands
@@ -110,4 +118,8 @@ curl -s ".../sessions/{session_id}/events" | jq '[.data[] | select(.type == "tur
 
 # Assert: session is idle
 curl -s ".../sessions/{session_id}" | jq '.status == "idle"'
+
+# Assert: list hydration includes previews for this session
+curl -s ".../sessions" \
+  | jq --arg id "{session_id}" '.data[] | select(.id == $id) | (.preview != null and .output_preview != null)'
 ```

--- a/test_cases/api/sessions/TC003_multi_turn_conversation.md
+++ b/test_cases/api/sessions/TC003_multi_turn_conversation.md
@@ -6,14 +6,16 @@ Verify that an agent maintains context across multiple turns in the same session
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
 - LLM API keys configured
 
 ## Test Data
 
 | Field | Value |
 |-------|-------|
-| Agent Name | Memory Agent |
+| Agent Name | memory-agent |
 | Agent Prompt | You are a helpful assistant. Remember context from previous messages. |
 | Message 1 | My name is Alice. |
 | Message 2 | What is my name? |
@@ -22,10 +24,10 @@ Verify that an agent maintains context across multiple turns in the same session
 
 1. Create agent:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Memory Agent",
+       "name": "memory-agent",
        "system_prompt": "You are a helpful assistant. Remember context from previous messages."
      }'
    ```
@@ -33,7 +35,7 @@ Verify that an agent maintains context across multiple turns in the same session
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -41,7 +43,7 @@ Verify that an agent maintains context across multiple turns in the same session
 
 3. Send first message:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -55,7 +57,7 @@ Verify that an agent maintains context across multiple turns in the same session
 
 5. Send second message:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -69,7 +71,7 @@ Verify that an agent maintains context across multiple turns in the same session
 
 7. Get all messages:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/messages"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}/messages"
    ```
 
 ## Expected Result

--- a/test_cases/api/sessions/TC004_session_with_tool_use.md
+++ b/test_cases/api/sessions/TC004_session_with_tool_use.md
@@ -6,26 +6,28 @@ Verify that an agent with capabilities uses tools during a session and produces 
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
 - LLM API keys configured
 
 ## Test Data
 
 | Field | Value |
 |-------|-------|
-| Agent Name | Tool Agent |
+| Agent Name | tool-agent |
 | Agent Prompt | You are an assistant. Use available tools to help the user. |
 | Capabilities | `current_time` |
-| User Message | What is the current time? |
+| User Message | Use the current-time tool to get the current UTC time, convert it to America/Chicago, and return it in 24-hour ISO 8601 format with the UTC offset. |
 
 ## Steps
 
 1. Create agent with `current_time` capability:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Tool Agent",
+       "name": "tool-agent",
        "system_prompt": "You are an assistant. Always use the current_time tool when asked about time.",
        "capabilities": [{"ref": "current_time"}]
      }'
@@ -34,7 +36,7 @@ Verify that an agent with capabilities uses tools during a session and produces 
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -42,12 +44,12 @@ Verify that an agent with capabilities uses tools during a session and produces 
 
 3. Send message requesting time:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
          "role": "user",
-         "content": [{"type": "text", "text": "What is the current time?"}]
+         "content": [{"type": "text", "text": "Use the current-time tool to get the current UTC time, convert it to America/Chicago, and return it in 24-hour ISO 8601 format with the UTC offset."}]
        }
      }'
    ```
@@ -56,7 +58,7 @@ Verify that an agent with capabilities uses tools during a session and produces 
 
 5. Get events:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/events"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}/events"
    ```
 
 ## Expected Result
@@ -65,9 +67,10 @@ Verify that an agent with capabilities uses tools during a session and produces 
 
 | Check | Expected |
 |-------|----------|
-| `tool.called` event | Exists with `tool_name: "current_time"` |
+| `act.started` event | Exists before tool execution |
+| `tool.started` event | Exists for the current-time tool |
 | `tool.completed` event | Exists with successful result |
-| `reason.completed` | `has_tool_calls: true` |
+| `act.completed` event | Exists after tool execution |
 
 ### Agent Response
 
@@ -82,7 +85,11 @@ Verify that an agent with capabilities uses tools during a session and produces 
 ```bash
 # Assert: tool was called
 curl -s ".../sessions/{session_id}/events" \
-  | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "current_time")] | length > 0'
+  | jq '[.data[] | select(.type == "tool.started" and (.data.tool_call.name == "current_time" or .data.tool_call.name == "get_current_time"))] | length > 0'
+
+# Assert: tool completed successfully
+curl -s ".../sessions/{session_id}/events" \
+  | jq '[.data[] | select(.type == "tool.completed" and .data.success == true)] | length > 0'
 
 # Assert: turn completed
 curl -s ".../sessions/{session_id}/events" \

--- a/test_cases/api/sessions/TC005_session_list_and_filter.md
+++ b/test_cases/api/sessions/TC005_session_list_and_filter.md
@@ -6,58 +6,70 @@ Verify that sessions can be listed and filtered by agent_id.
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
+- The organization may contain sessions created by other tests or users
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Agent A name | session-agent-a |
+| Agent B name | session-agent-b |
+| Sessions to create | Two for Agent A; one for Agent B |
 
 ## Steps
 
 1. Create two agents:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Agent A", "system_prompt": "Agent A."}'
+     -d '{"name": "session-agent-a", "system_prompt": "Agent A."}'
 
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Agent B", "system_prompt": "Agent B."}'
+     -d '{"name": "session-agent-b", "system_prompt": "Agent B."}'
    ```
    Save `agent_a_id` and `agent_b_id`.
 
 2. Create sessions for each agent:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_a_id}"}'
 
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_a_id}"}'
 
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_b_id}"}'
    ```
+   Save the returned session IDs as `agent_a_session_1`, `agent_a_session_2`, and `agent_b_session_1`.
 
 3. List all sessions:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions"
+   curl -s "${BASE_URL}/api/v1/sessions"
    ```
 
 4. Filter sessions by Agent A:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions?agent_id={agent_a_id}"
+   curl -s "${BASE_URL}/api/v1/sessions?agent_id={agent_a_id}"
    ```
 
 5. Filter sessions by Agent B:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions?agent_id={agent_b_id}"
+   curl -s "${BASE_URL}/api/v1/sessions?agent_id={agent_b_id}"
    ```
 
 ## Expected Result
 
 | Check | Expected |
 |-------|----------|
-| Step 3: total sessions | >= 3 |
-| Step 4: sessions count | 2 (both for Agent A) |
+| Step 3: created sessions | All three saved session IDs are present |
+| Step 4: created Agent A sessions | Both saved Agent A session IDs are present |
 | Step 4: all `agent_id` values | Match `agent_a_id` |
-| Step 5: sessions count | 1 (for Agent B) |
-| Step 5: `agent_id` | Matches `agent_b_id` |
+| Step 5: created Agent B session | Saved Agent B session ID is present |
+| Step 5: all `agent_id` values | Match `agent_b_id` |

--- a/test_cases/api/sessions/TC006_cancel_active_turn.md
+++ b/test_cases/api/sessions/TC006_cancel_active_turn.md
@@ -6,14 +6,16 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
 - LLM API keys configured
 
 ## Test Data
 
 | Field | Value |
 |-------|-------|
-| Agent Name | Slow Agent |
+| Agent Name | slow-agent |
 | Agent Prompt | You are an assistant. Write a very long, detailed essay about the history of computing. |
 | User Message | Write the essay now. |
 
@@ -21,10 +23,10 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 
 1. Create agent:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Slow Agent",
+       "name": "slow-agent",
        "system_prompt": "You are an assistant. Write a very long, detailed essay about the history of computing."
      }'
    ```
@@ -32,7 +34,7 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -40,7 +42,7 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 
 3. Send message to trigger a long response:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -52,12 +54,12 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 
 4. While session is active, cancel the turn:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/cancel"
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/cancel"
    ```
 
 5. Wait briefly, then check session status:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}"
    ```
 
 ## Expected Result
@@ -66,5 +68,5 @@ Verify that an active turn can be cancelled and the session returns to idle stat
 |-------|----------|
 | Step 4: HTTP status | 200 |
 | Step 5: session `status` | `"idle"` |
-| Events contain cancellation | `turn.cancelled` or `turn.completed` event |
+| Events contain cancellation | `turn.cancelled` event |
 | Events contain lifecycle settle | `session.idled` event emitted after `turn.cancelled` |

--- a/test_cases/api/sessions/TC007_delete_session.md
+++ b/test_cases/api/sessions/TC007_delete_session.md
@@ -6,21 +6,30 @@ Verify that a session can be deleted and is no longer accessible.
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Agent name | temp-agent |
+| Agent prompt | Temporary. |
 
 ## Steps
 
 1. Create agent:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Temp Agent", "system_prompt": "Temporary."}'
+     -d '{"name": "temp-agent", "system_prompt": "Temporary."}'
    ```
    Save `agent_id`.
 
 2. Create session:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{"agent_id": "{agent_id}"}'
    ```
@@ -28,17 +37,17 @@ Verify that a session can be deleted and is no longer accessible.
 
 3. Delete session:
    ```bash
-   curl -s -X DELETE "http://localhost:9300/api/v1/sessions/{session_id}"
+   curl -s -X DELETE "${BASE_URL}/api/v1/sessions/{session_id}"
    ```
 
 4. Attempt to fetch deleted session:
    ```bash
-   curl -s -o /dev/null -w "%{http_code}" "http://localhost:9300/api/v1/sessions/{session_id}"
+   curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/sessions/{session_id}"
    ```
 
 ## Expected Result
 
 | Check | Expected |
 |-------|----------|
-| Step 3: HTTP status | 200 |
+| Step 3: HTTP status | 204 with no response body |
 | Step 4: HTTP status | 404 |

--- a/test_cases/api/sessions/TC008_session_with_model_override.md
+++ b/test_cases/api/sessions/TC008_session_with_model_override.md
@@ -6,24 +6,35 @@ Verify that a session can override the agent's default model and that the overri
 
 ## Preconditions
 
-- API server running (`just start-dev`)
+- API server running locally (`just start-dev`) or a deployed API is available
+- Set `BASE_URL` to the API origin (for example, `http://localhost:9300`)
+- For authenticated deployments, configure `curl` with the required authorization and organization headers
 - LLM API keys configured
 - At least two models available (check `GET /v1/models`)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Agent name | model-test-agent |
+| Default model | Any enabled model |
+| Override model | A different enabled model |
+| User message | Hello. |
 
 ## Steps
 
 1. List available models:
    ```bash
-   curl -s "http://localhost:9300/api/v1/models"
+   curl -s "${BASE_URL}/api/v1/models"
    ```
    Pick two model IDs.
 
 2. Create agent with default model:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+   curl -s -X POST "${BASE_URL}/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Model Test Agent",
+       "name": "model-test-agent",
        "system_prompt": "You are a helpful assistant.",
        "default_model_id": "{model_id_1}"
      }'
@@ -32,7 +43,7 @@ Verify that a session can override the agent's default model and that the overri
 
 3. Create session with model override:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions" \
      -H "Content-Type: application/json" \
      -d '{
        "agent_id": "{agent_id}",
@@ -43,7 +54,7 @@ Verify that a session can override the agent's default model and that the overri
 
 4. Send message:
    ```bash
-   curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
+   curl -s -X POST "${BASE_URL}/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
@@ -55,7 +66,12 @@ Verify that a session can override the agent's default model and that the overri
 
 5. Wait for completion, then check events:
    ```bash
-   curl -s "http://localhost:9300/api/v1/sessions/{session_id}/events"
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}/events"
+   ```
+
+6. Fetch the session and confirm its selected model:
+   ```bash
+   curl -s "${BASE_URL}/api/v1/sessions/{session_id}"
    ```
 
 ## Expected Result
@@ -63,5 +79,5 @@ Verify that a session can override the agent's default model and that the overri
 | Check | Expected |
 |-------|----------|
 | Session `model_id` | `{model_id_2}` (override, not agent default) |
-| `reason.completed` event | `model` field matches `{model_id_2}` |
 | Agent responds | `output.message.completed` event exists |
+| Output model metadata | `output.message.completed.message.metadata.model` or `llm.generation.metadata.model` matches `{model_id_2}` |


### PR DESCRIPTION
## What changed
Refreshed all eight session API manual cases for current response, preview-hydration, event, filtering, deletion, and model-metadata contracts. Cases now support local or authenticated deployed targets through `BASE_URL` and use valid agent slugs.

The TC006 cancellation case still requires `turn.cancelled` followed by `session.idled` and idle status, preserving EVE-708 as a genuine product defect.

## Why
The 2026-07-10 SaaS functional run found stale assertions that created false failures and obscured the real cancellation defect.

## Before / After
Before: cases expected zeroed initial usage, detail previews, `tool.called`, shared-org exact counts, DELETE 200, and `reason.completed` model metadata.

After: cases expect `usage: null`, list-hydrated previews, current tool lifecycle events, created-ID membership, DELETE 204, and supported output/generation model metadata.

## Risk
- Low
- Manual test documentation only; runtime behavior is unchanged. Incorrect assertions could misclassify future functional results.

## Security
- Threat categories reviewed: No security-relevant code changes; only manual test Markdown changed.
- Findings and resolutions: Secret-pattern scan passed. Authenticated deployment instructions refer to headers without including credentials.

## Follow-ups
No follow-ups. EVE-708 remains the owning product defect for cancellation settling.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)