### PR TITLE
test(memory): expect scoped memory in workflow fs test

### DIFF
--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -657,7 +657,7 @@ async fn test_session_filesystem() {
 
     let fs_url = format!("{}/v1/sessions/{}/fs", API_BASE_URL, session.id);
 
-    // Step 3: List root directory (should be empty)
+    // Step 3: List root directory (new sessions mount scoped memory under the reserved memory root)
     println!("\nStep 3: Listing root directory...");
     let list_response = client
         .get(&fs_url)
@@ -667,8 +667,11 @@ async fn test_session_filesystem() {
 
     assert_eq!(list_response.status(), 200);
     let list_result: Value = list_response.json().await.expect("Failed to parse");
-    assert_eq!(list_result["data"].as_array().unwrap().len(), 0);
-    println!("Root directory is empty");
+    let root_entries = list_result["data"].as_array().unwrap();
+    assert_eq!(root_entries.len(), 1);
+    assert_eq!(root_entries[0]["path"], "/memory");
+    assert_eq!(root_entries[0]["is_directory"], true);
+    println!("Root directory contains scoped memory mount");
 
     // Step 4: Create a file
     println!("\nStep 4: Creating file...");


### PR DESCRIPTION
## What changed
Updated the push-only workflow filesystem test to expect the scoped memory mount at the session root. This matches the shipped EVE-699 behavior where new sessions expose `/memory` with scoped user/agent memory underneath.

## Why
Main CI for merged PR #2675 failed in `Workflow Tests (Server + Worker)` because `test_session_filesystem` still asserted a fresh session root had zero entries. After scoped memory mounts, the root correctly contains `/memory`.

## Before / After
Before: main CI failed on merge commit `3b84301`:

```text
test test_session_filesystem ... FAILED
assertion `left == right` failed
left: 1
right: 0
```

After: focused local workflow validation passed against a local CI-like API server on `localhost:9000`:

```text
cargo test -p everruns-server --test workflow_test test_session_filesystem -- --exact --test-threads=1 --nocapture
# test result: ok. 1 passed; 0 failed
```

`just pre-push` also passed.

## Risk
- Low
- Test-only change. Risk is limited to workflow test expectations around the session filesystem root.

## Security
- Threat categories reviewed: No security-relevant code changes; this only updates a test assertion.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
