### PR TITLE
fix(reporting): optimize fact_session projection for large histories

### DIFF
--- a/crates/server/migrations/102_session_reporting_event_counts.sql
+++ b/crates/server/migrations/102_session_reporting_event_counts.sql
@@ -1,0 +1,89 @@
+-- Denormalize session turn/tool counts for fact_session projection (EVE-731).
+--
+-- `project_session` previously recomputed correlated COUNT(*) subqueries over
+-- `events` on every snapshot upsert. As session history grows, each projection
+-- update rescanned the full event log. Keep incremental counters on `sessions`
+-- maintained by statement-level INSERT/DELETE triggers so repeated projection
+-- work reads O(1) fields instead of scanning history.
+
+ALTER TABLE sessions
+    ADD COLUMN turn_count BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN tool_call_count BIGINT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN sessions.turn_count IS
+    'Denormalized: count of turn.completed, turn.failed, and turn.cancelled events';
+COMMENT ON COLUMN sessions.tool_call_count IS
+    'Denormalized: count of tool.completed events';
+
+-- One-time backfill from canonical events before triggers take over.
+UPDATE sessions s
+SET
+    turn_count = counts.turn_count,
+    tool_call_count = counts.tool_call_count
+FROM (
+    SELECT
+        e.session_id,
+        count(*) FILTER (
+            WHERE e.event_type IN ('turn.completed', 'turn.failed', 'turn.cancelled')
+        ) AS turn_count,
+        count(*) FILTER (WHERE e.event_type = 'tool.completed') AS tool_call_count
+    FROM events e
+    GROUP BY e.session_id
+) counts
+WHERE s.id = counts.session_id;
+
+CREATE OR REPLACE FUNCTION sessions_reporting_event_counts_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE sessions s
+    SET
+        turn_count = s.turn_count + delta.turn_count,
+        tool_call_count = s.tool_call_count + delta.tool_call_count
+    FROM (
+        SELECT
+            session_id,
+            count(*) FILTER (
+                WHERE event_type IN ('turn.completed', 'turn.failed', 'turn.cancelled')
+            ) AS turn_count,
+            count(*) FILTER (WHERE event_type = 'tool.completed') AS tool_call_count
+        FROM new_rows
+        GROUP BY session_id
+    ) delta
+    WHERE s.id = delta.session_id
+      AND (delta.turn_count > 0 OR delta.tool_call_count > 0);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sessions_reporting_event_counts_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE sessions s
+    SET
+        turn_count = GREATEST(s.turn_count - delta.turn_count, 0),
+        tool_call_count = GREATEST(s.tool_call_count - delta.tool_call_count, 0)
+    FROM (
+        SELECT
+            session_id,
+            count(*) FILTER (
+                WHERE event_type IN ('turn.completed', 'turn.failed', 'turn.cancelled')
+            ) AS turn_count,
+            count(*) FILTER (WHERE event_type = 'tool.completed') AS tool_call_count
+        FROM old_rows
+        GROUP BY session_id
+    ) delta
+    WHERE s.id = delta.session_id
+      AND (delta.turn_count > 0 OR delta.tool_call_count > 0);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER sessions_reporting_event_counts_insert
+    AFTER INSERT ON events
+    REFERENCING NEW TABLE AS new_rows
+    FOR EACH STATEMENT EXECUTE FUNCTION sessions_reporting_event_counts_insert();
+
+CREATE TRIGGER sessions_reporting_event_counts_delete
+    AFTER DELETE ON events
+    REFERENCING OLD TABLE AS old_rows
+    FOR EACH STATEMENT EXECUTE FUNCTION sessions_reporting_event_counts_delete();

--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -38,6 +38,18 @@ impl InMemoryDatabase {
             created_at: now,
         };
         self.events.write().insert(id, row.clone());
+        {
+            let mut sessions = self.sessions.write();
+            if let Some(session) = sessions.get_mut(&row.session_id) {
+                match row.event_type.as_str() {
+                    "turn.completed" | "turn.failed" | "turn.cancelled" => {
+                        session.turn_count += 1;
+                    }
+                    "tool.completed" => session.tool_call_count += 1,
+                    _ => {}
+                }
+            }
+        }
         let org_id = {
             let sessions = self.sessions.read();
             sessions.get(&row.session_id).map(|session| session.org_id)

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -92,6 +92,8 @@ impl InMemoryDatabase {
             total_output_tokens: 0,
             total_cache_read_tokens: 0,
             total_cache_creation_tokens: 0,
+            turn_count: 0,
+            tool_call_count: 0,
             total_actual_cost_usd: 0.0,
             total_estimated_cost_usd: 0.0,
             total_cost_usd: 0.0,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -777,6 +777,12 @@ pub struct SessionRow {
     /// Cumulative cache creation tokens for all LLM calls in this session
     #[sqlx(default)]
     pub total_cache_creation_tokens: i64,
+    /// Denormalized count of turn.completed, turn.failed, and turn.cancelled events
+    #[sqlx(default)]
+    pub turn_count: i64,
+    /// Denormalized count of tool.completed events
+    #[sqlx(default)]
+    pub tool_call_count: i64,
     /// Cumulative provider-reported actual cost in USD for this session
     #[sqlx(default)]
     pub total_actual_cost_usd: f64,

--- a/crates/server/src/storage/reporting/mod.rs
+++ b/crates/server/src/storage/reporting/mod.rs
@@ -1,6 +1,7 @@
 pub mod models;
 pub mod outbox;
 pub mod postgres_query_backend;
+mod projection_timing;
 
 pub use outbox::PostgresReportingProjector;
 pub use postgres_query_backend::PostgresReportingQueryBackend;

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use sqlx::{PgPool, Postgres, pool::PoolConnection};
+use std::time::Instant;
 use uuid::Uuid;
 
 use super::models::ReportingOutboxRow;
+use super::projection_timing::{FACT_SESSION_UPSERT, maybe_warn_slow_projection};
 use crate::domains::reporting::types::{ProjectorRunResult, ReportingBackfillResult};
 
 const STALE_PROCESSING_MINUTES: i32 = 15;
@@ -1172,7 +1174,8 @@ impl PostgresReportingProjector {
 
     async fn project_session(&self, org_id: i64, source_id: &str) -> Result<()> {
         let id = Uuid::parse_str(source_id).context("invalid session source id")?;
-        sqlx::query(
+        let started = Instant::now();
+        let result = sqlx::query(
             r#"
             INSERT INTO fact_session (
                 org_id, source_key, session_id, user_id, principal_id, agent_id,
@@ -1206,24 +1209,14 @@ impl PostgresReportingProjector {
                     THEN GREATEST(EXTRACT(EPOCH FROM (s.finished_at - s.started_at)) * 1000, 0)::BIGINT
                     ELSE 0
                 END,
-                (
-                    SELECT COUNT(*)
-                    FROM events e
-                    WHERE e.session_id = s.id
-                      AND e.event_type IN ('turn.completed', 'turn.failed', 'turn.cancelled')
-                ),
+                s.turn_count,
                 s.total_input_tokens,
                 s.total_output_tokens,
                 s.total_cache_read_tokens,
                 s.total_cache_creation_tokens,
                 s.total_input_tokens + s.total_output_tokens
                     + s.total_cache_read_tokens + s.total_cache_creation_tokens,
-                (
-                    SELECT COUNT(*)
-                    FROM events e
-                    WHERE e.session_id = s.id
-                      AND e.event_type = 'tool.completed'
-                ),
+                s.tool_call_count,
                 NOW()
             FROM sessions s
             LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
@@ -1257,6 +1250,14 @@ impl PostgresReportingProjector {
         .bind(org_id)
         .execute(&self.pool)
         .await?;
+        maybe_warn_slow_projection(
+            FACT_SESSION_UPSERT,
+            started.elapsed(),
+            result.rows_affected(),
+            "session",
+            Some("session_snapshot"),
+            org_id,
+        );
         self.project_configured_capabilities(org_id, id).await?;
         Ok(())
     }

--- a/crates/server/src/storage/reporting/projection_timing.rs
+++ b/crates/server/src/storage/reporting/projection_timing.rs
@@ -1,0 +1,218 @@
+use std::time::Duration;
+
+use tracing::warn;
+
+/// Stable identifiers for reporting projection SQL families.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProjectionQueryFamily {
+    pub operation: &'static str,
+    pub query_family: &'static str,
+}
+
+pub(crate) const FACT_SESSION_UPSERT: ProjectionQueryFamily = ProjectionQueryFamily {
+    operation: "reporting.project_session",
+    query_family: "fact_session_upsert",
+};
+
+/// Host-supplied deployment context for slow-projection warnings.
+#[derive(Debug, Clone, Default)]
+struct ProjectionHostContext {
+    environment: Option<String>,
+    service_version: Option<String>,
+}
+
+impl ProjectionHostContext {
+    fn from_env() -> Self {
+        Self {
+            environment: std::env::var("OTEL_ENVIRONMENT").ok(),
+            service_version: std::env::var("OTEL_SERVICE_VERSION").ok(),
+        }
+    }
+}
+
+fn slow_threshold() -> Duration {
+    const DEFAULT_MS: u64 = 1_000;
+    let millis = std::env::var("REPORTING_PROJECTION_SLOW_THRESHOLD_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_MS);
+    Duration::from_millis(millis.max(1))
+}
+
+fn warn_slow_projection(
+    family: ProjectionQueryFamily,
+    elapsed: Duration,
+    rows_affected: u64,
+    source_type: &str,
+    event_kind: Option<&str>,
+    org_id: i64,
+    threshold: Duration,
+) {
+    if elapsed < threshold {
+        return;
+    }
+
+    let host = ProjectionHostContext::from_env();
+    warn!(
+        operation = family.operation,
+        query_family = family.query_family,
+        elapsed_ms = elapsed.as_millis() as u64,
+        rows_affected,
+        source_type,
+        event_kind,
+        org_id,
+        environment = host.environment.as_deref(),
+        service_version = host.service_version.as_deref(),
+        "Reporting projection query exceeded slow threshold"
+    );
+}
+
+/// Emit one structured warning when projection work crosses the slow threshold.
+/// Includes only stable operation metadata — no tenant content, SQL parameters,
+/// or PII.
+pub(crate) fn maybe_warn_slow_projection(
+    family: ProjectionQueryFamily,
+    elapsed: Duration,
+    rows_affected: u64,
+    source_type: &str,
+    event_kind: Option<&str>,
+    org_id: i64,
+) {
+    warn_slow_projection(
+        family,
+        elapsed,
+        rows_affected,
+        source_type,
+        event_kind,
+        org_id,
+        slow_threshold(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::{Layer, Registry};
+
+    struct CaptureVisitor {
+        fields: Vec<(String, String)>,
+    }
+
+    impl Visit for CaptureVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .push((field.name().to_string(), format!("{value:?}")));
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+    }
+
+    type CapturedEvents = Arc<Mutex<Vec<Vec<(String, String)>>>>;
+
+    struct CaptureLayer {
+        events: CapturedEvents,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = CaptureVisitor { fields: Vec::new() };
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.fields);
+        }
+    }
+
+    fn field_map(fields: &[(String, String)]) -> std::collections::BTreeMap<&str, &str> {
+        fields
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn slow_warning_includes_required_fields_and_redacts_sensitive_payload() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let layer = CaptureLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        unsafe {
+            std::env::set_var("OTEL_ENVIRONMENT", "test");
+            std::env::set_var("OTEL_SERVICE_VERSION", "1.2.3");
+        }
+
+        warn_slow_projection(
+            FACT_SESSION_UPSERT,
+            Duration::from_millis(50),
+            1,
+            "session",
+            Some("session_snapshot"),
+            42,
+            Duration::from_millis(1),
+        );
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let fields = field_map(&captured[0]);
+        assert_eq!(fields.get("operation"), Some(&"reporting.project_session"));
+        assert_eq!(fields.get("query_family"), Some(&"fact_session_upsert"));
+        assert_eq!(fields.get("elapsed_ms"), Some(&"50"));
+        assert_eq!(fields.get("rows_affected"), Some(&"1"));
+        assert_eq!(fields.get("source_type"), Some(&"session"));
+        assert_eq!(fields.get("event_kind"), Some(&"session_snapshot"));
+        assert_eq!(fields.get("org_id"), Some(&"42"));
+        assert_eq!(fields.get("environment"), Some(&"test"));
+        assert_eq!(fields.get("service_version"), Some(&"1.2.3"));
+        assert!(!fields.contains_key("session_id"));
+        assert!(!fields.contains_key("source_id"));
+        assert!(!fields.contains_key("sql"));
+        assert!(!fields.contains_key("title"));
+
+        unsafe {
+            std::env::remove_var("OTEL_ENVIRONMENT");
+            std::env::remove_var("OTEL_SERVICE_VERSION");
+        }
+    }
+
+    #[test]
+    fn fast_projection_emits_no_warning() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let layer = CaptureLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        warn_slow_projection(
+            FACT_SESSION_UPSERT,
+            Duration::from_millis(10),
+            1,
+            "session",
+            None,
+            1,
+            Duration::from_millis(1_000),
+        );
+
+        assert!(events.lock().unwrap().is_empty());
+    }
+}

--- a/crates/server/tests/reporting_integration_test.rs
+++ b/crates/server/tests/reporting_integration_test.rs
@@ -714,3 +714,214 @@ async fn reporting_event_repair_benchmark() {
         elapsed.as_millis()
     );
 }
+
+#[tokio::test]
+async fn fact_session_projection_uses_denormalized_counts_for_large_histories() {
+    let server = TestServer::new().await;
+    let org = server
+        .db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: format!("Reporting fact session org {}", Uuid::now_v7()),
+            created_by: None,
+        })
+        .await
+        .expect("create fact session projection org");
+    let session_id =
+        create_reporting_repair_session(&server, org.org_id, "fact-session-large").await;
+    let base_time = Utc::now() - Duration::days(90);
+
+    let (event_count, turn_events, tool_events): (i64, i64, i64) = sqlx::query_as(
+        r#"
+        WITH inserted AS (
+            INSERT INTO events (
+                id, session_id, sequence, event_type, data, context, ts, created_at
+            )
+            SELECT uuidv7(),
+                   $1,
+                   n,
+                   CASE (n % 3)
+                       WHEN 0 THEN 'turn.completed'
+                       WHEN 1 THEN 'tool.completed'
+                       ELSE 'output.message.delta'
+                   END,
+                   '{}'::jsonb,
+                   '{}'::jsonb,
+                   $2 + n * INTERVAL '1 microsecond',
+                   $2 + n * INTERVAL '1 microsecond'
+              FROM generate_series(1, 3000) n
+            RETURNING event_type
+        )
+        SELECT COUNT(*)::BIGINT,
+               COUNT(*) FILTER (
+                   WHERE event_type IN ('turn.completed', 'turn.failed', 'turn.cancelled')
+               )::BIGINT,
+               COUNT(*) FILTER (WHERE event_type = 'tool.completed')::BIGINT
+          FROM inserted
+        "#,
+    )
+    .bind(session_id)
+    .bind(base_time)
+    .fetch_one(&server.pool)
+    .await
+    .expect("seed large session history");
+
+    assert_eq!(event_count, 3000);
+    assert_eq!(turn_events, 1000);
+    assert_eq!(tool_events, 1000);
+
+    let (session_turn_count, session_tool_count): (i64, i64) =
+        sqlx::query_as("SELECT turn_count, tool_call_count FROM sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_one(&server.pool)
+            .await
+            .expect("load denormalized session counters");
+    assert_eq!((session_turn_count, session_tool_count), (1000, 1000));
+
+    let plan: Vec<(String,)> = sqlx::query_as(
+        r#"
+        EXPLAIN
+        INSERT INTO fact_session (
+            org_id, source_key, session_id, user_id, principal_id, agent_id,
+            agent_name_snapshot, harness_id, harness_name_snapshot, app_id,
+            blueprint_id, created_at, time_bucket_day, session_status, started_at,
+            finished_at, last_active_at, session_count, duration_ms, turn_count,
+            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+            total_tokens, tool_call_count, projected_at
+        )
+        SELECT
+            s.org_id,
+            'session:' || s.id::TEXT,
+            s.id,
+            s.resolved_owner_user_id,
+            s.owner_principal_id,
+            s.agent_id,
+            a.name,
+            s.harness_id,
+            h.name,
+            s.app_id,
+            s.blueprint_id,
+            s.created_at,
+            (s.created_at AT TIME ZONE 'UTC')::DATE,
+            s.status,
+            s.started_at,
+            s.finished_at,
+            s.updated_at,
+            1,
+            CASE
+                WHEN s.started_at IS NOT NULL AND s.finished_at IS NOT NULL
+                THEN GREATEST(EXTRACT(EPOCH FROM (s.finished_at - s.started_at)) * 1000, 0)::BIGINT
+                ELSE 0
+            END,
+            s.turn_count,
+            s.total_input_tokens,
+            s.total_output_tokens,
+            s.total_cache_read_tokens,
+            s.total_cache_creation_tokens,
+            s.total_input_tokens + s.total_output_tokens
+                + s.total_cache_read_tokens + s.total_cache_creation_tokens,
+            s.tool_call_count,
+            NOW()
+        FROM sessions s
+        LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+        LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+        WHERE s.id = $1 AND s.org_id = $2
+        ON CONFLICT (org_id, source_key) DO UPDATE SET
+            turn_count = EXCLUDED.turn_count,
+            tool_call_count = EXCLUDED.tool_call_count,
+            projected_at = NOW()
+        "#,
+    )
+    .bind(session_id)
+    .bind(org.org_id)
+    .fetch_all(&server.pool)
+    .await
+    .expect("explain fact_session upsert");
+    let plan_text = plan
+        .iter()
+        .map(|(line,)| line.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !plan_text.contains("events"),
+        "fact_session upsert must not scan events; plan:\n{plan_text}"
+    );
+
+    async fn enqueue_session_snapshot(pool: &sqlx::PgPool, session_id: Uuid) {
+        sqlx::query(
+            r#"
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            SELECT org_id, 'session', id::TEXT, updated_at::TEXT, 'session_snapshot', 'pending', NOW()
+              FROM sessions
+             WHERE id = $1
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO UPDATE SET
+                status = 'pending',
+                next_attempt_at = NOW(),
+                updated_at = NOW()
+            "#,
+        )
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .expect("enqueue session snapshot");
+    }
+
+    enqueue_session_snapshot(&server.pool, session_id).await;
+    let projector = PostgresReportingProjector::new(server.pool.clone());
+
+    let first_started = std::time::Instant::now();
+    projector
+        .run_once(org.org_id, 1)
+        .await
+        .expect("first session projection");
+    let first_elapsed = first_started.elapsed();
+
+    let (fact_turn_count, fact_tool_count): (i64, i64) = sqlx::query_as(
+        "SELECT turn_count, tool_call_count FROM fact_session WHERE session_id = $1",
+    )
+    .bind(session_id)
+    .fetch_one(&server.pool)
+    .await
+    .expect("load projected session fact");
+    assert_eq!((fact_turn_count, fact_tool_count), (1000, 1000));
+
+    sqlx::query("UPDATE sessions SET updated_at = NOW() WHERE id = $1")
+        .bind(session_id)
+        .execute(&server.pool)
+        .await
+        .expect("touch session for repeated projection");
+    enqueue_session_snapshot(&server.pool, session_id).await;
+
+    let repeat_started = std::time::Instant::now();
+    projector
+        .run_once(org.org_id, 1)
+        .await
+        .expect("repeated session projection");
+    let repeat_elapsed = repeat_started.elapsed();
+
+    let (fact_turn_count, fact_tool_count): (i64, i64) = sqlx::query_as(
+        "SELECT turn_count, tool_call_count FROM fact_session WHERE session_id = $1",
+    )
+    .bind(session_id)
+    .fetch_one(&server.pool)
+    .await
+    .expect("reload projected session fact after repeat");
+    assert_eq!((fact_turn_count, fact_tool_count), (1000, 1000));
+
+    assert!(
+        first_elapsed < std::time::Duration::from_millis(500),
+        "first projection took {first_elapsed:?} with {event_count} events"
+    );
+    assert!(
+        repeat_elapsed < std::time::Duration::from_millis(500),
+        "repeated projection took {repeat_elapsed:?} with {event_count} events"
+    );
+    eprintln!(
+        "fact_session projection benchmark: {event_count} events, first={}ms repeat={}ms",
+        first_elapsed.as_millis(),
+        repeat_elapsed.as_millis()
+    );
+}


### PR DESCRIPTION
## What changed

`fact_session` projection no longer rescans the full `events` table on every session snapshot upsert. Turn and tool-call totals are read from denormalized `sessions.turn_count` and `sessions.tool_call_count` columns maintained incrementally by INSERT/DELETE triggers. Slow projection work now emits a structured `tracing::warn!` with stable operation metadata for SaaS hosts to map to Sentry.

## Why

Live dev reporting projector runs crossed the SQLx slow-query threshold (~1.3s) on `INSERT INTO fact_session ... ON CONFLICT DO UPDATE` because correlated `COUNT(*)` subqueries over `events` rescanned growing session histories on every projection update (EVE-731).

## Before / After

**Before:** `project_session` used two correlated `COUNT(*)` subqueries over `events` per upsert — O(session history size) per projection.

**After:** Projection reads `s.turn_count` / `s.tool_call_count` from `sessions` — O(1) per projection.

Integration test seeds 3,000 events and benchmarks repeated projection:

```text
fact_session projection benchmark: 3000 events, first=8ms repeat=8ms
```

`EXPLAIN` confirms the upsert plan does not reference the `events` table.

## Risk

- Medium — new migration adds columns + triggers; incorrect trigger logic could drift counts. Mitigated by one-time backfill, DELETE trigger symmetry, and integration test asserting fact totals match expected counts after repeated projection.

## Security

- Threat categories reviewed: TM-SQL, TM-DOS
- Findings and resolutions:
  - TM-SQL: Trigger predicates are fixed event-type lists; no user input in trigger SQL.
  - TM-DOS: Removes repeated full-history scans, reducing DB contention under large sessions.
  - Slow-projection warnings intentionally exclude tenant content, SQL parameters, and PII (only stable operation/query-family metadata, elapsed time, rows affected, org_id, host env).

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (migration backfills existing sessions; triggers maintain counts going forward)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
