### PR TITLE
feat(api): surface structured task result via A2A + MCP

### DIFF
--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -719,11 +719,47 @@ async fn handle_tasks_get(
         Err(err) => return internal_error(err).into_response(),
     };
 
+    // EVE-728: surface the task's deterministic structured result (result.json
+    // reported via a `result_schema`, EVE-678) as an A2A artifact. Reading is
+    // org-scoped (TM-A2A-012) and the channel-binding check above already
+    // fenced the session to this API key's channel, so a leaked session id from
+    // another channel cannot exfiltrate its result.
+    let structured_result = match crate::domains::session_tasks::read_structured_task_result(
+        &state.db,
+        auth.org_id,
+        session_id,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(err) => return internal_error(err).into_response(),
+    };
+
     let mut task = build_task_json(session.id, state_label, None);
+    if let Some(result) = structured_result
+        && let Some(obj) = task.as_object_mut()
+    {
+        obj.insert(
+            "artifacts".to_string(),
+            json!([a2a_result_artifact(result)]),
+        );
+    }
     if legacy_response {
         task = legacy_task_json(task);
     }
     (StatusCode::OK, rpc_success(rpc_id, task)).into_response()
+}
+
+/// Wrap a task's structured `result.json` (EVE-678) as an A2A `Artifact` with a
+/// single `DataPart`, so `tasks/get` callers receive the deterministic machine
+/// result rather than only the last-message / status text. Shape follows the
+/// A2A `Artifact` model (`artifactId` + `name` + typed `parts`).
+fn a2a_result_artifact(result: Value) -> Value {
+    json!({
+        "artifactId": "result",
+        "name": "result",
+        "parts": [{ "kind": "data", "data": result }],
+    })
 }
 
 /// THREAT[TM-A2A-012]: `tasks/cancel` performs a destructive action on a

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -1095,12 +1095,30 @@ async fn handle_tasks_get(
 
     match tool_session_get_status(&args, org, state).await {
         Ok(status_json) => {
-            let status_value: Value = serde_json::from_str(&status_json).unwrap_or(Value::Null);
+            let mut status_value: Value = serde_json::from_str(&status_json).unwrap_or(Value::Null);
             let session_status = status_value
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or("");
             let task_status = tasks::task_status_from_session_status(session_status);
+
+            // EVE-728: when the task reported a deterministic structured result
+            // (result.json via a `result_schema`, EVE-678), surface it under
+            // `result.structured_result` so Tasks clients get the machine result
+            // instead of only last-message / status text. The read is org-scoped
+            // (same org `tool_session_get_status` already validated), preserving
+            // tenant isolation. Parse failures / absent results are silently
+            // skipped — the status payload is still returned.
+            if let Ok(session_id) = task_id.parse::<everruns_core::typed_id::SessionId>()
+                && let Ok(Some(structured)) =
+                    crate::domains::session_tasks::read_structured_task_result(
+                        &state.db, org.org_id, session_id,
+                    )
+                    .await
+                && let Some(obj) = status_value.as_object_mut()
+            {
+                obj.insert("structured_result".to_string(), structured);
+            }
 
             let mut task = tasks::task_handle(task_id, task_status);
             // The full session_get_status payload is the task's result view. For

--- a/crates/server/src/domains/session_tasks/mod.rs
+++ b/crates/server/src/domains/session_tasks/mod.rs
@@ -1,4 +1,6 @@
 pub mod commands;
 pub mod queries;
+pub mod result;
 
 pub use commands::*;
+pub use result::read_structured_task_result;

--- a/crates/server/src/domains/session_tasks/result.rs
+++ b/crates/server/src/domains/session_tasks/result.rs
@@ -1,0 +1,83 @@
+// Structured task result retrieval (EVE-678 → EVE-728).
+//
+// A task declared with a `result_schema` records a deterministic, schema-valid
+// `result.json` when its child calls `report_result` (see EVE-678,
+// `everruns_core::capabilities::subagents::ReportResultTool`). The validated
+// object is written to the owning session's virtual filesystem at
+// `/.tasks/{task_id}/result.json` and the owning `session_tasks` row gets a
+// `result_path` pointer.
+//
+// The A2A and MCP task surfaces both expose a session as a "task" handle, so
+// this helper resolves that structured result for a session id and hands it to
+// each surface (A2A `tasks/get` artifact, MCP Tasks `tasks/get` result). See
+// `specs/a2a-channel.md` / `specs/mcp.md`.
+
+use everruns_core::SessionId;
+use serde_json::Value;
+
+use crate::storage::StorageBackend;
+
+/// Read the deterministic structured result (`result.json`) reported for a
+/// session, if any.
+///
+/// Returns `Ok(None)` when the session has no owned task that reported a
+/// structured result (the common case — a plain agent turn produces
+/// last-message text, not a schema-bound result).
+///
+/// When a session owns more than one result-bearing task, the most recently
+/// updated one wins. That keeps the contract deterministic for the typical
+/// single-result task while still surfacing the freshest result if an app
+/// re-runs the work.
+///
+/// # Tenant isolation
+///
+/// Every read is scoped by `org_id`. The session is loaded via
+/// `get_session(org_id, ..)`, which both enforces the tenant boundary and
+/// yields the `workspace_id` that owns the VFS where `report_result` wrote the
+/// file — so a caller in one org can never read another org's result file even
+/// if it guesses a session id.
+pub async fn read_structured_task_result(
+    db: &StorageBackend,
+    org_id: i64,
+    session_id: SessionId,
+) -> anyhow::Result<Option<Value>> {
+    // Org-scoped session load. Also yields the workspace id backing the VFS:
+    // `report_result` writes keyed by the owning session's workspace, so we
+    // read it back with the same key.
+    let Some(session) = db.get_session(org_id, session_id).await? else {
+        return Ok(None);
+    };
+
+    // Owned tasks that reported a structured result. `result_path` is only ever
+    // set by `report_result`, which requires a declared `result_schema`, so its
+    // presence alone is a sufficient marker — no need to re-inspect the spec.
+    let rows = db.list_session_tasks(session_id, None, None).await?;
+    let mut best: Option<everruns_core::SessionTask> = None;
+    for row in &rows {
+        let task = row.to_task()?;
+        if task.result_path.is_none() {
+            continue;
+        }
+        match &best {
+            Some(current) if current.updated_at >= task.updated_at => {}
+            _ => best = Some(task),
+        }
+    }
+    let Some(result_path) = best.and_then(|task| task.result_path) else {
+        return Ok(None);
+    };
+
+    // The session VFS is keyed by the workspace id (the file was written with
+    // the owning session's `workspace_id`); read the file back with that key.
+    let Some(file) = db
+        .get_session_file(session.workspace_id, &result_path)
+        .await?
+    else {
+        return Ok(None);
+    };
+    let Some(bytes) = file.content else {
+        return Ok(None);
+    };
+    let value = serde_json::from_slice::<Value>(&bytes)?;
+    Ok(Some(value))
+}

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -931,6 +931,222 @@ async fn a2a_tasks_get_returns_non_terminal_for_freshly_dispatched_task() {
     assert_eq!(malformed_response["error"]["code"], -32602);
 }
 
+/// Send a JSON-RPC request to an A2A channel and return the parsed envelope.
+async fn a2a_rpc(
+    server: &TestServer,
+    app_id: &str,
+    channel_id: &str,
+    api_key: &str,
+    method: &str,
+    params: Value,
+) -> Value {
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "rpc-1",
+        "method": method,
+        "params": params,
+    }))
+    .unwrap();
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json()
+}
+
+/// Seed a deterministic structured result (EVE-678) on `session_id`: create a
+/// `result_schema`-bound task owned by the session, point it at a result file,
+/// and write that file into the session's workspace VFS. Returns the JSON we
+/// stored so callers can assert round-trip fidelity.
+async fn seed_structured_result(server: &TestServer, session_id: &str, result: Value) {
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, SessionTaskUpdate, new_session_task, task_result_path,
+    };
+    use everruns_server::storage::models::CreateSessionFileRow;
+
+    let sid = session_id.parse::<SessionId>().expect("valid session id");
+    let session = server
+        .db
+        .get_session(DEFAULT_ORG_ID, sid)
+        .await
+        .expect("get_session")
+        .expect("session exists");
+
+    // Create the owning task in a non-terminal state, then set `result_path`
+    // via an update — mirroring how `report_result` records the pointer.
+    let task = new_session_task(
+        CreateSessionTask {
+            session_id: sid,
+            id: None,
+            kind: "subagent".to_string(),
+            display_name: "structured result".to_string(),
+            spec: json!({ "result_schema": { "type": "object" } }),
+            state: SessionTaskState::Running,
+            links: Default::default(),
+            wake_policy: Default::default(),
+        },
+        chrono::Utc::now(),
+    );
+    server
+        .db
+        .create_session_task(&task)
+        .await
+        .expect("create task");
+
+    let path = task_result_path(&task.id);
+    server
+        .db
+        .update_session_task(
+            sid,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                result_path: Some(path.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("set result_path");
+
+    // The VFS is keyed by the owning session's workspace id (that's the key
+    // `report_result` writes with, and the key the reader reads back with).
+    server
+        .db
+        .create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(session.workspace_id),
+            path,
+            content: Some(serde_json::to_vec(&result).unwrap()),
+            is_directory: false,
+            is_readonly: false,
+        })
+        .await
+        .expect("write result file");
+}
+
+/// A task that reported a schema-bound `result.json` (EVE-678) exposes it as an
+/// A2A `tasks/get` artifact `DataPart`, not just last-message / status text.
+#[tokio::test]
+async fn a2a_tasks_get_surfaces_structured_result_artifact() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-result-artifact", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    let send = a2a_rpc(
+        &server,
+        app_id,
+        channel_id,
+        &api_key,
+        "message/send",
+        json!({ "message": { "role": "user", "parts": [{ "kind": "text", "text": "triage" }] } }),
+    )
+    .await;
+    let task_id = send["result"]["id"].as_str().unwrap().to_string();
+
+    // No structured result yet → no artifacts on the task.
+    let before = a2a_rpc(
+        &server,
+        app_id,
+        channel_id,
+        &api_key,
+        "tasks/get",
+        json!({ "id": task_id }),
+    )
+    .await;
+    assert!(
+        before["result"].get("artifacts").is_none(),
+        "no artifacts before a result is reported, got {before}"
+    );
+
+    let expected = json!({ "verdict": "spam", "confidence": 0.97 });
+    seed_structured_result(&server, &task_id, expected.clone()).await;
+
+    let after = a2a_rpc(
+        &server,
+        app_id,
+        channel_id,
+        &api_key,
+        "tasks/get",
+        json!({ "id": task_id }),
+    )
+    .await;
+    let artifacts = after["result"]["artifacts"]
+        .as_array()
+        .expect("artifacts present after reporting a result");
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0]["name"], "result");
+    let parts = artifacts[0]["parts"].as_array().expect("artifact parts");
+    assert_eq!(parts[0]["kind"], "data");
+    assert_eq!(parts[0]["data"], expected);
+}
+
+/// Tenant isolation: a second channel's API key must not receive another
+/// channel's structured-result artifact — the cross-channel lookup collapses to
+/// `-32001 Task not found` with no artifact leak.
+#[tokio::test]
+async fn a2a_tasks_get_structured_result_not_leaked_cross_channel() {
+    let server = TestServer::in_memory().await;
+    let (app_a, key_a) = create_app_with_a2a(&server, "a2a-result-owner", "{{a2a.text}}").await;
+    let app_a_id = app_a["id"].as_str().unwrap();
+    let chan_a = app_a["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_a_id).await;
+
+    let (app_b, key_b) = create_app_with_a2a(&server, "a2a-result-snoop", "{{a2a.text}}").await;
+    let app_b_id = app_b["id"].as_str().unwrap();
+    let chan_b = app_b["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_b_id).await;
+
+    let send = a2a_rpc(
+        &server,
+        app_a_id,
+        chan_a,
+        &key_a,
+        "message/send",
+        json!({ "message": { "role": "user", "parts": [{ "kind": "text", "text": "secret" }] } }),
+    )
+    .await;
+    let task_id = send["result"]["id"].as_str().unwrap().to_string();
+    seed_structured_result(&server, &task_id, json!({ "secret": "value" })).await;
+
+    // Channel B (a different app/channel in the same org) cannot read the task
+    // or its artifact.
+    let snoop = a2a_rpc(
+        &server,
+        app_b_id,
+        chan_b,
+        &key_b,
+        "tasks/get",
+        json!({ "id": task_id }),
+    )
+    .await;
+    assert_eq!(snoop["error"]["code"], -32001);
+    assert!(snoop.get("result").is_none() || snoop["result"].is_null());
+
+    // The owning channel still sees the artifact.
+    let owner = a2a_rpc(
+        &server,
+        app_a_id,
+        chan_a,
+        &key_a,
+        "tasks/get",
+        json!({ "id": task_id }),
+    )
+    .await;
+    assert_eq!(
+        owner["result"]["artifacts"][0]["parts"][0]["data"]["secret"],
+        "value"
+    );
+}
+
 /// `tasks/cancel` returns the task with state=canceled and is idempotent — a
 /// second cancel returns the already-canceled task without a new state
 /// transition.

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -3527,6 +3527,110 @@ async fn test_mcp_tasks_get_round_trip() {
     );
 }
 
+/// Seed a deterministic structured result (EVE-678) on `session_id`: create a
+/// `result_schema`-bound task owned by the session, point it at a result file,
+/// and write that file into the session's workspace VFS.
+async fn seed_structured_result(server: &TestServer, session_id: &str, result: Value) {
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, SessionTaskUpdate, new_session_task, task_result_path,
+    };
+    use everruns_server::storage::models::CreateSessionFileRow;
+
+    let sid = session_id.parse::<SessionId>().expect("valid session id");
+    let session = server
+        .db
+        .get_session(DEFAULT_ORG_ID, sid)
+        .await
+        .expect("get_session")
+        .expect("session exists");
+
+    let task = new_session_task(
+        CreateSessionTask {
+            session_id: sid,
+            id: None,
+            kind: "subagent".to_string(),
+            display_name: "structured result".to_string(),
+            spec: json!({ "result_schema": { "type": "object" } }),
+            state: SessionTaskState::Running,
+            links: Default::default(),
+            wake_policy: Default::default(),
+        },
+        chrono::Utc::now(),
+    );
+    server
+        .db
+        .create_session_task(&task)
+        .await
+        .expect("create task");
+
+    let path = task_result_path(&task.id);
+    server
+        .db
+        .update_session_task(
+            sid,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                result_path: Some(path.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("set result_path");
+
+    server
+        .db
+        .create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(session.workspace_id),
+            path,
+            content: Some(serde_json::to_vec(&result).unwrap()),
+            is_directory: false,
+            is_readonly: false,
+        })
+        .await
+        .expect("write result file");
+}
+
+/// EVE-728: when a task reported a schema-bound `result.json`, `tasks/get`
+/// surfaces it under `result.structured_result` for Tasks clients — not just
+/// the last-message / status snapshot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_get_surfaces_structured_result() {
+    let server = TestServer::new().await;
+
+    let run = mcp_task_tool_call(&server, "agent_run", json!({ "message": "task result" })).await;
+    let task_id = run["result"]["taskId"].as_str().unwrap().to_string();
+
+    // Before a structured result is reported, only the status snapshot is
+    // present under `result`.
+    let before = mcp_call_with_headers(
+        &server,
+        "tasks/get",
+        json!({ "taskId": task_id }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+    assert!(
+        before["result"]["result"]
+            .get("structured_result")
+            .is_none()
+    );
+
+    let expected = json!({ "verdict": "ok", "score": 42 });
+    seed_structured_result(&server, &task_id, expected.clone()).await;
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/get",
+        json!({ "taskId": task_id }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    assert_eq!(resp["result"]["taskId"].as_str(), Some(task_id.as_str()));
+    assert_eq!(resp["result"]["result"]["structured_result"], expected);
+}
+
 /// tasks/get for 2025-* is method_not_found (extension doesn't exist there).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_tasks_get_rejected_for_2025() {

--- a/specs/a2a-channel.md
+++ b/specs/a2a-channel.md
@@ -222,6 +222,31 @@ separate task table in this iteration:
 session id. An unknown but well-formed task id surfaces `-32001 Task not
 found`. A malformed task id surfaces `-32602 Invalid params`.
 
+**Structured result artifact.** When the underlying session reported a
+deterministic, schema-bound result (`result.json`, produced by a task declared
+with a `result_schema` — see [`specs/subagents.md`](subagents.md) and
+[`specs/session-tasks.md`](session-tasks.md)), `tasks/get` surfaces that JSON as
+an A2A `Artifact` on the task rather than leaving the caller to parse
+last-message text:
+
+```json
+"artifacts": [
+  {
+    "artifactId": "result",
+    "name": "result",
+    "parts": [{ "kind": "data", "data": { "...": "the result.json object" } }]
+  }
+]
+```
+
+The artifact is present only when a result was reported; a plain agent turn
+returns the task with no `artifacts`. When a session reported more than one
+structured result the most recently updated one wins. Retrieval is org-scoped
+and further fenced by the same channel-binding check as the rest of `tasks/get`
+(TM-A2A-012): the artifact for a session created by one channel is never
+returned to an API key for a different channel, even within the same org — the
+cross-channel lookup collapses to `-32001 Task not found` with no artifact leak.
+
 `tasks/cancel` cancels the in-flight durable workflow for the underlying
 session and emits a `turn.cancelled` event so subsequent `tasks/get` calls
 observe the canceled state. Cancelling an already-terminal task is
@@ -368,6 +393,10 @@ Coverage required:
    not found`.
 7. Validation: empty text parts rejected; non-`message/send` methods
    rejected; malformed envelopes rejected.
+8. Structured result: a session that reported a schema-bound `result.json`
+   surfaces it as the `tasks/get` artifact `DataPart`; a session with no
+   reported result has no `artifacts`; the artifact is not leaked to a
+   different channel's API key (cross-channel lookup stays `-32001`).
 
 ## Rate Limiting
 

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -144,6 +144,18 @@ into the tools/call `result`; the existing `content` / `structuredContent` are
 untouched. `tasks/get` returns a `Task` object (`taskId`, `status`, `ttlMs`,
 `pollIntervalMs`) with the full `session_get_status` payload under `result`.
 
+**Structured result.** When the task's session reported a deterministic,
+schema-bound result (`result.json`, produced by a task declared with a
+`result_schema` — see [`specs/subagents.md`](subagents.md) and
+[`specs/session-tasks.md`](session-tasks.md)), `tasks/get` adds that JSON under
+`result.structured_result`, so Tasks clients get the machine result instead of
+re-parsing last-message text. It is additive: the existing status snapshot
+(session status, latest output, events) is unchanged, and a plain agent turn
+that reported no structured result omits the field. Retrieval is scoped by the
+same org `session_get_status` already validated, so tenant isolation is
+preserved; when a session reported more than one structured result the most
+recently updated one wins.
+
 > **RC schema note.** The Tasks extension is still an experimental RC and its
 > authoritative sources disagree on the duration field spelling: the
 > [overview docs](https://modelcontextprotocol.io/extensions/tasks/overview)


### PR DESCRIPTION
## What changed
A task that reported a deterministic, schema-bound result (`result.json`, produced by a task declared with a `result_schema` — EVE-678) now exposes that JSON on both external task surfaces, instead of leaving callers to parse last-message / status text:

- **Inbound A2A `tasks/get`** returns the result as an A2A `Artifact` with a single `DataPart`:
  ```json
  "artifacts": [
    { "artifactId": "result", "name": "result",
      "parts": [{ "kind": "data", "data": { "...": "the result.json object" } }] }
  ]
  ```
  The `artifacts` field is present only when a result was reported; a plain agent turn returns the task unchanged.
- **MCP Tasks extension `tasks/get`** adds the same JSON under `result.structured_result`, additively — the existing `session_get_status` snapshot is untouched and the field is omitted when no result was reported.

Both surfaces share one new helper, `read_structured_task_result` (session_tasks domain): an org-scoped lookup of a session's result-bearing task plus its `result.json` in the session workspace VFS. When a session reported more than one structured result, the most recently updated one wins.

## Why
Follow-up split from EVE-682 (item 3). EVE-678 landed deterministic task results (`result.json`), but the A2A and MCP task surfaces still only surfaced last-message/status text, so agent-to-agent and MCP callers could not consume the machine-readable result they had explicitly asked for via `result_schema`.

## Before / After
A2A `tasks/get` for a session that reported a structured result:
- **Before:** task object with `status` only; the structured result was unreachable over A2A.
- **After:** same task object plus `artifacts[0].parts[0].data` = the reported JSON.

MCP `tasks/get`:
- **Before:** `result` = session status snapshot only.
- **After:** `result.structured_result` = the reported JSON (snapshot otherwise unchanged).

Evidence — new in-memory A2A integration tests (exercise the real HTTP handler → reader → storage end-to-end):
```
running 2 tests
test a2a_tasks_get_surfaces_structured_result_artifact ... ok
test a2a_tasks_get_structured_result_not_leaked_cross_channel ... ok
test result: ok. 2 passed; 0 failed
```
`cargo fmt --check`, `cargo clippy -p everruns-server --all-targets --all-features` (clean), and `cargo check -p everruns-server` all pass locally. The new MCP test (`test_mcp_tasks_get_surfaces_structured_result`) is Postgres-backed like its sibling task tests and compiles locally; it runs in CI.

## Risk
- Low
- Purely additive read-side wiring on two existing endpoints. No schema/migration changes. A malformed or oversized `result.json` is handled the same way the task owner's existing workspace-files read already handles it; parse failures are skipped (MCP) or surfaced as an internal error (A2A) rather than corrupting the response.

## Security
- Threat categories reviewed: **TM-A2A-012** (A2A channel/tenant isolation), **TM-TENANT** (org scoping), **TM-API** (data surfaced on existing endpoints), **TM-DOS**.
- Findings and resolutions:
  - The shared reader loads the session via `get_session(org_id, ..)`, so every read is org-scoped and a caller in one org cannot read another org's result even by guessing a session id.
  - A2A `tasks/get` keeps its existing channel-binding check (TM-A2A-012): a session created by one channel still collapses to `-32001 Task not found` for a different channel's API key — the new artifact is fenced by the same check, covered by `a2a_tasks_get_structured_result_not_leaked_cross_channel`.
  - MCP reads under the same org that `tool_session_get_status` already validated for the request.
  - No new unbounded loops: at most one owned-task scan (bounded per session) and one session-file read. No new injection, auth, or SQL surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; absent-result omits the field/artifact; 2025-* MCP clients and non-opted-in clients unaffected)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-728.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21yJXXdWU3jhfTo8RpwNs)_