### PR TITLE
fix(storage): bound message history reads

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -8,9 +8,12 @@
 
 use async_trait::async_trait;
 use everruns_core::budget::{BudgetSummary, BudgetToolResponse};
-use everruns_core::capabilities::{AgentCapabilityConfig, CapabilityRegistry};
+use everruns_core::capabilities::{
+    AgentCapabilityConfig, CapabilityRegistry, collect_message_filters_only,
+};
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
+use everruns_core::message_retriever::MessageRetriever;
 use everruns_core::permissions::PermissionResolver;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
@@ -23,7 +26,7 @@ use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverId, DriverRegistry, EgressRequest,
     EgressRequestKind, EgressService, EventData, Harness, HarnessStatus, Message, MessageRole,
     Session, SessionParticipant, SessionStatus, ToolDefinition, ToolResultContentPart,
-    UtilityLlmService, merge_harness,
+    UtilityLlmService, merge_harness, resolve_runtime_capabilities,
 };
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
@@ -320,6 +323,31 @@ impl DirectWorkerAdapters {
             org_rate_limiter: None,
             quota: crate::domains::session_files::limits::QuotaLimits::from_env(),
         }
+    }
+
+    async fn load_turn_messages(
+        &self,
+        session: &Session,
+        agent: Option<&Agent>,
+        harness: Option<&Harness>,
+    ) -> Result<Vec<Message>> {
+        let harness_chain: Vec<Harness> = harness.cloned().into_iter().collect();
+        let resolved =
+            resolve_runtime_capabilities(&harness_chain, agent, session, &self.capability_registry);
+        let message_filters = collect_message_filters_only(
+            &resolved.effective_overlay.capabilities,
+            &self.capability_registry,
+        );
+        let mut query = everruns_core::MessageQuery::new(session.id);
+        message_filters.apply_message_filters(&mut query);
+
+        let retriever = crate::storage::DbMessageRetriever::new(self.db.clone());
+        let mut messages = retriever.load_filtered(query).await.map_err(|error| {
+            tracing::error!("Failed to load bounded turn messages: {error}");
+            store_error("Failed to load messages")
+        })?;
+        message_filters.apply_post_load_filters(&mut messages);
+        Ok(messages)
     }
 
     /// Set the agent runner for platform management tools (send_message, etc.)
@@ -1403,8 +1431,13 @@ impl WorkerAdapters for DirectWorkerAdapters {
         let mut mcp_tool_definitions = org_mcp_tool_definitions;
         mcp_tool_definitions.extend(local_mcp_tool_definitions);
 
-        // Load messages
-        let messages = self.load_messages(session_id).await?;
+        // Load messages through the same capability-aware windowing used by
+        // reason atoms. Long sessions should fetch a bounded prompt candidate
+        // set (for example infinity_context's head+tail window), not the whole
+        // event history.
+        let messages = self
+            .load_turn_messages(&session, agent.as_ref(), harness.as_ref())
+            .await?;
 
         // Load model (session > agent > harness > default)
         let model = if let Some(model_id) = session.model_id {

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -7,7 +7,7 @@ use crate::domains::common::CommandErrorKind;
 const COMMAND_API_VERSION_V1: &str = "v1";
 const MAX_EXECUTE_COMMAND_PARAMS_BYTES: usize = 1024 * 1024;
 const DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT: i32 = 200;
-const MAX_TURN_CONTEXT_MESSAGE_LIMIT: i32 = 5_000;
+const MAX_TURN_CONTEXT_MESSAGE_LIMIT: i32 = crate::storage::repository::MESSAGE_SAFETY_LIMIT as i32;
 
 fn normalize_turn_context_message_limit(requested_limit: Option<i32>, default_limit: i32) -> i32 {
     let normalized_default = default_limit.clamp(1, MAX_TURN_CONTEXT_MESSAGE_LIMIT);

--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -409,9 +409,10 @@ impl InMemoryDatabase {
         } else if limit.is_some() {
             result.clear();
         } else if result.len() > MESSAGE_SAFETY_LIMIT {
-            // No explicit limit: cap to the earliest N rows, matching the
+            // No explicit limit: cap to the latest N rows, matching the
             // Postgres backend's safety cap on this path.
-            result.truncate(MESSAGE_SAFETY_LIMIT);
+            let drain_end = result.len() - MESSAGE_SAFETY_LIMIT;
+            result.drain(0..drain_end);
         }
         Ok(result)
     }

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -884,6 +884,8 @@ async fn test_list_message_events_filtered_caps_unbounded_history() {
         .await
         .unwrap();
     assert_eq!(limited.len(), cap);
+    assert_eq!(limited.first().unwrap().sequence, (total - cap + 1) as i32);
+    assert_eq!(limited.last().unwrap().sequence, total as i32);
 }
 
 #[tokio::test]

--- a/crates/server/src/storage/message_history_timing.rs
+++ b/crates/server/src/storage/message_history_timing.rs
@@ -1,0 +1,208 @@
+use std::time::Duration;
+
+use tracing::warn;
+
+/// Stable identifiers for message-history event-read families.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MessageHistoryQueryFamily {
+    pub operation: &'static str,
+    pub query_family: &'static str,
+}
+
+pub(crate) const MESSAGE_HISTORY_EVENTS: MessageHistoryQueryFamily = MessageHistoryQueryFamily {
+    operation: "storage.list_message_events",
+    query_family: "message_history_events",
+};
+
+pub(crate) const FILTERED_MESSAGE_HISTORY_EVENTS: MessageHistoryQueryFamily =
+    MessageHistoryQueryFamily {
+        operation: "storage.list_message_events_filtered",
+        query_family: "filtered_message_history_events",
+    };
+
+#[derive(Debug, Clone, Default)]
+struct MessageHistoryHostContext {
+    environment: Option<String>,
+    service_version: Option<String>,
+}
+
+impl MessageHistoryHostContext {
+    fn from_env() -> Self {
+        Self {
+            environment: std::env::var("OTEL_ENVIRONMENT").ok(),
+            service_version: std::env::var("OTEL_SERVICE_VERSION").ok(),
+        }
+    }
+}
+
+fn slow_threshold() -> Duration {
+    const DEFAULT_MS: u64 = 1_000;
+    let millis = std::env::var("MESSAGE_HISTORY_SLOW_THRESHOLD_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_MS);
+    Duration::from_millis(millis.max(1))
+}
+
+fn warn_slow_message_history(
+    family: MessageHistoryQueryFamily,
+    elapsed: Duration,
+    row_count: u64,
+    limit: i64,
+    threshold: Duration,
+) {
+    if elapsed < threshold {
+        return;
+    }
+
+    let host = MessageHistoryHostContext::from_env();
+    warn!(
+        operation = family.operation,
+        query_family = family.query_family,
+        elapsed_ms = elapsed.as_millis() as u64,
+        row_count,
+        limit,
+        environment = host.environment.as_deref(),
+        service_version = host.service_version.as_deref(),
+        "Message history event read exceeded slow threshold"
+    );
+}
+
+/// Emit one structured warning when a message-history event read crosses the
+/// slow threshold. Includes only stable operation metadata: no SQL, parameter
+/// values, session ids, org ids, event payload, or message content.
+pub(crate) fn maybe_warn_slow_message_history(
+    family: MessageHistoryQueryFamily,
+    elapsed: Duration,
+    row_count: u64,
+    limit: i64,
+) {
+    warn_slow_message_history(family, elapsed, row_count, limit, slow_threshold());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::{Layer, Registry};
+
+    type CapturedFields = Vec<Vec<(String, String)>>;
+
+    struct CaptureVisitor {
+        fields: Vec<(String, String)>,
+    }
+
+    impl Visit for CaptureVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .push((field.name().to_string(), format!("{value:?}")));
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+    }
+
+    struct CaptureLayer {
+        events: Arc<Mutex<CapturedFields>>,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = CaptureVisitor { fields: Vec::new() };
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.fields);
+        }
+    }
+
+    fn field_map(fields: &[(String, String)]) -> std::collections::HashMap<&str, &str> {
+        fields
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn slow_warning_includes_required_fields_and_redacts_sensitive_payload() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let layer = CaptureLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        unsafe {
+            std::env::set_var("OTEL_ENVIRONMENT", "test");
+            std::env::set_var("OTEL_SERVICE_VERSION", "1.2.3");
+        }
+
+        warn_slow_message_history(
+            MESSAGE_HISTORY_EVENTS,
+            Duration::from_millis(50),
+            2_000,
+            2_000,
+            Duration::from_millis(1),
+        );
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let fields = field_map(&captured[0]);
+        assert_eq!(
+            fields.get("operation"),
+            Some(&"storage.list_message_events")
+        );
+        assert_eq!(fields.get("query_family"), Some(&"message_history_events"));
+        assert_eq!(fields.get("elapsed_ms"), Some(&"50"));
+        assert_eq!(fields.get("row_count"), Some(&"2000"));
+        assert_eq!(fields.get("limit"), Some(&"2000"));
+        assert_eq!(fields.get("environment"), Some(&"test"));
+        assert_eq!(fields.get("service_version"), Some(&"1.2.3"));
+        assert!(!fields.contains_key("session_id"));
+        assert!(!fields.contains_key("org_id"));
+        assert!(!fields.contains_key("sql"));
+        assert!(!fields.contains_key("params"));
+        assert!(!fields.contains_key("content"));
+        assert!(!fields.contains_key("data"));
+
+        unsafe {
+            std::env::remove_var("OTEL_ENVIRONMENT");
+            std::env::remove_var("OTEL_SERVICE_VERSION");
+        }
+    }
+
+    #[test]
+    fn fast_read_emits_no_warning() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let layer = CaptureLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        warn_slow_message_history(
+            MESSAGE_HISTORY_EVENTS,
+            Duration::from_millis(10),
+            100,
+            2_000,
+            Duration::from_millis(50),
+        );
+
+        assert!(events.lock().unwrap().is_empty());
+    }
+}

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -18,6 +18,7 @@ pub mod encryption;
 pub mod harness_store;
 pub mod leased_resource_store;
 pub mod memory;
+mod message_history_timing;
 pub mod message_store;
 pub mod models;
 pub mod org_feature_flags_cache;

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -10,6 +10,10 @@ use everruns_core::typed_id::{EventId, SessionId};
 use tracing::warn;
 use uuid::Uuid;
 
+use crate::storage::message_history_timing::{
+    FILTERED_MESSAGE_HISTORY_EVENTS, MESSAGE_HISTORY_EVENTS, maybe_warn_slow_message_history,
+};
+
 /// Shared filter builder for `list_events_advanced` (and its `around_id` branch).
 /// Pushes type/time/context/tag/tool/search predicates onto the running query.
 fn push_common_filters(qb: &mut sqlx::QueryBuilder<sqlx::Postgres>, params: &ListEventsParams) {
@@ -487,6 +491,7 @@ impl Database {
         session_id: SessionId,
         limit: Option<i32>,
     ) -> Result<Vec<EventRow>> {
+        let started = std::time::Instant::now();
         let rows = if let Some(limit) = limit.filter(|limit| *limit > 0) {
             // Subquery: get most recent N by sequence DESC, then re-order ASC
             sqlx::query_as::<_, EventRow>(
@@ -509,15 +514,19 @@ impl Database {
         } else if limit.is_some() {
             Vec::new()
         } else {
-            // Safety cap when no explicit limit — prevents unbounded result sets.
+            // Safety cap when no explicit limit — prevents unbounded result sets
+            // and keeps the latest prompt-relevant rows.
             sqlx::query_as::<_, EventRow>(
                 r#"
-                SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
-                FROM events
-                WHERE session_id = $1
-                  AND event_type IN ('input.message', 'output.message.completed', 'tool.completed')
+                SELECT * FROM (
+                    SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
+                    FROM events
+                    WHERE session_id = $1
+                      AND event_type IN ('input.message', 'output.message.completed', 'tool.completed')
+                    ORDER BY sequence DESC
+                    LIMIT $2
+                ) recent
                 ORDER BY sequence ASC
-                LIMIT $2
                 "#,
             )
             .bind(session_id.uuid())
@@ -525,6 +534,17 @@ impl Database {
             .fetch_all(&self.pool)
             .await?
         };
+
+        let effective_limit = limit
+            .filter(|limit| *limit > 0)
+            .map(i64::from)
+            .unwrap_or(MESSAGE_SAFETY_LIMIT as i64);
+        maybe_warn_slow_message_history(
+            MESSAGE_HISTORY_EVENTS,
+            started.elapsed(),
+            rows.len() as u64,
+            effective_limit,
+        );
 
         Ok(rows)
     }
@@ -558,6 +578,7 @@ impl Database {
         &self,
         query: &MessageQuery,
     ) -> Result<Vec<EventRow>> {
+        let started = std::time::Instant::now();
         // Build dynamic SQL query
         let mut sql = String::from(
             "SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at FROM events WHERE session_id = $1",
@@ -648,8 +669,10 @@ impl Database {
         // Whether the final SQL emits rows newest-first (needs reversing back to
         // chronological order after fetch).
         let mut needs_reverse = false;
+        let effective_limit: i64;
         match (query.offset, query.limit) {
             (Some(offset), Some(limit)) => {
+                effective_limit = limit.max(0);
                 sql = format!(
                     "SELECT * FROM ({sql} ORDER BY sequence ASC OFFSET {}) offset_events ORDER BY sequence DESC LIMIT {}",
                     offset.max(0),
@@ -658,9 +681,11 @@ impl Database {
                 needs_reverse = true;
             }
             (Some(offset), None) => {
+                effective_limit = -1;
                 sql.push_str(&format!(" ORDER BY sequence ASC OFFSET {}", offset.max(0)));
             }
             (None, Some(limit)) if keep_head > 0 => {
+                effective_limit = keep_head as i64 + limit.max(0);
                 // Head+tail load: keep the first `keep_head` (the task anchor) plus
                 // the latest `limit` tail, de-duplicated when the windows overlap.
                 //
@@ -688,10 +713,12 @@ impl Database {
                 );
             }
             (None, Some(limit)) => {
+                effective_limit = limit.max(0);
                 sql.push_str(&format!(" ORDER BY sequence DESC LIMIT {}", limit.max(0)));
                 needs_reverse = true;
             }
             (None, None) => {
+                effective_limit = MESSAGE_SAFETY_LIMIT as i64;
                 // Safety cap on the otherwise-unbounded full-history read. This
                 // branch is reached when MessageRetriever::load_filtered forces
                 // limit/offset = None to fetch the full candidate set for
@@ -741,6 +768,12 @@ impl Database {
         if needs_reverse {
             rows.reverse();
         }
+        maybe_warn_slow_message_history(
+            FILTERED_MESSAGE_HISTORY_EVENTS,
+            started.elapsed(),
+            rows.len() as u64,
+            effective_limit,
+        );
 
         Ok(rows)
     }

--- a/crates/server/src/storage/repository.rs
+++ b/crates/server/src/storage/repository.rs
@@ -10,7 +10,7 @@ use super::reporting::models::ReportingOutboxRow;
 use super::repositories::Database;
 
 /// Shared hard cap for otherwise-unbounded message history reads.
-pub const MESSAGE_SAFETY_LIMIT: usize = 5_000;
+pub const MESSAGE_SAFETY_LIMIT: usize = 2_000;
 
 /// Shared storage contract for repository operations that must stay identical
 /// across PostgreSQL and in-memory backends.

--- a/crates/server/tests/repository_conformance_test.rs
+++ b/crates/server/tests/repository_conformance_test.rs
@@ -293,10 +293,9 @@ async fn run_repository_conformance(repo: &dyn Repository, label: &str, harness_
         .await
         .expect("list message events without explicit limit");
     assert_eq!(uncapped.len(), MESSAGE_SAFETY_LIMIT);
-    assert_eq!(
-        uncapped.first().expect("first capped event").sequence,
-        1,
-        "unbounded list_message_events_limited keeps the earliest capped window"
+    assert!(
+        uncapped.first().expect("first capped event").sequence > 1,
+        "unbounded list_message_events_limited keeps the latest capped window"
     );
 
     let filtered = repo

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1245,6 +1245,217 @@ async fn test_message_events_filtered_keep_head_loads_head_and_tail() {
 }
 
 #[tokio::test]
+async fn test_long_message_history_reads_are_bounded_and_index_supported() {
+    let backend = create_test_backend().await;
+
+    let agent = backend
+        .create_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: everruns_core::AgentId::new().to_string(),
+                name: format!("long-history-agent-{}", &Uuid::now_v7().to_string()[..8]),
+                display_name: Some("Long History Test Agent".to_string()),
+                description: None,
+                system_prompt: "Test".to_string(),
+                default_model_id: None,
+
+                harness_id: ensure_test_harness_id(&backend).await,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: None,
+                max_iterations: None,
+                parallel_tool_calls: None,
+            },
+        )
+        .await
+        .expect("Failed to create agent");
+
+    let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
+    let session = backend
+        .create_session(CreateSessionRow {
+            workspace_id: None,
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        })
+        .await
+        .expect("Failed to create session");
+
+    let total = 3_050;
+    for index in 1..=total {
+        let (event_type, data) = if index == total - 1 {
+            (
+                "output.message.completed",
+                json!({
+                    "message": {
+                        "role": "agent",
+                        "content": [{
+                            "type": "tool_call",
+                            "id": "call-final",
+                            "name": "lookup",
+                            "arguments": "{}"
+                        }]
+                    }
+                }),
+            )
+        } else if index == total {
+            (
+                "tool.completed",
+                json!({
+                    "tool_call_id": "call-final",
+                    "tool_name": "lookup",
+                    "result": "final result"
+                }),
+            )
+        } else {
+            (
+                "input.message",
+                json!({
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": format!("message {index}")}]
+                    }
+                }),
+            )
+        };
+
+        backend
+            .create_event(CreateEventRow {
+                session_id: session.id,
+                event_type: event_type.to_string(),
+                ts: Utc::now(),
+                context: json!({"turn_id": format!("turn-{index}")}),
+                data,
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .expect("Failed to create long-history event");
+    }
+
+    let started = std::time::Instant::now();
+    let fallback = backend
+        .list_message_events_limited(session.id, None)
+        .await
+        .expect("list bounded fallback history");
+    let fallback_elapsed = started.elapsed();
+    assert_eq!(
+        fallback.len(),
+        everruns_server::storage::repository::MESSAGE_SAFETY_LIMIT
+    );
+    assert_eq!(
+        fallback.first().expect("first fallback row").sequence,
+        1_051
+    );
+    assert_eq!(fallback.last().expect("last fallback row").sequence, total);
+
+    let fallback_bytes: usize = fallback
+        .iter()
+        .map(|event| {
+            event.data.to_string().len()
+                + event.context.to_string().len()
+                + event
+                    .metadata
+                    .as_ref()
+                    .map(|value| value.to_string().len())
+                    .unwrap_or(0)
+                + event
+                    .tags
+                    .as_ref()
+                    .map(|tags| tags.iter().map(String::len).sum::<usize>())
+                    .unwrap_or(0)
+        })
+        .sum();
+
+    let window = backend
+        .list_message_events_filtered(
+            &MessageQuery::new(session.id)
+                .with_limit(64)
+                .with_keep_head(1),
+        )
+        .await
+        .expect("list bounded head+tail history");
+    assert_eq!(window.len(), 65);
+    assert_eq!(window.first().expect("head anchor").sequence, 1);
+    assert_eq!(
+        window[window.len() - 2].event_type,
+        "output.message.completed"
+    );
+    assert_eq!(
+        window.last().expect("tool result").event_type,
+        "tool.completed"
+    );
+    assert_eq!(
+        window.last().unwrap().data["tool_call_id"].as_str(),
+        Some("call-final")
+    );
+
+    let pool = backend.pool().expect("postgres pool");
+    let plan_rows: Vec<(String,)> = sqlx::query_as(
+        r#"
+        EXPLAIN (ANALYZE, BUFFERS)
+        SELECT * FROM (
+            SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at
+            FROM events
+            WHERE session_id = $1
+              AND event_type IN ('input.message', 'output.message.completed', 'tool.completed')
+            ORDER BY sequence DESC
+            LIMIT $2
+        ) recent
+        ORDER BY sequence ASC
+        "#,
+    )
+    .bind(session.id.uuid())
+    .bind(everruns_server::storage::repository::MESSAGE_SAFETY_LIMIT as i64)
+    .fetch_all(pool)
+    .await
+    .expect("explain bounded message history query");
+    let plan = plan_rows
+        .into_iter()
+        .map(|row| row.0)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plan.contains("idx_events_messages"),
+        "message history query should use idx_events_messages:\n{plan}"
+    );
+    assert!(
+        !plan.contains("Seq Scan on events"),
+        "message history query should not seq-scan events:\n{plan}"
+    );
+
+    println!(
+        "long message-history benchmark: before_rows={total}, after_rows={}, bytes_returned={}, service_time_ms={}, plan=\n{}",
+        fallback.len(),
+        fallback_bytes,
+        fallback_elapsed.as_millis(),
+        plan
+    );
+}
+
+#[tokio::test]
 async fn test_event_filter_types() {
     let backend = create_test_backend().await;
 


### PR DESCRIPTION
## What changed
Bound message-history event reads for long sessions so turn-context loading no longer materializes thousands of full event rows on the hot path.

- Direct worker turn context now loads messages through the same capability-aware `MessageQuery` filtering used by reason atoms, preserving configured head+tail windows and post-load notices.
- The unfiltered message-event fallback now returns the latest capped window in chronological order, with the shared safety cap reduced from 5,000 to 2,000.
- Worker gRPC turn-context requests can no longer raise their message limit above the shared storage safety cap.
- Slow message-history reads now emit structured warnings with stable operation/query-family metadata, elapsed time, row count, limit, environment, and service version, without SQL params, IDs, or payload content.

## Why
EVE-730 tracked a live dev slow SQLx query during a support-app turn: the direct worker path requested 3,031 message-related events because it loaded session message events without applying the existing capability/window filters. That made long-session turns pull too many full `events` rows before prompt construction.

## Before / After
Before:
- Observed query family: `events WHERE session_id = $1 AND event_type IN (...) ORDER BY sequence ASC LIMIT $2`.
- Observed live read returned 3,031 rows and took 1.120s.
- Root cause: direct worker `load_turn_context` used the unfiltered message-event read, whose fallback cap was 5,000, so a 3,031-event session fit under the cap and all rows were materialized.

After:
- Normal direct-worker turns use capability-aware filtered message loading; an infinity-context head+tail query in the regression fixture returns 65 rows while preserving the first task-anchor message plus the final tool-call/result pair.
- The unfiltered fallback is latest-windowed and capped at 2,000 rows, still returned chronologically.
- PostgreSQL plan is index-supported: `EXPLAIN (ANALYZE, BUFFERS)` uses `Index Scan Backward using idx_events_messages`; no `Seq Scan on events`.
- Benchmark fixture with 3,050 relevant events: `before_rows=3050`, `after_rows=2000`, `bytes_returned=200032`, service time `16 ms`, DB execution time `0.542 ms`.
- HTTP smoke with full local stack and encrypted LLM-sim provider: `POST /v1/sessions/{session_id}/messages` returned 201 in 43 ms; assistant response was observed after 1 second.

Local validation:
- `cargo fmt --check`
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings`
- `cargo test -p everruns-server storage::message_history_timing --lib`
- `cargo test -p everruns-server storage::memory::tests::test_list_message_events_filtered_caps_unbounded_history --lib`
- `DATABASE_URL=postgres://everruns:everruns@localhost:27132/everruns_test cargo test -p everruns-server --test repository_integration_test test_long_message_history_reads_are_bounded_and_index_supported -- --nocapture`
- `DATABASE_URL=postgres://everruns:everruns@localhost:27132/everruns_test cargo test -p everruns-server --test repository_conformance_test -- --nocapture`
- `cargo test -p everruns-server grpc_service::worker_service_impl::tests::normalize_turn_context_message_limit --lib`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
- PR CI green, including Clippy, unit tests, PostgreSQL integration tests, worker durable tests, release binaries, MSRV, CodeQL, license, format, lockfile, migration immutability, server test enumeration, SDK compat, and CI opt-out policy.

## Risk
- Medium.
- Turn context assembly changes for direct-worker execution: if a harness/agent capability overlay is wrong, the direct path will now reflect that config instead of bypassing it.
- Long sessions that relied on the old unfiltered fallback seeing earliest messages now receive the latest capped window; this matches the documented latest-N message limit contract and the existing filtered backend behavior.
- Tool-call/result pairing is covered by the long-history regression fixture across the head+tail boundary.

## Security
- Threat categories reviewed: TM-DOS, TM-SQL, TM-LLM, TM-TENANT, TM-OBS.
- Findings and resolutions: resource-exhaustion risk is reduced by applying capability windows in the hot path and lowering the fallback cap. SQL remains parameterized for caller-controlled values; dynamic numeric fragments come from trusted bounded `MessageQuery` fields after clamping. Session scoping is still by `session_id` and no cross-tenant scope is widened. Prompt correctness risk is mitigated by preserving deterministic chronological ordering, head anchors, and adjacent tool-call/result rows. Slow-read telemetry intentionally excludes SQL params, session/org IDs, message content, event data, and other payload fields.
- No threat-model update was needed because this tightens existing bounded-read mitigations rather than adding a new trust boundary or accepted risk.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
