### PR TITLE
test(cli): wait for harness seed before agent e2e

### DIFF
--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -123,6 +123,32 @@ else
 fi
 
 # ========================================
+# Test: Harness seed readiness
+# ========================================
+
+log_test "get seed harness"
+HARNESSES_OUTPUT=""
+HARNESS_ID=""
+for _ in {1..30}; do
+  HARNESSES_OUTPUT=$(curl -s "$API_URL/v1/harnesses" -H "Authorization: ${EVERRUNS_API_KEY:-test}") || {
+    sleep 1
+    continue
+  }
+  HARNESS_ID=$(echo "$HARNESSES_OUTPUT" | jq -r '.data[0].id')
+  if [ -n "$HARNESS_ID" ] && [ "$HARNESS_ID" != "null" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ -n "$HARNESS_ID" ] && [ "$HARNESS_ID" != "null" ]; then
+  log_pass "found seed harness: $HARNESS_ID"
+else
+  log_fail "no harness found (required for agent and session creation)"
+  echo "$HARNESSES_OUTPUT"
+  exit 1
+fi
+
+# ========================================
 # Test: Agents CRUD
 # ========================================
 
@@ -173,32 +199,6 @@ if [ "$AGENT_NAME" = "cli-test-agent" ]; then
 else
   log_fail "agents get did not return correct agent name"
   echo "$GET_OUTPUT"
-fi
-
-# ========================================
-# Test: Harness (get seed harness for session creation)
-# ========================================
-
-log_test "get seed harness"
-HARNESSES_OUTPUT=""
-HARNESS_ID=""
-for _ in {1..30}; do
-  HARNESSES_OUTPUT=$(curl -s "$API_URL/v1/harnesses" -H "Authorization: ${EVERRUNS_API_KEY:-test}") || {
-    sleep 1
-    continue
-  }
-  HARNESS_ID=$(echo "$HARNESSES_OUTPUT" | jq -r '.data[0].id')
-  if [ -n "$HARNESS_ID" ] && [ "$HARNESS_ID" != "null" ]; then
-    break
-  fi
-  sleep 1
-done
-if [ -n "$HARNESS_ID" ] && [ "$HARNESS_ID" != "null" ]; then
-  log_pass "found seed harness: $HARNESS_ID"
-else
-  log_fail "no harness found (required for session creation)"
-  echo "$HARNESSES_OUTPUT"
-  exit 1
 fi
 
 # ========================================


### PR DESCRIPTION
## What changed
Moved the CLI E2E script's seeded-harness readiness wait before the first `agents create` call.

The script already needed a seeded harness later for session creation; this change reuses that wait earlier so cold-start DEV_MODE runs do not treat `/health` as proof that seed data is visible.

## Why
Post-merge main CI for PR #2682 failed in `CLI E2E Tests`: `agents create` returned a 500 immediately after the server became healthy. The server was running in DEV_MODE with `AUTH_MODE=none`, and the failure happened before the script's existing harness-readiness wait.

## Before / After
Before:
- Main CI run `29141473964` failed `CLI E2E Tests` at `agents create` with `500 internal_error`.
- The script waited for harness seed readiness only after agent CRUD.

After:
- `agents create` runs only after `/v1/harnesses` returns a seeded harness.
- Local cold-boot reproduction with the CI env passed all 11 CLI E2E checks after the script change.

Validation:
- `bash -n scripts/cli-e2e-test.sh`
- Cold-boot DEV_MODE server on `localhost:9000`, then `EVERRUNS_API_KEY=cli-e2e-test-key EVERRUNS_API_URL=http://localhost:9000 ./scripts/cli-e2e-test.sh` passed all 11 checks.
- `just pre-push`
- PR CI green.

## Risk
- Low.
- Test script only. The main risk is adding up to 30 seconds of wait if seed data is unexpectedly unavailable; that is preferable to a cold-start flake and fails with a clear message.

## Security
- Threat categories reviewed: No security-relevant code changes.
- Findings and resolutions: This changes only local/CI test ordering and does not alter product code, auth, data access, logging, or runtime behavior.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
