### PR TITLE
feat(core): embeddable in-process task transition observer (EVE-729)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -118,6 +118,7 @@ pub mod session_sqldb;
 pub mod session_task;
 pub mod skill;
 pub mod system_allowlist;
+pub mod task_observer;
 pub mod vector_store;
 pub mod workspace;
 pub mod workspace_roots;
@@ -511,6 +512,7 @@ pub use skill::{
     ParsedSkillMd, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus, SkillUsage,
     SkillValidationResult, parse_skill_md, validate_skill_md, validate_skill_name,
 };
+pub use task_observer::{TaskTransition, TaskTransitionObserver};
 pub use typed_id::{
     AgentId, AgentIdentityId, AgentVersionId, AppChannelId, AppId, DeclarativeCapabilityId,
     EvalCaseId, EvalId, EvalResultId, EvalRunId, EventId, ExecId, HarnessId, IdMarker,

--- a/crates/core/src/task_observer.rs
+++ b/crates/core/src/task_observer.rs
@@ -1,0 +1,107 @@
+// Embeddable in-process task-transition observer (EVE-729).
+//
+// A `TaskTransition` names a lifecycle transition a `SessionTaskRegistry` fires
+// on: reaching a terminal state, entering `awaiting_input`, or emitting an
+// outbound message. A `TaskTransitionObserver` receives those transitions in
+// process — the same seam the server's webhook dispatcher uses, minus HTTP.
+//
+// Design Decision: the enum + trait live in `everruns-core` (not the server) so
+// `everruns-runtime` embedders can observe task transitions without depending on
+// the control-plane server or making HTTP calls. The server webhook dispatcher
+// (`DirectTaskWebhookNotifier`) is one implementation of this trait; in-process
+// embedders provide their own. A `SessionTaskRegistry` fires each real
+// transition once to every registered observer, so an in-process observer sees
+// exactly the same transitions the webhook path fires (see the parity test in
+// `crates/server/src/storage/session_task_store.rs`).
+//
+// Filter semantics: `Terminal` is the regression-safe default (org webhooks only
+// ever fire on it); `AwaitingInput` and `Message` are the non-terminal
+// transitions that are opt-in per delivery target via `event_filter` (EVE-682).
+// The `filter_value` / `event_name` strings are shared with webhook payloads so
+// the two paths stay byte-for-byte aligned.
+
+use async_trait::async_trait;
+
+use crate::session_task::SessionTask;
+
+/// A task lifecycle transition an observer can be notified of.
+///
+/// `Terminal` is the only transition org webhooks ever fire on (regression-safe).
+/// `AwaitingInput` and `Message` are opt-in per delivery target via
+/// `event_filter` (EVE-682).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskTransition {
+    /// Task reached a terminal state (succeeded / failed / canceled).
+    Terminal,
+    /// Task transitioned into `awaiting_input`.
+    AwaitingInput,
+    /// Task emitted an outbound message.
+    Message,
+}
+
+impl TaskTransition {
+    /// The `event_filter` member string that enables this transition.
+    pub fn filter_value(&self) -> &'static str {
+        match self {
+            Self::Terminal => "terminal",
+            Self::AwaitingInput => "awaiting_input",
+            Self::Message => "message",
+        }
+    }
+
+    /// The `event` field value in a delivered webhook payload.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::Terminal => "task.terminal",
+            Self::AwaitingInput => "task.awaiting_input",
+            Self::Message => "task.message",
+        }
+    }
+}
+
+/// Receive task-transition notifications in process.
+///
+/// A `SessionTaskRegistry` invokes `on_transition` once per real transition for
+/// every registered observer. Implementations must treat delivery as
+/// best-effort: the registry logs errors and never fails the underlying task
+/// operation because an observer returned `Err`. Observers must not block for
+/// long — the registry dispatches them off the task-update path, but a slow
+/// observer still delays its own delivery.
+///
+/// The server webhook dispatcher (`DirectTaskWebhookNotifier`) is one
+/// implementation. Embedders of `everruns-runtime` implement this trait to get
+/// in-process callbacks with the same transition semantics, without HTTP.
+#[async_trait]
+pub trait TaskTransitionObserver: Send + Sync + 'static {
+    /// Handle one task transition. Best-effort: returning `Err` is logged and
+    /// never fails the task operation that produced the transition.
+    async fn on_transition(
+        &self,
+        task: &SessionTask,
+        transition: TaskTransition,
+    ) -> anyhow::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_value_and_event_name_are_stable() {
+        // These strings are a wire contract shared with webhook payloads and the
+        // per-task `event_filter`; changing them silently breaks delivery.
+        assert_eq!(TaskTransition::Terminal.filter_value(), "terminal");
+        assert_eq!(
+            TaskTransition::AwaitingInput.filter_value(),
+            "awaiting_input"
+        );
+        assert_eq!(TaskTransition::Message.filter_value(), "message");
+
+        assert_eq!(TaskTransition::Terminal.event_name(), "task.terminal");
+        assert_eq!(
+            TaskTransition::AwaitingInput.event_name(),
+            "task.awaiting_input"
+        );
+        assert_eq!(TaskTransition::Message.event_name(), "task.message");
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -113,6 +113,11 @@ pub use backends::{
 };
 pub use builders::{AgentBuilder, HarnessBuilder, SessionBuilder, SingleSessionBuilder};
 pub use everruns_core::AssembledTurnContext;
+// Embeddable in-process task-transition observation (EVE-729): embedders
+// implement `TaskTransitionObserver` to receive task lifecycle transitions
+// (terminal / awaiting_input / outbound message) in process, with the same
+// filter semantics as server webhook delivery but without HTTP.
+pub use everruns_core::task_observer::{TaskTransition, TaskTransitionObserver};
 pub use file_store_decorators::{
     ApprovalGatingFileStore, DEFAULT_WRITE_BLOCKLIST, FileApprovalGate, WriteBlocklistFileStore,
 };

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1561,7 +1561,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 db: self.db.clone(),
                 egress_service: egress.clone(),
             });
-            registry = registry.with_notifier(notifier);
+            registry = registry.with_transition_observer(notifier);
         }
         Some(Arc::new(registry))
     }
@@ -1784,7 +1784,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 db: self.db.clone(),
                 egress_service: egress.clone(),
             });
-            registry = registry.with_notifier(notifier);
+            registry = registry.with_transition_observer(notifier);
         }
         Arc::new(registry)
     }
@@ -2176,7 +2176,7 @@ struct WebhookTarget {
 /// spawn time and delivery pins DNS, so no re-validation is needed here.
 fn spec_push_config_targets(
     spec: &serde_json::Value,
-    event: crate::storage::session_task_store::TaskWebhookEvent,
+    event: crate::storage::session_task_store::TaskTransition,
 ) -> Vec<WebhookTarget> {
     let Some(entries) = spec.get("push_configs").and_then(|v| v.as_array()) else {
         return Vec::new();
@@ -2210,13 +2210,13 @@ fn spec_push_config_targets(
 }
 
 #[async_trait::async_trait]
-impl crate::storage::session_task_store::TaskWebhookNotifier for DirectTaskWebhookNotifier {
-    async fn notify(
+impl crate::storage::session_task_store::TaskTransitionObserver for DirectTaskWebhookNotifier {
+    async fn on_transition(
         &self,
         task: &everruns_core::session_task::SessionTask,
-        event: crate::storage::session_task_store::TaskWebhookEvent,
+        event: crate::storage::session_task_store::TaskTransition,
     ) -> anyhow::Result<()> {
-        use crate::storage::session_task_store::TaskWebhookEvent;
+        use crate::storage::session_task_store::TaskTransition;
 
         // Resolve org_id from session (unscoped lookup — no harness required).
         // Server-internal dispatch only: this is never a user-facing read, so
@@ -2234,7 +2234,7 @@ impl crate::storage::session_task_store::TaskWebhookNotifier for DirectTaskWebho
 
         // Org webhooks are terminal-only and unchanged (EVE-579): they never
         // fire on non-terminal events.
-        if event == TaskWebhookEvent::Terminal {
+        if event == TaskTransition::Terminal {
             let webhooks = self
                 .db
                 .list_enabled_org_task_webhooks(session.org_id)
@@ -2368,7 +2368,7 @@ mod task_webhook_request_tests {
     }
 
     use super::spec_push_config_targets;
-    use crate::storage::session_task_store::TaskWebhookEvent;
+    use crate::storage::session_task_store::TaskTransition;
 
     #[test]
     fn spec_push_configs_filter_by_event() {
@@ -2383,7 +2383,7 @@ mod task_webhook_request_tests {
             ]
         });
 
-        let terminal = spec_push_config_targets(&spec, TaskWebhookEvent::Terminal);
+        let terminal = spec_push_config_targets(&spec, TaskTransition::Terminal);
         let terminal_urls: Vec<&str> = terminal.iter().map(|t| t.url.as_str()).collect();
         assert_eq!(
             terminal_urls,
@@ -2391,7 +2391,7 @@ mod task_webhook_request_tests {
             "terminal must include the explicit terminal filter and the default"
         );
 
-        let message = spec_push_config_targets(&spec, TaskWebhookEvent::Message);
+        let message = spec_push_config_targets(&spec, TaskTransition::Message);
         let message_urls: Vec<&str> = message.iter().map(|t| t.url.as_str()).collect();
         assert_eq!(message_urls, vec!["https://a.example.com"]);
         assert_eq!(
@@ -2400,13 +2400,13 @@ mod task_webhook_request_tests {
             "secret must be carried through for signing"
         );
 
-        let awaiting = spec_push_config_targets(&spec, TaskWebhookEvent::AwaitingInput);
+        let awaiting = spec_push_config_targets(&spec, TaskTransition::AwaitingInput);
         let awaiting_urls: Vec<&str> = awaiting.iter().map(|t| t.url.as_str()).collect();
         assert_eq!(awaiting_urls, vec!["https://b.example.com"]);
 
         // No push_configs key → no targets.
         assert!(
-            spec_push_config_targets(&serde_json::json!({}), TaskWebhookEvent::Terminal).is_empty()
+            spec_push_config_targets(&serde_json::json!({}), TaskTransition::Terminal).is_empty()
         );
     }
 }

--- a/crates/server/src/storage/session_task_store.rs
+++ b/crates/server/src/storage/session_task_store.rs
@@ -37,51 +37,16 @@ pub trait SessionTaskWaker: Send + Sync {
 }
 
 // ============================================================================
-// TaskWebhookNotifier — fire outbound HTTP on task transitions
+// Task transition observers — in-process callbacks on task transitions
 // ============================================================================
 
-/// A task transition that can trigger webhook delivery.
-///
-/// `Terminal` is the only event org webhooks ever fire on (regression-safe).
-/// The non-terminal events are opt-in per-task via `event_filter` (EVE-682).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskWebhookEvent {
-    /// Task reached a terminal state (succeeded / failed / canceled).
-    Terminal,
-    /// Task transitioned into `awaiting_input`.
-    AwaitingInput,
-    /// Task emitted an outbound message.
-    Message,
-}
-
-impl TaskWebhookEvent {
-    /// The `event_filter` member string that enables this event.
-    pub fn filter_value(&self) -> &'static str {
-        match self {
-            Self::Terminal => "terminal",
-            Self::AwaitingInput => "awaiting_input",
-            Self::Message => "message",
-        }
-    }
-
-    /// The `event` field value in the delivered webhook payload.
-    pub fn event_name(&self) -> &'static str {
-        match self {
-            Self::Terminal => "task.terminal",
-            Self::AwaitingInput => "task.awaiting_input",
-            Self::Message => "task.message",
-        }
-    }
-}
-
-/// Fire outbound HTTP webhooks on task transitions. Terminal transitions notify
-/// enabled org webhooks plus any per-task push configs; non-terminal events
-/// notify only per-task push configs whose `event_filter` opts in (EVE-682).
-/// Errors are best-effort (logged, never fatal).
-#[async_trait]
-pub trait TaskWebhookNotifier: Send + Sync + 'static {
-    async fn notify(&self, task: &SessionTask, event: TaskWebhookEvent) -> anyhow::Result<()>;
-}
+// The transition enum and observer trait live in `everruns-core`
+// (`TaskTransition` / `TaskTransitionObserver`) so `everruns-runtime` embedders
+// can observe transitions in process without depending on the server or HTTP.
+// The server's webhook dispatcher (`DirectTaskWebhookNotifier`) is one
+// implementation; the registry fires each transition once to every registered
+// observer (EVE-729).
+pub use everruns_core::task_observer::{TaskTransition, TaskTransitionObserver};
 
 // ============================================================================
 // DbSessionTaskRegistry
@@ -93,7 +58,7 @@ pub struct DbSessionTaskRegistry {
     db: Arc<StorageBackend>,
     emitter: Option<Arc<dyn EventEmitter>>,
     waker: Option<Arc<dyn SessionTaskWaker>>,
-    notifier: Option<Arc<dyn TaskWebhookNotifier>>,
+    observers: Vec<Arc<dyn TaskTransitionObserver>>,
 }
 
 impl DbSessionTaskRegistry {
@@ -102,7 +67,7 @@ impl DbSessionTaskRegistry {
             db,
             emitter: None,
             waker: None,
-            notifier: None,
+            observers: Vec::new(),
         }
     }
 
@@ -120,10 +85,14 @@ impl DbSessionTaskRegistry {
         self
     }
 
-    /// Attach a webhook notifier. Fires outbound HTTP to all enabled org
-    /// webhooks on terminal task transitions. Best-effort only.
-    pub fn with_notifier(mut self, notifier: Arc<dyn TaskWebhookNotifier>) -> Self {
-        self.notifier = Some(notifier);
+    /// Attach a task-transition observer. Each observer receives every real
+    /// transition (terminal / awaiting_input / outbound message) once, off the
+    /// task-update path. Best-effort only: observer errors are logged and never
+    /// fail the task operation. The server's webhook dispatcher is registered
+    /// here as one observer; in-process embedders can register their own so they
+    /// see the same transitions the webhook path fires (EVE-729).
+    pub fn with_transition_observer(mut self, observer: Arc<dyn TaskTransitionObserver>) -> Self {
+        self.observers.push(observer);
         self
     }
 
@@ -236,23 +205,28 @@ impl DbSessionTaskRegistry {
         self.try_wake(task.session_id, &text).await;
     }
 
-    /// Fire webhook notifications for a task transition (best-effort). Spawns a
-    /// detached task so outbound HTTP latency never blocks task updates.
-    fn try_notify_webhooks(&self, task: &SessionTask, event: TaskWebhookEvent) {
-        let Some(notifier) = self.notifier.clone() else {
+    /// Notify all registered observers of a task transition (best-effort).
+    /// Each observer is dispatched on its own detached task so downstream
+    /// latency (e.g. outbound webhook HTTP) never blocks task updates and one
+    /// slow observer never delays another.
+    fn notify_transition(&self, task: &SessionTask, transition: TaskTransition) {
+        if self.observers.is_empty() {
             return;
-        };
-        let task = task.clone();
-        tokio::spawn(async move {
-            if let Err(e) = notifier.notify(&task, event).await {
-                tracing::warn!(
-                    task_id = %task.id,
-                    session_id = %task.session_id,
-                    event = ?event,
-                    "TaskWebhookNotifier failed (best-effort): {e}"
-                );
-            }
-        });
+        }
+        for observer in &self.observers {
+            let observer = observer.clone();
+            let task = task.clone();
+            tokio::spawn(async move {
+                if let Err(e) = observer.on_transition(&task, transition).await {
+                    tracing::warn!(
+                        task_id = %task.id,
+                        session_id = %task.session_id,
+                        transition = ?transition,
+                        "TaskTransitionObserver failed (best-effort): {e}"
+                    );
+                }
+            });
+        }
     }
 }
 
@@ -288,9 +262,9 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
 
         // Read prior state so we can detect the transition this update makes.
         // Best-effort: if the read fails we still proceed with the update.
-        // The notifier needs `prior` for both terminal and awaiting_input
-        // transitions (EVE-682), so it has the same gating as the waker.
-        let needs_prior = (self.waker.is_some() || self.notifier.is_some())
+        // Observers need `prior` for both terminal and awaiting_input
+        // transitions (EVE-682), so they have the same gating as the waker.
+        let needs_prior = (self.waker.is_some() || !self.observers.is_empty())
             && (wants_terminal_wake || wants_awaiting_input_wake);
         let prior = if needs_prior {
             self.get(session_id, task_id).await.ok().flatten()
@@ -316,9 +290,9 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
             if let Some(prior) = &prior {
                 if wants_terminal_wake {
                     self.maybe_wake_on_terminal(prior, task).await;
-                    // Webhook notifications fire on the same terminal transition.
+                    // Observers fire on the same terminal transition.
                     if !prior.state.is_terminal() && task.state.is_terminal() {
-                        self.try_notify_webhooks(task, TaskWebhookEvent::Terminal);
+                        self.notify_transition(task, TaskTransition::Terminal);
                     }
                 }
                 if wants_awaiting_input_wake {
@@ -330,7 +304,7 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
                     if prior.state != SessionTaskState::AwaitingInput
                         && task.state == SessionTaskState::AwaitingInput
                     {
-                        self.try_notify_webhooks(task, TaskWebhookEvent::AwaitingInput);
+                        self.notify_transition(task, TaskTransition::AwaitingInput);
                     }
                 }
             }
@@ -453,7 +427,7 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
             let msg_text = task_message_text(&stored.content);
             self.maybe_wake_on_outbound_message(&task, &msg_text).await;
             // Per-task push configs may opt into message delivery (EVE-682).
-            self.try_notify_webhooks(&task, TaskWebhookEvent::Message);
+            self.notify_transition(&task, TaskTransition::Message);
         }
 
         // An inbound answer to the pending input request resumes the task.
@@ -535,37 +509,49 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // Recording test notifier (webhook dispatch)
+    // Recording test observer (stands in for a webhook or in-process observer)
     // -------------------------------------------------------------------------
 
     #[derive(Default, Clone)]
-    struct RecordingNotifier {
-        calls: Arc<Mutex<Vec<(String, TaskWebhookEvent)>>>,
+    struct RecordingObserver {
+        calls: Arc<Mutex<Vec<(String, TaskTransition)>>>,
     }
 
-    impl RecordingNotifier {
-        fn recorded(&self) -> Vec<(String, TaskWebhookEvent)> {
+    impl RecordingObserver {
+        fn recorded(&self) -> Vec<(String, TaskTransition)> {
             self.calls.lock().unwrap().clone()
+        }
+
+        fn transitions(&self) -> Vec<TaskTransition> {
+            self.recorded().into_iter().map(|(_, t)| t).collect()
         }
     }
 
     #[async_trait::async_trait]
-    impl TaskWebhookNotifier for RecordingNotifier {
-        async fn notify(&self, task: &SessionTask, event: TaskWebhookEvent) -> anyhow::Result<()> {
-            self.calls.lock().unwrap().push((task.id.clone(), event));
+    impl TaskTransitionObserver for RecordingObserver {
+        async fn on_transition(
+            &self,
+            task: &SessionTask,
+            transition: TaskTransition,
+        ) -> anyhow::Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((task.id.clone(), transition));
             Ok(())
         }
     }
 
-    fn registry_with_notifier(notifier: Arc<RecordingNotifier>) -> DbSessionTaskRegistry {
-        DbSessionTaskRegistry::new(Arc::new(StorageBackend::in_memory())).with_notifier(notifier)
+    fn registry_with_observer(observer: Arc<RecordingObserver>) -> DbSessionTaskRegistry {
+        DbSessionTaskRegistry::new(Arc::new(StorageBackend::in_memory()))
+            .with_transition_observer(observer)
     }
 
-    /// `try_notify_webhooks` spawns a detached task; poll until the expected
-    /// number of notifications land (or fail after a bounded number of yields).
-    async fn wait_for_notifications(notifier: &RecordingNotifier, expected: usize) {
+    /// `notify_transition` spawns a detached task per observer; poll until the
+    /// expected number of notifications land (or give up after bounded yields).
+    async fn wait_for_notifications(observer: &RecordingObserver, expected: usize) {
         for _ in 0..200 {
-            if notifier.recorded().len() >= expected {
+            if observer.recorded().len() >= expected {
                 return;
             }
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
@@ -1098,14 +1084,14 @@ mod tests {
         );
     }
 
-    /// The registry fires webhook notifications on terminal, awaiting_input, and
+    /// The registry fires observer notifications on terminal, awaiting_input, and
     /// outbound-message transitions — each exactly once per real transition, and
-    /// never on inbound messages. Event-filter honoring is the notifier's job
-    /// (tested there); here we assert the store emits the right event kinds.
+    /// never on inbound messages. Event-filter honoring is the observer's job
+    /// (tested there); here we assert the store emits the right transition kinds.
     #[tokio::test]
-    async fn notifier_fires_on_terminal_awaiting_input_and_outbound() {
-        let notifier = Arc::new(RecordingNotifier::default());
-        let registry = registry_with_notifier(notifier.clone());
+    async fn observer_fires_on_terminal_awaiting_input_and_outbound() {
+        let observer = Arc::new(RecordingObserver::default());
+        let registry = registry_with_observer(observer.clone());
         let session_id = SessionId::new();
 
         let task = registry
@@ -1142,7 +1128,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wait_for_notifications(&notifier, 1).await;
+        wait_for_notifications(&observer, 1).await;
 
         // Repeated awaiting_input churn: no extra notification.
         registry
@@ -1176,7 +1162,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wait_for_notifications(&notifier, 2).await;
+        wait_for_notifications(&observer, 2).await;
 
         // Terminal transition fires Terminal.
         registry
@@ -1190,20 +1176,19 @@ mod tests {
             )
             .await
             .unwrap();
-        wait_for_notifications(&notifier, 3).await;
+        wait_for_notifications(&observer, 3).await;
 
-        let events: Vec<TaskWebhookEvent> =
-            notifier.recorded().into_iter().map(|(_, e)| e).collect();
+        let events: Vec<TaskTransition> = observer.transitions();
         assert!(
-            events.contains(&TaskWebhookEvent::AwaitingInput),
+            events.contains(&TaskTransition::AwaitingInput),
             "expected an awaiting_input notification, got: {events:?}"
         );
         assert!(
-            events.contains(&TaskWebhookEvent::Message),
+            events.contains(&TaskTransition::Message),
             "expected an outbound message notification, got: {events:?}"
         );
         assert!(
-            events.contains(&TaskWebhookEvent::Terminal),
+            events.contains(&TaskTransition::Terminal),
             "expected a terminal notification, got: {events:?}"
         );
         // Exactly one of each — no double-fire on awaiting_input churn, and the
@@ -1212,6 +1197,107 @@ mod tests {
             events.len(),
             3,
             "each transition must notify exactly once, got: {events:?}"
+        );
+    }
+
+    /// EVE-729 parity: an in-process observer registered alongside the webhook
+    /// observer receives exactly the same transitions, in the same order, that
+    /// the webhook path fires. Both observers share the registry's single
+    /// transition-detection path, so an embedder's in-process callback is
+    /// guaranteed the same event stream as HTTP webhook delivery — no HTTP.
+    #[tokio::test]
+    async fn in_process_observer_has_parity_with_webhook_observer() {
+        // `webhook` stands in for the server's DirectTaskWebhookNotifier; both
+        // are just `TaskTransitionObserver`s after EVE-729.
+        let webhook = Arc::new(RecordingObserver::default());
+        let in_process = Arc::new(RecordingObserver::default());
+        let registry = DbSessionTaskRegistry::new(Arc::new(StorageBackend::in_memory()))
+            .with_transition_observer(webhook.clone())
+            .with_transition_observer(in_process.clone());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(create_input_with_policy(session_id, TaskWakePolicy::Silent))
+            .await
+            .unwrap();
+
+        // Drive running -> awaiting_input -> (answer resumes) running -> outbound
+        // message -> terminal, waiting for each transition to land on both
+        // observers before the next so the recorded order is deterministic.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Running),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    input_request: Some(TaskInputRequest {
+                        id: "req_1".to_string(),
+                        prompt: "Approve?".to_string(),
+                        expected: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        wait_for_notifications(&webhook, 1).await;
+        wait_for_notifications(&in_process, 1).await;
+
+        let mut answer = NewTaskMessage::inbound_text("yes");
+        answer.in_reply_to = Some("req_1".to_string());
+        registry
+            .record_message(session_id, &task.id, answer)
+            .await
+            .unwrap();
+        registry
+            .record_message(
+                session_id,
+                &task.id,
+                NewTaskMessage::outbound_text("progress"),
+            )
+            .await
+            .unwrap();
+        wait_for_notifications(&webhook, 2).await;
+        wait_for_notifications(&in_process, 2).await;
+
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Succeeded),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        wait_for_notifications(&webhook, 3).await;
+        wait_for_notifications(&in_process, 3).await;
+
+        let webhook_events = webhook.transitions();
+        let in_process_events = in_process.transitions();
+        assert_eq!(
+            webhook_events,
+            vec![
+                TaskTransition::AwaitingInput,
+                TaskTransition::Message,
+                TaskTransition::Terminal,
+            ],
+            "webhook observer should see the canonical transition stream"
+        );
+        assert_eq!(
+            in_process_events, webhook_events,
+            "in-process observer must receive the same transitions the webhook path fires"
         );
     }
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -407,6 +407,22 @@ awaiting_input, and outbound-message transitions; per-config `event_filter`
 selects which land. Delivery is best-effort — failures are logged, never fatal,
 and never block the task update.
 
+### Transition observers (in-process, EVE-729)
+
+Webhook delivery is one consumer of a lower-level seam: a `SessionTaskRegistry`
+fires each real transition (terminal / awaiting_input / outbound message) once to
+every registered `TaskTransitionObserver`. The trait and its `TaskTransition`
+enum live in `everruns-core` (`task_observer`) so `everruns-runtime` embedders
+can observe task transitions in process — with the same filter semantics — without
+HTTP or a dependency on the control-plane server. The server's webhook dispatcher
+(`DirectTaskWebhookNotifier`) is one implementation registered via
+`with_transition_observer`; embedders register their own. Because both share the
+registry's single transition-detection path, an in-process observer receives
+exactly the transitions the webhook path fires (asserted by the parity test in
+`crates/server/src/storage/session_task_store.rs`). Dispatch is best-effort and
+off the task-update path: each observer runs on its own detached task, so one
+slow observer never blocks task updates or another observer.
+
 ## Migration
 
 No backward compatibility is required; data migrates forward once:


### PR DESCRIPTION
## What changed
Adds a core-level, embeddable task-transition observer to `everruns-core` so `everruns-runtime` embedders can receive in-process callbacks when a session task transitions — reaching a terminal state, entering `awaiting_input`, or emitting an outbound message — with the same filter semantics as webhook delivery, but without HTTP.

- New `everruns_core::task_observer` module: a `TaskTransition` enum (`Terminal` / `AwaitingInput` / `Message`, with the shared `filter_value` / `event_name` wire strings) and a `TaskTransitionObserver` trait (`on_transition(&SessionTask, TaskTransition)`). Re-exported from both `everruns-core` and `everruns-runtime`.
- `DbSessionTaskRegistry` now fans each real transition out to a list of registered observers (`with_transition_observer`) instead of holding a single webhook notifier. Each observer runs on its own detached task, so downstream latency never blocks task updates and one observer never blocks another.
- The server webhook dispatcher `DirectTaskWebhookNotifier` becomes one implementation of the new trait (`on_transition`), keeping all of its existing delivery logic (org-webhook + per-task push-config resolution, `event_filter` honoring, HMAC signing, SSRF DNS pinning) unchanged.

## Why
Follow-up split from EVE-682 (item 4). The `TaskWebhookEvent` enum + fire points added there were the natural seam, but they lived in the server crate and were HTTP-only. Lifting the transition contract into `everruns-core` lets embedders observe task lifecycle in process without depending on the control-plane server or making HTTP calls, while keeping webhook delivery as just one consumer of the same seam.

## Before / After
No observable behavior change for existing server webhook delivery. Server wiring registers exactly one observer (the webhook notifier), so it fires on exactly the same transitions, once each, as before — confirmed by the existing store test (renamed `observer_fires_on_terminal_awaiting_input_and_outbound`) and the webhook adapter tests.

New capability proven by a parity test: registering an in-process observer alongside the webhook observer on one registry and driving a full lifecycle (running → awaiting_input → resume → outbound message → terminal) yields the identical transition stream for both:

```
running 14 tests
test storage::session_task_store::tests::in_process_observer_has_parity_with_webhook_observer ... ok
test storage::session_task_store::tests::observer_fires_on_terminal_awaiting_input_and_outbound ... ok
test result: ok. 14 passed; 0 failed
```

## Risk
- Low
- The seam is an internal trait refactor with no wire/API/schema change and no new dependencies. The only server-facing change is `Option<notifier>` → `Vec<observer>`; server code registers a single observer, preserving prior fire-once-per-transition behavior. Webhook delivery logic (signing, DNS pinning, org scoping, event filtering) is byte-for-byte unchanged.

## Security
- Threat categories reviewed: TM-API / TM-WEB (task webhook delivery path), TM-TENANT (org scoping in the notifier). No mitigation changed.
- Findings and resolutions: None. The webhook dispatcher's existing mitigations are preserved verbatim — `THREAT[TM-API-020]` DNS pinning (`require_dns_pinning`), HMAC-SHA256 signing, and server-internal org-boundary resolution via `get_session_unscoped`. No new endpoints, input parsing, egress, or dependencies are introduced. In-process observers run only within an embedder's own process (opt-in, compile-time-registered), adding no remote attack surface; per-transition fan-out is bounded by the number of registered observers, not attacker-controlled. No threat-model update required.

## Follow-ups
No follow-ups. The runtime crate exposes and can consume the trait today (re-exported); wiring a concrete in-process observer into any specific runtime registry is left to embedders by design.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal seam; no external contract change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21yJXXdWU3jhfTo8RpwNs)_