### PR TITLE
fix(durable): make workflow start idempotent

### DIFF
--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -92,6 +92,30 @@ impl PostgresWorkflowEventStore {
         &self.pool
     }
 
+    async fn existing_initial_task_id(&self, workflow_id: Uuid) -> Result<Uuid, StoreError> {
+        sqlx::query_scalar(
+            r#"
+            SELECT id
+            FROM durable_task_queue
+            WHERE workflow_id = $1
+            ORDER BY created_at ASC, id ASC
+            LIMIT 1
+            "#,
+        )
+        .bind(workflow_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to load existing workflow task: {}", e);
+            StoreError::Database(e.to_string())
+        })?
+        .ok_or_else(|| {
+            StoreError::Database(format!(
+                "workflow {workflow_id} already exists without an initial task"
+            ))
+        })
+    }
+
     /// Create a workflow, write its initial events, and enqueue the first task in
     /// one transaction. This is the hot path for a new session turn.
     pub async fn start_workflow_with_task(
@@ -130,23 +154,36 @@ impl PostgresWorkflowEventStore {
             .await
             .map_err(|e| StoreError::Database(e.to_string()))?;
 
-        sqlx::query(
+        let inserted_workflow_id = sqlx::query_scalar::<_, Uuid>(
             r#"
             INSERT INTO durable_workflow_instances (
                 id, workflow_type, status, input, started_at
             )
             VALUES ($1, $2, 'running', $3, NOW())
+            ON CONFLICT (id) DO NOTHING
+            RETURNING id
             "#,
         )
         .bind(workflow_id)
         .bind(workflow_type)
         .bind(&workflow_input)
-        .execute(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await
         .map_err(|e| {
             error!("Failed to create started workflow: {}", e);
             StoreError::Database(e.to_string())
         })?;
+
+        if inserted_workflow_id.is_none() {
+            tx.rollback().await.ok();
+            let existing_task_id = self.existing_initial_task_id(workflow_id).await?;
+            debug!(
+                %workflow_id,
+                %existing_task_id,
+                "reused existing initial workflow task after duplicate start"
+            );
+            return Ok(existing_task_id);
+        }
 
         sqlx::query(
             r#"

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -9,7 +9,7 @@
 
 #![cfg(feature = "postgres-tests")]
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use chrono::Utc;
 use serde_json::json;
@@ -468,6 +468,72 @@ async fn test_start_workflow_with_task_writes_initial_state_in_one_step() {
     let task = store.get_task(task_id).await.unwrap();
     assert_eq!(task.status, TaskStatus::Pending);
     assert_eq!(task.activity_type, "process_input");
+
+    cleanup_workflow(&store, workflow_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_start_workflow_with_task_is_idempotent_for_concurrent_same_workflow() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+    let barrier = Arc::new(tokio::sync::Barrier::new(8));
+
+    let mut handles = Vec::new();
+    for attempt in 0..8 {
+        let store = store.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .start_workflow_with_task(
+                    workflow_id,
+                    "turn_workflow",
+                    json!({"session_id": "session_race"}),
+                    TaskDefinition {
+                        workflow_id: Some(workflow_id),
+                        activity_id: format!("input-{attempt}"),
+                        activity_type: "process_input".to_string(),
+                        input: json!({"session_id": "session_race", "attempt": attempt}),
+                        options: ActivityOptions::default(),
+                    },
+                )
+                .await
+        }));
+    }
+
+    let mut task_ids = Vec::new();
+    for handle in handles {
+        task_ids.push(handle.await.unwrap().unwrap());
+    }
+    task_ids.sort();
+    task_ids.dedup();
+    assert_eq!(
+        task_ids.len(),
+        1,
+        "concurrent duplicate starts must reuse the first queued task"
+    );
+
+    let workflow = store.get_workflow_info(workflow_id).await.unwrap();
+    assert_eq!(workflow.status, WorkflowStatus::Running);
+
+    let events = store.load_events(workflow_id).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0].1,
+        WorkflowEvent::WorkflowStarted { .. }
+    ));
+    assert!(matches!(
+        &events[1].1,
+        WorkflowEvent::ActivityScheduled { .. }
+    ));
+
+    let task_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM durable_task_queue WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(task_count, 1);
 
     cleanup_workflow(&store, workflow_id).await;
 }


### PR DESCRIPTION
## What changed
Made the PostgreSQL workflow start path idempotent when duplicate callers race to start the same workflow id. A losing duplicate start now reuses the first queued initial task instead of attempting a second seed-event/task write.

Added a concurrent Postgres regression that drives eight simultaneous `start_workflow_with_task` calls for one workflow id and verifies there is one task and the two expected initial events.

## Why
EVE-735 tracked intermittent red main CI from `durable_workflow_events` unique-key collisions on `(workflow_id, sequence_num) = (..., 0)`. That points at duplicate start attempts racing around the first event write; the start path should tolerate an at-least-once retry for the same workflow id.

## Before / After
Before: duplicate starts could surface a Postgres `23505` unique violation while seeding event sequence 0, failing unrelated CI runs.

After: the duplicate start path returns the already-created initial task. Evidence:
- `DATABASE_URL='postgres://everruns:everruns@localhost:27332/everruns_test' CARGO_TARGET_DIR=target/eve735 cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests test_start_workflow_with_task_is_idempotent_for_concurrent_same_workflow -- --exact --nocapture`
- `DATABASE_URL='postgres://everruns:everruns@localhost:27332/everruns_test' CARGO_TARGET_DIR=target/eve735 cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests test_start_workflow_with_task -- --nocapture`
- `cargo clippy -p everruns-durable --test postgres_integration_test --features postgres-tests -- -D warnings`
- `PORT_PREFIX=273 just start-all --no-watch`; `/health` returned `200`, `/api/v1/durable/health` returned healthy with one active worker.
- `just pre-push`
- PR CI green, including `Integration Tests (PostgreSQL)`, `Worker Tests (Durable Execution)`, `Unit Tests (Pure)`, `Clippy Lints`, `Build Release Binaries`, and generated `Build Check`.

## Risk
- Low / Medium / High: Medium
- What can break: duplicate workflow-id starts now prefer the first queued task. If a workflow row exists without an initial task, the helper returns an explicit database error instead of creating a second task/event log.

## Security
- Threat categories reviewed: TM-DURABLE, TM-DOS
- Findings and resolutions: No new external entry point, auth path, tenant boundary, or unbounded input was introduced. The change reduces duplicate task/event amplification for an existing workflow id and preserves append-only event ordering.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
