### PR TITLE
feat(session-tasks): surface root_session_id on task reads (EVE-681)

### DIFF
--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -9295,6 +9295,21 @@ export interface components {
          * @example design-docs
          */
         name: string;
+        /**
+         * @description Owning agent when `scope = agent`.
+         * @example agent_01933b5a000070008000000000000001
+         */
+        owner_agent_id?: string | null;
+        /**
+         * Format: uuid
+         * @description Owning user when `scope = user`.
+         */
+        owner_user_id?: string | null;
+        /**
+         * @description Ownership scope (`org`, `agent`, or `user`).
+         * @example org
+         */
+        scope: string;
         /** @description Source-specific configuration (git remote, github repo, manual upload). */
         source: components["schemas"]["MemorySourceResponse"];
         /**
@@ -10745,6 +10760,21 @@ export interface components {
        * @example design-docs
        */
       name: string;
+      /**
+       * @description Owning agent when `scope = agent`.
+       * @example agent_01933b5a000070008000000000000001
+       */
+      owner_agent_id?: string | null;
+      /**
+       * Format: uuid
+       * @description Owning user when `scope = user`.
+       */
+      owner_user_id?: string | null;
+      /**
+       * @description Ownership scope (`org`, `agent`, or `user`).
+       * @example org
+       */
+      scope: string;
       /** @description Source-specific configuration (git remote, github repo, manual upload). */
       source: components["schemas"]["MemorySourceResponse"];
       /**
@@ -14146,6 +14176,14 @@ export interface components {
       progress?: null | components["schemas"]["BackgroundProgress"];
       /** @description Machine result in the session VFS: `/.tasks/{task_id}/result.json`. */
       result_path?: string | null;
+      /**
+       * @description Root of the owning session's delegation tree (EVE-680). Populated on
+       *     API reads from the denormalized storage column so cross-session tooling
+       *     (e.g. the Work view) can group a whole tree's tasks by one id. `None`
+       *     for a top-level session that is its own root, or when unavailable.
+       *     Storage-derived, never client-settable on create.
+       */
+      root_session_id?: string | null;
       /** @description Owning session. */
       session_id: string;
       /** @description Kind-specific input (instructions, tool args, external agent id). */

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -4005,6 +4005,12 @@ export interface SessionTask {
   /** `task_*` public ID. */
   id: string;
   session_id: string;
+  /**
+   * Root of the owning session's delegation tree (EVE-680). Surfaced on API
+   * reads so cross-session tooling can group a whole tree's tasks by one id.
+   * `null`/absent for a top-level session that is its own root.
+   */
+  root_session_id?: string | null;
   /** Task kind: "subagent", "external_agent", "background_tool", "monitor", etc. */
   kind: string;
   /** Human-readable label. */

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -2464,6 +2464,7 @@ mod tests {
         crate::session_task::SessionTask {
             id: format!("task_{run_id}"),
             session_id,
+            root_session_id: None,
             kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
             display_name: "Test external agent".to_string(),
             spec: json!({ "run_id": run_id }),
@@ -2802,6 +2803,7 @@ mod tests {
         let fake_task = SessionTask {
             id: task_id.clone(),
             session_id: ctx.session_id,
+            root_session_id: None,
             kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
             display_name: "Echo".to_string(),
             spec: json!({ "run_id": &run_id }),

--- a/crates/core/src/capabilities/background_execution.rs
+++ b/crates/core/src/capabilities/background_execution.rs
@@ -127,6 +127,7 @@ mod tests {
         let task = SessionTask {
             id: "t1".to_string(),
             session_id: crate::SessionId::new(),
+            root_session_id: None,
             kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
             display_name: "test".to_string(),
             spec: serde_json::json!({ "tool": "get_current_time", "reattachable": true }),
@@ -161,6 +162,7 @@ mod tests {
         let task = SessionTask {
             id: "t2".to_string(),
             session_id: crate::SessionId::new(),
+            root_session_id: None,
             kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
             display_name: "test".to_string(),
             spec: serde_json::json!({ "tool": "some_side_effecting_tool", "reattachable": false }),
@@ -195,6 +197,7 @@ mod tests {
         let task = SessionTask {
             id: "t3".to_string(),
             session_id: crate::SessionId::new(),
+            root_session_id: None,
             kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
             display_name: "test".to_string(),
             spec: serde_json::json!({ "tool": "old_task_without_reattachable_flag" }),

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -201,6 +201,14 @@ pub struct SessionTask {
     /// Owning session.
     #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub session_id: SessionId,
+    /// Root of the owning session's delegation tree (EVE-680). Populated on
+    /// API reads from the denormalized storage column so cross-session tooling
+    /// (e.g. the Work view) can group a whole tree's tasks by one id. `None`
+    /// for a top-level session that is its own root, or when unavailable.
+    /// Storage-derived, never client-settable on create.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub root_session_id: Option<SessionId>,
     /// Task kind: "subagent", "external_agent", "background_tool", "monitor", …
     pub kind: String,
     /// Human-readable label.
@@ -434,6 +442,9 @@ pub fn new_session_task(input: CreateSessionTask, now: DateTime<Utc>) -> Session
     SessionTask {
         id: input.id.unwrap_or_else(generate_task_id),
         session_id: input.session_id,
+        // Denormalized at storage insert from the owning session's root; a
+        // freshly-built task carries no root until read back.
+        root_session_id: None,
         kind: input.kind,
         display_name: input.display_name,
         spec: input.spec,

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -3881,6 +3881,7 @@ mod tests {
         crate::session_task::SessionTask {
             id: "t-reattach".to_string(),
             session_id: SessionId::new(),
+            root_session_id: None,
             kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
             display_name: "Reattach test".to_string(),
             spec,

--- a/crates/internal-protocol/benches/session_task_encoding.rs
+++ b/crates/internal-protocol/benches/session_task_encoding.rs
@@ -29,6 +29,7 @@ fn sample_task() -> st::SessionTask {
     st::SessionTask {
         id: "task_0123456789abcdef".to_string(),
         session_id: SessionId::new(),
+        root_session_id: None,
         kind: st::TASK_KIND_SUBAGENT.to_string(),
         display_name: "Investigate CI flake in worker integration suite".to_string(),
         spec: serde_json::json!({

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -2386,6 +2386,7 @@ mod tests {
         st::SessionTask {
             id: "task_abc123".to_string(),
             session_id: SessionId::new(),
+            root_session_id: None,
             kind: st::TASK_KIND_SUBAGENT.to_string(),
             display_name: "Investigate flake".to_string(),
             spec: serde_json::json!({

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -1540,6 +1540,9 @@ pub fn proto_to_session_task(
     Ok(st::SessionTask {
         id: p.id,
         session_id: SessionId::from_uuid(parse_uuid_lenient(&session_uuid.value)),
+        // Storage-derived (EVE-680); surfaced on API storage reads via
+        // `SessionTaskRow::to_task`, not carried over the worker protocol.
+        root_session_id: None,
         kind: p.kind,
         display_name: p.display_name,
         spec: bytes_to_json_value(&p.spec_json),

--- a/crates/server/src/storage/memory/session_tasks.rs
+++ b/crates/server/src/storage/memory/session_tasks.rs
@@ -466,6 +466,35 @@ mod tests {
             });
     }
 
+    #[test]
+    fn to_task_surfaces_root_session_id() {
+        // EVE-681: the delegation-tree root is denormalized on the row and must
+        // now round-trip onto the core SessionTask so cross-session tooling
+        // (the Work view) can group a whole tree by one id.
+        let db = InMemoryDatabase::new();
+        let session_id = SessionId::new();
+        let root = SessionId::new();
+        terminal_row(&db, session_id, "task_root", "running", None, None);
+        db.session_tasks
+            .write()
+            .get_mut("task_root")
+            .unwrap()
+            .root_session_id = Some(root);
+
+        let row = db.session_tasks.read().get("task_root").unwrap().clone();
+        let task = row.to_task().expect("to_task");
+        assert_eq!(task.root_session_id, Some(root));
+
+        // A NULL root column surfaces as None (top-level session / unavailable).
+        db.session_tasks
+            .write()
+            .get_mut("task_root")
+            .unwrap()
+            .root_session_id = None;
+        let row = db.session_tasks.read().get("task_root").unwrap().clone();
+        assert_eq!(row.to_task().expect("to_task").root_session_id, None);
+    }
+
     #[tokio::test]
     async fn prune_removes_only_old_terminal_tasks_and_their_messages() {
         let db = InMemoryDatabase::new();

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2341,6 +2341,7 @@ impl SessionTaskRow {
         Ok(everruns_core::SessionTask {
             id: self.id.clone(),
             session_id: self.session_id,
+            root_session_id: self.root_session_id,
             kind: self.kind.clone(),
             display_name: self.display_name.clone(),
             spec: self.spec.clone(),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -33091,6 +33091,13 @@
             ],
             "description": "Machine result in the session VFS: `/.tasks/{task_id}/result.json`."
           },
+          "root_session_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Root of the owning session's delegation tree (EVE-680). Populated on\nAPI reads from the denormalized storage column so cross-session tooling\n(e.g. the Work view) can group a whole tree's tasks by one id. `None`\nfor a top-level session that is its own root, or when unavailable.\nStorage-derived, never client-settable on create."
+          },
           "session_id": {
             "type": "string",
             "description": "Owning session."


### PR DESCRIPTION
## What changed
`GET /v1/tasks` (and session task reads) now return `root_session_id` on each `SessionTask`. The delegation-tree root (EVE-680) was already denormalized on `session_task` rows and accepted as a **filter** on `GET /v1/tasks`, but `SessionTaskRow::to_task` dropped it, so the field could be filtered on yet never appeared in the response. Consumers can now group a whole delegation tree's tasks by a single id from the task snapshot itself.

This is the foundational, self-contained first PR of EVE-681 — it unblocks the cross-session **Work view** (grouping tasks by root), which is a pure consumer of this field.

## Why
The Work view needs to render an org's background tasks grouped by `root_session_id` as a live tree. Without the field on the response, client-side grouping is impossible and a UI would have to issue one filtered request per root. Surfacing the already-stored value is the minimal enabling change.

## Before / After
`GET /v1/tasks` response object, for a task in a delegation tree:

Before:
```json
{ "id": "task_…", "session_id": "…", "kind": "subagent", "state": "running", … }
```
After:
```json
{ "id": "task_…", "session_id": "…", "root_session_id": "…", "kind": "subagent", "state": "running", … }
```
`root_session_id` is omitted for a top-level session that is its own root (serde `skip_serializing_if`). Proof: new unit test `to_task_surfaces_root_session_id` asserts the row value round-trips onto the core `SessionTask` and that a NULL root surfaces as `None`. OpenAPI spec + generated UI types regenerated and verified (`SessionTask.root_session_id`).

Validation run locally: `cargo fmt --check`, `cargo clippy -D warnings` (core/server/internal-protocol), `cargo test -p everruns-server to_task_surfaces_root_session_id`, `pnpm api-types:check`, `pnpm typecheck`, `pnpm lint` — all green.

## Risk
- Low
- Purely additive: a new optional, storage-derived field on a read DTO. It is never client-settable on create and is not carried over the worker protocol (`proto_to_session_task` sets `None`), so no gRPC/schema change. No behavior change to any existing field.

## Security
- Threat categories reviewed: TM-API, TM-TENANT. `root_session_id` is read from the same org-scoped storage rows already returned by these endpoints; it exposes no cross-tenant data (the value is a session id within the caller's org, already reachable via the existing `root_session_id` filter). No new input parsing, egress, or auth surface.
- Findings and resolutions: None.

## Follow-ups
- Carry `root_session_id` on the `task.updated` event/worker-protocol snapshot so cross-session live tooling gets it on deltas too (today it is surfaced only on storage reads / initial GET). Tracked under EVE-681 as part of the Work view work.
- Cross-session Work view UI consuming this field (EVE-681, next PR).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive optional field; no protocol change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Linear: EVE-681

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5wcmVhWzrpSTGv2SjY57Q)_