### PR TITLE
feat(runtime): mid-turn task wake delivery — EVE-681 (part A)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -120,6 +120,7 @@ pub mod skill;
 pub mod system_allowlist;
 pub mod task_observer;
 pub mod vector_store;
+pub mod wake_queue;
 pub mod workspace;
 pub mod workspace_roots;
 
@@ -512,7 +513,7 @@ pub use skill::{
     ParsedSkillMd, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus, SkillUsage,
     SkillValidationResult, parse_skill_md, validate_skill_md, validate_skill_name,
 };
-pub use task_observer::{TaskTransition, TaskTransitionObserver};
+pub use task_observer::{ObservingTaskRegistry, TaskTransition, TaskTransitionObserver};
 pub use typed_id::{
     AgentId, AgentIdentityId, AgentVersionId, AppChannelId, AppId, DeclarativeCapabilityId,
     EvalCaseId, EvalId, EvalResultId, EvalRunId, EventId, ExecId, HarnessId, IdMarker,
@@ -521,6 +522,7 @@ pub use typed_id::{
     PaymentPolicyId, PluginInstallId, PluginMarketplaceId, PrincipalId, ProviderId, ScheduleId,
     SessionId, SessionParticipantId, SkillId, TurnId, TypedId, WorkspaceId,
 };
+pub use wake_queue::{PendingWake, SessionWakeQueue, wake_text_for};
 
 // Audit logging re-exports
 pub use audit::{

--- a/crates/core/src/task_observer.rs
+++ b/crates/core/src/task_observer.rs
@@ -20,9 +20,16 @@
 // The `filter_value` / `event_name` strings are shared with webhook payloads so
 // the two paths stay byte-for-byte aligned.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
-use crate::session_task::SessionTask;
+use crate::error::Result;
+use crate::session_task::{
+    CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
+    SessionTaskState, SessionTaskUpdate, TaskMessage, TaskMessageDirection,
+};
+use crate::typed_id::SessionId;
 
 /// A task lifecycle transition an observer can be notified of.
 ///
@@ -82,6 +89,159 @@ pub trait TaskTransitionObserver: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
 }
 
+/// A [`SessionTaskRegistry`] decorator that fans real task transitions out to
+/// registered [`TaskTransitionObserver`]s.
+///
+/// This is the reusable, storage-agnostic form of the fan-out the server's
+/// `DbSessionTaskRegistry` performs inline (EVE-729): it wraps *any* inner
+/// registry (in-memory, SQLite, gRPC) so an embedder — e.g. `everruns-runtime`
+/// with a [`crate::wake_queue::SessionWakeQueue`] — gets the same transition
+/// notifications without depending on the control-plane server.
+///
+/// Transition detection mirrors `DbSessionTaskRegistry` exactly so mid-turn and
+/// between-turn delivery agree on *when* a wake fires:
+///
+///   * `Terminal` — fired once when an update moves a non-terminal task into a
+///     terminal state, gated on this update's own intent (an update that does
+///     not set a terminal state never fires it, so a racing heartbeat cannot
+///     wake on another writer's transition).
+///   * `AwaitingInput` — fired once on the transition into `awaiting_input`.
+///   * `Message` — fired for each outbound message.
+///
+/// Observers are awaited in registration order (fast, in-process consumers); a
+/// failing observer is logged and never fails the underlying task op.
+pub struct ObservingTaskRegistry {
+    inner: Arc<dyn SessionTaskRegistry>,
+    observers: Vec<Arc<dyn TaskTransitionObserver>>,
+}
+
+impl ObservingTaskRegistry {
+    pub fn new(inner: Arc<dyn SessionTaskRegistry>) -> Self {
+        Self {
+            inner,
+            observers: Vec::new(),
+        }
+    }
+
+    /// Register an observer to receive every real transition.
+    pub fn with_observer(mut self, observer: Arc<dyn TaskTransitionObserver>) -> Self {
+        self.observers.push(observer);
+        self
+    }
+
+    /// Whether any observer is registered (fan-out is otherwise a no-op).
+    pub fn has_observers(&self) -> bool {
+        !self.observers.is_empty()
+    }
+
+    async fn notify(&self, task: &SessionTask, transition: TaskTransition) {
+        for observer in &self.observers {
+            if let Err(e) = observer.on_transition(task, transition).await {
+                tracing::warn!(
+                    task_id = %task.id,
+                    session_id = %task.session_id,
+                    transition = ?transition,
+                    "TaskTransitionObserver failed (best-effort): {e}"
+                );
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl SessionTaskRegistry for ObservingTaskRegistry {
+    async fn create(&self, input: CreateSessionTask) -> Result<SessionTask> {
+        self.inner.create(input).await
+    }
+
+    async fn update(
+        &self,
+        session_id: SessionId,
+        task_id: &str,
+        update: SessionTaskUpdate,
+    ) -> Result<Option<SessionTask>> {
+        // Only this update's own intent can trigger a wake, so a racing
+        // heartbeat/progress update never fires on another writer's transition.
+        let wants_terminal = update.state.is_some_and(|s| s.is_terminal());
+        let wants_awaiting_input =
+            update.input_request.is_some() || update.state == Some(SessionTaskState::AwaitingInput);
+
+        let needs_prior = self.has_observers() && (wants_terminal || wants_awaiting_input);
+        let prior = if needs_prior {
+            self.inner.get(session_id, task_id).await.ok().flatten()
+        } else {
+            None
+        };
+
+        let updated = self.inner.update(session_id, task_id, update).await?;
+
+        if let (Some(task), Some(prior)) = (&updated, &prior) {
+            if wants_terminal && !prior.state.is_terminal() && task.state.is_terminal() {
+                self.notify(task, TaskTransition::Terminal).await;
+            }
+            if wants_awaiting_input
+                && prior.state != SessionTaskState::AwaitingInput
+                && task.state == SessionTaskState::AwaitingInput
+            {
+                self.notify(task, TaskTransition::AwaitingInput).await;
+            }
+        }
+        Ok(updated)
+    }
+
+    async fn get(&self, session_id: SessionId, task_id: &str) -> Result<Option<SessionTask>> {
+        self.inner.get(session_id, task_id).await
+    }
+
+    async fn list(
+        &self,
+        session_id: SessionId,
+        filter: Option<&SessionTaskFilter>,
+    ) -> Result<Vec<SessionTask>> {
+        self.inner.list(session_id, filter).await
+    }
+
+    async fn request_cancel(
+        &self,
+        session_id: SessionId,
+        task_id: &str,
+    ) -> Result<Option<SessionTask>> {
+        self.inner.request_cancel(session_id, task_id).await
+    }
+
+    async fn record_message(
+        &self,
+        session_id: SessionId,
+        task_id: &str,
+        message: NewTaskMessage,
+    ) -> Result<TaskMessage> {
+        let direction = message.direction;
+        let stored = self
+            .inner
+            .record_message(session_id, task_id, message)
+            .await?;
+        if direction == TaskMessageDirection::Outbound
+            && self.has_observers()
+            && let Ok(Some(task)) = self.inner.get(session_id, task_id).await
+        {
+            self.notify(&task, TaskTransition::Message).await;
+        }
+        Ok(stored)
+    }
+
+    async fn list_messages(
+        &self,
+        session_id: SessionId,
+        task_id: &str,
+        limit: Option<u32>,
+        after_id: Option<&str>,
+    ) -> Result<Vec<TaskMessage>> {
+        self.inner
+            .list_messages(session_id, task_id, limit, after_id)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,5 +263,213 @@ mod tests {
             "task.awaiting_input"
         );
         assert_eq!(TaskTransition::Message.event_name(), "task.message");
+    }
+
+    // ---- ObservingTaskRegistry fan-out gating -----------------------------
+
+    use crate::session_task::{
+        SessionTaskState, TaskWakePolicy, apply_task_update, new_session_task,
+    };
+    use crate::typed_id::SessionId;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MemRegistry {
+        tasks: Mutex<HashMap<String, SessionTask>>,
+    }
+
+    #[async_trait]
+    impl SessionTaskRegistry for MemRegistry {
+        async fn create(&self, input: CreateSessionTask) -> Result<SessionTask> {
+            let task = new_session_task(input, chrono::Utc::now());
+            self.tasks
+                .lock()
+                .unwrap()
+                .insert(task.id.clone(), task.clone());
+            Ok(task)
+        }
+        async fn update(
+            &self,
+            session_id: SessionId,
+            task_id: &str,
+            update: SessionTaskUpdate,
+        ) -> Result<Option<SessionTask>> {
+            let mut tasks = self.tasks.lock().unwrap();
+            let Some(task) = tasks.get_mut(task_id) else {
+                return Ok(None);
+            };
+            if task.session_id != session_id {
+                return Ok(None);
+            }
+            apply_task_update(task, update, chrono::Utc::now());
+            Ok(Some(task.clone()))
+        }
+        async fn get(&self, session_id: SessionId, task_id: &str) -> Result<Option<SessionTask>> {
+            Ok(self
+                .tasks
+                .lock()
+                .unwrap()
+                .get(task_id)
+                .filter(|t| t.session_id == session_id)
+                .cloned())
+        }
+        async fn list(
+            &self,
+            _session_id: SessionId,
+            _filter: Option<&SessionTaskFilter>,
+        ) -> Result<Vec<SessionTask>> {
+            Ok(Vec::new())
+        }
+        async fn request_cancel(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+        ) -> Result<Option<SessionTask>> {
+            Ok(None)
+        }
+        async fn record_message(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+            message: NewTaskMessage,
+        ) -> Result<TaskMessage> {
+            Ok(TaskMessage {
+                id: "tmsg_x".into(),
+                task_id: task_id.into(),
+                direction: message.direction,
+                content: message.content,
+                in_reply_to: message.in_reply_to,
+                created_at: chrono::Utc::now(),
+            })
+        }
+        async fn list_messages(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _limit: Option<u32>,
+            _after_id: Option<&str>,
+        ) -> Result<Vec<TaskMessage>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        seen: Mutex<Vec<TaskTransition>>,
+    }
+
+    #[async_trait]
+    impl TaskTransitionObserver for Recorder {
+        async fn on_transition(
+            &self,
+            _task: &SessionTask,
+            transition: TaskTransition,
+        ) -> anyhow::Result<()> {
+            self.seen.lock().unwrap().push(transition);
+            Ok(())
+        }
+    }
+
+    async fn seed_running(reg: &MemRegistry, session_id: SessionId) -> String {
+        reg.create(CreateSessionTask {
+            id: None,
+            session_id,
+            kind: "background_tool".into(),
+            display_name: "T".into(),
+            spec: serde_json::Value::Null,
+            state: SessionTaskState::Running,
+            links: Default::default(),
+            wake_policy: TaskWakePolicy::OnActivity,
+        })
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn fires_terminal_once_and_not_on_heartbeat() {
+        let inner = Arc::new(MemRegistry::default());
+        let recorder = Arc::new(Recorder::default());
+        let reg = ObservingTaskRegistry::new(inner.clone()).with_observer(recorder.clone());
+        let session_id = SessionId::new();
+        let task_id = seed_running(&inner, session_id).await;
+
+        // A heartbeat-only update (no state change) must not fire any transition.
+        reg.update(
+            session_id,
+            &task_id,
+            SessionTaskUpdate {
+                heartbeat_at: Some(chrono::Utc::now()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            recorder.seen.lock().unwrap().is_empty(),
+            "heartbeat must not fire a transition"
+        );
+
+        // Transition to terminal fires exactly one Terminal.
+        reg.update(
+            session_id,
+            &task_id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // A redundant terminal-state update on an already-terminal task must not
+        // re-fire (prior is already terminal).
+        reg.update(
+            session_id,
+            &task_id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *recorder.seen.lock().unwrap(),
+            vec![TaskTransition::Terminal],
+            "terminal fires exactly once, never on heartbeat or re-terminal"
+        );
+    }
+
+    #[tokio::test]
+    async fn fires_awaiting_input_only_on_entry() {
+        let inner = Arc::new(MemRegistry::default());
+        let recorder = Arc::new(Recorder::default());
+        let reg = ObservingTaskRegistry::new(inner.clone()).with_observer(recorder.clone());
+        let session_id = SessionId::new();
+        let task_id = seed_running(&inner, session_id).await;
+
+        reg.update(
+            session_id,
+            &task_id,
+            SessionTaskUpdate {
+                input_request: Some(crate::session_task::TaskInputRequest {
+                    id: "ir_1".into(),
+                    prompt: "approve?".into(),
+                    expected: None,
+                }),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *recorder.seen.lock().unwrap(),
+            vec![TaskTransition::AwaitingInput],
+            "awaiting_input fires once on entry"
+        );
     }
 }

--- a/crates/core/src/wake_queue.rs
+++ b/crates/core/src/wake_queue.rs
@@ -1,0 +1,325 @@
+// Mid-turn task wake delivery (EVE-681, part A).
+//
+// Wake-ups are a registry-level delivery policy: when a task emits qualifying
+// outbound activity (see `TaskWakePolicy`), the owning session's agent is woken
+// so it can react. Historically the only delivery path was a between-turn
+// steering message — a parent that spawned background work finished its turn,
+// idled, and only reacted on its next turn (see the Wake-ups section of
+// `specs/session-tasks.md`).
+//
+// `SessionWakeQueue` adds the *mid-turn* path. It is a per-session queue that
+// sits behind the registry seam: the registry fans qualifying task transitions
+// into it (via the EVE-729 `TaskTransitionObserver` seam), and the agentic turn
+// loop drains it at each iteration boundary — before the next LLM call —
+// injecting the wake payloads as context alongside the reloaded conversation.
+//
+// Exactly-once claim point
+// -------------------------
+// The queue is the single source of truth for an undelivered wake. Each real
+// transition enqueues exactly one `PendingWake` (the registry guarantees one
+// observer notification per real transition). `drain` atomically removes and
+// returns a session's queued wakes under a single lock — that removal *is* the
+// claim. A wake is therefore delivered mid-turn (drained by a running turn's
+// next iteration) XOR queued for the next turn (drained by that turn's first
+// iteration), never both:
+//
+//   * turn cancellation / seal / max-iterations: an undrained wake stays in the
+//     queue and is delivered by the next turn's first drain (between-turn
+//     fallback), because nothing removed it.
+//   * a wake landing mid-loop is visible to the very next iteration, because the
+//     loop drains at the top of every reason step.
+//
+// The queue is process-local. Within a single runtime/worker process it gives
+// exactly-once delivery; durable exactly-once across a worker restart is a
+// property of the *persistent* transition source (the durable signal store on
+// the server path), not of this in-memory queue. The server durable-worker
+// wiring is intentionally out of scope for part A — see the PR / spec notes.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::session_task::{SessionTask, TaskWakePolicy};
+use crate::task_observer::{TaskTransition, TaskTransitionObserver};
+use crate::typed_id::SessionId;
+
+/// A wake destined for a session's running (or next) turn.
+///
+/// `text` is the rendered, model-facing payload — the task snapshot summary plus
+/// (for `OnActivity`) its latest progress/detail. The loop injects it as a user
+/// message so the next LLM call reacts to it alongside pending tool results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingWake {
+    pub task_id: String,
+    pub session_id: SessionId,
+    pub transition: TaskTransition,
+    pub text: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Render the wake text for a task transition under the task's `wake_policy`.
+///
+/// Returns `None` when the policy does not wake on this transition (so the
+/// caller enqueues nothing). This encodes the same gating the between-turn
+/// waker uses (`DbSessionTaskRegistry::maybe_wake_*`) so mid-turn and
+/// between-turn delivery agree on *when* a wake fires:
+///
+///   * `Silent`     — never.
+///   * `OnTerminal` — only on a terminal transition.
+///   * `OnActivity` — terminal, `awaiting_input`, and outbound messages.
+///
+/// The text is rendered purely from the task snapshot: the terminal summary /
+/// result path, the awaiting-input prompt, or the latest progress / detail for
+/// a message. The full message thread stays in the task record; the wake tells
+/// the agent to look.
+pub fn wake_text_for(task: &SessionTask, transition: TaskTransition) -> Option<String> {
+    match (task.wake_policy, transition) {
+        (TaskWakePolicy::Silent, _) => None,
+        (TaskWakePolicy::OnTerminal, TaskTransition::Terminal)
+        | (TaskWakePolicy::OnActivity, TaskTransition::Terminal) => {
+            let mut parts = vec![format!(
+                "Task \"{}\" ({}) finished: {}.",
+                task.display_name, task.id, task.state
+            )];
+            if let Some(summary) = &task.summary {
+                parts.push(format!("- summary: {summary}"));
+            }
+            if let Some(result_path) = &task.result_path {
+                parts.push(format!("- result_path: {result_path}"));
+            }
+            Some(parts.join("\n"))
+        }
+        (TaskWakePolicy::OnTerminal, _) => None,
+        (TaskWakePolicy::OnActivity, TaskTransition::AwaitingInput) => {
+            let prompt = task
+                .input_request
+                .as_ref()
+                .map(|r| r.prompt.as_str())
+                .unwrap_or("Task is awaiting input.");
+            Some(format!(
+                "Task \"{}\" ({}) is awaiting input: {}",
+                task.display_name, task.id, prompt
+            ))
+        }
+        (TaskWakePolicy::OnActivity, TaskTransition::Message) => {
+            // Observers do not receive the message body (it is not on the task
+            // snapshot); surface the latest progress/detail so the agent knows
+            // what changed, and read the thread via `get_task` for the payload.
+            let detail = task
+                .state_detail
+                .as_deref()
+                .filter(|s| !s.trim().is_empty())
+                .or_else(|| task.progress.as_ref().and_then(|p| p.label.as_deref()))
+                .unwrap_or("structured progress update");
+            Some(format!(
+                "Task \"{}\" ({}) sent a message: {}",
+                task.display_name, task.id, detail
+            ))
+        }
+    }
+}
+
+/// Per-session mid-turn wake queue behind the registry seam.
+///
+/// Feed it by registering it as a [`TaskTransitionObserver`] on an
+/// [`crate::task_observer::ObservingTaskRegistry`] (or the server's
+/// `DbSessionTaskRegistry`). Drain it from the turn loop with [`Self::drain`].
+#[derive(Default)]
+pub struct SessionWakeQueue {
+    queues: Mutex<HashMap<SessionId, VecDeque<PendingWake>>>,
+}
+
+impl SessionWakeQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enqueue a wake for `task`'s owning session if its policy wakes on
+    /// `transition`. Returns `true` when a wake was enqueued.
+    pub fn note_transition(&self, task: &SessionTask, transition: TaskTransition) -> bool {
+        let Some(text) = wake_text_for(task, transition) else {
+            return false;
+        };
+        let wake = PendingWake {
+            task_id: task.id.clone(),
+            session_id: task.session_id,
+            transition,
+            text,
+            created_at: Utc::now(),
+        };
+        self.queues
+            .lock()
+            .expect("wake queue mutex poisoned")
+            .entry(task.session_id)
+            .or_default()
+            .push_back(wake);
+        true
+    }
+
+    /// Atomically remove and return all wakes queued for `session_id`.
+    ///
+    /// This is the exactly-once claim point: a drained wake is gone from the
+    /// queue and can never be delivered again.
+    pub fn drain(&self, session_id: SessionId) -> Vec<PendingWake> {
+        let mut guard = self.queues.lock().expect("wake queue mutex poisoned");
+        match guard.get_mut(&session_id) {
+            Some(queue) => queue.drain(..).collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Number of wakes currently queued for `session_id` (not consuming).
+    pub fn pending_len(&self, session_id: SessionId) -> usize {
+        self.queues
+            .lock()
+            .expect("wake queue mutex poisoned")
+            .get(&session_id)
+            .map_or(0, VecDeque::len)
+    }
+
+    /// Whether any wake is queued for `session_id` (not consuming).
+    pub fn has_pending(&self, session_id: SessionId) -> bool {
+        self.pending_len(session_id) > 0
+    }
+}
+
+/// The queue is a [`TaskTransitionObserver`] so it can be attached to the same
+/// seam the server webhook dispatcher uses (EVE-729). Terminal and
+/// awaiting-input transitions render at full fidelity from the snapshot; a
+/// message transition renders from the snapshot's progress/detail.
+#[async_trait]
+impl TaskTransitionObserver for SessionWakeQueue {
+    async fn on_transition(
+        &self,
+        task: &SessionTask,
+        transition: TaskTransition,
+    ) -> anyhow::Result<()> {
+        self.note_transition(task, transition);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_task::{
+        CreateSessionTask, SessionTaskState, TaskInputRequest, new_session_task,
+    };
+
+    fn task_with_policy(policy: TaskWakePolicy) -> SessionTask {
+        let session_id = SessionId::new();
+        let mut task = new_session_task(
+            CreateSessionTask {
+                id: None,
+                session_id,
+                kind: "subagent".into(),
+                display_name: "Test Runner".into(),
+                spec: serde_json::Value::Null,
+                state: SessionTaskState::Running,
+                links: Default::default(),
+                wake_policy: policy,
+            },
+            Utc::now(),
+        );
+        task.state = SessionTaskState::Succeeded;
+        task
+    }
+
+    #[test]
+    fn silent_never_wakes() {
+        for transition in [
+            TaskTransition::Terminal,
+            TaskTransition::AwaitingInput,
+            TaskTransition::Message,
+        ] {
+            assert!(wake_text_for(&task_with_policy(TaskWakePolicy::Silent), transition).is_none());
+        }
+    }
+
+    #[test]
+    fn on_terminal_wakes_only_on_terminal() {
+        let task = task_with_policy(TaskWakePolicy::OnTerminal);
+        assert!(wake_text_for(&task, TaskTransition::Terminal).is_some());
+        assert!(wake_text_for(&task, TaskTransition::AwaitingInput).is_none());
+        assert!(wake_text_for(&task, TaskTransition::Message).is_none());
+    }
+
+    #[test]
+    fn on_activity_wakes_on_all_three() {
+        let mut task = task_with_policy(TaskWakePolicy::OnActivity);
+        task.state = SessionTaskState::AwaitingInput;
+        task.input_request = Some(TaskInputRequest {
+            id: "ir_1".into(),
+            prompt: "pick a branch".into(),
+            expected: None,
+        });
+        let awaiting = wake_text_for(&task, TaskTransition::AwaitingInput).expect("awaiting wakes");
+        assert!(awaiting.contains("awaiting input"));
+        assert!(awaiting.contains("pick a branch"));
+
+        task.state = SessionTaskState::Running;
+        task.state_detail = Some("iteration 4/10".into());
+        let message = wake_text_for(&task, TaskTransition::Message).expect("message wakes");
+        assert!(message.contains("iteration 4/10"));
+
+        task.state = SessionTaskState::Failed;
+        assert!(wake_text_for(&task, TaskTransition::Terminal).is_some());
+    }
+
+    #[test]
+    fn terminal_text_includes_summary_and_result_path() {
+        let mut task = task_with_policy(TaskWakePolicy::OnTerminal);
+        task.summary = Some("all tests passed".into());
+        task.result_path = Some("/.tasks/task_x/result.json".into());
+        let text = wake_text_for(&task, TaskTransition::Terminal).unwrap();
+        assert!(text.contains("finished: succeeded"));
+        assert!(text.contains("all tests passed"));
+        assert!(text.contains("/.tasks/task_x/result.json"));
+    }
+
+    #[test]
+    fn drain_is_exactly_once() {
+        let queue = SessionWakeQueue::new();
+        let task = task_with_policy(TaskWakePolicy::OnTerminal);
+        let session_id = task.session_id;
+
+        assert!(queue.note_transition(&task, TaskTransition::Terminal));
+        assert_eq!(queue.pending_len(session_id), 1);
+
+        let first = queue.drain(session_id);
+        assert_eq!(first.len(), 1, "first drain returns the wake");
+        assert_eq!(first[0].task_id, task.id);
+
+        let second = queue.drain(session_id);
+        assert!(
+            second.is_empty(),
+            "second drain returns nothing — claimed once"
+        );
+        assert_eq!(queue.pending_len(session_id), 0);
+    }
+
+    #[test]
+    fn silent_transition_enqueues_nothing() {
+        let queue = SessionWakeQueue::new();
+        let task = task_with_policy(TaskWakePolicy::Silent);
+        assert!(!queue.note_transition(&task, TaskTransition::Terminal));
+        assert_eq!(queue.pending_len(task.session_id), 0);
+    }
+
+    #[test]
+    fn queues_are_isolated_per_session() {
+        let queue = SessionWakeQueue::new();
+        let a = task_with_policy(TaskWakePolicy::OnTerminal);
+        let b = task_with_policy(TaskWakePolicy::OnTerminal);
+        queue.note_transition(&a, TaskTransition::Terminal);
+        queue.note_transition(&b, TaskTransition::Terminal);
+        assert_eq!(queue.drain(a.session_id).len(), 1);
+        assert_eq!(
+            queue.pending_len(b.session_id),
+            1,
+            "draining A leaves B intact"
+        );
+    }
+}

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -530,6 +530,23 @@ impl InProcessRuntimeBuilder {
         let persisting_emitter =
             PersistingEventEmitter::new(backends.event_bus.clone(), backends.message_store.clone());
 
+        // Mid-turn wake delivery (EVE-681, part A): when a task registry is
+        // present, wrap it so qualifying task transitions fan out to a
+        // per-session `SessionWakeQueue`. The turn loop drains that queue at
+        // each reason iteration boundary. Without a registry there is no
+        // background work to wake on, so the queue is left absent (inert).
+        let (session_task_registry, session_wake_queue) = match backends.session_task_registry {
+            Some(inner) => {
+                let wake_queue = Arc::new(everruns_core::SessionWakeQueue::new());
+                let observing = everruns_core::ObservingTaskRegistry::new(inner)
+                    .with_observer(wake_queue.clone());
+                let wrapped: Arc<dyn everruns_core::session_task::SessionTaskRegistry> =
+                    Arc::new(observing);
+                (Some(wrapped), Some(wake_queue))
+            }
+            None => (None, None),
+        };
+
         Ok(InProcessRuntime {
             platform_definition: Arc::new(self.platform_definition),
             harness_store: backends.harness_store,
@@ -543,7 +560,8 @@ impl InProcessRuntimeBuilder {
             file_store,
             storage_store: backends.storage_store,
             connection_resolver: backends.connection_resolver,
-            session_task_registry: backends.session_task_registry,
+            session_task_registry,
+            session_wake_queue,
             schedule_store_factory: backends.schedule_store_factory,
             platform_store_factory: backends.platform_store_factory,
             mcp_auth_provider: self
@@ -589,6 +607,10 @@ pub struct InProcessRuntime {
     storage_store: Arc<dyn SessionStorageStore>,
     connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
     session_task_registry: Option<Arc<dyn everruns_core::session_task::SessionTaskRegistry>>,
+    /// Mid-turn wake queue fed by `session_task_registry` transitions and
+    /// drained at each reason iteration boundary (EVE-681, part A). Present iff
+    /// a task registry was configured.
+    session_wake_queue: Option<Arc<everruns_core::SessionWakeQueue>>,
     schedule_store_factory: Option<crate::backends::ScheduleStoreFactory>,
     platform_store_factory: Option<crate::backends::PlatformStoreFactory>,
     mcp_auth_provider: Arc<dyn everruns_mcp::McpAuthProvider>,
@@ -706,6 +728,13 @@ impl InProcessRuntime {
                 }
                 TurnAction::ExecuteReason => {
                     let ctx = state_machine.context();
+                    let session_id = ctx.session_id;
+                    // Iteration boundary: drain queued task wakes and inject
+                    // them before the LLM call so this reason reacts to them
+                    // (EVE-681, part A). Draining here also delivers wakes that
+                    // arrived while the session was idle, on the next turn's
+                    // first iteration (between-turn fallback).
+                    self.drain_and_inject_wakes(session_id).await?;
                     let base_context =
                         AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
                             .with_workspace_id(session.workspace_id);
@@ -724,13 +753,21 @@ impl InProcessRuntime {
                     )
                     .await?;
                     previous_response_id = reason_result.response_id.clone();
+                    // If a wake landed during this reason (e.g. a background
+                    // task settling on another task), continue a would-idle turn
+                    // so it is delivered on the very next iteration rather than
+                    // after the session idles.
+                    let has_pending_wakes = self
+                        .session_wake_queue
+                        .as_ref()
+                        .is_some_and(|q| q.has_pending(session_id));
                     state_machine.on_reason_completed(
                         reason_result.text.clone(),
                         reason_result.has_tool_calls,
                         reason_result.tool_calls.len(),
                         reason_result.success,
                         reason_result.error.clone(),
-                        false,
+                        has_pending_wakes,
                     );
                     if reason_result.has_tool_calls {
                         last_reason_result = Some(reason_result);
@@ -826,6 +863,45 @@ impl InProcessRuntime {
         text: impl Into<String>,
     ) -> Result<TurnResult> {
         self.run_turn(session_id, InputMessage::user(text)).await
+    }
+
+    /// Drain any queued task wakes for `session_id` and inject them into the
+    /// conversation as user messages so the next reason reacts to them
+    /// (EVE-681, part A). Returns the number of wakes injected.
+    ///
+    /// Called at the top of every reason iteration — before the LLM call — so a
+    /// task completion that landed during the previous act (or while idle) is
+    /// visible to the very next iteration. `SessionWakeQueue::drain` is the
+    /// exactly-once claim point: a drained wake is removed and never delivered
+    /// twice, so a wake is delivered mid-turn XOR on the next turn's first
+    /// drain, never both.
+    async fn drain_and_inject_wakes(&self, session_id: SessionId) -> Result<usize> {
+        let Some(queue) = &self.session_wake_queue else {
+            return Ok(0);
+        };
+        let wakes = queue.drain(session_id);
+        if wakes.is_empty() {
+            return Ok(0);
+        }
+        let count = wakes.len();
+        for wake in wakes {
+            // Persist the wake as a user message (history reload picks it up)
+            // and emit the input event on the raw bus so it appears in the turn
+            // span without the persisting emitter double-storing it — mirroring
+            // how `run_turn` records the initial input message.
+            let message = self
+                .message_store
+                .add_input_message(session_id, InputMessage::user(wake.text))
+                .await?;
+            self.event_bus
+                .emit(EventRequest::new(
+                    session_id,
+                    EventContext::empty(),
+                    InputMessageData::new(message),
+                ))
+                .await?;
+        }
+        Ok(count)
     }
 
     /// Load the current message history for a session.

--- a/crates/runtime/tests/mid_turn_wake_test.rs
+++ b/crates/runtime/tests/mid_turn_wake_test.rs
@@ -1,0 +1,493 @@
+//! Mid-turn task wake delivery over the in-process runtime (EVE-681, part A).
+//!
+//! A parent turn runs several reason iterations while a background child task
+//! completes at iteration k < N. The child's terminal wake must be injected
+//! into the parent's iteration k+1 context — delivered mid-turn, without the
+//! turn idling — and exactly once. The LLM is simulated, so the scenario is
+//! deterministic and runs without credentials.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityStatus};
+use everruns_core::driver_registry::DriverRegistry;
+use everruns_core::error::Result;
+use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
+use everruns_core::session_task::{
+    CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
+    SessionTaskState, SessionTaskUpdate, TaskMessage, TaskWakePolicy, apply_task_update,
+    generate_task_message_id, new_session_task,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use everruns_core::typed_id::SessionId;
+use everruns_core::{
+    AgentId, CapabilityRegistry, DriverId, HarnessId, PlatformDefinition, ResolvedModel,
+};
+use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
+
+const CHILD_TASK_ID: &str = "task_wakedemo_child";
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory task registry (test double for the durable registry).
+// Routes updates through the canonical `apply_task_update` so transition
+// detection in `ObservingTaskRegistry` behaves exactly as in production.
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct TestTaskRegistry {
+    tasks: Mutex<HashMap<String, SessionTask>>,
+    messages: Mutex<Vec<TaskMessage>>,
+}
+
+#[async_trait]
+impl SessionTaskRegistry for TestTaskRegistry {
+    async fn create(&self, input: CreateSessionTask) -> Result<SessionTask> {
+        let task = new_session_task(input, chrono::Utc::now());
+        self.tasks
+            .lock()
+            .unwrap()
+            .insert(task.id.clone(), task.clone());
+        Ok(task)
+    }
+
+    async fn update(
+        &self,
+        session_id: SessionId,
+        task_id: &str,
+        update: SessionTaskUpdate,
+    ) -> Result<Option<SessionTask>> {
+        let mut tasks = self.tasks.lock().unwrap();
+        let Some(task) = tasks.get_mut(task_id) else {
+            return Ok(None);
+        };
+        if task.session_id != session_id {
+            return Ok(None);
+        }
+        apply_task_update(task, update, chrono::Utc::now());
+        Ok(Some(task.clone()))
+    }
+
+    async fn get(&self, session_id: SessionId, task_id: &str) -> Result<Option<SessionTask>> {
+        Ok(self
+            .tasks
+            .lock()
+            .unwrap()
+            .get(task_id)
+            .filter(|t| t.session_id == session_id)
+            .cloned())
+    }
+
+    async fn list(
+        &self,
+        session_id: SessionId,
+        _filter: Option<&SessionTaskFilter>,
+    ) -> Result<Vec<SessionTask>> {
+        Ok(self
+            .tasks
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|t| t.session_id == session_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn request_cancel(
+        &self,
+        session_id: SessionId,
+        task_id: &str,
+    ) -> Result<Option<SessionTask>> {
+        let mut tasks = self.tasks.lock().unwrap();
+        let Some(task) = tasks.get_mut(task_id) else {
+            return Ok(None);
+        };
+        if task.session_id != session_id {
+            return Ok(None);
+        }
+        task.cancel_requested_at
+            .get_or_insert_with(chrono::Utc::now);
+        Ok(Some(task.clone()))
+    }
+
+    async fn record_message(
+        &self,
+        _session_id: SessionId,
+        task_id: &str,
+        message: NewTaskMessage,
+    ) -> Result<TaskMessage> {
+        let record = TaskMessage {
+            id: generate_task_message_id(),
+            task_id: task_id.to_string(),
+            direction: message.direction,
+            content: message.content,
+            in_reply_to: message.in_reply_to,
+            created_at: chrono::Utc::now(),
+        };
+        self.messages.lock().unwrap().push(record.clone());
+        Ok(record)
+    }
+
+    async fn list_messages(
+        &self,
+        _session_id: SessionId,
+        task_id: &str,
+        _limit: Option<u32>,
+        _after_id: Option<&str>,
+    ) -> Result<Vec<TaskMessage>> {
+        Ok(self
+            .messages
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|m| m.task_id == task_id)
+            .cloned()
+            .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wake-demo capability: a tool that spawns a child task and one that completes
+// it, both through the session's task registry (so completing it fires the
+// transition observer that feeds the mid-turn wake queue).
+// ---------------------------------------------------------------------------
+
+struct WakeDemoCapability {
+    /// Wake policy the spawned child is created with (drives the OnActivity /
+    /// Silent regression variants).
+    policy: TaskWakePolicy,
+}
+
+impl Capability for WakeDemoCapability {
+    fn id(&self) -> &str {
+        "wake_demo"
+    }
+    fn name(&self) -> &str {
+        "Wake Demo"
+    }
+    fn description(&self) -> &str {
+        "Testing capability: spawn and complete a child task through the registry."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(SpawnChildTool {
+                policy: self.policy,
+            }),
+            Box::new(CompleteChildTool),
+        ]
+    }
+}
+
+struct SpawnChildTool {
+    policy: TaskWakePolicy,
+}
+
+#[async_trait]
+impl Tool for SpawnChildTool {
+    fn name(&self) -> &str {
+        "spawn_child"
+    }
+    fn description(&self) -> &str {
+        "Spawn a background child task."
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    fn requires_context(&self) -> bool {
+        true
+    }
+    async fn execute(&self, _arguments: serde_json::Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("spawn_child requires context")
+    }
+    async fn execute_with_context(
+        &self,
+        _arguments: serde_json::Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(registry) = &context.session_task_registry else {
+            return ToolExecutionResult::tool_error("no task registry");
+        };
+        let created = registry
+            .create(CreateSessionTask {
+                id: Some(CHILD_TASK_ID.to_string()),
+                session_id: context.session_id,
+                kind: "background_tool".to_string(),
+                display_name: "Doc Reviewer".to_string(),
+                spec: serde_json::Value::Null,
+                state: SessionTaskState::Running,
+                links: Default::default(),
+                wake_policy: self.policy,
+            })
+            .await;
+        match created {
+            Ok(task) => ToolExecutionResult::success(serde_json::json!({ "task_id": task.id })),
+            Err(e) => ToolExecutionResult::tool_error(format!("create failed: {e}")),
+        }
+    }
+}
+
+struct CompleteChildTool;
+
+#[async_trait]
+impl Tool for CompleteChildTool {
+    fn name(&self) -> &str {
+        "complete_child"
+    }
+    fn description(&self) -> &str {
+        "Mark the background child task complete."
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    fn requires_context(&self) -> bool {
+        true
+    }
+    async fn execute(&self, _arguments: serde_json::Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("complete_child requires context")
+    }
+    async fn execute_with_context(
+        &self,
+        _arguments: serde_json::Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(registry) = &context.session_task_registry else {
+            return ToolExecutionResult::tool_error("no task registry");
+        };
+        let updated = registry
+            .update(
+                context.session_id,
+                CHILD_TASK_ID,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Succeeded),
+                    summary: Some("reviewed 3 documents; all clear".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        match updated {
+            Ok(_) => ToolExecutionResult::success(serde_json::json!({ "completed": true })),
+            Err(e) => ToolExecutionResult::tool_error(format!("update failed: {e}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn platform(policy: TaskWakePolicy) -> PlatformDefinition {
+    let mut caps = CapabilityRegistry::new();
+    caps.register(WakeDemoCapability { policy });
+    let mut drivers = DriverRegistry::new();
+    everruns_core::llmsim_driver::register_driver(&mut drivers);
+    PlatformDefinition::new(caps, drivers)
+}
+
+async fn build_runtime(
+    policy: TaskWakePolicy,
+    script: Vec<SimTurn>,
+    registry: Arc<TestTaskRegistry>,
+) -> (everruns_runtime::InProcessRuntime, SessionId) {
+    let harness_id = HarnessId::new();
+    let agent_id = AgentId::new();
+    let session_id = SessionId::new();
+
+    let harness = HarnessBuilder::new("wake", "Coordinate background work.")
+        .id(harness_id)
+        .capability("wake_demo")
+        .build();
+    let agent = AgentBuilder::new("agent", "Delegate, then react to results.")
+        .id(agent_id)
+        .max_iterations(8)
+        .build();
+    let session = SessionBuilder::new(harness_id)
+        .id(session_id)
+        .agent(agent_id)
+        .build();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform(policy))
+        .llm_sim(LlmSimConfig::scripted(script))
+        .default_model(ResolvedModel {
+            model: "llmsim-model".to_string(),
+            provider_type: DriverId::LlmSim,
+            api_key: Some("fake-key".to_string()),
+            base_url: None,
+            provider_metadata: None,
+        })
+        .harness(harness)
+        .agent(agent)
+        .session(session)
+        .with_session_task_registry(registry)
+        .build()
+        .await
+        .expect("build runtime");
+
+    (runtime, session_id)
+}
+
+fn tool_call(name: &str) -> SimTurn {
+    SimTurn::ToolCalls(vec![SimToolCall {
+        name: name.to_string(),
+        arguments: serde_json::json!({}),
+        id: None,
+    }])
+}
+
+fn wake_message_count(messages: &[everruns_core::Message], needle: &str) -> usize {
+    messages
+        .iter()
+        .filter(|m| {
+            m.content
+                .iter()
+                .any(|p| p.as_text().is_some_and(|t| t.contains(needle)))
+        })
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Child completes at iteration 2; the terminal wake is injected into the
+/// parent's iteration-3 context, mid-turn, exactly once, and the turn never
+/// idled in between.
+#[tokio::test]
+async fn terminal_wake_injected_mid_turn_exactly_once() {
+    let registry = Arc::new(TestTaskRegistry::default());
+    let script = vec![
+        tool_call("spawn_child"),    // iter 1: spawn background child (running)
+        tool_call("complete_child"), // iter 2: child completes -> wake enqueued
+        SimTurn::Assistant("Acknowledged the completed review.".to_string()), // iter 3
+    ];
+    let (runtime, session_id) =
+        build_runtime(TaskWakePolicy::OnTerminal, script, registry.clone()).await;
+
+    let turn = runtime
+        .run_text_turn(
+            session_id,
+            "Kick off a doc review and wrap up when it lands.",
+        )
+        .await
+        .expect("run turn");
+
+    assert!(turn.success, "turn should succeed: {:?}", turn.error);
+    // input reason(1)->act, reason(2)->act, reason(3, sees wake)->complete.
+    assert!(
+        turn.iterations >= 3,
+        "turn must run past the completion iteration, not idle: {turn:?}"
+    );
+
+    let messages = runtime.messages(session_id).await.expect("messages");
+    let wakes = wake_message_count(&messages, "finished: succeeded");
+    assert_eq!(
+        wakes, 1,
+        "terminal wake must be injected exactly once (mid-turn XOR next-turn): {messages:#?}"
+    );
+
+    // The wake carried the child's summary so the agent can react without a
+    // follow-up read.
+    assert_eq!(
+        wake_message_count(&messages, "reviewed 3 documents"),
+        1,
+        "wake payload should include the task summary"
+    );
+}
+
+/// Exactly-once across the mid-turn/next-turn boundary: once a wake is drained
+/// mid-turn it is claimed and must not be redelivered on a later turn.
+#[tokio::test]
+async fn wake_is_not_redelivered_on_the_next_turn() {
+    let registry = Arc::new(TestTaskRegistry::default());
+    let script = vec![
+        // Turn 1: spawn, complete (wake enqueued), then react (drains it).
+        tool_call("spawn_child"),
+        tool_call("complete_child"),
+        SimTurn::Assistant("Acknowledged.".to_string()),
+        // Turn 2: nothing new — the earlier wake must not reappear.
+        SimTurn::Assistant("Nothing else to do.".to_string()),
+    ];
+    let (runtime, session_id) =
+        build_runtime(TaskWakePolicy::OnTerminal, script, registry.clone()).await;
+
+    runtime
+        .run_text_turn(session_id, "Kick off a review.")
+        .await
+        .expect("turn 1");
+    let after_turn_1 = wake_message_count(
+        &runtime.messages(session_id).await.unwrap(),
+        "finished: succeeded",
+    );
+    assert_eq!(after_turn_1, 1, "wake delivered once in turn 1");
+
+    runtime
+        .run_text_turn(session_id, "Anything else?")
+        .await
+        .expect("turn 2");
+    let after_turn_2 = wake_message_count(
+        &runtime.messages(session_id).await.unwrap(),
+        "finished: succeeded",
+    );
+    assert_eq!(
+        after_turn_2, 1,
+        "claimed wake must not be redelivered on the next turn (exactly-once)"
+    );
+}
+
+/// Silent tasks never wake, even on terminal completion (regression).
+#[tokio::test]
+async fn silent_task_never_wakes_mid_turn() {
+    let registry = Arc::new(TestTaskRegistry::default());
+    let script = vec![
+        tool_call("spawn_child"),
+        tool_call("complete_child"),
+        SimTurn::Assistant("Done.".to_string()),
+    ];
+    let (runtime, session_id) =
+        build_runtime(TaskWakePolicy::Silent, script, registry.clone()).await;
+
+    let turn = runtime
+        .run_text_turn(session_id, "Run a silent background job.")
+        .await
+        .expect("run turn");
+    assert!(turn.success);
+
+    let messages = runtime.messages(session_id).await.expect("messages");
+    assert_eq!(
+        wake_message_count(&messages, "finished"),
+        0,
+        "Silent policy must never inject a wake: {messages:#?}"
+    );
+}
+
+/// OnActivity delivers a mid-turn wake on the child's terminal transition too
+/// (superset of OnTerminal).
+#[tokio::test]
+async fn on_activity_delivers_terminal_wake_mid_turn() {
+    let registry = Arc::new(TestTaskRegistry::default());
+    let script = vec![
+        tool_call("spawn_child"),
+        tool_call("complete_child"),
+        SimTurn::Assistant("Reacting to the update.".to_string()),
+    ];
+    let (runtime, session_id) =
+        build_runtime(TaskWakePolicy::OnActivity, script, registry.clone()).await;
+
+    let turn = runtime
+        .run_text_turn(session_id, "Monitor and react.")
+        .await
+        .expect("run turn");
+    assert!(turn.success);
+
+    let messages = runtime.messages(session_id).await.expect("messages");
+    assert_eq!(
+        wake_message_count(&messages, "finished: succeeded"),
+        1,
+        "OnActivity should deliver the terminal wake mid-turn exactly once"
+    );
+}

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -302,9 +302,37 @@ were retired in migration 062.
 
 Waking the parent is a registry-level delivery policy on outbound activity,
 not per-capability code. `wake_policy` on the task selects: wake on terminal
-transition, wake on any `post`/`request_input`, or silent (parent polls).
-Delivery uses the existing steering-message mechanism. This replaces the A2A
-synthetic wake-up message and pre-empts the subagent Phase 1b variant.
+transition, wake on any `post`/`request_input`, or silent (parent polls). This
+replaces the A2A synthetic wake-up message and pre-empts the subagent Phase 1b
+variant.
+
+There are two delivery paths, selected by whether the parent has an active turn:
+
+- **Idle parent → between-turn steering.** The waker injects a synthetic user
+  message and starts (or steers) a turn. Unchanged.
+- **Active parent → mid-turn injection.** The wake payload (task snapshot plus
+  the outbound message / `report_progress` data) is enqueued and consumed at the
+  parent's next agentic-loop iteration boundary — before the next LLM call —
+  appearing as injected context alongside the reloaded conversation, so the
+  parent reacts within the same turn instead of after it idles.
+
+The mid-turn queue lives behind the registry seam (`SessionWakeQueue` in
+`everruns-core`, fed via the `TaskTransitionObserver` seam by an
+`ObservingTaskRegistry` decorator over any registry, so runtime and server
+share it). The turn loop drains it at each reason iteration boundary.
+
+**Exactly-once.** The queue is the single source of truth for an undelivered
+wake: each real transition enqueues one entry (the registry fires each
+transition once per observer), and `drain` atomically removes a session's
+entries under one lock — that removal *is* the claim. A wake is therefore
+delivered mid-turn (drained by a running turn's next iteration) **xor** queued
+for the next turn (drained by that turn's first iteration), never both. Turn
+cancellation, seal, and max-iterations leave undrained wakes in the queue for
+the next turn (between-turn fallback); a completion landing mid-loop is visible
+to the very next iteration. Within a process the queue gives exactly-once;
+durable exactly-once across a worker restart is a property of the *persistent*
+transition source (the durable signal store), fenced by task `attempt`
+(`expected_attempt`), not of the in-memory queue.
 
 ## Durability and recovery
 
@@ -515,6 +543,23 @@ No backward compatibility is required; data migrates forward once:
   `awaiting_input` entry and outbound messages. `Silent` never wakes.
   A2A's legacy `wake_parent` call is gated on `session_task_registry.is_none()`
   (backward compat for sessions without a registry).
+- Mid-turn delivery (EVE-681, part A): `SessionWakeQueue`
+  (`crates/core/src/wake_queue.rs`) is a per-session queue behind the registry
+  seam; `ObservingTaskRegistry` (`crates/core/src/task_observer.rs`) is a
+  storage-agnostic decorator that fans qualifying transitions to observers
+  (the reusable form of `DbSessionTaskRegistry`'s inline fan-out). The
+  `everruns-runtime` in-process loop wraps its injected registry with this
+  decorator + queue and drains the queue at every reason iteration boundary
+  (`InProcessRuntime::drain_and_inject_wakes`), injecting each wake as a user
+  message before the LLM call and continuing a would-idle turn while wakes are
+  pending. `wake_text_for` renders the same terminal/awaiting_input/message text
+  the between-turn waker uses, so both paths agree on *when* a wake fires. The
+  server durable-worker path (draining the queue at
+  `unified_worker::schedule_next_activity`'s signal-consume boundary, persisted
+  through the durable signal store, with exactly-once across worker restart) is
+  **not** wired in part A — it needs live Postgres/NATS/gRPC to validate and is
+  deferred to a reviewed follow-up. The cross-session Work view (part B) depends
+  on EVE-680's `root_session_id` and is also deferred.
 - Background tool cancellation is cooperative: runs with a task record
   heartbeat every ~2s and poll `cancel_requested_at`, winding down to
   `canceled` when set (works across worker processes).


### PR DESCRIPTION
## What changed

Part A of EVE-681. A background task's wake can now be consumed **inside the parent's running turn** instead of only between turns.

- New `SessionWakeQueue` (`everruns-core`) — a per-session, in-process queue behind the registry seam. It is fed qualifying task transitions through the EVE-729 `TaskTransitionObserver` seam and rendered from the task snapshot per `wake_policy` (`Silent` → nothing, `OnTerminal` → terminal, `OnActivity` → terminal + awaiting_input + message), using the same text the between-turn waker produces.
- New `ObservingTaskRegistry` (`everruns-core`) — a storage-agnostic `SessionTaskRegistry` decorator that fans real transitions out to observers. This is the reusable form of the fan-out `DbSessionTaskRegistry` does inline, so runtime and (future) server share one seam.
- The `everruns-runtime` in-process loop wraps its injected registry with the decorator + queue and **drains the queue at each reason iteration boundary — before the next LLM call** — injecting each wake as a user message alongside the reloaded conversation, and continuing a would-idle turn while wakes are pending. Idle sessions still get the wake on the next turn's first drain (between-turn fallback, unchanged).

**Exactly-once claim point:** the queue is the single source of truth. Each real transition enqueues one entry; `drain` atomically removes a session's entries under one lock — that removal *is* the claim. A wake is delivered mid-turn **xor** on the next turn's first drain, never both. Cancellation / seal / max-iterations leave undrained wakes queued for the next turn; a completion landing mid-loop is visible to the very next iteration.

## Why

Wake-ups were delivered only as between-turn steering messages: a parent that spawned background work finished its turn, idled, and reacted to completions only on its next turn — parallel delegation felt like polling. SOTA harnesses inject completions into the running loop so the parent reacts immediately (spawn workers → keep planning → consume results as they land, in one turn).

## Before / After

Behavior is observable via the deterministic llmsim integration test `crates/runtime/tests/mid_turn_wake_test.rs` (no LLM key, no live infra):

- **Before:** a task completing during a parent turn was not reflected until a later turn; the in-process loop hardcoded `has_pending_user_messages = false` and drained no queue.
- **After:** `terminal_wake_injected_mid_turn_exactly_once` — child completes at iteration 2, the parent's iteration-3 context contains the wake (`finished: succeeded` + the child's summary), the turn ran past the completion iteration (did not idle), and the wake appears exactly once. `wake_is_not_redelivered_on_the_next_turn` — a claimed wake is not redelivered. `silent_task_never_wakes_mid_turn` and `on_activity_delivers_terminal_wake_mid_turn` cover the policy matrix.

Evidence (local):
- `cargo test -p everruns-runtime` — all green (incl. 4 new mid-turn tests, 24 existing in_process_runtime, 24 runtime_host).
- `cargo test -p everruns-core --lib wake_queue` / `task_observer` — 7 + 2 new unit tests green (policy gating, exactly-once drain, per-session isolation; terminal fires once and not on a heartbeat, awaiting_input on entry).
- `bash scripts/lib/pre-push.sh` — all checks pass (workspace `cargo fmt --check` + `cargo clippy --all-targets --all-features -D warnings`).

## Risk

- **Low.** Change is confined to `everruns-core` (two additive modules) and the `everruns-runtime` in-process loop. No server/API/DB/migration/UI surface. The queue is inert unless a task registry is configured; the between-turn path and all existing runtime tests are unchanged.
- What could break: the runtime turn loop now injects user messages mid-turn and may run one extra reason iteration to consume a pending wake (bounded by `max_iterations`).

## Security

- Threat categories reviewed: **TM-TENANT**, **TM-LLM**, **TM-DOS**.
  - **TM-TENANT** — the queue is keyed by `SessionId`; `drain(session_id)` and `note_transition` (via `task.session_id`) are strictly session-scoped, and `ObservingTaskRegistry` preserves the inner registry's session-ownership checks on `get`/`update`. No cross-session/cross-tenant path. Queue is process-local to a single embedder.
  - **TM-LLM** — wake text renders task-controlled fields (`display_name`, `summary`, `state_detail`) into a user message in the parent's prompt. This is the **same** content and trust boundary the existing between-turn waker already crosses; the mid-turn path introduces no new attacker-influenced field. No API keys or prompt secrets touched.
  - **TM-DOS** — the per-session queue is drained every reason iteration; while a session is idle a task that spams transitions could grow the in-process queue until the next turn. Bounded by task transition frequency and embedder-controlled; noted as a follow-up for the server path (where the durable signal store already bounds).
- No SQL, auth, file-path, or endpoint changes.

## Follow-ups

- **Server durable-worker wiring (deferred, needs human review + live infra).** Draining the queue at `unified_worker::schedule_next_activity`'s signal-consume boundary, persisting it through the durable signal store, and proving exactly-once across a forced worker restart / re-claim (attempt-fenced) requires live Postgres/Valkey/NATS/gRPC that cannot be validated locally. The shared `SessionWakeQueue` + `ObservingTaskRegistry` primitives are built for this; wiring is intentionally out of part A to avoid landing a concurrency-sensitive durable-path change unreviewed. The llmsim server e2e and worker-restart duplicate-delivery tests are CI/live-infra-gated and land with that follow-up.
- **Part B — cross-session Work view (`apps/ui`).** Depends on EVE-680's `root_session_id` (not landed); the org-scoped tree view degrades to per-session grouping without it. Out of scope here.
- **Optional queue bound for the idle-session case** (TM-DOS note above) — evaluate alongside the server wiring.

EVE-681 stays **In Progress**.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; between-turn path unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01D21yJXXdWU3jhfTo8RpwNs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21yJXXdWU3jhfTo8RpwNs)_