### PR TITLE
feat(export): export image content and link subagents in ATIF

### DIFF
--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -345,11 +345,13 @@ pub struct ExportSessionQuery {
 /// Default (`format=jsonl`): all materialized messages (user, agent) as
 /// newline-delimited JSON, one complete JSON object per line; delta events are
 /// excluded. `format=atif` returns a single ATIF-v1.7 trajectory JSON document
-/// folded from the session's event log (see `specs/atif-adoption.md`); when
-/// image content parts were flattened to `"[image]"` markers, the response
-/// carries an `X-Atif-Images-Omitted` header with the total count, and
-/// documents over the 50 MiB `ATIF_EXPORT_MAX_BYTES` cap are rejected with
-/// 413. The response includes `Content-Disposition: attachment` for browser
+/// folded from the session's event log (see `specs/atif-adoption.md`); image
+/// content parts are exported as ATIF multimodal ContentParts. When an image
+/// cannot be materialized (an inline image with neither a URL nor bytes) it is
+/// flattened to an `"[image]"` marker and the response carries an
+/// `X-Atif-Images-Omitted` header with that count (usually 0 and absent).
+/// Documents over the 50 MiB `ATIF_EXPORT_MAX_BYTES` cap are rejected with 413.
+/// The response includes `Content-Disposition: attachment` for browser
 /// download.
 #[utoipa::path(
     get,
@@ -361,7 +363,7 @@ pub struct ExportSessionQuery {
         ("cursor" = Option<String>, Query, description = "ATIF segmented export: opaque continuation cursor from the previous segment")
     ),
     responses(
-        (status = 200, description = "JSONL file with one message per line, or one ATIF trajectory JSON document (with X-Atif-Images-Omitted header when image parts were flattened to markers). With segmented=true, one ATIF segment linked forward by continued_trajectory_ref.", content_type = "application/x-ndjson"),
+        (status = 200, description = "JSONL file with one message per line, or one ATIF trajectory JSON document (images export as multimodal ContentParts; X-Atif-Images-Omitted header only when an image could not be materialized). With segmented=true, one ATIF segment linked forward by continued_trajectory_ref.", content_type = "application/x-ndjson"),
         (status = 400, description = "Invalid ID format, or malformed/foreign segmented-export cursor"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Session not found"),

--- a/crates/server/src/atif.rs
+++ b/crates/server/src/atif.rs
@@ -65,9 +65,13 @@ pub struct AtifOptions {
 #[derive(Debug)]
 pub struct BuiltTrajectory {
     pub document: Value,
-    /// Image content parts flattened to `"[image]"` markers across the whole
-    /// document (step messages and observation content). Also recorded inside
-    /// the document as root `extra.images_omitted` when non-zero.
+    /// Image content parts that could NOT be materialized into an ATIF image
+    /// ContentPart (an inline image carrying neither a URL nor base64 bytes) and
+    /// were therefore flattened to `"[image]"` markers across the whole document
+    /// (step messages and observation content). Materialized images (URL, file
+    /// reference, or inlined base64) are exported as real content parts and do
+    /// NOT count here, so this is typically 0. Also recorded inside the document
+    /// as root `extra.images_omitted` when non-zero.
     pub images_omitted: usize,
 }
 
@@ -590,7 +594,10 @@ fn usage_to_metrics(usage: &TokenUsage) -> Value {
 struct AgentStepAcc {
     timestamp: DateTime<Utc>,
     model_name: Option<String>,
-    message: String,
+    /// ATIF `message` value: a JSON string for text-only content, or a
+    /// ContentPart array (RFC v1.6 multimodal) when materialized image parts
+    /// are present.
+    message: Value,
     reasoning: Option<String>,
     tool_calls: Vec<Value>,
     observations: Vec<Value>,
@@ -603,7 +610,7 @@ impl AgentStepAcc {
         Self {
             timestamp,
             model_name: None,
-            message: String::new(),
+            message: Value::String(String::new()),
             reasoning: None,
             tool_calls: Vec::new(),
             observations: Vec::new(),
@@ -627,7 +634,8 @@ struct Fold {
     open: Option<AgentStepAcc>,
     pending_thinking: Option<String>,
     last_model: Option<String>,
-    /// Image content parts flattened to `"[image]"` markers so far.
+    /// Image content parts that could not be materialized and were flattened to
+    /// `"[image]"` markers so far (materialized images do not count).
     images_omitted: usize,
 }
 
@@ -658,16 +666,12 @@ impl Fold {
             EventData::InputMessage(data) => {
                 self.flush();
                 let mut omitted = Vec::new();
-                let text = self.content_or_redacted(flatten_message_text(
-                    &data.message,
-                    self.redact,
-                    &mut omitted,
-                ));
+                let message = build_message_content(&data.message, self.redact, &mut omitted);
                 self.images_omitted += omitted.len();
                 let mut step = Map::new();
                 step.insert("timestamp".to_string(), json!(timestamp(event)));
                 step.insert("source".to_string(), json!("user"));
-                step.insert("message".to_string(), json!(text));
+                step.insert("message".to_string(), message);
                 let mut extra = Map::new();
                 append_omitted_images(&mut extra, omitted);
                 if !extra.is_empty() {
@@ -679,11 +683,7 @@ impl Fold {
                 self.flush();
                 let mut acc = AgentStepAcc::new(event.ts);
                 let mut omitted = Vec::new();
-                acc.message = self.content_or_redacted(flatten_message_text(
-                    &data.message,
-                    self.redact,
-                    &mut omitted,
-                ));
+                acc.message = build_message_content(&data.message, self.redact, &mut omitted);
                 self.images_omitted += omitted.len();
                 append_omitted_images(&mut acc.extra, omitted);
                 acc.reasoning = data
@@ -781,15 +781,14 @@ impl Fold {
             }
             EventData::ToolCompleted(data) => {
                 let mut omitted = Vec::new();
-                let content = if let Some(err) = &data.error {
-                    format!("[error] {err}")
+                let content: Value = if let Some(err) = &data.error {
+                    Value::String(self.content_or_redacted(format!("[error] {err}")))
                 } else {
-                    data.result
-                        .as_ref()
-                        .map(|parts| flatten_content_parts(parts, self.redact, &mut omitted))
-                        .unwrap_or_default()
+                    match &data.result {
+                        Some(parts) => build_observation_content(parts, self.redact, &mut omitted),
+                        None => Value::String(String::new()),
+                    }
                 };
-                let content = self.content_or_redacted(content);
                 self.images_omitted += omitted.len();
                 let mut extra = Map::new();
                 extra.insert("tool_name".to_string(), json!(data.tool_name));
@@ -799,11 +798,22 @@ impl Fold {
                 }
                 let acc = self.open.get_or_insert_with(|| AgentStepAcc::new(event.ts));
                 append_omitted_images(&mut acc.extra, omitted);
-                acc.observations.push(json!({
-                    "source_call_id": data.tool_call_id,
-                    "content": content,
-                    "extra": extra,
-                }));
+                let mut observation = Map::new();
+                observation.insert("source_call_id".to_string(), json!(data.tool_call_id));
+                observation.insert("content".to_string(), content);
+                observation.insert("extra".to_string(), Value::Object(extra));
+                // Subagent linkage (Harbor RFC 0001): when this tool call spawned
+                // a subagent, attach a `subagent_trajectory_ref` pointing at the
+                // child session's own ATIF export. Ref-only — the child's events
+                // are not embedded (this fold sees only one session's events; see
+                // specs/atif-adoption.md, "Subagent trajectories").
+                if let Some(child) = subagent_child_session(data) {
+                    observation.insert(
+                        "subagent_trajectory_ref".to_string(),
+                        subagent_trajectory_ref(&child),
+                    );
+                }
+                acc.observations.push(Value::Object(observation));
             }
             // Turn events are boundaries, not steps: close the open step and
             // record turn stats at the root extension point.
@@ -886,7 +896,7 @@ impl Fold {
         if let Some(model) = acc.model_name.or_else(|| self.last_model.clone()) {
             step.insert("model_name".to_string(), json!(model));
         }
-        step.insert("message".to_string(), json!(acc.message));
+        step.insert("message".to_string(), acc.message);
         if let Some(reasoning) = acc.reasoning {
             step.insert("reasoning_content".to_string(), json!(reasoning));
         }
@@ -930,39 +940,179 @@ fn timestamp(event: &Event) -> String {
     event.ts.to_rfc3339()
 }
 
-/// Flatten a message's text-bearing content to one string. Tool calls and
-/// results are represented elsewhere in the step; images become a marker and
-/// their locator record is appended to `omitted`.
-fn flatten_message_text(message: &Message, redact: bool, omitted: &mut Vec<Value>) -> String {
-    let mut parts: Vec<String> = Vec::new();
-    for part in &message.content {
-        match part {
-            ContentPart::Text(t) => parts.push(t.text.clone()),
-            ContentPart::Image(_) | ContentPart::ImageFile(_) => {
-                parts.push("[image]".to_string());
-                omitted.extend(omitted_image_ref(part, redact));
-            }
-            ContentPart::ToolCall(_) | ContentPart::ToolResult(_) => {}
-        }
-    }
-    parts.join("\n")
+/// Build the ATIF `message` value for a step message. Tool-call/tool-result
+/// parts are represented elsewhere on the step and are skipped here.
+fn build_message_content(message: &Message, redact: bool, omitted: &mut Vec<Value>) -> Value {
+    build_content_value(&message.content, redact, false, omitted)
 }
 
-/// Flatten tool-result content parts to a single observation string. Images
-/// become a marker and their locator record is appended to `omitted`.
-fn flatten_content_parts(parts: &[ContentPart], redact: bool, omitted: &mut Vec<Value>) -> String {
-    let mut out: Vec<String> = Vec::new();
+/// Build the ATIF observation `content` value for a tool result. Non-media
+/// parts (tool calls/results embedded in a result) are serialized to text as
+/// before.
+fn build_observation_content(
+    parts: &[ContentPart],
+    redact: bool,
+    omitted: &mut Vec<Value>,
+) -> Value {
+    build_content_value(parts, redact, true, omitted)
+}
+
+/// Fold content parts into an ATIF `message`/`content` value.
+///
+/// Text-only content yields a JSON **string** (backward compatible, and what
+/// text-only consumers/scorers expect). When at least one image part can be
+/// materialized into an ATIF image ContentPart, the value is a ContentPart
+/// **array** (Harbor RFC 0001 / ATIF v1.6 multimodal): ordered text and image
+/// parts. The RFC allows `message`/`content` to be a string OR an array, so
+/// both shapes are spec-legal; consumers that only read text can still project
+/// the `text` parts out of an array.
+///
+/// `serialize_other` controls non-media parts (`ToolCall`/`ToolResult`): step
+/// messages skip them (represented elsewhere on the step), observations
+/// serialize them to a JSON text part as before.
+///
+/// An image that cannot be materialized (an inline image with neither a URL nor
+/// base64 bytes) is flattened to an `"[image]"` text marker and its locator is
+/// appended to `omitted`; such images keep the legacy `extra.omitted_images`
+/// bookkeeping.
+fn build_content_value(
+    parts: &[ContentPart],
+    redact: bool,
+    serialize_other: bool,
+    omitted: &mut Vec<Value>,
+) -> Value {
+    let redacted = |s: &str| {
+        if redact {
+            REDACTED.to_string()
+        } else {
+            s.to_string()
+        }
+    };
+    let mut atif_parts: Vec<Value> = Vec::new();
+    let mut has_image = false;
     for part in parts {
         match part {
-            ContentPart::Text(t) => out.push(t.text.clone()),
-            ContentPart::Image(_) | ContentPart::ImageFile(_) => {
-                out.push("[image]".to_string());
-                omitted.extend(omitted_image_ref(part, redact));
+            ContentPart::Text(t) => {
+                atif_parts.push(json!({ "type": "text", "text": redacted(&t.text) }));
             }
-            other => out.push(serde_json::to_string(other).unwrap_or_default()),
+            ContentPart::Image(_) | ContentPart::ImageFile(_) => match image_source(part, redact) {
+                Some(source) => {
+                    has_image = true;
+                    atif_parts.push(json!({ "type": "image", "source": source }));
+                }
+                None => {
+                    // Genuinely unmaterializable: keep the marker + locator so
+                    // the omission is still visible and counted.
+                    atif_parts.push(json!({ "type": "text", "text": "[image]" }));
+                    omitted.extend(omitted_image_ref(part, redact));
+                }
+            },
+            ContentPart::ToolCall(_) | ContentPart::ToolResult(_) => {
+                if serialize_other {
+                    atif_parts.push(json!({
+                        "type": "text",
+                        "text": redacted(&serde_json::to_string(part).unwrap_or_default()),
+                    }));
+                }
+            }
         }
     }
-    out.join("\n")
+    if has_image {
+        Value::Array(atif_parts)
+    } else {
+        // No materialized image → collapse to the text projection (a string),
+        // preserving the prior behavior for text-only and omitted-image content.
+        let text = atif_parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Value::String(text)
+    }
+}
+
+/// Build an ATIF image ContentPart `source` for an image part, or `None` when
+/// the image cannot be materialized (an inline image with neither URL nor
+/// base64). Prefers a lean reference over inlined bytes:
+/// - `Image { url }` → `source.path = url`.
+/// - `ImageFile { image_id }` → `source.path` = the org-scoped file-serving
+///   route (`/v1/images/{image_id}`); a consumer with the same auth fetches the
+///   bytes. Keeps documents small and within the export size cap.
+/// - `Image { base64 }` (no URL) → an inline `data:` URI in `source.path`. This
+///   is the only self-contained representation, but it bloats the document and
+///   counts toward the segment byte cap, so it is a last resort.
+///
+/// `media_type` (structural) is preserved when known. Under `redact`, the
+/// content-bearing `path` is blanked while the structural `media_type` is kept.
+fn image_source(part: &ContentPart, redact: bool) -> Option<Value> {
+    let mut source = Map::new();
+    match part {
+        ContentPart::Image(image) => {
+            // Materializable only if there is some locator to point at.
+            if image.url.is_none() && image.base64.is_none() {
+                return None;
+            }
+            if let Some(media_type) = &image.media_type {
+                source.insert("media_type".to_string(), json!(media_type));
+            }
+            let path = if redact {
+                REDACTED.to_string()
+            } else if let Some(url) = &image.url {
+                url.clone()
+            } else {
+                let b64 = image.base64.as_deref().unwrap_or_default();
+                let media_type = image.media_type.as_deref().unwrap_or("image/png");
+                format!("data:{media_type};base64,{b64}")
+            };
+            source.insert("path".to_string(), json!(path));
+        }
+        ContentPart::ImageFile(file) => {
+            let path = if redact {
+                REDACTED.to_string()
+            } else {
+                format!("/v1/images/{}", file.image_id)
+            };
+            source.insert("path".to_string(), json!(path));
+        }
+        _ => return None,
+    }
+    Some(Value::Object(source))
+}
+
+/// The child session id of a subagent spawn, if this tool result is one.
+///
+/// The `spawn_agent` tool (subagent target) returns a JSON object carrying
+/// `subagent_id` = the child session id (see
+/// `crates/core/src/capabilities/subagents.rs`); the tool result is emitted as
+/// a single text ContentPart holding that JSON. Returns `None` for any other
+/// tool or a result without a `subagent_id`.
+fn subagent_child_session(data: &everruns_core::events::ToolCompletedData) -> Option<String> {
+    if data.tool_name != "spawn_agent" {
+        return None;
+    }
+    for part in data.result.as_ref()? {
+        if let ContentPart::Text(t) = part
+            && let Ok(value) = serde_json::from_str::<Value>(&t.text)
+            && let Some(id) = value.get("subagent_id").and_then(Value::as_str)
+            && !id.is_empty()
+        {
+            return Some(id.to_string());
+        }
+    }
+    None
+}
+
+/// Build the `subagent_trajectory_ref` array for an observation that spawned the
+/// child session `child_session_id`. Ref-only: `trajectory_path` points at the
+/// child's own ATIF export (a resolvable location per Harbor RFC 0001, which
+/// requires at least one of `trajectory_id`/`trajectory_path`); `session_id` is
+/// informational. The child trajectory is not embedded (see the ToolCompleted
+/// handler and specs/atif-adoption.md).
+fn subagent_trajectory_ref(child_session_id: &str) -> Value {
+    json!([{
+        "trajectory_path": format!("/v1/sessions/{child_session_id}/export?format=atif"),
+        "session_id": child_session_id,
+    }])
 }
 
 /// Locator record for an image content part flattened to a `"[image]"`
@@ -1422,7 +1572,7 @@ mod tests {
     }
 
     #[test]
-    fn images_flatten_to_markers_and_record_refs() {
+    fn images_export_as_multimodal_content_parts() {
         use everruns_core::message::{ImageContentPart, ImageFileContentPart};
         use everruns_core::typed_id::ImageId;
 
@@ -1472,38 +1622,90 @@ mod tests {
             Map::new(),
             AtifOptions::default(),
         );
-        assert_eq!(built.images_omitted, 3);
+        // Every image is materialized, so nothing is omitted.
+        assert_eq!(built.images_omitted, 0);
         let value = built.document;
-        assert_eq!(value["extra"]["images_omitted"], json!(3));
+        assert!(value["extra"].get("images_omitted").is_none());
 
-        // User step: markers stay in the text, locator refs land in step extra.
+        // User step: message is a ContentPart array (text + URL image + file
+        // image source referencing the file-serving route).
         let steps = value["steps"].as_array().unwrap();
-        assert_eq!(steps[0]["message"], json!("look at this\n[image]\n[image]"));
-        let user_refs = steps[0]["extra"]["omitted_images"].as_array().unwrap();
-        assert_eq!(user_refs.len(), 2);
-        assert_eq!(user_refs[0], json!({"url": "https://example.com/cat.png"}));
-        assert_eq!(user_refs[1]["file_id"], json!(image_id.to_string()));
-        assert_eq!(user_refs[1]["filename"], json!("cat.png"));
-
-        // Observation content keeps the marker; the base64 payload is dropped
-        // and the ref is recorded on the owning agent step.
-        let s1 = &steps[1];
+        let user_msg = steps[0]["message"].as_array().unwrap();
+        assert_eq!(user_msg[0], json!({"type": "text", "text": "look at this"}));
         assert_eq!(
-            s1["observation"]["results"][0]["content"],
-            json!("done\n[image]")
+            user_msg[1],
+            json!({"type": "image", "source": {"path": "https://example.com/cat.png"}})
         );
         assert_eq!(
-            s1["extra"]["omitted_images"],
+            user_msg[2],
+            json!({"type": "image", "source": {"path": format!("/v1/images/{image_id}")}})
+        );
+        assert!(steps[0]["extra"].get("omitted_images").is_none());
+
+        // Observation content is a ContentPart array; the base64 image inlines
+        // as a data: URI source with its media type.
+        let s1 = &steps[1];
+        let obs = s1["observation"]["results"][0]["content"]
+            .as_array()
+            .unwrap();
+        assert_eq!(obs[0], json!({"type": "text", "text": "done"}));
+        assert_eq!(
+            obs[1],
+            json!({"type": "image", "source": {"media_type": "image/png", "path": "data:image/png;base64,aGVsbG8="}})
+        );
+        assert!(s1["extra"].get("omitted_images").is_none());
+    }
+
+    #[test]
+    fn unmaterializable_image_is_still_omitted_and_counted() {
+        use everruns_core::message::ImageContentPart;
+
+        let session = SessionId::new();
+        let mut user = Message::user("no locator here");
+        // An inline image with neither URL nor base64 cannot be materialized.
+        user.content.push(ContentPart::Image(ImageContentPart {
+            url: None,
+            base64: None,
+            media_type: Some("image/png".to_string()),
+        }));
+        let events = vec![event(session, InputMessageData::new(user))];
+
+        let built = build_trajectory(
+            Some("session_x"),
+            &events,
+            Map::new(),
+            AtifOptions::default(),
+        );
+        assert_eq!(built.images_omitted, 1);
+        let value = built.document;
+        assert_eq!(value["extra"]["images_omitted"], json!(1));
+        // Text-only (no materialized image) → the message stays a string with
+        // the `[image]` marker, and the locator lands in step extra.
+        let steps = value["steps"].as_array().unwrap();
+        assert_eq!(steps[0]["message"], json!("no locator here\n[image]"));
+        assert_eq!(
+            steps[0]["extra"]["omitted_images"],
             json!([{"media_type": "image/png"}])
         );
-        let serialized = serde_json::to_string(&value).unwrap();
-        assert!(
-            !serialized.contains("aGVsbG8="),
-            "raw image bytes must never be exported"
-        );
+    }
 
-        // Redaction blanks content-bearing locators, keeps structural ones.
-        let redacted = build_trajectory(
+    #[test]
+    fn redaction_blanks_image_sources() {
+        use everruns_core::message::{ImageContentPart, ImageFileContentPart};
+        use everruns_core::typed_id::ImageId;
+
+        let session = SessionId::new();
+        let image_id = ImageId::new();
+        let mut user = Message::user("secret url");
+        user.content
+            .push(ContentPart::Image(ImageContentPart::from_url(
+                "https://example.com/private.png",
+            )));
+        user.content
+            .push(ContentPart::ImageFile(ImageFileContentPart::new(image_id)));
+        let events = vec![event(session, InputMessageData::new(user))];
+
+        let value = build_trajectory(
             Some("session_x"),
             &events,
             Map::new(),
@@ -1512,10 +1714,128 @@ mod tests {
             },
         )
         .document;
-        let refs = &redacted["steps"][0]["extra"]["omitted_images"];
-        assert_eq!(refs[0]["url"], json!(REDACTED));
-        assert_eq!(refs[1]["file_id"], json!(image_id.to_string()));
-        assert_eq!(refs[1]["filename"], json!(REDACTED));
+        let msg = value["steps"][0]["message"].as_array().unwrap();
+        // Text is redacted, image sources are blanked (path), structure kept.
+        assert_eq!(msg[0], json!({"type": "text", "text": REDACTED}));
+        assert_eq!(msg[1]["source"]["path"], json!(REDACTED));
+        assert_eq!(msg[2]["source"]["path"], json!(REDACTED));
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(!serialized.contains("example.com"));
+    }
+
+    #[test]
+    fn segments_byte_bound_with_inline_image_parts() {
+        use everruns_core::message::ImageContentPart;
+
+        let session = SessionId::new();
+        let session_id = "session_x";
+        // Two messages each carrying a sizeable inlined base64 image, so the
+        // per-step serialized size is dominated by the image ContentPart.
+        let big_b64 = "A".repeat(2000);
+        let mut m0 = Message::user("first");
+        m0.content
+            .push(ContentPart::Image(ImageContentPart::from_base64(
+                big_b64.clone(),
+                "image/png",
+            )));
+        let mut m1 = Message::user("second");
+        m1.content
+            .push(ContentPart::Image(ImageContentPart::from_base64(
+                big_b64,
+                "image/png",
+            )));
+        let events = vec![
+            event(session, InputMessageData::new(m0)),
+            event(session, InputMessageData::new(m1)),
+        ];
+
+        // A cap just above one image step forces one step per segment, proving
+        // image ContentParts count toward the byte budget.
+        let (walked, docs) = walk_segments(session_id, &events, 4096 + 1500);
+        assert_eq!(
+            docs.len(),
+            2,
+            "each oversized image step gets its own segment"
+        );
+        assert_eq!(walked.len(), 2);
+        for (i, step) in walked.iter().enumerate() {
+            assert_eq!(step["step_id"], json!(i + 1));
+            assert!(step["message"].is_array(), "image step message is an array");
+        }
+    }
+
+    #[test]
+    fn subagent_spawn_attaches_trajectory_ref() {
+        let session = SessionId::new();
+        let child = SessionId::new();
+        let spawn_call = ToolCall {
+            id: "call_spawn".to_string(),
+            name: "spawn_agent".to_string(),
+            arguments: json!({"target": {"type": "subagent"}, "name": "Worker"}),
+        };
+        // The spawn tool result is a single text ContentPart holding the JSON
+        // object the dispatcher returns (carries `subagent_id`).
+        let spawn_result = json!({
+            "subagent_id": child.to_string(),
+            "name": "Worker",
+            "status": "running",
+            "task_id": "task_123",
+        })
+        .to_string();
+        let events = vec![
+            event(
+                session,
+                InputMessageData::new(Message::user("delegate this")),
+            ),
+            event(
+                session,
+                OutputMessageCompletedData::new(Message::assistant_with_tools(
+                    "spawning",
+                    vec![spawn_call],
+                )),
+            ),
+            event(
+                session,
+                ToolCompletedData::success(
+                    "call_spawn".to_string(),
+                    "spawn_agent".to_string(),
+                    vec![ContentPart::text(spawn_result)],
+                    Some(5),
+                ),
+            ),
+        ];
+
+        let value = build_trajectory(
+            Some("session_x"),
+            &events,
+            Map::new(),
+            AtifOptions::default(),
+        )
+        .document;
+        let refs = &value["steps"][1]["observation"]["results"][0]["subagent_trajectory_ref"];
+        assert_eq!(
+            refs[0]["trajectory_path"],
+            json!(format!("/v1/sessions/{child}/export?format=atif"))
+        );
+        assert_eq!(refs[0]["session_id"], json!(child.to_string()));
+    }
+
+    #[test]
+    fn non_spawn_tool_has_no_subagent_ref() {
+        let session = SessionId::new();
+        let value = build_trajectory(
+            Some("session_x"),
+            &sample_events(session),
+            Map::new(),
+            AtifOptions::default(),
+        )
+        .document;
+        // The sample session's tool observation is a plain search, not a spawn.
+        assert!(
+            value["steps"][1]["observation"]["results"][0]
+                .get("subagent_trajectory_ref")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -195,9 +195,11 @@ inventory::submit! { CommandDescriptor::of::<ListMessages>() }
 #[derive(Debug, Serialize)]
 pub struct ExportSessionJsonl {
     pub body: String,
-    /// Image content parts flattened to `"[image]"` markers in the ATIF
-    /// document (always 0 for the JSONL format, which keeps parts verbatim).
-    /// Surfaced by the HTTP route as the `X-Atif-Images-Omitted` header.
+    /// Image content parts that could not be materialized into an ATIF image
+    /// ContentPart and were flattened to `"[image]"` markers in the ATIF
+    /// document (typically 0, since most images export as content parts; always
+    /// 0 for the JSONL format, which keeps parts verbatim). Surfaced by the HTTP
+    /// route as the `X-Atif-Images-Omitted` header.
     pub atif_images_omitted: usize,
 }
 

--- a/crates/server/tests/evals_integration_test.rs
+++ b/crates/server/tests/evals_integration_test.rs
@@ -1124,7 +1124,7 @@ async fn seed_session_with_raw_events(
 }
 
 #[tokio::test]
-async fn test_session_export_atif_images_omitted_header() {
+async fn test_session_export_atif_image_content_multimodal() {
     use everruns_core::events::InputMessageData;
     use everruns_core::message::{ContentPart, ImageContentPart, ImageFileContentPart, Message};
     use everruns_core::typed_id::ImageId;
@@ -1155,21 +1155,27 @@ async fn test_session_export_atif_images_omitted_header() {
         .get(&format!("/v1/sessions/{}/export?format=atif", session_id))
         .await
         .assert_status(StatusCode::OK);
-    assert_eq!(
-        response
-            .headers()
-            .get("x-atif-images-omitted")
-            .expect("lossiness header"),
-        "2"
-    );
+    // Both images are materialized (URL + file reference), so nothing is
+    // omitted and the lossiness header is absent.
+    assert!(response.headers().get("x-atif-images-omitted").is_none());
     let trajectory = response.json_value();
-    assert_eq!(trajectory["extra"]["images_omitted"], json!(2));
+    assert!(trajectory["extra"].get("images_omitted").is_none());
     let step = &trajectory["steps"][0];
-    assert!(step["message"].as_str().unwrap().contains("[image]"));
-    let refs = step["extra"]["omitted_images"].as_array().expect("refs");
-    assert_eq!(refs[0]["url"], json!("https://example.com/cat.png"));
-    assert_eq!(refs[1]["file_id"], json!(image_id.to_string()));
-    assert_eq!(refs[1]["filename"], json!("cat.png"));
+    // `message` is now a ContentPart array with real image sources, not a
+    // flattened `[image]` marker string.
+    let parts = step["message"]
+        .as_array()
+        .expect("multimodal message array");
+    assert_eq!(parts[0], json!({"type": "text", "text": "look at this"}));
+    assert_eq!(
+        parts[1],
+        json!({"type": "image", "source": {"path": "https://example.com/cat.png"}})
+    );
+    assert_eq!(
+        parts[2],
+        json!({"type": "image", "source": {"path": format!("/v1/images/{image_id}")}})
+    );
+    assert!(step["extra"].get("omitted_images").is_none());
 
     // The default JSONL export never carries the ATIF lossiness header.
     let response = server
@@ -1177,6 +1183,50 @@ async fn test_session_export_atif_images_omitted_header() {
         .await
         .assert_status(StatusCode::OK);
     assert!(response.headers().get("x-atif-images-omitted").is_none());
+}
+
+#[tokio::test]
+async fn test_session_export_atif_unmaterializable_image_sets_header() {
+    use everruns_core::events::InputMessageData;
+    use everruns_core::message::{ContentPart, ImageContentPart, Message};
+
+    let server = TestServer::in_memory().await;
+    let mut message = Message::user("look at this");
+    // An inline image with neither URL nor base64 cannot be materialized, so it
+    // stays a marker and is counted as omitted.
+    message.content.push(ContentPart::Image(ImageContentPart {
+        url: None,
+        base64: None,
+        media_type: Some("image/png".to_string()),
+    }));
+    let session_id = seed_session_with_raw_events(
+        &server,
+        vec![(
+            "input.message",
+            serde_json::to_value(InputMessageData::new(message)).expect("serialize input event"),
+        )],
+    )
+    .await;
+
+    let response = server
+        .get(&format!("/v1/sessions/{}/export?format=atif", session_id))
+        .await
+        .assert_status(StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("x-atif-images-omitted")
+            .expect("lossiness header"),
+        "1"
+    );
+    let trajectory = response.json_value();
+    assert_eq!(trajectory["extra"]["images_omitted"], json!(1));
+    let step = &trajectory["steps"][0];
+    assert!(step["message"].as_str().unwrap().contains("[image]"));
+    assert_eq!(
+        step["extra"]["omitted_images"],
+        json!([{"media_type": "image/png"}])
+    );
 }
 
 #[tokio::test]
@@ -1223,6 +1273,69 @@ async fn test_session_export_atif_over_cap_returns_413() {
         .get(&format!("/v1/sessions/{}/export", session_id))
         .await
         .assert_status(StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_session_export_atif_subagent_trajectory_ref() {
+    use everruns_core::events::{InputMessageData, OutputMessageCompletedData, ToolCompletedData};
+    use everruns_core::message::{ContentPart, Message};
+    use everruns_core::tool_types::ToolCall;
+    use everruns_core::typed_id::SessionId as CoreSessionId;
+
+    let server = TestServer::in_memory().await;
+    let child = CoreSessionId::new();
+    let spawn_call = ToolCall {
+        id: "call_spawn".to_string(),
+        name: "spawn_agent".to_string(),
+        arguments: json!({"target": {"type": "subagent"}, "name": "Worker"}),
+    };
+    let spawn_result = json!({
+        "subagent_id": child.to_string(),
+        "name": "Worker",
+        "status": "running",
+        "task_id": "task_123",
+    })
+    .to_string();
+    let session_id = seed_session_with_raw_events(
+        &server,
+        vec![
+            (
+                "input.message",
+                serde_json::to_value(InputMessageData::new(Message::user("delegate this")))
+                    .expect("serialize input event"),
+            ),
+            (
+                "output.message.completed",
+                serde_json::to_value(OutputMessageCompletedData::new(
+                    Message::assistant_with_tools("spawning", vec![spawn_call]),
+                ))
+                .expect("serialize output event"),
+            ),
+            (
+                "tool.completed",
+                serde_json::to_value(ToolCompletedData::success(
+                    "call_spawn".to_string(),
+                    "spawn_agent".to_string(),
+                    vec![ContentPart::text(spawn_result)],
+                    Some(5),
+                ))
+                .expect("serialize tool event"),
+            ),
+        ],
+    )
+    .await;
+
+    let response = server
+        .get(&format!("/v1/sessions/{}/export?format=atif", session_id))
+        .await
+        .assert_status(StatusCode::OK);
+    let trajectory = response.json_value();
+    let refs = &trajectory["steps"][1]["observation"]["results"][0]["subagent_trajectory_ref"];
+    assert_eq!(
+        refs[0]["trajectory_path"],
+        json!(format!("/v1/sessions/{child}/export?format=atif"))
+    );
+    assert_eq!(refs[0]["session_id"], json!(child.to_string()));
 }
 
 /// Seed a session with `n` user messages as `input.message` events, oldest

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11540,7 +11540,7 @@
           "sessions"
         ],
         "summary": "Export session messages as a JSONL file (default) or as an ATIF trajectory",
-        "description": "Default (`format=jsonl`): all materialized messages (user, agent) as\nnewline-delimited JSON, one complete JSON object per line; delta events are\nexcluded. `format=atif` returns a single ATIF-v1.7 trajectory JSON document\nfolded from the session's event log (see `specs/atif-adoption.md`); when\nimage content parts were flattened to `\"[image]\"` markers, the response\ncarries an `X-Atif-Images-Omitted` header with the total count, and\ndocuments over the 50 MiB `ATIF_EXPORT_MAX_BYTES` cap are rejected with\n413. The response includes `Content-Disposition: attachment` for browser\ndownload.",
+        "description": "Default (`format=jsonl`): all materialized messages (user, agent) as\nnewline-delimited JSON, one complete JSON object per line; delta events are\nexcluded. `format=atif` returns a single ATIF-v1.7 trajectory JSON document\nfolded from the session's event log (see `specs/atif-adoption.md`); image\ncontent parts are exported as ATIF multimodal ContentParts. When an image\ncannot be materialized (an inline image with neither a URL nor bytes) it is\nflattened to an `\"[image]\"` marker and the response carries an\n`X-Atif-Images-Omitted` header with that count (usually 0 and absent).\nDocuments over the 50 MiB `ATIF_EXPORT_MAX_BYTES` cap are rejected with 413.\nThe response includes `Content-Disposition: attachment` for browser\ndownload.",
         "operationId": "export_session_jsonl",
         "parameters": [
           {
@@ -11582,7 +11582,7 @@
         ],
         "responses": {
           "200": {
-            "description": "JSONL file with one message per line, or one ATIF trajectory JSON document (with X-Atif-Images-Omitted header when image parts were flattened to markers). With segmented=true, one ATIF segment linked forward by continued_trajectory_ref.",
+            "description": "JSONL file with one message per line, or one ATIF trajectory JSON document (images export as multimodal ContentParts; X-Atif-Images-Omitted header only when an image could not be materialized). With segmented=true, one ATIF segment linked forward by continued_trajectory_ref.",
             "content": {
               "application/x-ndjson": {}
             }

--- a/specs/atif-adoption.md
+++ b/specs/atif-adoption.md
@@ -75,14 +75,48 @@ the existing dataset formats), plus case identity (`source_key`, `eval_run_id`,
   `extra.source_key` → `trajectory_id` → `session_id`), so re-import
   converges.
 
-## Limits
+## Image content
 
-- **Images are never exported raw.** Every image content part is flattened to
-  an `"[image]"` marker in step/observation text, and the fold records what
-  was omitted: locators only (url / file_id / media_type / filename as
-  present on the part, never bytes) in step-level `extra.omitted_images[]`,
-  plus a root `extra.images_omitted` total. Both keys appear only when at
-  least one image was omitted.
+Image content parts are exported as ATIF multimodal ContentParts (Harbor
+RFC 0001 / ATIF v1.6), not dropped. When a step message or a tool-result
+observation contains image parts, its `message` / `content` becomes a
+**ContentPart array** (text parts + image parts, in order) instead of a
+flattened string; text-only content stays a string (the RFC allows either, so
+text-only consumers are unaffected). Each image becomes an ATIF image
+ContentPart with a `source`, choosing the leanest faithful representation:
+
+- `Image { url }` → `source.path` = the URL.
+- `ImageFile { image_id }` → `source.path` = the org-scoped file-serving route
+  `/v1/images/{image_id}` (a consumer with the same auth fetches the bytes),
+  keeping documents small.
+- `Image { base64 }` with no URL → an inline `data:` URI in `source.path`. This
+  is the only self-contained option but bloats the document and counts toward
+  the export size cap, so it is a last resort.
+
+`source.media_type` is preserved when known. `redact_content` blanks the
+content-bearing `source.path` while keeping the structural `media_type`; the
+always-on secret scrubber still runs over every produced source.
+
+**Omitted images (now rare).** Only an image that cannot be materialized — an
+inline `Image` carrying neither a URL nor base64 bytes — is flattened to an
+`"[image]"` marker; its locator (media_type / filename as present, never bytes)
+is recorded in step-level `extra.omitted_images[]` and counted in a root
+`extra.images_omitted` total. Both keys appear only when at least one image was
+genuinely omitted, so this total is typically 0.
+
+## Subagent trajectories
+
+everruns sessions can spawn subagents (`specs/subagents.md`). When the fold
+sees a `spawn_agent` tool result carrying a `subagent_id` (the child session
+id), it attaches a `subagent_trajectory_ref` (Harbor RFC 0001) to that
+`observation.results[]` entry: `trajectory_path` points at the child's own ATIF
+export (`/v1/sessions/{child}/export?format=atif`, a resolvable location per the
+RFC's ref rules), plus the informational `session_id`. This is **ref-only** —
+the child trajectory is not embedded as `subagent_trajectories[]`, because this
+fold sees only one session's event log and has no access to child-session
+events. Embedding (recursive fold of resolvable child sessions) is a follow-up.
+
+## Limits
 - **Session export size cap.** Plain `?format=atif` returns one synchronous
   JSON document and enforces `ATIF_EXPORT_MAX_BYTES` (50 MiB, defined in
   `crates/server/src/atif.rs`); larger documents are rejected with HTTP 413
@@ -109,9 +143,9 @@ the existing dataset formats), plus case identity (`source_key`, `eval_run_id`,
     cursor only selects a step offset within that session, so it cannot widen
     scope.
   - Root `extra` carries per-segment bookkeeping: `segment_index`,
-    `continued_trajectory_ref` (mirrored), and `images_omitted` for **this**
-    segment. The session-level `turns` roll-up is carried once, on the final
-    segment.
+    `continued_trajectory_ref` (mirrored), and `images_omitted` (genuinely
+    unmaterializable images) for **this** segment. The session-level `turns`
+    roll-up is carried once, on the final segment.
   - **Byte bounding.** Segments are packed greedily and stop before the
     serialized segment would exceed `ATIF_EXPORT_MAX_BYTES`; each segment holds
     at least one step. **Caveat:** a single step whose own serialization exceeds
@@ -123,7 +157,9 @@ the existing dataset formats), plus case identity (`source_key`, `eval_run_id`,
     walk the chain and detect lossiness without parsing each body.
 - **Lossiness header.** Successful ATIF session exports set
   `X-Atif-Images-Omitted: <N>` only when N > 0 (per segment on the segmented
-  path), so clients can detect a lossy export without parsing the body.
+  path), so clients can detect a lossy export without parsing the body. Since
+  most images now export as content parts, N is typically 0 and the header is
+  usually absent.
 
 ## Security
 
@@ -148,13 +184,14 @@ reflects what has shipped on `main`.
 3. ✅ **Segmented session export** — `?format=atif&segmented=true` with
    `continued_trajectory_ref` linking + opaque cursor, for sessions over the
    size cap (see Limits).
+4. ✅ **Fold fidelity** — image content parts exported as ATIF multimodal
+   ContentParts (see Image content) and subagent spawns linked via
+   `subagent_trajectory_ref` (see Subagent trajectories).
 
 ## Non-goals (v1)
 
-- `subagent_trajectories` (session tasks are not folded into embedded
-  subagent trajectories yet).
-- ATIF image content parts (images are flattened to markers with locator
-  records — see Limits).
+- Embedding subagents as `subagent_trajectories[]` (child sessions are linked
+  by ref only; recursive embedding is a follow-up — see Subagent trajectories).
 - Importing trajectories as *results* (the existing external-run import in
   `specs/evals.md` covers scored results; ATIF import produces cases).
 


### PR DESCRIPTION
## What changed
Closes two ATIF export fidelity gaps in the shared fold (`crates/server/src/atif.rs`), so every export surface — session export, segmented export, and eval dataset export — improves at once.

**Image content export.** Image content parts in step messages and tool-result observations are now exported as ATIF v1.6 multimodal `ContentPart` arrays instead of being flattened to an `"[image]"` text marker with only locator records. Each image becomes an ATIF image ContentPart with a `source`, choosing the leanest faithful representation:
- `Image { url }` → `source.path` = the URL.
- `ImageFile { image_id }` → `source.path` = the org-scoped file-serving route `/v1/images/{image_id}` (a consumer with the same auth fetches the bytes) — keeps documents lean.
- `Image { base64 }` with no URL → an inline `data:` URI in `source.path` (last resort; it bloats the doc and counts toward the size cap).

Text-only content still serializes as a JSON string (the RFC allows string OR array, so text-only consumers are unaffected). Only an image that genuinely cannot be materialized — an inline `Image` with neither a URL nor bytes — is still flattened to a marker and counted in `extra.omitted_images` / `extra.images_omitted`, so the omitted total and the `X-Atif-Images-Omitted` header are now typically 0.

**Subagent trajectory linkage.** When the fold sees a `spawn_agent` tool result carrying `subagent_id` (the child session id), it attaches a Harbor RFC 0001 `subagent_trajectory_ref` on the corresponding `observation.results[]` entry: `trajectory_path` points at the child's own ATIF export (`/v1/sessions/{child}/export?format=atif`, a resolvable location per the RFC's ref rules) plus the informational `session_id`. This is **ref-only** — see Follow-ups.

Both `redact_content` (blanks image `source.path`) and the always-on secret scrubber apply to the new content. Segmentation byte-bounds image ContentParts (a single oversized inline-base64 step follows the existing single-oversized-step rule).

## Why
Multi-image and multi-agent sessions previously exported lossily: images were dropped to `"[image]"` markers, and subagent sessions were folded flat with no link to the child trajectory. This made ATIF exports unusable for multimodal analysis and multi-agent post-training pipelines. Both gaps were explicit v1 non-goals now being closed.

## Before / After
Session with an image message, `GET /v1/sessions/{id}/export?format=atif`:

Before — flattened marker + omission bookkeeping:
```json
"message": "look at this\n[image]",
"extra": { "omitted_images": [{ "url": "https://example.com/cat.png" }] }
```
`X-Atif-Images-Omitted: 1`

After — real multimodal ContentParts, no omission:
```json
"message": [
  { "type": "text", "text": "look at this" },
  { "type": "image", "source": { "path": "https://example.com/cat.png" } },
  { "type": "image", "source": { "path": "/v1/images/img_..." } }
]
```
(no `X-Atif-Images-Omitted` header)

Subagent-bearing session — observation now carries:
```json
"subagent_trajectory_ref": [
  { "trajectory_path": "/v1/sessions/{child}/export?format=atif", "session_id": "{child}" }
]
```

Evidence: new unit tests in `atif.rs` (multimodal parts, image_id→file-route source, base64→inline source, unmaterializable→omitted, redaction blanks sources, segmentation byte-bounding with image parts, subagent ref present / absent for non-spawn tools) and integration tests in `evals_integration_test.rs` driving the real `?format=atif` route (multimodal export, unmaterializable-image header, subagent ref). All pass. Prior marker/omission tests updated to the new reality.

## Risk
- Low
- `message`/`content` can now be a JSON array (not only a string) on ATIF exports whenever a materializable image is present. This is RFC-legal (string OR array); the ATIF importer already tolerates array messages. Text-only steps are unchanged. Base64 inlining can enlarge documents, but it is bounded by the existing 50 MiB cap and segmentation.

## Security
- Threat categories reviewed: TM-API, TM-TENANT, TM-DOS.
- Findings and resolutions:
  - **TM-TENANT / data exposure:** image sources and the subagent ref emit only the session's own image ids / child session id as relative, org-scoped routes (`/v1/images/{id}`, `/v1/sessions/{child}/export`). No bytes and no cross-tenant identifiers are emitted; fetching still requires org-scoped auth. `redact_content` blanks source paths and the always-on secret scrubber runs over every produced source.
  - **TM-DOS:** inline base64 sources count toward `ATIF_EXPORT_MAX_BYTES`; the whole-doc path still 413s over cap and the segmented path byte-bounds image parts (single oversized step returned alone, no loop). No new unbounded work.
  - **TM-API:** no new endpoints, inputs, or query params; only the export body shape and two OpenAPI description strings changed. We emit a relative path, we never fetch it, so no SSRF surface is introduced.

## Follow-ups
- Embed child subagent trajectories as `subagent_trajectories[]` (recursive fold of resolvable child sessions, depth-limited). Deferred because this fold is pure over a single session's event log and has no child-session event access here; shipping ref-only keeps the change in scope and is RFC-compliant. Noted in `specs/atif-adoption.md`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)