### PR TITLE
test(llm-tests): retry subagent live e2e on transient transport (EVE-736)

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -433,3 +433,48 @@ mod quota_detector_tests {
         assert!(!is_quota_exhausted("permission denied for this model"));
     }
 }
+
+#[cfg(test)]
+mod transient_transport_detector_tests {
+    use super::is_transient_transport_error;
+
+    #[test]
+    fn matches_observed_live_flakes() {
+        // The exact signature flaking `main` on the live OpenAI matrix.
+        assert!(is_transient_transport_error(
+            "LLM error: Stream error: Transport error: error decoding response body"
+        ));
+        assert!(is_transient_transport_error("error decoding response body"));
+        assert!(is_transient_transport_error("connection reset by peer"));
+        assert!(is_transient_transport_error(
+            "connection closed before message completed"
+        ));
+        assert!(is_transient_transport_error("hyper: incomplete message"));
+        assert!(is_transient_transport_error("operation timed out"));
+        // Case-insensitive.
+        assert!(is_transient_transport_error("TRANSPORT ERROR: broken pipe"));
+    }
+
+    #[test]
+    fn matches_child_turn_wrapped_transport_error() {
+        // The subagent live e2e settles the child task Failed with the child
+        // turn's error wrapped in a "child turn failed: ..." message; a transient
+        // transport blip there must still be recognized so the whole flow retries.
+        assert!(is_transient_transport_error(
+            "child turn failed: LLM error: Stream error: Transport error: error decoding response body"
+        ));
+    }
+
+    #[test]
+    fn does_not_match_real_functional_errors() {
+        // Genuine functional/contract breaks must still fail the test loudly.
+        assert!(!is_transient_transport_error(
+            "Model not available: gpt-99-nonexistent"
+        ));
+        assert!(!is_transient_transport_error(
+            "Bad request: invalid schema for tool"
+        ));
+        assert!(!is_transient_transport_error("child turn failed: "));
+        assert!(!is_transient_transport_error(""));
+    }
+}

--- a/crates/llm-tests/tests/subagent_live_test.rs
+++ b/crates/llm-tests/tests/subagent_live_test.rs
@@ -129,13 +129,18 @@ impl LocalSessionRunner for RuntimeRunner {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn background_spawn_agent_subagent_live_end_to_end() {
-    let config = ANTHROPIC_HAIKU;
-    let Some(model) = config.model() else {
-        eprintln!("Skipping: {} not set", config.label());
-        return;
-    };
+/// Run one full live attempt of the subagent e2e flow.
+///
+/// Returns `Err(msg)` only when a *transient transport* blip (network/stream
+/// decode hiccup) was observed at the parent turn or the child-turn settle — the
+/// caller retries on that. Every real (assertion / functional) failure panics
+/// inside this function so it fails loudly and immediately, keeping full
+/// coverage rather than skipping (the deliberate policy behind reverting the
+/// earlier skip-on-transient mechanism in #2550).
+async fn run_subagent_live_attempt(
+    config: &ProviderModelConfig,
+) -> std::result::Result<(), String> {
+    let model = config.model().expect("model set (checked by caller)");
 
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(SubagentCapability);
@@ -188,8 +193,9 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
         .expect("runtime builds");
     runtime_cell.set(runtime.clone()).ok().expect("set once");
 
-    // 1. Parent turn: the real model must choose to call spawn_agent.
-    let turn = runtime
+    // 1. Parent turn: the real model must choose to call spawn_agent. A transient
+    //    transport/stream-decode blip here is retried by the caller, not failed.
+    let turn = match runtime
         .run_text_turn(
             parent_id,
             &format!(
@@ -199,8 +205,23 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
             ),
         )
         .await
-        .expect("parent turn runs");
-    assert!(turn.success, "parent turn failed: {:?}", turn.error);
+    {
+        Ok(turn) => turn,
+        Err(err) => {
+            let msg = err.to_string();
+            if is_transient_transport_error(&msg) {
+                return Err(format!("parent turn transport error: {msg}"));
+            }
+            panic!("parent turn runs: {msg}");
+        }
+    };
+    if !turn.success {
+        let err = turn.error.clone().unwrap_or_default();
+        if is_transient_transport_error(&err) {
+            return Err(format!("parent turn failed transiently: {err}"));
+        }
+        panic!("parent turn failed: {:?}", turn.error);
+    }
 
     let parent_messages = runtime.messages(parent_id).await.expect("parent messages");
     let spawn_call = parent_messages
@@ -237,12 +258,25 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
     let settled = settled.expect("subagent task should settle within 120s");
-    assert_eq!(
-        settled.state,
-        SessionTaskState::Succeeded,
-        "task error: {:?}",
-        settled.error
-    );
+    if settled.state != SessionTaskState::Succeeded {
+        // The child turn runs a real LLM through the watcher; a transient
+        // transport blip there settles the task Failed with the transport error
+        // wrapped in the child-turn message — retry rather than red CI.
+        let err_msg = settled
+            .error
+            .as_ref()
+            .map(|e| e.message.clone())
+            .unwrap_or_default();
+        if is_transient_transport_error(&err_msg) {
+            return Err(format!(
+                "child task settled with transport error: {err_msg}"
+            ));
+        }
+        panic!(
+            "subagent task did not succeed: state={:?} error={:?}",
+            settled.state, settled.error
+        );
+    }
 
     // 4. The summary is the child's REAL model reply.
     let summary = settled.summary.as_deref().expect("settled task summary");
@@ -268,4 +302,39 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
     println!("parent turn iterations: {}", turn.iterations);
     println!("task settled: {} — summary: {summary}", settled.state);
     println!("child reply: {child_reply}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn background_spawn_agent_subagent_live_end_to_end() {
+    let config = ANTHROPIC_HAIKU;
+    if config.model().is_none() {
+        eprintln!("Skipping: {} not set", config.label());
+        return;
+    }
+
+    // Live e2e against a real provider: a transient transport/stream-decode blip
+    // (e.g. "Transport error: error decoding response body") is infrastructure
+    // flakiness, not a regression, and must not red main CI. Retry the whole flow
+    // on transient transport faults (fresh runtime state each attempt) while
+    // still failing loudly and immediately on any real assertion/functional
+    // failure. Mirrors the bounded retry the rest of the live matrix uses via
+    // `run_live_turn!` (EVE-736).
+    const MAX_ATTEMPTS: usize = 3;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match run_subagent_live_attempt(&config).await {
+            Ok(()) => return,
+            Err(transient) => {
+                assert!(
+                    attempt < MAX_ATTEMPTS,
+                    "subagent live test still hitting transient transport failures after \
+                     {MAX_ATTEMPTS} attempts: {transient}"
+                );
+                eprintln!(
+                    "subagent live test attempt {attempt}/{MAX_ATTEMPTS} hit transient \
+                     transport failure, retrying: {transient}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What changed
The live subagent end-to-end test (`subagent_live_test`) now tolerates transient transport/stream-decode blips instead of reding CI on them. The whole flow is wrapped in a bounded retry (fresh runtime state per attempt) that retries **only** on a transient transport fault observed at the parent turn or the child-turn settle; every real assertion/functional failure still panics immediately, so genuine regressions fail loudly and coverage is unchanged.

Also adds unit tests for the `is_transient_transport_error` detector.

## Why
EVE-736: the live-provider matrix intermittently reds `main` with `LLM error: Stream error: Transport error: error decoding response body` — infrastructure flakiness talking to a real provider, not a code regression. The three OpenAI cases named in the issue (`test_basic_completion`, `test_tool_call`, `test_file_system_tool_schemas_accepted` in `agent_run_basic.rs`) **already** absorb this via the `run_live_turn!` bounded-retry macro. `subagent_live_test` was the one remaining live binary in the `Integration Tests (PostgreSQL)` job (ci.yml runs `--test agent_run_basic --test agent_run_with_thinking --test subagent_live_test`) with no transient-transport protection: its parent turn used `.expect(...)` and the child settle asserted `Succeeded` unconditionally, so a single stream-decode blip failed the whole suite.

Policy decision (the issue asks for it explicitly): the earlier skip-on-transient mechanism (#2550) was reverted because skipping silently drops coverage. The durable answer already adopted across the matrix is **bounded retry** — it keeps full coverage while absorbing genuine network blips. This PR extends that same policy to the last unprotected live binary rather than reintroducing a skip.

## Before / After
Before: a transient transport fault at the parent turn (`.expect("parent turn runs")`) or a child task settling `Failed` with a wrapped transport error would panic/assert and red CI.

After: such faults trigger up to 3 bounded retries with fresh state; only a persistent transient failure (after 3 attempts) or any real assertion/functional failure fails the test.

Evidence (local):

```
# detector unit tests + live test skip path (no key)
running 6 tests
test llm_test_matrix::transient_transport_detector_tests::matches_observed_live_flakes ... ok
test llm_test_matrix::transient_transport_detector_tests::matches_child_turn_wrapped_transport_error ... ok
test llm_test_matrix::transient_transport_detector_tests::does_not_match_real_functional_errors ... ok
Skipping: ANTHROPIC_API_KEY:claude-haiku-4-5-20251001 not set
test background_spawn_agent_subagent_live_end_to_end ... ok
test result: ok. 6 passed; 0 failed

# full live e2e against real Anthropic (ANTHROPIC_API_KEY set)
parent turn iterations: 2
task settled: succeeded — summary: EVERRUNS_LIVE_OK
child reply: EVERRUNS_LIVE_OK
test background_spawn_agent_subagent_live_end_to_end ... ok
test result: ok. 1 passed; 0 failed
```

`cargo fmt -p everruns-llm-tests --check` and `cargo clippy -p everruns-llm-tests --tests --features llm-tests -- -D warnings` both clean.

## Risk
- Low
- Test-only change to a single live integration test plus additive unit tests. No production code touched. Worst case is the retry loop masks a *persistently* transient provider outage (still surfaced loudly after 3 attempts) — real functional/assertion failures are excluded from the transient classification and fail immediately.

## Security
- Threat categories reviewed: No security-relevant code changes — test-only. Transient classification is a narrow substring match on transport/stream-decode signatures; auth/functional errors are not matched and still fail loudly.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. The three OpenAI cases named in EVE-736 were already retry-protected on `main`; this PR closes the remaining gap in the CI live matrix.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only, additive)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FL6TJZLnSuYeUykTpPQYoZ)_