### PR TITLE
fix(core): make activate_skill missing-name error self-repairing

### DIFF
--- a/crates/core/src/capabilities/skills_scoped.rs
+++ b/crates/core/src/capabilities/skills_scoped.rs
@@ -624,7 +624,10 @@ impl Tool for ActivateSkillTool {
         ctx: &ToolContext,
     ) -> ToolExecutionResult {
         let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
-            return ToolExecutionResult::tool_error("Missing required parameter: name");
+            return ToolExecutionResult::tool_error(
+                "Missing required parameter: name. Call as \
+                 activate_skill({\"name\":\"ship\"}). Use list_skills to see valid skill names.",
+            );
         };
         let skill_args = arguments
             .get("arguments")

--- a/crates/core/src/capabilities/skills_scoped/tests.rs
+++ b/crates/core/src/capabilities/skills_scoped/tests.rs
@@ -384,6 +384,33 @@ async fn activate_skill_not_found() {
     }
 }
 
+#[tokio::test]
+async fn activate_skill_missing_name_returns_actionable_error() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let activate = &cap.tools()[1];
+    let result = activate
+        .execute_with_context(json!({}), &ctx(fs, sid))
+        .await;
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            // Names the missing field, shows an example JSON shape, and points
+            // at list_skills so a malformed call can self-repair.
+            assert!(msg.contains("name"), "should name the missing field: {msg}");
+            assert!(
+                msg.contains("{\"name\":\"ship\"}"),
+                "should include an example JSON shape: {msg}"
+            );
+            assert!(
+                msg.contains("list_skills"),
+                "should mention list_skills: {msg}"
+            );
+        }
+        other => panic!("expected error, got {other:?}"),
+    }
+}
+
 // ----------------------------------------------------------------------------
 // write_skill / read_skill
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
When the built-in `activate_skill` tool is called without its required `name` argument, the returned tool error now tells the model/user how to recover: it names the missing field, shows an example call shape, and points at `list_skills` to discover valid skill names. Successful activation behavior is unchanged.

## Why
The previous error — `Missing required parameter: name` — is correct but not self-repairing. In a recent agent session, the model called `activate_skill` with no arguments while routing to a skill; the bare error gave it nothing to act on, and it only recovered later by guessing `name="ship"`. The new message closes that loop so a malformed call can self-repair in-session.

## Before / After
Tool error returned from `ActivateSkillTool` when called with `{}`:

**Before:**
```
Missing required parameter: name
```

**After:**
```
Missing required parameter: name. Call as activate_skill({"name":"ship"}). Use list_skills to see valid skill names.
```

Verified by the new regression test `activate_skill_missing_name_returns_actionable_error`, which drives the real execution path (`execute_with_context({})`) and asserts the error names the missing field, includes the `{"name":"ship"}` example, and mentions `list_skills`:
```
test capabilities::skills_scoped::tests::activate_skill_missing_name_returns_actionable_error ... ok
test result: ok. 14 passed; 0 failed; 0 ignored
```

## Risk
- Low
- Only a static error string changes on the missing-`name` branch. No control flow, schema, or success-path change. The missing-`name` branch returns before touching the filesystem, so no other behavior is affected.

## Security
- Threat categories reviewed: TM-TOOL (tool execution path). No security-relevant code changes — the diff alters a static error-message string only. No user input is interpolated into the message, and no injection, auth, data-exposure, or resource surface is touched. No nearby `THREAT` comments are affected.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal error-string only; no contract change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-core --lib skills_scoped` — 14 passed, 0 failed
- `cargo fmt -p everruns-core --check` — clean
- `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` — clean

Smoke testing note: the affected surface is solely this tool's error return; the regression test exercises the real code path end-to-end at the tool boundary, so a full-stack smoke run would add no signal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVQzHTNFYsCBiknri2yD6r)_