### PR TITLE
docs(mcp): reconcile tasks field names

### DIFF
--- a/crates/local/tests/spawn_agent_runtime_test.rs
+++ b/crates/local/tests/spawn_agent_runtime_test.rs
@@ -392,6 +392,22 @@ async fn spawn_agent_dispatches_subagent_and_handoff_via_llmsim() {
         "child transcript should contain its marker: {child_reply}"
     );
 
+    // The background subagent completion queues a wake for the parent. Drain it
+    // before the handoff prompt so the content-keyed llmsim sees the handoff
+    // request as the latest user-authored instruction.
+    let drain = runtime
+        .run_text_turn(
+            parent_session_id,
+            "Acknowledge the completed subagent update.",
+        )
+        .await
+        .expect("parent wake-drain turn runs");
+    assert!(
+        drain.success,
+        "parent wake-drain turn failed: {:?}",
+        drain.error
+    );
+
     // ---- Target 2: agent handoff (foreground) ------------------------------
     let turn = runtime
         .run_text_turn(

--- a/crates/server/src/api/mcp_endpoint/tasks.rs
+++ b/crates/server/src/api/mcp_endpoint/tasks.rs
@@ -19,17 +19,8 @@
 // 2025-* clients (and 2026 clients that did not opt in) see the pre-existing
 // shapes unchanged — the task fields are strictly additive.
 //
-// Schema source: the official MCP Tasks extension docs
-// (https://modelcontextprotocol.io/extensions/tasks/overview) and SEP-2663
-// (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663 /
-// https://github.com/modelcontextprotocol/experimental-ext-tasks).
-//
-// ASSUMPTION / FIELDS TO RECONCILE: the extension is still an experimental RC
-// and the two authoritative sources disagree on the duration field spelling —
-// the overview page uses `ttlMs` / `pollIntervalMs`, while the PR summary uses
-// `ttlSeconds` / `pollIntervalMilliseconds`. We emit `ttlMs` / `pollIntervalMs`
-// (the docs page, which shows concrete JSON) and centralize them here so a
-// single edit reconciles the wire shape once the spec freezes.
+// Schema source: final SEP-2663 and the official MCP Tasks extension overview.
+// Both specify `ttlMs` / `pollIntervalMs`, so those field names are canonical.
 
 use serde_json::{Value, json};
 
@@ -244,5 +235,7 @@ mod tests {
         assert_eq!(result["status"], "working");
         assert!(result.get("ttlMs").is_some());
         assert!(result.get("pollIntervalMs").is_some());
+        assert!(result.get("ttlSeconds").is_none());
+        assert!(result.get("pollIntervalMilliseconds").is_none());
     }
 }

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -3375,6 +3375,28 @@ fn tasks_opt_in_meta() -> Value {
     })
 }
 
+fn assert_final_tasks_duration_fields(result: &Value) {
+    assert!(
+        result.get("ttlMs").and_then(Value::as_u64).is_some(),
+        "final SEP-2663 task shape must include ttlMs, got: {result}"
+    );
+    assert!(
+        result
+            .get("pollIntervalMs")
+            .and_then(Value::as_u64)
+            .is_some(),
+        "final SEP-2663 task shape must include pollIntervalMs, got: {result}"
+    );
+    assert!(
+        result.get("ttlSeconds").is_none(),
+        "draft ttlSeconds field must not be emitted, got: {result}"
+    );
+    assert!(
+        result.get("pollIntervalMilliseconds").is_none(),
+        "draft pollIntervalMilliseconds field must not be emitted, got: {result}"
+    );
+}
+
 /// tools/call with the 2026 protocol header AND the tasks opt-in `_meta`.
 async fn mcp_task_tool_call(server: &TestServer, tool: &str, arguments: Value) -> Value {
     mcp_call_with_headers(
@@ -3441,8 +3463,7 @@ async fn test_mcp_agent_run_returns_task_handle_for_2026() {
     let task_id = result["taskId"].as_str().expect("taskId present");
     assert!(task_id.starts_with("session_"), "taskId is session id");
     assert_eq!(result["status"], "working");
-    assert!(result.get("ttlMs").is_some());
-    assert!(result.get("pollIntervalMs").is_some());
+    assert_final_tasks_duration_fields(result);
 
     // Legacy content preserved: taskId equals the session_id in the body.
     let body = tool_json(&resp);
@@ -3508,6 +3529,7 @@ async fn test_mcp_tasks_get_round_trip() {
 
     let result = &resp["result"];
     assert_eq!(result["taskId"].as_str(), Some(task_id.as_str()));
+    assert_final_tasks_duration_fields(result);
     let status = result["status"].as_str().unwrap();
     assert!(
         [

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -91,7 +91,9 @@ alignment. It is not new capability: Everruns already runs long agent turns as
 the poll pattern (`agent_run` returns a session id + hint, clients poll
 `session_get_status`), all state Postgres-backed with no server-side session
 memory. Tasks is the standardized vocabulary for that same pattern, so a
-**task handle is a session id**.
+**task handle is a session id**. Field names follow final SEP-2663 and the
+official Tasks extension overview: task handles use `ttlMs` and
+`pollIntervalMs`.
 
 The whole surface is gated: it activates only when the negotiated protocol is
 `2026-07-28` **and** the client advertised the extension. `2025-*` clients (and
@@ -155,16 +157,6 @@ that reported no structured result omits the field. Retrieval is scoped by the
 same org `session_get_status` already validated, so tenant isolation is
 preserved; when a session reported more than one structured result the most
 recently updated one wins.
-
-> **RC schema note.** The Tasks extension is still an experimental RC and its
-> authoritative sources disagree on the duration field spelling: the
-> [overview docs](https://modelcontextprotocol.io/extensions/tasks/overview)
-> use `ttlMs` / `pollIntervalMs` (with concrete JSON), while the
-> [SEP-2663 PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663)
-> summary uses `ttlSeconds` / `pollIntervalMilliseconds`. Everruns emits
-> `ttlMs` / `pollIntervalMs` and centralizes the field names in
-> `api/mcp_endpoint/tasks.rs` so a single edit reconciles the wire shape once
-> the spec freezes.
 
 Implementation: `crates/server/src/api/mcp_endpoint/tasks.rs` (mapping helpers,
 capability gating, task-handle shapes) and `mod.rs` (`handle_tasks_method` and


### PR DESCRIPTION
## What changed
Reconciled the MCP Tasks field-name documentation now that SEP-2663 is Final: Everruns documents and tests `ttlMs` / `pollIntervalMs` as the canonical wire fields, and the endpoint tests now reject the old draft spellings `ttlSeconds` / `pollIntervalMilliseconds`.

Also repaired a red CI unit test in the local runtime delegation proof: the test now drains the queued background-subagent completion wake before issuing the foreground handoff prompt, so llmsim sees the intended handoff instruction as the latest user-authored message.

## Why
EVE-726 was waiting for the SEP-2663 freeze before removing the temporary RC note. The official final SEP-2663 page marks the proposal Final and specifies `ttlMs` / `pollIntervalMs`, so the local docs and tests can now stop carrying the draft-field ambiguity.

The runtime proof repair was needed because current main injects task completion wakes at the next turn boundary. Without an explicit neutral drain turn, the synthetic wake supersedes the handoff prompt for the content-keyed llmsim driver, and CI fails before this PR can merge.

## Before / After
Before: `specs/mcp.md` and the MCP task helper carried an RC warning that authoritative sources disagreed on duration field names, and endpoint tests only asserted the canonical fields existed. The local spawn-agent runtime proof could miss the handoff branch when a queued task wake was injected before llmsim read the handoff prompt.

After: docs/source comments identify final SEP-2663 as the schema source, server endpoint tests assert the canonical fields are numeric while old draft fields are absent, and the runtime proof deterministically exercises both subagent and agent-handoff targets.

Evidence:
- `DATABASE_URL='postgres://everruns:everruns@localhost:27332/everruns_test' cargo test -p everruns-server api::mcp_endpoint::tasks --lib` — 6 passed
- `DATABASE_URL='postgres://everruns:everruns@localhost:27332/everruns_test' cargo test -p everruns-server --test mcp_endpoint_test test_mcp_tasks -- --test-threads=1 --nocapture` — 9 passed
- `DATABASE_URL='postgres://everruns:everruns@localhost:27332/everruns_test' cargo test -p everruns-server --test mcp_endpoint_test test_mcp_agent_run -- --test-threads=1 --nocapture` — 7 passed after resetting stale local fixture data
- `cargo test -p everruns-local --test spawn_agent_runtime_test spawn_agent_dispatches_subagent_and_handoff_via_llmsim -- --exact --nocapture` — 1 passed
- `DATABASE_URL='postgres://everruns:everruns@localhost:27332/everruns_test' cargo clippy -p everruns-server --test mcp_endpoint_test -- -D warnings`
- `bash scripts/lib/check-migration-ordering.sh` — migrations sequential (001..103)
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `just pre-push` — passed after the final push commit

Smoke: skipped intentionally for the EVE-726 field-name slice because runtime MCP task serialization code is unchanged; the impacted endpoint behavior is covered by the integration tests above. The CI repair is a test-only deterministic proof fix, validated by the exact failed test.

## Risk
- Low
- Main risk is documentation or test drift around the MCP task wire shape. The runtime already emitted `ttlMs` / `pollIntervalMs`; this PR locks that expectation into tests and removes stale uncertainty.
- The local runtime proof change is test-only and does not alter runtime wake or delegation behavior.

## Security
- Threat categories reviewed: No security-relevant code changes; MCP server surface reviewed against TM-MCP, TM-API, TM-TENANT, and TM-DOS because the touched tests cover `/mcp` task responses. Runtime proof repair reviewed as test-only coverage around delegation task wake handling.
- Findings and resolutions: No auth, routing, tenant scoping, input parsing, persistence, dependency, or resource-limit behavior changed. No threat-model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

