### PR TITLE
feat(export): fold model-view for ATIF dataset export

### DIFF
--- a/crates/server/src/atif.rs
+++ b/crates/server/src/atif.rs
@@ -185,12 +185,58 @@ fn assemble_document(
 
 /// Build one dataset NDJSON record for an eval case: a complete ATIF
 /// trajectory with reward and case identity in root `extra`.
+///
+/// Folds the raw event log. Used by the whole-session export path; the eval
+/// **dataset** export uses [`build_case_record_from_messages`] instead so its
+/// rows reflect the compaction model view (specs/dataset-export.md).
 pub fn build_case_record(
     run: &everruns_core::eval::EvalRun,
     result: &everruns_core::eval::EvalCaseResult,
     events: &[Event],
     options: AtifOptions,
 ) -> Value {
+    let (extra, session_id) = case_extra(run, result);
+    build_trajectory(session_id.as_deref(), events, extra, options).document
+}
+
+/// Build one dataset NDJSON record from the case's **model-view** messages
+/// (post-compaction masking) rather than the raw event log, so training rows
+/// match what the model actually saw (specs/dataset-export.md, Model-view
+/// faithfulness). Reward and case identity go in root `extra`, same as
+/// [`build_case_record`].
+///
+/// Model-view messages carry no per-step token usage or turn boundaries, so
+/// steps have no `metrics` and there is no `extra.turns`; case-level token
+/// totals from the result are surfaced in `final_metrics` instead.
+pub fn build_case_record_from_messages(
+    run: &everruns_core::eval::EvalRun,
+    result: &everruns_core::eval::EvalCaseResult,
+    messages: &[Message],
+    options: AtifOptions,
+) -> Value {
+    let (extra, session_id) = case_extra(run, result);
+    let steps = fold_messages(messages, options.redact_content);
+    let final_metrics = case_final_metrics(result, steps.len());
+    let mut value = assemble_document(
+        session_id.as_deref(),
+        None,
+        None,
+        final_metrics,
+        steps,
+        extra,
+    );
+    // Same always-on secret scrubbing as every other export path. Content
+    // redaction was already applied structurally during the fold.
+    sanitize_value(&mut value, false);
+    value
+}
+
+/// Reward + case-identity `extra` shared by both dataset record builders, plus
+/// the case session id (as the ATIF root `session_id`).
+fn case_extra(
+    run: &everruns_core::eval::EvalRun,
+    result: &everruns_core::eval::EvalCaseResult,
+) -> (Map<String, Value>, Option<String>) {
     let mut extra = Map::new();
     extra.insert(
         "reward".to_string(),
@@ -206,8 +252,228 @@ pub fn build_case_record(
         json!(result.eval_case_id.to_string()),
     );
     extra.insert("case_name".to_string(), json!(result.case_name));
-    let session_id = result.session_id.map(|s| s.to_string());
-    build_trajectory(session_id.as_deref(), events, extra, options).document
+    (extra, result.session_id.map(|s| s.to_string()))
+}
+
+/// Fold post-compaction model-view messages into ATIF steps. Mirrors the event
+/// fold's step shape (user/agent steps, tool-call parts → `tool_calls[]`,
+/// thinking → `reasoning_content`, tool results → `observation.results[]`) but
+/// over reconstructed `Message`s, so it reflects exactly what the model saw.
+fn fold_messages(messages: &[Message], redact: bool) -> Vec<Value> {
+    use everruns_core::message::MessageRole;
+
+    let mut steps: Vec<Value> = Vec::new();
+    // Index of the agent step that trailing tool results attach observations to.
+    let mut open_agent: Option<usize> = None;
+
+    for message in messages {
+        let ts = json!(message.created_at.to_rfc3339());
+        match message.role {
+            MessageRole::System | MessageRole::User => {
+                let source = if message.role == MessageRole::System {
+                    "system"
+                } else {
+                    "user"
+                };
+                let mut omitted = Vec::new();
+                let content = build_message_content(message, redact, &mut omitted);
+                let mut step = Map::new();
+                step.insert("timestamp".to_string(), ts);
+                step.insert("source".to_string(), json!(source));
+                step.insert("message".to_string(), content);
+                let mut extra = Map::new();
+                append_omitted_images(&mut extra, omitted);
+                if !extra.is_empty() {
+                    step.insert("extra".to_string(), Value::Object(extra));
+                }
+                steps.push(Value::Object(step));
+                open_agent = None;
+            }
+            MessageRole::Agent => {
+                let mut omitted = Vec::new();
+                let content = build_message_content(message, redact, &mut omitted);
+                let mut step = Map::new();
+                step.insert("timestamp".to_string(), ts);
+                step.insert("source".to_string(), json!("agent"));
+                step.insert("message".to_string(), content);
+                if let Some(thinking) = &message.thinking {
+                    let reasoning = if redact {
+                        REDACTED.to_string()
+                    } else {
+                        thinking.clone()
+                    };
+                    step.insert("reasoning_content".to_string(), json!(reasoning));
+                }
+                let tool_calls: Vec<Value> = message
+                    .tool_calls()
+                    .iter()
+                    .map(|tc| {
+                        json!({
+                            "tool_call_id": tc.id,
+                            "function_name": tc.name,
+                            "arguments": if redact {
+                                Value::String(REDACTED.to_string())
+                            } else {
+                                tc.arguments.clone()
+                            },
+                        })
+                    })
+                    .collect();
+                if !tool_calls.is_empty() {
+                    step.insert("tool_calls".to_string(), Value::Array(tool_calls));
+                }
+                let mut extra = Map::new();
+                append_omitted_images(&mut extra, omitted);
+                if !extra.is_empty() {
+                    step.insert("extra".to_string(), Value::Object(extra));
+                }
+                steps.push(Value::Object(step));
+                open_agent = Some(steps.len() - 1);
+            }
+            MessageRole::ToolResult => {
+                let mut omitted = Vec::new();
+                let Some(observation) =
+                    message_tool_result_observation(message, redact, &mut omitted)
+                else {
+                    continue;
+                };
+                // Attach to the open agent step, synthesizing a bare one if a
+                // tool result somehow leads (defensive; normally impossible).
+                let idx = match open_agent {
+                    Some(i) => i,
+                    None => {
+                        let mut step = Map::new();
+                        step.insert("timestamp".to_string(), ts);
+                        step.insert("source".to_string(), json!("agent"));
+                        step.insert("message".to_string(), json!(""));
+                        steps.push(Value::Object(step));
+                        let i = steps.len() - 1;
+                        open_agent = Some(i);
+                        i
+                    }
+                };
+                if let Value::Object(step) = &mut steps[idx] {
+                    if !omitted.is_empty() {
+                        match step.get_mut("extra") {
+                            Some(Value::Object(m)) => append_omitted_images(m, omitted),
+                            _ => {
+                                let mut m = Map::new();
+                                append_omitted_images(&mut m, omitted);
+                                step.insert("extra".to_string(), Value::Object(m));
+                            }
+                        }
+                    }
+                    match step.get_mut("observation") {
+                        Some(Value::Object(obs)) => {
+                            if let Some(Value::Array(results)) = obs.get_mut("results") {
+                                results.push(observation);
+                            }
+                        }
+                        _ => {
+                            step.insert(
+                                "observation".to_string(),
+                                json!({ "results": [observation] }),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (i, step) in steps.iter_mut().enumerate() {
+        if let Value::Object(map) = step {
+            map.insert("step_id".to_string(), json!(i + 1));
+        }
+    }
+    steps
+}
+
+/// Build one ATIF observation from a model-view tool-result message: the
+/// result/error text (plus any attached images as image ContentParts) and, when
+/// the result is a subagent spawn, the `subagent_trajectory_ref` linkage.
+fn message_tool_result_observation(
+    message: &Message,
+    redact: bool,
+    omitted: &mut Vec<Value>,
+) -> Option<Value> {
+    let tr = message.tool_result_content()?;
+    let base = if let Some(err) = &tr.error {
+        format!("[error] {err}")
+    } else if let Some(res) = &tr.result {
+        match res {
+            Value::String(s) => s.clone(),
+            other => serde_json::to_string(other).unwrap_or_default(),
+        }
+    } else {
+        String::new()
+    };
+    let base = if redact { REDACTED.to_string() } else { base };
+
+    // Images carried alongside the result (tool_result_with_images) export as
+    // multimodal image ContentParts, matching the event-fold behavior.
+    let mut atif_parts: Vec<Value> = vec![json!({ "type": "text", "text": base.clone() })];
+    let mut has_image = false;
+    for part in &message.content {
+        if matches!(part, ContentPart::Image(_) | ContentPart::ImageFile(_)) {
+            match image_source(part, redact) {
+                Some(source) => {
+                    has_image = true;
+                    atif_parts.push(json!({ "type": "image", "source": source }));
+                }
+                None => {
+                    atif_parts.push(json!({ "type": "text", "text": "[image]" }));
+                    omitted.extend(omitted_image_ref(part, redact));
+                }
+            }
+        }
+    }
+    let content = if has_image {
+        Value::Array(atif_parts)
+    } else {
+        Value::String(base)
+    };
+
+    let mut obs = Map::new();
+    obs.insert("source_call_id".to_string(), json!(tr.tool_call_id));
+    obs.insert("content".to_string(), content);
+    let mut extra = Map::new();
+    extra.insert(
+        "status".to_string(),
+        json!(if tr.error.is_some() {
+            "error"
+        } else {
+            "success"
+        }),
+    );
+    obs.insert("extra".to_string(), Value::Object(extra));
+    // Subagent linkage parity with the event fold: a spawn result carries the
+    // child session id under `subagent_id`.
+    if let Some(res) = &tr.result
+        && let Some(id) = res.get("subagent_id").and_then(Value::as_str)
+        && !id.is_empty()
+    {
+        obs.insert(
+            "subagent_trajectory_ref".to_string(),
+            subagent_trajectory_ref(id),
+        );
+    }
+    Some(Value::Object(obs))
+}
+
+/// Case-level `final_metrics` for the model-view fold. Messages carry no
+/// per-step usage, so token totals come from the case result (the same source
+/// the `trajectory` format's `metadata` uses).
+fn case_final_metrics(result: &everruns_core::eval::EvalCaseResult, total_steps: usize) -> Value {
+    let mut m = Map::new();
+    if let Some(t) = result.input_tokens {
+        m.insert("total_prompt_tokens".to_string(), json!(t));
+    }
+    if let Some(t) = result.output_tokens {
+        m.insert("total_completion_tokens".to_string(), json!(t));
+    }
+    m.insert("total_steps".to_string(), json!(total_steps));
+    Value::Object(m)
 }
 
 // ============================================================================
@@ -1917,6 +2183,237 @@ mod tests {
                 .contains('/')
         );
         assert_eq!(record["session_id"], json!(session.to_string()));
+    }
+
+    // ------------------------------------------------------------------
+    // Model-view (dataset) message fold
+    // ------------------------------------------------------------------
+
+    /// A minimal passing run/result pair for the dataset record builders.
+    fn sample_run_and_result(
+        session: SessionId,
+    ) -> (
+        everruns_core::eval::EvalRun,
+        everruns_core::eval::EvalCaseResult,
+    ) {
+        use everruns_core::eval::{
+            CaseResultStatus, EvalCaseResult, EvalRun, EvalRunSource, EvalRunStatus,
+        };
+        use everruns_core::typed_id::{EvalCaseId, EvalResultId, EvalRunId};
+
+        let run = EvalRun {
+            public_id: EvalRunId::new(),
+            internal_id: uuid::Uuid::nil(),
+            org_id: 1,
+            target: None,
+            model_override: None,
+            filter_tags: None,
+            status: EvalRunStatus::Completed,
+            source: EvalRunSource::Internal,
+            attribution: None,
+            triggered_by: "test".to_string(),
+            started_at: None,
+            completed_at: None,
+            summary: None,
+            results: vec![],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let result = EvalCaseResult {
+            public_id: EvalResultId::new(),
+            internal_id: uuid::Uuid::nil(),
+            eval_case_id: EvalCaseId::new(),
+            case_name: Some("case-one".to_string()),
+            session_id: Some(session),
+            target: None,
+            target_snapshot: None,
+            status: CaseResultStatus::Passed,
+            scores: Some(json!([{"pass": true, "value": 1.0, "reason": "ok"}])),
+            metadata: None,
+            turns: Some(1),
+            latency_ms: Some(10),
+            input_tokens: Some(11),
+            output_tokens: Some(22),
+            error_message: None,
+            artifacts: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        (run, result)
+    }
+
+    #[test]
+    fn message_fold_maps_roles_to_steps() {
+        let session = SessionId::new();
+        let (run, result) = sample_run_and_result(session);
+
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "search".to_string(),
+            arguments: json!({"q": "weather"}),
+        };
+        let mut agent = Message::assistant_with_tools("checking", vec![tool_call]);
+        agent.thinking = Some("let me look".to_string());
+        let messages = vec![
+            Message::user("hi there"),
+            agent,
+            Message::tool_result("call_1", Some(json!("sunny, 21C")), None),
+            Message::assistant("It is sunny."),
+        ];
+
+        let doc = build_case_record_from_messages(&run, &result, &messages, AtifOptions::default());
+        // No per-step metrics or turns roll-up on the model-view fold.
+        assert!(doc["extra"].get("turns").is_none());
+        // Case-level token totals surface in final_metrics.
+        assert_eq!(doc["final_metrics"]["total_prompt_tokens"], json!(11));
+        assert_eq!(doc["final_metrics"]["total_completion_tokens"], json!(22));
+
+        let steps = doc["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 3, "user, agent(tool+obs), agent(final)");
+        assert_eq!(steps[0]["source"], json!("user"));
+        assert_eq!(steps[0]["message"], json!("hi there"));
+        assert_eq!(steps[0]["step_id"], json!(1));
+
+        let s1 = &steps[1];
+        assert_eq!(s1["source"], json!("agent"));
+        assert_eq!(s1["message"], json!("checking"));
+        assert_eq!(s1["reasoning_content"], json!("let me look"));
+        assert_eq!(s1["tool_calls"][0]["tool_call_id"], json!("call_1"));
+        assert_eq!(s1["tool_calls"][0]["function_name"], json!("search"));
+        assert_eq!(
+            s1["observation"]["results"][0]["source_call_id"],
+            json!("call_1")
+        );
+        assert_eq!(
+            s1["observation"]["results"][0]["content"],
+            json!("sunny, 21C")
+        );
+        assert!(
+            s1.get("metrics").is_none(),
+            "messages carry no per-step usage"
+        );
+
+        assert_eq!(steps[2]["message"], json!("It is sunny."));
+        assert_eq!(doc["extra"]["reward"]["pass"], json!(true));
+    }
+
+    #[test]
+    fn message_fold_reflects_model_view_masking() {
+        use everruns_core::capabilities::compaction::{
+            CompactionConfig, build_model_view_messages,
+        };
+
+        let session = SessionId::new();
+        let (run, result) = sample_run_and_result(session);
+
+        // Five tool-call/result iterations. Default cost-control masking keeps
+        // the two most recent tool results and masks the three oldest.
+        let mut messages = vec![Message::user("start")];
+        for i in 0..5 {
+            let call = ToolCall {
+                id: format!("call_{i}"),
+                name: "fetch".to_string(),
+                arguments: json!({"n": i}),
+            };
+            messages.push(Message::assistant_with_tools(
+                format!("iter {i}"),
+                vec![call],
+            ));
+            messages.push(Message::tool_result(
+                format!("call_{i}"),
+                Some(json!(format!("BULKY_RESULT_{i}"))),
+                None,
+            ));
+        }
+
+        // Folding the raw (unmasked) messages keeps every distinctive result.
+        let raw = build_case_record_from_messages(&run, &result, &messages, AtifOptions::default());
+        let raw_str = serde_json::to_string(&raw).unwrap();
+        for i in 0..5 {
+            assert!(
+                raw_str.contains(&format!("BULKY_RESULT_{i}")),
+                "unmasked fold keeps result {i}",
+            );
+        }
+
+        // Folding the model view drops the masked (older) tool-result content —
+        // exactly the training-faithfulness the dataset export now guarantees.
+        let masked_messages =
+            build_model_view_messages(&messages, &CompactionConfig::default(), None).messages;
+        let masked = build_case_record_from_messages(
+            &run,
+            &result,
+            &masked_messages,
+            AtifOptions::default(),
+        );
+        let masked_str = serde_json::to_string(&masked).unwrap();
+        for i in 0..3 {
+            assert!(
+                !masked_str.contains(&format!("BULKY_RESULT_{i}")),
+                "masked result {i} must be absent from the model-view fold",
+            );
+        }
+        for i in 3..5 {
+            assert!(
+                masked_str.contains(&format!("BULKY_RESULT_{i}")),
+                "recent result {i} must survive in the model-view fold",
+            );
+        }
+        assert!(
+            masked_str.contains("masked"),
+            "masked results carry the compaction summary marker",
+        );
+    }
+
+    #[test]
+    fn message_fold_redacts_and_links_subagents() {
+        let session = SessionId::new();
+        let (run, result) = sample_run_and_result(session);
+        let child = SessionId::new();
+
+        let spawn_call = ToolCall {
+            id: "call_spawn".to_string(),
+            name: "spawn_agent".to_string(),
+            arguments: json!({"target": {"type": "subagent"}}),
+        };
+        let messages = vec![
+            Message::user("delegate secret sk-abcdef0123456789ABCDEF"),
+            Message::assistant_with_tools("spawning", vec![spawn_call]),
+            Message::tool_result(
+                "call_spawn",
+                Some(json!({"subagent_id": child.to_string(), "status": "running"})),
+                None,
+            ),
+        ];
+
+        // Subagent linkage parity with the event fold.
+        let doc = build_case_record_from_messages(&run, &result, &messages, AtifOptions::default());
+        let refs = &doc["steps"][1]["observation"]["results"][0]["subagent_trajectory_ref"];
+        assert_eq!(
+            refs[0]["trajectory_path"],
+            json!(format!("/v1/sessions/{child}/export?format=atif"))
+        );
+        // Secret scrubbing applies on the model-view path too.
+        assert!(
+            !serde_json::to_string(&doc)
+                .unwrap()
+                .contains("sk-abcdef0123456789ABCDEF")
+        );
+
+        // Redaction blanks content but preserves structure.
+        let redacted = build_case_record_from_messages(
+            &run,
+            &result,
+            &messages,
+            AtifOptions {
+                redact_content: true,
+            },
+        );
+        assert_eq!(redacted["steps"][0]["message"], json!(REDACTED));
+        assert_eq!(
+            redacted["steps"][1]["tool_calls"][0]["function_name"],
+            json!("spawn_agent")
+        );
     }
 
     // ------------------------------------------------------------------

--- a/crates/server/src/domains/evals/dataset_export.rs
+++ b/crates/server/src/domains/evals/dataset_export.rs
@@ -34,15 +34,14 @@ pub async fn build_dataset_ndjson(
     // compaction model-view masking so the dataset matches what the model saw
     // (not the lossless durable log). The default config is used here; honoring
     // the exact per-run compaction config is a documented follow-up.
+    //
+    // Every format — including ATIF — folds the model-view messages, so ATIF
+    // training rows never contain content the model did not read (masked/dropped
+    // tool results). Only the whole-session export (`?format=atif`) still folds
+    // the raw event log, which is a debug/backup surface. See
+    // specs/dataset-export.md (Model-view faithfulness) and specs/atif-adoption.md.
     let retriever = DbMessageRetriever::new(db.clone());
     let compaction = CompactionConfig::default();
-    // The ATIF format folds the raw event log (per-iteration steps, tool
-    // observations, per-step metrics) rather than reconstructed messages, so
-    // it reads events directly. See specs/atif-adoption.md.
-    let event_service = crate::services::EventService::new(
-        db.clone(),
-        crate::event_delivery::EventDelivery::in_memory(),
-    );
 
     let mut body = String::new();
     let mut count: u64 = 0;
@@ -55,25 +54,21 @@ pub async fn build_dataset_ndjson(
         let Some(session_id) = result.session_id else {
             continue;
         };
+        let stored = retriever
+            .load(session_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("load session messages: {e}"))?;
+        let messages = build_model_view_messages(&stored, &compaction, None).messages;
         let record = if req.format == DatasetFormat::Atif {
-            let events = event_service
-                .list(session_id.uuid(), None, None, &[], &[], None, None)
-                .await
-                .map_err(|e| anyhow::anyhow!("load session events: {e}"))?;
-            crate::atif::build_case_record(
+            crate::atif::build_case_record_from_messages(
                 run,
                 result,
-                &events,
+                &messages,
                 crate::atif::AtifOptions {
                     redact_content: req.redaction.redact_content,
                 },
             )
         } else {
-            let stored = retriever
-                .load(session_id)
-                .await
-                .map_err(|e| anyhow::anyhow!("load session messages: {e}"))?;
-            let messages = build_model_view_messages(&stored, &compaction, None).messages;
             dataset::build_record(req.format, run, result, &messages, &req.redaction)
         };
         let line = serde_json::to_string(&record)?;

--- a/crates/server/tests/evals_integration_test.rs
+++ b/crates/server/tests/evals_integration_test.rs
@@ -921,6 +921,262 @@ async fn test_dataset_export_atif_format_produces_atif_trajectories() {
     assert!(body.contains("[REDACTED]"));
 }
 
+/// Seed a completed run whose case session has `n` tool-call/result iterations
+/// (each result a distinctive `BULKY_RESULT_{i}` string). Returns
+/// `(eval_id, run_id, session_id)`.
+async fn seed_run_with_tool_iterations(
+    server: &TestServer,
+    n: usize,
+) -> (String, String, SessionId) {
+    use everruns_core::events::{InputMessageData, OutputMessageCompletedData, ToolCompletedData};
+    use everruns_core::message::{ContentPart, Message};
+    use everruns_core::tool_types::ToolCall;
+    use uuid::Uuid;
+
+    let eval: Eval = server
+        .post("/v1/evals", json!({ "name": "modelview eval" }))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let case: EvalCase = server
+        .post(
+            &format!("/v1/evals/{}/cases", eval.public_id),
+            json!({
+                "name": "case-mv",
+                "conversation": [{"content": "start"}],
+                "scorers": [{"type": "contains", "text": "ok", "weight": 1.0}]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let eval_row = server
+        .db
+        .get_eval_by_public_id(TEST_ORG_ID, &eval.public_id.to_string())
+        .await
+        .expect("load eval")
+        .expect("eval exists");
+    let case_row = server
+        .db
+        .get_eval_case_by_public_id(eval_row.id, &case.public_id.to_string())
+        .await
+        .expect("load case")
+        .expect("case exists");
+
+    let principal = server
+        .db
+        .create_principal(CreatePrincipalRow {
+            id: everruns_core::PrincipalId::new(),
+            org_id: TEST_ORG_ID,
+            kind: "system".to_string(),
+            subject_id: Some(Uuid::now_v7()),
+            parent_principal_id: None,
+            resolved_user_id: None,
+            metadata: json!({ "source": "modelview_test" }),
+        })
+        .await
+        .expect("create principal");
+    let session = server
+        .db
+        .create_session(CreateSessionRow {
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: principal.id,
+            resolved_owner_user_id: None,
+            title: Some("Eval: case-mv".to_string()),
+            locale: None,
+            tags: vec!["eval".to_string()],
+            model_id: None,
+            capabilities: json!([]),
+            tools: json!([]),
+            mcp_servers: json!({}),
+            system_prompt: None,
+            initial_files: json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            workspace_id: None,
+        })
+        .await
+        .expect("create session");
+    let session_id: SessionId = session.id;
+
+    // Seed the session's event log; `retriever.load` reconstructs the messages
+    // from these, and cost-control compaction then masks the older tool results.
+    let mut seeded: Vec<serde_json::Value> =
+        vec![serde_json::to_value(InputMessageData::new(Message::user("start"))).unwrap()];
+    let mut event_types: Vec<&str> = vec!["input.message"];
+    for i in 0..n {
+        let call = ToolCall {
+            id: format!("call_{i}"),
+            name: "fetch".to_string(),
+            arguments: json!({ "n": i }),
+        };
+        seeded.push(
+            serde_json::to_value(OutputMessageCompletedData::new(
+                Message::assistant_with_tools(format!("iter {i}"), vec![call]),
+            ))
+            .unwrap(),
+        );
+        event_types.push("output.message.completed");
+        seeded.push(
+            serde_json::to_value(ToolCompletedData::success(
+                format!("call_{i}"),
+                "fetch".to_string(),
+                vec![ContentPart::text(format!("BULKY_RESULT_{i}"))],
+                Some(1),
+            ))
+            .unwrap(),
+        );
+        event_types.push("tool.completed");
+    }
+    for (event_type, data) in event_types.into_iter().zip(seeded) {
+        server
+            .db
+            .create_event(CreateEventRow {
+                session_id,
+                event_type: event_type.to_string(),
+                ts: chrono::Utc::now(),
+                context: json!({}),
+                data,
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .expect("seed event");
+    }
+
+    let run_public_id = EvalRunId::from_uuid(Uuid::now_v7()).to_string();
+    let run_row = server
+        .db
+        .create_eval_run(
+            TEST_ORG_ID,
+            CreateEvalRunRow {
+                public_id: run_public_id.clone(),
+                eval_id: eval_row.id,
+                target: None,
+                model_override: None,
+                filter_tags: None,
+                triggered_by: "test".to_string(),
+            },
+        )
+        .await
+        .expect("create run");
+    let target = json!({ "type": "session", "harness_id": TEST_HARNESS_ID });
+    let result = server
+        .db
+        .create_eval_case_result(CreateEvalCaseResultRow {
+            public_id: EvalResultId::from_uuid(Uuid::now_v7()).to_string(),
+            eval_run_id: run_row.id,
+            eval_case_id: case_row.id,
+            target: Some(target.clone()),
+            target_snapshot: Some(target),
+            artifacts: None,
+        })
+        .await
+        .expect("create result");
+    server
+        .db
+        .update_eval_case_result(
+            result.id,
+            UpdateEvalCaseResultRow {
+                status: Some("passed".to_string()),
+                session_id: Some(session_id.uuid()),
+                scores: Some(json!([{ "pass": true, "value": 1.0, "reason": "ok" }])),
+                turns: Some(1),
+                latency_ms: Some(100),
+                input_tokens: Some(10),
+                output_tokens: Some(20),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed result");
+    server
+        .db
+        .update_eval_run_status(run_row.id, "completed", Some(json!({ "total": 1 })))
+        .await
+        .expect("complete run");
+
+    (eval.public_id.to_string(), run_public_id, session_id)
+}
+
+/// The ATIF **dataset** export folds the compaction model view, so tool results
+/// the model no longer saw (masked by cost-control compaction) are absent from
+/// the training rows — while the raw session export (a debug surface) still
+/// carries them. This contrast is the whole point of model-view faithfulness.
+#[tokio::test]
+async fn test_dataset_export_atif_uses_model_view_not_raw_log() {
+    use everruns_server::domains::evals::dataset::DatasetFormat;
+
+    let server = TestServer::in_memory().await;
+    // Five tool iterations: default cost-control masking keeps the two most
+    // recent tool results and masks the three oldest.
+    let (eval_id, run_id, session_id) = seed_run_with_tool_iterations(&server, 5).await;
+    let service = EvalService::new(server.db.clone());
+    let caller = Caller::internal(TEST_ORG_ID);
+
+    let handle = service
+        .create_dataset_export(
+            &caller,
+            &eval_id,
+            &run_id,
+            ExportEvalRunDatasetRequest {
+                format: DatasetFormat::Atif,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("enqueue export")
+        .expect("run exists");
+    let done = await_dataset(
+        &service,
+        &caller,
+        &eval_id,
+        &run_id,
+        &handle.public_id.to_string(),
+    )
+    .await;
+    assert_eq!(done.status, EvalDatasetStatus::Completed);
+    let dataset_body = done.body.expect("completed dataset has body");
+
+    // Model view: the three oldest tool results are masked out; the two most
+    // recent survive.
+    for i in 0..3 {
+        assert!(
+            !dataset_body.contains(&format!("BULKY_RESULT_{i}")),
+            "masked tool result {i} must be absent from the ATIF dataset row",
+        );
+    }
+    for i in 3..5 {
+        assert!(
+            dataset_body.contains(&format!("BULKY_RESULT_{i}")),
+            "recent tool result {i} must be present in the ATIF dataset row",
+        );
+    }
+
+    // Contrast: the raw session ATIF export (event-log fold) still carries every
+    // result — it is a debug/backup surface, not training data.
+    let raw = server
+        .get(&format!("/v1/sessions/{}/export?format=atif", session_id))
+        .await
+        .assert_status(StatusCode::OK);
+    let raw_body = raw.text();
+    for i in 0..5 {
+        assert!(
+            raw_body.contains(&format!("BULKY_RESULT_{i}")),
+            "raw session export must carry every tool result (missing {i})",
+        );
+    }
+}
+
 #[tokio::test]
 async fn test_atif_import_creates_and_updates_cases_idempotently() {
     let server = TestServer::in_memory().await;

--- a/specs/atif-adoption.md
+++ b/specs/atif-adoption.md
@@ -61,9 +61,12 @@ the existing dataset formats), plus case identity (`source_key`, `eval_run_id`,
   default `jsonl`).
 - **Dataset export** (✅ shipped): `format: "atif"` on the eval dataset
   export produces NDJSON with one complete ATIF trajectory per case (see
-  `specs/dataset-export.md`). Unlike the message-based formats, ATIF folds the
-  raw event log (per-iteration steps and observations), not the compaction
-  model view. Same policy gate, filters, and redaction controls.
+  `specs/dataset-export.md`). Like the other dataset formats, ATIF folds the
+  **model-view messages** (post-compaction masking), so training rows never
+  contain content the model did not read; it carries no per-step token metrics
+  (messages lack per-step usage). This differs from the whole-session export
+  below, which folds the raw event log. Same policy gate, filters, and
+  redaction controls.
 - **Import** (✅ shipped): `POST /v1/evals/{eval_id}/atif_import` accepts
   NDJSON or JSON (array, single object, or `{ "trajectories": [...] }`) and
   upserts eval cases: user steps → the case `conversation` (multi-turn

--- a/specs/dataset-export.md
+++ b/specs/dataset-export.md
@@ -95,11 +95,15 @@ synchronous.
   `{ source_key, eval_run_id, case_id, case_name, session_id, reward: { pass, score, scorers: [{name, value, pass, reason}] }, messages: [...model-view messages...], metadata: { model, turns, input_tokens, output_tokens, latency_ms } }`
 - `sft`: `{ source_key, messages: [{role, content}], reward: { pass, score, scorers } }` — chat-message shape loadable by common SFT pipelines, with reward in a sidecar field so verifiable-reward filtering happens before training.
 - `atif`: one complete ATIF-v1.7 trajectory object per line, folded from the
-  case session's **event log** (per-iteration agent steps, tool observations,
-  per-step metrics — not the model-view messages), with reward and case
-  identity in root `extra` (`extra.reward = { pass, score, scorers }`,
-  `extra.source_key`, ...). Same policy gate, filters, scrubbing, and
-  redaction as the other formats. See `specs/atif-adoption.md`.
+  case session's **model-view messages** (the same post-compaction masking as
+  the other dataset formats), with reward and case identity in root `extra`
+  (`extra.reward = { pass, score, scorers }`, `extra.source_key`, ...). Because
+  it folds the model view rather than the raw event log, ATIF rows carry no
+  per-step token metrics or turn roll-up (messages lack per-step usage);
+  case-level token totals appear in `final_metrics`. Same policy gate, filters,
+  scrubbing, and redaction as the other formats. See `specs/atif-adoption.md`.
+  (The whole-session export, `?format=atif`, still folds the raw event log — it
+  is a debug/backup surface, not training data.)
 
 Scorer identities are not persisted on the result (only the ordered
 `Vec<Score>`), but the runner emits exactly one score per scorer in definition


### PR DESCRIPTION
## What changed
The eval dataset export's `format: "atif"` now folds the **compaction model view** (post-masking messages) instead of the raw session event log. Training rows therefore reflect what the model actually saw: tool results that compaction masked or dropped no longer appear in the ATIF steps, matching the faithfulness the `trajectory` and `sft` dataset formats already guarantee.

A new messages→ATIF fold (`build_case_record_from_messages`) mirrors the event fold's step shape — user/agent steps, `tool_calls`, `reasoning_content`, `observation.results[]`, and `subagent_trajectory_ref` — but over the reconstructed, model-view `Vec<Message>`. Because model-view messages carry no per-step token usage or turn boundaries, steps have no `metrics` and the document has no `extra.turns`; case-level token totals from the result surface in `final_metrics` instead. Reward-in-`extra`, `source_key`, filters, scrubbing, redaction, and the `DATASET_EXPORT` gate are all unchanged.

**Scope:** only the eval dataset ATIF path changes. The whole-session export (`?format=atif`) still folds the raw event log — it is a debug/backup surface, not training data, so it is deliberately left as-is.

## Why
`specs/dataset-export.md` requires exported trajectories to be the model view (what the model read post-compaction) — the whole point of faithful SFT/RL training data. The ATIF path was the one format still folding the lossless event log, so ATIF training rows could contain content the model never actually read. This closes that gap.

## Before / After
Session with 5 tool-call/result iterations; default cost-control compaction masks the 3 oldest tool results and keeps the 2 most recent.

- **Before:** ATIF dataset rows folded the event log → all 5 raw tool-result payloads present, including the 3 the model no longer saw.
- **After:** ATIF dataset rows fold the model view → the 3 masked payloads are absent (replaced by the compaction summary); the 2 recent survive. The raw `?format=atif` session export still carries all 5 (debug surface).

Evidence (new tests):
- `atif::tests::message_fold_reflects_model_view_masking` — deterministic unit contrast: unmasked fold keeps every distinctive result; folding `build_model_view_messages(...)` output drops the 3 masked ones.
- `atif::tests::message_fold_maps_roles_to_steps` — role→step mapping, tool calls, reasoning, observation, case-level `final_metrics`, no per-step `metrics`.
- `atif::tests::message_fold_redacts_and_links_subagents` — redaction blanks content, secret scrubbing applies, subagent ref preserved.
- `evals_integration_test::test_dataset_export_atif_uses_model_view_not_raw_log` — end-to-end through the real dataset-export service: masked payloads absent from the ATIF dataset row while the raw session ATIF export carries all of them.

All pass. The existing `test_dataset_export_atif_format_produces_atif_trajectories` still passes (simple sessions fold identically).

## Risk
- Low
- ATIF dataset rows now omit per-step token `metrics` and `extra.turns` (model-view messages lack per-step usage); case-level totals are in `final_metrics`. This is inherent to folding the model view and matches the `trajectory`/`sft` formats. The whole-session export is unchanged.

## Security
- Threat categories reviewed: TM-OBS, TM-TENANT.
- Findings and resolutions: no change to the trust boundary. The export stays org-scoped through `get_run`, behind the `DATASET_EXPORT` gate, with always-on secret scrubbing and the same `redact_content` control (now applied structurally in the message fold, then scrubbed). Moving from the event log to the model view can only *reduce* exposed content (masked tool results are dropped), never widen it.

## Follow-ups
- Honor the exact per-run compaction config for model-view reconstruction (resolving the run's harness/agent/session capability chain, which the export path does not plumb). The default `CompactionConfig` is used until then — this is the pre-existing dataset-export follow-up and now applies to ATIF too. No new follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)