### PR TITLE
fix(test): stop spawn_agent llmsim proof double-spawning a subagent

### DIFF
--- a/crates/local/tests/spawn_agent_runtime_test.rs
+++ b/crates/local/tests/spawn_agent_runtime_test.rs
@@ -392,21 +392,15 @@ async fn spawn_agent_dispatches_subagent_and_handoff_via_llmsim() {
         "child transcript should contain its marker: {child_reply}"
     );
 
-    // The background subagent completion queues a wake for the parent. Drain it
-    // before the handoff prompt so the content-keyed llmsim sees the handoff
-    // request as the latest user-authored instruction.
-    let drain = runtime
-        .run_text_turn(
-            parent_session_id,
-            "Acknowledge the completed subagent update.",
-        )
-        .await
-        .expect("parent wake-drain turn runs");
-    assert!(
-        drain.success,
-        "parent wake-drain turn failed: {:?}",
-        drain.error
-    );
+    // The background subagent completion queues a wake for the parent; the
+    // runtime injects it as a user message on the next turn's first reason
+    // iteration. We deliberately do NOT drain it with an intermediate turn: any
+    // parent turn whose own prompt matches no llmsim pattern would walk the
+    // newest-first scan back to the still-present TRIGGER_SUBAGENT message and
+    // spawn a *second* subagent (the wake text itself matches nothing). The
+    // handoff turn below is safe precisely because its newer TRIGGER_HANDOFF
+    // message wins the newest-first scan, so the stale subagent trigger is never
+    // reached and the pending wake is absorbed harmlessly.
 
     // ---- Target 2: agent handoff (foreground) ------------------------------
     let turn = runtime


### PR DESCRIPTION
## What changed
The in-process `spawn_agent` runtime proof (`spawn_agent_dispatches_subagent_and_handoff_via_llmsim`) no longer fires a spurious second subagent spawn. The intermediate "wake-drain" parent turn is removed; the subagent-kind task count now stays at exactly 1 across the whole test. No production code changes — this is a test-choreography fix.

## Why
The test failed **100% of the time** (0/40 local runs) at the assertion `the handoff must not be recorded under the subagent kind` (`left: 2, right: 1`).

Root cause: the llmsim `Conditional` matcher scans the **entire** user-message history newest-first and fires the first matching pattern (`crates/core/src/llmsim_driver.rs:471-483`). The first parent turn's `DELEGATE_TO_SUBAGENT` prompt stays in history. The intermediate wake-drain turn's prompt (`"Acknowledge the completed subagent update."`) matches no pattern, so the newest-first scan walked back to that stale trigger and spawned a **second** subagent. `max_iterations(2)` doesn't help — it bounds spawns within a single turn, but the drain turn is a separate turn re-firing the trigger.

The drain turn was never necessary: the background completion's wake is injected as a non-matching user message, and the handoff turn's own newer `DELEGATE_TO_HANDOFF` message wins the newest-first scan — so the stale trigger is never reached and the pending wake is absorbed harmlessly.

## Before / After
- **Before:** `spawn_agent_dispatches_subagent_and_handoff_via_llmsim` → `FAILED ... left: 2, right: 1` on every run (0/40 passed).
- **After:** 160/160 runs pass (60× `--test-threads=1` + 100× default multi-thread scheduling). `cargo fmt --check` and `cargo clippy -p everruns-local --tests` clean.

## Risk
- Low
- Test-only change in `crates/local/tests/`. No runtime/production code touched; no change to `spawn_agent` behavior. Worst case is reduced coverage of the (unnecessary) drain path, which never exercised production logic the handoff turn doesn't already cover.

## Security
- Threat categories reviewed: No security-relevant code changes — the diff is confined to a single integration test's turn sequencing and comments.
- Findings and resolutions: None.

## Follow-ups
- The llmsim `Conditional` matcher's newest-first full-history scan has a latent footgun: any parent turn whose own prompt matches no pattern re-fires the most recent stale trigger. This is a deliberate design trade-off (documented at `crates/core/src/llmsim_driver.rs:462-470` to avoid wake-notifications masking a real trigger), not a bug to change here, but tests that reuse a session across multiple triggering turns must ensure each later turn carries its own newer matching prompt. Noting it so future llmsim-driven multi-turn tests don't reintroduce the same shape.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only; n/a)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FvLRyEooSVgq4x2urqCFM4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvLRyEooSVgq4x2urqCFM4)_