### PR TITLE
chore(release): prepare v0.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.7] - 2026-07-11
+
+### Highlights
+
+- **Real-time session tasks** — Task state transitions now wake a running session mid-turn on the durable path, deliver every transition, and support per-task webhook configs and structured task results over A2A + MCP (EVE-681) ([#2699](https://github.com/everruns/everruns/pull/2699), [#2691](https://github.com/everruns/everruns/pull/2691), [#2690](https://github.com/everruns/everruns/pull/2690), [#2681](https://github.com/everruns/everruns/pull/2681), [#2674](https://github.com/everruns/everruns/pull/2674)).
+- **Scoped agent & user memory** — Added scoped memory for agents and users.
+- **Composer model/effort menu** — Combined model and effort selection into one composer menu with recent models ([#2663](https://github.com/everruns/everruns/pull/2663)).
+- **Speed selector** — New LLM speed selector mapped to OpenAI's `service_tier` ([#2669](https://github.com/everruns/everruns/pull/2669)).
+- **Detached & handoff sessions** — Spawn detached peer sessions and invite handoff agents ([#2684](https://github.com/everruns/everruns/pull/2684), [#2655](https://github.com/everruns/everruns/pull/2655)).
+
+### What's Changed
+
+- feat(session-tasks): deliver task wakes mid-turn on the durable path (EVE-681) ([#2699](https://github.com/everruns/everruns/pull/2699)) by [@chaliy](https://github.com/chaliy)
+- fix(test): stop spawn_agent llmsim proof double-spawning a subagent ([#2700](https://github.com/everruns/everruns/pull/2700)) by [@chaliy](https://github.com/chaliy)
+- feat(session-tasks): surface root_session_id on task reads (EVE-681) ([#2690](https://github.com/everruns/everruns/pull/2690)) by [@chaliy](https://github.com/chaliy)
+- docs(api): use scanner-safe example for push-config secret ([#2696](https://github.com/everruns/everruns/pull/2696)) by [@chaliy](https://github.com/chaliy)
+- docs(mcp): reconcile tasks field names by [@chaliy](https://github.com/chaliy)
+- fix(duckduckgo): clarify instant-answer scope, add empty-result caveat ([#2689](https://github.com/everruns/everruns/pull/2689)) by [@chaliy](https://github.com/chaliy)
+- fix(core): make activate_skill missing-name error self-repairing ([#2694](https://github.com/everruns/everruns/pull/2694)) by [@chaliy](https://github.com/chaliy)
+- chore(process-issues): doubt issue text and reproduce before fixing ([#2695](https://github.com/everruns/everruns/pull/2695)) by [@chaliy](https://github.com/chaliy)
+- feat(export): export image content and link subagent trajectories in ATIF ([#2692](https://github.com/everruns/everruns/pull/2692)) by [@chaliy](https://github.com/chaliy)
+- test(delegation): in-process spawn_agent runtime proof via llmsim ([#2687](https://github.com/everruns/everruns/pull/2687)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): add detached peer session spawning ([#2684](https://github.com/everruns/everruns/pull/2684)) by [@chaliy](https://github.com/chaliy)
+- feat(runtime): mid-turn task wake delivery — EVE-681 (part A) ([#2691](https://github.com/everruns/everruns/pull/2691)) by [@chaliy](https://github.com/chaliy)
+- fix(durable): make workflow start idempotent ([#2688](https://github.com/everruns/everruns/pull/2688)) by [@chaliy](https://github.com/chaliy)
+- feat(core): embeddable in-process task transition observer (EVE-729) ([#2686](https://github.com/everruns/everruns/pull/2686)) by [@chaliy](https://github.com/chaliy)
+- test(cli): wait for harness seed before agent e2e ([#2685](https://github.com/everruns/everruns/pull/2685)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): bound message history reads ([#2682](https://github.com/everruns/everruns/pull/2682)) by [@chaliy](https://github.com/chaliy)
+- feat(api): surface structured task result via A2A + MCP ([#2681](https://github.com/everruns/everruns/pull/2681)) by [@chaliy](https://github.com/chaliy)
+- fix(reporting): optimize fact_session projection for large histories ([#2680](https://github.com/everruns/everruns/pull/2680)) by [@chaliy](https://github.com/chaliy)
+- test(memory): expect scoped memory in workflow fs test ([#2679](https://github.com/everruns/everruns/pull/2679)) by [@chaliy](https://github.com/chaliy)
+- feat(cli): typed --harness flag on agents create/update (EVE-693) by [@chaliy](https://github.com/chaliy)
+- feat(memory): add scoped agent and user memory by [@chaliy](https://github.com/chaliy)
+- feat(session-tasks): per-task webhook configs + all-transition delivery ([#2674](https://github.com/everruns/everruns/pull/2674)) by [@chaliy](https://github.com/chaliy)
+- test(catalog): refresh agent MCP and app cases ([#2677](https://github.com/everruns/everruns/pull/2677)) by [@chaliy](https://github.com/chaliy)
+- test(sessions): refresh API contract cases ([#2676](https://github.com/everruns/everruns/pull/2676)) by [@chaliy](https://github.com/chaliy)
+- fix(fs): present persisted output paths via file store ([#2673](https://github.com/everruns/everruns/pull/2673)) by [@chaliy](https://github.com/chaliy)
+- fix(signup): show inline password-policy error instead of native block ([#2672](https://github.com/everruns/everruns/pull/2672)) by [@chaliy](https://github.com/chaliy)
+- fix(subagents): rename interim tool to report_task_progress ([#2671](https://github.com/everruns/everruns/pull/2671)) by [@chaliy](https://github.com/chaliy)
+- feat(llm): add speed selector mapped to OpenAI service_tier ([#2669](https://github.com/everruns/everruns/pull/2669)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): return fresh user name after profile updates ([#2668](https://github.com/everruns/everruns/pull/2668)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): combined model/effort composer menu with recent models ([#2663](https://github.com/everruns/everruns/pull/2663)) by [@chaliy](https://github.com/chaliy)
+- fix(fs): preserve primary mount path identity ([#2666](https://github.com/everruns/everruns/pull/2666)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp-ui): edit MCP server name, description, and URL ([#2670](https://github.com/everruns/everruns/pull/2670)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): honor GitHub-reported email_verified in OAuth ([#2656](https://github.com/everruns/everruns/pull/2656)) by [@chaliy](https://github.com/chaliy)
+- fix(core): strip echoed [time] annotations from assistant replies ([#2657](https://github.com/everruns/everruns/pull/2657)) by [@chaliy](https://github.com/chaliy)
+- fix(members-ui): hide owner-only controls from org admins, show errors ([#2667](https://github.com/everruns/everruns/pull/2667)) by [@chaliy](https://github.com/chaliy)
+- docs(skills): require PR template structure by [@chaliy](https://github.com/chaliy)
+- fix(test-cases): align TC010 disabled-chat copy with Platform Chat rebrand ([#2658](https://github.com/everruns/everruns/pull/2658)) by [@chaliy](https://github.com/chaliy)
+- chore(policy): allow yolop attribution by [@chaliy](https://github.com/chaliy)
+- fix(auth): normalize user email to case-insensitive identity ([#2661](https://github.com/everruns/everruns/pull/2661)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): derive JWT platform roles from database ([#2659](https://github.com/everruns/everruns/pull/2659)) by [@chaliy](https://github.com/chaliy)
+- docs(skills): clarify issue processing workflow by [@chaliy](https://github.com/chaliy)
+- feat(sessions): invite handoff agents ([#2655](https://github.com/everruns/everruns/pull/2655)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): preserve invite return_to through signup ([#2654](https://github.com/everruns/everruns/pull/2654)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): derive rate-limit client IP from trusted proxy hops, not leftmost XFF ([#2652](https://github.com/everruns/everruns/pull/2652)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): reject unsupported personal access token scopes at creation ([#2651](https://github.com/everruns/everruns/pull/2651)) by [@chaliy](https://github.com/chaliy)
+- fix(auth-ui): refetch current user after email verification ([#2653](https://github.com/everruns/everruns/pull/2653)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): settle session to idle when a turn is cancelled ([#2650](https://github.com/everruns/everruns/pull/2650)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): reject harnesses requiring unavailable capabilities ([#2649](https://github.com/everruns/everruns/pull/2649)) by [@chaliy](https://github.com/chaliy)
+- chore(skills): remove agent-browser skill ([#2648](https://github.com/everruns/everruns/pull/2648)) by [@chaliy](https://github.com/chaliy)
+- chore(cursor): remove cloud agent environment config ([#2642](https://github.com/everruns/everruns/pull/2642)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.6] - 2026-07-10
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,9 +428,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -464,15 +464,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.135.0"
+version = "1.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74b780f2f36912bae71b4f4f8ed9a0a88832b4681a1add3caf5ca25dbc8ab2d"
+checksum = "cf9484190cd923402dcc480aa92a582e3c370312d35d5d9564bbcdbbb5b69f8f"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -500,11 +500,12 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
- "aws-smithy-observability 0.2.6",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -518,13 +519,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -552,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.21"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -563,32 +564,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -630,22 +610,13 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.1.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
-dependencies = [
- "aws-smithy-runtime-api",
 ]
 
 [[package]]
@@ -664,11 +635,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.64.0",
+ "aws-smithy-http",
  "aws-smithy-http-client",
- "aws-smithy-observability 0.3.0",
+ "aws-smithy-observability",
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.2.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -714,17 +685,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "http 1.4.2",
-]
-
-[[package]]
-name = "aws-smithy-schema"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
@@ -762,14 +722,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.1.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1160,9 +1120,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -1178,9 +1138,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1206,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2470,11 +2430,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.6"
+version = "0.17.7"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2491,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2508,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2562,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2582,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2640,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2665,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2680,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2695,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2712,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2728,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2749,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2764,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2781,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2804,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2819,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2834,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2861,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2878,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2891,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2907,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2925,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2949,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2969,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2985,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2999,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3017,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3037,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3052,11 +3012,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.6"
+version = "0.17.7"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3096,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3193,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3210,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3226,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4345,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4480,9 +4440,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
  "bitflags 2.13.0",
  "inotify-sys",
@@ -4654,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -4670,9 +4630,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4681,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -5080,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5149,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -6403,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
 dependencies = [
  "logos 0.16.1",
  "miette",
@@ -6955,9 +6915,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6967,9 +6927,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7672,9 +7632,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -8279,9 +8239,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.5"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -8478,9 +8438,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -8538,9 +8498,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -9010,7 +8970,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "thiserror 2.0.18",
 ]
 
@@ -9979,18 +9939,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10087,9 +10047,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.6"
+version = "0.17.7"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -149,11 +149,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.6" }
+everruns-core = { path = "crates/core", version = "0.17.7" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.6" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.7" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.6" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.7" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.6", default-features = false }
+everruns-core = { path = "../core", version = "0.17.7", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.6", default-features = false }
+everruns-core = { path = "../core", version = "0.17.7", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.6", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.7", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.6", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.7", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.6", default-features = false }
+everruns-core = { path = "../core", version = "0.17.7", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.6", default-features = false }
+everruns-core = { path = "../core", version = "0.17.7", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.6", default-features = false }
+everruns-core = { path = "../core", version = "0.17.7", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What changed

Prepares the **v0.17.7** patch release (from v0.17.6). Bumps the workspace version, UI package version, and path-dependency publish pins to `0.17.7`; regenerates `Cargo.lock`; and adds the `0.17.7` CHANGELOG section covering 50 commits since v0.17.6.

Notable user-facing changes in this release:
- Real-time session tasks: mid-turn task wake delivery on the durable path, all-transition delivery, per-task webhook configs, and structured task results over A2A + MCP (EVE-681).
- Scoped agent & user memory.
- Combined model/effort composer menu with recent models.
- LLM speed selector mapped to OpenAI `service_tier`.
- Detached peer session spawning and handoff-agent invites.
- Numerous auth hardening fixes (case-insensitive email identity, DB-derived JWT roles, trusted-proxy client IP, PAT scope validation, OAuth `email_verified`).

## Why

Cut a patch release so the accumulated changes on `main` since v0.17.6 are tagged, published, and adoptable downstream (SaaS).

## Before / After

Version bump only; no runtime behavior change from this PR itself.

```
Cargo.toml workspace.package.version: 0.17.6 → 0.17.7
apps/ui/package.json version:         0.17.6 → 0.17.7
path-dep publish pins:                synced to 0.17.7 (sync-publish-pin-versions.py --check ✓)
migrations:                           sequential (001..103) ✓
```

## Risk
- Low
- Release-metadata only. On merge, the auto-tag workflow creates `v0.17.7` and dispatches Docker / CLI binaries / crates.io / Homebrew publishing.

## Security
- Threat categories reviewed: No security-relevant code changes in this PR (version/changelog/lockfile only).
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Post-merge
After merging, the release workflow automatically creates git tag `v0.17.7`, the GitHub Release from CHANGELOG.md, and dispatches Docker image, CLI binary, crates.io, and Homebrew publishing.

## Checklist
- [x] Tests added or updated (n/a — release metadata)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J29TEuEoLjFD69MSpPBvC6)_