### PR TITLE
fix(llm): retry structured in-band provider errors

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1017,10 +1017,9 @@ impl ChatDriver for AnthropicChatDriver {
                                     phase: None,
                                 })))
                             }
-                            "error" => Ok(LlmStreamEvent::Error(format!(
-                                "Anthropic stream error: {}",
-                                event.data
-                            ))),
+                            "error" => Ok(LlmStreamEvent::Error(
+                                format!("Anthropic stream error: {}", event.data).into(),
+                            )),
                             "ping" => {
                                 // Keep-alive ping, ignore
                                 Ok(LlmStreamEvent::TextDelta(String::new()))
@@ -1031,7 +1030,9 @@ impl ChatDriver for AnthropicChatDriver {
                             }
                         }
                     }
-                    Err(e) => Ok(LlmStreamEvent::Error(format!("Stream error: {}", e))),
+                    Err(e) => Ok(LlmStreamEvent::Error(
+                        format!("Stream error: {}", e).into(),
+                    )),
                 }
             }
         }));

--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -88,7 +88,7 @@ fn golden(event: LlmStreamEvent) -> Golden {
                 finish: finish_reason,
             }
         }
-        LlmStreamEvent::Error(e) => Golden::Error(e),
+        LlmStreamEvent::Error(e) => Golden::Error(e.to_string()),
         other => panic!("unexpected event variant in golden capture: {other:?}"),
     }
 }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -41,7 +41,9 @@ use crate::events::{
     ReasonThinkingStartedData, RecoveryMode, TokenUsage, ToolDefinitionSummary,
     TranscriptRepairAction, TranscriptRepairedData,
 };
-use crate::llm_retry::is_transient_error_message;
+use crate::llm_retry::{
+    LlmRetryConfig, RetryMetadata, is_transient_error_message, is_transient_stream_error,
+};
 use crate::message::{Message, MessageRole};
 use crate::message_retriever::MessageRetriever;
 use crate::openresponses_protocol::{
@@ -353,6 +355,32 @@ fn stream_event_advances_stall_deadline(event: &LlmStreamEvent) -> bool {
         | LlmStreamEvent::Done(_)
         | LlmStreamEvent::Error(_) => false,
     }
+}
+
+fn should_retry_stream_error(
+    error: &crate::driver_registry::LlmStreamError,
+    retry_attempts: u32,
+    max_retries: u32,
+    has_output: bool,
+) -> bool {
+    retry_attempts < max_retries && !has_output && is_transient_stream_error(error)
+}
+
+fn merge_retry_metadata(
+    existing: Option<RetryMetadata>,
+    additional: &RetryMetadata,
+) -> Option<RetryMetadata> {
+    if !additional.had_retries() {
+        return existing;
+    }
+
+    let mut merged = existing.unwrap_or_default();
+    merged.attempts += additional.attempts;
+    merged.total_retry_wait += additional.total_retry_wait;
+    if additional.last_rate_limit_info.is_some() {
+        merged.last_rate_limit_info = additional.last_rate_limit_info.clone();
+    }
+    Some(merged)
 }
 
 fn unix_now_secs() -> u64 {
@@ -1095,7 +1123,8 @@ impl ReasonAtom {
                 // retry attempt causes duplicate error messages in the UI.
                 // The durable worker emits a single error event when all retries
                 // are exhausted (DLQ).
-                let is_transient = is_transient_error_message(&error_msg);
+                let is_transient = e.is_transient_llm_error()
+                    || (e.llm_error_kind().is_none() && is_transient_error_message(&error_msg));
                 let mut output_message_id = None;
 
                 if !is_transient {
@@ -1804,6 +1833,8 @@ impl ReasonAtom {
         // 14. Process stream with batched output.message.delta emissions
         // Batch deltas every 100ms to reduce event volume while providing real-time feedback
         const DELTA_BATCH_INTERVAL_MS: u64 = 100;
+        let retry_config = LlmRetryConfig::default();
+        let mut stream_retry_metadata = RetryMetadata::default();
         let (
             text,
             thinking,
@@ -1812,7 +1843,7 @@ impl ReasonAtom {
             completion_metadata,
             time_to_first_token_ms,
             pending_delta,
-        ) = {
+        ) = 'stream_attempt: loop {
             let mut stream = match chat_driver
                 .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
                 .await
@@ -2189,6 +2220,7 @@ impl ReasonAtom {
             let mut thinking_signature: Option<String> = None;
             let mut tool_calls = Vec::new();
             let mut completion_metadata: Option<LlmCompletionMetadata> = None;
+            let mut stream_has_output = false;
             let mut pending_delta = String::new();
             let mut pending_thinking_delta = String::new();
             let mut last_delta_emit = Instant::now();
@@ -2254,6 +2286,7 @@ impl ReasonAtom {
                         if delta.is_empty() {
                             continue;
                         }
+                        stream_has_output = true;
                         // Track time-to-first-token on first non-empty delta
                         if time_to_first_token_ms.is_none() {
                             let ttft = llm_start.elapsed().as_millis() as u64;
@@ -2323,6 +2356,7 @@ impl ReasonAtom {
                         if delta.is_empty() {
                             continue;
                         }
+                        stream_has_output = true;
                         if let Some(t) = append_guarded_thinking_delta(
                             &mut armed_guardrails,
                             &mut thinking,
@@ -2374,6 +2408,7 @@ impl ReasonAtom {
                         }
                     }
                     LlmStreamEvent::ThinkingSignature(signature) => {
+                        stream_has_output = true;
                         // Capture the cryptographic signature for thinking content (required to send it back)
                         tracing::debug!(
                             session_id = %session_id,
@@ -2390,6 +2425,7 @@ impl ReasonAtom {
                         summary,
                         token_count,
                     } => {
+                        stream_has_output = true;
                         // Preserve the opaque artifact as the assistant message's
                         // thinking_signature so the next request can replay
                         // reasoning context, and emit a durable reason.item event
@@ -2430,6 +2466,7 @@ impl ReasonAtom {
                         }
                     }
                     LlmStreamEvent::ToolCalls(calls) => {
+                        stream_has_output |= !calls.is_empty();
                         tool_calls = calls;
                     }
                     LlmStreamEvent::Done(metadata) => {
@@ -2524,6 +2561,30 @@ impl ReasonAtom {
                             break;
                         }
 
+                        if should_retry_stream_error(
+                            &err,
+                            stream_retry_metadata.attempts,
+                            retry_config.max_retries,
+                            stream_has_output,
+                        ) {
+                            let wait_duration =
+                                retry_config.calculate_backoff(stream_retry_metadata.attempts);
+                            tracing::warn!(
+                                session_id = %session_id,
+                                turn_id = %context.turn_id,
+                                attempt = stream_retry_metadata.attempts + 1,
+                                max_retries = retry_config.max_retries,
+                                wait_secs = wait_duration.as_secs_f64(),
+                                error_code = err.code.as_deref().unwrap_or("none"),
+                                error_status = err.status,
+                                error = %err,
+                                "ReasonAtom: transient stream error before output, retrying"
+                            );
+                            stream_retry_metadata.record_retry(wait_duration, None);
+                            tokio::time::sleep(wait_duration).await;
+                            continue 'stream_attempt;
+                        }
+
                         // No useful output collected — treat as a real failure.
                         let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
                         let event_context = EventContext::from_atom_context(context).with_span(
@@ -2538,7 +2599,7 @@ impl ReasonAtom {
                             tools_summary,
                             runtime_agent.model.clone(),
                             Some(model_with_provider.provider_type.to_string()),
-                            err.clone(),
+                            err.to_string(),
                             Some(llm_duration_ms),
                             time_to_first_token_ms,
                         );
@@ -2550,7 +2611,7 @@ impl ReasonAtom {
                                 generation_data,
                             ))
                             .await;
-                        return Err(AgentLoopError::llm(err));
+                        return Err(AgentLoopError::llm_kind(err.kind(), err.to_string()));
                     }
                 }
                 // Per-event heartbeat after processing the event, so accumulated_len
@@ -2566,7 +2627,12 @@ impl ReasonAtom {
                     last_stream_heartbeat = Instant::now();
                 }
             }
-            (
+            if let Some(metadata) = completion_metadata.as_mut() {
+                metadata.retry_metadata =
+                    merge_retry_metadata(metadata.retry_metadata.take(), &stream_retry_metadata);
+            }
+
+            break 'stream_attempt (
                 text,
                 thinking,
                 thinking_signature,
@@ -2574,7 +2640,7 @@ impl ReasonAtom {
                 completion_metadata,
                 time_to_first_token_ms,
                 pending_delta,
-            )
+            );
         };
         let (mut text, mut thinking, thinking_signature, mut tool_calls) =
             (text, thinking, thinking_signature, tool_calls);

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -15,7 +15,7 @@
 // specific provider implementations.
 
 use crate::credential_schema::CredentialFormSchema;
-use crate::error::{AgentLoopError, Result};
+use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::openresponses_protocol::{CompactRequest, CompactResponse};
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::{ToolCall, ToolDefinition};
@@ -33,6 +33,82 @@ use std::sync::Arc;
 
 /// Type alias for the LLM response stream
 pub type LlmResponseStream = Pin<Box<dyn Stream<Item = Result<LlmStreamEvent>> + Send>>;
+
+/// Structured provider error emitted inside an accepted response stream.
+///
+/// Providers should preserve the wire error code and HTTP status when they are
+/// available. Runtime retry classification uses those fields before falling
+/// back to the human-readable message for legacy drivers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LlmStreamError {
+    /// Stable machine-readable provider error code, when supplied.
+    pub code: Option<String>,
+    /// HTTP status associated with the stream error, when supplied.
+    pub status: Option<u16>,
+    /// Human-readable diagnostic text.
+    pub message: String,
+}
+
+impl LlmStreamError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            code: None,
+            status: None,
+            message: message.into(),
+        }
+    }
+
+    /// Build a stream error while preserving provider-supplied structure.
+    pub fn provider(
+        code: Option<impl Into<String>>,
+        status: Option<u16>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.map(Into::into),
+            status,
+            message: message.into(),
+        }
+    }
+
+    /// Map the preserved structure to Everruns' semantic provider error kind.
+    pub fn kind(&self) -> LlmErrorKind {
+        if let Some(code) = self.code.as_deref()
+            && let Some(kind) = LlmErrorKind::from_provider_code(code)
+        {
+            return kind;
+        }
+        if let Some(status) = self.status {
+            return LlmErrorKind::from_provider_status(status, &self.message);
+        }
+        LlmErrorKind::from_error_text(&self.message)
+    }
+}
+
+impl std::error::Error for LlmStreamError {}
+
+impl std::fmt::Display for LlmStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.code, self.status) {
+            (Some(code), Some(status)) => write!(f, "{code} ({status}): {}", self.message),
+            (Some(code), None) => write!(f, "{code}: {}", self.message),
+            (None, Some(status)) => write!(f, "({status}): {}", self.message),
+            (None, None) => f.write_str(&self.message),
+        }
+    }
+}
+
+impl From<String> for LlmStreamError {
+    fn from(message: String) -> Self {
+        Self::new(message)
+    }
+}
+
+impl From<&str> for LlmStreamError {
+    fn from(message: &str) -> Self {
+        Self::new(message)
+    }
+}
 
 /// Events emitted during LLM streaming
 #[derive(Debug, Clone)]
@@ -68,7 +144,7 @@ pub enum LlmStreamEvent {
     /// Streaming completed
     Done(Box<LlmCompletionMetadata>),
     /// Error during streaming
-    Error(String),
+    Error(LlmStreamError),
 }
 
 /// Model information discovered from a provider's list_models API
@@ -213,7 +289,12 @@ pub trait ChatDriver: Send + Sync {
                 }
                 LlmStreamEvent::ToolCalls(calls) => tool_calls = calls,
                 LlmStreamEvent::Done(meta) => metadata = *meta,
-                LlmStreamEvent::Error(err) => return Err(crate::error::AgentLoopError::llm(err)),
+                LlmStreamEvent::Error(err) => {
+                    return Err(crate::error::AgentLoopError::llm_kind(
+                        err.kind(),
+                        err.to_string(),
+                    ));
+                }
             }
         }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -38,6 +38,29 @@ pub enum LlmErrorKind {
 }
 
 impl LlmErrorKind {
+    /// Classify a provider's stable machine-readable error code.
+    pub fn from_provider_code(code: &str) -> Option<Self> {
+        let code = code.trim().to_ascii_lowercase();
+        match code.as_str() {
+            "insufficient_quota" | "billing_hard_limit_reached" | "credit_balance_too_low" => {
+                Some(Self::QuotaExhausted)
+            }
+            "authentication_error" | "invalid_api_key" | "permission_denied" => {
+                Some(Self::Authentication)
+            }
+            "rate_limit_exceeded" | "rate_limit_error" | "overloaded_error" => {
+                Some(Self::RateLimited)
+            }
+            "server_error"
+            | "internal_error"
+            | "processing_error"
+            | "service_unavailable"
+            | "timeout" => Some(Self::Unavailable),
+            "invalid_request_error" | "model_not_found" => Some(Self::InvalidRequest),
+            _ => None,
+        }
+    }
+
     /// Classify a provider HTTP error from status code + response body.
     ///
     /// Quota/billing patterns are checked before the status code because
@@ -51,7 +74,9 @@ impl LlmErrorKind {
         match status {
             401 | 403 => LlmErrorKind::Authentication,
             429 => LlmErrorKind::RateLimited,
-            408 | 500..=599 => LlmErrorKind::Unavailable,
+            408 | 409 => LlmErrorKind::Unavailable,
+            501 => LlmErrorKind::Other,
+            500..=599 => LlmErrorKind::Unavailable,
             400..=499 => LlmErrorKind::InvalidRequest,
             _ => LlmErrorKind::Other,
         }
@@ -311,6 +336,23 @@ impl AgentLoopError {
                         || msg.contains("(529)")
                 }
                 _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    /// Check whether an LLM failure is safe to retry.
+    ///
+    /// Semantic driver classification is authoritative. Untyped legacy errors
+    /// retain the message-based fallback until all drivers preserve structure.
+    pub fn is_transient_llm_error(&self) -> bool {
+        match self {
+            AgentLoopError::Llm(err) => match err.kind {
+                LlmErrorKind::RateLimited | LlmErrorKind::Unavailable => true,
+                LlmErrorKind::Authentication
+                | LlmErrorKind::QuotaExhausted
+                | LlmErrorKind::InvalidRequest => false,
+                LlmErrorKind::Other => crate::llm_retry::is_transient_error_message(&err.message),
             },
             _ => false,
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -295,8 +295,8 @@ pub use driver_registry::{
     DriverFactory, DriverId, DriverOAuthConfig, DriverOAuthFlow, DriverRegistry, EmbedRequest,
     EmbedResponse, EmbeddingsDriver, EmbeddingsDriverError, EmbeddingsDriverFactory, LlmCallConfig,
     LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamEvent, ProviderConfig, ServiceKind,
-    fold_system_messages,
+    LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamError, LlmStreamEvent, ProviderConfig,
+    ServiceKind, fold_system_messages,
 };
 
 // LLM retry types re-exports

--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -433,6 +433,31 @@ pub fn is_transient_error_message(message: &str) -> bool {
     .any(|needle| msg.contains(needle))
 }
 
+/// Classify an in-band provider error using structured fields first.
+///
+/// Machine-readable provider codes are authoritative, followed by HTTP status.
+/// Message matching is retained only for legacy drivers that cannot preserve
+/// either field.
+pub fn is_transient_stream_error(error: &crate::driver_registry::LlmStreamError) -> bool {
+    if let Some(code) = error.code.as_deref()
+        && let Some(kind) = crate::error::LlmErrorKind::from_provider_code(code)
+    {
+        return matches!(
+            kind,
+            crate::error::LlmErrorKind::RateLimited | crate::error::LlmErrorKind::Unavailable
+        );
+    }
+
+    if let Some(status) = error
+        .status
+        .and_then(|status| reqwest::StatusCode::from_u16(status).ok())
+    {
+        return is_transient_error(status);
+    }
+
+    is_transient_error_message(&error.message)
+}
+
 // ============================================================================
 // Generic retry executor
 // ============================================================================
@@ -794,6 +819,32 @@ mod tests {
             "invalid_request_error: bad tool schema"
         ));
         assert!(!is_transient_error_message("Model not available: gpt-99"));
+    }
+
+    #[test]
+    fn structured_stream_error_prefers_code_and_status_over_message() {
+        use crate::driver_registry::LlmStreamError;
+
+        assert!(is_transient_stream_error(&LlmStreamError::provider(
+            Some("processing_error"),
+            None,
+            "An error occurred while processing your request.",
+        )));
+        assert!(is_transient_stream_error(&LlmStreamError::provider(
+            None::<String>,
+            Some(503),
+            "opaque failure",
+        )));
+        assert!(!is_transient_stream_error(&LlmStreamError::provider(
+            Some("invalid_request_error"),
+            Some(503),
+            "server unavailable",
+        )));
+        assert!(!is_transient_stream_error(&LlmStreamError::provider(
+            Some("insufficient_quota"),
+            Some(429),
+            "rate limit",
+        )));
     }
 
     #[test]

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -597,10 +597,9 @@ impl ChatDriver for OpenAIProtocolChatDriver {
                         let event = match result {
                             Ok(event) => event,
                             Err(e) => {
-                                return vec![Ok(LlmStreamEvent::Error(format!(
-                                    "Stream error: {}",
-                                    e
-                                )))];
+                                return vec![Ok(LlmStreamEvent::Error(
+                                    format!("Stream error: {}", e).into(),
+                                ))];
                             }
                         };
 
@@ -701,10 +700,9 @@ impl ChatDriver for OpenAIProtocolChatDriver {
                                 }
                                 vec![Ok(LlmStreamEvent::TextDelta(String::new()))]
                             }
-                            Err(e) => vec![Ok(LlmStreamEvent::Error(format!(
-                                "Failed to parse chunk: {}",
-                                e
-                            )))],
+                            Err(e) => vec![Ok(LlmStreamEvent::Error(
+                                format!("Failed to parse chunk: {}", e).into(),
+                            ))],
                         }
                     }
                 })

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -1408,12 +1408,14 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                                             raw_error = %json.get("error").unwrap_or(&json),
                                             "OpenResponsesDriver: received streaming error event (fallback parser)"
                                         );
-                                        let formatted = if error_code != "unknown" {
-                                            format!("{}: {}", error_code, error_msg)
-                                        } else {
-                                            error_msg.to_string()
-                                        };
-                                        Ok(LlmStreamEvent::Error(formatted))
+                                        Ok(LlmStreamEvent::Error(
+                                            crate::driver_registry::LlmStreamError::provider(
+                                                (error_code != "unknown")
+                                                    .then_some(error_code.to_string()),
+                                                None,
+                                                error_msg,
+                                            ),
+                                        ))
                                     }
 
                                     _ => {
@@ -1422,13 +1424,14 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                                     }
                                 }
                             }
-                            Err(e) => Ok(LlmStreamEvent::Error(format!(
-                                "Failed to parse event: {}",
-                                e
-                            ))),
+                            Err(e) => Ok(LlmStreamEvent::Error(
+                                format!("Failed to parse event: {}", e).into(),
+                            )),
                         }
                     }
-                    Err(e) => Ok(LlmStreamEvent::Error(format!("Stream error: {}", e))),
+                    Err(e) => Ok(LlmStreamEvent::Error(
+                        format!("Stream error: {}", e).into(),
+                    )),
                 }
             }
         }));
@@ -1667,22 +1670,39 @@ fn handle_streaming_event(
         }
 
         StreamingEvent::Error { error, .. } => {
-            let msg = if let Some(code) = &error.code {
-                format!("{}: {}", code, error.message)
-            } else {
-                error.message.clone()
-            };
             tracing::warn!(
                 error_code = error.code.as_deref().unwrap_or("none"),
                 error_message = %error.message,
                 "OpenResponsesDriver: received streaming error event from provider"
             );
-            LlmStreamEvent::Error(msg)
+            LlmStreamEvent::Error(crate::driver_registry::LlmStreamError::provider(
+                error.code,
+                None,
+                error.message,
+            ))
+        }
+
+        StreamingEvent::ResponseFailed { response, .. } => {
+            let error = response.error.unwrap_or(types::Error {
+                code: "processing_error".to_string(),
+                message: "The provider failed while processing the response".to_string(),
+            });
+            tracing::warn!(
+                response_id = %response.id,
+                error_code = %error.code,
+                error_message = %error.message,
+                "OpenResponsesDriver: response failed in stream"
+            );
+            LlmStreamEvent::Error(crate::driver_registry::LlmStreamError::provider(
+                Some(error.code),
+                None,
+                error.message,
+            ))
         }
 
         StreamingEvent::RefusalDelta { delta, .. } => {
             // Treat refusal as an error message
-            LlmStreamEvent::Error(format!("Model refused: {}", delta))
+            LlmStreamEvent::Error(format!("Model refused: {}", delta).into())
         }
 
         // All other events: emit empty delta to maintain stream continuity
@@ -3966,6 +3986,47 @@ mod tests {
             }
             other => panic!("Expected ReasonItem event, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn response_failed_preserves_provider_error_code() {
+        use std::sync::Mutex;
+
+        let event: StreamingEvent = serde_json::from_value(serde_json::json!({
+            "type": "response.failed",
+            "sequence_number": 7,
+            "response": {
+                "id": "resp_failed",
+                "object": "response",
+                "created_at": 1,
+                "status": "failed",
+                "model": "gpt-5",
+                "output": [],
+                "tools": [],
+                "error": {
+                    "code": "processing_error",
+                    "message": "An error occurred while processing your request."
+                }
+            }
+        }))
+        .expect("response.failed should deserialize");
+
+        let result = handle_streaming_event(
+            event,
+            &Mutex::new(0),
+            &Mutex::new(0),
+            &Mutex::new(None),
+            &Mutex::new(Vec::new()),
+            &Mutex::new(None),
+            "gpt-5".to_string(),
+            None,
+        );
+
+        let LlmStreamEvent::Error(error) = result else {
+            panic!("expected structured stream error");
+        };
+        assert_eq!(error.code.as_deref(), Some("processing_error"));
+        assert!(crate::llm_retry::is_transient_stream_error(&error));
     }
 
     #[test]

--- a/crates/core/tests/openai_protocol_wire.rs
+++ b/crates/core/tests/openai_protocol_wire.rs
@@ -80,7 +80,7 @@ fn golden(event: LlmStreamEvent) -> Golden {
                 finish: finish_reason,
             }
         }
-        LlmStreamEvent::Error(e) => Golden::Error(e),
+        LlmStreamEvent::Error(e) => Golden::Error(e.to_string()),
         other => panic!("unexpected event variant in golden capture: {other:?}"),
     }
 }

--- a/crates/core/tests/openresponses_protocol_wire.rs
+++ b/crates/core/tests/openresponses_protocol_wire.rs
@@ -82,7 +82,7 @@ fn golden(event: LlmStreamEvent) -> Golden {
                 finish: finish_reason,
             }
         }
-        LlmStreamEvent::Error(e) => Golden::Error(e),
+        LlmStreamEvent::Error(e) => Golden::Error(e.to_string()),
         other => panic!("unexpected event variant in golden capture: {other:?}"),
     }
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -209,9 +209,11 @@ impl everruns_core::ChatDriver for FlakyStreamDriver {
 
         if attempt == 0 {
             return Ok(Box::pin(stream::iter(vec![Ok(
-                everruns_core::LlmStreamEvent::Error(
-                    "server_error: transient upstream failure".to_string(),
-                ),
+                everruns_core::LlmStreamEvent::Error(everruns_core::LlmStreamError::provider(
+                    Some("processing_error"),
+                    None,
+                    "An error occurred while processing your request.",
+                )),
             )])));
         }
 
@@ -1029,10 +1031,7 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
 }
 
 #[tokio::test]
-async fn test_reason_atom_does_not_retry_transient_stream_error() {
-    // Stream-level errors are NOT retried at the atom level.
-    // Transient retries happen at the driver level (HTTP 429/5xx).
-    // The atom reports the error as a failure to avoid duplicate user-visible messages.
+async fn test_reason_atom_retries_structured_processing_error_before_output() {
     use everruns_core::in_memory::InMemoryEventEmitter;
 
     let (
@@ -1089,11 +1088,11 @@ async fn test_reason_atom_does_not_retry_transient_stream_error() {
         .expect("ReasonAtom should return Ok with failure result");
 
     assert!(
-        !result.success,
-        "Stream error should not be retried at atom level"
+        result.success,
+        "processing_error should receive a bounded retry"
     );
-    // Only one attempt — no retry
-    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(result.text, "Recovered after retry.");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
 
     let events = event_emitter.events().await;
     let llm_event = events
@@ -1102,7 +1101,13 @@ async fn test_reason_atom_does_not_retry_transient_stream_error() {
         .expect("llm.generation event should be emitted");
 
     if let everruns_core::EventData::LlmGeneration(data) = &llm_event.data {
-        assert!(!data.metadata.success, "Should report failure");
+        assert!(data.metadata.success, "retry should recover the generation");
+        let retry = data
+            .metadata
+            .retry
+            .as_ref()
+            .expect("retry metadata should be recorded");
+        assert_eq!(retry.attempts, 1);
     } else {
         panic!("Expected llm.generation event data");
     }
@@ -1490,7 +1495,7 @@ impl everruns_core::ChatDriver for ToolCallsThenErrorDriver {
             }])),
             // Trailing server error after valid output
             Ok(everruns_core::LlmStreamEvent::Error(
-                "server_error: An error occurred while processing your request.".to_string(),
+                "server_error: An error occurred while processing your request.".into(),
             )),
         ])))
     }
@@ -1579,7 +1584,7 @@ impl everruns_core::ChatDriver for TextThenErrorDriver {
                 "Here are the links:\n\n- Research Agent:".to_string(),
             )),
             Ok(everruns_core::LlmStreamEvent::Error(
-                "server_error: internal failure".to_string(),
+                "server_error: internal failure".into(),
             )),
         ])))
     }
@@ -1652,7 +1657,10 @@ async fn test_reason_atom_preserves_text_on_trailing_stream_error() {
 /// Driver that emits an error without any prior output (pure failure).
 /// This should still fail as before — no partial output to recover.
 #[derive(Clone, Debug)]
-struct PureErrorDriver;
+struct PureErrorDriver {
+    attempts: Arc<AtomicUsize>,
+    code: &'static str,
+}
 
 #[async_trait]
 impl everruns_core::ChatDriver for PureErrorDriver {
@@ -1661,14 +1669,19 @@ impl everruns_core::ChatDriver for PureErrorDriver {
         _messages: Vec<everruns_core::LlmMessage>,
         _config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
         Ok(Box::pin(stream::iter(vec![Ok(
-            everruns_core::LlmStreamEvent::Error("server_error: total failure".to_string()),
+            everruns_core::LlmStreamEvent::Error(everruns_core::LlmStreamError::provider(
+                Some(self.code),
+                None,
+                "An error occurred while processing your request.",
+            )),
         )])))
     }
 }
 
 #[tokio::test]
-async fn test_reason_atom_still_fails_on_pure_stream_error() {
+async fn test_reason_atom_exhausts_bounded_processing_error_retries() {
     use everruns_core::in_memory::InMemoryEventEmitter;
 
     let (
@@ -1686,8 +1699,15 @@ async fn test_reason_atom_still_fails_on_pure_stream_error() {
         .seed(session_id.into(), vec![Message::user("Hello!")])
         .await;
 
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_registry = Arc::clone(&attempts);
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(DriverId::LlmSim, |_config| Box::new(PureErrorDriver));
+    driver_registry.register(DriverId::LlmSim, move |_config| {
+        Box::new(PureErrorDriver {
+            attempts: Arc::clone(&attempts_for_registry),
+            code: "processing_error",
+        })
+    });
 
     let event_emitter = InMemoryEventEmitter::new();
 
@@ -1725,6 +1745,67 @@ async fn test_reason_atom_still_fails_on_pure_stream_error() {
     );
     assert!(result.error.is_some());
     assert!(!result.has_tool_calls);
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        3,
+        "initial call + 2 retries"
+    );
+}
+
+#[tokio::test]
+async fn test_reason_atom_does_not_retry_non_transient_provider_code() {
+    use everruns_core::in_memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Hello!")])
+        .await;
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_registry = Arc::clone(&attempts);
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(DriverId::LlmSim, move |_config| {
+        Box::new(PureErrorDriver {
+            attempts: Arc::clone(&attempts_for_registry),
+            code: "invalid_request_error",
+        })
+    });
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        InMemoryEventEmitter::new(),
+    );
+    let result = atom
+        .execute(ReasonInput {
+            context: create_context(session_id),
+            harness_id,
+            agent_id: Some(agent_id.into()),
+            org_id: 0,
+            mcp_tool_definitions: vec![],
+            previous_response_id: None,
+            iteration: 1,
+        })
+        .await
+        .expect("ReasonAtom should return a failure result");
+
+    assert!(!result.success);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }
 
 // ============================================================================

--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -69,7 +69,7 @@ async fn fireworks_chat_streams_response() {
                     meta.finish_reason, meta.prompt_tokens, meta.completion_tokens,
                 );
             }
-            LlmStreamEvent::Error(e) => error = Some(e),
+            LlmStreamEvent::Error(e) => error = Some(e.to_string()),
             _ => {}
         }
     }

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -688,7 +688,8 @@ impl ChatDriver for GeminiChatDriver {
                             buffer.push_str(&String::from_utf8_lossy(&bytes));
                         }
                         Some(Err(e)) => {
-                            let result = Ok(LlmStreamEvent::Error(format!("Stream error: {}", e)));
+                            let result =
+                                Ok(LlmStreamEvent::Error(format!("Stream error: {}", e).into()));
                             return Some((
                                 result,
                                 (

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -86,7 +86,7 @@ fn golden(event: LlmStreamEvent) -> Golden {
                 finish: finish_reason,
             }
         }
-        LlmStreamEvent::Error(e) => Golden::Error(e),
+        LlmStreamEvent::Error(e) => Golden::Error(e.to_string()),
         other => panic!("unexpected event variant in golden capture: {other:?}"),
     }
 }

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -77,7 +77,7 @@ async fn openrouter_chat_with_session_id_and_routing_succeeds() {
                     meta.provider_cost_usd,
                 );
             }
-            LlmStreamEvent::Error(e) => error = Some(e),
+            LlmStreamEvent::Error(e) => error = Some(e.to_string()),
             _ => {}
         }
     }

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -55,7 +55,7 @@ graph TD
 
 1. **Trait Definition**: See `crates/core/src/driver_registry.rs` for `ChatDriver` trait, `LlmStreamEvent`, `ProviderType`, and `LlmCallConfig`.
 
-2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error).
+2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error). In-band provider failures use `LlmStreamError` so stable provider code and HTTP status survive the driver boundary.
 
 3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `Bedrock` (AWS Bedrock ConverseStream), `Mai` (Microsoft MAI via Azure AI Foundry, OpenAI-compatible Chat Completions), `Fireworks` (Fireworks AI open models, OpenAI-compatible Chat Completions), `LlmSim` (testing).
 
@@ -578,7 +578,19 @@ The following HTTP status codes trigger automatic retry:
 - `429` - Too Many Requests (Rate Limited)
 - `5xx` - Server Errors (except 501 Not Implemented)
 
-In-band stream errors (provider errors inside an accepted SSE stream) are **not** retried at the atom level to avoid duplicate user-visible error messages. The driver-level HTTP retry handles transient failures before the stream is established.
+In-band stream errors inside an accepted response are retried only when all of
+the following hold:
+
+- no text, thinking, tool call, or completion output has been produced
+- the structured provider code or HTTP status classifies the error as transient
+- the bounded default retry budget has not been exhausted
+
+Provider code is authoritative, followed by HTTP status; message matching is a
+compatibility fallback for legacy drivers. `processing_error`, provider server
+errors, ordinary rate limits, and transient HTTP statuses receive bounded retry.
+Authentication, invalid-request, and exhausted billing/quota errors fail fast.
+Once output exists, the runtime preserves it as a partial success instead of
+replaying the generation and risking duplicate visible output.
 
 ### Rate Limit Header Support
 


### PR DESCRIPTION
## What changed
Structured in-band provider failures now preserve their machine-readable code and optional HTTP status through `LlmStreamError`. The runtime retries transient pre-output failures with the existing bounded retry policy, while preserving partial-output behavior and fail-fast handling for authentication, quota, and invalid requests. OpenAI Responses `response.failed` events now retain their provider error code.

Callers implementing `ChatDriver` must construct `LlmStreamEvent::Error(LlmStreamError)`; string errors can use `.into()`, while provider errors should use `LlmStreamError::provider(code, status, message)`.

## Why
An accepted Codex stream failed after roughly 61 seconds with provider code `processing_error`. A custom driver reduced it to a message string, and Everruns' message fallback did not recognize the generic text as transient, so the request failed without a bounded retry. HTTP retry cannot cover failures delivered after an SSE stream has been accepted.

## Before / After
Before: an in-stream `processing_error` with no model output produced a terminal `processing_error` after one provider call.

After: the same structured code retries before any output, succeeds if a later attempt completes, and stops after the configured two retries. Regression evidence also proves `invalid_request_error` is attempted once and partial output is never replayed.

## Risk
- Medium
- `LlmStreamEvent::Error` now carries `LlmStreamError`, so external `ChatDriver` implementations must update construction and string extraction.
- A narrow set of accepted streams may issue up to two additional provider requests. The retry is bounded and disabled after any output event.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions: no credential/auth changes or new dependencies; provider diagnostics retain the existing disclosure path; retries are capped at two, require a transient code/status/message classification, and cannot replay after provider output. Authentication, quota exhaustion, and invalid requests remain non-transient. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)