### PR TITLE
fix(tools): preserve requested output verbosity

### DIFF
--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -9,8 +9,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use everruns_core::ToolHints;
 use everruns_core::tool_output_sanitizer::{
     READ_FILE_DEFAULT_LIMIT, build_bytes_read_file_result, clean_exec_output,
-    output_verbosity_budget, parse_read_file_window_args, priority_aware_truncate,
-    resolve_auto_mode,
+    output_verbosity_budget, parse_read_file_window_args, resolve_auto_mode,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -292,7 +291,11 @@ impl Tool for SandboxExecTool {
         let effective_mode = resolve_auto_mode(output_mode, success_sentinel);
         let clean_output = clean_exec_output(&result.output);
         let output = if let Some(budget) = output_verbosity_budget(effective_mode) {
-            priority_aware_truncate(&clean_output, budget)
+            everruns_core::tool_output_sanitizer::truncate_exec_stream(
+                &clean_output,
+                budget,
+                success_sentinel,
+            )
         } else {
             clean_output.clone()
         };

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -16,9 +16,9 @@
 // - Runs as an always-on final hook before EVE-225 hard-limit truncation
 // - EVE-245: annotates truncated stdout with file reference so agent knows
 //   it can read_file the full output with offset/limit
-// - EVE-562: after persistence, compacts model-facing stdout/stderr so the
-//   LLM never receives unbounded inline output when full output is already
-//   in /outputs. Success → AUTO_SUCCESS_BUDGET; failure → NORMAL_BUDGET.
+// - EVE-562: after persistence, applies the requested output mode to
+//   model-facing stdout/stderr. Default auto mode uses a compact success
+//   window; explicit modes retain their fixed budgets.
 
 use std::sync::Arc;
 
@@ -27,7 +27,9 @@ use serde_json::json;
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 use crate::atoms::PostToolExecHook;
-use crate::tool_output_sanitizer::{AUTO_SUCCESS_BUDGET, NORMAL_BUDGET, priority_aware_truncate};
+use crate::tool_output_sanitizer::{
+    output_verbosity_budget, priority_aware_truncate, resolve_auto_mode, truncate_exec_stream,
+};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{SessionFileSystem, ToolContext};
 use crate::typed_id::SessionId;
@@ -154,9 +156,9 @@ pub fn annotate_truncated_output(truncated: &str, file_path: &str, full_size: us
 /// After successful persistence, compact the inline model-facing output fields
 /// in the result JSON so the LLM never carries unbounded content forward.
 ///
-/// Budget policy (EVE-562):
-/// - Success (`exit_code == 0` or `success == true`): `AUTO_SUCCESS_BUDGET` (≈384 B)
-/// - Failure: `NORMAL_BUDGET` (≈8 KiB diagnostic window)
+/// Budget policy (EVE-562): resolve the requested mode against the process
+/// outcome. Default `auto` uses the compact success window or normal failure
+/// window; explicit modes retain their documented fixed budgets.
 ///
 /// The same budget applies to both `stdout`/`output` and `stderr`. Full content
 /// is always recoverable from the persisted `/outputs/` files.
@@ -164,17 +166,16 @@ pub fn compact_persisted_result_for_model(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     stdout_path: &str,
     stdout_full_size: usize,
+    output_mode: &str,
 ) {
-    let budget = if is_success_result(obj) {
-        AUTO_SUCCESS_BUDGET
-    } else {
-        NORMAL_BUDGET
-    };
+    let exit_code = result_exit_code(obj);
+    let budget = output_verbosity_budget(resolve_auto_mode(output_mode, exit_code));
 
     // Compact stdout (or output fallback field) and append file pointer.
     for field in ["stdout", "output"] {
         if let Some(text) = obj.get(field).and_then(|v| v.as_str()) {
-            let compacted = compact_with_annotation(text, budget, stdout_path, stdout_full_size);
+            let compacted =
+                compact_with_annotation(text, budget, exit_code, stdout_path, stdout_full_size);
             obj.insert(field.to_string(), json!(compacted));
             break; // only one of stdout/output is expected
         }
@@ -184,13 +185,17 @@ pub fn compact_persisted_result_for_model(
     compact_stderr_inline(obj, budget);
 }
 
-/// Compact the inline `stderr` field to `budget` bytes using priority-aware truncation.
+/// Compact the inline `stderr` field to `budget` bytes using outcome-aware truncation.
 ///
 /// Called from `compact_persisted_result_for_model` and also directly when stderr was
 /// persisted but there is no stdout file (so `compact_persisted_result_for_model` was
 /// not invoked).
-fn compact_stderr_inline(obj: &mut serde_json::Map<String, serde_json::Value>, budget: usize) {
-    if let Some(stderr_text) = obj.get("stderr").and_then(|v| v.as_str())
+fn compact_stderr_inline(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    budget: Option<usize>,
+) {
+    if let Some(budget) = budget
+        && let Some(stderr_text) = obj.get("stderr").and_then(|v| v.as_str())
         && stderr_text.len() > budget
     {
         let compacted = priority_aware_truncate(stderr_text, budget);
@@ -198,26 +203,31 @@ fn compact_stderr_inline(obj: &mut serde_json::Map<String, serde_json::Value>, b
     }
 }
 
-/// Determine whether a result JSON object represents success.
-fn is_success_result(obj: &serde_json::Map<String, serde_json::Value>) -> bool {
+/// Return a sentinel exit code suitable for outcome-aware truncation.
+fn result_exit_code(obj: &serde_json::Map<String, serde_json::Value>) -> i32 {
     if let Some(code) = obj.get("exit_code").and_then(|v| v.as_i64()) {
-        return code == 0;
+        return if code == 0 { 0 } else { 1 };
     }
     if let Some(ok) = obj.get("success").and_then(|v| v.as_bool()) {
-        return ok;
+        return if ok { 0 } else { 1 };
     }
     // Default to success when neither field is present (non-exec tools).
-    true
+    0
 }
 
 /// Compact `text` to `budget` bytes and append a file-reference annotation.
-fn compact_with_annotation(text: &str, budget: usize, file_path: &str, full_size: usize) -> String {
-    if text.len() <= budget {
-        annotate_truncated_output(text, file_path, full_size)
-    } else {
-        let compacted = priority_aware_truncate(text, budget);
-        annotate_truncated_output(&compacted, file_path, full_size)
-    }
+fn compact_with_annotation(
+    text: &str,
+    budget: Option<usize>,
+    exit_code: i32,
+    file_path: &str,
+    full_size: usize,
+) -> String {
+    let compacted = budget.filter(|budget| text.len() > *budget).map_or_else(
+        || text.to_string(),
+        |budget| truncate_exec_stream(text, budget, exit_code),
+    );
+    annotate_truncated_output(&compacted, file_path, full_size)
 }
 
 pub const TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID: &str = "tool_output_persistence";
@@ -316,6 +326,11 @@ impl PostToolExecHook for PersistOutputHook {
         )
         .await
         {
+            let output_mode = tool_call
+                .arguments
+                .get("output")
+                .and_then(|value| value.as_str())
+                .unwrap_or("auto");
             // Enrich result JSON with file references and compact inline output (EVE-562).
             if let Some(ref mut json_val) = result.result
                 && let Some(obj) = json_val.as_object_mut()
@@ -324,11 +339,12 @@ impl PostToolExecHook for PersistOutputHook {
 
                 if let Some(ref path) = persist_result.stdout_path {
                     let display_path = file_store.display_path(path);
-                    // Compact inline stdout/output to the success/failure budget and
-                    // append the file-reference pointer. Explicit modes (verbose, full,
-                    // normal) cannot produce unbounded model-facing output after
-                    // persistence succeeds — full content is in /outputs/.
-                    compact_persisted_result_for_model(obj, &display_path, stdout.len());
+                    compact_persisted_result_for_model(
+                        obj,
+                        &display_path,
+                        stdout.len(),
+                        output_mode,
+                    );
 
                     output_files.push(display_path.clone());
                     // full_output points to the stdout file only; stderr (if persisted)
@@ -345,11 +361,9 @@ impl PostToolExecHook for PersistOutputHook {
                     // Compact stderr inline when stdout was not persisted (if stdout was
                     // persisted, compact_persisted_result_for_model already handled this).
                     if persist_result.stdout_path.is_none() {
-                        let budget = if is_success_result(obj) {
-                            AUTO_SUCCESS_BUDGET
-                        } else {
-                            NORMAL_BUDGET
-                        };
+                        let exit_code = result_exit_code(obj);
+                        let budget =
+                            output_verbosity_budget(resolve_auto_mode(output_mode, exit_code));
                         compact_stderr_inline(obj, budget);
                     }
                 }
@@ -628,6 +642,66 @@ mod tests {
         SessionId::from(Uuid::nil())
     }
 
+    fn persistence_tool_def() -> ToolDefinition {
+        use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy};
+
+        ToolDefinition::Builtin(BuiltinTool {
+            name: "bash".to_string(),
+            display_name: None,
+            description: "execute a command".to_string(),
+            parameters: json!({}),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default().with_persist_output(true),
+            full_parameters: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_hook_honors_explicit_normal_and_persists_losslessly() {
+        let mut lines = vec!["src/runtime.rs:10: first relevant match".to_string()];
+        lines.extend((0..1200).map(|i| format!("src/module_{i}.rs: ordinary source line")));
+        lines.extend((0..300).map(|i| format!("src/errors_{i}.rs: struct ErrorContext{i}")));
+        let full_output = lines.join("\n");
+        let visible_output =
+            crate::tool_output_sanitizer::truncate_exec_stream(&full_output, NORMAL_BUDGET, 0);
+        let store = Arc::new(MockFileStore::default());
+        let mut context = ToolContext::new(test_session_id());
+        context.file_store = Some(store.clone());
+        let tool_call = ToolCall {
+            id: "call-normal".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({"command": "git grep Error", "output": "normal"}),
+        };
+        let mut result = ToolResult {
+            tool_call_id: tool_call.id.clone(),
+            result: Some(json!({
+                "stdout": visible_output,
+                "stderr": "",
+                "exit_code": 0,
+                "success": true,
+            })),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: Some(full_output.clone()),
+        };
+
+        PersistOutputHook
+            .after_exec(&tool_call, &persistence_tool_def(), &mut result, &context)
+            .await;
+
+        let inline = result.result.as_ref().unwrap()["stdout"].as_str().unwrap();
+        assert!(inline.len() > AUTO_SUCCESS_BUDGET + 200);
+        assert!(inline.len() <= NORMAL_BUDGET + 200);
+        assert!(inline.contains("first relevant match"));
+        assert_eq!(
+            store.content("/outputs/call-normal.stdout").as_deref(),
+            Some(full_output.as_str())
+        );
+    }
+
     #[tokio::test]
     async fn test_persist_large_output_persists_stdout_below_budget() {
         let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::default());
@@ -747,7 +821,12 @@ mod tests {
         obj.insert("stdout".to_string(), json!(large_stdout));
         obj.insert("exit_code".to_string(), json!(0));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_stdout_len);
+        compact_persisted_result_for_model(
+            &mut obj,
+            "/outputs/call.stdout",
+            large_stdout_len,
+            "auto",
+        );
 
         let inline = obj["stdout"].as_str().unwrap();
         // Inline stdout must be compact (budget + annotation pointer).
@@ -770,7 +849,12 @@ mod tests {
         obj.insert("stdout".to_string(), json!(large_stdout));
         obj.insert("exit_code".to_string(), json!(1));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_stdout_len);
+        compact_persisted_result_for_model(
+            &mut obj,
+            "/outputs/call.stdout",
+            large_stdout_len,
+            "auto",
+        );
 
         let inline = obj["stdout"].as_str().unwrap();
         assert!(
@@ -791,7 +875,7 @@ mod tests {
         obj.insert("stdout".to_string(), json!(small));
         obj.insert("exit_code".to_string(), json!(0));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", small.len());
+        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", small.len(), "auto");
 
         let inline = obj["stdout"].as_str().unwrap();
         assert!(
@@ -805,22 +889,46 @@ mod tests {
     }
 
     #[test]
-    fn test_compact_oversized_full_mode_is_capped() {
-        // Explicit "full" mode would have left large inline stdout; persistence
-        // must compact it regardless of the verbosity mode.
+    fn test_compact_oversized_full_mode_stays_full() {
         let large = "z".repeat(NORMAL_BUDGET * 3);
         let large_len = large.len();
         let mut obj = serde_json::Map::new();
-        obj.insert("stdout".to_string(), json!(large));
+        obj.insert("stdout".to_string(), json!(large.clone()));
         obj.insert("exit_code".to_string(), json!(0));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_len);
+        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_len, "full");
 
         let inline = obj["stdout"].as_str().unwrap();
-        assert!(
-            inline.len() <= AUTO_SUCCESS_BUDGET + 200,
-            "full-mode output must still be compacted after persistence"
+        assert!(inline.starts_with(&large));
+        assert!(inline.contains("full output saved to"));
+    }
+
+    #[test]
+    fn test_compact_explicit_normal_preserves_leading_search_matches() {
+        let mut lines = vec![
+            "src/runtime.rs:10: query_history registration".to_string(),
+            "src/runtime.rs:11: history capability".to_string(),
+        ];
+        lines.extend((0..1200).map(|i| format!("src/module_{i}.rs: ordinary source line")));
+        lines.extend((0..300).map(|i| format!("src/errors_{i}.rs: struct ErrorContext{i}")));
+        let output = lines.join("\n");
+        let mut obj = serde_json::Map::new();
+        obj.insert("stdout".to_string(), json!(output.clone()));
+        obj.insert("exit_code".to_string(), json!(0));
+
+        compact_persisted_result_for_model(
+            &mut obj,
+            "/outputs/call.stdout",
+            output.len(),
+            "normal",
         );
+
+        let inline = obj["stdout"].as_str().unwrap();
+        assert!(inline.len() > AUTO_SUCCESS_BUDGET + 200);
+        assert!(inline.len() <= NORMAL_BUDGET + 200);
+        assert!(inline.contains("query_history registration"));
+        assert!(inline.contains("history capability"));
+        assert!(inline.contains("full output saved to"));
     }
 
     #[test]
@@ -833,7 +941,12 @@ mod tests {
         obj.insert("stderr".to_string(), json!(large_stderr));
         obj.insert("exit_code".to_string(), json!(1));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_stdout_len);
+        compact_persisted_result_for_model(
+            &mut obj,
+            "/outputs/call.stdout",
+            large_stdout_len,
+            "auto",
+        );
 
         let inline_stderr = obj["stderr"].as_str().unwrap();
         assert!(
@@ -852,7 +965,12 @@ mod tests {
         obj.insert("output".to_string(), json!(large_output));
         obj.insert("exit_code".to_string(), json!(0));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_output_len);
+        compact_persisted_result_for_model(
+            &mut obj,
+            "/outputs/call.stdout",
+            large_output_len,
+            "auto",
+        );
 
         let inline = obj["output"].as_str().unwrap();
         assert!(
@@ -869,7 +987,7 @@ mod tests {
         obj.insert("result".to_string(), json!("ok"));
         obj.insert("exit_code".to_string(), json!(0));
 
-        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", 0);
+        compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", 0, "auto");
 
         // Non-exec result shape untouched
         assert_eq!(obj.get("stdout"), None);
@@ -885,7 +1003,7 @@ mod tests {
         let mut obj = serde_json::Map::new();
         obj.insert("stderr".to_string(), json!(large));
 
-        compact_stderr_inline(&mut obj, NORMAL_BUDGET);
+        compact_stderr_inline(&mut obj, Some(NORMAL_BUDGET));
 
         let inline = obj["stderr"].as_str().unwrap();
         assert!(

--- a/crates/core/src/exec_tool_result.rs
+++ b/crates/core/src/exec_tool_result.rs
@@ -6,6 +6,7 @@
 
 use crate::tool_output_sanitizer::{
     clean_exec_output, output_verbosity_budget, priority_aware_truncate, resolve_auto_mode,
+    truncate_exec_stream,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,7 +31,7 @@ impl ExecToolResultPayload {
         let effective_mode = resolve_auto_mode(output_mode, exit_code);
         let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(effective_mode) {
             (
-                priority_aware_truncate(&clean_stdout, budget),
+                truncate_exec_stream(&clean_stdout, budget, exit_code),
                 priority_aware_truncate(&clean_stderr, budget.min(4096)),
             )
         } else {
@@ -183,6 +184,23 @@ mod tests {
             "explicit normal mode should not compact to auto-success budget on success"
         );
         assert!(payload.stdout.len() <= NORMAL_BUDGET);
+    }
+
+    #[test]
+    fn successful_source_search_preserves_leading_matches() {
+        let mut lines = vec![
+            "src/runtime.rs:10: first relevant match".to_string(),
+            "src/runtime.rs:11: second relevant match".to_string(),
+        ];
+        lines.extend((0..1200).map(|i| format!("src/module_{i}.rs: ordinary source line")));
+        lines.extend((0..300).map(|i| format!("src/errors_{i}.rs: struct ErrorContext{i}")));
+        let stdout = lines.join("\n");
+
+        let payload = ExecToolResultPayload::new(&stdout, "", 0, "normal");
+
+        assert!(payload.truncated);
+        assert!(payload.stdout.contains("first relevant match"));
+        assert!(payload.stdout.contains("second relevant match"));
     }
 
     #[test]

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -476,6 +476,20 @@ pub fn sanitize_exec_output(text: &str, max_bytes: usize) -> String {
     priority_aware_truncate(&cleaned, max_bytes)
 }
 
+/// Truncate an exec stream according to the process outcome.
+///
+/// Error-priority matching is useful for failed commands, but source/search
+/// output from successful commands can legitimately contain words such as
+/// `error`. Treating those lines as diagnostics can hide the leading matches,
+/// so successful output uses the predictable head/tail window instead.
+pub fn truncate_exec_stream(text: &str, max_bytes: usize, exit_code: i32) -> String {
+    if exit_code == 0 {
+        middle_truncate(text, max_bytes)
+    } else {
+        priority_aware_truncate(text, max_bytes)
+    }
+}
+
 // ============================================================================
 // Priority-aware truncation (EVE-246)
 // ============================================================================

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -150,7 +150,7 @@ Exec tools (bash, daytona_exec, e2b_exec, deno_exec, sprites_exec, docker_exec) 
 The pipeline:
 1. **Strip ANSI** — remove SGR, CSI, OSC escape sequences
 2. **Collapse CR lines** — `\r`-overwritten lines (progress bars) reduced to final content
-3. **Truncate** — priority-aware truncation at the budget determined by the `output` verbosity parameter
+3. **Truncate** — apply the budget determined by the `output` verbosity parameter. Failed commands prioritize diagnostic regions; successful commands preserve a predictable head/tail window so source or search output containing words such as `error` does not displace leading evidence.
 
 ### Output Verbosity (EVE-236, EVE-489)
 
@@ -165,7 +165,7 @@ All exec tools accept an `output` parameter controlling how much output is retur
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation — when the LLM needs every line |
 
-Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET` so the model relies on the persisted log; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. `AUTO_SUCCESS_BUDGET` is intentionally sized so the inline `stdout` field — including the `[full output saved to ... — use read_file ...]` pointer that `PersistOutputHook` appends — stays around 512 bytes total. The pointer uses the session filesystem's display identity. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. Explicit `silent`/`concise`/`normal`/`verbose`/`full` are opt-ins for a fixed inline window and continue to behave exactly as before — they ignore exit code.
+Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET` so the model relies on the persisted log; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. `AUTO_SUCCESS_BUDGET` is intentionally sized so the inline `stdout` field — including the `[full output saved to ... — use read_file ...]` pointer that `PersistOutputHook` appends — stays around 512 bytes total. The pointer uses the session filesystem's display identity. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. The persistence hook reads the original tool-call argument and does not re-resolve explicit `silent`/`concise`/`normal`/`verbose`/`full` modes to `auto`; those modes retain their fixed inline window and ignore exit code.
 
 Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and the files are readable with `read_file`. The persisted files are the source of truth for full logs; the inline payload is sized for next-step reasoning. See `crates/core/src/tool_output_sanitizer.rs` for budget constants, `output_verbosity_budget()`, and `resolve_auto_mode()`.
 


### PR DESCRIPTION
## What changed
Exec output persistence now honors the caller's explicit `output` mode instead of re-compacting every successful result to the `auto` success budget. Successful command output uses a predictable head/tail window, preserving leading source-search matches even when later lines contain words such as `error`; failed commands keep diagnostic-priority truncation.

Full cleaned output remains persisted under `/outputs/`, and the existing final 64 KiB tool-result hard limit remains unchanged.

## Why
Persistence applied a second, outcome-only compaction pass after each exec tool had already honored `silent`, `concise`, `normal`, `verbose`, or `full`. A successful search requested with `output: normal` could therefore shrink from roughly 8 KiB to the approximately 384-byte `auto` window. The second pass also treated ordinary successful source lines containing error-like words as diagnostics, which could displace the leading matches the model needed.

## Before / After
Before:

- Explicit `normal` output from a successful persisted command was reduced to `AUTO_SUCCESS_BUDGET`.
- A successful source search with relevant matches first and many later `ErrorContext` lines could lose those leading matches.

After, covered by deterministic regression tests:

- Explicit `normal` remains above the auto-success budget and within `NORMAL_BUDGET`, including the persisted-output pointer.
- Leading `query_history`/source matches remain inline for successful searches.
- The persisted stdout is byte-for-byte equal to the full cleaned output.
- Default `auto` success/failure budgets and failed-command diagnostic prioritization remain covered.

Validation after synchronizing with Everruns 0.17.8 `main`:

- `cargo test -p everruns-core tool_output_persistence --all-features` — 31 passed
- `cargo test -p everruns-core exec_tool_result --all-features` — 9 passed
- `cargo test -p everruns-container-sandbox --all-features --lib` — 39 passed
- `just pre-push` — all 10 available checks passed; UI checks skipped because `node_modules` is absent
- `bash scripts/lib/check-migration-ordering.sh` — migrations sequential (001..103)

The direct persistence-hook regression test is the end-to-end smoke proof for this flow: it executes the hook with explicit `normal`, verifies the leading match remains inline, and verifies the full cleaned output is persisted losslessly.

## Risk
- Medium
- Explicit `verbose` and `full` requests can intentionally return more inline content than before persistence; the always-on 64 KiB hard ceiling still bounds serialized tool results.
- Default `auto` behavior is unchanged.

## Security
- Threat categories reviewed: TM-TOOL-005, TM-AGENT-012, TM-DOS-014
- Findings and resolutions: the change adds no execution authority, input boundary, filesystem scope, dependency, or secret-bearing path. Larger caller-selected inline windows modestly increase exposure to untrusted tool-result content and prompt consumption, but results remain role-separated, full output persistence retains its existing quota/size handling, and `OutputHardLimitHook` still enforces the final 64 KiB ceiling. No new threat or mitigation change requires a threat-model update.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
