### PR TITLE
feat(local): execute due session schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+### What's Changed
+
+- `everruns-local` now executes due one-shot and recurring session schedules through `LocalSessionRunner::send_message`, with atomic claims, stale recovery, retryable delivery failures, timezone-aware advancement, graceful lifecycle, and tracing. Embedded hosts that enable scheduled monitors must start and retain `LocalScheduleRunner`.
+
 ## [0.17.7] - 2026-07-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,7 +1667,7 @@ checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "winnow 0.7.15",
 ]
 
@@ -1777,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2913,9 +2923,12 @@ version = "0.17.7"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
+ "cron",
  "dirs",
  "everruns-core",
  "everruns-runtime",
+ "futures",
  "libc",
  "parking_lot",
  "rusqlite",
@@ -6093,7 +6106,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -6103,7 +6125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -6112,7 +6134,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -6123,7 +6145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6134,6 +6156,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -8330,7 +8361,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -8367,7 +8398,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook",
  "siphasher",

--- a/crates/local/Cargo.toml
+++ b/crates/local/Cargo.toml
@@ -32,6 +32,7 @@ everruns-runtime.workspace = true
 # Async
 tokio = { workspace = true, features = ["rt", "time", "sync"] }
 async-trait.workspace = true
+futures.workspace = true
 
 # Sync
 parking_lot.workspace = true
@@ -41,6 +42,8 @@ serde_json.workspace = true
 
 # Types
 chrono.workspace = true
+chrono-tz = "0.10"
+cron = "0.17"
 uuid.workspace = true
 
 # Error handling

--- a/crates/local/README.md
+++ b/crates/local/README.md
@@ -26,6 +26,10 @@ harness engine for building unstoppable agents.
 - **`LocalScheduleStore`** — a `SessionScheduleStore` over SQLite, with an
   additive JSON `metadata` bag (name/color/kind/…) kept local rather than
   widening the shared core primitive.
+- **`LocalScheduleRunner`** — an explicitly started/stopped in-process runner
+  for due one-shot and recurring schedules. It uses atomic SQLite claims,
+  recovers interrupted claims, and delivers prompts through
+  `LocalSessionRunner::send_message`.
 - **`LocalPlatformStore`** — a `PlatformStore` that implements the
   subagent-critical core honestly and returns explicit unsupported errors for
   platform-management-only operations.
@@ -69,6 +73,24 @@ let _builder = InProcessRuntimeBuilder::new().backends(local.runtime_backends.cl
 # Ok(())
 # }
 ```
+
+Hosts that enable `create_schedule` or scheduled `spawn_background` calls must
+also run the executor for their lifetime. Use the same `LocalSessionRunner`
+implementation that backs `LocalPlatformStore`, then retain the handle:
+
+```rust,ignore
+let schedule_runner = local.start_schedule_runner(session_runner.clone())?;
+let local = local.with_platform_runner(session_runner);
+
+// Keep `schedule_runner` alive with the host, then stop cleanly.
+schedule_runner.shutdown().await?;
+```
+
+Delivery is at-least-once across a process crash: concurrent live runners do
+not deliver the same occurrence, and claims are heartbeated while
+`send_message` runs, but a crash after the host accepts a message and before
+SQLite records completion can cause a retry. Embedded hosts should make
+scheduled turns tolerant of that standard crash window.
 
 See the integration tests under [`tests/`](./tests) for end-to-end coverage of
 task lifecycle, restart survivability, schedule round-trips, composability, and

--- a/crates/local/src/backends.rs
+++ b/crates/local/src/backends.rs
@@ -18,6 +18,9 @@ use everruns_runtime::{PlatformStoreFactory, RuntimeBackends, ScheduleStoreFacto
 use crate::db::SqliteDb;
 use crate::platform_store::{LocalPlatformStore, LocalSessionRunner};
 use crate::profile::LocalProfile;
+use crate::schedule_runner::{
+    LocalScheduleRunner, LocalScheduleRunnerConfig, LocalScheduleRunnerHandle,
+};
 use crate::schedule_store::LocalScheduleStore;
 use crate::task_registry::LocalSessionTaskRegistry;
 
@@ -104,6 +107,29 @@ impl LocalBackends {
             self.org_id,
             self.profile.owner_principal_id,
         )
+    }
+
+    /// Start the in-process schedule runner with production defaults.
+    ///
+    /// Retain the returned handle for the host lifetime and call
+    /// [`LocalScheduleRunnerHandle::shutdown`] during graceful shutdown.
+    pub fn start_schedule_runner(
+        &self,
+        runner: Arc<dyn LocalSessionRunner>,
+    ) -> Result<LocalScheduleRunnerHandle> {
+        self.start_schedule_runner_with_config(runner, LocalScheduleRunnerConfig::default())
+    }
+
+    /// Start the in-process schedule runner with custom polling and claim settings.
+    pub fn start_schedule_runner_with_config(
+        &self,
+        runner: Arc<dyn LocalSessionRunner>,
+        config: LocalScheduleRunnerConfig,
+    ) -> Result<LocalScheduleRunnerHandle> {
+        LocalScheduleRunner::new(self.schedule_store()?, runner)
+            .with_config(config)
+            .start()
+            .map_err(everruns_core::AgentLoopError::from)
     }
 
     /// Attach a platform store factory built from a caller-supplied

--- a/crates/local/src/db.rs
+++ b/crates/local/src/db.rs
@@ -10,6 +10,7 @@
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use rusqlite::Connection;
@@ -44,6 +45,7 @@ impl SqliteDb {
         // restarts; foreign_keys keeps message rows tied to their task.
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "foreign_keys", true)?;
+        conn.busy_timeout(Duration::from_secs(5))?;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })
@@ -56,6 +58,14 @@ impl SqliteDb {
     ) -> LocalResult<T> {
         let guard = self.conn.lock();
         f(&guard).map_err(LocalError::from)
+    }
+
+    pub(crate) fn with_conn_mut<T>(
+        &self,
+        f: impl FnOnce(&mut Connection) -> rusqlite::Result<T>,
+    ) -> LocalResult<T> {
+        let mut guard = self.conn.lock();
+        f(&mut guard).map_err(LocalError::from)
     }
 }
 

--- a/crates/local/src/lib.rs
+++ b/crates/local/src/lib.rs
@@ -7,6 +7,8 @@
 //!   over SQLite, persisting tasks and their message channel.
 //! - [`LocalScheduleStore`] — a [`everruns_core::traits::SessionScheduleStore`]
 //!   over SQLite, with an additive JSON metadata bag (see its module docs).
+//! - [`LocalScheduleRunner`] — an explicitly managed in-process executor that
+//!   claims due schedules and delivers them through [`LocalSessionRunner`].
 //! - [`LocalPlatformStore`] — a [`everruns_core::platform_store::PlatformStore`]
 //!   implementing the subagent-critical core honestly and returning explicit
 //!   unsupported errors for platform-management-only operations.
@@ -27,6 +29,7 @@ mod error;
 mod platform_store;
 mod profile;
 mod runtime_builder;
+mod schedule_runner;
 mod schedule_store;
 mod task_registry;
 
@@ -36,5 +39,8 @@ pub use error::{LocalError, LocalResult};
 pub use platform_store::{LocalPlatformStore, LocalSessionRunner};
 pub use profile::LocalProfile;
 pub use runtime_builder::LocalRuntimeBuilder;
+pub use schedule_runner::{
+    LocalScheduleRunner, LocalScheduleRunnerConfig, LocalScheduleRunnerHandle,
+};
 pub use schedule_store::LocalScheduleStore;
 pub use task_registry::LocalSessionTaskRegistry;

--- a/crates/local/src/schedule_runner.rs
+++ b/crates/local/src/schedule_runner.rs
@@ -1,0 +1,255 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use futures::StreamExt;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
+
+use crate::{LocalError, LocalResult, LocalScheduleStore, LocalSessionRunner};
+
+/// Runtime settings for [`LocalScheduleRunner`].
+#[derive(Clone, Debug)]
+pub struct LocalScheduleRunnerConfig {
+    /// How often the SQLite store is checked for due schedules.
+    pub poll_interval: Duration,
+    /// How long an unfinished claim remains exclusive before another runner may recover it.
+    pub claim_timeout: Duration,
+    /// Maximum schedules claimed per poll.
+    pub batch_size: usize,
+}
+
+const MAX_BATCH_SIZE: usize = 1_000;
+
+impl Default for LocalScheduleRunnerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(1),
+            claim_timeout: Duration::from_secs(30),
+            batch_size: 32,
+        }
+    }
+}
+
+/// Explicitly started in-process executor for schedules in a [`LocalScheduleStore`].
+pub struct LocalScheduleRunner {
+    store: LocalScheduleStore,
+    session_runner: Arc<dyn LocalSessionRunner>,
+    config: LocalScheduleRunnerConfig,
+}
+
+impl LocalScheduleRunner {
+    pub fn new(store: LocalScheduleStore, session_runner: Arc<dyn LocalSessionRunner>) -> Self {
+        Self {
+            store,
+            session_runner,
+            config: LocalScheduleRunnerConfig::default(),
+        }
+    }
+
+    pub fn with_config(mut self, config: LocalScheduleRunnerConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Spawn the polling task. Retain the returned handle for the host lifetime.
+    pub fn start(self) -> LocalResult<LocalScheduleRunnerHandle> {
+        if self.config.poll_interval.is_zero() {
+            return Err(LocalError::Config(
+                "schedule poll interval must be positive".into(),
+            ));
+        }
+        if self.config.claim_timeout.is_zero() {
+            return Err(LocalError::Config(
+                "schedule claim timeout must be positive".into(),
+            ));
+        }
+        if self.config.batch_size == 0 {
+            return Err(LocalError::Config(
+                "schedule batch size must be positive".into(),
+            ));
+        }
+        if self.config.batch_size > MAX_BATCH_SIZE {
+            return Err(LocalError::Config(format!(
+                "schedule batch size must not exceed {MAX_BATCH_SIZE}"
+            )));
+        }
+        let runner_id = uuid::Uuid::now_v7().to_string();
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let join = tokio::spawn(async move {
+            tracing::info!(
+                runner_id,
+                poll_interval_ms = self.config.poll_interval.as_millis(),
+                claim_timeout_ms = self.config.claim_timeout.as_millis(),
+                batch_size = self.config.batch_size,
+                "Local schedule runner started"
+            );
+            let mut interval = tokio::time::interval(self.config.poll_interval);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    biased;
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                    _ = interval.tick() => {
+                        if let Err(error) = self.poll_once(&runner_id).await {
+                            tracing::error!(runner_id, error = %error, "Local schedule poll failed");
+                        }
+                    }
+                }
+            }
+            tracing::info!(runner_id, "Local schedule runner stopped");
+        });
+        Ok(LocalScheduleRunnerHandle {
+            shutdown_tx,
+            join: Some(join),
+        })
+    }
+
+    async fn poll_once(&self, runner_id: &str) -> everruns_core::Result<()> {
+        let claimed = self.store.claim_due(
+            runner_id,
+            Utc::now(),
+            self.config.claim_timeout,
+            self.config.batch_size,
+        )?;
+        if !claimed.is_empty() {
+            tracing::debug!(
+                runner_id,
+                count = claimed.len(),
+                "Claimed due local schedules"
+            );
+        }
+        futures::stream::iter(claimed)
+            .for_each_concurrent(self.config.batch_size, |claim| async move {
+                self.process_claim(claim, runner_id).await;
+            })
+            .await;
+        Ok(())
+    }
+
+    async fn process_claim(&self, claim: crate::schedule_store::ClaimedSchedule, runner_id: &str) {
+        let schedule = &claim.schedule;
+        tracing::debug!(
+            runner_id,
+            schedule_id = %schedule.id,
+            session_id = %schedule.session_id,
+            "Delivering local schedule"
+        );
+        let delivery = self.deliver_with_heartbeat(&claim, runner_id).await;
+        match delivery {
+            Ok(()) => match self.store.complete_delivery(&claim, runner_id, Utc::now()) {
+                Ok(()) => tracing::info!(
+                    runner_id,
+                    schedule_id = %schedule.id,
+                    session_id = %schedule.session_id,
+                    "Local schedule delivered"
+                ),
+                Err(error) => tracing::error!(
+                    runner_id,
+                    schedule_id = %schedule.id,
+                    session_id = %schedule.session_id,
+                    error = %error,
+                    "Local schedule was delivered but its claim could not be completed"
+                ),
+            },
+            Err(error) => {
+                let error_text = bounded_error(&error.to_string());
+                if let Err(release_error) = self.store.fail_delivery(&claim, runner_id, &error_text)
+                {
+                    tracing::error!(
+                        runner_id,
+                        schedule_id = %schedule.id,
+                        session_id = %schedule.session_id,
+                        error = %release_error,
+                        "Local schedule failed and its claim could not be released"
+                    );
+                }
+                tracing::warn!(
+                    runner_id,
+                    schedule_id = %schedule.id,
+                    session_id = %schedule.session_id,
+                    error = %error,
+                    "Local schedule delivery failed; occurrence released for retry"
+                );
+            }
+        }
+    }
+
+    async fn deliver_with_heartbeat(
+        &self,
+        claim: &crate::schedule_store::ClaimedSchedule,
+        runner_id: &str,
+    ) -> everruns_core::Result<()> {
+        let schedule = &claim.schedule;
+        let delivery = self
+            .session_runner
+            .send_message(schedule.session_id, &schedule.description);
+        tokio::pin!(delivery);
+        let heartbeat_interval = (self.config.claim_timeout / 3).max(Duration::from_millis(1));
+        let mut heartbeat = tokio::time::interval(heartbeat_interval);
+        heartbeat.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        heartbeat.tick().await;
+        loop {
+            tokio::select! {
+                result = &mut delivery => return result,
+                _ = heartbeat.tick() => {
+                    if !self.store.renew_claim(claim, runner_id, Utc::now())? {
+                        return Err(everruns_core::AgentLoopError::store(format!(
+                            "local schedule claim {} was lost during delivery",
+                            claim.claim_id
+                        )));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn bounded_error(error: &str) -> String {
+    const MAX_ERROR_BYTES: usize = 4_096;
+    if error.len() <= MAX_ERROR_BYTES {
+        return error.to_string();
+    }
+    let mut end = MAX_ERROR_BYTES;
+    while !error.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &error[..end])
+}
+
+/// Owned lifecycle handle for a running local schedule executor.
+pub struct LocalScheduleRunnerHandle {
+    shutdown_tx: watch::Sender<bool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl LocalScheduleRunnerHandle {
+    /// Stop claiming new schedules and wait for the current delivery to finish.
+    pub async fn shutdown(mut self) -> LocalResult<()> {
+        let _ = self.shutdown_tx.send(true);
+        if let Some(join) = self.join.take() {
+            join.await.map_err(|error| {
+                LocalError::Other(format!("local schedule runner task failed: {error}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Stop immediately. Unfinished claims become eligible after `claim_timeout`.
+    pub fn abort(mut self) {
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+    }
+}
+
+impl Drop for LocalScheduleRunnerHandle {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+}

--- a/crates/local/src/schedule_store.rs
+++ b/crates/local/src/schedule_store.rs
@@ -13,6 +13,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session_schedule::{
     MAX_ACTIVE_SCHEDULES_PER_SESSION, ScheduleLimitError, SessionSchedule,
@@ -20,8 +21,10 @@ use everruns_core::session_schedule::{
 };
 use everruns_core::traits::SessionScheduleStore;
 use everruns_core::typed_id::{PrincipalId, ScheduleId, SessionId};
-use rusqlite::OptionalExtension;
+use rusqlite::{OptionalExtension, TransactionBehavior};
 use serde_json::Value;
+use std::str::FromStr;
+use std::time::Duration;
 
 use crate::db::SqliteDb;
 use crate::error::LocalError;
@@ -34,6 +37,12 @@ pub struct LocalScheduleStore {
     org_id: i64,
     /// Principal stamped on created schedules.
     owner_principal_id: PrincipalId,
+}
+
+#[derive(Debug)]
+pub(crate) struct ClaimedSchedule {
+    pub schedule: SessionSchedule,
+    pub claim_id: String,
 }
 
 impl LocalScheduleStore {
@@ -55,13 +64,92 @@ impl LocalScheduleStore {
                     session_id  TEXT NOT NULL,
                     enabled     INTEGER NOT NULL,
                     snapshot    TEXT NOT NULL,
-                    metadata    TEXT NOT NULL DEFAULT '{}'
+                    metadata    TEXT NOT NULL DEFAULT '{}',
+                    next_trigger_at_ms INTEGER,
+                    claimed_by  TEXT,
+                    claimed_at_ms INTEGER,
+                    last_delivery_error TEXT,
+                    runner_migrated INTEGER NOT NULL DEFAULT 1
                  );
                  CREATE INDEX IF NOT EXISTS idx_local_schedules_session
                     ON local_schedules(org_id, session_id);",
             )
         })
         .map_err(AgentLoopError::from)?;
+        Self::migrate_runner_columns(db)?;
+        Ok(())
+    }
+
+    fn migrate_runner_columns(db: &SqliteDb) -> Result<()> {
+        db.with_conn_mut(|conn| {
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let columns = {
+                let mut stmt = tx.prepare("PRAGMA table_info(local_schedules)")?;
+                stmt.query_map([], |row| row.get::<_, String>(1))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?
+            };
+            for (name, sql_type) in [
+                ("next_trigger_at_ms", "INTEGER"),
+                ("claimed_by", "TEXT"),
+                ("claimed_at_ms", "INTEGER"),
+                ("last_delivery_error", "TEXT"),
+                ("runner_migrated", "INTEGER NOT NULL DEFAULT 0"),
+            ] {
+                if !columns.iter().any(|column| column == name) {
+                    tx.execute(
+                        &format!("ALTER TABLE local_schedules ADD COLUMN {name} {sql_type}"),
+                        [],
+                    )?;
+                }
+            }
+            tx.execute(
+                "CREATE INDEX IF NOT EXISTS idx_local_schedules_due
+                 ON local_schedules(enabled, next_trigger_at_ms, claimed_at_ms)",
+                [],
+            )?;
+            tx.commit()
+        })
+        .map_err(AgentLoopError::from)?;
+
+        let rows: Vec<(String, String)> = db
+            .with_conn(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT id, snapshot FROM local_schedules WHERE runner_migrated = 0",
+                )?;
+                stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+                    .collect()
+            })
+            .map_err(AgentLoopError::from)?;
+        for (id, json) in rows {
+            let mut schedule: SessionSchedule = serde_json::from_str(&json)
+                .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+            if schedule.enabled
+                && schedule.next_trigger_at.is_none()
+                && schedule.cron_expression.is_some()
+            {
+                match next_cron_trigger(&schedule, Utc::now()) {
+                    Ok(next) => {
+                        schedule.next_trigger_at = Some(next);
+                        schedule.updated_at = Utc::now();
+                    }
+                    Err(error) => {
+                        tracing::warn!(schedule_id = %schedule.id, error = %error, "Local recurring schedule could not be migrated for execution");
+                    }
+                }
+            }
+            let snapshot = serde_json::to_string(&schedule)
+                .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+            let next_ms = schedule.next_trigger_at.map(|time| time.timestamp_millis());
+            db.with_conn(|conn| {
+                conn.execute(
+                    "UPDATE local_schedules
+                     SET snapshot = ?2, next_trigger_at_ms = ?3, runner_migrated = 1
+                     WHERE id = ?1",
+                    rusqlite::params![id, snapshot, next_ms],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        }
         Ok(())
     }
 
@@ -83,9 +171,9 @@ impl LocalScheduleStore {
         cron_expression: Option<String>,
         scheduled_at: Option<DateTime<Utc>>,
         timezone: String,
-    ) -> SessionSchedule {
+    ) -> Result<SessionSchedule> {
         let now = Utc::now();
-        SessionSchedule {
+        let mut schedule = SessionSchedule {
             id: ScheduleId::new(),
             session_id,
             owner_principal_id: self.owner_principal_id,
@@ -103,7 +191,11 @@ impl LocalScheduleStore {
             trigger_count: 0,
             created_at: now,
             updated_at: now,
+        };
+        if schedule.cron_expression.is_some() {
+            schedule.next_trigger_at = Some(next_cron_trigger(&schedule, now)?);
         }
+        Ok(schedule)
     }
 
     fn insert(&self, schedule: &SessionSchedule, metadata: &Value) -> Result<()> {
@@ -115,16 +207,20 @@ impl LocalScheduleStore {
         let session = schedule.session_id.to_string();
         let enabled = schedule.enabled as i64;
         let org_id = self.org_id;
+        let next_trigger_at_ms = schedule.next_trigger_at.map(|time| time.timestamp_millis());
         self.db
             .with_conn(|conn| {
                 conn.execute(
-                    "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                    "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata, next_trigger_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                      ON CONFLICT(id) DO UPDATE SET
                         enabled = excluded.enabled,
                         snapshot = excluded.snapshot,
-                        metadata = excluded.metadata",
-                    rusqlite::params![id, org_id, session, enabled, snapshot, metadata_json],
+                        metadata = excluded.metadata,
+                        next_trigger_at_ms = excluded.next_trigger_at_ms,
+                        claimed_by = CASE WHEN excluded.enabled = 0 THEN NULL ELSE claimed_by END,
+                        claimed_at_ms = CASE WHEN excluded.enabled = 0 THEN NULL ELSE claimed_at_ms END",
+                    rusqlite::params![id, org_id, session, enabled, snapshot, metadata_json, next_trigger_at_ms],
                 )
             })
             .map_err(AgentLoopError::from)?;
@@ -172,7 +268,7 @@ impl LocalScheduleStore {
             cron_expression,
             scheduled_at,
             timezone,
-        );
+        )?;
         self.insert(&schedule, &metadata)?;
         Ok(schedule)
     }
@@ -201,6 +297,214 @@ impl LocalScheduleStore {
             None => Ok(None),
         }
     }
+
+    /// Last scheduled-delivery error, retained until a later delivery succeeds.
+    pub async fn last_delivery_error(&self, schedule_id: ScheduleId) -> Result<Option<String>> {
+        let id = schedule_id.to_string();
+        let org_id = self.org_id;
+        self.db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT last_delivery_error FROM local_schedules WHERE id = ?1 AND org_id = ?2",
+                    rusqlite::params![id, org_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map(|value| value.flatten())
+            })
+            .map_err(AgentLoopError::from)
+    }
+
+    pub(crate) fn claim_due(
+        &self,
+        runner_id: &str,
+        now: DateTime<Utc>,
+        claim_timeout: Duration,
+        limit: usize,
+    ) -> Result<Vec<ClaimedSchedule>> {
+        let now_ms = now.timestamp_millis();
+        let timeout_ms = i64::try_from(claim_timeout.as_millis()).unwrap_or(i64::MAX);
+        let stale_before_ms = now_ms.saturating_sub(timeout_ms);
+        let org_id = self.org_id;
+        let runner_id = runner_id.to_string();
+        self.db
+            .with_conn_mut(|conn| {
+                let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let candidates = {
+                    let mut stmt = tx.prepare(
+                        "SELECT id, snapshot FROM local_schedules
+                         WHERE org_id = ?1 AND enabled = 1
+                           AND next_trigger_at_ms IS NOT NULL AND next_trigger_at_ms <= ?2
+                           AND (claimed_at_ms IS NULL OR claimed_at_ms <= ?3)
+                         ORDER BY next_trigger_at_ms ASC LIMIT ?4",
+                    )?;
+                    stmt.query_map(
+                        rusqlite::params![org_id, now_ms, stale_before_ms, limit as i64],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    )?
+                    .collect::<rusqlite::Result<Vec<_>>>()?
+                };
+                let mut claimed = Vec::with_capacity(candidates.len());
+                for (id, snapshot) in candidates {
+                    let changed = tx.execute(
+                        "UPDATE local_schedules SET claimed_by = ?2, claimed_at_ms = ?3
+                         WHERE id = ?1 AND org_id = ?4 AND enabled = 1
+                           AND (claimed_at_ms IS NULL OR claimed_at_ms <= ?5)",
+                        rusqlite::params![id, runner_id, now_ms, org_id, stale_before_ms],
+                    )?;
+                    if changed == 1 {
+                        claimed.push((snapshot, id));
+                    }
+                }
+                tx.commit()?;
+                claimed
+                    .into_iter()
+                    .map(|(snapshot, id)| {
+                        serde_json::from_str(&snapshot)
+                            .map(|schedule| ClaimedSchedule {
+                                schedule,
+                                claim_id: id,
+                            })
+                            .map_err(|error| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    0,
+                                    rusqlite::types::Type::Text,
+                                    Box::new(error),
+                                )
+                            })
+                    })
+                    .collect()
+            })
+            .map_err(AgentLoopError::from)
+    }
+
+    pub(crate) fn complete_delivery(
+        &self,
+        claim: &ClaimedSchedule,
+        runner_id: &str,
+        delivered_at: DateTime<Utc>,
+    ) -> Result<()> {
+        let mut schedule = claim.schedule.clone();
+        schedule.last_triggered_at = Some(delivered_at);
+        schedule.trigger_count = schedule.trigger_count.saturating_add(1);
+        schedule.updated_at = delivered_at;
+        if schedule.cron_expression.is_some() {
+            schedule.next_trigger_at = Some(next_cron_trigger(&schedule, delivered_at)?);
+        } else {
+            schedule.enabled = false;
+            schedule.next_trigger_at = None;
+        }
+        let snapshot = serde_json::to_string(&schedule)
+            .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        let next_ms = schedule.next_trigger_at.map(|time| time.timestamp_millis());
+        let changed = self
+            .db
+            .with_conn(|conn| {
+                conn.execute(
+                    "UPDATE local_schedules
+                     SET enabled = ?3, snapshot = ?4, next_trigger_at_ms = ?5,
+                         claimed_by = NULL, claimed_at_ms = NULL, last_delivery_error = NULL
+                     WHERE id = ?1 AND org_id = ?2 AND claimed_by = ?6",
+                    rusqlite::params![
+                        claim.claim_id,
+                        self.org_id,
+                        schedule.enabled as i64,
+                        snapshot,
+                        next_ms,
+                        runner_id,
+                    ],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        if changed != 1 {
+            return Err(AgentLoopError::store(format!(
+                "local schedule claim {} is no longer owned by runner",
+                claim.claim_id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn renew_claim(
+        &self,
+        claim: &ClaimedSchedule,
+        runner_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<bool> {
+        let changed = self
+            .db
+            .with_conn(|conn| {
+                conn.execute(
+                    "UPDATE local_schedules SET claimed_at_ms = ?4
+                     WHERE id = ?1 AND org_id = ?2 AND claimed_by = ?3",
+                    rusqlite::params![
+                        claim.claim_id,
+                        self.org_id,
+                        runner_id,
+                        now.timestamp_millis(),
+                    ],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        Ok(changed == 1)
+    }
+
+    pub(crate) fn fail_delivery(
+        &self,
+        claim: &ClaimedSchedule,
+        runner_id: &str,
+        error: &str,
+    ) -> Result<()> {
+        let changed = self
+            .db
+            .with_conn(|conn| {
+                conn.execute(
+                    "UPDATE local_schedules
+                     SET claimed_by = NULL, claimed_at_ms = NULL, last_delivery_error = ?4
+                     WHERE id = ?1 AND org_id = ?2 AND claimed_by = ?3",
+                    rusqlite::params![claim.claim_id, self.org_id, runner_id, error],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        if changed != 1 {
+            return Err(AgentLoopError::store(format!(
+                "local schedule claim {} is no longer owned by runner",
+                claim.claim_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn next_cron_trigger(schedule: &SessionSchedule, after: DateTime<Utc>) -> Result<DateTime<Utc>> {
+    let expression = schedule
+        .cron_expression
+        .as_deref()
+        .ok_or_else(|| AgentLoopError::config("recurring schedule has no cron expression"))?;
+    let fields: Vec<_> = expression.split_whitespace().collect();
+    let normalized = match fields.len() {
+        5 => format!("0 {} *", fields.join(" ")),
+        6 | 7 => expression.to_string(),
+        _ => {
+            return Err(AgentLoopError::config(format!(
+                "invalid cron expression '{expression}'"
+            )));
+        }
+    };
+    let cron = cron::Schedule::from_str(&normalized).map_err(|error| {
+        AgentLoopError::config(format!("invalid cron expression '{expression}': {error}"))
+    })?;
+    let timezone = Tz::from_str(&schedule.timezone).map_err(|error| {
+        AgentLoopError::config(format!(
+            "invalid IANA timezone '{}': {error}",
+            schedule.timezone
+        ))
+    })?;
+    let local_after = after.with_timezone(&timezone);
+    cron.after(&local_after)
+        .next()
+        .map(|next| next.with_timezone(&Utc))
+        .ok_or_else(|| AgentLoopError::config("cron expression has no future occurrence"))
 }
 
 #[async_trait]
@@ -237,13 +541,15 @@ impl SessionScheduleStore for LocalScheduleStore {
             validate_cron_min_interval(cron).map_err(ScheduleLimitError::Rejected)?;
         }
 
-        let schedule = self.build_schedule(
-            session_id,
-            description,
-            cron_expression,
-            scheduled_at,
-            timezone,
-        );
+        let schedule = self
+            .build_schedule(
+                session_id,
+                description,
+                cron_expression,
+                scheduled_at,
+                timezone,
+            )
+            .map_err(ScheduleLimitError::Store)?;
         let snapshot = serde_json::to_string(&schedule)
             .map_err(|e| ScheduleLimitError::Store(AgentLoopError::from(LocalError::from(e))))?;
         let metadata_json = serde_json::to_string(&Value::Object(Default::default()))
@@ -276,9 +582,9 @@ impl SessionScheduleStore for LocalScheduleStore {
                     return Ok(false);
                 }
                 conn.execute(
-                    "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                    rusqlite::params![id, org_id, session, enabled, snapshot, metadata_json],
+                    "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata, next_trigger_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    rusqlite::params![id, org_id, session, enabled, snapshot, metadata_json, schedule.next_trigger_at.map(|time| time.timestamp_millis())],
                 )?;
                 Ok(true)
             })

--- a/crates/local/tests/schedule_runner_test.rs
+++ b/crates/local/tests/schedule_runner_test.rs
@@ -1,0 +1,489 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::platform_store::{PlatformCreateSessionRequest, PlatformMessage};
+use everruns_core::session::Session;
+use everruns_core::session_schedule::{ScheduleType, SessionSchedule};
+use everruns_core::traits::SessionScheduleStore;
+use everruns_core::typed_id::{AgentId, HarnessId, PrincipalId, ScheduleId, SessionId};
+use everruns_local::{
+    LocalScheduleRunner, LocalScheduleRunnerConfig, LocalScheduleStore, LocalSessionRunner,
+    SqliteDb,
+};
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+#[derive(Default)]
+struct RecordingRunner {
+    attempts: AtomicUsize,
+    failures_remaining: AtomicUsize,
+    delivered: Mutex<Vec<(SessionId, String)>>,
+    attempt_notify: Notify,
+    delivery_notify: Notify,
+}
+
+impl RecordingRunner {
+    fn failing(times: usize) -> Self {
+        Self {
+            failures_remaining: AtomicUsize::new(times),
+            ..Self::default()
+        }
+    }
+
+    async fn wait_for_attempts(&self, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while self.attempts.load(Ordering::SeqCst) < expected {
+                self.attempt_notify.notified().await;
+            }
+        })
+        .await
+        .expect("timed out waiting for delivery attempt");
+    }
+
+    async fn wait_for_deliveries(&self, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while self.delivered.lock().len() < expected {
+                self.delivery_notify.notified().await;
+            }
+        })
+        .await
+        .expect("timed out waiting for scheduled delivery");
+    }
+}
+
+#[async_trait]
+impl LocalSessionRunner for RecordingRunner {
+    async fn create_session(
+        &self,
+        _harness_id: HarnessId,
+        _agent_id: Option<AgentId>,
+        _title: Option<&str>,
+        _locale: Option<&str>,
+        _parent_session_id: Option<SessionId>,
+    ) -> Result<Session> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn create_session_with_options(
+        &self,
+        _request: PlatformCreateSessionRequest,
+    ) -> Result<Session> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        self.attempt_notify.notify_waiters();
+        if self
+            .failures_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(AgentLoopError::tool("injected delivery failure"));
+        }
+        self.delivered
+            .lock()
+            .push((session_id, content.to_string()));
+        self.delivery_notify.notify_waiters();
+        Ok(())
+    }
+
+    async fn list_sessions(
+        &self,
+        _limit: Option<usize>,
+        _agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn get_messages(
+        &self,
+        _session_id: SessionId,
+        _limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+}
+
+struct BlockingRunner {
+    attempts: AtomicUsize,
+    entered: Notify,
+    block: Notify,
+}
+
+impl Default for BlockingRunner {
+    fn default() -> Self {
+        Self {
+            attempts: AtomicUsize::new(0),
+            entered: Notify::new(),
+            block: Notify::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl LocalSessionRunner for BlockingRunner {
+    async fn create_session(
+        &self,
+        _harness_id: HarnessId,
+        _agent_id: Option<AgentId>,
+        _title: Option<&str>,
+        _locale: Option<&str>,
+        _parent_session_id: Option<SessionId>,
+    ) -> Result<Session> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn send_message(&self, _session_id: SessionId, _content: &str) -> Result<()> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        self.entered.notify_waiters();
+        self.block.notified().await;
+        Ok(())
+    }
+
+    async fn list_sessions(
+        &self,
+        _limit: Option<usize>,
+        _agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn get_messages(
+        &self,
+        _session_id: SessionId,
+        _limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+
+    async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+        Err(AgentLoopError::tool("unused in schedule runner test"))
+    }
+}
+
+fn config(poll_interval: Duration, claim_timeout: Duration) -> LocalScheduleRunnerConfig {
+    LocalScheduleRunnerConfig {
+        poll_interval,
+        claim_timeout,
+        batch_size: 8,
+    }
+}
+
+fn store(db: SqliteDb) -> LocalScheduleStore {
+    LocalScheduleStore::new(db, 1, PrincipalId::from_seed(1)).unwrap()
+}
+
+#[tokio::test]
+async fn one_shot_delivers_once_and_disables_schedule() {
+    let store = store(SqliteDb::open_in_memory().unwrap());
+    let session_id = SessionId::new();
+    let schedule = store
+        .create_schedule(
+            session_id,
+            "wake up".into(),
+            None,
+            Some(chrono::Utc::now() + chrono::Duration::milliseconds(50)),
+            "UTC".into(),
+        )
+        .await
+        .unwrap();
+    let session_runner = Arc::new(RecordingRunner::default());
+    let handle = LocalScheduleRunner::new(store.clone(), session_runner.clone())
+        .with_config(config(Duration::from_millis(10), Duration::from_secs(1)))
+        .start()
+        .unwrap();
+
+    session_runner.wait_for_deliveries(1).await;
+    tokio::time::sleep(Duration::from_millis(75)).await;
+    handle.shutdown().await.unwrap();
+
+    assert_eq!(
+        session_runner.delivered.lock().as_slice(),
+        &[(session_id, "wake up".into())]
+    );
+    let persisted = store
+        .list_schedules(session_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|item| item.id == schedule.id)
+        .unwrap();
+    assert!(!persisted.enabled);
+    assert!(persisted.next_trigger_at.is_none());
+    assert!(persisted.last_triggered_at.is_some());
+    assert_eq!(persisted.trigger_count, 1);
+}
+
+#[tokio::test]
+async fn recurring_schedule_advances_and_delivers_more_than_once() {
+    let store = store(SqliteDb::open_in_memory().unwrap());
+    let session_id = SessionId::new();
+    let schedule = store
+        .create_schedule(
+            session_id,
+            "tick".into(),
+            Some("*/1 * * * * *".into()),
+            None,
+            "America/Chicago".into(),
+        )
+        .await
+        .unwrap();
+    let first_trigger = schedule.next_trigger_at.unwrap();
+    let session_runner = Arc::new(RecordingRunner::default());
+    let handle = LocalScheduleRunner::new(store.clone(), session_runner.clone())
+        .with_config(config(Duration::from_millis(20), Duration::from_secs(1)))
+        .start()
+        .unwrap();
+
+    session_runner.wait_for_deliveries(2).await;
+    handle.shutdown().await.unwrap();
+
+    let persisted = store.list_schedules(session_id).await.unwrap().remove(0);
+    assert!(persisted.enabled);
+    assert!(persisted.trigger_count >= 2);
+    assert!(persisted.last_triggered_at.is_some());
+    assert!(persisted.next_trigger_at.unwrap() > first_trigger);
+}
+
+#[tokio::test]
+async fn concurrent_runners_do_not_duplicate_an_occurrence() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("schedules.db");
+    let store_a = store(SqliteDb::open(&path).unwrap());
+    let store_b = store(SqliteDb::open(&path).unwrap());
+    let session_id = SessionId::new();
+    store_a
+        .create_schedule(
+            session_id,
+            "once".into(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".into(),
+        )
+        .await
+        .unwrap();
+    let session_runner = Arc::new(RecordingRunner::default());
+    let runner_config = config(Duration::from_millis(5), Duration::from_secs(1));
+    let handle_a = LocalScheduleRunner::new(store_a, session_runner.clone())
+        .with_config(runner_config.clone())
+        .start()
+        .unwrap();
+    let handle_b = LocalScheduleRunner::new(store_b, session_runner.clone())
+        .with_config(runner_config)
+        .start()
+        .unwrap();
+
+    session_runner.wait_for_deliveries(1).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    handle_a.shutdown().await.unwrap();
+    handle_b.shutdown().await.unwrap();
+    assert_eq!(session_runner.delivered.lock().len(), 1);
+}
+
+#[tokio::test]
+async fn active_claim_heartbeat_prevents_slow_delivery_from_being_reclaimed() {
+    let store = store(SqliteDb::open_in_memory().unwrap());
+    let session_id = SessionId::new();
+    store
+        .create_schedule(
+            session_id,
+            "slow".into(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".into(),
+        )
+        .await
+        .unwrap();
+    let session_runner = Arc::new(BlockingRunner::default());
+    let runner_config = config(Duration::from_millis(5), Duration::from_millis(75));
+    let handle_a = LocalScheduleRunner::new(store.clone(), session_runner.clone())
+        .with_config(runner_config.clone())
+        .start()
+        .unwrap();
+    let handle_b = LocalScheduleRunner::new(store, session_runner.clone())
+        .with_config(runner_config)
+        .start()
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), session_runner.entered.notified())
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_eq!(session_runner.attempts.load(Ordering::SeqCst), 1);
+
+    session_runner.block.notify_one();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    handle_a.shutdown().await.unwrap();
+    handle_b.shutdown().await.unwrap();
+    assert_eq!(session_runner.attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn stale_claim_is_recovered_after_interrupted_runner() {
+    let store = store(SqliteDb::open_in_memory().unwrap());
+    let session_id = SessionId::new();
+    store
+        .create_schedule(
+            session_id,
+            "recover".into(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".into(),
+        )
+        .await
+        .unwrap();
+    let blocked = Arc::new(BlockingRunner::default());
+    let runner_config = config(Duration::from_millis(10), Duration::from_millis(100));
+    let interrupted = LocalScheduleRunner::new(store.clone(), blocked.clone())
+        .with_config(runner_config.clone())
+        .start()
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(2), blocked.entered.notified())
+        .await
+        .unwrap();
+    interrupted.abort();
+
+    let recovered = Arc::new(RecordingRunner::default());
+    let recovery_handle = LocalScheduleRunner::new(store.clone(), recovered.clone())
+        .with_config(runner_config)
+        .start()
+        .unwrap();
+    recovered.wait_for_deliveries(1).await;
+    recovery_handle.shutdown().await.unwrap();
+
+    assert_eq!(blocked.attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(recovered.delivered.lock().len(), 1);
+    assert_eq!(
+        store.list_schedules(session_id).await.unwrap()[0].trigger_count,
+        1
+    );
+}
+
+#[tokio::test]
+async fn failed_delivery_is_recorded_and_retried() {
+    let store = store(SqliteDb::open_in_memory().unwrap());
+    let session_id = SessionId::new();
+    let schedule = store
+        .create_schedule(
+            session_id,
+            "retry".into(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".into(),
+        )
+        .await
+        .unwrap();
+    let session_runner = Arc::new(RecordingRunner::failing(1));
+    let handle = LocalScheduleRunner::new(store.clone(), session_runner.clone())
+        .with_config(config(Duration::from_millis(200), Duration::from_secs(1)))
+        .start()
+        .unwrap();
+
+    session_runner.wait_for_attempts(1).await;
+    let recorded = store
+        .last_delivery_error(schedule.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(recorded.contains("injected delivery failure"));
+    let retryable = store.list_schedules(session_id).await.unwrap().remove(0);
+    assert!(retryable.enabled);
+    assert_eq!(retryable.trigger_count, 0);
+    assert!(retryable.next_trigger_at.is_some());
+
+    session_runner.wait_for_deliveries(1).await;
+    handle.shutdown().await.unwrap();
+    let completed = store.list_schedules(session_id).await.unwrap().remove(0);
+    assert_eq!(completed.trigger_count, 1);
+    assert!(!completed.enabled);
+    assert!(
+        store
+            .last_delivery_error(schedule.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn existing_recurring_schedule_is_migrated_and_executed() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root.path().join("legacy.db");
+    let session_id = SessionId::new();
+    let now = chrono::Utc::now();
+    let legacy = SessionSchedule {
+        id: ScheduleId::new(),
+        session_id,
+        owner_principal_id: PrincipalId::from_seed(1),
+        resolved_owner_user_id: None,
+        owner: None,
+        effective_owner: None,
+        description: "legacy recurring".into(),
+        cron_expression: Some("*/1 * * * * *".into()),
+        scheduled_at: None,
+        timezone: "UTC".into(),
+        enabled: true,
+        schedule_type: ScheduleType::Recurring,
+        next_trigger_at: None,
+        last_triggered_at: None,
+        trigger_count: 0,
+        created_at: now,
+        updated_at: now,
+    };
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE local_schedules (
+                id TEXT PRIMARY KEY,
+                org_id INTEGER NOT NULL,
+                session_id TEXT NOT NULL,
+                enabled INTEGER NOT NULL,
+                snapshot TEXT NOT NULL,
+                metadata TEXT NOT NULL DEFAULT '{}'
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata)
+             VALUES (?1, 1, ?2, 1, ?3, '{}')",
+            rusqlite::params![
+                legacy.id.to_string(),
+                session_id.to_string(),
+                serde_json::to_string(&legacy).unwrap(),
+            ],
+        )
+        .unwrap();
+    }
+
+    let store = store(SqliteDb::open(&path).unwrap());
+    assert!(
+        store.list_schedules(session_id).await.unwrap()[0]
+            .next_trigger_at
+            .is_some()
+    );
+    let session_runner = Arc::new(RecordingRunner::default());
+    let handle = LocalScheduleRunner::new(store, session_runner.clone())
+        .with_config(config(Duration::from_millis(10), Duration::from_secs(1)))
+        .start()
+        .unwrap();
+    session_runner.wait_for_deliveries(1).await;
+    handle.shutdown().await.unwrap();
+}

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -209,6 +209,7 @@ In-memory stores vanish when the process exits. For an embedded, single-process 
 |---|---|
 | `LocalSessionTaskRegistry` | Session tasks and their message channel |
 | `LocalScheduleStore` | Session schedules (with a local `metadata` JSON bag) |
+| `LocalScheduleRunner` | In-process execution of due local schedules |
 | `LocalPlatformStore` | Subagent-critical platform store core |
 | `LocalProfile` | Local data dir, workspace, and identity defaults |
 | `LocalBackends` | Composes the above into `RuntimeBackends` |
@@ -239,6 +240,25 @@ let runtime = InProcessRuntimeBuilder::new()
     .build()
     .await?;
 ```
+
+If the embedded platform enables scheduled monitors, persistence alone is not
+enough: start the local executor with the same `LocalSessionRunner` used to
+drive live sessions, retain its handle for the host lifetime, and shut it down
+gracefully:
+
+```rust
+let schedule_runner = local.start_schedule_runner(session_runner.clone())?;
+let local = local.with_platform_runner(session_runner);
+
+// During host shutdown:
+schedule_runner.shutdown().await?;
+```
+
+The runner atomically claims due SQLite records, recovers stale claims after an
+interrupted process, advances timezone-aware recurring schedules, and retries
+failed `send_message` delivery. Delivery is at-least-once across the narrow
+crash window between the host accepting a message and SQLite recording its
+completion.
 
 `LocalBackends` only adds the local stores — it preserves a caller-supplied event bus (via `RuntimeBackends`) and session file-system factory (via the platform's `PlatformDefinition`), so it composes with the [custom backends](#custom-backends) above rather than replacing them. See [docs.rs/everruns-local](https://docs.rs/everruns-local) for the full API.
 

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -285,6 +285,24 @@ local `metadata` JSON column rather than by widening the shared core
 task-lifecycle, restart-survivability, schedule round-trip, composability, and
 embedded-turn coverage.
 
+Persisting a session schedule does not execute it by itself. Embedded hosts
+that expose scheduled monitors explicitly start and retain
+`LocalScheduleRunner` for the host lifetime. The runner atomically claims due
+rows across SQLite connections, heartbeats live claims, recovers stale claims,
+advances recurring cron occurrences in their IANA timezone, and disables
+successful one-shots. It delivers the stored prompt through the host's existing
+`LocalSessionRunner::send_message` implementation; storage never owns session
+execution. Failed deliveries release the occurrence for retry and retain a
+diagnostic error. Shutdown stops new claims and waits for an active delivery;
+forced abort leaves the lease for stale recovery. See `crates/local/` for the
+public lifecycle API and tests.
+
+This boundary provides at-least-once delivery across process failure. Atomic
+claims prevent duplicate delivery by concurrent healthy runners, but a crash
+after `send_message` accepts the prompt and before SQLite commits completion
+can retry that occurrence. Hosts should keep scheduled turns idempotent across
+that unavoidable external-delivery window.
+
 ## Context and Capabilities
 
 Capabilities continue to live in `everruns-core`.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -689,6 +689,7 @@ All `/v1/durable/*` HTTP endpoints require explicit platform-user auth. The auth
 | TM-SCHED-003 | Concurrent execution overload | Medium | `max_concurrent` field enforced; trigger skipped if limit reached | MITIGATED |
 | TM-SCHED-004 | Invalid cron expression DoS | Low | Cron parser validates expression at creation time; invalid expressions rejected | MITIGATED |
 | TM-SCHED-005 | Scheduler crash leaves tasks untriggered | Medium | Durable execution ensures tasks are created; if executor crashes, tasks auto-reclaimed via heartbeat | MITIGATED |
+| TM-SCHED-006 | Embedded schedule duplication or stranding after runner failure | Medium | `everruns-local` claims due occurrences in an immediate SQLite transaction, scopes claims by org, heartbeats claims during host delivery, and reclaims only stale leases. Successful delivery advances or disables the stored occurrence; failure releases it for retry. The external `send_message` boundary is at-least-once: a process crash after host acceptance but before completion commit can retry, so embedded hosts must tolerate duplicate scheduled prompts in that narrow window. Batch size is bounded to prevent unbounded poll work. | MITIGATED |
 
 ## 11. Observability (TM-OBS)
 


### PR DESCRIPTION
## What changed
Embedded hosts can now explicitly start an in-process `everruns-local` runner that executes due one-shot and recurring session schedules through their configured `LocalSessionRunner::send_message` seam. Atomic SQLite claims, live claim heartbeats, stale recovery, retryable delivery failures, timezone-aware cron advancement, graceful shutdown, tracing, and schema migration make the path safe for production embedders.

## Why
`everruns-local` persisted session schedules but never executed them, so scheduled monitors reported success and then remained stranded indefinitely. EVE-747 requires the execution behavior in the reusable local runtime layer rather than in downstream hosts such as Yolop.

## Before / After
Before: a due local schedule remained enabled with `trigger_count = 0`, no `last_triggered_at`, and no host message.

After: the end-to-end smoke test observed exactly one `send_message`; the successful one-shot was disabled, `next_trigger_at` was cleared, and trigger metadata was recorded. Recurring, concurrent-runner, slow-delivery heartbeat, interrupted-runner recovery, legacy-schema migration, and failed-delivery retry cases also pass.

## Risk
- Medium
- SQLite schema evolution and scheduler lifecycle are new behavior for embedders that opt in.
- Delivery is at-least-once across the narrow crash window after host acceptance and before the completion commit; this is documented for hosts.
- Hosted/server scheduler behavior is unchanged and its focused tests pass.

## Security
- Threat categories reviewed: TM-SCHED, TM-DOS, TM-OBS, and the local SQLite boundary.
- Findings and resolutions: claims are org-scoped and use parameterized SQL inside an immediate transaction; active deliveries heartbeat their leases; stale claims are recoverable; batch size and persisted error size are bounded; prompt content is not traced; the crash-window residual is documented in `specs/threat-model.md` as TM-SCHED-006. The new `chrono-tz` dependency is narrowly scoped to timezone-correct cron calculation.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `just pre-push`
- `cargo test -p everruns-local`
- `cargo clippy -p everruns-local --all-targets --all-features -- -D warnings`
- `cargo test -p everruns-server session_scheduler --lib`
- `cargo test -p everruns-local --test schedule_runner_test one_shot_delivers_once_and_disables_schedule -- --exact --nocapture`
- Final GitHub Actions: all 30 required checks passed, including Docs Build & Check, PostgreSQL and S3 integrations, full unit tests, MSRV, release binaries, SDK compatibility, CodeQL, and Docker.
