### PR TITLE
fix(files): support glob path filters in grep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,6 +2561,7 @@ dependencies = [
  "everruns-openui",
  "fetchkit",
  "futures",
+ "globset",
  "hex",
  "http 1.4.2",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ clap = { version = "4", features = ["derive", "env"] }
 serde_yaml = "0.9"
 eventsource-stream = "0.2"
 regex = "1.11"
+globset = "0.4"
 time = "0.3"
 parking_lot = "0.12"
 dialoguer = "0.12"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -64,8 +64,9 @@ base64.workspace = true
 sha2.workspace = true
 hex.workspace = true
 
-# Regex for argument substitution
+# Pattern matching
 regex.workspace = true
+globset.workspace = true
 
 # Text diff rendering for edit_file previews
 similar = "3"

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -1446,7 +1446,7 @@ impl Tool for GrepFilesTool {
                 },
                 "path_pattern": {
                     "type": "string",
-                    "description": "Optional path pattern to filter files (e.g., '*.txt', 'docs/*')"
+                    "description": "Optional glob filtering canonical paths (e.g., '*.txt', 'docs/*', 'src/**/*.rs'). Basename-only globs match at any depth; non-glob values use legacy substring matching"
                 },
                 "offset": {
                     "type": "integer",

--- a/crates/core/src/mount_fs.rs
+++ b/crates/core/src/mount_fs.rs
@@ -426,6 +426,28 @@ impl SessionFileSystem for MountFs {
     ) -> Result<Vec<GrepMatch>> {
         match path_pattern {
             Some(pp) => {
+                let matcher = crate::session_path::GrepPathPattern::new(pp)?;
+                if matcher.is_glob() && (!pp.starts_with('/') || pp.starts_with(WORKSPACE_MOUNT)) {
+                    let mut matches = Vec::new();
+                    for resolved in self.grep_mounts() {
+                        matches.extend(
+                            resolved
+                                .backend
+                                .grep_files(session_id, pattern, Some(&resolved.backend_path))
+                                .await?
+                                .into_iter()
+                                .map(|grep_match| resolved.map_grep_match(grep_match))
+                                .filter(|grep_match| matcher.is_match(&grep_match.path)),
+                        );
+                    }
+                    matches.sort_by(|a, b| {
+                        a.path
+                            .cmp(&b.path)
+                            .then(a.line_number.cmp(&b.line_number))
+                            .then(a.line.cmp(&b.line))
+                    });
+                    return Ok(matches);
+                }
                 let resolved = self.resolve(pp)?;
                 Ok(resolved
                     .backend
@@ -486,6 +508,7 @@ impl SessionFileSystem for MountFs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_path::GrepPathPattern;
 
     fn sid() -> SessionId {
         SessionId::from_seed(1)
@@ -565,11 +588,12 @@ mod tests {
             pattern: &str,
             path_pattern: Option<&str>,
         ) -> Result<Vec<GrepMatch>> {
+            let path_pattern = path_pattern.map(GrepPathPattern::new).transpose()?;
             let files = self.files.lock().unwrap();
             let mut matches = Vec::new();
             for (path, content) in files.iter() {
-                if let Some(filter) = path_pattern
-                    && !path.contains(filter)
+                if let Some(filter) = &path_pattern
+                    && !filter.is_match(path)
                 {
                     continue;
                 }
@@ -743,6 +767,59 @@ mod tests {
             paths,
             vec![
                 "/README.md".to_string(),
+                "/workspace/roots/backend/Cargo.toml".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn grep_resolves_workspace_glob_to_backend_namespace() {
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(backend);
+        fs.write_file(sid(), "/workspace/src/lib.rs", "needle", "text")
+            .await
+            .unwrap();
+        fs.write_file(sid(), "/workspace/docs/readme.md", "needle", "text")
+            .await
+            .unwrap();
+
+        let matches = fs
+            .grep_files(sid(), "needle", Some("/workspace/src/**/*.rs"))
+            .await
+            .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].path, "/src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn grep_glob_searches_every_matching_mount() {
+        let workspace: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let volume: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::new(workspace).with_mount("/workspace/roots/backend", volume, "/");
+        fs.write_file(sid(), "/workspace/Cargo.toml", "needle", "text")
+            .await
+            .unwrap();
+        fs.write_file(
+            sid(),
+            "/workspace/roots/backend/Cargo.toml",
+            "needle",
+            "text",
+        )
+        .await
+        .unwrap();
+
+        let paths: Vec<_> = fs
+            .grep_files(sid(), "needle", Some("**/*.toml"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|hit| hit.path)
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                "/Cargo.toml".to_string(),
                 "/workspace/roots/backend/Cargo.toml".to_string()
             ]
         );

--- a/crates/core/src/session_path.rs
+++ b/crates/core/src/session_path.rs
@@ -15,6 +15,76 @@
 /// It is purely a *view*; addressing is done by [`crate::mount_fs::MountFs`].
 pub const WORKSPACE_PREFIX: &str = "/workspace";
 
+/// Compiled filter for [`crate::traits::SessionFileSystem::grep_files`].
+///
+/// Patterns containing glob metacharacters use segment-aware glob semantics.
+/// A basename-only glob (for example `*.rs`) matches at any depth. Patterns
+/// without glob metacharacters retain the legacy substring behavior.
+#[derive(Debug, Clone)]
+pub struct GrepPathPattern {
+    matcher: GrepPathMatcher,
+}
+
+#[derive(Debug, Clone)]
+enum GrepPathMatcher {
+    All,
+    Substring(String),
+    Glob(globset::GlobMatcher),
+}
+
+impl GrepPathPattern {
+    pub fn new(pattern: &str) -> crate::error::Result<Self> {
+        let normalized = to_session_path(pattern);
+        let relative = normalized.trim_start_matches('/');
+        if relative.is_empty() {
+            return Ok(Self {
+                matcher: GrepPathMatcher::All,
+            });
+        }
+        if !relative
+            .chars()
+            .any(|ch| matches!(ch, '*' | '?' | '[' | '{'))
+        {
+            return Ok(Self {
+                matcher: GrepPathMatcher::Substring(relative.to_string()),
+            });
+        }
+
+        let glob = if relative.contains('/') {
+            relative.to_string()
+        } else {
+            format!("**/{relative}")
+        };
+        let matcher = globset::GlobBuilder::new(&glob)
+            .literal_separator(true)
+            .backslash_escape(false)
+            .build()
+            .map_err(|error| {
+                crate::error::AgentLoopError::tool(format!(
+                    "invalid grep path_pattern {pattern:?}: {error}"
+                ))
+            })?
+            .compile_matcher();
+        Ok(Self {
+            matcher: GrepPathMatcher::Glob(matcher),
+        })
+    }
+
+    pub fn is_match(&self, canonical_path: &str) -> bool {
+        let relative = to_session_path(canonical_path);
+        let relative = relative.trim_start_matches('/');
+        match &self.matcher {
+            GrepPathMatcher::All => true,
+            GrepPathMatcher::Substring(needle) => relative.contains(needle),
+            GrepPathMatcher::Glob(matcher) => matcher.is_match(relative),
+        }
+    }
+
+    pub fn is_glob(&self) -> bool {
+        matches!(&self.matcher, GrepPathMatcher::Glob(_))
+    }
+}
+
 /// Canonical leading-slash session path from any accepted spelling: collapses
 /// repeated slashes, strips the `/workspace` alias, ensures a single leading
 /// slash, and trims a trailing slash.
@@ -125,5 +195,30 @@ mod tests {
             to_display_path("/workspace/src/lib.rs"),
             "/workspace/src/lib.rs"
         );
+    }
+
+    #[test]
+    fn grep_path_patterns_support_globs_and_legacy_substrings() {
+        let cases = [
+            ("src/**/*.rs", "/src/lib.rs", true),
+            ("src/**/*.rs", "/src/nested/mod.rs", true),
+            ("src/**/*.rs", "/docs/lib.rs", false),
+            ("**/*", "/notes.txt", true),
+            ("**/*", "/src/lib.rs", true),
+            ("docs/*", "/docs/readme.md", true),
+            ("docs/*", "/docs/nested/guide.md", false),
+            ("*.txt", "/notes.txt", true),
+            ("*.txt", "/nested/notes.txt", true),
+            ("/workspace/src/**/*.rs", "/src/lib.rs", true),
+            ("docs", "/my-docs/readme.md", true),
+        ];
+        for (pattern, path, expected) in cases {
+            let matcher = GrepPathPattern::new(pattern).unwrap();
+            assert_eq!(
+                matcher.is_match(path),
+                expected,
+                "pattern={pattern} path={path}"
+            );
+        }
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -512,7 +512,10 @@ pub trait SessionFileSystem: Send + Sync {
     /// Get file metadata
     async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>>;
 
-    /// Search files by pattern (grep)
+    /// Search file contents, optionally filtering canonical paths by glob.
+    ///
+    /// Basename-only globs match at any depth. Non-glob path filters retain
+    /// legacy substring matching; see `specs/file-store.md`.
     async fn grep_files(
         &self,
         session_id: SessionId,

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -364,6 +364,9 @@ impl SessionFileSystem for InMemorySessionFileStore {
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
+        let path_pattern = path_pattern
+            .map(everruns_core::session_path::GrepPathPattern::new)
+            .transpose()?;
         let files = self.files.read().await;
         let mut matches = Vec::new();
 
@@ -371,8 +374,8 @@ impl SessionFileSystem for InMemorySessionFileStore {
             if *sid != session_id || entry.file.is_directory || entry.file.encoding != "text" {
                 continue;
             }
-            if let Some(path_pattern) = path_pattern
-                && !path.contains(path_pattern)
+            if let Some(path_pattern) = &path_pattern
+                && !path_pattern.is_match(path)
             {
                 continue;
             }
@@ -575,5 +578,46 @@ fn file_info(file: &SessionFile) -> FileInfo {
         size_bytes: file.size_bytes,
         created_at: file.created_at,
         updated_at: file.updated_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn grep_path_pattern_supports_globs_and_substring_compatibility() {
+        let store = InMemorySessionFileStore::new();
+        let session = SessionId::from_seed(1);
+        for path in [
+            "/src/lib.rs",
+            "/src/nested/mod.rs",
+            "/docs/readme.md",
+            "/notes.txt",
+        ] {
+            store
+                .write_file(session, path, "needle", "text")
+                .await
+                .unwrap();
+        }
+
+        let mut glob_paths: Vec<_> = store
+            .grep_files(session, "needle", Some("src/**/*.rs"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|hit| hit.path)
+            .collect();
+        glob_paths.sort();
+        assert_eq!(glob_paths, vec!["/src/lib.rs", "/src/nested/mod.rs"]);
+
+        let substring_paths: Vec<_> = store
+            .grep_files(session, "needle", Some("docs"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|hit| hit.path)
+            .collect();
+        assert_eq!(substring_paths, vec!["/docs/readme.md"]);
     }
 }

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -509,7 +509,9 @@ impl SessionFileSystem for RealDiskFileStore {
         let root = self.root();
         let pattern = pattern.to_string();
         let path_pattern = match path_pattern {
-            Some(path) => Some(self.paths.parse_input(path)?.as_relative().to_string()),
+            Some(path) => Some(everruns_core::session_path::GrepPathPattern::new(
+                self.paths.parse_input(path)?.as_relative(),
+            )?),
             None => None,
         };
 
@@ -565,7 +567,7 @@ impl SessionFileSystem for RealDiskFileStore {
                     continue;
                 }
                 if let Some(filter) = &path_pattern
-                    && !rel_str.contains(filter.as_str())
+                    && !filter.is_match(&rel_str)
                 {
                     continue;
                 }
@@ -1171,6 +1173,72 @@ mod tests {
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].path, "/src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn grep_path_pattern_supports_globs() {
+        let (store, _dir) = make_store();
+        let session = sid();
+        for path in [
+            "/src/lib.rs",
+            "/src/nested/mod.rs",
+            "/docs/readme.md",
+            "/docs/nested/guide.md",
+            "/notes.txt",
+            "/nested/notes.txt",
+        ] {
+            store
+                .write_file(session, path, "needle", "text")
+                .await
+                .expect("write fixture");
+        }
+
+        let cases = [
+            ("src/**/*.rs", vec!["/src/lib.rs", "/src/nested/mod.rs"]),
+            (
+                "**/*",
+                vec![
+                    "/docs/nested/guide.md",
+                    "/docs/readme.md",
+                    "/nested/notes.txt",
+                    "/notes.txt",
+                    "/src/lib.rs",
+                    "/src/nested/mod.rs",
+                ],
+            ),
+            ("docs/*", vec!["/docs/readme.md"]),
+            ("*.txt", vec!["/nested/notes.txt", "/notes.txt"]),
+            (
+                "/workspace/src/**/*.rs",
+                vec!["/src/lib.rs", "/src/nested/mod.rs"],
+            ),
+        ];
+
+        for (path_pattern, expected) in cases {
+            let mut paths: Vec<_> = store
+                .grep_files(session, "needle", Some(path_pattern))
+                .await
+                .expect("grep")
+                .into_iter()
+                .map(|hit| hit.path)
+                .collect();
+            paths.sort();
+            assert_eq!(paths, expected, "path_pattern={path_pattern}");
+        }
+
+        let host_pattern = Path::new(&store.display_root())
+            .join("src/**/*.rs")
+            .display()
+            .to_string();
+        let mut paths: Vec<_> = store
+            .grep_files(session, "needle", Some(&host_pattern))
+            .await
+            .expect("host-absolute glob")
+            .into_iter()
+            .map(|hit| hit.path)
+            .collect();
+        paths.sort();
+        assert_eq!(paths, vec!["/src/lib.rs", "/src/nested/mod.rs"]);
     }
 
     #[tokio::test]

--- a/crates/server/src/api/memory_files.rs
+++ b/crates/server/src/api/memory_files.rs
@@ -115,7 +115,9 @@ pub struct UpdateMemoryFileRequest {
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct GrepRequest {
+    /// Regex pattern to search for.
     pub pattern: String,
+    /// Optional path glob (`**/*.rs`, `docs/*.md`).
     #[serde(default)]
     pub path_pattern: Option<String>,
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1212,19 +1212,23 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
         let mut matches: Vec<GrepMatch> = results.into_iter().flat_map(|r| r.matches).collect();
 
-        // Also search virtual mounts (use regex path filtering to match DB semantics)
+        // Also search virtual mounts with the shared canonical-path glob semantics.
         if let Some(registry) = &self.virtual_registry
             && let Ok(regex) = regex::Regex::new(pattern)
         {
-            let path_regex = path_pattern
-                .map(regex::Regex::new)
+            let path_matcher = path_pattern
+                .map(everruns_core::session_path::GrepPathPattern::new)
                 .transpose()
                 .unwrap_or(None);
             let virtual_matches = registry.grep(&session_id, &regex, None, 512 * 1024);
             matches.extend(
                 virtual_matches
                     .into_iter()
-                    .filter(|vm| path_regex.as_ref().is_none_or(|re| re.is_match(&vm.path)))
+                    .filter(|vm| {
+                        path_matcher
+                            .as_ref()
+                            .is_none_or(|matcher| matcher.is_match(&vm.path))
+                    })
                     .map(|vm| GrepMatch {
                         path: vm.path,
                         line_number: vm.line_number,

--- a/crates/server/src/domains/memory/files.rs
+++ b/crates/server/src/domains/memory/files.rs
@@ -261,16 +261,21 @@ impl MemoryFileService {
         // bubbling up from Postgres as a generic 500.
         regex::Regex::new(pattern)
             .map_err(|e| MemoryFsError::InvalidPattern(format!("pattern: {e}")))?;
-        if let Some(pp) = path_pattern {
-            regex::Regex::new(pp)
-                .map_err(|e| MemoryFsError::InvalidPattern(format!("path_pattern: {e}")))?;
-        }
+        let path_matcher = path_pattern
+            .map(everruns_core::session_path::GrepPathPattern::new)
+            .transpose()
+            .map_err(|e| MemoryFsError::InvalidPattern(format!("path_pattern: {e}")))?;
         let rows = self
             .db
-            .grep_memory_files(memory_id, pattern, path_pattern, GREP_MAX_FILE_BYTES)
+            .grep_memory_files(memory_id, pattern, None, GREP_MAX_FILE_BYTES)
             .await?;
         Ok(rows
             .into_iter()
+            .filter(|row| {
+                path_matcher
+                    .as_ref()
+                    .is_none_or(|matcher| matcher.is_match(&row.path))
+            })
             .map(|r| GrepMatchInfo {
                 path: r.path,
                 size_bytes: r.size_bytes,
@@ -606,6 +611,34 @@ mod tests {
         let hits = svc.grep(mem.id, "quick", None).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].path, "/notes/alpha.md");
+    }
+
+    #[tokio::test]
+    async fn grep_filters_paths_with_globs() {
+        let db = make_db();
+        let mem = seed_memory(&db, false).await;
+        let svc = MemoryFileService::new(db.clone());
+
+        for path in ["/notes/alpha.md", "/notes/nested/beta.md", "/notes.txt"] {
+            svc.create_file(
+                &mem,
+                NewFileInput {
+                    path: path.into(),
+                    content: Some("needle".into()),
+                    is_directory: false,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let hits = svc
+            .grep(mem.id, "needle", Some("notes/*.md"))
+            .await
+            .unwrap();
+        let paths: Vec<_> = hits.into_iter().map(|hit| hit.path).collect();
+
+        assert_eq!(paths, vec!["/notes/alpha.md"]);
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -752,18 +752,19 @@ impl WorkspaceFileService {
         // Also search virtual mounts (same per-file and NFA caps, TM-DOS-008)
         if let Some(registry) = &self.virtual_registry {
             let regex = build_grep_regex(&req.pattern)?;
-            let path_regex = req
+            let path_matcher = req
                 .path_pattern
                 .as_deref()
-                .map(build_grep_regex)
+                .map(everruns_core::session_path::GrepPathPattern::new)
                 .transpose()?;
-            // Pass None for path filter — we apply regex filtering below to match DB semantics
+            // Apply the shared path matcher after reading virtual entries.
             let virtual_matches =
                 registry.grep(&session_id, &regex, None, MAX_GREP_FILE_BYTES as usize);
-            for vm in virtual_matches
-                .into_iter()
-                .filter(|vm| path_regex.as_ref().is_none_or(|re| re.is_match(&vm.path)))
-            {
+            for vm in virtual_matches.into_iter().filter(|vm| {
+                path_matcher
+                    .as_ref()
+                    .is_none_or(|matcher| matcher.is_match(&vm.path))
+            }) {
                 // Group by file path into GrepResult entries
                 if let Some(existing) = results.iter_mut().find(|r| r.path == vm.path) {
                     existing.matches.push(GrepMatch {
@@ -1339,7 +1340,7 @@ pub async fn grep_session_files(
     pattern: &str,
     path_pattern: Option<&str>,
 ) -> Result<Vec<GrepResult>> {
-    // TM-DOS-008: cap pattern and path_pattern length, then cap compiled NFA size.
+    // TM-DOS-008: cap content/path pattern lengths, then cap content-regex NFA size.
     anyhow::ensure!(
         pattern.len() <= MAX_GREP_PATTERN_LEN,
         "Regex pattern too long (max {} characters)",
@@ -1354,11 +1355,16 @@ pub async fn grep_session_files(
     }
 
     let regex = build_grep_regex(pattern)?;
+    let path_matcher = path_pattern
+        .map(everruns_core::session_path::GrepPathPattern::new)
+        .transpose()?;
 
     // Get matching files from database. MAX_GREP_FILE_BYTES is passed so the
     // storage backend never loads content from files that exceed the per-file cap.
+    // Path glob semantics are shared with the runtime backends and applied below;
+    // the repository receives no backend-specific regex filter.
     let files = db
-        .grep_session_files(session_id, pattern, path_pattern, MAX_GREP_FILE_BYTES)
+        .grep_session_files(session_id, pattern, None, MAX_GREP_FILE_BYTES)
         .await?;
 
     let mut results = Vec::new();
@@ -1366,6 +1372,12 @@ pub async fn grep_session_files(
 
     // For each matching file, find the actual line matches
     for file_info in files {
+        if path_matcher
+            .as_ref()
+            .is_some_and(|matcher| !matcher.is_match(&file_info.path))
+        {
+            continue;
+        }
         // Defense-in-depth: skip oversized files even if the storage filter missed them.
         if file_info.size_bytes > MAX_GREP_FILE_BYTES {
             continue;
@@ -1479,6 +1491,23 @@ mod tests {
         assert_eq!(results[0].matches.len(), 1);
         assert_eq!(results[0].matches[0].line_number, 2);
         assert!(results[0].matches[0].line.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn grep_session_files_filters_paths_with_globs() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        seed_file(&db, sid, "/src/main.rs", "needle").await;
+        seed_file(&db, sid, "/src/nested/lib.rs", "needle").await;
+        seed_file(&db, sid, "/docs/readme.md", "needle").await;
+
+        let results = grep_session_files(&db, sid, "needle", Some("src/**/*.rs"))
+            .await
+            .unwrap();
+        let mut paths: Vec<_> = results.into_iter().map(|result| result.path).collect();
+        paths.sort();
+
+        assert_eq!(paths, vec!["/src/main.rs", "/src/nested/lib.rs"]);
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/memory/memories.rs
+++ b/crates/server/src/storage/memory/memories.rs
@@ -488,8 +488,8 @@ impl InMemoryDatabase {
         path_pattern: Option<&str>,
         max_file_bytes: i64,
     ) -> Result<Vec<MemoryFileInfoRow>> {
-        // Use regex for both the content pattern and the optional path filter
-        // so dev/in-memory behavior matches the Postgres `~` semantics.
+        // Content uses regex. Path filtering is applied by the service with the
+        // shared glob matcher, so repositories receive `None` for path_pattern.
         let content_re =
             regex::Regex::new(pattern).map_err(|e| anyhow::anyhow!("invalid pattern: {e}"))?;
         let path_re = path_pattern

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -242,8 +242,13 @@ The following behaviors hold across all implementations:
    always exists.
 5. **`grep_files`** searches text files only. Implementations are free to
    skip binary content, oversized files, and explicitly excluded
-   directories. `path_pattern` is a plain substring match against the
-   canonical path (no glob expansion); `Some("")` matches every path.
+   directories. `path_pattern` filters canonical workspace paths using globs:
+   `*` and `?` match within one path segment, `**` crosses directories, and
+   bracket classes and brace alternation are supported. A basename-only glob
+   such as `*.txt` matches at any depth. `/workspace` and supported host-absolute
+   aliases are normalized before matching. Patterns without glob
+   metacharacters retain the legacy substring behavior; `Some("")` matches
+   every path.
 6. **`list_directory` ambiguity.** The trait currently returns an empty
    `Vec<FileInfo>` both when the path is missing and when it exists but is
    not a directory. Callers that need to distinguish "empty directory"


### PR DESCRIPTION
## What changed
`grep_files.path_pattern` now honors segment-aware glob syntax consistently across session, memory, mounted, in-memory, and real-disk filesystems.

Supported behavior includes `*` and `?` within a segment, `**` across directories, bracket classes, brace alternation, basename-only globs at any depth, and normalized `/workspace` or supported host-path aliases. Plain non-glob values retain legacy substring matching.

## Why
The tool schema advertised glob examples such as `*.txt` and `docs/*`, while runtime backends treated them as literal substrings. Valid searches such as `src/**/*.rs` silently returned zero files and pushed agents into redundant fallback searches.

## Before / After
Before, a path filter of `src/**/*.rs` matched no files because the asterisks were treated literally.

After, focused regression tests show it matches both `/src/main.rs` and `/src/nested/lib.rs` while excluding non-Rust and out-of-scope paths. The same contract is covered in Core mount routing, Runtime in-memory/real-disk stores, Server session storage, and Server memory storage.

## Risk
- Medium
- Path filters containing glob metacharacters now follow the documented glob contract instead of backend-specific substring or regex behavior. Plain path filters preserve substring compatibility.

## Security
- Threat categories reviewed: TM-FS, TM-DOS-008, TM-TENANT
- Findings and resolutions: glob matching uses `globset` without backtracking; existing content-regex, pattern-length, file-size, and total-scan limits remain in place. Filtering stays inside the already session- or memory-scoped result set, so tenant boundaries are unchanged.

## Follow-ups
Output persistence and successful-command truncation behavior are intentionally excluded and will be handled separately.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no comments or review threads present)

Post-sync validation: migration sequence 001..103; Core glob tests 9/9; Runtime backend glob tests 2/2; Server grep suite 24/24; cargo fmt; OpenAPI regenerated and verified.