### PR TITLE
fix(fs): align file-tool guidance with active path identity

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -12,11 +12,13 @@
 //! - `delete_file`: Delete a file or directory
 //! - `stat_file`: Get file metadata
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus, SystemPromptContext};
+use super::{
+    Capability, CapabilityLocalization, CapabilityStatus, SystemPromptContext, ToolDefinitionHook,
+};
 use crate::error::{FileSystemErrorClass, classify_fs_error};
 use crate::session_file::SessionFile;
 use crate::tool_output_sanitizer::build_binary_read_file_result;
-use crate::tool_types::ToolHints;
+use crate::tool_types::{ToolDefinition, ToolHints};
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::{SessionFileSystem, ToolContext};
 use crate::truncation_info::{TruncationInfo, TruncationReason};
@@ -24,6 +26,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use similar::TextDiff;
+use std::sync::Arc;
 
 /// Image MIME types recognized by LLM vision APIs (OpenAI, Anthropic)
 const IMAGE_EXTENSIONS: &[(&str, &str)] = &[
@@ -45,6 +48,15 @@ fn image_media_type(path: &str) -> Option<&'static str> {
 
 /// Workspace prefix used in file paths
 const WORKSPACE_PREFIX: &str = "/workspace";
+const SESSION_FILE_SYSTEM_TOOL_NAMES: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit_file",
+    "list_directory",
+    "grep_files",
+    "delete_file",
+    "stat_file",
+];
 const MAX_EDIT_DIFF_CHARS: usize = 16_000;
 const LIST_DIRECTORY_DEFAULT_LIMIT: usize = 200;
 const LIST_DIRECTORY_MAX_LIMIT: usize = 1_000;
@@ -56,6 +68,358 @@ fn escape_xml_text(content: &str) -> String {
         .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
+}
+
+/// Model-visible path identity derived from the active primary `SessionFileSystem`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FilePathPresentation {
+    root: String,
+}
+
+impl FilePathPresentation {
+    fn vfs() -> Self {
+        Self {
+            root: WORKSPACE_PREFIX.to_string(),
+        }
+    }
+
+    fn from_context(ctx: &SystemPromptContext) -> Self {
+        Self::from_file_store(
+            ctx.file_store
+                .as_ref()
+                .map(|store| store.as_ref() as &dyn SessionFileSystem),
+        )
+    }
+
+    fn from_file_store(store: Option<&dyn SessionFileSystem>) -> Self {
+        let root = store
+            .map(SessionFileSystem::display_root)
+            .unwrap_or_else(|| WORKSPACE_PREFIX.to_string());
+        Self { root }
+    }
+
+    fn uses_vfs_namespace(&self) -> bool {
+        self.root == WORKSPACE_PREFIX
+    }
+
+    fn root_guidance(&self) -> String {
+        if self.uses_vfs_namespace() {
+            format!(
+                "Workspace root: `{WORKSPACE_PREFIX}`. All file paths must start with `{WORKSPACE_PREFIX}`. "
+            )
+        } else {
+            let escaped_root = escape_xml_text(&self.root);
+            format!(
+                "Workspace root: `{escaped_root}`. Paths may be relative to this root or absolute under it. "
+            )
+        }
+    }
+
+    fn system_prompt_preview(&self) -> String {
+        if self.uses_vfs_namespace() {
+            format!(
+                "Workspace root: `{WORKSPACE_PREFIX}`. All file paths must start with `{WORKSPACE_PREFIX}`."
+            )
+        } else {
+            format!(
+                "Workspace root: `{}`. Paths may be relative to this root or absolute under it.",
+                self.root
+            )
+        }
+    }
+
+    fn path_param_description(&self, example: &str) -> String {
+        if self.uses_vfs_namespace() {
+            format!(
+                "Workspace-relative path (e.g., '{example}'). A leading '/' or '{WORKSPACE_PREFIX}/' prefix is also accepted."
+            )
+        } else {
+            format!(
+                "Path relative to `{}` (e.g., '{example}') or an absolute path under `{}`.",
+                self.root, self.root
+            )
+        }
+    }
+
+    fn generic_path_param_description(&self) -> String {
+        if self.uses_vfs_namespace() {
+            "Path to the file or directory. A leading '/' or '/workspace/' prefix is also accepted."
+                .to_string()
+        } else {
+            format!(
+                "Path relative to `{}` or an absolute path under `{}`.",
+                self.root, self.root
+            )
+        }
+    }
+
+    fn list_directory_path_description(&self) -> String {
+        if self.uses_vfs_namespace() {
+            format!(
+                "Workspace-relative directory path to list (e.g., 'src'). Defaults to the workspace root; a leading '/' or '{WORKSPACE_PREFIX}/' prefix is also accepted."
+            )
+        } else {
+            format!(
+                "Directory path relative to `{}` (e.g., 'src'). Defaults to `{}` when omitted.",
+                self.root, self.root
+            )
+        }
+    }
+
+    fn parameters_schema_for_tool(&self, tool_name: &str) -> Option<Value> {
+        match tool_name {
+            "read_file" => Some(read_file_parameters_schema(self)),
+            "write_file" => Some(write_file_parameters_schema(self)),
+            "edit_file" => Some(edit_file_parameters_schema(self)),
+            "list_directory" => Some(list_directory_parameters_schema(self)),
+            "grep_files" => Some(grep_files_parameters_schema()),
+            "delete_file" => Some(delete_file_parameters_schema(self)),
+            "stat_file" => Some(stat_file_parameters_schema(self)),
+            _ => None,
+        }
+    }
+}
+
+struct FilePathPresentationHook {
+    presentation: FilePathPresentation,
+}
+
+impl ToolDefinitionHook for FilePathPresentationHook {
+    fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
+        tools
+            .into_iter()
+            .map(|tool| {
+                if !SESSION_FILE_SYSTEM_TOOL_NAMES.contains(&tool.name()) {
+                    return tool;
+                }
+                let Some(schema) = self.presentation.parameters_schema_for_tool(tool.name()) else {
+                    return tool;
+                };
+                match tool {
+                    ToolDefinition::Builtin(mut builtin) => {
+                        builtin.parameters = schema.clone();
+                        if let Some(full) = builtin.full_parameters.as_mut() {
+                            *full = schema;
+                        }
+                        ToolDefinition::Builtin(builtin)
+                    }
+                    ToolDefinition::ClientSide(mut client) => {
+                        client.parameters = schema.clone();
+                        if let Some(full) = client.full_parameters.as_mut() {
+                            *full = schema;
+                        }
+                        ToolDefinition::ClientSide(client)
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+fn read_file_parameters_schema(presentation: &FilePathPresentation) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": presentation.path_param_description("docs/readme.txt")
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Starting line number (0-indexed). Default: 0",
+                "default": 0,
+                "minimum": 0
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max lines to return. Default varies by file type: 2000 (source/text), 500 (logs, tail-biased), 100 (CSV/TSV with header). Explicit value always wins.",
+                "default": 2000,
+                "minimum": 1
+            }
+        },
+        "required": ["path"],
+        "additionalProperties": false
+    })
+}
+
+fn write_file_parameters_schema(presentation: &FilePathPresentation) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": presentation.path_param_description("docs/notes.txt")
+            },
+            "content": {
+                "type": "string",
+                "description": "Content to write to the file"
+            },
+            "encoding": {
+                "type": "string",
+                "enum": ["text", "base64"],
+                "default": "text",
+                "description": "Content encoding: 'text' for plain text, 'base64' for binary data"
+            }
+        },
+        "required": ["path", "content"],
+        "additionalProperties": false
+    })
+}
+
+fn edit_file_parameters_schema(presentation: &FilePathPresentation) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": presentation.path_param_description("src/main.rs")
+            },
+            "expected_hash": {
+                "type": "string",
+                "description": "Current content hash from read_file or write_file (format: 'sha256:...')"
+            },
+            "edits": {
+                "type": "array",
+                "description": "One or more replacements to apply, each matched against the original file content. Use a single-element array for one replacement.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "old_text": {
+                            "type": "string",
+                            "description": "Exact text to replace"
+                        },
+                        "new_text": {
+                            "type": "string",
+                            "description": "Replacement text"
+                        }
+                    },
+                    "required": ["old_text", "new_text"],
+                    "additionalProperties": false
+                },
+                "minItems": 1
+            }
+        },
+        "required": ["path", "expected_hash", "edits"],
+        "additionalProperties": false
+    })
+}
+
+fn list_directory_parameters_schema(presentation: &FilePathPresentation) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "default": presentation.root,
+                "description": presentation.list_directory_path_description()
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Starting item offset for large directories. Default: 0",
+                "default": 0,
+                "minimum": 0
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max directory entries to return. Default: 200, maximum: 1000",
+                "default": LIST_DIRECTORY_DEFAULT_LIMIT,
+                "minimum": 1,
+                "maximum": LIST_DIRECTORY_MAX_LIMIT
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn grep_files_parameters_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "pattern": {
+                "type": "string",
+                "description": "Regex pattern to search for"
+            },
+            "path_pattern": {
+                "type": "string",
+                "description": "Optional path pattern to filter files (e.g., '*.txt', 'docs/*')"
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Starting match offset. Default: 0",
+                "default": 0,
+                "minimum": 0
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max matches to return. Default: 200, maximum: 1000",
+                "default": GREP_FILES_DEFAULT_LIMIT,
+                "minimum": 1,
+                "maximum": GREP_FILES_MAX_LIMIT
+            }
+        },
+        "required": ["pattern"],
+        "additionalProperties": false
+    })
+}
+
+fn delete_file_parameters_schema(presentation: &FilePathPresentation) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": presentation.generic_path_param_description()
+            },
+            "recursive": {
+                "type": "boolean",
+                "default": false,
+                "description": "If true, delete directories and all contents recursively"
+            }
+        },
+        "required": ["path"],
+        "additionalProperties": false
+    })
+}
+
+fn stat_file_parameters_schema(presentation: &FilePathPresentation) -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": presentation.generic_path_param_description()
+            }
+        },
+        "required": ["path"],
+        "additionalProperties": false
+    })
+}
+
+#[cfg(test)]
+fn schema_contains_workspace(value: &Value) -> bool {
+    fn walk(value: &Value) -> bool {
+        match value {
+            Value::String(text) => text.contains(WORKSPACE_PREFIX),
+            Value::Array(items) => items.iter().any(walk),
+            Value::Object(fields) => fields.values().any(walk),
+            _ => false,
+        }
+    }
+    walk(value)
+}
+
+#[cfg(test)]
+fn filesystem_tool_schemas_with_presentation(
+    presentation: &FilePathPresentation,
+) -> Vec<(String, Value)> {
+    SESSION_FILE_SYSTEM_TOOL_NAMES
+        .iter()
+        .filter_map(|name| {
+            presentation
+                .parameters_schema_for_tool(name)
+                .map(|schema| ((*name).to_string(), schema))
+        })
+        .collect()
 }
 
 // ============================================================================
@@ -431,7 +795,7 @@ impl Capability for FileSystemCapability {
         r#"Tools to access and manipulate files in the session workspace - read, write, list, grep, and more.
 
 > [!NOTE]
-> Each session has its own isolated workspace at `/workspace`. Files persist for the session duration.
+> Each session has its own isolated workspace. Files persist for the session duration.
 
 > [!TIP]
 > Use `list_directory` to explore the workspace structure before reading or writing files."#
@@ -444,7 +808,7 @@ impl Capability for FileSystemCapability {
             r#"Інструменти для доступу до файлів у робочому просторі сесії та роботи з ними — читання, запис, перегляд, пошук grep тощо.
 
 > [!NOTE]
-> Кожна сесія має власний ізольований робочий простір у `/workspace`. Файли зберігаються протягом усієї сесії.
+> Кожна сесія має власний ізольований робочий простір. Файли зберігаються протягом усієї сесії.
 
 > [!TIP]
 > Використовуйте `list_directory`, щоб дослідити структуру робочого простору перед читанням або записом файлів."#,
@@ -465,33 +829,27 @@ impl Capability for FileSystemCapability {
 
     async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
         use crate::tool_output_sanitizer::READ_ECONOMY_HINT;
-        let root = ctx
-            .file_store
-            .as_ref()
-            .map(|store| store.display_root())
-            .unwrap_or_else(|| WORKSPACE_PREFIX.to_string());
-        let root_guidance = if root == WORKSPACE_PREFIX {
-            format!(
-                "Workspace root: `{WORKSPACE_PREFIX}`. All file paths must start with `{WORKSPACE_PREFIX}`. "
-            )
-        } else {
-            let escaped_root = escape_xml_text(&root);
-            format!(
-                "Workspace root: `{escaped_root}`. `{WORKSPACE_PREFIX}` is also accepted as an alias for this root. "
-            )
-        };
+        let presentation = FilePathPresentation::from_context(ctx);
         Some(format!(
             "<capability id=\"{}\">\n{}Directories are created on write. Read files before claiming what they contain — never speculate about code you have not opened.{}\n</capability>",
             self.id(),
-            root_guidance,
+            presentation.root_guidance(),
             READ_ECONOMY_HINT
         ))
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
-        Some(format!(
-            "Workspace root: `{WORKSPACE_PREFIX}`. All file paths must start with `{WORKSPACE_PREFIX}`."
-        ))
+        Some(FilePathPresentation::vfs().system_prompt_preview())
+    }
+
+    fn tool_definition_hooks_with_context(
+        &self,
+        ctx: &SystemPromptContext,
+        _config: &serde_json::Value,
+    ) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        vec![Arc::new(FilePathPresentationHook {
+            presentation: FilePathPresentation::from_context(ctx),
+        })]
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -546,29 +904,7 @@ impl Tool for ReadFileTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Workspace-relative path to the file (e.g., 'docs/readme.txt'). A leading '/' or '/workspace/' prefix is also accepted."
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Starting line number (0-indexed). Default: 0",
-                    "default": 0,
-                    "minimum": 0
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max lines to return. Default varies by file type: 2000 (source/text), 500 (logs, tail-biased), 100 (CSV/TSV with header). Explicit value always wins.",
-                    "default": 2000,
-                    "minimum": 1
-                }
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
+        read_file_parameters_schema(&FilePathPresentation::vfs())
     }
 
     fn hints(&self) -> ToolHints {
@@ -864,27 +1200,7 @@ impl Tool for WriteFileTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Workspace-relative path for the file (e.g., 'docs/notes.txt'). A leading '/' or '/workspace/' prefix is also accepted."
-                },
-                "content": {
-                    "type": "string",
-                    "description": "Content to write to the file"
-                },
-                "encoding": {
-                    "type": "string",
-                    "enum": ["text", "base64"],
-                    "default": "text",
-                    "description": "Content encoding: 'text' for plain text, 'base64' for binary data"
-                }
-            },
-            "required": ["path", "content"],
-            "additionalProperties": false
-        })
+        write_file_parameters_schema(&FilePathPresentation::vfs())
     }
 
     fn hints(&self) -> ToolHints {
@@ -1012,41 +1328,7 @@ impl Tool for EditFileTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Workspace-relative path to the existing text file (e.g., 'src/main.rs'). A leading '/' or '/workspace/' prefix is also accepted."
-                },
-                "expected_hash": {
-                    "type": "string",
-                    "description": "Current content hash from read_file or write_file (format: 'sha256:...')"
-                },
-                "edits": {
-                    "type": "array",
-                    "description": "One or more replacements to apply, each matched against the original file content. Use a single-element array for one replacement.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "old_text": {
-                                "type": "string",
-                                "description": "Exact text to replace"
-                            },
-                            "new_text": {
-                                "type": "string",
-                                "description": "Replacement text"
-                            }
-                        },
-                        "required": ["old_text", "new_text"],
-                        "additionalProperties": false
-                    },
-                    "minItems": 1
-                }
-            },
-            "required": ["path", "expected_hash", "edits"],
-            "additionalProperties": false
-        })
+        edit_file_parameters_schema(&FilePathPresentation::vfs())
     }
 
     fn hints(&self) -> ToolHints {
@@ -1263,30 +1545,7 @@ impl Tool for ListDirectoryTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "default": "/workspace",
-                    "description": "Workspace-relative directory path to list (e.g., 'src'). Defaults to the workspace root; a leading '/' or '/workspace/' prefix is also accepted."
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Starting item offset for large directories. Default: 0",
-                    "default": 0,
-                    "minimum": 0
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max directory entries to return. Default: 200, maximum: 1000",
-                    "default": LIST_DIRECTORY_DEFAULT_LIMIT,
-                    "minimum": 1,
-                    "maximum": LIST_DIRECTORY_MAX_LIMIT
-                }
-            },
-            "additionalProperties": false
-        })
+        list_directory_parameters_schema(&FilePathPresentation::vfs())
     }
 
     fn hints(&self) -> ToolHints {
@@ -1306,10 +1565,6 @@ impl Tool for ListDirectoryTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let path = arguments
-            .get("path")
-            .and_then(|v| v.as_str())
-            .unwrap_or("/workspace");
         let offset = arguments
             .get("offset")
             .and_then(|v| v.as_u64())
@@ -1328,6 +1583,12 @@ impl Tool for ListDirectoryTool {
                 );
             }
         };
+
+        let path = arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| "/".to_string());
 
         // Normalize path to strip /workspace prefix for storage
         // The store (MountFs in production) is the sole resolver: hand it the
@@ -1437,34 +1698,7 @@ impl Tool for GrepFilesTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "pattern": {
-                    "type": "string",
-                    "description": "Regex pattern to search for"
-                },
-                "path_pattern": {
-                    "type": "string",
-                    "description": "Optional path pattern to filter files (e.g., '*.txt', 'docs/*')"
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Starting match offset. Default: 0",
-                    "default": 0,
-                    "minimum": 0
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max matches to return. Default: 200, maximum: 1000",
-                    "default": GREP_FILES_DEFAULT_LIMIT,
-                    "minimum": 1,
-                    "maximum": GREP_FILES_MAX_LIMIT
-                }
-            },
-            "required": ["pattern"],
-            "additionalProperties": false
-        })
+        grep_files_parameters_schema()
     }
 
     fn hints(&self) -> ToolHints {
@@ -1609,22 +1843,7 @@ impl Tool for DeleteFileTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Path to the file or directory to delete"
-                },
-                "recursive": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "If true, delete directories and all contents recursively"
-                }
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
+        delete_file_parameters_schema(&FilePathPresentation::vfs())
     }
 
     fn hints(&self) -> ToolHints {
@@ -1738,17 +1957,7 @@ impl Tool for StatFileTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Path to the file or directory"
-                }
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
+        stat_file_parameters_schema(&FilePathPresentation::vfs())
     }
 
     fn hints(&self) -> ToolHints {
@@ -2422,7 +2631,7 @@ mod tests {
         let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
 
         assert!(prompt.contains("Workspace root: `/host/repo`"));
-        assert!(prompt.contains("`/workspace` is also accepted"));
+        assert!(!prompt.contains("/workspace"));
     }
 
     #[tokio::test]
@@ -3327,5 +3536,142 @@ mod tests {
     fn localized_name_differs_from_default() {
         let cap = FileSystemCapability;
         assert_ne!(cap.localized_name(Some("uk")), cap.name());
+    }
+
+    #[test]
+    fn host_backed_tool_schemas_contain_no_workspace_guidance() {
+        let presentation = FilePathPresentation::from_file_store(Some(
+            &MockFileStore::with_display_root("/repo") as &dyn SessionFileSystem,
+        ));
+        for (tool_name, schema) in filesystem_tool_schemas_with_presentation(&presentation) {
+            assert!(
+                !schema_contains_workspace(&schema),
+                "tool '{tool_name}' schema must not advertise /workspace for host-backed roots"
+            );
+            if tool_name == "list_directory" {
+                assert_eq!(schema["properties"]["path"]["default"], "/repo");
+            }
+        }
+    }
+
+    #[test]
+    fn vfs_tool_schemas_advertise_workspace_identity() {
+        let presentation = FilePathPresentation::vfs();
+        let schemas = filesystem_tool_schemas_with_presentation(&presentation);
+        let path_tools = ["read_file", "write_file", "edit_file", "list_directory"];
+        for tool_name in path_tools {
+            let schema = schemas
+                .iter()
+                .find(|(name, _)| name == tool_name)
+                .map(|(_, schema)| schema)
+                .expect("schema present");
+            assert!(
+                schema_contains_workspace(schema),
+                "tool '{tool_name}' schema should mention /workspace for VFS sessions"
+            );
+        }
+        assert_eq!(
+            schemas
+                .iter()
+                .find(|(name, _)| name == "list_directory")
+                .unwrap()
+                .1["properties"]["path"]["default"],
+            "/workspace"
+        );
+    }
+
+    #[tokio::test]
+    async fn assembled_prompt_uses_host_root_without_workspace_guidance() {
+        use crate::AgentCapabilityConfig;
+        use crate::capabilities::{CapabilityRegistry, collect_capabilities_with_configs};
+
+        let store = Arc::new(MockFileStore::with_display_root("/repo"));
+        let ctx = SystemPromptContext {
+            session_id: SessionId::new(),
+            locale: None,
+            file_store: Some(store),
+            model: None,
+        };
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities_with_configs(
+            &[AgentCapabilityConfig::new(
+                SESSION_FILE_SYSTEM_CAPABILITY_ID,
+            )],
+            &registry,
+            &ctx,
+        )
+        .await;
+
+        let prompt = collected.system_prompt_prefix().expect("system prompt");
+        assert!(prompt.contains("Workspace root: `/repo`"));
+        assert!(!prompt.contains("/workspace"));
+    }
+
+    #[tokio::test]
+    async fn tool_definition_hook_applies_host_root_to_eager_and_deferred_schemas() {
+        use crate::capabilities::tool_search::ToolSearchCapability;
+        use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition};
+
+        let store = Arc::new(MockFileStore::with_display_root("/repo"));
+        let ctx = SystemPromptContext {
+            session_id: SessionId::new(),
+            locale: None,
+            file_store: Some(store),
+            model: None,
+        };
+        let cap = FileSystemCapability;
+        let hooks = cap.tool_definition_hooks_with_context(&ctx, &json!({}));
+        assert_eq!(hooks.len(), 1);
+
+        let read_file = ToolDefinition::Builtin(BuiltinTool {
+            name: "read_file".to_string(),
+            display_name: None,
+            description: "Read file".to_string(),
+            parameters: ReadFileTool.parameters_schema(),
+            policy: Default::default(),
+            category: None,
+            deferrable: DeferrablePolicy::Automatic,
+            hints: Default::default(),
+            full_parameters: None,
+        });
+        let eager = hooks[0].transform(vec![read_file.clone()]);
+        assert!(!schema_contains_workspace(eager[0].full_parameters()));
+
+        let defer_cap = ToolSearchCapability::with_threshold(1);
+        let defer_hooks =
+            defer_cap.tool_definition_hooks_with_context(&ctx, &json!({ "threshold": 1 }));
+        let deferred = defer_hooks[0].transform(hooks[0].transform(vec![
+            read_file,
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "other_tool".to_string(),
+                display_name: None,
+                description: "Other".to_string(),
+                parameters: json!({"type": "object"}),
+                policy: Default::default(),
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: Default::default(),
+                full_parameters: None,
+            }),
+        ]));
+        let read = deferred
+            .iter()
+            .find(|tool| tool.name() == "read_file")
+            .expect("read_file present");
+        assert!(!schema_contains_workspace(read.full_parameters()));
+    }
+
+    #[tokio::test]
+    async fn list_directory_without_path_uses_host_display_root() {
+        let store = Arc::new(MockFileStore::with_display_root("/repo"));
+        store.add_text_file("/notes.txt", "hello");
+        let context = make_context(store);
+
+        let result = ListDirectoryTool
+            .execute_with_context(json!({}), &context)
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["path"], "/repo");
     }
 }

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -183,6 +183,22 @@ Each backend owns its `display_path`/`display_root`:
 - For additional mounted roots, returned file paths include the stable mounted
   prefix, e.g. `/workspace/roots/backend/Cargo.toml`.
 
+### Model-facing path guidance (EVE-748)
+
+The active primary `SessionFileSystem` owns the model-visible path identity in
+capability system prompts and file-tool parameter schemas:
+
+- Host-backed primaries teach their canonical `display_root()` (for example
+  `/repo`).
+- VFS/in-memory primaries teach `/workspace`.
+- Named secondary mounts remain discoverable through their mounted namespace.
+
+Legacy `/workspace` input aliases may remain accepted internally for host-backed
+stores, but host-backed model context must not advertise them. Storage keys and
+routing paths stay internal and must not leak into prompt text or schemas.
+`FileSystemCapability` applies this through a `FilePathPresentation` hook at
+tool-definition assembly time.
+
 ### Encoding
 
 File content is round-tripped through two encodings:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

File-system capability guidance and tool schemas now follow the active `SessionFileSystem` display identity. Host-backed sessions teach the canonical host root (e.g. `/repo`) in system prompts and all file-tool parameter schemas; VFS/in-memory sessions continue to teach `/workspace`. A reusable `FilePathPresentation` hook applies at tool-definition assembly time so eager and deferred/tool-search surfaces stay consistent.

## Why

Host-backed stores already exposed real paths in tool results and shell output, but schemas and prompts still advertised `/workspace`, causing repeated path confusion in model context. Fixes EVE-748.

## Before / After

**Before (host-backed root `/repo`):**
- System prompt: `Workspace root: /repo. /workspace is also accepted as an alias.`
- `list_directory.path` schema default: `"/workspace"`
- Path descriptions: `A leading '/' or '/workspace/' prefix is also accepted.`

**After (host-backed root `/repo`):**
- System prompt: `Workspace root: /repo. Paths may be relative to this root or absolute under it.` (no `/workspace` mention)
- `list_directory.path` schema default: `"/repo"`
- Path descriptions reference `/repo` only
- Omitting `list_directory.path` lists root and returns `path: "/repo"` (not `/workspace`)

**VFS unchanged:** schemas and prompts still teach `/workspace`.

Evidence:
```
cargo test -p everruns-core file_system::tests  # 73 passed
```

## Risk

- Low — presentation-only change; path routing, containment, and alias acceptance at execution time are unchanged.
- Models on host-backed embedders may shift to host-root paths in tool calls (intended).

## Security

- Threat categories reviewed: TM-LLM (prompt construction), TM-FS (path presentation), TM-TOOL (tool schema assembly)
- Findings: Dynamic host roots remain XML-escaped in system prompts. Path presentation is not a sandbox boundary; containment checks unchanged.
- No new threat surface introduced.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (VFS `/workspace` behavior preserved; legacy input aliases still accepted internally)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4d1d8c9-3200-4d91-90ee-762e6d20e124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4d1d8c9-3200-4d91-90ee-762e6d20e124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

