### PR TITLE
test(fs): enforce model-visible path identity end-to-end

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -161,6 +161,7 @@ pub mod openresponses_protocol;
 pub mod openresponses_types;
 pub mod outline;
 pub mod output_guardrail;
+pub mod path_identity;
 pub mod platform_definition;
 pub mod platform_store;
 pub mod resource_ownership;

--- a/crates/core/src/path_identity.rs
+++ b/crates/core/src/path_identity.rs
@@ -1,0 +1,229 @@
+// Model-visible path identity conformance (EVE-750).
+//
+// Shared helpers for asserting that serialized values exposed to the model use
+// the active `SessionFileSystem` display identity. The contract is documented
+// in `specs/file-store.md` under "Model-visible path identity".
+
+use crate::session_path::WORKSPACE_PREFIX;
+use crate::traits::SessionFileSystem;
+use serde_json::Value;
+
+/// Expected path identity for a filesystem backend.
+#[derive(Debug, Clone)]
+pub struct PathIdentityExpectations {
+    /// Canonical model-visible root (`/workspace` for VFS, host path for real disk).
+    pub expected_root: String,
+    /// Prefixes that must not appear in model-visible absolute paths.
+    pub forbidden_prefixes: Vec<String>,
+    /// Additional mount namespaces allowed even when they share a substring with
+    /// a forbidden primary-root alias (e.g. `/workspace/roots/backend/`).
+    pub allowed_mount_prefixes: Vec<String>,
+}
+
+impl PathIdentityExpectations {
+    /// Derive expectations from a live store.
+    pub fn for_store(store: &dyn SessionFileSystem) -> Self {
+        let root = store.display_root();
+        if root == WORKSPACE_PREFIX {
+            Self::vfs()
+        } else {
+            Self::host_backed(&root)
+        }
+    }
+
+    /// In-memory/VFS sessions expose `/workspace`.
+    pub fn vfs() -> Self {
+        Self {
+            expected_root: WORKSPACE_PREFIX.to_string(),
+            forbidden_prefixes: vec![],
+            allowed_mount_prefixes: vec![],
+        }
+    }
+
+    /// Host-backed sessions expose the real root and must not leak `/workspace`
+    /// except under explicit secondary-mount namespaces.
+    pub fn host_backed(root: &str) -> Self {
+        Self {
+            expected_root: root.to_string(),
+            forbidden_prefixes: vec![WORKSPACE_PREFIX.to_string()],
+            allowed_mount_prefixes: vec![format!("{WORKSPACE_PREFIX}/roots/")],
+        }
+    }
+
+    fn is_allowed_path(&self, path: &str) -> bool {
+        self.allowed_mount_prefixes
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+    }
+
+    fn violates_forbidden_prefix(&self, path: &str) -> Option<String> {
+        if self.is_allowed_path(path) {
+            return None;
+        }
+        self.forbidden_prefixes
+            .iter()
+            .find(|prefix| path == *prefix || path.starts_with(&format!("{prefix}/")))
+            .cloned()
+    }
+}
+
+/// Whether a string looks like an absolute filesystem path rather than prose,
+/// markup, or instructional text.
+pub fn looks_like_absolute_path(value: &str) -> bool {
+    value.starts_with('/')
+        && !value.contains(' ')
+        && value.len() > 1
+        && !value.contains('<')
+        && !value.contains('>')
+        && !value.contains('`')
+}
+
+/// Recursively collect absolute path-like strings from a serialized value.
+pub fn collect_absolute_paths(value: &Value, json_path: &str, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::String(text) if looks_like_absolute_path(text) => {
+            out.push((json_path.to_string(), text.clone()));
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_absolute_paths(item, &format!("{json_path}[{index}]"), out);
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                let child_path = if json_path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{json_path}.{key}")
+                };
+                collect_absolute_paths(item, &child_path, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Assert no collected absolute path violates the forbidden-prefix contract.
+///
+/// Panics with a descriptive message on violation.
+pub fn assert_no_forbidden_prefixes(
+    value: &Value,
+    expectations: &PathIdentityExpectations,
+    context: &str,
+) {
+    let mut paths = Vec::new();
+    collect_absolute_paths(value, "", &mut paths);
+    for (json_path, path) in paths {
+        if let Some(prefix) = expectations.violates_forbidden_prefix(&path) {
+            panic!("{context}: forbidden path prefix `{prefix}` in `{path}` at `{json_path}`");
+        }
+    }
+}
+
+/// Assert every absolute path in `value` is under the expected root or an
+/// allowed mount namespace.
+pub fn assert_paths_under_expected_root(
+    value: &Value,
+    expectations: &PathIdentityExpectations,
+    context: &str,
+) {
+    let mut paths = Vec::new();
+    collect_absolute_paths(value, "", &mut paths);
+    let root = &expectations.expected_root;
+    for (json_path, path) in paths {
+        if expectations.is_allowed_path(&path) {
+            continue;
+        }
+        let ok = path == root.as_str() || path.starts_with(&format!("{root}/"));
+        assert!(
+            ok,
+            "{context}: path `{path}` at `{json_path}` is not under expected root `{root}`"
+        );
+    }
+}
+
+/// Assert a serialized model-visible value conforms to the store's path identity.
+pub fn assert_model_visible_value(value: &Value, store: &dyn SessionFileSystem, context: &str) {
+    let expectations = PathIdentityExpectations::for_store(store);
+    assert_no_forbidden_prefixes(value, &expectations, context);
+    assert_paths_under_expected_root(value, &expectations, context);
+}
+
+/// Assert assembled system prompt text uses the expected root and does not
+/// advertise forbidden aliases in host-backed mode.
+pub fn assert_system_prompt(prompt: &str, expectations: &PathIdentityExpectations) {
+    assert!(
+        prompt.contains(&format!("Workspace root: `{}`", expectations.expected_root))
+            || prompt.contains(&format!(
+                "Workspace root: `{}/`",
+                expectations.expected_root
+            )),
+        "system prompt must identify expected root `{}`; got:\n{prompt}",
+        expectations.expected_root
+    );
+
+    if expectations.expected_root != WORKSPACE_PREFIX {
+        for prefix in &expectations.forbidden_prefixes {
+            assert!(
+                !prompt.contains(&format!("`{prefix}` is also accepted")),
+                "host-backed system prompt must not advertise `{prefix}` alias; got:\n{prompt}"
+            );
+        }
+    }
+}
+
+/// Assert a tool JSON result conforms to the active store identity.
+pub fn assert_tool_result_paths_conform(
+    store: &dyn SessionFileSystem,
+    tool_name: &str,
+    response: &Value,
+) {
+    assert_model_visible_value(response, store, tool_name);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn looks_like_absolute_path_rejects_prose() {
+        assert!(!looks_like_absolute_path(
+            "A leading '/' or '/workspace/' prefix is also accepted."
+        ));
+        assert!(looks_like_absolute_path("/workspace/crates/server"));
+        assert!(looks_like_absolute_path("/tmp/repo/src/lib.rs"));
+    }
+
+    #[test]
+    fn collect_absolute_paths_walks_nested_values() {
+        let value = json!({
+            "path": "/repo/crates/server",
+            "entries": [{"path": "/repo/crates/server/main.rs"}],
+            "note": "not a path"
+        });
+        let mut paths = Vec::new();
+        collect_absolute_paths(&value, "", &mut paths);
+        assert_eq!(paths.len(), 2);
+        let collected: Vec<_> = paths.into_iter().map(|(_, path)| path).collect();
+        assert!(collected.contains(&"/repo/crates/server".to_string()));
+        assert!(collected.contains(&"/repo/crates/server/main.rs".to_string()));
+    }
+
+    #[test]
+    fn assert_no_forbidden_prefixes_allows_secondary_mounts() {
+        let expectations = PathIdentityExpectations::host_backed("/repo");
+        let value = json!({
+            "path": "/workspace/roots/backend/Cargo.toml"
+        });
+        assert_no_forbidden_prefixes(&value, &expectations, "secondary mount");
+    }
+
+    #[test]
+    #[should_panic(expected = "forbidden path prefix `/workspace`")]
+    fn assert_no_forbidden_prefixes_rejects_primary_alias() {
+        let expectations = PathIdentityExpectations::host_backed("/repo");
+        let value = json!({ "path": "/workspace/crates/server" });
+        assert_no_forbidden_prefixes(&value, &expectations, "read_file");
+    }
+}

--- a/crates/runtime/tests/model_visible_path_identity_test.rs
+++ b/crates/runtime/tests/model_visible_path_identity_test.rs
@@ -1,0 +1,408 @@
+// EVE-750: end-to-end conformance for model-visible filesystem path identity.
+//
+// Exercises tool results, system prompts, persistence hooks, and the recursive
+// path scanner across in-memory, real-disk, and MountFs backends.
+
+use everruns_core::atoms::PostToolExecHook;
+use everruns_core::capabilities::{
+    CapabilityRegistry, DeleteFileTool, DistillOutputHook, EditFileTool, FileSystemCapability,
+    GrepFilesTool, ListDirectoryTool, PersistOutputHook, ReadFileTool,
+    SESSION_FILE_SYSTEM_CAPABILITY_ID, StatFileTool, SystemPromptContext, WriteFileTool,
+    collect_capabilities,
+};
+use everruns_core::path_identity::{
+    PathIdentityExpectations, assert_model_visible_value, assert_no_forbidden_prefixes,
+    assert_system_prompt, assert_tool_result_paths_conform, collect_absolute_paths,
+};
+use everruns_core::session_path::WORKSPACE_PREFIX;
+use everruns_core::tool_types::{
+    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResult,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use everruns_core::{Capability, MountFs, SessionFileSystem, SessionId, WorkspaceRootSet};
+use everruns_runtime::{InMemorySessionFileStore, RealDiskFileStore, multi_root_file_system};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn production_context(session: SessionId, store: Arc<dyn SessionFileSystem>) -> ToolContext {
+    ToolContext::with_file_store(session, MountFs::wrap(store))
+}
+
+fn production_context_direct(session: SessionId, store: Arc<dyn SessionFileSystem>) -> ToolContext {
+    ToolContext::with_file_store(session, store)
+}
+
+fn expect_success(result: ToolExecutionResult) -> Value {
+    match result {
+        ToolExecutionResult::Success(value) => value,
+        ToolExecutionResult::SuccessWithImages { result, .. } => result,
+        other => panic!("expected success, got {other:?}"),
+    }
+}
+
+async fn seed_target_file(store: &dyn SessionFileSystem, session: SessionId, rel: &str) {
+    store
+        .write_file(session, rel, "target body", "text")
+        .await
+        .unwrap();
+}
+
+async fn read_hash(ctx: &ToolContext, path: &str) -> String {
+    let result = ReadFileTool
+        .execute_with_context(json!({ "path": path }), ctx)
+        .await;
+    expect_success(result)["content_hash"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn assert_read_paths(
+    ctx: &ToolContext,
+    store: &dyn SessionFileSystem,
+    input: &str,
+    expected_display: &str,
+) {
+    let result = ReadFileTool
+        .execute_with_context(json!({ "path": input }), ctx)
+        .await;
+    let value = expect_success(result);
+    assert_eq!(value["path"], expected_display);
+    assert_tool_result_paths_conform(store, "read_file", &value);
+}
+
+async fn run_read_input_matrix(
+    store: Arc<dyn SessionFileSystem>,
+    expectations: &PathIdentityExpectations,
+    rel: &str,
+    ctx: ToolContext,
+) {
+    let session = SessionId::from_seed(7501);
+    seed_target_file(store.as_ref(), session, rel).await;
+
+    let expected = store.display_path(&format!("/{rel}"));
+    let legacy = format!("{WORKSPACE_PREFIX}/{rel}");
+
+    assert_read_paths(&ctx, store.as_ref(), rel, &expected).await;
+    assert_read_paths(&ctx, store.as_ref(), &legacy, &expected).await;
+    assert_read_paths(&ctx, store.as_ref(), &expected, &expected).await;
+
+    let err = ReadFileTool
+        .execute_with_context(json!({ "path": "/definitely/missing/file.txt" }), &ctx)
+        .await;
+    match err {
+        ToolExecutionResult::ToolError(message) => {
+            assert_no_forbidden_prefixes(&json!(message), expectations, "read_file error");
+            if expectations.expected_root != WORKSPACE_PREFIX {
+                assert!(
+                    !message.contains(WORKSPACE_PREFIX),
+                    "error must not leak `/workspace`: {message}"
+                );
+            }
+        }
+        other => panic!("expected tool error, got {other:?}"),
+    }
+}
+
+async fn run_write_list_grep_stat_delete_matrix(
+    store: Arc<dyn SessionFileSystem>,
+    expectations: &PathIdentityExpectations,
+    ctx: ToolContext,
+) {
+    let root = expectations.expected_root.clone();
+    let rel = "matrix/out.txt";
+
+    let write = WriteFileTool
+        .execute_with_context(
+            json!({ "path": format!("{WORKSPACE_PREFIX}/{rel}"), "content": "matrix" }),
+            &ctx,
+        )
+        .await;
+    let write_value = expect_success(write);
+    let expected = store.display_path(&format!("/{rel}"));
+    assert_eq!(write_value["path"], expected);
+    assert_tool_result_paths_conform(store.as_ref(), "write_file", &write_value);
+
+    let list = ListDirectoryTool
+        .execute_with_context(json!({}), &ctx)
+        .await;
+    let list_value = expect_success(list);
+    assert_eq!(list_value["path"], root);
+    assert_tool_result_paths_conform(store.as_ref(), "list_directory", &list_value);
+
+    let grep = GrepFilesTool
+        .execute_with_context(json!({ "pattern": "matrix" }), &ctx)
+        .await;
+    let grep_value = expect_success(grep);
+    assert!(
+        grep_value["matches"].as_array().unwrap().iter().all(|m| {
+            let path = m["path"].as_str().unwrap();
+            path.starts_with(&format!("{root}/")) || path == root
+        }),
+        "grep matches must use active root: {grep_value}"
+    );
+    assert_tool_result_paths_conform(store.as_ref(), "grep_files", &grep_value);
+
+    let stat = StatFileTool
+        .execute_with_context(json!({ "path": rel }), &ctx)
+        .await;
+    let stat_value = expect_success(stat);
+    assert_eq!(stat_value["path"], expected);
+    assert_tool_result_paths_conform(store.as_ref(), "stat_file", &stat_value);
+
+    let hash = read_hash(&ctx, &expected).await;
+    let edit = EditFileTool
+        .execute_with_context(
+            json!({
+                "path": format!("{WORKSPACE_PREFIX}/{rel}"),
+                "edits": [{"old_text": "matrix", "new_text": "edited"}],
+                "expected_hash": hash
+            }),
+            &ctx,
+        )
+        .await;
+    let edit_value = expect_success(edit);
+    assert_eq!(edit_value["path"], expected);
+    assert_tool_result_paths_conform(store.as_ref(), "edit_file", &edit_value);
+
+    let delete = DeleteFileTool
+        .execute_with_context(json!({ "path": rel }), &ctx)
+        .await;
+    let delete_value = expect_success(delete);
+    assert_eq!(delete_value["path"], expected);
+    assert_tool_result_paths_conform(store.as_ref(), "delete_file", &delete_value);
+}
+
+async fn assert_system_prompt_for_store(store: Arc<dyn SessionFileSystem>) {
+    let expectations = PathIdentityExpectations::for_store(store.as_ref());
+    let cap = FileSystemCapability;
+    let ctx = SystemPromptContext {
+        session_id: SessionId::from_seed(7503),
+        locale: None,
+        file_store: Some(store),
+        model: None,
+    };
+    let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+    assert_system_prompt(&prompt, &expectations);
+    assert_no_forbidden_prefixes(&json!(prompt), &expectations, "system prompt");
+}
+
+fn output_tool_def(persist_output: bool) -> ToolDefinition {
+    let hints = if persist_output {
+        ToolHints::default().with_persist_output(true)
+    } else {
+        ToolHints::default()
+    };
+    ToolDefinition::Builtin(BuiltinTool {
+        name: "test_output".to_string(),
+        display_name: None,
+        description: "test output".to_string(),
+        parameters: json!({}),
+        policy: ToolPolicy::Auto,
+        category: None,
+        deferrable: DeferrablePolicy::default(),
+        hints,
+        full_parameters: None,
+    })
+}
+
+fn output_tool_call() -> ToolCall {
+    ToolCall {
+        id: "call_identity".to_string(),
+        name: "test_output".to_string(),
+        arguments: json!({}),
+    }
+}
+
+async fn assert_persistence_identity(store: Arc<dyn SessionFileSystem>, wrap_mount: bool) {
+    let session = SessionId::from_seed(7504);
+    let ctx = if wrap_mount {
+        production_context(session, store.clone())
+    } else {
+        production_context_direct(session, store.clone())
+    };
+    let expectations = PathIdentityExpectations::for_store(store.as_ref());
+    let root = store.display_root();
+    let stdout_path = format!("{root}/outputs/call_identity.stdout");
+
+    let mut persist_result = ToolResult {
+        tool_call_id: "call_identity".to_string(),
+        result: Some(json!({
+            "stdout": "stdout body",
+            "stderr": "stderr body",
+            "exit_code": 0,
+        })),
+        images: None,
+        error: None,
+        connection_required: None,
+        raw_output: Some("stdout body\n--- stderr ---\nstderr body".to_string()),
+    };
+    PersistOutputHook
+        .after_exec(
+            &output_tool_call(),
+            &output_tool_def(true),
+            &mut persist_result,
+            &ctx,
+        )
+        .await;
+    let persist_value = persist_result.result.as_ref().unwrap();
+    assert_model_visible_value(persist_value, store.as_ref(), "persist_output");
+    assert_eq!(persist_value["full_output"], json!(stdout_path));
+
+    let rows: Vec<_> = (0..2000)
+        .map(|i| json!({"id": i, "name": format!("row-{i}")}))
+        .collect();
+    let mut distill_result = ToolResult {
+        tool_call_id: "call_identity".to_string(),
+        result: Some(json!({"rows": rows})),
+        images: None,
+        error: None,
+        connection_required: None,
+        raw_output: None,
+    };
+    DistillOutputHook
+        .after_exec(
+            &output_tool_call(),
+            &output_tool_def(false),
+            &mut distill_result,
+            &ctx,
+        )
+        .await;
+    let distill_value = distill_result.result.as_ref().unwrap();
+    assert_model_visible_value(distill_value, store.as_ref(), "distill_output");
+    assert_no_forbidden_prefixes(distill_value, &expectations, "distill_output");
+}
+
+fn assert_file_tool_schemas(store: Arc<dyn SessionFileSystem>) {
+    let expectations = PathIdentityExpectations::for_store(store.as_ref());
+    let cap = FileSystemCapability;
+    for tool in cap.tools() {
+        let schema = tool.parameters_schema();
+        assert_no_forbidden_prefixes(&schema, &expectations, tool.name());
+    }
+}
+
+async fn run_backend_suite(store: Arc<dyn SessionFileSystem>, wrap_mount: bool) {
+    let expectations = PathIdentityExpectations::for_store(store.as_ref());
+    let session_read = SessionId::from_seed(7501);
+    let session_write = SessionId::from_seed(7502);
+    let ctx_for = |session| {
+        if wrap_mount {
+            production_context(session, store.clone())
+        } else {
+            production_context_direct(session, store.clone())
+        }
+    };
+
+    run_read_input_matrix(
+        store.clone(),
+        &expectations,
+        "crates/server",
+        ctx_for(session_read),
+    )
+    .await;
+    run_write_list_grep_stat_delete_matrix(store.clone(), &expectations, ctx_for(session_write))
+        .await;
+    assert_system_prompt_for_store(store.clone()).await;
+    assert_persistence_identity(store.clone(), wrap_mount).await;
+    assert_file_tool_schemas(store);
+}
+
+#[tokio::test]
+async fn in_memory_vfs_path_identity_conformance() {
+    let store: Arc<dyn SessionFileSystem> = Arc::new(InMemorySessionFileStore::new());
+    assert_eq!(store.display_root(), WORKSPACE_PREFIX);
+    run_backend_suite(store, true).await;
+}
+
+#[tokio::test]
+async fn real_disk_path_identity_conformance() {
+    let root = TempDir::new().unwrap();
+    let store: Arc<dyn SessionFileSystem> = Arc::new(RealDiskFileStore::new(root.path()).unwrap());
+    run_backend_suite(store.clone(), true).await;
+
+    let mounted = MountFs::wrap(store);
+    run_backend_suite(Arc::new(mounted), false).await;
+}
+
+#[tokio::test]
+async fn multi_root_secondary_mount_path_identity() {
+    let session = SessionId::from_seed(7505);
+    let primary = TempDir::new().unwrap();
+    let secondary = TempDir::new().unwrap();
+    let roots = WorkspaceRootSet::new(
+        primary.path(),
+        [("backend".to_string(), secondary.path().to_path_buf())],
+    )
+    .unwrap();
+    let store = multi_root_file_system(&roots).unwrap();
+    let expectations = PathIdentityExpectations::for_store(store.as_ref());
+    let ctx = production_context_direct(session, Arc::new(store.clone()));
+
+    let secondary_path = "/workspace/roots/backend/run.log";
+    WriteFileTool
+        .execute_with_context(json!({ "path": secondary_path, "content": "log" }), &ctx)
+        .await;
+
+    let read = ReadFileTool
+        .execute_with_context(json!({ "path": secondary_path }), &ctx)
+        .await;
+    let read_value = expect_success(read);
+    assert_eq!(read_value["path"], secondary_path);
+    assert_tool_result_paths_conform(store.as_ref(), "read_file", &read_value);
+    assert_no_forbidden_prefixes(&read_value, &expectations, "secondary read");
+}
+
+#[tokio::test]
+#[should_panic(expected = "forbidden path prefix `/workspace`")]
+async fn recursive_scan_catches_unlisted_path_field() {
+    let expectations = PathIdentityExpectations::host_backed("/repo");
+    let value = json!({
+        "future_surface": {
+            "nested_pointer": "/workspace/secret/leak.txt"
+        }
+    });
+    let mut paths = Vec::new();
+    collect_absolute_paths(&value, "", &mut paths);
+    assert_eq!(paths.len(), 1);
+    assert_no_forbidden_prefixes(&value, &expectations, "future field");
+}
+
+#[tokio::test]
+async fn collected_capability_prompt_uses_store_root() {
+    let root = TempDir::new().unwrap();
+    let store: Arc<dyn SessionFileSystem> = Arc::new(RealDiskFileStore::new(root.path()).unwrap());
+    let expectations = PathIdentityExpectations::for_store(store.as_ref());
+    let ctx = SystemPromptContext {
+        session_id: SessionId::from_seed(7506),
+        locale: None,
+        file_store: Some(store),
+        model: None,
+    };
+    let registry = CapabilityRegistry::runtime_builtins();
+    let collected = collect_capabilities(
+        &[SESSION_FILE_SYSTEM_CAPABILITY_ID.to_string()],
+        &registry,
+        &ctx,
+    )
+    .await;
+    let prompt = collected.system_prompt_prefix().expect("system prompt");
+    assert_system_prompt(&prompt, &expectations);
+    assert_no_forbidden_prefixes(&json!(prompt), &expectations, "collected prompt");
+
+    for def in &collected.tool_definitions {
+        let name = def.name();
+        if name.starts_with("read_")
+            || name.starts_with("write_")
+            || name.starts_with("edit_")
+            || name.starts_with("list_")
+            || name.starts_with("grep_")
+            || name.starts_with("delete_")
+            || name.starts_with("stat_")
+        {
+            assert_no_forbidden_prefixes(def.parameters(), &expectations, name);
+        }
+    }
+}

--- a/crates/runtime/tests/model_visible_path_identity_test.rs
+++ b/crates/runtime/tests/model_visible_path_identity_test.rs
@@ -275,12 +275,27 @@ async fn assert_persistence_identity(store: Arc<dyn SessionFileSystem>, wrap_mou
     assert_no_forbidden_prefixes(distill_value, &expectations, "distill_output");
 }
 
-fn assert_file_tool_schemas(store: Arc<dyn SessionFileSystem>) {
+async fn assert_file_tool_schemas(store: Arc<dyn SessionFileSystem>) {
     let expectations = PathIdentityExpectations::for_store(store.as_ref());
-    let cap = FileSystemCapability;
-    for tool in cap.tools() {
-        let schema = tool.parameters_schema();
-        assert_no_forbidden_prefixes(&schema, &expectations, tool.name());
+    let ctx = SystemPromptContext {
+        session_id: SessionId::from_seed(7507),
+        locale: None,
+        file_store: Some(store),
+        model: None,
+    };
+    let registry = CapabilityRegistry::runtime_builtins();
+    let collected = collect_capabilities(
+        &[SESSION_FILE_SYSTEM_CAPABILITY_ID.to_string()],
+        &registry,
+        &ctx,
+    )
+    .await;
+    let mut tools = collected.tool_definitions;
+    for hook in &collected.tool_definition_hooks {
+        tools = hook.transform(tools);
+    }
+    for def in &tools {
+        assert_no_forbidden_prefixes(def.parameters(), &expectations, def.name());
     }
 }
 
@@ -307,7 +322,7 @@ async fn run_backend_suite(store: Arc<dyn SessionFileSystem>, wrap_mount: bool) 
         .await;
     assert_system_prompt_for_store(store.clone()).await;
     assert_persistence_identity(store.clone(), wrap_mount).await;
-    assert_file_tool_schemas(store);
+    assert_file_tool_schemas(store).await;
 }
 
 #[tokio::test]
@@ -392,7 +407,11 @@ async fn collected_capability_prompt_uses_store_root() {
     assert_system_prompt(&prompt, &expectations);
     assert_no_forbidden_prefixes(&json!(prompt), &expectations, "collected prompt");
 
-    for def in &collected.tool_definitions {
+    let mut tools = collected.tool_definitions;
+    for hook in &collected.tool_definition_hooks {
+        tools = hook.transform(tools);
+    }
+    for def in &tools {
         let name = def.name();
         if name.starts_with("read_")
             || name.starts_with("write_")

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -199,6 +199,41 @@ routing paths stay internal and must not leak into prompt text or schemas.
 `FileSystemCapability` applies this through a `FilePathPresentation` hook at
 tool-definition assembly time.
 
+### Model-visible path identity conformance (EVE-750)
+
+Every surface that can enter model context or a transcript must agree on one
+display identity owned by the active `SessionFileSystem`:
+
+- assembled system prompt and filesystem capability instructions;
+- tool results, errors, persisted `output_files` / `full_output` pointers, and
+  distillation notes;
+- paths returned by list, grep, stat, read, write, edit, and delete tools.
+
+**Invariants**
+
+- Host-backed primary rooted at `/repo`: every model-visible project path is
+  `/repo` or starts with `/repo/`. No prompt, schema default, result, error, or
+  persisted pointer may advertise `/workspace` as the active namespace.
+- VFS/in-memory primary: the established virtual identity remains `/workspace`
+  across prompt guidance, tool results, and persisted references.
+- Named secondary mounts: paths use the configured mounted virtual namespace
+  (e.g. `/workspace/roots/backend/...`) and do not leak backing-store locations.
+
+**Compatibility inputs vs presentation**
+
+Legacy `/workspace/...` input may remain accepted for routing on host-backed
+stores, but accepted aliases must be canonicalized before any path is returned,
+narrated, or persisted. Input compatibility is not model-visible identity.
+
+**Conformance**
+
+Tests use `everruns_core::path_identity` helpers (`assert_model_visible_value`,
+`assert_no_forbidden_prefixes`, `assert_tool_result_paths_conform`) and the
+runtime integration suite in
+`crates/runtime/tests/model_visible_path_identity_test.rs`. The harness
+recursively scans serialized JSON for absolute path-like strings rather than
+enumerating field names, so new model-visible fields cannot bypass the check.
+
 ### Encoding
 
 File content is round-tripped through two encodings:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
Adds a reusable `path_identity` conformance harness and a runtime integration suite that enforces one model-visible filesystem namespace across tool results, system prompts, persistence hooks, and serialized JSON surfaces.

Host-backed sessions no longer advertise `/workspace` in the filesystem system prompt or use it as the `list_directory` default path. The omitted-path default and prompt guidance now follow `SessionFileSystem::display_root()`.

## Why
EVE-750 — existing helper-level tests did not prove that all model-visible surfaces agree. Residual `/workspace` references could leak into prompts, results, and persisted pointers after host-backed roots switched to real paths (e.g. `/repo`).

## Before / After
**Before:** Host-backed filesystem prompt said `/repo` is the root but also advertised `` `/workspace` is also accepted ``; `list_directory` schema default was hardcoded `/workspace`; no recursive scan caught new model-visible path fields.

**After:** `cargo test -p everruns-runtime --test model_visible_path_identity_test` passes across in-memory VFS, real-disk, MountFs, and multi-root backends. Example host-backed invariant enforced by the harness:
- Input `/workspace/crates/server` → result path `/tmp/.../crates/server` (canonical host root)
- Serialized tool JSON recursively scanned; `/workspace/...` forbidden in host mode except under `/workspace/roots/...` secondary mounts

## Risk
- Low — test infrastructure plus small prompt/default alignment in filesystem capability
- Host-backed callers relying on model-facing `/workspace` guidance in prompts/schemas may see updated text (input alias acceptance unchanged)

## Security
- Threat categories reviewed: TM-FS (path presentation and containment boundaries)
- Findings: harness validates semantic path conversion only; no substring rewriting of file contents. Existing traversal/containment behavior preserved by existing tests.
- No new trust boundaries introduced.

## Follow-ups
- EVE-748: dynamic filesystem tool schema descriptions/examples still mention `/workspace/` as accepted input spelling in static schemas; harness currently checks path-like schema values only.
- EVE-749: filesystem tool narration still formats raw argument paths (basename-only for read/edit; full path for list_directory) rather than routing through `display_path`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (legacy `/workspace` input routing unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fbf3c98-ad25-48c3-9278-574d818a893c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fbf3c98-ad25-48c3-9278-574d818a893c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

