### PR TITLE
fix(fs): render filesystem narration through path presentation

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -49,7 +49,8 @@ use crate::tool_fingerprint::{
     tool_call_fingerprint, tool_error_fingerprint, tool_result_fingerprint,
 };
 use crate::tool_narration::{
-    ToolNarrationPhase, render_group_headline_with_locale, render_tool_narration_with_locale,
+    ToolNarrationContext, ToolNarrationPhase, render_group_headline_with_locale,
+    render_tool_narration_with_locale,
 };
 use crate::tool_types::{SideEffectClass, ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
@@ -818,6 +819,7 @@ where
             if let Some(tool_call) = tool_calls.iter().find(|tc| tc.id == summary.id) {
                 let tool_def = tool_map.get(tool_call.name.as_str()).copied();
                 summary.narration = Some(self.render_tool_narration(
+                    &context,
                     tool_def,
                     tool_call,
                     ToolNarrationPhase::Started,
@@ -908,6 +910,7 @@ where
             && let Some(tool_call) = tool_calls.first()
         {
             completed_headline = Some(self.render_tool_narration(
+                &context,
                 tool_map.get(tool_call.name.as_str()).copied(),
                 tool_call,
                 ToolNarrationPhase::Completed,
@@ -995,17 +998,35 @@ where
 {
     fn render_tool_narration(
         &self,
+        atom_context: &AtomContext,
         tool_def: Option<&ToolDefinition>,
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         locale: Option<&str>,
     ) -> String {
+        let wrapped_store = self.wrap_file_store_for_narration(atom_context);
+        let ctx = ToolNarrationContext::new(wrapped_store.as_deref());
         for hook in &self.tool_call_hooks {
-            if let Some(narration) = hook.narration(tool_def, tool_call, phase, locale) {
+            if let Some(narration) = hook.narration(tool_def, tool_call, phase, locale, ctx) {
                 return narration;
             }
         }
         render_tool_narration_with_locale(tool_def, tool_call, phase, locale)
+    }
+
+    /// Mirror the file-store wrapping applied during tool execution so
+    /// path-bearing narration uses the same mount resolver and workspace key.
+    fn wrap_file_store_for_narration(
+        &self,
+        atom_context: &AtomContext,
+    ) -> Option<Arc<dyn SessionFileSystem>> {
+        let store = self.file_store.as_ref()?.clone();
+        let store = if let Some(workspace_id) = atom_context.workspace_id {
+            crate::traits::WorkspaceScopedFileSystem::wrap(store, workspace_id)
+        } else {
+            store
+        };
+        Some(crate::mount_fs::MountFs::wrap_if_needed(store))
     }
 
     fn transform_tool_call_for_execution(&self, tool_call: ToolCall) -> ToolCall {
@@ -1447,6 +1468,7 @@ where
                     tool_call_fingerprint: Some(tool_call_fingerprint.clone()),
                     display_name: display_name.clone(),
                     narration: Some(self.render_tool_narration(
+                        context,
                         tool_def,
                         &tool_call,
                         ToolNarrationPhase::Started,
@@ -1487,6 +1509,7 @@ where
                         tool_error_fingerprint(&tool_call.name, "error", &error_msg),
                     )
                     .with_narration(Some(self.render_tool_narration(
+                        context,
                         None,
                         &tool_call,
                         ToolNarrationPhase::Failed,
@@ -1543,7 +1566,7 @@ where
         // is a mount + cwd, not a per-store prefix. Applied over the
         // workspace-keyed store so resolution sits above re-keying.
         if let Some(store) = tool_context.file_store.take() {
-            tool_context.file_store = Some(crate::mount_fs::MountFs::wrap(store));
+            tool_context.file_store = Some(crate::mount_fs::MountFs::wrap_if_needed(store));
         }
         if let Some(ref store) = self.sqldb_store {
             tool_context.sqldb_store = Some(store.clone());
@@ -1749,6 +1772,7 @@ where
                             .and_then(|(_, name)| name.clone()),
                     )
                     .with_narration(Some(self.render_tool_narration(
+                        context,
                         Some(tool_def),
                         &tool_call,
                         ToolNarrationPhase::Completed,
@@ -1772,6 +1796,7 @@ where
                             .and_then(|(_, name)| name.clone()),
                     )
                     .with_narration(Some(self.render_tool_narration(
+                        context,
                         Some(tool_def),
                         &tool_call,
                         ToolNarrationPhase::Failed,
@@ -1876,6 +1901,7 @@ where
                                 .and_then(|(_, name)| name.clone()),
                         )
                         .with_narration(Some(self.render_tool_narration(
+                            context,
                             Some(tool_def),
                             &tool_call,
                             ToolNarrationPhase::Failed,
@@ -2251,6 +2277,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for IntegrationFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             _s: SessionId,

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1777,6 +1777,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for TestFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -423,6 +423,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/capabilities/bashkit_shell/mod.rs
+++ b/crates/core/src/capabilities/bashkit_shell/mod.rs
@@ -293,6 +293,7 @@ impl Tool for BashTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Bash");
         Some(crate::tool_narration::narrate_shell_exec(
@@ -1379,6 +1380,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -525,6 +525,7 @@ impl Tool for ReadFileTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_read_file(
             &tool_call.arguments,
@@ -843,6 +844,7 @@ impl Tool for WriteFileTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_write_file(
             &tool_call.arguments,
@@ -991,6 +993,7 @@ impl Tool for EditFileTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_edit_file(
             &tool_call.arguments,
@@ -1242,11 +1245,13 @@ impl Tool for ListDirectoryTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_list_directory(
             &tool_call.arguments,
             phase,
             locale,
+            ctx,
         ))
     }
 
@@ -1416,6 +1421,7 @@ impl Tool for GrepFilesTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_grep_files(
             &tool_call.arguments,
@@ -1588,6 +1594,7 @@ impl Tool for DeleteFileTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_delete_file(
             &tool_call.arguments,
@@ -1717,6 +1724,7 @@ impl Tool for StatFileTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_stat_file(
             &tool_call.arguments,
@@ -1818,7 +1826,7 @@ impl Tool for StatFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tool_narration::ToolNarrationPhase;
+    use crate::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
     use crate::tool_types::ToolCall;
 
     #[test]
@@ -1830,7 +1838,13 @@ mod tests {
             arguments: serde_json::json!({ "path": "/workspace/AGENTS.md" }),
         };
         assert_eq!(
-            cap.narrate(None, &read, ToolNarrationPhase::Completed, None),
+            cap.narrate(
+                None,
+                &read,
+                ToolNarrationPhase::Completed,
+                None,
+                ToolNarrationContext::default()
+            ),
             Some("Read AGENTS.md".to_string())
         );
         // A tool this capability does not own returns None for its owner to handle.
@@ -1840,7 +1854,13 @@ mod tests {
             arguments: serde_json::json!({ "command": "ls" }),
         };
         assert_eq!(
-            cap.narrate(None, &bash, ToolNarrationPhase::Started, None),
+            cap.narrate(
+                None,
+                &bash,
+                ToolNarrationPhase::Started,
+                None,
+                ToolNarrationContext::default()
+            ),
             None
         );
     }
@@ -2004,6 +2024,10 @@ mod tests {
                 None if path.starts_with('/') => format!("{WORKSPACE_PREFIX}{path}"),
                 None => format!("{WORKSPACE_PREFIX}/{path}"),
             }
+        }
+
+        fn is_mount_resolver(&self) -> bool {
+            false
         }
 
         async fn read_file(

--- a/crates/core/src/capabilities/human_intent.rs
+++ b/crates/core/src/capabilities/human_intent.rs
@@ -61,6 +61,7 @@ impl ToolCallHook for HumanIntentToolCallHook {
         tool_call: &ToolCall,
         _phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         human_intent(&tool_call.arguments).map(truncate_intent)
     }
@@ -144,7 +145,13 @@ mod tests {
         };
 
         assert_eq!(
-            hook.narration(None, &tool_call, ToolNarrationPhase::Started, None),
+            hook.narration(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Started,
+                None,
+                Default::default()
+            ),
             Some("Listing all harnesses".to_string())
         );
 

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -1286,6 +1286,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for EmptyFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             _session_id: SessionId,
@@ -1696,6 +1700,10 @@ mod tests {
 
         #[async_trait]
         impl SessionFileSystem for MapFileStore {
+            fn is_mount_resolver(&self) -> bool {
+                false
+            }
+
             async fn read_file(
                 &self,
                 session_id: SessionId,

--- a/crates/core/src/capabilities/mcp.rs
+++ b/crates/core/src/capabilities/mcp.rs
@@ -160,6 +160,7 @@ impl Capability for McpCapability {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         // Generic search narration for provider/MCP search tools (`*__search`).
         if !tool_call.name.ends_with("__search") {

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -947,11 +947,12 @@ pub trait Capability: Send + Sync {
         tool_call: &ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         self.tools()
             .iter()
             .find(|tool| tool.name() == tool_call.name)
-            .and_then(|tool| tool.narrate(tool_call, phase, locale))
+            .and_then(|tool| tool.narrate(tool_call, phase, locale, ctx))
     }
 
     /// Returns user-defined hook specifications contributed by this capability.
@@ -1109,6 +1110,7 @@ pub trait ToolCallHook: Send + Sync {
         _tool_call: &ToolCall,
         _phase: crate::tool_narration::ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         None
     }
@@ -1132,8 +1134,9 @@ impl ToolCallHook for CapabilityNarrationHook {
         tool_call: &ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        self.0.narrate(tool_def, tool_call, phase, locale)
+        self.0.narrate(tool_def, tool_call, phase, locale, ctx)
     }
 }
 
@@ -1816,6 +1819,7 @@ impl Tool for UnifiedSpawnAgentTool {
         tool_call: &ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let target_type = tool_call
             .arguments
@@ -1823,7 +1827,7 @@ impl Tool for UnifiedSpawnAgentTool {
             .and_then(|target| target.get("type"))
             .and_then(serde_json::Value::as_str)?;
         self.provider_for(target_type)
-            .and_then(|tool| tool.narrate(tool_call, phase, locale))
+            .and_then(|tool| tool.narrate(tool_call, phase, locale, ctx))
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -273,6 +273,7 @@ impl Tool for SandboxExecTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Sandbox");
         Some(crate::tool_narration::narrate_shell_exec(

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -121,6 +121,7 @@ impl Tool for KvStoreTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Key-Value Store");
         Some(crate::tool_narration::narrate_secret_store(
@@ -331,6 +332,7 @@ impl Tool for SecretStoreTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Secret Store");
         Some(crate::tool_narration::narrate_secret_store(

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -322,6 +322,7 @@ impl Tool for ListSkillsTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         crate::tool_narration::narrate_skill(&tool_call.name, &tool_call.arguments, phase, locale)
     }
@@ -450,6 +451,7 @@ impl Tool for ActivateSkillFromVfsTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         crate::tool_narration::narrate_skill(&tool_call.name, &tool_call.arguments, phase, locale)
     }
@@ -777,6 +779,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/capabilities/skills_scoped.rs
+++ b/crates/core/src/capabilities/skills_scoped.rs
@@ -481,6 +481,7 @@ impl Tool for ListSkillsTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         crate::tool_narration::narrate_skill(&tool_call.name, &tool_call.arguments, phase, locale)
     }
@@ -583,6 +584,7 @@ impl Tool for ActivateSkillTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         crate::tool_narration::narrate_skill(&tool_call.name, &tool_call.arguments, phase, locale)
     }
@@ -746,6 +748,7 @@ impl Tool for ReadSkillTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         crate::tool_narration::narrate_skill(&tool_call.name, &tool_call.arguments, phase, locale)
     }

--- a/crates/core/src/capabilities/skills_scoped/tests.rs
+++ b/crates/core/src/capabilities/skills_scoped/tests.rs
@@ -42,6 +42,10 @@ impl MockFs {
 
 #[async_trait]
 impl SessionFileSystem for MockFs {
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
+
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let files = self.files.lock().unwrap();
         Ok(files

--- a/crates/core/src/capabilities/stateless_todo_list.rs
+++ b/crates/core/src/capabilities/stateless_todo_list.rs
@@ -120,6 +120,7 @@ impl Tool for WriteTodosTool {
         _tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_write_todos(phase, locale))
     }

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -1031,6 +1031,7 @@ impl Tool for SpawnSubagentAsAgentTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_subagent_spawn(
             &tool_call.arguments,
@@ -2402,6 +2403,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MemoryFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             session_id: crate::typed_id::SessionId,

--- a/crates/core/src/capabilities/tool_output_distillation.rs
+++ b/crates/core/src/capabilities/tool_output_distillation.rs
@@ -579,6 +579,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(&self, _s: SessionId, _p: &str) -> Result<Option<SessionFile>> {
             Ok(None)
         }

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -555,6 +555,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -501,6 +501,7 @@ impl Tool for ToolSearchTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_tool_search(
             &tool_call.arguments,

--- a/crates/core/src/capabilities/web_fetch/mod.rs
+++ b/crates/core/src/capabilities/web_fetch/mod.rs
@@ -507,6 +507,7 @@ impl Tool for WebFetchTool {
         tool_call: &crate::tool_types::ToolCall,
         phase: crate::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(crate::tool_narration::narrate_web_fetch(
             &tool_call.arguments,
@@ -1776,6 +1777,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/hook_dispatch.rs
+++ b/crates/core/src/hook_dispatch.rs
@@ -239,6 +239,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/mount_fs.rs
+++ b/crates/core/src/mount_fs.rs
@@ -109,6 +109,18 @@ impl MountFs {
         Arc::new(Self::new(workspace))
     }
 
+    /// Wrap only when `workspace` is not already a [`MountFs`].
+    ///
+    /// Re-wrapping would collapse nested mount tables (e.g. multi-root
+    /// workspaces) into a single primary view and break named-mount display.
+    pub fn wrap_if_needed(workspace: Arc<dyn SessionFileSystem>) -> Arc<dyn SessionFileSystem> {
+        if workspace.is_mount_resolver() {
+            workspace
+        } else {
+            Self::wrap(workspace)
+        }
+    }
+
     /// Register an additional mount (e.g. a read-only skills source or a named
     /// volume) backed by a different store. Longest-prefix wins at resolution.
     pub fn with_mount(
@@ -312,6 +324,10 @@ impl SessionFileSystem for MountFs {
         self.primary.display_root()
     }
 
+    fn is_mount_resolver(&self) -> bool {
+        true
+    }
+
     fn resolve_path(&self, input: &str) -> String {
         // The absolute virtual path: relative inputs resolve against cwd,
         // `.`/`..` collapse, leading `..` clamps at root. This is the namespace
@@ -500,6 +516,10 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for FlatStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(&self, sid: SessionId, path: &str) -> Result<Option<SessionFile>> {
             let files = self.files.lock().unwrap();
             Ok(files.get(path).map(|content| SessionFile {
@@ -746,5 +766,14 @@ mod tests {
                 "/workspace/roots/backend/Cargo.toml".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn mount_fs_identifies_as_resolver() {
+        let workspace: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        let fs = MountFs::wrap(workspace);
+        assert!(fs.is_mount_resolver());
+        let again = MountFs::wrap_if_needed(fs.clone());
+        assert!(Arc::ptr_eq(&fs, &again));
     }
 }

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -18,7 +18,9 @@ use crate::localization::{
     BackendLocale, backend_strings, format_more_actions, localized_tool_display_name,
     resolve_backend_locale,
 };
+use crate::session_path::WORKSPACE_PREFIX;
 use crate::tool_types::{ToolCall, ToolDefinition};
+use crate::traits::SessionFileSystem;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolNarrationPhase {
@@ -26,6 +28,21 @@ pub enum ToolNarrationPhase {
     Waiting,
     Completed,
     Failed,
+}
+
+/// Optional execution context for path-bearing tool narration.
+///
+/// When a [`SessionFileSystem`] is present, path-bearing helpers render through
+/// its `display_path` contract so narration matches tool results.
+#[derive(Clone, Copy, Default)]
+pub struct ToolNarrationContext<'a> {
+    pub file_store: Option<&'a dyn SessionFileSystem>,
+}
+
+impl<'a> ToolNarrationContext<'a> {
+    pub fn new(file_store: Option<&'a dyn SessionFileSystem>) -> Self {
+        Self { file_store }
+    }
 }
 
 fn title_case(name: &str) -> String {
@@ -205,10 +222,40 @@ pub fn labeled_phrase(
     }
 }
 
-fn location_phrase(arguments: &Value, locale: Option<&str>) -> String {
-    arg_str(arguments, &["path", "directory", "working_dir"])
+/// Present a filesystem path for narration using the active store contract.
+///
+/// When `file_store` is absent (generic fallback / offline builders), falls
+/// back to the legacy argument echo with localized root phrasing.
+pub fn present_filesystem_path(
+    file_store: Option<&dyn SessionFileSystem>,
+    input: Option<&str>,
+    locale: Option<&str>,
+) -> String {
+    if let Some(store) = file_store {
+        let raw = input
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(WORKSPACE_PREFIX);
+        return store.display_path(raw);
+    }
+    location_phrase_from_raw(input, locale)
+}
+
+fn location_phrase(
+    arguments: &Value,
+    locale: Option<&str>,
+    ctx: ToolNarrationContext<'_>,
+) -> String {
+    let raw = arg_str(arguments, &["path", "directory", "working_dir"]);
+    present_filesystem_path(ctx.file_store, raw, locale)
+}
+
+fn location_phrase_from_raw(input: Option<&str>, locale: Option<&str>) -> String {
+    input
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
         .map(|value| {
-            if value == "." || value == "/workspace" {
+            if value == "." || value == WORKSPACE_PREFIX {
                 backend_strings(locale).current_directory.to_string()
             } else {
                 value.to_string()
@@ -424,8 +471,9 @@ pub fn narrate_list_directory(
     arguments: &Value,
     phase: ToolNarrationPhase,
     locale: Option<&str>,
+    ctx: ToolNarrationContext<'_>,
 ) -> String {
-    let target = location_phrase(arguments, locale);
+    let target = location_phrase(arguments, locale, ctx);
     let verbs = pick(
         locale,
         (
@@ -831,6 +879,132 @@ mod tests {
 
     fn args(value: serde_json::Value) -> serde_json::Value {
         value
+    }
+
+    #[test]
+    fn list_directory_helper_without_store_echoes_legacy_alias() {
+        let a = args(json!({ "path": "/workspace/crates" }));
+        assert_eq!(
+            narrate_list_directory(
+                &a,
+                ToolNarrationPhase::Completed,
+                None,
+                ToolNarrationContext::default()
+            ),
+            "Listed files in /workspace/crates"
+        );
+    }
+
+    #[test]
+    fn list_directory_helper_uses_store_display_path() {
+        use crate::error::Result;
+        use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+        use crate::typed_id::SessionId;
+        use async_trait::async_trait;
+
+        struct HostBackedStore {
+            root: String,
+        }
+
+        #[async_trait]
+        impl SessionFileSystem for HostBackedStore {
+            fn display_root(&self) -> String {
+                self.root.clone()
+            }
+
+            fn display_path(&self, path: &str) -> String {
+                if path == "/" || path == "/workspace" || path == "." {
+                    return self.root.clone();
+                }
+                if path == self.root || path.starts_with(&format!("{}/", self.root)) {
+                    return path.to_string();
+                }
+                if let Some(rest) = path.strip_prefix("/workspace/") {
+                    return format!("{}/{}", self.root.trim_end_matches('/'), rest);
+                }
+                if path.starts_with('/') {
+                    return format!(
+                        "{}/{}",
+                        self.root.trim_end_matches('/'),
+                        path.trim_start_matches('/')
+                    );
+                }
+                format!("{}/{}", self.root.trim_end_matches('/'), path)
+            }
+
+            fn is_mount_resolver(&self) -> bool {
+                false
+            }
+
+            async fn read_file(&self, _: SessionId, _: &str) -> Result<Option<SessionFile>> {
+                Ok(None)
+            }
+            async fn write_file(
+                &self,
+                _: SessionId,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> Result<SessionFile> {
+                Err(anyhow::anyhow!("stub").into())
+            }
+            async fn delete_file(&self, _: SessionId, _: &str, _: bool) -> Result<bool> {
+                Ok(false)
+            }
+            async fn list_directory(&self, _: SessionId, _: &str) -> Result<Vec<FileInfo>> {
+                Ok(vec![])
+            }
+            async fn stat_file(&self, _: SessionId, _: &str) -> Result<Option<FileStat>> {
+                Ok(None)
+            }
+            async fn grep_files(
+                &self,
+                _: SessionId,
+                _: &str,
+                _: Option<&str>,
+            ) -> Result<Vec<GrepMatch>> {
+                Ok(vec![])
+            }
+            async fn create_directory(&self, _: SessionId, _: &str) -> Result<FileInfo> {
+                Err(anyhow::anyhow!("stub").into())
+            }
+        }
+
+        let store = HostBackedStore {
+            root: "/repo".to_string(),
+        };
+        let ctx = ToolNarrationContext::new(Some(&store));
+        let workspace_alias = args(json!({ "path": "/workspace/crates" }));
+        assert_eq!(
+            narrate_list_directory(&workspace_alias, ToolNarrationPhase::Started, None, ctx),
+            "Listing files in /repo/crates"
+        );
+        assert_eq!(
+            narrate_list_directory(&workspace_alias, ToolNarrationPhase::Completed, None, ctx),
+            "Listed files in /repo/crates"
+        );
+        assert_eq!(
+            narrate_list_directory(&workspace_alias, ToolNarrationPhase::Failed, None, ctx),
+            "Failed to list files in /repo/crates"
+        );
+
+        let relative = args(json!({ "path": "crates" }));
+        assert_eq!(
+            narrate_list_directory(&relative, ToolNarrationPhase::Completed, None, ctx),
+            "Listed files in /repo/crates"
+        );
+
+        let host_absolute = args(json!({ "path": "/repo/crates" }));
+        assert_eq!(
+            narrate_list_directory(&host_absolute, ToolNarrationPhase::Completed, None, ctx),
+            "Listed files in /repo/crates"
+        );
+
+        let root = args(json!({}));
+        assert_eq!(
+            narrate_list_directory(&root, ToolNarrationPhase::Completed, None, ctx),
+            "Listed files in /repo"
+        );
     }
 
     #[test]

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -553,6 +553,7 @@ pub trait Tool: Send + Sync {
         _tool_call: &crate::tool_types::ToolCall,
         _phase: crate::tool_narration::ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         None
     }
@@ -2293,6 +2294,10 @@ mod tests {
 
     #[async_trait]
     impl crate::traits::SessionFileSystem for TestFileStore {
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
+
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -459,6 +459,11 @@ pub trait SessionFileSystem: Send + Sync {
         crate::session_path::to_session_path(input)
     }
 
+    /// Whether this store is already a mount-based resolver ([`MountFs`]).
+    ///
+    /// Used to avoid re-wrapping nested mount tables when building tool context.
+    fn is_mount_resolver(&self) -> bool;
+
     /// Read a file by path
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>>;
 
@@ -639,6 +644,10 @@ impl SessionFileSystem for WorkspaceScopedFileSystem {
     fn resolve_path(&self, input: &str) -> String {
         self.inner.resolve_path(input)
     }
+
+    fn is_mount_resolver(&self) -> bool {
+        self.inner.is_mount_resolver()
+    }
 }
 
 #[async_trait]
@@ -653,6 +662,10 @@ impl<T: SessionFileSystem + ?Sized> SessionFileSystem for std::sync::Arc<T> {
 
     fn resolve_path(&self, input: &str) -> String {
         (**self).resolve_path(input)
+    }
+
+    fn is_mount_resolver(&self) -> bool {
+        (**self).is_mount_resolver()
     }
 
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {

--- a/crates/runtime/src/file_store_decorators.rs
+++ b/crates/runtime/src/file_store_decorators.rs
@@ -171,6 +171,10 @@ impl SessionFileSystem for WriteBlocklistFileStore {
         self.check(&file.path)?;
         self.inner.seed_initial_file(session_id, file).await
     }
+
+    fn is_mount_resolver(&self) -> bool {
+        self.inner.is_mount_resolver()
+    }
 }
 
 /// Embedder-supplied approval callback used by [`ApprovalGatingFileStore`].
@@ -341,6 +345,10 @@ impl SessionFileSystem for ApprovalGatingFileStore {
 
     async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
         self.inner.seed_initial_file(session_id, file).await
+    }
+
+    fn is_mount_resolver(&self) -> bool {
+        self.inner.is_mount_resolver()
     }
 }
 

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -407,6 +407,10 @@ impl SessionFileSystem for InMemorySessionFileStore {
             .ok_or_else(|| AgentLoopError::store(format!("directory not found: {normalized}")))?;
         Ok(file_info(&file))
     }
+
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
 }
 
 /// In-memory implementation of session key/value and secret storage.

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -209,6 +209,10 @@ impl SessionFileSystem for RealDiskFileStore {
         }
     }
 
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
+
     async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
         // Clear any prior readonly mark so seeding always wins over a
         // previous starter-file declaration with the same path.

--- a/crates/runtime/tests/filesystem_narration_paths_test.rs
+++ b/crates/runtime/tests/filesystem_narration_paths_test.rs
@@ -1,0 +1,515 @@
+// EVE-749: filesystem tool narration must use the active SessionFileSystem
+// display_path contract so transcript paths match tool results.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use everruns_core::MessageRetriever;
+use everruns_core::atoms::{ActInput, AtomContext};
+use everruns_core::capabilities::{
+    CapabilityRegistry, FileSystemCapability, SystemPromptContext,
+    collect_capabilities_with_configs,
+};
+use everruns_core::driver_registry::DriverRegistry;
+use everruns_core::in_memory::{
+    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryMessageRetriever,
+    InMemoryProviderStore,
+};
+use everruns_core::tool_narration::{
+    ToolNarrationContext, ToolNarrationPhase, narrate_list_directory,
+};
+use everruns_core::traits::{
+    AgentStore, EventEmitter, HarnessStore, ProviderStore, SessionFileSystem, SessionMutator,
+    SessionStore,
+};
+use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
+use everruns_core::{
+    Agent, AgentCapabilityConfig, EventData, Harness, HarnessStatus, MountFs, Session,
+    SessionStatus, ToolCall, WorkspaceRootSet,
+};
+use everruns_runtime::{
+    InMemorySessionFileStore, RealDiskFileStore, RuntimeHostAdapter, RuntimeHostTurnContext,
+    execute_act_activity, multi_root_file_system,
+};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+#[derive(Clone, Default)]
+struct TestSessionStore {
+    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+}
+
+impl TestSessionStore {
+    async fn insert(&self, session: Session) {
+        self.sessions.write().await.insert(session.id, session);
+    }
+
+    async fn set_status(&self, session_id: SessionId, status: SessionStatus) -> Session {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions.get_mut(&session_id).expect("session exists");
+        session.status = status;
+        session.updated_at = Utc::now();
+        session.clone()
+    }
+}
+
+#[async_trait]
+impl SessionStore for TestSessionStore {
+    async fn get_session(
+        &self,
+        session_id: SessionId,
+    ) -> everruns_core::error::Result<Option<Session>> {
+        Ok(self.sessions.read().await.get(&session_id).cloned())
+    }
+}
+
+#[async_trait]
+impl SessionMutator for TestSessionStore {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> everruns_core::error::Result<Session> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions.get_mut(&session_id).expect("session exists");
+        session.title = Some(title);
+        Ok(session.clone())
+    }
+}
+
+#[derive(Clone)]
+struct NarrationTestHost {
+    capability_registry: CapabilityRegistry,
+    harness_store: Arc<InMemoryHarnessStore>,
+    session_store: Arc<TestSessionStore>,
+    message_store: Arc<InMemoryMessageRetriever>,
+    provider_store: Arc<InMemoryProviderStore>,
+    event_emitter: Arc<InMemoryEventEmitter>,
+    file_store: Arc<dyn SessionFileSystem>,
+}
+
+#[async_trait]
+impl RuntimeHostAdapter for NarrationTestHost {
+    async fn get_agent(
+        &self,
+        _org_id: i64,
+        _agent_id: everruns_core::typed_id::AgentId,
+    ) -> everruns_core::error::Result<Option<Agent>> {
+        Ok(None)
+    }
+
+    async fn get_harness(
+        &self,
+        _org_id: i64,
+        harness_id: HarnessId,
+    ) -> everruns_core::error::Result<Option<Harness>> {
+        Ok(self
+            .harness_store
+            .get_harness_chain(harness_id)
+            .await?
+            .into_iter()
+            .last())
+    }
+
+    async fn set_session_status(
+        &self,
+        _org_id: i64,
+        session_id: SessionId,
+        status: SessionStatus,
+    ) -> everruns_core::error::Result<Session> {
+        Ok(self.session_store.set_status(session_id, status).await)
+    }
+
+    async fn load_turn_context(
+        &self,
+        _org_id: i64,
+        session_id: SessionId,
+    ) -> everruns_core::error::Result<RuntimeHostTurnContext> {
+        Ok(RuntimeHostTurnContext {
+            agent: None,
+            session: self
+                .session_store
+                .get_session(session_id)
+                .await?
+                .expect("session exists"),
+            messages: self.message_store.load(session_id).await?,
+            model: None,
+            mcp_tool_definitions: vec![],
+        })
+    }
+
+    fn capability_registry(&self) -> CapabilityRegistry {
+        self.capability_registry.clone()
+    }
+
+    fn driver_registry(&self) -> DriverRegistry {
+        DriverRegistry::new()
+    }
+
+    fn harness_store(&self, _org_id: i64) -> Arc<dyn HarnessStore> {
+        self.harness_store.clone()
+    }
+
+    fn agent_store(&self, _org_id: i64) -> Arc<dyn AgentStore> {
+        Arc::new(InMemoryAgentStore::new())
+    }
+
+    fn session_store(&self, _org_id: i64) -> Arc<dyn SessionStore> {
+        self.session_store.clone()
+    }
+
+    fn session_mutator(&self, _org_id: i64) -> Arc<dyn SessionMutator> {
+        self.session_store.clone()
+    }
+
+    fn provider_store(&self, _org_id: i64) -> Arc<dyn ProviderStore> {
+        self.provider_store.clone()
+    }
+
+    fn message_store(&self) -> Arc<dyn MessageRetriever> {
+        self.message_store.clone()
+    }
+
+    fn event_emitter(&self) -> Arc<dyn EventEmitter> {
+        self.event_emitter.clone()
+    }
+
+    fn file_store(&self) -> Arc<dyn SessionFileSystem> {
+        self.file_store.clone()
+    }
+}
+
+fn harness(harness_id: HarnessId) -> Harness {
+    Harness {
+        id: harness_id,
+        name: "files".into(),
+        display_name: Some("Files".into()),
+        description: None,
+        system_prompt: None,
+        parent_harness_id: None,
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![AgentCapabilityConfig::new("session_file_system")],
+        initial_files: vec![],
+        network_access: None,
+        parallel_tool_calls: None,
+        mcp_servers: Default::default(),
+        embedder_metadata: Default::default(),
+        is_built_in: false,
+        status: HarnessStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+    }
+}
+
+fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
+    Session {
+        id: session_id,
+        workspace_id: everruns_core::WorkspaceId::from_uuid(session_id.uuid()),
+        organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+        harness_id,
+        agent_id: None,
+        agent_version_id: None,
+        agent_identity_id: None,
+        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+        resolved_owner_user_id: None,
+        owner: None,
+        effective_owner: None,
+        title: None,
+        goal: None,
+        locale: None,
+        preview: None,
+        output_preview: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: vec![],
+        tools: vec![],
+        mcp_servers: Default::default(),
+        system_prompt: None,
+        initial_files: vec![],
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        parallel_tool_calls: None,
+        status: SessionStatus::Started,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        started_at: None,
+        finished_at: None,
+        usage: None,
+        is_pinned: None,
+        active_schedule_count: None,
+        features: vec![],
+        parent_session_id: None,
+        forked_from_session_id: None,
+        forked_from_sequence: None,
+        blueprint_id: None,
+        blueprint_config: None,
+    }
+}
+
+async fn build_tool_definitions(
+    host: &NarrationTestHost,
+    session_id: SessionId,
+) -> Vec<everruns_core::ToolDefinition> {
+    let ctx = SystemPromptContext::without_file_store(session_id);
+    let collected = collect_capabilities_with_configs(
+        &[AgentCapabilityConfig::new("session_file_system")],
+        &host.capability_registry,
+        &ctx,
+    )
+    .await;
+    collected
+        .tools
+        .into_iter()
+        .map(|tool| tool.to_definition())
+        .collect()
+}
+
+struct NarrationEvents {
+    started: String,
+    completed: String,
+    result_path: String,
+}
+
+async fn run_list_directory_act(
+    host: &NarrationTestHost,
+    session_id: SessionId,
+    harness_id: HarnessId,
+    path: Value,
+) -> NarrationEvents {
+    let tool_definitions = build_tool_definitions(host, session_id).await;
+    let result = execute_act_activity(
+        host,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                MessageId::from_uuid(Uuid::now_v7()),
+            ),
+            harness_id,
+            agent_id: None,
+            tool_calls: vec![ToolCall {
+                id: "call_list".into(),
+                name: "list_directory".into(),
+                arguments: json!({ "path": path }),
+            }],
+            tool_definitions,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        },
+    )
+    .await
+    .expect("act succeeds");
+
+    assert_eq!(result.success_count, 1, "list_directory should succeed");
+    let tool_result = &result.results[0].result;
+    let result_path = tool_result
+        .result
+        .as_ref()
+        .and_then(|value| value.get("path"))
+        .and_then(|value| value.as_str())
+        .expect("result path")
+        .to_string();
+
+    let events = host.event_emitter.events().await;
+    let started = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::ToolStarted(data) if data.tool_call.name == "list_directory" => {
+                data.narration.clone()
+            }
+            _ => None,
+        })
+        .expect("tool.started narration");
+    let completed = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::ToolCompleted(data) if data.tool_name == "list_directory" => {
+                data.narration.clone()
+            }
+            _ => None,
+        })
+        .expect("tool.completed narration");
+
+    NarrationEvents {
+        started,
+        completed,
+        result_path,
+    }
+}
+
+fn host_with_store(file_store: Arc<dyn SessionFileSystem>) -> NarrationTestHost {
+    let mut capability_registry = CapabilityRegistry::new();
+    capability_registry.register(FileSystemCapability);
+    NarrationTestHost {
+        capability_registry,
+        harness_store: Arc::new(InMemoryHarnessStore::new()),
+        session_store: Arc::new(TestSessionStore::default()),
+        message_store: Arc::new(InMemoryMessageRetriever::new()),
+        provider_store: Arc::new(InMemoryProviderStore::new()),
+        event_emitter: Arc::new(InMemoryEventEmitter::new()),
+        file_store,
+    }
+}
+
+#[tokio::test]
+async fn real_disk_list_directory_narration_uses_host_paths() {
+    let workspace = TempDir::new().unwrap();
+    std::fs::create_dir_all(workspace.path().join("crates")).unwrap();
+    let store = Arc::new(RealDiskFileStore::new(workspace.path()).expect("store"));
+    let expected = store.display_path("/workspace/crates");
+
+    let host = host_with_store(store);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    host.harness_store.add_harness(harness(harness_id)).await;
+    host.session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let events =
+        run_list_directory_act(&host, session_id, harness_id, json!("/workspace/crates")).await;
+
+    assert!(
+        !events.started.contains("/workspace/crates"),
+        "started narration leaked alias: {}",
+        events.started
+    );
+    assert!(
+        !events.completed.contains("/workspace/crates"),
+        "completed narration leaked alias: {}",
+        events.completed
+    );
+    assert_eq!(events.started, format!("Listing files in {expected}"));
+    assert_eq!(events.completed, format!("Listed files in {expected}"));
+    assert_eq!(events.result_path, expected);
+}
+
+#[tokio::test]
+async fn mount_fs_list_directory_narration_matches_results() {
+    let workspace = TempDir::new().unwrap();
+    std::fs::create_dir_all(workspace.path().join("crates")).unwrap();
+    let backend = Arc::new(RealDiskFileStore::new(workspace.path()).expect("store"));
+    let store = MountFs::wrap(backend);
+    let expected = store.display_path("crates");
+
+    let host = host_with_store(store);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    host.harness_store.add_harness(harness(harness_id)).await;
+    host.session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let events = run_list_directory_act(&host, session_id, harness_id, json!("crates")).await;
+
+    assert_eq!(events.started, format!("Listing files in {expected}"));
+    assert_eq!(events.completed, format!("Listed files in {expected}"));
+    assert_eq!(events.result_path, expected);
+}
+
+#[tokio::test]
+async fn in_memory_list_directory_narration_keeps_workspace_alias() {
+    let store = Arc::new(InMemorySessionFileStore::new());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    store
+        .create_directory(session_id, "/crates")
+        .await
+        .expect("seed dir");
+
+    let host = host_with_store(store);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    host.harness_store.add_harness(harness(harness_id)).await;
+    host.session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let events =
+        run_list_directory_act(&host, session_id, harness_id, json!("/workspace/crates")).await;
+
+    assert_eq!(events.started, "Listing files in /workspace/crates");
+    assert_eq!(events.completed, "Listed files in /workspace/crates");
+    assert_eq!(events.result_path, "/workspace/crates");
+}
+
+#[tokio::test]
+async fn named_mount_narration_preserves_mount_path() {
+    let session_id = SessionId::from_seed(749);
+    let primary = TempDir::new().unwrap();
+    let secondary = TempDir::new().unwrap();
+    let roots = WorkspaceRootSet::new(
+        primary.path(),
+        [("backend".to_string(), secondary.path().to_path_buf())],
+    )
+    .unwrap();
+    let store = multi_root_file_system(&roots).expect("multi-root store");
+    store
+        .create_directory(session_id, "/workspace/roots/backend")
+        .await
+        .expect("seed mount dir");
+
+    let mount_path = "/workspace/roots/backend";
+    assert_eq!(
+        store.display_path(mount_path),
+        mount_path,
+        "named mount display_path must preserve virtual mount identity"
+    );
+    assert!(
+        store.is_mount_resolver(),
+        "multi-root store must identify as mount resolver"
+    );
+    let wrapped = MountFs::wrap_if_needed(store.clone());
+    let ctx = ToolNarrationContext::new(Some(wrapped.as_ref()));
+    assert_eq!(
+        narrate_list_directory(
+            &json!({ "path": mount_path }),
+            ToolNarrationPhase::Started,
+            None,
+            ctx,
+        ),
+        format!("Listing files in {mount_path}"),
+        "helper narration must match mount display_path"
+    );
+    let host = host_with_store(store);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    host.harness_store.add_harness(harness(harness_id)).await;
+    host.session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let events = run_list_directory_act(&host, session_id, harness_id, json!(mount_path)).await;
+
+    assert_eq!(events.started, format!("Listing files in {mount_path}"));
+    assert_eq!(events.completed, format!("Listed files in {mount_path}"));
+    assert_eq!(events.result_path, mount_path);
+}
+
+#[tokio::test]
+async fn list_directory_root_inputs_narrate_display_root() {
+    let workspace = TempDir::new().unwrap();
+    let store = Arc::new(RealDiskFileStore::new(workspace.path()).expect("store"));
+    let expected_root = store.display_root();
+
+    let host = host_with_store(store);
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    host.harness_store.add_harness(harness(harness_id)).await;
+    host.session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    for path in [json!("/workspace"), json!("."), json!("/")] {
+        let events = run_list_directory_act(&host, session_id, harness_id, path).await;
+        assert_eq!(events.completed, format!("Listed files in {expected_root}"));
+        assert_eq!(events.result_path, expected_root);
+    }
+}

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -408,6 +408,7 @@ impl Tool for NarratingTool {
         _tool_call: &ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         use everruns_core::tool_narration::ToolNarrationPhase;
         match phase {
@@ -465,6 +466,7 @@ impl everruns_core::capabilities::ToolCallHook for ExplicitNarrationHook {
         tool_call: &ToolCall,
         _phase: everruns_core::tool_narration::ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         if tool_call.name == "narrating_tool" {
             Some("Explicit hook narration wins".to_string())

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -1091,6 +1091,10 @@ fn file_system_display_error(error: impl std::fmt::Display) -> AgentLoopError {
 
 #[async_trait]
 impl SessionFileSystem for WorkspaceFileService {
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
+
     async fn seed_initial_file(
         &self,
         session_id: SessionId,

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -117,6 +117,10 @@ impl DbSessionFileStore {
 
 #[async_trait]
 impl SessionFileSystem for DbSessionFileStore {
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
+
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let path = Self::normalize_path(path);
         let row = self

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1523,6 +1523,10 @@ fn proto_model_with_provider_to_model(proto: proto::ResolvedModel) -> Result<Res
 
 #[async_trait]
 impl SessionFileSystem for GrpcAdapter {
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
+
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let mut client = self.client.inner.lock().await;
 

--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -854,6 +854,10 @@ mod tests {
                 updated_at: now,
             })
         }
+
+        fn is_mount_resolver(&self) -> bool {
+            false
+        }
     }
 
     // Drive the production `reconcile_orphans` loop with an injected executor

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -675,4 +675,8 @@ impl<A: WorkerAdapters> everruns_core::traits::SessionFileSystem for SessionAdap
             .create_directory(session_id.uuid(), path)
             .await
     }
+
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
 }

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -251,6 +251,10 @@ impl CodingCliSessionFileStore {
 
 #[async_trait]
 impl SessionFileSystem for CodingCliSessionFileStore {
+    fn is_mount_resolver(&self) -> bool {
+        false
+    }
+
     async fn read_file(
         &self,
         session_id: SessionId,

--- a/integrations/brave-search/src/tools.rs
+++ b/integrations/brave-search/src/tools.rs
@@ -67,6 +67,7 @@ impl Tool for BraveWebSearchTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(everruns_core::tool_narration::narrate_search_web(
             &tool_call.arguments,

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -160,6 +160,7 @@ impl Capability for BrowserlessCapability {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let url = tool_call
             .arguments
@@ -278,11 +279,23 @@ mod tests {
         };
         // Narration shows host+path only — no scheme, userinfo, or query.
         assert_eq!(
-            cap.narrate(None, &call, ToolNarrationPhase::Started, None),
+            cap.narrate(
+                None,
+                &call,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default()
+            ),
             Some("Navigating to example.com/page".to_string())
         );
         assert_eq!(
-            cap.narrate(None, &call, ToolNarrationPhase::Completed, None),
+            cap.narrate(
+                None,
+                &call,
+                ToolNarrationPhase::Completed,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default()
+            ),
             Some("Navigated to example.com/page".to_string())
         );
 
@@ -292,7 +305,13 @@ mod tests {
             arguments: serde_json::json!({}),
         };
         assert_eq!(
-            cap.narrate(None, &screenshot, ToolNarrationPhase::Completed, None),
+            cap.narrate(
+                None,
+                &screenshot,
+                ToolNarrationPhase::Completed,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default()
+            ),
             Some("Took screenshot".to_string())
         );
 
@@ -303,7 +322,13 @@ mod tests {
             arguments: serde_json::json!({}),
         };
         assert_eq!(
-            cap.narrate(None, &other, ToolNarrationPhase::Started, None),
+            cap.narrate(
+                None,
+                &other,
+                ToolNarrationPhase::Started,
+                None,
+                everruns_core::tool_narration::ToolNarrationContext::default()
+            ),
             None
         );
     }

--- a/integrations/cursor/src/lib.rs
+++ b/integrations/cursor/src/lib.rs
@@ -111,6 +111,7 @@ impl Capability for CursorCapability {
         tool_call: &ToolCall,
         phase: ToolNarrationPhase,
         _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let target = tool_call
             .arguments

--- a/integrations/cursor/tests/plugin_registration.rs
+++ b/integrations/cursor/tests/plugin_registration.rs
@@ -75,7 +75,13 @@ fn cursor_narration_names_agent_work() {
     };
 
     let narration = cap
-        .narrate(None, &call, ToolNarrationPhase::Started, None)
+        .narrate(
+            None,
+            &call,
+            ToolNarrationPhase::Started,
+            None,
+            everruns_core::tool_narration::ToolNarrationContext::default(),
+        )
         .expect("narration");
     assert_eq!(narration, "Starting Cursor agent: Fix checkout bug");
 }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -441,6 +441,7 @@ impl Tool for DaytonaExecTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Daytona");
         Some(everruns_core::tool_narration::narrate_shell_exec(

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -218,6 +218,7 @@ impl Tool for DenoExecTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Deno");
         Some(everruns_core::tool_narration::narrate_shell_exec(

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -379,6 +379,7 @@ impl Tool for DockerExecTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Docker");
         Some(everruns_core::tool_narration::narrate_shell_exec(

--- a/integrations/duckduckgo/src/tools.rs
+++ b/integrations/duckduckgo/src/tools.rs
@@ -22,6 +22,7 @@ impl Tool for DuckDuckGoSearchTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         Some(everruns_core::tool_narration::narrate_search_web(
             &tool_call.arguments,

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -234,6 +234,7 @@ impl Tool for E2BExecTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("E2B");
         Some(everruns_core::tool_narration::narrate_shell_exec(

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -201,6 +201,7 @@ impl Tool for SpritesExecTool {
         tool_call: &everruns_core::tool_types::ToolCall,
         phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Sprites");
         Some(everruns_core::tool_narration::narrate_shell_exec(

--- a/specs/tool-narration.md
+++ b/specs/tool-narration.md
@@ -115,6 +115,11 @@ When the relevant argument is absent, drop the value and keep the bare verb.
 
 Arguments shown in narration are **display values, not faithful echoes**:
 
+- **Filesystem paths.** When a [`SessionFileSystem`] is available on the act path,
+  path-bearing helpers (e.g. `narrate_list_directory`) render through
+  `display_path()` so narration matches tool results. Capabilities receive this
+  via [`ToolNarrationContext`] on `Tool::narrate` / `ToolCallHook::narration`.
+  Offline builders without a store fall back to legacy argument echo.
 - **Truncate.** queries / patterns / commands: ~48–80 chars with an ellipsis.
   File paths show the basename only.
 - **URLs.** show host + path; strip the scheme, query string, and fragment (the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Filesystem tool narration now renders paths through the active `SessionFileSystem::display_path()` contract instead of echoing raw tool-call arguments. The act path passes a `ToolNarrationContext` (with the same mount-resolved file store used for execution) into capability/tool narration hooks, so `list_directory` and other path-bearing helpers show the same model-visible identity as tool results.

`MountFs::wrap_if_needed` prevents double-wrapping existing mount resolvers (multi-root workspaces), which previously collapsed named mounts into primary host paths during narration.

## Why

For host-backed sessions rooted at `/repo`, a call like `list_directory({ "path": "/workspace/crates" })` executed correctly and returned `/repo/crates/...` in results, but narration still said `Listed files in /workspace/crates`. That leaked a retired alias into the transcript and could reinforce wrong path namespaces for users and the model.

Fixes EVE-749.

## Before / After

**Before:** `list_directory` on a RealDisk store with `path: "/workspace/crates"` narrated `Listed files in /workspace/crates` while results showed `/repo/crates`.

**After:** All lifecycle phases (started/completed/failed) narrate `Listed files in /repo/crates`, matching the tool result `path` field. VFS/in-memory sessions continue narrating `/workspace/...`; named secondary mounts keep `/workspace/roots/...` identities.

Evidence:
```text
cargo test -p everruns-core list_directory_helper mount_fs_identifies --lib  # 3 passed
cargo test -p everruns-runtime --test filesystem_narration_paths_test         # 5 passed
```

## Risk

- Medium — touches the narration API seam (`Tool::narrate`, `Capability::narrate`, `ToolCallHook::narration`) across capabilities and integrations, but non-filesystem narration is unchanged (new context parameter is ignored).
- Mount wrapping change affects every act-path tool execution; mitigated by `wrap_if_needed` only skipping re-wrap when `is_mount_resolver()` is true.

## Security

- Threat categories reviewed: TM-FS, TM-TOOL
- Narration only exposes paths already permitted by `display_path()`; no new path sources or host-path string replacement in embedders. Failed/out-of-root paths are not normalized into misleading in-root display paths (RealDisk returns raw input on parse failure).
- Findings and resolutions: No new exposure surface; behavior aligns narration with existing presentation contract.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (narration API extended with `ToolNarrationContext`; offline builders without a file store keep legacy echo)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf56e709-3029-46be-9766-9ea176907ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf56e709-3029-46be-9766-9ea176907ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

