### PR TITLE
chore(release): prepare v0.17.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.8] - 2026-07-11
+
+### Highlights
+
+- **Embedded schedule execution** — `everruns-local` now runs due one-shot and recurring session schedules through the host's live `LocalSessionRunner`, with atomic claims, stale recovery, retryable delivery, timezone-aware advancement, and graceful lifecycle. Embedded hosts that enable scheduled monitors must start and retain `LocalScheduleRunner` ([#2706](https://github.com/everruns/everruns/pull/2706)).
+
 ### What's Changed
 
-- `everruns-local` now executes due one-shot and recurring session schedules through `LocalSessionRunner::send_message`, with atomic claims, stale recovery, retryable delivery failures, timezone-aware advancement, graceful lifecycle, and tracing. Embedded hosts that enable scheduled monitors must start and retain `LocalScheduleRunner`.
+- feat(local): execute due session schedules ([#2706](https://github.com/everruns/everruns/pull/2706)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): harden audit client IP extraction ([#2704](https://github.com/everruns/everruns/pull/2704)) by [@chaliy](https://github.com/chaliy)
+- fix(llm): retry structured in-band provider errors ([#2702](https://github.com/everruns/everruns/pull/2702)) by [@chaliy](https://github.com/chaliy)
+- test(local): stabilize spawn_agent runtime proof ([#2703](https://github.com/everruns/everruns/pull/2703)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.17.7] - 2026-07-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,11 +2440,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.7"
+version = "0.17.8"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3025,11 +3025,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.7"
+version = "0.17.8"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.7"
+version = "0.17.8"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -149,11 +149,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.7" }
+everruns-core = { path = "crates/core", version = "0.17.8" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.7" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.8" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.7" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.8" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.7", default-features = false }
+everruns-core = { path = "../core", version = "0.17.8", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.7", default-features = false }
+everruns-core = { path = "../core", version = "0.17.8", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -125,10 +125,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.7", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.8", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.7", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.8", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.7", default-features = false }
+everruns-core = { path = "../core", version = "0.17.8", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.7", default-features = false }
+everruns-core = { path = "../core", version = "0.17.8", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.7", default-features = false }
+everruns-core = { path = "../core", version = "0.17.8", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What changed

- Prepares the v0.17.8 workspace and UI version.
- Synchronizes published internal-crate pins and the Cargo lockfile.
- Adds release notes for the embedded local schedule runner and other changes since v0.17.7.

## Why

EVE-747 requires a published `everruns-local` release so embedded hosts can consume `LocalScheduleRunner`.

## Before / After

- Before: the merged schedule runner existed only on `main` at workspace version 0.17.7.
- After: the release workflow can publish v0.17.8, including `everruns-local` and its internal dependencies.

## Risk

Low. This PR changes release metadata, internal published-crate version pins, and generated lockfile versions; it does not change runtime code.

## Security

No security-relevant runtime changes. The existing provenance-checked release and crates publication workflows remain unchanged.

## Follow-ups

None.

## Checklist

- [x] `just pre-push`
- [x] Published path-dependency pins synchronized
- [x] Migration ordering and immutability checks passed
- [x] Changelog includes user-facing impact
- [ ] Required CI checks are green
- [ ] Review comments are addressed
