### PR TITLE
feat(models): surface Sonnet 5 and recent Gemini models in catalog

### DIFF
--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -373,6 +373,8 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["claude-3-haiku"], ModelVendor::Anthropic, ANTHROPIC),
     // Google Gemini
     md(&["gemini-3.1-pro-preview"], ModelVendor::Google, GEMINI),
+    md(&["gemini-3.5-flash"], ModelVendor::Google, GEMINI),
+    md(&["gemini-3.1-flash-lite"], ModelVendor::Google, GEMINI),
     md(&["gemini-2.5-pro"], ModelVendor::Google, GEMINI),
     md(&["gemini-2.5-flash"], ModelVendor::Google, GEMINI),
     md(&["gemini-2.0-flash"], ModelVendor::Google, GEMINI),
@@ -3194,6 +3196,97 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
             supports_phases: false,
         }),
 
+        // Gemini 3.5 Flash — current-gen Flash. Source: models.dev (google
+        // provider). Reasoning effort (minimal/low/medium/high) is offered
+        // upstream but, consistent with the other Gemini profiles here, effort
+        // selection is left unset.
+        "gemini-3.5-flash" => Some(ModelProfile {
+            name: "Gemini 3.5 Flash".into(),
+            family: "gemini-3.5-flash".into(),
+            description: None,
+            release_date: Some("2026-05-19".into()),
+            last_updated: Some("2026-05-19".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2025-01-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 1.50,
+                output: 9.00,
+                cache_read: Some(0.15),
+                cost_tiers: vec![],
+            }),
+            limits: Some(ModelLimits {
+                context: 1_048_576,
+                input: None,
+                output: 65_536,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![
+                    Modality::Text,
+                    Modality::Image,
+                    Modality::Audio,
+                    Modality::Video,
+                    Modality::Pdf,
+                ],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            speed: None,
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
+        // Gemini 3.1 Flash Lite — low-latency, high-volume tier. Source:
+        // models.dev (google provider). Reasoning effort is offered upstream but
+        // left unset here, consistent with the other Gemini profiles.
+        "gemini-3.1-flash-lite" => Some(ModelProfile {
+            name: "Gemini 3.1 Flash Lite".into(),
+            family: "gemini-3.1-flash-lite".into(),
+            description: None,
+            release_date: Some("2026-05-07".into()),
+            last_updated: Some("2026-05-07".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2025-01-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 0.25,
+                output: 1.50,
+                cache_read: Some(0.025),
+                cost_tiers: vec![],
+            }),
+            limits: Some(ModelLimits {
+                context: 1_048_576,
+                input: None,
+                output: 65_536,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![
+                    Modality::Text,
+                    Modality::Image,
+                    Modality::Audio,
+                    Modality::Video,
+                    Modality::Pdf,
+                ],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            speed: None,
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
         "gemini-2.5-pro" => Some(ModelProfile {
             name: "Gemini 2.5 Pro".into(),
             family: "gemini-2.5-pro".into(),
@@ -3538,6 +3631,8 @@ mod tests {
         (DriverId::Anthropic, "claude-3-haiku"),
         // Gemini
         (DriverId::Gemini, "gemini-3.1-pro-preview"),
+        (DriverId::Gemini, "gemini-3.5-flash"),
+        (DriverId::Gemini, "gemini-3.1-flash-lite"),
         (DriverId::Gemini, "gemini-2.5-pro"),
         (DriverId::Gemini, "gemini-2.5-flash"),
         (DriverId::Gemini, "gemini-2.0-flash"),

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -124,6 +124,7 @@ mod seed_ids {
     pub const O1_PREVIEW: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021e);
 
     // Anthropic Models (0x300-0x3FF)
+    pub const CLAUDE_SONNET_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030c);
     pub const CLAUDE_OPUS_4_7: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000309);
     pub const CLAUDE_SONNET_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030a);
     pub const CLAUDE_HAIKU_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030b);
@@ -137,12 +138,16 @@ mod seed_ids {
     pub const CLAUDE_3_5_HAIKU: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000308);
     // 1M-context variants (`[1m]` model ids), 0x3a0+ sub-range.
     pub const CLAUDE_OPUS_4_7_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a7);
+    pub const CLAUDE_SONNET_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a5);
 
     // LlmSim Models (0x400-0x4FF)
     pub const LLMSIM_DEFAULT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000401);
     pub const LLMSIM_LATENCY: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000402);
 
     // Gemini Models (0x600-0x6FF)
+    pub const GEMINI_31_PRO_PREVIEW: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000604);
+    pub const GEMINI_35_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000605);
+    pub const GEMINI_31_FLASH_LITE: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000606);
     pub const GEMINI_25_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
     pub const GEMINI_25_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000602);
     pub const GEMINI_20_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
@@ -2025,6 +2030,26 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
+    // Anthropic Claude Sonnet 5 (current-gen Sonnet)
+    SeedModel {
+        id: seed_ids::CLAUDE_SONNET_5,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-sonnet-5",
+        display_name: "Claude Sonnet 5",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        // 1M-context twin of the 200K base above (driver sends the `context-1m`
+        // beta header for `[1m]` ids). Keeps a 1M Sonnet in the default picker
+        // now that the bare `claude-sonnet-5` profile is the 200K variant.
+        id: seed_ids::CLAUDE_SONNET_5_1M,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-sonnet-5[1m]",
+        display_name: "Claude Sonnet 5 (1M)",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
     // Anthropic Claude 4.7 / 4.6 series
     SeedModel {
         id: seed_ids::CLAUDE_OPUS_4_7,
@@ -2050,7 +2075,7 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
         model_id: "claude-sonnet-4-6",
         display_name: "Claude Sonnet 4.6",
-        enabled: true,     // Enabled by default
+        enabled: false,    // Superseded by Sonnet 5
         is_favorite: true, // Favorite model
     },
     SeedModel {
@@ -2129,14 +2154,39 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // Google Gemini
+    // Google Gemini 3.x series (current gen)
+    SeedModel {
+        id: seed_ids::GEMINI_31_PRO_PREVIEW,
+        provider_id: seed_ids::GEMINI_PROVIDER,
+        model_id: "gemini-3.1-pro-preview",
+        display_name: "Gemini 3.1 Pro Preview",
+        enabled: false,
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        id: seed_ids::GEMINI_35_FLASH,
+        provider_id: seed_ids::GEMINI_PROVIDER,
+        model_id: "gemini-3.5-flash",
+        display_name: "Gemini 3.5 Flash",
+        enabled: false,
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        id: seed_ids::GEMINI_31_FLASH_LITE,
+        provider_id: seed_ids::GEMINI_PROVIDER,
+        model_id: "gemini-3.1-flash-lite",
+        display_name: "Gemini 3.1 Flash Lite",
+        enabled: false,
+        is_favorite: false,
+    },
+    // Google Gemini 2.x series (superseded)
     SeedModel {
         id: seed_ids::GEMINI_25_PRO,
         provider_id: seed_ids::GEMINI_PROVIDER,
         model_id: "gemini-2.5-pro",
         display_name: "Gemini 2.5 Pro",
         enabled: false,
-        is_favorite: true, // Favorite model
+        is_favorite: false,
     },
     SeedModel {
         id: seed_ids::GEMINI_25_FLASH,
@@ -2144,7 +2194,7 @@ const SEED_MODELS: &[SeedModel] = &[
         model_id: "gemini-2.5-flash",
         display_name: "Gemini 2.5 Flash",
         enabled: false,
-        is_favorite: true, // Favorite model
+        is_favorite: false,
     },
     SeedModel {
         id: seed_ids::GEMINI_20_FLASH,
@@ -3526,6 +3576,66 @@ mod tests {
         assert!(
             result.updated >= 1,
             "should detect model display_name change"
+        );
+    }
+
+    /// End-to-end catalog check: after seeding, the current-generation models
+    /// must surface for the picker. `claude-sonnet-5` (and its 1M twin) is the
+    /// enabled favorite Sonnet while the superseded `claude-sonnet-4-6` is
+    /// disabled, and the Gemini 3.x models are catalogued. Guards against the
+    /// profile registry and seed catalog drifting apart again.
+    #[tokio::test]
+    async fn test_seed_surfaces_current_gen_models() {
+        let db = make_db();
+        seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .unwrap();
+
+        let by_id = |models: &[crate::storage::models::ModelRow]| {
+            models
+                .iter()
+                .map(|m| (m.model_id.clone(), (m.enabled, m.is_favorite)))
+                .collect::<std::collections::HashMap<_, _>>()
+        };
+
+        let anthropic = db
+            .list_models_for_provider(DEFAULT_ORG_ID, seed_ids::ANTHROPIC_PROVIDER)
+            .await
+            .unwrap();
+        let anthropic = by_id(&anthropic);
+        assert_eq!(
+            anthropic.get("claude-sonnet-5"),
+            Some(&(true, true)),
+            "Sonnet 5 must be the enabled favorite Sonnet"
+        );
+        assert_eq!(
+            anthropic.get("claude-sonnet-5[1m]"),
+            Some(&(true, true)),
+            "Sonnet 5 (1M) twin must be seeded and enabled"
+        );
+        assert_eq!(
+            anthropic.get("claude-sonnet-4-6").map(|v| v.0),
+            Some(false),
+            "Sonnet 4.6 must be demoted to disabled once superseded by Sonnet 5"
+        );
+
+        let gemini = db
+            .list_models_for_provider(DEFAULT_ORG_ID, seed_ids::GEMINI_PROVIDER)
+            .await
+            .unwrap();
+        let gemini = by_id(&gemini);
+        assert!(
+            gemini.contains_key("gemini-3.1-pro-preview"),
+            "Gemini 3.1 Pro Preview must be catalogued"
+        );
+        assert_eq!(
+            gemini.get("gemini-3.5-flash").map(|v| v.1),
+            Some(true),
+            "Gemini 3.5 Flash must be catalogued as a favorite"
+        );
+        assert!(
+            gemini.contains_key("gemini-3.1-flash-lite"),
+            "Gemini 3.1 Flash Lite must be catalogued"
         );
     }
 


### PR DESCRIPTION
## What changed
The seed catalog (`SEED_MODELS`) now surfaces the current-generation Anthropic and Google models to the picker/default selection:

- **Claude Sonnet 5** (and its `[1m]` twin) is seeded as the enabled favorite Sonnet; **Claude Sonnet 4.6** is demoted to disabled (kept as a favorite), mirroring how prior-generation Sonnets are handled.
- **Gemini 3.1 Pro Preview**, **3.5 Flash**, and **3.1 Flash-Lite** are catalogued. 3.1 Pro Preview and 3.5 Flash become the current-gen favorites; the superseded 2.5 Pro/Flash pair loses its favorite flag.
- New profiles for `gemini-3.5-flash` and `gemini-3.1-flash-lite` were added to the profile registry (pricing/limits/capabilities sourced from models.dev per the module's no-guessing rule), plus registry entries and resolution-test coverage. `gemini-3.1-pro-preview` and `claude-sonnet-5` profiles already existed and are unchanged.

## Why
`claude-sonnet-5` already had a complete *profile* in `model_profiles.rs`, but a profile is only metadata — it never places a model in a provider's picker. That is the job of `SEED_MODELS` in `crates/server/src/seed.rs`, which had no Sonnet 5 row. Because model listing sorts **enabled → favorite → name**, the newest *catalogued* enabled-favorite Sonnet (4.6) always won, so agents/UI kept defaulting to Sonnet 4.6. The Gemini catalog had the same lag, stopping at 2.5 while 3.x profiles already existed. This PR closes that drift between the profile registry and the seed catalog.

## Before / After
**Before** — Anthropic provider's top enabled favorite Sonnet is `claude-sonnet-4-6`; `claude-sonnet-5` is absent from the catalog. Gemini catalog tops out at `gemini-2.5-*`.

**After** — after real seeding, the catalog surfaces the current generation. Proven end-to-end by `test_seed_surfaces_current_gen_models`, which seeds via `seed_all` and asserts the listed catalog:

```
running 1 test
test seed::tests::test_seed_surfaces_current_gen_models ... ok
test result: ok. 1 passed; 0 failed; ...
```

The test asserts `claude-sonnet-5` = (enabled: true, favorite: true), `claude-sonnet-5[1m]` = (true, true), `claude-sonnet-4-6` enabled = false, and that `gemini-3.1-pro-preview` / `gemini-3.5-flash` (favorite) / `gemini-3.1-flash-lite` are catalogued.

## Risk
- **Low**
- Static model-catalog data plus one new profile arm. The only behavioral change is which model surfaces as the default Anthropic Sonnet (4.6 → 5). Seed upsert re-applies the curated `enabled`/`is_favorite` flags on every run (keyed by stable UUID), consistent with existing catalog management. Gemini rows remain `enabled: false` (provider is off until a key is configured), so no default-provider behavior changes there.

## Security
- Threat categories reviewed: **No security-relevant code changes.** The diff adds static, compile-time model metadata (`model_profiles.rs`) and static catalog rows (`seed.rs`) that flow through existing seeding code — no new auth, API, query, tool, tenancy, filesystem, or input-parsing surface, and no dependency changes.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC1EdJ386YxTHeUQZ2h8ns)_