### PR TITLE
chore(models): default to GPT-5.6 Sol and seed Claude Opus 4.8

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -125,6 +125,7 @@ mod seed_ids {
 
     // Anthropic Models (0x300-0x3FF)
     pub const CLAUDE_SONNET_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030c);
+    pub const CLAUDE_OPUS_4_8: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030d);
     pub const CLAUDE_OPUS_4_7: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000309);
     pub const CLAUDE_SONNET_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030a);
     pub const CLAUDE_HAIKU_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030b);
@@ -2030,7 +2031,15 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // Anthropic Claude Sonnet 5 (current-gen Sonnet)
+    // Anthropic current-gen (Opus 4.8, Sonnet 5)
+    SeedModel {
+        id: seed_ids::CLAUDE_OPUS_4_8,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-opus-4-8",
+        display_name: "Claude Opus 4.8",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
     SeedModel {
         id: seed_ids::CLAUDE_SONNET_5,
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
@@ -2240,8 +2249,8 @@ const SEED_MODELS: &[SeedModel] = &[
     },
 ];
 
-/// Default model ID for org settings seeding (GPT-5.5)
-const DEFAULT_MODEL_ID: Uuid = seed_ids::GPT_5_5;
+/// Default model ID for org settings seeding (GPT-5.6 Sol)
+const DEFAULT_MODEL_ID: Uuid = seed_ids::GPT_5_6_SOL;
 
 /// Seed organization settings (default model, etc.)
 async fn seed_organization_settings(db: &StorageBackend) -> anyhow::Result<SeedResult> {
@@ -3389,6 +3398,36 @@ mod tests {
             settings.default_model_id,
             Some(everruns_core::ModelId::from_uuid(DEFAULT_MODEL_ID))
         );
+    }
+
+    #[tokio::test]
+    async fn test_seed_all_sets_default_and_seeds_opus_48() {
+        let db = make_db();
+        seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .unwrap();
+
+        // Platform default model is GPT-5.6 Sol.
+        let settings = db
+            .get_organization_settings(DEFAULT_ORG_ID)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            settings.default_model_id,
+            Some(everruns_core::ModelId::from_uuid(seed_ids::GPT_5_6_SOL)),
+        );
+
+        // Claude Opus 4.8 is seeded for the Anthropic provider, enabled and
+        // marked favorite (the recommended Anthropic model).
+        let opus = db
+            .get_model(DEFAULT_ORG_ID, seed_ids::CLAUDE_OPUS_4_8)
+            .await
+            .unwrap()
+            .expect("claude-opus-4-8 should be seeded");
+        assert_eq!(opus.model_id, "claude-opus-4-8");
+        assert!(opus.enabled, "claude-opus-4-8 should be enabled");
+        assert!(opus.is_favorite, "claude-opus-4-8 should be favorite");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
- The platform's out-of-the-box **default model changes from GPT-5.5 to GPT-5.6 Sol**. A freshly-seeded organization (any org with no `default_model_id` yet) now gets GPT-5.6 Sol as its default.
- **Claude Opus 4.8 is now seeded for the Anthropic provider**, enabled and marked favorite, so it appears as the recommended Anthropic model in the default org's picker. Its profile already existed in the model registry; only the seed row was missing (the newest seeded Anthropic Opus was 4.7).

Data-only change in `crates/server/src/seed.rs` (one default constant + one seed model entry + its well-known UUID).

## Why
Refresh the default model selection to the current-generation flagships: GPT-5.6 Sol (OpenAI) as the platform default and Claude Opus 4.8 as the recommended Anthropic model.

## Before / After
Seeding a fresh default org via the real `seed_all` startup path:

| | Before | After |
|---|---|---|
| `organization_settings.default_model_id` | GPT-5.5 | **GPT-5.6 Sol** |
| Newest enabled+favorite Anthropic Opus | Claude Opus 4.7 | **Claude Opus 4.8** (4.7 retained) |

Evidence (local):
- `cargo test -p everruns-server --lib seed::` → **33 passed**, including the new `test_seed_all_sets_default_and_seeds_opus_48` (runs real `seed_all`, asserts default == GPT-5.6 Sol and that `claude-opus-4-8` is seeded enabled+favorite) and `test_seed_all_second_run_all_unchanged` (idempotent re-seed).
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` → clean.
- `cargo fmt -p everruns-server --check` → clean.
- `bash scripts/lib/check-migration-ordering.sh` → `001..103` sequential (no migration changes).

## Risk
- **Low.**
- Only affects seeding when an org has no `default_model_id`; `seed_organization_settings` leaves an org's explicit default untouched. Seed model creation is an idempotent upsert by well-known UUID. No API, schema, or migration changes.

## Security
- Threat categories reviewed: **TM-LLM** (model selection — no API keys or prompt construction touched) and **TM-TENANT** (seeding writes only to `DEFAULT_ORG_ID`; the "only set default when unset" guard is unchanged). Values are compile-time constants — no injection, authz, or secret surface; no new dependencies.
- Findings and resolutions: **None.**

## Follow-ups
- **GLM-5.2 (OpenRouter / Zhipu) intentionally deferred.** It is not in the model registry; adding it needs a new vendor plus a full model profile (pricing, context, output limits) sourced from models.dev, which `model_profiles.rs` explicitly forbids guessing. Safe to defer until that data is available.
- `claude-fable-5` and `claude-sonnet-5` exist in the registry but are likewise not seeded — out of scope for this change; can be added later if desired.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (existing explicit defaults unaffected; re-seed idempotent)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVuin87XQGZQUKG6aLK7HW)_