### PR TITLE
feat(core): auto-continue after LLM usage-limit errors

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -181,6 +181,10 @@ export default defineConfig({
                         { label: "Message Metadata", slug: "capabilities/message-metadata" },
                         { label: "Task Management", slug: "capabilities/task-management" },
                         { label: "Schedules", slug: "capabilities/session-schedules" },
+                        {
+                          label: "Auto-Continue After Usage Limit",
+                          slug: "capabilities/usage-limit-auto-continue",
+                        },
                         { label: "Sub Agents", slug: "capabilities/sub-agents" },
                         { label: "AGENTS.md", slug: "capabilities/agent-instructions" },
                         { label: "Agent Skills", slug: "capabilities/agent-skills" },

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -410,6 +410,7 @@ fn is_error_placeholder_message(msg: &Message) -> bool {
                 | user_facing_error_codes::MODEL_UNAVAILABLE
                 | user_facing_error_codes::REQUEST_TOO_LARGE
                 | user_facing_error_codes::PROVIDER_RATE_LIMITED
+                | user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED
                 | user_facing_error_codes::PROVIDER_MISCONFIGURED
                 | user_facing_error_codes::PROVIDER_QUOTA_EXHAUSTED
                 | user_facing_error_codes::PROVIDER_UNAVAILABLE

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -782,67 +782,26 @@ impl ReasonAtom {
         self
     }
 
-    /// Schedule a one-shot continuation for a usage-limit error, firing shortly
-    /// after the provider's reported reset time. Returns `true` when a
-    /// continuation was actually scheduled (so the caller may promise automatic
-    /// resumption in the error copy). Best-effort: a missing schedule store,
-    /// absent reset time, or store failure logs and returns `false` rather than
-    /// failing the turn.
-    async fn schedule_usage_limit_continuation(
+    /// Collect the [`LlmErrorHandler`]s contributed by the active capabilities,
+    /// paired with each capability's per-agent config. Handlers are invoked
+    /// generically on the terminal-error path; the reason atom has no knowledge
+    /// of any specific capability's behavior. Capabilities that contribute no
+    /// handler — the common case — are skipped at zero allocation cost.
+    fn collect_llm_error_handlers(
         &self,
-        session_id: SessionId,
-        source_error: &UserFacingError,
-        cfg: &crate::capabilities::AutoContinueConfig,
-    ) -> bool {
-        let Some(store) = &self.schedule_store else {
-            return false;
-        };
-        let Some(resets_at) = source_error
-            .fields
-            .get("resets_at")
-            .and_then(|v| v.as_i64())
-        else {
-            return false;
-        };
-        let Some(reset_time) = chrono::DateTime::from_timestamp(resets_at, 0) else {
-            return false;
-        };
-
-        // Fire `delay_seconds` after the reset. Clamp into the future so a
-        // stale/past reset (clock skew, limit already cleared) still fires
-        // instead of being dropped by the store's past-time next-trigger rule.
-        let now = chrono::Utc::now();
-        let delay = chrono::Duration::seconds(cfg.delay_seconds);
-        let scheduled_at = (reset_time + delay).max(now + delay);
-
-        match store
-            .create_schedule(
-                session_id,
-                cfg.prompt.clone(),
-                None,
-                Some(scheduled_at),
-                "UTC".to_string(),
-            )
-            .await
-        {
-            Ok(schedule) => {
-                tracing::info!(
-                    session_id = %session_id,
-                    schedule_id = %schedule.id,
-                    scheduled_at = %scheduled_at,
-                    "usage_limit_auto_continue: scheduled continuation after usage-limit reset"
-                );
-                true
-            }
-            Err(e) => {
-                tracing::warn!(
-                    session_id = %session_id,
-                    error = %e,
-                    "usage_limit_auto_continue: failed to schedule continuation"
-                );
-                false
-            }
-        }
+        resolved_capability_configs: &[crate::AgentCapabilityConfig],
+    ) -> Vec<(
+        Arc<dyn crate::llm_error_handler::LlmErrorHandler>,
+        serde_json::Value,
+    )> {
+        resolved_capability_configs
+            .iter()
+            .filter_map(|cfg| {
+                let cap = self.capability_registry.get(cfg.capability_ref.as_str())?;
+                let handler = cap.llm_error_handler()?;
+                Some((handler, cfg.config.clone()))
+            })
+            .collect()
     }
 
     /// Set the file store for capabilities that need filesystem access.
@@ -1113,18 +1072,17 @@ impl ReasonAtom {
             }
         };
 
-        let (error_disclosure, error_context, auto_continue_cfg, call_result) = match assembled {
+        let (error_disclosure, error_context, error_handlers, call_result) = match assembled {
             Ok(assembled) => {
                 let error_disclosure = crate::capabilities::resolve_error_disclosure(
                     &assembled.resolved_capability_configs,
                     error_disclosure_override(&assembled.messages).as_deref(),
                 );
-                // Resolved before `assembled` is consumed by the LLM call so the
-                // terminal-error path below knows whether auto-continue is active
-                // even though it no longer has the capability configs.
-                let auto_continue_cfg = crate::capabilities::resolve_usage_limit_auto_continue(
-                    &assembled.resolved_capability_configs,
-                );
+                // Collected before `assembled` is consumed by the LLM call so the
+                // terminal-error path below can run capability error handlers even
+                // though it no longer has the capability configs.
+                let error_handlers =
+                    self.collect_llm_error_handlers(&assembled.resolved_capability_configs);
                 let error_context = UserFacingErrorContext::default()
                     .with_provider(assembled.model_with_provider.provider_type.to_string())
                     .with_model_id(assembled.model_with_provider.model.clone());
@@ -1142,17 +1100,12 @@ impl ReasonAtom {
                         assembled,
                     )
                     .await;
-                (
-                    error_disclosure,
-                    error_context,
-                    auto_continue_cfg,
-                    call_result,
-                )
+                (error_disclosure, error_context, error_handlers, call_result)
             }
             Err(error) => (
                 ErrorDisclosure::default(),
                 UserFacingErrorContext::default(),
-                None,
+                Vec::new(),
                 Err(error),
             ),
         };
@@ -1208,24 +1161,6 @@ impl ReasonAtom {
                 let error_msg = e.to_string();
                 let mut source_error = e.user_facing_error(error_context);
 
-                // Usage-limit auto-continue: when the capability is active and
-                // the provider reported a concrete reset time, schedule a
-                // one-shot continuation shortly after the reset and flag the
-                // error so its copy promises automatic resumption. The `auto_continue`
-                // flag is only set when the continuation was actually scheduled,
-                // so the copy never over-promises.
-                if source_error.code == crate::user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED
-                    && let Some(cfg) = &auto_continue_cfg
-                    && self
-                        .schedule_usage_limit_continuation(context.session_id, &source_error, cfg)
-                        .await
-                {
-                    source_error = source_error.with_field("auto_continue", true);
-                }
-
-                let user_error = source_error.apply_disclosure(error_disclosure, Some(&error_msg));
-                let user_error_text = user_error.fallback_message();
-
                 // Only emit user-facing error events for non-transient errors.
                 // Transient errors (server errors, rate limits, timeouts) will be
                 // retried by the durable task engine. Emitting error events on each
@@ -1234,6 +1169,36 @@ impl ReasonAtom {
                 // are exhausted (DLQ).
                 let is_transient = e.is_transient_llm_error()
                     || (e.llm_error_kind().is_none() && is_transient_error_message(&error_msg));
+
+                // Capability error-handler seam: on the terminal (non-retried)
+                // error path, let active capabilities react — perform a side
+                // effect and/or augment the user-facing error fields — before the
+                // message is built. The atom stays behavior-agnostic; each handler
+                // (e.g. `usage_limit_auto_continue`) owns its own logic.
+                if !is_transient && !error_handlers.is_empty() {
+                    let services = crate::llm_error_handler::LlmErrorHandlerServices {
+                        schedule_store: self.schedule_store.clone(),
+                    };
+                    for (handler, config) in &error_handlers {
+                        let outcome = {
+                            let ctx = crate::llm_error_handler::LlmErrorContext {
+                                session_id: context.session_id,
+                                error_code: &source_error.code,
+                                error_fields: &source_error.fields,
+                                config,
+                                services: &services,
+                            };
+                            handler.on_llm_error(&ctx).await
+                        };
+                        for (key, value) in outcome.extra_error_fields {
+                            source_error = source_error.with_field(key, value);
+                        }
+                    }
+                }
+
+                let user_error = source_error.apply_disclosure(error_disclosure, Some(&error_msg));
+                let user_error_text = user_error.fallback_message();
+
                 let mut output_message_id = None;
 
                 if !is_transient {

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -782,24 +782,24 @@ impl ReasonAtom {
         self
     }
 
-    /// Collect the [`LlmErrorHandler`]s contributed by the active capabilities,
-    /// paired with each capability's per-agent config. Handlers are invoked
+    /// Collect the [`LlmErrorHook`]s contributed by the active capabilities,
+    /// paired with each capability's per-agent config. Hooks are invoked
     /// generically on the terminal-error path; the reason atom has no knowledge
     /// of any specific capability's behavior. Capabilities that contribute no
-    /// handler — the common case — are skipped at zero allocation cost.
-    fn collect_llm_error_handlers(
+    /// hook — the common case — are skipped at zero allocation cost.
+    fn collect_llm_error_hooks(
         &self,
         resolved_capability_configs: &[crate::AgentCapabilityConfig],
     ) -> Vec<(
-        Arc<dyn crate::llm_error_handler::LlmErrorHandler>,
+        Arc<dyn crate::llm_error_hook::LlmErrorHook>,
         serde_json::Value,
     )> {
         resolved_capability_configs
             .iter()
             .filter_map(|cfg| {
                 let cap = self.capability_registry.get(cfg.capability_ref.as_str())?;
-                let handler = cap.llm_error_handler()?;
-                Some((handler, cfg.config.clone()))
+                let hook = cap.llm_error_hook()?;
+                Some((hook, cfg.config.clone()))
             })
             .collect()
     }
@@ -1072,17 +1072,17 @@ impl ReasonAtom {
             }
         };
 
-        let (error_disclosure, error_context, error_handlers, call_result) = match assembled {
+        let (error_disclosure, error_context, error_hooks, call_result) = match assembled {
             Ok(assembled) => {
                 let error_disclosure = crate::capabilities::resolve_error_disclosure(
                     &assembled.resolved_capability_configs,
                     error_disclosure_override(&assembled.messages).as_deref(),
                 );
                 // Collected before `assembled` is consumed by the LLM call so the
-                // terminal-error path below can run capability error handlers even
+                // terminal-error path below can run capability error hooks even
                 // though it no longer has the capability configs.
-                let error_handlers =
-                    self.collect_llm_error_handlers(&assembled.resolved_capability_configs);
+                let error_hooks =
+                    self.collect_llm_error_hooks(&assembled.resolved_capability_configs);
                 let error_context = UserFacingErrorContext::default()
                     .with_provider(assembled.model_with_provider.provider_type.to_string())
                     .with_model_id(assembled.model_with_provider.model.clone());
@@ -1100,7 +1100,7 @@ impl ReasonAtom {
                         assembled,
                     )
                     .await;
-                (error_disclosure, error_context, error_handlers, call_result)
+                (error_disclosure, error_context, error_hooks, call_result)
             }
             Err(error) => (
                 ErrorDisclosure::default(),
@@ -1170,25 +1170,25 @@ impl ReasonAtom {
                 let is_transient = e.is_transient_llm_error()
                     || (e.llm_error_kind().is_none() && is_transient_error_message(&error_msg));
 
-                // Capability error-handler seam: on the terminal (non-retried)
+                // Capability error-hook seam: on the terminal (non-retried)
                 // error path, let active capabilities react — perform a side
                 // effect and/or augment the user-facing error fields — before the
-                // message is built. The atom stays behavior-agnostic; each handler
+                // message is built. The atom stays behavior-agnostic; each hook
                 // (e.g. `usage_limit_auto_continue`) owns its own logic.
-                if !is_transient && !error_handlers.is_empty() {
-                    let services = crate::llm_error_handler::LlmErrorHandlerServices {
+                if !is_transient && !error_hooks.is_empty() {
+                    let services = crate::llm_error_hook::LlmErrorHookServices {
                         schedule_store: self.schedule_store.clone(),
                     };
-                    for (handler, config) in &error_handlers {
+                    for (hook, config) in &error_hooks {
                         let outcome = {
-                            let ctx = crate::llm_error_handler::LlmErrorContext {
+                            let ctx = crate::llm_error_hook::LlmErrorContext {
                                 session_id: context.session_id,
                                 error_code: &source_error.code,
                                 error_fields: &source_error.fields,
                                 config,
                                 services: &services,
                             };
-                            handler.on_llm_error(&ctx).await
+                            hook.on_llm_error(&ctx).await
                         };
                         for (key, value) in outcome.extra_error_fields {
                             source_error = source_error.with_field(key, value);

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -730,6 +730,12 @@ pub struct ReasonAtom {
     /// end-of-message output guardrails (e.g. moderation). When absent, those
     /// guardrails fail open and the seam is a no-op.
     utility_llm_service: Option<Arc<dyn crate::UtilityLlmService>>,
+    /// Optional session schedule store. Used by the `usage_limit_auto_continue`
+    /// capability to schedule a one-shot continuation after a provider usage
+    /// limit resets. When absent, the capability degrades to a no-op (no
+    /// continuation is scheduled and the error copy makes no auto-resume
+    /// promise).
+    schedule_store: Option<Arc<dyn crate::traits::SessionScheduleStore>>,
 }
 
 impl ReasonAtom {
@@ -762,6 +768,80 @@ impl ReasonAtom {
             partial_stream_store: None,
             reasoning_effort_handle: None,
             utility_llm_service: None,
+            schedule_store: None,
+        }
+    }
+
+    /// Set the session schedule store used by `usage_limit_auto_continue` to
+    /// schedule a continuation after a provider usage limit resets.
+    pub fn with_schedule_store(
+        mut self,
+        store: Arc<dyn crate::traits::SessionScheduleStore>,
+    ) -> Self {
+        self.schedule_store = Some(store);
+        self
+    }
+
+    /// Schedule a one-shot continuation for a usage-limit error, firing shortly
+    /// after the provider's reported reset time. Returns `true` when a
+    /// continuation was actually scheduled (so the caller may promise automatic
+    /// resumption in the error copy). Best-effort: a missing schedule store,
+    /// absent reset time, or store failure logs and returns `false` rather than
+    /// failing the turn.
+    async fn schedule_usage_limit_continuation(
+        &self,
+        session_id: SessionId,
+        source_error: &UserFacingError,
+        cfg: &crate::capabilities::AutoContinueConfig,
+    ) -> bool {
+        let Some(store) = &self.schedule_store else {
+            return false;
+        };
+        let Some(resets_at) = source_error
+            .fields
+            .get("resets_at")
+            .and_then(|v| v.as_i64())
+        else {
+            return false;
+        };
+        let Some(reset_time) = chrono::DateTime::from_timestamp(resets_at, 0) else {
+            return false;
+        };
+
+        // Fire `delay_seconds` after the reset. Clamp into the future so a
+        // stale/past reset (clock skew, limit already cleared) still fires
+        // instead of being dropped by the store's past-time next-trigger rule.
+        let now = chrono::Utc::now();
+        let delay = chrono::Duration::seconds(cfg.delay_seconds);
+        let scheduled_at = (reset_time + delay).max(now + delay);
+
+        match store
+            .create_schedule(
+                session_id,
+                cfg.prompt.clone(),
+                None,
+                Some(scheduled_at),
+                "UTC".to_string(),
+            )
+            .await
+        {
+            Ok(schedule) => {
+                tracing::info!(
+                    session_id = %session_id,
+                    schedule_id = %schedule.id,
+                    scheduled_at = %scheduled_at,
+                    "usage_limit_auto_continue: scheduled continuation after usage-limit reset"
+                );
+                true
+            }
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %e,
+                    "usage_limit_auto_continue: failed to schedule continuation"
+                );
+                false
+            }
         }
     }
 
@@ -1033,11 +1113,17 @@ impl ReasonAtom {
             }
         };
 
-        let (error_disclosure, error_context, call_result) = match assembled {
+        let (error_disclosure, error_context, auto_continue_cfg, call_result) = match assembled {
             Ok(assembled) => {
                 let error_disclosure = crate::capabilities::resolve_error_disclosure(
                     &assembled.resolved_capability_configs,
                     error_disclosure_override(&assembled.messages).as_deref(),
+                );
+                // Resolved before `assembled` is consumed by the LLM call so the
+                // terminal-error path below knows whether auto-continue is active
+                // even though it no longer has the capability configs.
+                let auto_continue_cfg = crate::capabilities::resolve_usage_limit_auto_continue(
+                    &assembled.resolved_capability_configs,
                 );
                 let error_context = UserFacingErrorContext::default()
                     .with_provider(assembled.model_with_provider.provider_type.to_string())
@@ -1056,11 +1142,17 @@ impl ReasonAtom {
                         assembled,
                     )
                     .await;
-                (error_disclosure, error_context, call_result)
+                (
+                    error_disclosure,
+                    error_context,
+                    auto_continue_cfg,
+                    call_result,
+                )
             }
             Err(error) => (
                 ErrorDisclosure::default(),
                 UserFacingErrorContext::default(),
+                None,
                 Err(error),
             ),
         };
@@ -1114,7 +1206,23 @@ impl ReasonAtom {
                 );
 
                 let error_msg = e.to_string();
-                let source_error = e.user_facing_error(error_context);
+                let mut source_error = e.user_facing_error(error_context);
+
+                // Usage-limit auto-continue: when the capability is active and
+                // the provider reported a concrete reset time, schedule a
+                // one-shot continuation shortly after the reset and flag the
+                // error so its copy promises automatic resumption. The `auto_continue`
+                // flag is only set when the continuation was actually scheduled,
+                // so the copy never over-promises.
+                if source_error.code == crate::user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED
+                    && let Some(cfg) = &auto_continue_cfg
+                    && self
+                        .schedule_usage_limit_continuation(context.session_id, &source_error, cfg)
+                        .await
+                {
+                    source_error = source_error.with_field("auto_continue", true);
+                }
+
                 let user_error = source_error.apply_disclosure(error_disclosure, Some(&error_msg));
                 let user_error_text = user_error.fallback_message();
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -149,6 +149,7 @@ mod tool_call_repair;
 mod tool_output_distillation;
 mod tool_output_persistence;
 mod tool_search;
+mod usage_limit_auto_continue;
 pub mod user_hooks;
 mod util;
 #[cfg(feature = "web-fetch")]
@@ -327,6 +328,10 @@ pub use subagents::{
     ReportResultTool, ReportTaskProgressTool, SUBAGENTS_CAPABILITY_ID, SpawnSubagentAsAgentTool,
     SubagentCapability, report_result_tool_for_child_session,
     report_task_progress_tool_for_child_session,
+};
+pub use usage_limit_auto_continue::{
+    AutoContinueConfig, USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID, UsageLimitAutoContinueCapability,
+    resolve_usage_limit_auto_continue,
 };
 // Blueprint types are exported directly from the trait definitions above
 pub use bashkit_shell::{
@@ -1309,6 +1314,7 @@ impl CapabilityRegistry {
         registry.register(tool_output_persistence::ToolOutputPersistenceCapability);
         registry.register(tool_output_distillation::ToolOutputDistillationCapability);
         registry.register(LoopDetectionCapability);
+        registry.register(UsageLimitAutoContinueCapability);
         registry.register(ToolCallRepairCapability);
         registry.register(PromptCanaryGuardrailCapability);
         registry.register(GuardrailsCapability);
@@ -1408,6 +1414,10 @@ impl CapabilityRegistry {
 
         // Loop detection (EVE-227: detect repeated identical tool calls)
         registry.register(LoopDetectionCapability);
+
+        // Auto-continue after an LLM usage limit resets: resumes interrupted
+        // work once the provider limit clears. Behavior-only (no tools).
+        registry.register(UsageLimitAutoContinueCapability);
 
         // Tool-call repair (EVE-600): opt-in salvage of malformed tool-call
         // arguments. Disabled by default — registered so agents can enable it,
@@ -3117,6 +3127,7 @@ mod tests {
             "fake_crm",
             "fake_financial",
             "loop_detection",
+            "usage_limit_auto_continue",
             "tool_call_repair",
             "error_disclosure",
             "prompt_canary_guardrail",
@@ -3164,6 +3175,7 @@ mod tests {
             "tool_output_persistence",
             "tool_output_distillation",
             "loop_detection",
+            "usage_limit_auto_continue",
             "tool_call_repair",
             "error_disclosure",
             "prompt_canary_guardrail",

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1329,7 +1329,6 @@ impl CapabilityRegistry {
         registry.register(tool_output_persistence::ToolOutputPersistenceCapability);
         registry.register(tool_output_distillation::ToolOutputDistillationCapability);
         registry.register(LoopDetectionCapability);
-        registry.register(UsageLimitAutoContinueCapability);
         registry.register(ToolCallRepairCapability);
         registry.register(PromptCanaryGuardrailCapability);
         registry.register(GuardrailsCapability);
@@ -1432,6 +1431,10 @@ impl CapabilityRegistry {
 
         // Auto-continue after an LLM usage limit resets: resumes interrupted
         // work once the provider limit clears. Behavior-only (no tools).
+        // Grade-only (not in `runtime_builtins`): its error hook needs the
+        // `schedule_store` host service to create the continuation and a schedule
+        // poller to fire it — neither is in the default in-process runtime — so it
+        // sits with `session_schedule` rather than the runtime-safe preset.
         registry.register(UsageLimitAutoContinueCapability);
 
         // Tool-call repair (EVE-600): opt-in salvage of malformed tool-call
@@ -3190,7 +3193,6 @@ mod tests {
             "tool_output_persistence",
             "tool_output_distillation",
             "loop_detection",
-            "usage_limit_auto_continue",
             "tool_call_repair",
             "error_disclosure",
             "prompt_canary_guardrail",

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -817,6 +817,19 @@ pub trait Capability: Send + Sync {
         None
     }
 
+    /// Returns a handler invoked when a turn fails with a *terminal* LLM error
+    /// (one that will not be retried), before the user-facing error message is
+    /// emitted. The handler may perform a side effect (e.g. schedule a
+    /// continuation) and/or return extra fields to augment the user-facing error
+    /// copy. This is the platform seam for capability-owned error recovery; the
+    /// reason atom invokes it generically and knows nothing about any specific
+    /// capability's behavior. See [`crate::llm_error_handler`].
+    ///
+    /// By default, returns None (no error handling).
+    fn llm_error_handler(&self) -> Option<Arc<dyn crate::llm_error_handler::LlmErrorHandler>> {
+        None
+    }
+
     /// Returns key/value [`Fact`]s this capability contributes to the model.
     ///
     /// Facts are routed by their [`Volatility`] so prompt caching is preserved:

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -817,16 +817,18 @@ pub trait Capability: Send + Sync {
         None
     }
 
-    /// Returns a handler invoked when a turn fails with a *terminal* LLM error
-    /// (one that will not be retried), before the user-facing error message is
-    /// emitted. The handler may perform a side effect (e.g. schedule a
+    /// Returns an in-process hook invoked when a turn fails with a *terminal*
+    /// LLM error (one that will not be retried), before the user-facing error
+    /// message is emitted. The hook may perform a side effect (e.g. schedule a
     /// continuation) and/or return extra fields to augment the user-facing error
-    /// copy. This is the platform seam for capability-owned error recovery; the
-    /// reason atom invokes it generically and knows nothing about any specific
-    /// capability's behavior. See [`crate::llm_error_handler`].
+    /// copy. This is the platform seam for capability-owned error recovery — the
+    /// same in-process hook family as [`Self::tool_call_hooks`] and
+    /// [`Self::message_filter_provider`]; the reason atom invokes it generically
+    /// and knows nothing about any specific capability's behavior. See
+    /// [`crate::llm_error_hook`].
     ///
-    /// By default, returns None (no error handling).
-    fn llm_error_handler(&self) -> Option<Arc<dyn crate::llm_error_handler::LlmErrorHandler>> {
+    /// By default, returns None (no error hook).
+    fn llm_error_hook(&self) -> Option<Arc<dyn crate::llm_error_hook::LlmErrorHook>> {
         None
     }
 

--- a/crates/core/src/capabilities/usage_limit_auto_continue.rs
+++ b/crates/core/src/capabilities/usage_limit_auto_continue.rs
@@ -3,20 +3,29 @@
 // When an LLM subscription/plan usage limit is hit — classified as
 // `provider_usage_limit_reached` with a concrete `resets_at` timestamp (e.g. the
 // ChatGPT/Codex `usage_limit_reached` body) — this capability makes the session
-// resume on its own once the limit resets. It contributes no tools; its presence
-// is the toggle, consumed by the reason atom's terminal-error path, which:
+// resume on its own once the limit resets.
 //
-//   1. appends a "we'll continue automatically" promise to the user-facing error
-//      copy (by setting the `auto_continue` error field), and
-//   2. schedules a one-shot session continuation at `resets_at + delay_seconds`
-//      that re-injects `prompt` to resume the interrupted work.
+// The behavior is fully encapsulated behind the platform's `LlmErrorHandler`
+// seam (`crate::llm_error_handler`): the capability contributes no tools and no
+// reason-atom special-casing. It supplies an error handler that, on the terminal
+// error path, when the error code matches:
 //
-// The promise (1) is only added when the continuation (2) was actually
-// scheduled, so the copy never over-promises.
+//   1. schedules a one-shot session continuation at `resets_at + delay_seconds`
+//      that re-injects `prompt` to resume the interrupted work, and
+//   2. returns an `auto_continue` error field so the user-facing copy promises
+//      automatic resumption.
+//
+// (2) is returned only when (1) actually succeeded, so the copy never
+// over-promises. The reason atom invokes this handler generically alongside any
+// other capability's handler — new error-recovery extensions are built the same
+// way, without touching the atom.
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel};
 use crate::capability_types::AgentCapabilityConfig;
+use crate::llm_error_handler::{LlmErrorContext, LlmErrorHandler, LlmErrorHandlerOutcome};
+use async_trait::async_trait;
 use serde_json::{Value, json};
+use std::sync::Arc;
 
 pub const USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID: &str = "usage_limit_auto_continue";
 
@@ -50,37 +59,40 @@ impl Default for AutoContinueConfig {
     }
 }
 
+impl AutoContinueConfig {
+    /// Parse settings from a single capability config JSON value, falling back
+    /// to defaults for any missing, blank, or out-of-range field.
+    pub fn from_config_value(config: &Value) -> Self {
+        let delay_seconds = config
+            .get("delay_seconds")
+            .and_then(Value::as_i64)
+            .filter(|secs| (0..=MAX_CONTINUATION_DELAY_SECS).contains(secs))
+            .unwrap_or(DEFAULT_CONTINUATION_DELAY_SECS);
+
+        let prompt = config
+            .get("prompt")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .unwrap_or(DEFAULT_CONTINUATION_PROMPT)
+            .to_string();
+
+        Self {
+            delay_seconds,
+            prompt,
+        }
+    }
+}
+
 /// Resolve the auto-continue settings for a turn, or `None` when the capability
-/// is not enabled for the agent/session. Mirrors `resolve_error_disclosure`:
-/// config is read from the enabled capability's entry, falling back to defaults
-/// for any missing or out-of-range field.
+/// is not enabled for the agent/session.
 pub fn resolve_usage_limit_auto_continue(
     configs: &[AgentCapabilityConfig],
 ) -> Option<AutoContinueConfig> {
-    let config = configs
+    configs
         .iter()
-        .find(|config| config.capability_id() == USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID)?;
-
-    let delay_seconds = config
-        .config
-        .get("delay_seconds")
-        .and_then(Value::as_i64)
-        .filter(|secs| (0..=MAX_CONTINUATION_DELAY_SECS).contains(secs))
-        .unwrap_or(DEFAULT_CONTINUATION_DELAY_SECS);
-
-    let prompt = config
-        .config
-        .get("prompt")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|p| !p.is_empty())
-        .unwrap_or(DEFAULT_CONTINUATION_PROMPT)
-        .to_string();
-
-    Some(AutoContinueConfig {
-        delay_seconds,
-        prompt,
-    })
+        .find(|config| config.capability_id() == USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID)
+        .map(|config| AutoContinueConfig::from_config_value(&config.config))
 }
 
 pub struct UsageLimitAutoContinueCapability;
@@ -120,6 +132,10 @@ impl Capability for UsageLimitAutoContinueCapability {
 
     fn category(&self) -> Option<&str> {
         Some("Core")
+    }
+
+    fn llm_error_handler(&self) -> Option<Arc<dyn LlmErrorHandler>> {
+        Some(Arc::new(UsageLimitAutoContinueHandler))
     }
 
     fn config_schema(&self) -> Option<Value> {
@@ -165,6 +181,72 @@ impl Capability for UsageLimitAutoContinueCapability {
             return Err("prompt must be a string".to_string());
         }
         Ok(())
+    }
+}
+
+/// Error handler that encapsulates the auto-continue behavior. Invoked by the
+/// reason atom through the generic `LlmErrorHandler` seam on a terminal LLM
+/// error; the reason atom itself has no knowledge of usage limits or scheduling.
+struct UsageLimitAutoContinueHandler;
+
+#[async_trait]
+impl LlmErrorHandler for UsageLimitAutoContinueHandler {
+    async fn on_llm_error(&self, ctx: &LlmErrorContext<'_>) -> LlmErrorHandlerOutcome {
+        // Only act on the usage-limit error this capability recovers from.
+        if ctx.error_code != crate::user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED {
+            return LlmErrorHandlerOutcome::noop();
+        }
+        // Best-effort: without a schedule store or a concrete reset time there
+        // is nothing to schedule, so make no auto-resume promise.
+        let Some(store) = &ctx.services.schedule_store else {
+            return LlmErrorHandlerOutcome::noop();
+        };
+        let Some(resets_at) = ctx.error_fields.get("resets_at").and_then(|v| v.as_i64()) else {
+            return LlmErrorHandlerOutcome::noop();
+        };
+        let Some(reset_time) = chrono::DateTime::from_timestamp(resets_at, 0) else {
+            return LlmErrorHandlerOutcome::noop();
+        };
+
+        let cfg = AutoContinueConfig::from_config_value(ctx.config);
+
+        // Fire `delay_seconds` after the reset. Clamp into the future so a
+        // stale/past reset (clock skew, limit already cleared) still fires
+        // instead of being dropped by the store's past-time next-trigger rule.
+        let now = chrono::Utc::now();
+        let delay = chrono::Duration::seconds(cfg.delay_seconds);
+        let scheduled_at = (reset_time + delay).max(now + delay);
+
+        match store
+            .create_schedule(
+                ctx.session_id,
+                cfg.prompt.clone(),
+                None,
+                Some(scheduled_at),
+                "UTC".to_string(),
+            )
+            .await
+        {
+            Ok(schedule) => {
+                tracing::info!(
+                    session_id = %ctx.session_id,
+                    schedule_id = %schedule.id,
+                    scheduled_at = %scheduled_at,
+                    "usage_limit_auto_continue: scheduled continuation after usage-limit reset"
+                );
+                // Unlock the "we'll continue automatically" message copy only
+                // now that a continuation was actually scheduled.
+                LlmErrorHandlerOutcome::noop().with_error_field("auto_continue", true)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %ctx.session_id,
+                    error = %e,
+                    "usage_limit_auto_continue: failed to schedule continuation"
+                );
+                LlmErrorHandlerOutcome::noop()
+            }
+        }
     }
 }
 
@@ -228,5 +310,164 @@ mod tests {
                 .is_err()
         );
         assert!(cap.validate_config(&json!({ "prompt": 5 })).is_err());
+    }
+
+    // ------------------------------------------------------------------------
+    // Handler tests (the encapsulated behavior, exercised via the seam)
+    // ------------------------------------------------------------------------
+
+    use crate::llm_error_handler::{LlmErrorContext, LlmErrorHandler, LlmErrorHandlerServices};
+    use crate::session_schedule::SessionSchedule;
+    use crate::traits::SessionScheduleStore;
+    use crate::typed_id::{PrincipalId, ScheduleId, SessionId};
+    use crate::user_facing_error::UserFacingErrorFields;
+    use crate::user_facing_error_codes;
+    use std::sync::Mutex;
+
+    /// Records the one-shot schedules the handler creates so tests can assert on
+    /// the description and fire time.
+    #[derive(Default)]
+    struct RecordingScheduleStore {
+        created: Mutex<Vec<(String, Option<chrono::DateTime<chrono::Utc>>)>>,
+    }
+
+    #[async_trait]
+    impl SessionScheduleStore for RecordingScheduleStore {
+        async fn create_schedule(
+            &self,
+            session_id: SessionId,
+            description: String,
+            cron_expression: Option<String>,
+            scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+            timezone: String,
+        ) -> crate::error::Result<SessionSchedule> {
+            self.created
+                .lock()
+                .unwrap()
+                .push((description.clone(), scheduled_at));
+            Ok(SessionSchedule {
+                id: ScheduleId::new(),
+                session_id,
+                owner_principal_id: PrincipalId::new(),
+                resolved_owner_user_id: None,
+                owner: None,
+                effective_owner: None,
+                description,
+                cron_expression: cron_expression.clone(),
+                scheduled_at,
+                timezone,
+                enabled: true,
+                schedule_type: SessionSchedule::derive_type(&cron_expression),
+                next_trigger_at: scheduled_at,
+                last_triggered_at: None,
+                trigger_count: 0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+
+        async fn cancel_schedule(
+            &self,
+            _session_id: SessionId,
+            _schedule_id: ScheduleId,
+        ) -> crate::error::Result<SessionSchedule> {
+            unimplemented!("not used by these tests")
+        }
+
+        async fn list_schedules(
+            &self,
+            _session_id: SessionId,
+        ) -> crate::error::Result<Vec<SessionSchedule>> {
+            Ok(vec![])
+        }
+
+        async fn count_active_schedules(
+            &self,
+            _session_id: SessionId,
+        ) -> crate::error::Result<u32> {
+            Ok(0)
+        }
+
+        async fn count_active_org_schedules(&self) -> crate::error::Result<u32> {
+            Ok(0)
+        }
+    }
+
+    fn usage_limit_fields(resets_at: i64) -> UserFacingErrorFields {
+        let mut fields = UserFacingErrorFields::new();
+        fields.insert("resets_at".to_string(), json!(resets_at));
+        fields
+    }
+
+    #[tokio::test]
+    async fn handler_schedules_continuation_and_flags_auto_continue() {
+        let store = Arc::new(RecordingScheduleStore::default());
+        let services = LlmErrorHandlerServices {
+            schedule_store: Some(store.clone()),
+        };
+        let fields = usage_limit_fields(1_783_767_823);
+        let config = json!({ "prompt": "Resume the migration" });
+        let ctx = LlmErrorContext {
+            session_id: SessionId::new(),
+            error_code: user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED,
+            error_fields: &fields,
+            config: &config,
+            services: &services,
+        };
+
+        let outcome = UsageLimitAutoContinueHandler.on_llm_error(&ctx).await;
+
+        // Continuation scheduled with the configured prompt.
+        let created = store.created.lock().unwrap();
+        assert_eq!(created.len(), 1);
+        assert_eq!(created[0].0, "Resume the migration");
+        assert!(created[0].1.is_some(), "continuation must have a fire time");
+
+        // Only now is the auto-continue message copy unlocked.
+        assert_eq!(
+            outcome.extra_error_fields.get("auto_continue"),
+            Some(&json!(true))
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_ignores_non_usage_limit_errors() {
+        let store = Arc::new(RecordingScheduleStore::default());
+        let services = LlmErrorHandlerServices {
+            schedule_store: Some(store.clone()),
+        };
+        let fields = usage_limit_fields(1_783_767_823);
+        let config = json!({});
+        let ctx = LlmErrorContext {
+            session_id: SessionId::new(),
+            error_code: user_facing_error_codes::PROVIDER_RATE_LIMITED,
+            error_fields: &fields,
+            config: &config,
+            services: &services,
+        };
+
+        let outcome = UsageLimitAutoContinueHandler.on_llm_error(&ctx).await;
+
+        assert!(store.created.lock().unwrap().is_empty());
+        assert_eq!(outcome, LlmErrorHandlerOutcome::noop());
+    }
+
+    #[tokio::test]
+    async fn handler_makes_no_promise_without_schedule_store() {
+        let services = LlmErrorHandlerServices {
+            schedule_store: None,
+        };
+        let fields = usage_limit_fields(1_783_767_823);
+        let config = json!({});
+        let ctx = LlmErrorContext {
+            session_id: SessionId::new(),
+            error_code: user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED,
+            error_fields: &fields,
+            config: &config,
+            services: &services,
+        };
+
+        let outcome = UsageLimitAutoContinueHandler.on_llm_error(&ctx).await;
+        assert_eq!(outcome, LlmErrorHandlerOutcome::noop());
     }
 }

--- a/crates/core/src/capabilities/usage_limit_auto_continue.rs
+++ b/crates/core/src/capabilities/usage_limit_auto_continue.rs
@@ -1,0 +1,232 @@
+// Usage-Limit Auto-Continue capability
+//
+// When an LLM subscription/plan usage limit is hit — classified as
+// `provider_usage_limit_reached` with a concrete `resets_at` timestamp (e.g. the
+// ChatGPT/Codex `usage_limit_reached` body) — this capability makes the session
+// resume on its own once the limit resets. It contributes no tools; its presence
+// is the toggle, consumed by the reason atom's terminal-error path, which:
+//
+//   1. appends a "we'll continue automatically" promise to the user-facing error
+//      copy (by setting the `auto_continue` error field), and
+//   2. schedules a one-shot session continuation at `resets_at + delay_seconds`
+//      that re-injects `prompt` to resume the interrupted work.
+//
+// The promise (1) is only added when the continuation (2) was actually
+// scheduled, so the copy never over-promises.
+
+use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel};
+use crate::capability_types::AgentCapabilityConfig;
+use serde_json::{Value, json};
+
+pub const USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID: &str = "usage_limit_auto_continue";
+
+/// Default delay, in seconds, after the reported reset time before the
+/// continuation fires. The reset is a lower bound; a small buffer avoids racing
+/// the provider's own clock (the motivating Codex case wants reset + 2 min).
+pub const DEFAULT_CONTINUATION_DELAY_SECS: i64 = 120;
+
+/// Default prompt re-injected to resume work once the limit resets.
+pub const DEFAULT_CONTINUATION_PROMPT: &str = "Continue tasks";
+
+/// Upper bound on the configurable delay (24h) so a misconfiguration cannot park
+/// a continuation arbitrarily far in the future.
+const MAX_CONTINUATION_DELAY_SECS: i64 = 86_400;
+
+/// Resolved auto-continue settings for a turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutoContinueConfig {
+    /// Seconds to wait after `resets_at` before firing the continuation.
+    pub delay_seconds: i64,
+    /// Prompt injected as the continuation turn's user message.
+    pub prompt: String,
+}
+
+impl Default for AutoContinueConfig {
+    fn default() -> Self {
+        Self {
+            delay_seconds: DEFAULT_CONTINUATION_DELAY_SECS,
+            prompt: DEFAULT_CONTINUATION_PROMPT.to_string(),
+        }
+    }
+}
+
+/// Resolve the auto-continue settings for a turn, or `None` when the capability
+/// is not enabled for the agent/session. Mirrors `resolve_error_disclosure`:
+/// config is read from the enabled capability's entry, falling back to defaults
+/// for any missing or out-of-range field.
+pub fn resolve_usage_limit_auto_continue(
+    configs: &[AgentCapabilityConfig],
+) -> Option<AutoContinueConfig> {
+    let config = configs
+        .iter()
+        .find(|config| config.capability_id() == USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID)?;
+
+    let delay_seconds = config
+        .config
+        .get("delay_seconds")
+        .and_then(Value::as_i64)
+        .filter(|secs| (0..=MAX_CONTINUATION_DELAY_SECS).contains(secs))
+        .unwrap_or(DEFAULT_CONTINUATION_DELAY_SECS);
+
+    let prompt = config
+        .config
+        .get("prompt")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .unwrap_or(DEFAULT_CONTINUATION_PROMPT)
+        .to_string();
+
+    Some(AutoContinueConfig {
+        delay_seconds,
+        prompt,
+    })
+}
+
+pub struct UsageLimitAutoContinueCapability;
+
+impl Capability for UsageLimitAutoContinueCapability {
+    fn id(&self) -> &str {
+        USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Auto-Continue After Usage Limit"
+    }
+
+    fn description(&self) -> &str {
+        "When an LLM usage limit is reached, automatically resume the interrupted work shortly after the limit resets."
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![CapabilityLocalization::text(
+            "uk",
+            "Автопродовження після ліміту використання",
+            "Коли досягнуто ліміт використання LLM, автоматично відновлює перервану роботу невдовзі після скидання ліміту.",
+        )]
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::Low
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("clock")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Core")
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "delay_seconds": {
+                    "type": "integer",
+                    "title": "Continuation delay (seconds)",
+                    "description": "How long to wait after the reported reset time before resuming work. A small buffer avoids racing the provider's reset clock.",
+                    "minimum": 0,
+                    "maximum": MAX_CONTINUATION_DELAY_SECS,
+                    "default": DEFAULT_CONTINUATION_DELAY_SECS
+                },
+                "prompt": {
+                    "type": "string",
+                    "title": "Continuation prompt",
+                    "description": "Message injected to resume the interrupted work when the limit resets.",
+                    "default": DEFAULT_CONTINUATION_PROMPT
+                }
+            },
+            "additionalProperties": false
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+        if let Some(delay) = config.get("delay_seconds") {
+            let secs = delay
+                .as_i64()
+                .ok_or_else(|| "delay_seconds must be an integer".to_string())?;
+            if !(0..=MAX_CONTINUATION_DELAY_SECS).contains(&secs) {
+                return Err(format!(
+                    "delay_seconds must be between 0 and {MAX_CONTINUATION_DELAY_SECS}"
+                ));
+            }
+        }
+        if let Some(prompt) = config.get("prompt")
+            && !prompt.is_string()
+        {
+            return Err("prompt must be a string".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap_config(config: Value) -> AgentCapabilityConfig {
+        AgentCapabilityConfig {
+            capability_ref: USAGE_LIMIT_AUTO_CONTINUE_CAPABILITY_ID.into(),
+            config,
+        }
+    }
+
+    #[test]
+    fn resolve_returns_none_without_capability() {
+        assert_eq!(resolve_usage_limit_auto_continue(&[]), None);
+    }
+
+    #[test]
+    fn resolve_uses_defaults_for_empty_config() {
+        let resolved = resolve_usage_limit_auto_continue(&[cap_config(json!({}))]).unwrap();
+        assert_eq!(resolved, AutoContinueConfig::default());
+    }
+
+    #[test]
+    fn resolve_reads_custom_delay_and_prompt() {
+        let resolved = resolve_usage_limit_auto_continue(&[cap_config(json!({
+            "delay_seconds": 300,
+            "prompt": "  Resume the migration  "
+        }))])
+        .unwrap();
+        assert_eq!(resolved.delay_seconds, 300);
+        assert_eq!(resolved.prompt, "Resume the migration");
+    }
+
+    #[test]
+    fn resolve_falls_back_on_out_of_range_or_blank_fields() {
+        let resolved = resolve_usage_limit_auto_continue(&[cap_config(json!({
+            "delay_seconds": -5,
+            "prompt": "   "
+        }))])
+        .unwrap();
+        assert_eq!(resolved.delay_seconds, DEFAULT_CONTINUATION_DELAY_SECS);
+        assert_eq!(resolved.prompt, DEFAULT_CONTINUATION_PROMPT);
+    }
+
+    #[test]
+    fn validate_rejects_bad_types_and_ranges() {
+        let cap = UsageLimitAutoContinueCapability;
+        assert!(
+            cap.validate_config(&json!({ "delay_seconds": 120 }))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&json!({ "delay_seconds": "x" }))
+                .is_err()
+        );
+        assert!(
+            cap.validate_config(&json!({ "delay_seconds": 999999999 }))
+                .is_err()
+        );
+        assert!(cap.validate_config(&json!({ "prompt": 5 })).is_err());
+    }
+}

--- a/crates/core/src/capabilities/usage_limit_auto_continue.rs
+++ b/crates/core/src/capabilities/usage_limit_auto_continue.rs
@@ -5,9 +5,9 @@
 // ChatGPT/Codex `usage_limit_reached` body) — this capability makes the session
 // resume on its own once the limit resets.
 //
-// The behavior is fully encapsulated behind the platform's `LlmErrorHandler`
-// seam (`crate::llm_error_handler`): the capability contributes no tools and no
-// reason-atom special-casing. It supplies an error handler that, on the terminal
+// The behavior is fully encapsulated behind the platform's `LlmErrorHook`
+// seam (`crate::llm_error_hook`): the capability contributes no tools and no
+// reason-atom special-casing. It supplies an error hook that, on the terminal
 // error path, when the error code matches:
 //
 //   1. schedules a one-shot session continuation at `resets_at + delay_seconds`
@@ -16,13 +16,13 @@
 //      automatic resumption.
 //
 // (2) is returned only when (1) actually succeeded, so the copy never
-// over-promises. The reason atom invokes this handler generically alongside any
-// other capability's handler — new error-recovery extensions are built the same
+// over-promises. The reason atom invokes this hook generically alongside any
+// other capability's hook — new error-recovery extensions are built the same
 // way, without touching the atom.
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel};
 use crate::capability_types::AgentCapabilityConfig;
-use crate::llm_error_handler::{LlmErrorContext, LlmErrorHandler, LlmErrorHandlerOutcome};
+use crate::llm_error_hook::{LlmErrorContext, LlmErrorHook, LlmErrorHookOutcome};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -134,8 +134,8 @@ impl Capability for UsageLimitAutoContinueCapability {
         Some("Core")
     }
 
-    fn llm_error_handler(&self) -> Option<Arc<dyn LlmErrorHandler>> {
-        Some(Arc::new(UsageLimitAutoContinueHandler))
+    fn llm_error_hook(&self) -> Option<Arc<dyn LlmErrorHook>> {
+        Some(Arc::new(UsageLimitAutoContinueHook))
     }
 
     fn config_schema(&self) -> Option<Value> {
@@ -184,28 +184,28 @@ impl Capability for UsageLimitAutoContinueCapability {
     }
 }
 
-/// Error handler that encapsulates the auto-continue behavior. Invoked by the
-/// reason atom through the generic `LlmErrorHandler` seam on a terminal LLM
+/// Error hook that encapsulates the auto-continue behavior. Invoked by the
+/// reason atom through the generic `LlmErrorHook` seam on a terminal LLM
 /// error; the reason atom itself has no knowledge of usage limits or scheduling.
-struct UsageLimitAutoContinueHandler;
+struct UsageLimitAutoContinueHook;
 
 #[async_trait]
-impl LlmErrorHandler for UsageLimitAutoContinueHandler {
-    async fn on_llm_error(&self, ctx: &LlmErrorContext<'_>) -> LlmErrorHandlerOutcome {
+impl LlmErrorHook for UsageLimitAutoContinueHook {
+    async fn on_llm_error(&self, ctx: &LlmErrorContext<'_>) -> LlmErrorHookOutcome {
         // Only act on the usage-limit error this capability recovers from.
         if ctx.error_code != crate::user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED {
-            return LlmErrorHandlerOutcome::noop();
+            return LlmErrorHookOutcome::noop();
         }
         // Best-effort: without a schedule store or a concrete reset time there
         // is nothing to schedule, so make no auto-resume promise.
         let Some(store) = &ctx.services.schedule_store else {
-            return LlmErrorHandlerOutcome::noop();
+            return LlmErrorHookOutcome::noop();
         };
         let Some(resets_at) = ctx.error_fields.get("resets_at").and_then(|v| v.as_i64()) else {
-            return LlmErrorHandlerOutcome::noop();
+            return LlmErrorHookOutcome::noop();
         };
         let Some(reset_time) = chrono::DateTime::from_timestamp(resets_at, 0) else {
-            return LlmErrorHandlerOutcome::noop();
+            return LlmErrorHookOutcome::noop();
         };
 
         let cfg = AutoContinueConfig::from_config_value(ctx.config);
@@ -236,7 +236,7 @@ impl LlmErrorHandler for UsageLimitAutoContinueHandler {
                 );
                 // Unlock the "we'll continue automatically" message copy only
                 // now that a continuation was actually scheduled.
-                LlmErrorHandlerOutcome::noop().with_error_field("auto_continue", true)
+                LlmErrorHookOutcome::noop().with_error_field("auto_continue", true)
             }
             Err(e) => {
                 tracing::warn!(
@@ -244,7 +244,7 @@ impl LlmErrorHandler for UsageLimitAutoContinueHandler {
                     error = %e,
                     "usage_limit_auto_continue: failed to schedule continuation"
                 );
-                LlmErrorHandlerOutcome::noop()
+                LlmErrorHookOutcome::noop()
             }
         }
     }
@@ -316,7 +316,7 @@ mod tests {
     // Handler tests (the encapsulated behavior, exercised via the seam)
     // ------------------------------------------------------------------------
 
-    use crate::llm_error_handler::{LlmErrorContext, LlmErrorHandler, LlmErrorHandlerServices};
+    use crate::llm_error_hook::{LlmErrorContext, LlmErrorHook, LlmErrorHookServices};
     use crate::session_schedule::SessionSchedule;
     use crate::traits::SessionScheduleStore;
     use crate::typed_id::{PrincipalId, ScheduleId, SessionId};
@@ -402,7 +402,7 @@ mod tests {
     #[tokio::test]
     async fn handler_schedules_continuation_and_flags_auto_continue() {
         let store = Arc::new(RecordingScheduleStore::default());
-        let services = LlmErrorHandlerServices {
+        let services = LlmErrorHookServices {
             schedule_store: Some(store.clone()),
         };
         let fields = usage_limit_fields(1_783_767_823);
@@ -415,7 +415,7 @@ mod tests {
             services: &services,
         };
 
-        let outcome = UsageLimitAutoContinueHandler.on_llm_error(&ctx).await;
+        let outcome = UsageLimitAutoContinueHook.on_llm_error(&ctx).await;
 
         // Continuation scheduled with the configured prompt.
         let created = store.created.lock().unwrap();
@@ -433,7 +433,7 @@ mod tests {
     #[tokio::test]
     async fn handler_ignores_non_usage_limit_errors() {
         let store = Arc::new(RecordingScheduleStore::default());
-        let services = LlmErrorHandlerServices {
+        let services = LlmErrorHookServices {
             schedule_store: Some(store.clone()),
         };
         let fields = usage_limit_fields(1_783_767_823);
@@ -446,15 +446,15 @@ mod tests {
             services: &services,
         };
 
-        let outcome = UsageLimitAutoContinueHandler.on_llm_error(&ctx).await;
+        let outcome = UsageLimitAutoContinueHook.on_llm_error(&ctx).await;
 
         assert!(store.created.lock().unwrap().is_empty());
-        assert_eq!(outcome, LlmErrorHandlerOutcome::noop());
+        assert_eq!(outcome, LlmErrorHookOutcome::noop());
     }
 
     #[tokio::test]
     async fn handler_makes_no_promise_without_schedule_store() {
-        let services = LlmErrorHandlerServices {
+        let services = LlmErrorHookServices {
             schedule_store: None,
         };
         let fields = usage_limit_fields(1_783_767_823);
@@ -467,7 +467,7 @@ mod tests {
             services: &services,
         };
 
-        let outcome = UsageLimitAutoContinueHandler.on_llm_error(&ctx).await;
-        assert_eq!(outcome, LlmErrorHandlerOutcome::noop());
+        let outcome = UsageLimitAutoContinueHook.on_llm_error(&ctx).await;
+        assert_eq!(outcome, LlmErrorHookOutcome::noop());
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -236,7 +236,8 @@ pub use traits::{
 pub use user_facing_error::{
     ErrorDisclosure, UserFacingError, UserFacingErrorContext, UserFacingErrorFields,
     classify_runtime_error_message, codes as user_facing_error_codes, is_provider_quota_message,
-    metadata_keys as user_facing_error_metadata_keys, trim_error_chain_prefixes,
+    is_usage_limit_message, metadata_keys as user_facing_error_metadata_keys,
+    parse_usage_limit_reset_at, trim_error_chain_prefixes,
 };
 pub use workspace_roots::{
     ADDITIONAL_ROOTS_MOUNT, PRIMARY_WORKSPACE_ROOT_NAME, RelPath, ResolvedPath, WorkspaceRoot,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -152,6 +152,7 @@ pub mod driver_registry;
 pub mod error;
 pub mod guardrail_checks;
 pub mod guardrail_gallery;
+pub mod llm_error_handler;
 pub mod llm_retry;
 pub mod message;
 pub mod message_filter;
@@ -205,6 +206,9 @@ pub use config_layer::{
 pub use error::{
     AgentLoopError, FileSystemError, FileSystemErrorClass, LlmError, LlmErrorKind, Result,
     StoreResultExt, classify_fs_error, from_json, json_val,
+};
+pub use llm_error_handler::{
+    LlmErrorContext, LlmErrorHandler, LlmErrorHandlerOutcome, LlmErrorHandlerServices,
 };
 pub use message::{
     ContentPart, ContentType, Controls, ExternalActor, ImageContentPart, ImageFileContentPart,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -152,7 +152,7 @@ pub mod driver_registry;
 pub mod error;
 pub mod guardrail_checks;
 pub mod guardrail_gallery;
-pub mod llm_error_handler;
+pub mod llm_error_hook;
 pub mod llm_retry;
 pub mod message;
 pub mod message_filter;
@@ -207,8 +207,8 @@ pub use error::{
     AgentLoopError, FileSystemError, FileSystemErrorClass, LlmError, LlmErrorKind, Result,
     StoreResultExt, classify_fs_error, from_json, json_val,
 };
-pub use llm_error_handler::{
-    LlmErrorContext, LlmErrorHandler, LlmErrorHandlerOutcome, LlmErrorHandlerServices,
+pub use llm_error_hook::{
+    LlmErrorContext, LlmErrorHook, LlmErrorHookOutcome, LlmErrorHookServices,
 };
 pub use message::{
     ContentPart, ContentType, Controls, ExternalActor, ImageContentPart, ImageFileContentPart,

--- a/crates/core/src/llm_error_handler.rs
+++ b/crates/core/src/llm_error_handler.rs
@@ -1,0 +1,73 @@
+// LLM error handler seam
+//
+// A capability extension point for reacting to a *terminal* LLM error (a turn
+// that failed and will not be retried). This is the platform seam that lets a
+// capability encapsulate error-recovery behavior — augmenting the user-facing
+// error copy and/or performing a side effect — without the reason atom hard-
+// coding any capability-specific logic. It mirrors the other capability seams
+// (`message_filter_provider`, `output_guardrails`, tool hooks): the reason atom
+// collects handlers from the active capabilities and invokes each generically.
+//
+// The first consumer is `usage_limit_auto_continue`, which schedules a
+// continuation after a provider usage limit resets, but the seam is deliberately
+// provider- and behavior-agnostic so other extensions can be built the same way.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::traits::SessionScheduleStore;
+use crate::typed_id::SessionId;
+use crate::user_facing_error::UserFacingErrorFields;
+use serde_json::Value;
+
+/// Host services made available to error handlers. Extend as new handlers need
+/// more surface; today only the session schedule store is exposed (each field is
+/// optional so a handler degrades to a no-op when its service is absent).
+#[derive(Clone, Default)]
+pub struct LlmErrorHandlerServices {
+    pub schedule_store: Option<Arc<dyn SessionScheduleStore>>,
+}
+
+/// Context handed to a capability's [`LlmErrorHandler`] on a terminal LLM error.
+pub struct LlmErrorContext<'a> {
+    /// Session whose turn failed.
+    pub session_id: SessionId,
+    /// Classified user-facing error code (e.g. `provider_usage_limit_reached`).
+    pub error_code: &'a str,
+    /// Structured fields captured by the classifier (e.g. `resets_at`).
+    pub error_fields: &'a UserFacingErrorFields,
+    /// The contributing capability's per-agent config JSON (may be `Null`).
+    pub config: &'a Value,
+    /// Host services the handler may use to perform side effects.
+    pub services: &'a LlmErrorHandlerServices,
+}
+
+/// Result of an [`LlmErrorHandler`]: extra fields to merge into the user-facing
+/// error (for example to unlock capability-specific message copy). The default
+/// is a no-op that changes nothing.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct LlmErrorHandlerOutcome {
+    /// Fields to merge into the `UserFacingError` before it is rendered/emitted.
+    pub extra_error_fields: UserFacingErrorFields,
+}
+
+impl LlmErrorHandlerOutcome {
+    /// An outcome that changes nothing.
+    pub fn noop() -> Self {
+        Self::default()
+    }
+
+    /// Add a field to merge into the user-facing error.
+    pub fn with_error_field(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.extra_error_fields.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// A capability's reaction to a terminal LLM error. Provided via
+/// `Capability::llm_error_handler`. Runs only on the terminal (non-retried)
+/// error path, before the user-facing error message is emitted.
+#[async_trait]
+pub trait LlmErrorHandler: Send + Sync {
+    async fn on_llm_error(&self, ctx: &LlmErrorContext<'_>) -> LlmErrorHandlerOutcome;
+}

--- a/crates/core/src/llm_error_hook.rs
+++ b/crates/core/src/llm_error_hook.rs
@@ -1,12 +1,15 @@
-// LLM error handler seam
+// LLM error hook seam
 //
-// A capability extension point for reacting to a *terminal* LLM error (a turn
+// An in-process capability hook for reacting to a *terminal* LLM error (a turn
 // that failed and will not be retried). This is the platform seam that lets a
 // capability encapsulate error-recovery behavior — augmenting the user-facing
 // error copy and/or performing a side effect — without the reason atom hard-
-// coding any capability-specific logic. It mirrors the other capability seams
-// (`message_filter_provider`, `output_guardrails`, tool hooks): the reason atom
-// collects handlers from the active capabilities and invokes each generically.
+// coding any capability-specific logic. It belongs to the same in-process hook
+// family as `ToolCallHook`, `MessageFilterProvider`, and `output_guardrails`
+// (typed traits returned from a `Capability::*` seam and invoked in-process with
+// host services) — as opposed to the user-hook system (`user_hook_types`), which
+// runs user-authored shell commands. The reason atom collects the hooks from the
+// active capabilities and invokes each generically.
 //
 // The first consumer is `usage_limit_auto_continue`, which schedules a
 // continuation after a provider usage limit resets, but the seam is deliberately
@@ -20,15 +23,15 @@ use crate::typed_id::SessionId;
 use crate::user_facing_error::UserFacingErrorFields;
 use serde_json::Value;
 
-/// Host services made available to error handlers. Extend as new handlers need
-/// more surface; today only the session schedule store is exposed (each field is
-/// optional so a handler degrades to a no-op when its service is absent).
+/// Host services made available to error hooks. Extend as new hooks need more
+/// surface; today only the session schedule store is exposed (each field is
+/// optional so a hook degrades to a no-op when its service is absent).
 #[derive(Clone, Default)]
-pub struct LlmErrorHandlerServices {
+pub struct LlmErrorHookServices {
     pub schedule_store: Option<Arc<dyn SessionScheduleStore>>,
 }
 
-/// Context handed to a capability's [`LlmErrorHandler`] on a terminal LLM error.
+/// Context handed to a capability's [`LlmErrorHook`] on a terminal LLM error.
 pub struct LlmErrorContext<'a> {
     /// Session whose turn failed.
     pub session_id: SessionId,
@@ -38,20 +41,20 @@ pub struct LlmErrorContext<'a> {
     pub error_fields: &'a UserFacingErrorFields,
     /// The contributing capability's per-agent config JSON (may be `Null`).
     pub config: &'a Value,
-    /// Host services the handler may use to perform side effects.
-    pub services: &'a LlmErrorHandlerServices,
+    /// Host services the hook may use to perform side effects.
+    pub services: &'a LlmErrorHookServices,
 }
 
-/// Result of an [`LlmErrorHandler`]: extra fields to merge into the user-facing
+/// Result of an [`LlmErrorHook`]: extra fields to merge into the user-facing
 /// error (for example to unlock capability-specific message copy). The default
 /// is a no-op that changes nothing.
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct LlmErrorHandlerOutcome {
+pub struct LlmErrorHookOutcome {
     /// Fields to merge into the `UserFacingError` before it is rendered/emitted.
     pub extra_error_fields: UserFacingErrorFields,
 }
 
-impl LlmErrorHandlerOutcome {
+impl LlmErrorHookOutcome {
     /// An outcome that changes nothing.
     pub fn noop() -> Self {
         Self::default()
@@ -65,9 +68,9 @@ impl LlmErrorHandlerOutcome {
 }
 
 /// A capability's reaction to a terminal LLM error. Provided via
-/// `Capability::llm_error_handler`. Runs only on the terminal (non-retried)
+/// `Capability::llm_error_hook`. Runs only on the terminal (non-retried)
 /// error path, before the user-facing error message is emitted.
 #[async_trait]
-pub trait LlmErrorHandler: Send + Sync {
-    async fn on_llm_error(&self, ctx: &LlmErrorContext<'_>) -> LlmErrorHandlerOutcome;
+pub trait LlmErrorHook: Send + Sync {
+    async fn on_llm_error(&self, ctx: &LlmErrorContext<'_>) -> LlmErrorHookOutcome;
 }

--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -413,6 +413,15 @@ pub fn send_error_message(err: &reqwest::Error, attempts: u32) -> String {
 /// This complements HTTP-status-based retry detection for streaming APIs that can
 /// emit retryable provider failures inside an otherwise successful event stream.
 pub fn is_transient_error_message(message: &str) -> bool {
+    // A subscription/plan usage limit (e.g. Codex `usage_limit_reached`) surfaces
+    // as a 429 ("too many requests") but does not recover within the retry
+    // window — it resets hours later at `resets_at`. Treating it as transient
+    // would waste retries and suppress the human-readable error message the
+    // reason atom emits for terminal failures, so it is explicitly non-transient.
+    if crate::user_facing_error::is_usage_limit_message(message) {
+        return false;
+    }
+
     let msg = message.trim().to_ascii_lowercase();
 
     [
@@ -845,6 +854,16 @@ mod tests {
             Some(429),
             "rate limit",
         )));
+    }
+
+    #[test]
+    fn test_is_transient_error_message_treats_usage_limit_as_non_transient() {
+        // Codex `usage_limit_reached` arrives as a 429 ("too many requests") but
+        // resets hours later — retrying inside the backoff window is pointless
+        // and would suppress the terminal user-facing message.
+        assert!(!is_transient_error_message(
+            "Codex API error (429 Too Many Requests): {\"error\":{\"type\":\"usage_limit_reached\",\"resets_at\":1783767823}}"
+        ));
     }
 
     #[test]

--- a/crates/core/src/user_facing_error.rs
+++ b/crates/core/src/user_facing_error.rs
@@ -13,6 +13,13 @@ pub mod codes {
     pub const MODEL_UNAVAILABLE: &str = "model_unavailable";
     pub const REQUEST_TOO_LARGE: &str = "request_too_large";
     pub const PROVIDER_RATE_LIMITED: &str = "provider_rate_limited";
+    /// Subscription/plan usage limit was reached (e.g. ChatGPT/Codex
+    /// `usage_limit_reached`). Distinct from `provider_rate_limited` (a short
+    /// transient throttle) because the reset is far in the future (hours) and
+    /// carries a concrete `resets_at` timestamp, and distinct from
+    /// `provider_quota_exhausted` (billing/credits) because it recovers on its
+    /// own at the reset time without operator action.
+    pub const PROVIDER_USAGE_LIMIT_REACHED: &str = "provider_usage_limit_reached";
     pub const PROVIDER_MISCONFIGURED: &str = "provider_misconfigured";
     /// Provider account is out of credits/quota (billing). Distinct from
     /// `provider_misconfigured` (bad/missing API key) so operators can tell
@@ -91,6 +98,37 @@ pub fn is_provider_quota_message(message: &str) -> bool {
         || lower.contains("insufficient quota")
         || lower.contains("exceeded your current quota")
         || lower.contains("credit balance is too low")
+}
+
+/// Subscription/plan usage-limit patterns shared by the string classifier and
+/// the transient-retry gate. These recover only at a future reset time (hours
+/// away), so unlike an ordinary 429 they must not be retried within the driver
+/// backoff window nor collapsed into the "wait a moment" rate-limit copy.
+///
+/// The canonical shape is the ChatGPT/Codex `429` body
+/// (`{"error":{"type":"usage_limit_reached", ...}}`), but the match is kept
+/// provider-agnostic so any driver surfacing the same wording is covered.
+pub fn is_usage_limit_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("usage_limit_reached")
+        || lower.contains("usage limit reached")
+        || lower.contains("usage limit has been reached")
+}
+
+/// Extract the absolute reset time (`resets_at`, unix seconds) from a usage-limit
+/// error body when present. Prefers the absolute `resets_at` field over the
+/// relative `resets_in_seconds` because this classifier is clock-free and callers
+/// want a stable timestamp they can render in the viewer's timezone.
+pub fn parse_usage_limit_reset_at(message: &str) -> Option<i64> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r#""resets_at"\s*:\s*(?P<resets_at>\d{9,})"#).expect("valid resets_at regex")
+    });
+    re.captures(message)?
+        .name("resets_at")?
+        .as_str()
+        .parse::<i64>()
+        .ok()
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -245,6 +283,7 @@ impl UserFacingError {
             codes::PROVIDER_RATE_LIMITED => {
                 "Rate limited by the AI provider. Please wait a moment.".to_string()
             }
+            codes::PROVIDER_USAGE_LIMIT_REACHED => usage_limit_reached_message(&self.fields),
             codes::PROVIDER_MISCONFIGURED => {
                 "There is a misconfiguration with the AI provider. Please contact support."
                     .to_string()
@@ -330,6 +369,18 @@ pub fn classify_runtime_error_message(
             .with_optional_field("model_id", context.model_id.clone());
     }
 
+    // Subscription/plan usage limit (e.g. ChatGPT/Codex `usage_limit_reached`).
+    // Checked before the generic 429 branch below: the outer error text carries
+    // "429 Too Many Requests", which would otherwise route it to the transient
+    // "wait a moment" rate-limit copy. This condition instead recovers on its
+    // own at `resets_at`, so it gets its own code and carries the reset time.
+    if is_usage_limit_message(normalized) {
+        return UserFacingError::new(codes::PROVIDER_USAGE_LIMIT_REACHED)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone())
+            .with_optional_field("resets_at", parse_usage_limit_reset_at(normalized));
+    }
+
     if lower.contains("(429)")
         || lower.contains("rate limit")
         || lower.contains("too many requests")
@@ -377,6 +428,30 @@ pub fn trim_error_chain_prefixes(error_chain: &str) -> &str {
         .trim_start_matches("InputAtom execution failed: ")
         .trim_start_matches("ReasonAtom execution failed: ")
         .trim_start_matches("ActAtom execution failed: ")
+}
+
+/// Render the copy for a subscription/plan usage-limit error. The `resets_at`
+/// field (unix seconds) is rendered as a UTC fallback; clients localize it into
+/// the viewer's timezone from the same raw field. When `auto_continue` is set —
+/// added by the emit site only when an auto-continue capability is active — the
+/// copy promises automatic resumption; otherwise it stays generic.
+fn usage_limit_reached_message(fields: &UserFacingErrorFields) -> String {
+    let mut message = String::from("You're out of LLM usage limits.");
+
+    if let Some(resets_at) = number_field(fields, "resets_at")
+        && let Some(reset) = chrono::DateTime::from_timestamp(resets_at as i64, 0)
+    {
+        message.push_str(&format!(
+            " Your usage limit resets at {}.",
+            reset.format("%H:%M UTC on %b %-d")
+        ));
+    }
+
+    if bool_field(fields, "auto_continue") {
+        message.push_str(" We'll continue work automatically once it resets.");
+    }
+
+    message
 }
 
 fn budget_exhausted_message(fields: &UserFacingErrorFields) -> String {
@@ -481,6 +556,10 @@ fn string_field<'a>(fields: &'a UserFacingErrorFields, key: &str) -> Option<&'a 
     fields.get(key)?.as_str()
 }
 
+fn bool_field(fields: &UserFacingErrorFields, key: &str) -> bool {
+    fields.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
 fn truncate_chars(value: &str, max_chars: usize) -> String {
     if value.chars().count() <= max_chars {
         return value.to_string();
@@ -582,6 +661,73 @@ mod tests {
         );
 
         assert_eq!(error.code, codes::PROVIDER_QUOTA_EXHAUSTED);
+    }
+
+    #[test]
+    fn classify_codex_usage_limit_reached_as_usage_limit() {
+        // The Codex/ChatGPT 429 usage-limit body must route to its own code
+        // (recovers at `resets_at`) rather than the transient rate-limit copy,
+        // and must capture the absolute reset timestamp for clients to localize.
+        let error = classify_runtime_error_message(
+            "LLM error: Codex API error (429 Too Many Requests): {\"error\":{\"type\":\"usage_limit_reached\",\"message\":\"The usage limit has been reached\",\"plan_type\":\"pro\",\"resets_at\":1783767823,\"eligible_promo\":null,\"resets_in_seconds\":12337}}",
+            &UserFacingErrorContext::default()
+                .with_provider("openai-codex")
+                .with_model_id("gpt-5-codex"),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_USAGE_LIMIT_REACHED);
+        assert_eq!(
+            string_field(&error.fields, "provider"),
+            Some("openai-codex")
+        );
+        assert_eq!(number_field(&error.fields, "resets_at"), Some(1783767823.0));
+
+        // Base copy is human-readable and names the reset time; without the
+        // capability field it makes no automatic-continuation promise.
+        let message = error.fallback_message();
+        assert!(
+            message.starts_with("You're out of LLM usage limits."),
+            "unexpected copy: {message}"
+        );
+        assert!(
+            message.contains("resets at"),
+            "missing reset time: {message}"
+        );
+        assert!(
+            !message.contains("automatically"),
+            "unexpected promise: {message}"
+        );
+    }
+
+    #[test]
+    fn usage_limit_message_without_reset_time_stays_generic() {
+        let error = classify_runtime_error_message(
+            "Some Provider API error (429): usage limit reached",
+            &UserFacingErrorContext::default(),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_USAGE_LIMIT_REACHED);
+        assert_eq!(number_field(&error.fields, "resets_at"), None);
+        assert_eq!(error.fallback_message(), "You're out of LLM usage limits.");
+    }
+
+    #[test]
+    fn usage_limit_message_appends_auto_continue_suffix_when_flagged() {
+        // The emit site sets `auto_continue` only when an auto-continue
+        // capability is active; the copy then promises automatic resumption.
+        let error = UserFacingError::new(codes::PROVIDER_USAGE_LIMIT_REACHED)
+            .with_field("resets_at", 1783767823)
+            .with_field("auto_continue", true);
+
+        let message = error.fallback_message();
+        assert!(
+            message.contains("resets at"),
+            "missing reset time: {message}"
+        );
+        assert!(
+            message.contains("We'll continue work automatically once it resets."),
+            "missing auto-continue promise: {message}"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -1145,6 +1145,11 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
     if let Some(utility_llm_service) = adapter.utility_llm_service() {
         atom = atom.with_utility_llm_service(utility_llm_service);
     }
+    // Schedule store powers the `usage_limit_auto_continue` capability, which
+    // schedules a continuation after a provider usage limit resets.
+    if let Some(schedule_store) = adapter.schedule_store(org_id) {
+        atom = atom.with_schedule_store(schedule_store);
+    }
 
     let input = ReasonInput {
         mcp_tool_definitions: turn_context.mcp_tool_definitions,

--- a/crates/runtime/tests/usage_limit_auto_continue_test.rs
+++ b/crates/runtime/tests/usage_limit_auto_continue_test.rs
@@ -1,0 +1,249 @@
+//! End-to-end runtime test for the `usage_limit_auto_continue` capability.
+//!
+//! Drives a real turn through the in-process runtime with an `LlmSim` driver
+//! scripted to fail with a Codex-style `usage_limit_reached` body, and verifies
+//! the `LlmErrorHook` seam fires end-to-end: a continuation is scheduled through
+//! the injected schedule store, and the user-facing error copy promises
+//! automatic resumption. A contrast case (capability disabled) proves the
+//! behavior is fully gated by the capability — the copy stays generic and
+//! nothing is scheduled even though the schedule store is present.
+
+use async_trait::async_trait;
+use everruns_core::capabilities::UsageLimitAutoContinueCapability;
+use everruns_core::driver_registry::DriverRegistry;
+use everruns_core::llmsim_driver::{LlmSimConfig, SimError, SimTurn};
+use everruns_core::session_schedule::SessionSchedule;
+use everruns_core::traits::SessionScheduleStore;
+use everruns_core::typed_id::{PrincipalId, ScheduleId, SessionId};
+use everruns_core::{
+    AgentId, CapabilityRegistry, DriverId, HarnessId, PlatformDefinition, ResolvedModel,
+};
+use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
+use std::sync::{Arc, Mutex};
+
+/// Codex/ChatGPT usage-limit 429 body. Classifies to
+/// `provider_usage_limit_reached` and carries an absolute `resets_at`.
+const CODEX_USAGE_LIMIT_BODY: &str = r#"Codex API error (429 Too Many Requests): {"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro","resets_at":1783767823,"eligible_promo":null,"resets_in_seconds":12337}}"#;
+
+/// Records the one-shot schedules created during a turn.
+#[derive(Default)]
+struct RecordingScheduleStore {
+    created: Mutex<Vec<(String, Option<chrono::DateTime<chrono::Utc>>)>>,
+}
+
+#[async_trait]
+impl SessionScheduleStore for RecordingScheduleStore {
+    async fn create_schedule(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+        timezone: String,
+    ) -> everruns_core::Result<SessionSchedule> {
+        self.created
+            .lock()
+            .unwrap()
+            .push((description.clone(), scheduled_at));
+        Ok(SessionSchedule {
+            id: ScheduleId::new(),
+            session_id,
+            owner_principal_id: PrincipalId::new(),
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            description,
+            cron_expression: cron_expression.clone(),
+            scheduled_at,
+            timezone,
+            enabled: true,
+            schedule_type: SessionSchedule::derive_type(&cron_expression),
+            next_trigger_at: scheduled_at,
+            last_triggered_at: None,
+            trigger_count: 0,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+    }
+
+    async fn cancel_schedule(
+        &self,
+        _session_id: SessionId,
+        _schedule_id: ScheduleId,
+    ) -> everruns_core::Result<SessionSchedule> {
+        unimplemented!("not used by this test")
+    }
+
+    async fn list_schedules(
+        &self,
+        _session_id: SessionId,
+    ) -> everruns_core::Result<Vec<SessionSchedule>> {
+        Ok(vec![])
+    }
+
+    async fn count_active_schedules(&self, _session_id: SessionId) -> everruns_core::Result<u32> {
+        Ok(0)
+    }
+
+    async fn count_active_org_schedules(&self) -> everruns_core::Result<u32> {
+        Ok(0)
+    }
+}
+
+fn platform_with_capability() -> PlatformDefinition {
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(UsageLimitAutoContinueCapability);
+    PlatformDefinition::new(capabilities, DriverRegistry::new())
+}
+
+fn llmsim_model() -> ResolvedModel {
+    ResolvedModel {
+        model: "llmsim-model".into(),
+        provider_type: DriverId::LlmSim,
+        api_key: Some("fake-key".into()),
+        base_url: None,
+        provider_metadata: None,
+    }
+}
+
+/// Collect every message text in the session transcript.
+macro_rules! message_texts {
+    ($runtime:expr, $session_id:expr) => {
+        $runtime
+            .messages($session_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|m| m.text().map(|t| t.to_string()))
+            .collect::<Vec<String>>()
+    };
+}
+
+#[tokio::test]
+async fn usage_limit_error_schedules_continuation_and_promises_resume() {
+    let harness_id: HarnessId = "harness_00000000000000000000000000000091".parse().unwrap();
+    let agent_id: AgentId = "agent_00000000000000000000000000000091".parse().unwrap();
+    let session_id: SessionId = "session_00000000000000000000000000000091".parse().unwrap();
+
+    let store = Arc::new(RecordingScheduleStore::default());
+    let store_for_factory = store.clone();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform_with_capability())
+        .llm_sim(LlmSimConfig::scripted(vec![SimTurn::Error(
+            SimError::Other(CODEX_USAGE_LIMIT_BODY.to_string()),
+        )]))
+        .default_model(llmsim_model())
+        .with_schedule_store_factory(Arc::new(move |_org_id| {
+            store_for_factory.clone() as Arc<dyn SessionScheduleStore>
+        }))
+        .harness(
+            HarnessBuilder::new("limits", "You do long-running work.")
+                .id(harness_id)
+                .capability("usage_limit_auto_continue")
+                .build(),
+        )
+        .agent(
+            AgentBuilder::new("worker", "Do the work.")
+                .id(agent_id)
+                .build(),
+        )
+        .session(
+            SessionBuilder::new(harness_id)
+                .id(session_id)
+                .agent(agent_id)
+                .build(),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    // The turn fails on the usage limit; we assert on the persisted effects
+    // regardless of the returned success flag.
+    let _ = runtime.run_text_turn(session_id, "Do the long task.").await;
+
+    // A continuation was scheduled through the injected store.
+    {
+        let created = store.created.lock().unwrap();
+        assert_eq!(
+            created.len(),
+            1,
+            "exactly one continuation must be scheduled"
+        );
+        assert_eq!(created[0].0, "Continue tasks");
+        assert!(created[0].1.is_some(), "continuation must have a fire time");
+    }
+
+    // The user-facing error copy names the limit and promises resumption.
+    let texts = message_texts!(runtime, session_id);
+    assert!(
+        texts
+            .iter()
+            .any(|t| t.contains("You're out of LLM usage limits")
+                && t.contains("continue work automatically")),
+        "error copy should promise auto-continue, got: {texts:?}"
+    );
+}
+
+#[tokio::test]
+async fn usage_limit_error_without_capability_stays_generic() {
+    let harness_id: HarnessId = "harness_00000000000000000000000000000092".parse().unwrap();
+    let agent_id: AgentId = "agent_00000000000000000000000000000092".parse().unwrap();
+    let session_id: SessionId = "session_00000000000000000000000000000092".parse().unwrap();
+
+    let store = Arc::new(RecordingScheduleStore::default());
+    let store_for_factory = store.clone();
+
+    // Same failure and schedule store, but the capability is NOT enabled on the
+    // harness. Nothing should be scheduled and the copy must stay generic.
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform_with_capability())
+        .llm_sim(LlmSimConfig::scripted(vec![SimTurn::Error(
+            SimError::Other(CODEX_USAGE_LIMIT_BODY.to_string()),
+        )]))
+        .default_model(llmsim_model())
+        .with_schedule_store_factory(Arc::new(move |_org_id| {
+            store_for_factory.clone() as Arc<dyn SessionScheduleStore>
+        }))
+        .harness(
+            HarnessBuilder::new("limits", "You do long-running work.")
+                .id(harness_id)
+                .build(),
+        )
+        .agent(
+            AgentBuilder::new("worker", "Do the work.")
+                .id(agent_id)
+                .build(),
+        )
+        .session(
+            SessionBuilder::new(harness_id)
+                .id(session_id)
+                .agent(agent_id)
+                .build(),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    let _ = runtime.run_text_turn(session_id, "Do the long task.").await;
+
+    assert!(
+        store.created.lock().unwrap().is_empty(),
+        "no continuation should be scheduled without the capability"
+    );
+
+    let texts = message_texts!(runtime, session_id);
+    // Still classified as a usage limit (core behavior), but no auto-continue promise.
+    assert!(
+        texts
+            .iter()
+            .any(|t| t.contains("You're out of LLM usage limits")),
+        "error should still classify as a usage limit, got: {texts:?}"
+    );
+    assert!(
+        texts
+            .iter()
+            .all(|t| !t.contains("continue work automatically")),
+        "generic copy must not promise auto-continue, got: {texts:?}"
+    );
+}

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -30,6 +30,7 @@ Fundamental capabilities for file operations, command execution, web access, ses
 | [Message Metadata](/capabilities/message-metadata/) | `message_metadata` | 0 |
 | [Task Management](/capabilities/task-management/) | `stateless_todo_list` | 1 |
 | [Schedules](/capabilities/session-schedules/) | `session_schedule` | 3 |
+| [Auto-Continue After Usage Limit](/capabilities/usage-limit-auto-continue/) | `usage_limit_auto_continue` | 0 |
 | [Sub Agents](/capabilities/sub-agents/) | `subagents` | 3 |
 | [AGENTS.md](/capabilities/agent-instructions/) | `agent_instructions` | 0 |
 | [Agent Skills](/capabilities/agent-skills/) | `skills` | 2 |

--- a/docs/capabilities/usage-limit-auto-continue.md
+++ b/docs/capabilities/usage-limit-auto-continue.md
@@ -20,10 +20,11 @@ the limit resets, often hours later. This capability makes the session resume on
 its own once the window clears, so long-running work is not silently stranded.
 
 It contributes **no tools**. The behavior is encapsulated behind a reusable
-platform seam — the capability supplies an *LLM error handler* that the agent
-runtime invokes generically when a turn fails with a terminal error. The runtime
-has no special-casing for usage limits; any capability can provide the same kind
-of error-recovery handler.
+platform seam — the capability supplies an *LLM error hook* (an in-process
+capability hook, the same family as tool-call hooks and message filters) that the
+agent runtime invokes generically when a turn fails with a terminal error. The
+runtime has no special-casing for usage limits; any capability can provide the
+same kind of error-recovery hook.
 
 ## How It Works
 

--- a/docs/capabilities/usage-limit-auto-continue.md
+++ b/docs/capabilities/usage-limit-auto-continue.md
@@ -89,7 +89,12 @@ otherwise require a human to manually restart the session.
 - Requires a provider whose error reports a concrete reset time; without one the
   error copy stays generic and no continuation is scheduled.
 - The continuation is delivered through the session schedule machinery, so it
-  depends on the schedule poller running in the deployment.
+  requires both a session schedule store and a schedule poller in the deployment.
+  The hosted platform provides both. The default embedded runtime provides
+  neither, so this capability is **not** part of the runtime-safe preset — an
+  embedder must wire a `SessionScheduleStore` (e.g. via a schedule-store factory)
+  and run a poller for it to take effect; otherwise its error hook is a no-op and
+  the error copy stays generic.
 
 ## See Also
 

--- a/docs/capabilities/usage-limit-auto-continue.md
+++ b/docs/capabilities/usage-limit-auto-continue.md
@@ -1,0 +1,94 @@
+---
+title: Auto-Continue After Usage Limit
+description: When an LLM subscription/plan usage limit is reached, automatically resume the interrupted work shortly after the limit resets.
+sidebar:
+  order: 33
+---
+
+| | |
+|---|---|
+| **ID** | `usage_limit_auto_continue` |
+| **Category** | Core |
+| **Features** | None |
+| **Dependencies** | None |
+| **Risk** | Low |
+
+Some providers cap usage per subscription window rather than per minute. When a
+plan usage limit is hit — for example the ChatGPT/Codex `429`
+`usage_limit_reached` response — the turn fails and the session goes idle until
+the limit resets, often hours later. This capability makes the session resume on
+its own once the window clears, so long-running work is not silently stranded.
+
+It contributes **no tools**. Its presence is the toggle: the reason atom's
+terminal-error path consumes it when a turn fails with the
+`provider_usage_limit_reached` error code.
+
+## How It Works
+
+1. **Classification** — The provider error is classified as
+   `provider_usage_limit_reached`, which captures the absolute reset time
+   (`resets_at`, unix seconds) reported by the provider. This is
+   driver-agnostic: any driver whose error body carries the `usage_limit_reached`
+   wording is covered.
+2. **Scheduling** — When the capability is enabled and a reset time is present,
+   a one-shot session schedule is created to fire `delay_seconds` after the
+   reset. When it fires, the configured `prompt` is injected as a user message
+   and the interrupted work resumes.
+3. **Message copy** — The user-facing error reads *"You're out of LLM usage
+   limits. Your usage limit resets at &lt;time&gt;."* When (and only when) a
+   continuation was actually scheduled, it appends *"We'll continue work
+   automatically once it resets."* — so the copy never promises a resumption
+   that will not happen. Without the capability, the same error stays generic
+   and no continuation is scheduled.
+
+## Configuration
+
+### Default
+
+```json
+{
+  "capabilities": ["usage_limit_auto_continue"]
+}
+```
+
+Defaults: continuation fires **120 seconds** after the reported reset with the
+prompt **"Continue tasks"**.
+
+### Custom delay and prompt
+
+```json
+{
+  "capabilities": [
+    {
+      "ref": "usage_limit_auto_continue",
+      "config": {
+        "delay_seconds": 300,
+        "prompt": "Resume the migration where you left off."
+      }
+    }
+  ]
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `delay_seconds` | integer (0–86400) | `120` | How long to wait after the reset before resuming. A small buffer avoids racing the provider's reset clock. |
+| `prompt` | string | `"Continue tasks"` | Message injected to resume work when the limit resets. |
+
+## When To Enable
+
+Use this capability for agents running long, autonomous, or scheduled work on
+provider plans that enforce usage-window limits, where a multi-hour stall would
+otherwise require a human to manually restart the session.
+
+## Limitations
+
+- Requires a provider whose error reports a concrete reset time; without one the
+  error copy stays generic and no continuation is scheduled.
+- The continuation is delivered through the session schedule machinery, so it
+  depends on the schedule poller running in the deployment.
+
+## See Also
+
+- [Schedules](/capabilities/session-schedules/) — the scheduling machinery the continuation reuses
+- [Capabilities](/features/capabilities/) — the capability model

--- a/docs/capabilities/usage-limit-auto-continue.md
+++ b/docs/capabilities/usage-limit-auto-continue.md
@@ -19,9 +19,11 @@ plan usage limit is hit — for example the ChatGPT/Codex `429`
 the limit resets, often hours later. This capability makes the session resume on
 its own once the window clears, so long-running work is not silently stranded.
 
-It contributes **no tools**. Its presence is the toggle: the reason atom's
-terminal-error path consumes it when a turn fails with the
-`provider_usage_limit_reached` error code.
+It contributes **no tools**. The behavior is encapsulated behind a reusable
+platform seam — the capability supplies an *LLM error handler* that the agent
+runtime invokes generically when a turn fails with a terminal error. The runtime
+has no special-casing for usage limits; any capability can provide the same kind
+of error-recovery handler.
 
 ## How It Works
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -241,23 +241,28 @@ Associates a capability with an agent via `ref` (CapabilityId) + optional `confi
 
 #### Capability Trait (everruns-core)
 
-See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `facts()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`, `llm_error_handler()`.
+See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `facts()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`, `llm_error_hook()`.
 
-##### LLM Error Handler Seam
+##### LLM Error Hook Seam
 
-`llm_error_handler() -> Option<Arc<dyn LlmErrorHandler>>` (default `None`) is the
-platform seam for **capability-owned error recovery**. When a turn fails with a
-*terminal* LLM error (one that will not be retried), the reason atom collects the
-handlers contributed by the active capabilities and invokes each generically —
-before the user-facing error message is built — passing an `LlmErrorContext`
-(session id, classified `error_code`, structured `error_fields`, the capability's
-per-agent config, and host `LlmErrorHandlerServices`). A handler may perform a
-side effect and/or return extra fields to merge into the `UserFacingError` (for
-example to unlock capability-specific message copy). The atom stays
-behavior-agnostic: it knows nothing about any specific capability's logic, so new
-error-recovery extensions are built purely as capabilities. The first consumer is
+`llm_error_hook() -> Option<Arc<dyn LlmErrorHook>>` (default `None`) is the
+platform seam for **capability-owned error recovery**. It is an *in-process
+capability hook* — the same family as `tool_call_hooks()`,
+`message_filter_provider()`, and `output_guardrails()` (typed traits invoked
+in-process with host services) — as distinct from the user-hook system
+(`specs/user-hooks.md`), which runs user-authored shell commands at lifecycle
+events. When a turn fails with a *terminal* LLM error (one that will not be
+retried), the reason atom collects the hooks contributed by the active
+capabilities and invokes each generically — before the user-facing error message
+is built — passing an `LlmErrorContext` (session id, classified `error_code`,
+structured `error_fields`, the capability's per-agent config, and host
+`LlmErrorHookServices`). A hook may perform a side effect and/or return extra
+fields to merge into the `UserFacingError` (for example to unlock
+capability-specific message copy). The atom stays behavior-agnostic: it knows
+nothing about any specific capability's logic, so new error-recovery extensions
+are built purely as capabilities. The first consumer is
 `usage_limit_auto_continue` (schedules a continuation after a provider usage limit
-resets); see `crates/core/src/llm_error_handler.rs`.
+resets); see `crates/core/src/llm_error_hook.rs`.
 
 ##### System Prompt Methods
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -241,7 +241,23 @@ Associates a capability with an agent via `ref` (CapabilityId) + optional `confi
 
 #### Capability Trait (everruns-core)
 
-See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `facts()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`.
+See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `CapabilityRegistry`. Key trait methods: `id()`, `name()`, `description()`, `status()`, `system_prompt_contribution()`, `facts()`, `tools()`, `mounts()`, `dependencies()`, `features()`, `message_filter_provider()`, `llm_error_handler()`.
+
+##### LLM Error Handler Seam
+
+`llm_error_handler() -> Option<Arc<dyn LlmErrorHandler>>` (default `None`) is the
+platform seam for **capability-owned error recovery**. When a turn fails with a
+*terminal* LLM error (one that will not be retried), the reason atom collects the
+handlers contributed by the active capabilities and invokes each generically —
+before the user-facing error message is built — passing an `LlmErrorContext`
+(session id, classified `error_code`, structured `error_fields`, the capability's
+per-agent config, and host `LlmErrorHandlerServices`). A handler may perform a
+side effect and/or return extra fields to merge into the `UserFacingError` (for
+example to unlock capability-specific message copy). The atom stays
+behavior-agnostic: it knows nothing about any specific capability's logic, so new
+error-recovery extensions are built purely as capabilities. The first consumer is
+`usage_limit_auto_continue` (schedules a continuation after a provider usage limit
+resets); see `crates/core/src/llm_error_handler.rs`.
 
 ##### System Prompt Methods
 

--- a/specs/error-disclosure.md
+++ b/specs/error-disclosure.md
@@ -22,6 +22,21 @@ bad API key. Quota/billing exhaustion now has its own user-facing code,
 `provider_quota_exhausted`, and is treated as non-transient (drivers fail
 fast instead of retrying it as a 429).
 
+Subscription/plan usage limits (e.g. the ChatGPT/Codex `429`
+`usage_limit_reached` body) are a third distinct case with their own code,
+`provider_usage_limit_reached`. Unlike an ordinary rate limit they do not
+recover within the driver backoff window — they reset hours later — and unlike
+quota exhaustion they need no operator action, recovering on their own at the
+reported reset time. The string classifier detects the `usage_limit_reached`
+wording provider-agnostically (so any driver surfacing it is covered), captures
+the absolute `resets_at` unix timestamp as an `error_fields` value for clients
+to localize, and `is_transient_error_message` treats it as non-transient so the
+human-readable message surfaces immediately instead of after pointless retries.
+The user-facing copy reads "You're out of LLM usage limits. Your usage limit
+resets at &lt;time&gt;." An `auto_continue` field, set by the emit site only when
+an auto-continue capability is active, appends a promise that work resumes
+automatically once the limit resets; absent it, the copy stays generic.
+
 ## Disclosure modes
 
 The `error_disclosure` capability (`crates/core/src/capabilities/error_disclosure.rs`)


### PR DESCRIPTION
## What changed

Handles provider **usage-limit** errors — e.g. the ChatGPT/Codex `429` `usage_limit_reached` body — as a distinct, legible, optionally self-healing condition:

1. **New user-facing error code `provider_usage_limit_reached`.** Driver-agnostic (classified from the error body, so any provider surfacing the same shape is covered), carrying the absolute `resets_at` timestamp. Copy: *"You're out of LLM usage limits. Your usage limit resets at &lt;time&gt;."* It is treated as **non-transient** (it resets hours later, not within the retry window) and is distinct from `provider_rate_limited` (a short throttle) and `provider_quota_exhausted` (billing).
2. **New opt-in capability `usage_limit_auto_continue`.** When a turn fails with that error, it schedules a one-shot session continuation shortly after the reported reset (default reset + 2 min) to resume the interrupted work, and appends *"We'll continue work automatically once it resets."* to the copy — **only when a continuation was actually scheduled**, so it never over-promises.
3. **New reusable platform seam `LlmErrorHook`.** An in-process capability hook (same family as `ToolCallHook` / `MessageFilterProvider` / `output_guardrails`), so error-recovery behavior is owned by capabilities and the reason atom stays behavior-agnostic. The capability is the first consumer; new error-recovery extensions are built the same way without touching the atom.

## Why

Long-running / autonomous agents on subscription-limited providers (Codex) silently stalled for hours when a usage window was hit: the error was mis-surfaced as a transient rate limit, the concrete reset time was discarded, and nothing resumed the work. This makes the failure legible and optionally self-healing.

## Before / After

**Before:** `usage_limit_reached` 429 → classified as `provider_rate_limited` → *"Rate limited by the AI provider. Please wait a moment."* (wrong — it's a multi-hour window), reset time discarded, session idle indefinitely.

**After:** → `provider_usage_limit_reached` → *"You're out of LLM usage limits. Your usage limit resets at 06:03 UTC on Jul 11."* With `usage_limit_auto_continue` enabled: + *"We'll continue work automatically once it resets."* and a one-shot continuation scheduled at reset + 2 min.

**Evidence:** unit tests (classification, reset-time rendering, non-transient gate, hook schedules-and-flags / ignores-other-codes / no-store-no-op) plus an end-to-end runtime test (`crates/runtime/tests/usage_limit_auto_continue_test.rs`) that drives a real turn through `InProcessRuntime` with an `LlmSim` scripted to fail with the Codex body and an injected `SessionScheduleStore`, asserting a continuation is scheduled and the copy promises resumption; the contrast case (capability disabled, same store present) schedules nothing and stays generic. Local: `everruns-core` lib 2744 passed; runtime e2e 2 passed; clippy + pre-push clean.

## Risk

- **Low.**
- Reached only on terminal LLM failures. The capability is **opt-in** and behavior-only (no tools); it is grade-only (not in the default runtime preset) because it needs the `schedule_store` host service and a schedule poller, and it degrades to a clean no-op when either is absent. Rebased onto latest `main`: resolved a benign adjacency conflict in `llm_retry.rs` (kept both new tests) and merged main's hardened `is_transient` computation with the new hook seam in `reason.rs`.

## Security

- **Threat categories reviewed:** TM-LLM (error/message handling), TM-DOS (schedule creation), TM-TENANT (org scoping).
- **Findings and resolutions:**
  - *TM-LLM — data exposure:* the user-facing message surfaces only a fixed template + the parsed `resets_at` unix timestamp — never the raw provider body. Raw error text stays gated by the existing `ErrorDisclosure` mechanism (unchanged). No new exposure.
  - *TM-DOS:* the continuation is created only on a terminal usage-limit failure (provider-gated, inherently rare), one one-shot schedule per failed turn. It deliberately uses `create_schedule` (bypassing the per-session/per-org caps) so an internal continuation isn't blocked by a full user schedule list; it fires one real worker turn at the reported reset and is self-limited by the provider's quota. See Follow-ups for a chain cap that bounds it further.
  - *TM-TENANT:* uses the same org-scoped schedule store already used by `session_schedule`; no cross-tenant surface added.
  - No `THREAT[]` comments were modified.

## Follow-ups

- **Freshness guard** ("only continue if nothing happened after the error"): skip the scheduled continuation when the session already advanced since the failure. Needs a schedule `kind` marker (proto + migration across worker/server/durable) so the poller can tell an internal continuation from a user schedule. Deferred because it's a cross-service schema/proto change; current behavior is safe (at worst one extra "Continue tasks" turn if the user manually resumed). The same marker would also exclude the internal continuation from the user's Schedules list / caps.
- **Auto-continue chain cap / backoff:** if a continuation itself hits the usage limit it schedules another, looping at the reset cadence until the limit clears. Consider a max-chain / backoff bound. Deferred — it is self-paced by the provider's reset window and opt-in.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXauqP3wqBQaCSQyGwzthM)_