### PR TITLE
fix(examples): add harness_id to weekend-concierge Agent initializer

### DIFF
--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -303,9 +303,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df73e492ac81310360b851abf4b5761df1a6292bd10b53b5589e17a2226880a"
+checksum = "5250bc36a0b27983b9eaebfe743bacb7dcb090546bd0106a375803545bafe5d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -314,6 +314,7 @@ dependencies = [
  "bitflags",
  "chrono",
  "clap",
+ "ed25519-dalek 2.2.0",
  "fancy-regex",
  "flate2",
  "futures-core",
@@ -326,7 +327,10 @@ dependencies = [
  "md-5",
  "num-traits",
  "os_display",
+ "rand 0.10.1",
  "regex",
+ "reqwest 0.13.2",
+ "rustls",
  "serde",
  "serde_json",
  "sha1",
@@ -336,6 +340,8 @@ dependencies = [
  "tower",
  "unit-prefix",
  "url",
+ "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -697,6 +703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -718,7 +725,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.2",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -797,7 +821,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -806,11 +839,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -859,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.3"
+version = "0.17.8"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -870,10 +918,11 @@ dependencies = [
  "bytes",
  "chrono",
  "cron",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "eventsource-stream",
  "fetchkit",
  "futures",
+ "globset",
  "hex",
  "inventory",
  "llmsim",
@@ -901,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.3"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -914,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.3"
+version = "0.17.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -956,7 +1005,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "libc",
  "rand 0.10.1",
@@ -977,6 +1026,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -3035,6 +3090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/examples/weekend-concierge-host/src/lib.rs
+++ b/examples/weekend-concierge-host/src/lib.rs
@@ -240,6 +240,7 @@ fn harness(harness_id: everruns_core::HarnessId) -> Harness {
 
 fn agent(
     agent_id: everruns_core::AgentId,
+    harness_id: everruns_core::HarnessId,
     default_model: Option<everruns_core::typed_id::ModelId>,
 ) -> Agent {
     Agent {
@@ -252,6 +253,7 @@ fn agent(
             "Keep the recommendation practical: one primary pick, one backup, one reason each."
                 .into(),
         default_model_id: default_model,
+        harness_id,
         default_version_id: None,
         forked_from_agent_id: None,
         forked_from_version_id: None,
@@ -382,7 +384,7 @@ pub async fn run_weekend_concierge_demo() -> ExampleResult<ExampleRun> {
             provider_metadata: None,
         })
         .harness(harness(harness_id))
-        .agent(agent(agent_id, None))
+        .agent(agent(agent_id, harness_id, None))
         .session(session(session_id, harness_id, agent_id))
         .seed_text_file(
             session_id,


### PR DESCRIPTION
## What changed
Restores compilation of the `weekend-concierge-host` example. The `everruns_core::Agent` struct gained a required `harness_id` field; the example's `agent()` helper built an `Agent` literal without it, so the crate no longer compiled. The host harness id is now threaded into `agent()` and set on the initializer. The example `Cargo.lock` is also refreshed to the current workspace crate versions (0.17.3 → 0.17.8, plus the new ed25519 transitive deps).

## Why
`weekend-concierge-host` is excluded from the Cargo workspace, so ordinary `cargo build`/CI never compiles it — only the scheduled **Examples Compile Check** ("Excluded Standalone Crates" job) does. That nightly went red on 2026-07-13 with:

```
error[E0063]: missing field `harness_id` in initializer of `everruns_core::Agent`
   --> src/lib.rs:245:5
error: could not compile `weekend-concierge-host` (lib) due to 1 previous error
```

## Before / After
- **Before:** `cargo check --manifest-path examples/weekend-concierge-host/Cargo.toml` → `error[E0063]: missing field harness_id`.
- **After:** same command → `Finished \`dev\` profile ... target(s)` (compiles clean, verified locally).

## Risk
- Low
- Example-only, non-workspace crate. No production code, API, or schema touched.

## Security
- Threat categories reviewed: No security-relevant code changes — example wiring only, using local in-process ids.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — compile-only example; the nightly compile check is the coverage)
- [x] Backward compatibility considered (no public surface change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SewsULJeGVpzQ5opXAv6GT)_