### PR TITLE
feat(ui): participant rail, join/leave lines, and addressing (EVE-759)

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -52,9 +52,17 @@ jest.mock("@/components/session/session-task-chips", () => ({
   SessionTaskChips: () => null,
 }));
 
+// The participants rail pulls in org context + participant queries; this suite
+// tests chat behavior, not the rail.
+jest.mock("@/components/session/session-participants-rail", () => ({
+  SessionParticipantsRail: () => null,
+}));
+
 jest.mock("@/hooks", () => ({
   useModels: () => ({ data: [] }),
   useProviders: () => ({ data: [] }),
+  useAgents: () => ({ data: [] }),
+  useSessionParticipants: () => ({ data: [] }),
   useImageAttachments: () => ({
     pendingImages: [],
     allUploaded: true,

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -84,7 +84,12 @@ export interface SessionContextValue {
   sendMessage: UseMutationResult<
     Message,
     Error,
-    { sessionId: string; content: string; controls?: Controls },
+    {
+      sessionId: string;
+      content: string;
+      controls?: Controls;
+      addressedParticipantId?: string | null;
+    },
     { optimisticId: string; content: string }
   >;
   // Turn cancellation
@@ -152,11 +157,13 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
       sessionId,
       content,
       controls,
+      addressedParticipantId,
     }: {
       sessionId: string;
       content: string;
       controls?: Controls;
-    }) => sendUserMessage(sessionId, content, controls),
+      addressedParticipantId?: string | null;
+    }) => sendUserMessage(sessionId, content, controls, addressedParticipantId),
     onMutate: async ({ sessionId, content }) => {
       // Create optimistic event immediately
       const optimisticId = `optimistic-${Date.now()}`;

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -6,22 +6,24 @@
  */
 "use client";
 
-import { Bot, CalendarClock, Loader2, Sparkles } from "lucide-react";
-import { memo, useCallback, useMemo } from "react";
+import { Bot, CalendarClock, Loader2, Sparkles, UserMinus, UserPlus } from "lucide-react";
+import { Fragment, memo, useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
 import type {
   ContentPart,
   Event,
   InputMessageData,
   OutputMessageCompletedData,
+  SessionParticipant,
   TurnFailedData,
   ToolCallSummary,
   ToolCompletedData,
   ToolProgressData,
 } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { getEventData, isImageFilePart } from "@/lib/api/types";
-import { useProviders } from "@/hooks";
+import { useAgents, useProviders } from "@/hooks";
 import { buildTraceConfigByDriver, resolveGenerationTraceUrl } from "@/lib/chat-trace";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { TraceLink } from "@/components/chat/trace-link";
@@ -70,6 +72,20 @@ interface ChatMessageListProps {
   loadingOlderEvents: boolean;
   getMessageText: (data: InputMessageData | OutputMessageCompletedData) => string;
   getToolCalls: (data: OutputMessageCompletedData) => ToolCallContent[];
+  /**
+   * Session participants, when known. Used to derive centered join/leave "system
+   * lines" in the transcript (there is no participant SSE event). Optional and
+   * guarded so single-host sessions render exactly as before.
+   */
+  participants?: SessionParticipant[];
+}
+
+/** A derived join/leave marker interleaved into the transcript by timestamp. */
+interface ParticipantMarker {
+  id: string;
+  ts: string;
+  kind: "join" | "leave";
+  participant: SessionParticipant;
 }
 
 type ActGroup = {
@@ -213,9 +229,11 @@ export const ChatMessageList = memo(function ChatMessageList({
   loadingOlderEvents,
   getMessageText,
   getToolCalls,
+  participants,
 }: ChatMessageListProps) {
   const { locale, t } = useLocale();
   const { data: providers } = useProviders();
+  const { data: agents } = useAgents();
   const traceConfigByDriver = useMemo(() => buildTraceConfigByDriver(providers), [providers]);
   const clientRequestedToolCallIds = useMemo(() => {
     const ids = new Set<string>();
@@ -297,6 +315,90 @@ export const ChatMessageList = memo(function ChatMessageList({
     () => buildActGroups(chatEvents, t("working")),
     [chatEvents, t],
   );
+
+  // Agent display-name lookup for participant system lines.
+  const agentNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const agent of agents ?? []) {
+      map.set(agent.id, getDisplayName(agent));
+    }
+    return map;
+  }, [agents]);
+
+  // Derive join/leave markers from participants. There is no participant SSE
+  // event, so lines are inferred from `joined_at` / `left_at`. Guarded: only a
+  // multi-participant session produces markers, and the original host's join is
+  // suppressed so ordinary 1:1 transcripts stay clean.
+  const participantMarkers = useMemo<ParticipantMarker[]>(() => {
+    if (!participants || participants.length < 2) return [];
+    const markers: ParticipantMarker[] = [];
+    for (const p of participants) {
+      if (p.role !== "host") {
+        markers.push({ id: `join-${p.id}`, ts: p.joined_at, kind: "join", participant: p });
+      }
+      if (p.left_at) {
+        markers.push({ id: `leave-${p.id}`, ts: p.left_at, kind: "leave", participant: p });
+      }
+    }
+    markers.sort((a, b) => a.ts.localeCompare(b.ts));
+    return markers;
+  }, [participants]);
+
+  // Assign each marker to the first transcript event whose timestamp is at or
+  // after it; markers after the last event render as a trailing block.
+  const { markersByEventId, trailingMarkers } = useMemo(() => {
+    const byEvent = new Map<string, ParticipantMarker[]>();
+    const trailing: ParticipantMarker[] = [];
+    if (participantMarkers.length === 0) {
+      return { markersByEventId: byEvent, trailingMarkers: trailing };
+    }
+    let mi = 0;
+    for (const event of chatEvents) {
+      while (mi < participantMarkers.length && participantMarkers[mi].ts <= event.ts) {
+        const list = byEvent.get(event.id) ?? [];
+        list.push(participantMarkers[mi]);
+        byEvent.set(event.id, list);
+        mi += 1;
+      }
+    }
+    while (mi < participantMarkers.length) {
+      trailing.push(participantMarkers[mi]);
+      mi += 1;
+    }
+    return { markersByEventId: byEvent, trailingMarkers: trailing };
+  }, [participantMarkers, chatEvents]);
+
+  const participantLabel = useCallback(
+    (p: SessionParticipant): string => {
+      if (p.kind === "agent") {
+        return (p.agent_id && agentNameById.get(p.agent_id)) || "Agent";
+      }
+      return "Participant";
+    },
+    [agentNameById],
+  );
+
+  const renderParticipantMarker = useCallback(
+    (marker: ParticipantMarker): ReactNode => {
+      const name = participantLabel(marker.participant);
+      const isJoin = marker.kind === "join";
+      return (
+        <div
+          key={marker.id}
+          className="flex items-center gap-4 py-2 text-xs font-medium text-muted-foreground sm:text-sm"
+        >
+          <div className="h-px flex-1 bg-border" />
+          <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+            {isJoin ? <UserPlus className="h-3.5 w-3.5" /> : <UserMinus className="h-3.5 w-3.5" />}
+            {isJoin ? `${name} joined the session` : `${name} left the session`}
+          </span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+      );
+    },
+    [participantLabel],
+  );
+
   const renderWorkLog = (event: Event, children: ReactNode) => {
     const turnId = getKnownTurnId(event);
     const durationMs = turnId ? turnDurationByTurnId.get(turnId) : undefined;
@@ -430,179 +532,196 @@ export const ChatMessageList = memo(function ChatMessageList({
         </div>
       )}
       {chatEvents.map((event) => {
-        if (
-          event.type === "tool.started" ||
-          event.type === "tool.completed" ||
-          event.type === "act.completed"
-        ) {
-          return null;
-        }
+        const eventNode = ((): ReactNode => {
+          if (
+            event.type === "tool.started" ||
+            event.type === "tool.completed" ||
+            event.type === "act.completed"
+          ) {
+            return null;
+          }
 
-        if (event.type === "context.compacted") {
-          const compactedData = getEventData(event, "context.compacted");
-          return compactedData ? <CompactionDivider key={event.id} data={compactedData} /> : null;
-        }
+          if (event.type === "context.compacted") {
+            const compactedData = getEventData(event, "context.compacted");
+            return compactedData ? <CompactionDivider key={event.id} data={compactedData} /> : null;
+          }
 
-        const turnFailedData = getEventData(event, "turn.failed");
-        if (turnFailedData) {
-          return (
-            <ChatErrorAlert key={event.id} message={getTurnFailedMessage(locale, turnFailedData)} />
-          );
-        }
-
-        if (isWorkLogEvent(event)) {
-          const turnId = getKnownTurnId(event);
-          if (turnId) {
-            const group = workLogEventsByTurnId.get(turnId) ?? [];
-            if (group[0]?.id !== event.id) return null;
-            return renderWorkLog(
-              event,
-              <div className="space-y-3">
-                {group.map((groupEvent) => renderWorkLogEventContent(groupEvent))}
-              </div>,
+          const turnFailedData = getEventData(event, "turn.failed");
+          if (turnFailedData) {
+            return (
+              <ChatErrorAlert
+                key={event.id}
+                message={getTurnFailedMessage(locale, turnFailedData)}
+              />
             );
           }
 
-          return renderWorkLog(event, renderWorkLogEventContent(event));
-        }
+          if (isWorkLogEvent(event)) {
+            const turnId = getKnownTurnId(event);
+            if (turnId) {
+              const group = workLogEventsByTurnId.get(turnId) ?? [];
+              if (group[0]?.id !== event.id) return null;
+              return renderWorkLog(
+                event,
+                <div className="space-y-3">
+                  {group.map((groupEvent) => renderWorkLogEventContent(groupEvent))}
+                </div>,
+              );
+            }
 
-        const isUser = event.type === "input.message";
-        const inputData = getEventData(event, "input.message");
-        const outputData = getEventData(event, "output.message.completed");
-        const data = inputData ?? outputData;
-        if (!data) return null;
+            return renderWorkLog(event, renderWorkLogEventContent(event));
+          }
 
-        const textContent = getMessageText(data);
-        const outputError = outputData ? getRuntimeErrorFromOutputMessage(outputData) : undefined;
-        if (outputData && outputError) {
-          return <ChatErrorAlert key={event.id} message={textContent} />;
-        }
-        const toolCalls = isUser
-          ? []
-          : outputData
-            ? getToolCalls(outputData).filter(
-                (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
-              )
-            : [];
-        const images = data.message?.content ? getMessageImages(data.message.content) : [];
-        // Deep link to this generation's trace on the provider (assistant
-        // messages only; user messages carry no provider response id).
-        const genTraceUrl = outputData
-          ? resolveGenerationTraceUrl(outputData.message?.metadata, traceConfigByDriver, {
-              sessionId,
-              turnId: event.context?.turn_id,
-            })
-          : null;
-        const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
-        const isToolOnlyMessage =
-          !isUser && toolCalls.length > 0 && !textContent && images.length === 0;
+          const isUser = event.type === "input.message";
+          const inputData = getEventData(event, "input.message");
+          const outputData = getEventData(event, "output.message.completed");
+          const data = inputData ?? outputData;
+          if (!data) return null;
 
-        if (isToolOnlyMessage) {
-          if (hasNarratedActEvents) return null;
-          return renderWorkLog(
-            event,
-            <div className="space-y-1">
-              <ToolActivityGroup
-                toolCalls={toolCalls}
-                toolResultsMap={toolResultsMap}
-                toolProgressMap={toolProgressMap}
-                toolOutputMap={toolOutputMap}
-              />
-            </div>,
-          );
-        }
+          const textContent = getMessageText(data);
+          const outputError = outputData ? getRuntimeErrorFromOutputMessage(outputData) : undefined;
+          if (outputData && outputError) {
+            return <ChatErrorAlert key={event.id} message={textContent} />;
+          }
+          const toolCalls = isUser
+            ? []
+            : outputData
+              ? getToolCalls(outputData).filter(
+                  (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
+                )
+              : [];
+          const images = data.message?.content ? getMessageImages(data.message.content) : [];
+          // Deep link to this generation's trace on the provider (assistant
+          // messages only; user messages carry no provider response id).
+          const genTraceUrl = outputData
+            ? resolveGenerationTraceUrl(outputData.message?.metadata, traceConfigByDriver, {
+                sessionId,
+                turnId: event.context?.turn_id,
+              })
+            : null;
+          const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
+          const isToolOnlyMessage =
+            !isUser && toolCalls.length > 0 && !textContent && images.length === 0;
 
-        return (
-          <div
-            key={event.id}
-            className={`chat-transcript-row space-y-2 ${isUser ? "scroll-mt-4" : ""}`}
-            data-message-anchor={isUser ? event.id : undefined}
-          >
-            {(textContent || images.length > 0) && (
-              <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-                {isUser ? (
-                  <div className={chatSurfaceStyles.userMessage}>
-                    {isScheduleTriggered && (
-                      <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                        <CalendarClock className="h-3 w-3" />
-                        <span>{t("scheduled")}</span>
-                      </div>
-                    )}
-                    <div className="flex items-start gap-2">
-                      <div className="flex-1 space-y-2">
-                        {textContent && <p className="whitespace-pre-wrap">{textContent}</p>}
-                        {images.length > 0 && (
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            {images.map((image) => (
-                              <MessageImage
-                                key={image.image_id}
-                                imageId={image.image_id}
-                                filename={image.filename}
-                              />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                      <MessageInfoIcon event={event} />
-                    </div>
-                  </div>
-                ) : (
-                  <div className={chatSurfaceStyles.agentMessageRow}>
-                    <div className={chatSurfaceStyles.agentIcon}>
-                      <Bot className="h-3.5 w-3.5" />
-                    </div>
-                    <div className="flex flex-1 items-start gap-2">
-                      <div className={chatSurfaceStyles.agentMessage}>
-                        {textContent && <MessageContent text={textContent} />}
-                        {images.length > 0 && (
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            {images.map((image) => (
-                              <MessageImage
-                                key={image.image_id}
-                                imageId={image.image_id}
-                                filename={image.filename}
-                              />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                      <MessageInfoIcon event={event} />
-                      {genTraceUrl && (
-                        <TraceLink href={genTraceUrl} label={t("trace_view_message")} />
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {toolCalls.length > 0 && !hasNarratedActEvents && (
-              <div className="ml-9 space-y-1">
+          if (isToolOnlyMessage) {
+            if (hasNarratedActEvents) return null;
+            return renderWorkLog(
+              event,
+              <div className="space-y-1">
                 <ToolActivityGroup
                   toolCalls={toolCalls}
                   toolResultsMap={toolResultsMap}
                   toolProgressMap={toolProgressMap}
                   toolOutputMap={toolOutputMap}
                 />
-              </div>
-            )}
+              </div>,
+            );
+          }
 
-            {(() => {
-              const turnId = getKnownTurnId(event);
-              if (turnId && workLogTurnIds.has(turnId)) return null;
-              return renderTurnDivider(
-                event.id,
-                turnDurationByEventId,
-                t("worked_for", {
-                  duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
-                }),
-                genTraceUrl,
-                t("trace_view_turn"),
-              );
-            })()}
-          </div>
-        );
+          return (
+            <div
+              key={event.id}
+              className={`chat-transcript-row space-y-2 ${isUser ? "scroll-mt-4" : ""}`}
+              data-message-anchor={isUser ? event.id : undefined}
+            >
+              {(textContent || images.length > 0) && (
+                <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+                  {isUser ? (
+                    <div className={chatSurfaceStyles.userMessage}>
+                      {isScheduleTriggered && (
+                        <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                          <CalendarClock className="h-3 w-3" />
+                          <span>{t("scheduled")}</span>
+                        </div>
+                      )}
+                      <div className="flex items-start gap-2">
+                        <div className="flex-1 space-y-2">
+                          {textContent && <p className="whitespace-pre-wrap">{textContent}</p>}
+                          {images.length > 0 && (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {images.map((image) => (
+                                <MessageImage
+                                  key={image.image_id}
+                                  imageId={image.image_id}
+                                  filename={image.filename}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        <MessageInfoIcon event={event} />
+                      </div>
+                    </div>
+                  ) : (
+                    <div className={chatSurfaceStyles.agentMessageRow}>
+                      <div className={chatSurfaceStyles.agentIcon}>
+                        <Bot className="h-3.5 w-3.5" />
+                      </div>
+                      <div className="flex flex-1 items-start gap-2">
+                        <div className={chatSurfaceStyles.agentMessage}>
+                          {textContent && <MessageContent text={textContent} />}
+                          {images.length > 0 && (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {images.map((image) => (
+                                <MessageImage
+                                  key={image.image_id}
+                                  imageId={image.image_id}
+                                  filename={image.filename}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        <MessageInfoIcon event={event} />
+                        {genTraceUrl && (
+                          <TraceLink href={genTraceUrl} label={t("trace_view_message")} />
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {toolCalls.length > 0 && !hasNarratedActEvents && (
+                <div className="ml-9 space-y-1">
+                  <ToolActivityGroup
+                    toolCalls={toolCalls}
+                    toolResultsMap={toolResultsMap}
+                    toolProgressMap={toolProgressMap}
+                    toolOutputMap={toolOutputMap}
+                  />
+                </div>
+              )}
+
+              {(() => {
+                const turnId = getKnownTurnId(event);
+                if (turnId && workLogTurnIds.has(turnId)) return null;
+                return renderTurnDivider(
+                  event.id,
+                  turnDurationByEventId,
+                  t("worked_for", {
+                    duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
+                  }),
+                  genTraceUrl,
+                  t("trace_view_turn"),
+                );
+              })()}
+            </div>
+          );
+        })();
+
+        const participantLines = markersByEventId.get(event.id);
+        if (participantLines && participantLines.length > 0) {
+          return (
+            <Fragment key={`row-${event.id}`}>
+              {participantLines.map((marker) => renderParticipantMarker(marker))}
+              {eventNode}
+            </Fragment>
+          );
+        }
+        return eventNode;
       })}
+      {trailingMarkers.map((marker) => renderParticipantMarker(marker))}
     </div>
   );
 });

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -7,14 +7,17 @@ import { getEventData } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
 import {
+  useAgents,
   useImageAttachments,
   useImageDropZone,
   useMessageScrollerVisibility,
   useModels,
   useScrollManager,
   useSessionCommands,
+  useSessionParticipants,
   useTurnKeyboardNavigation,
 } from "@/hooks";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 import { useChatModelSelection } from "@/hooks/use-chat-model-selection";
 import { executeSessionCommand } from "@/lib/api/commands";
 import { ApiError } from "@/lib/api/client";
@@ -28,6 +31,14 @@ import { ChatNavRail, type ChatNavAnchor } from "@/components/chat/chat-nav-rail
 import { ChatComposer } from "@/components/chat/chat-composer";
 import { MessageContent } from "@/components/chat/message-content";
 import { SessionTaskChips } from "@/components/session/session-task-chips";
+import { SessionParticipantsRail } from "@/components/session/session-participants-rail";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { StreamingMessage } from "@/components/streaming-message";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { Button } from "@/components/ui/button";
@@ -132,7 +143,10 @@ export function ChatPanel() {
   } = useSessionContext();
 
   const { data: models = [] } = useModels();
+  const { data: participants } = useSessionParticipants(sessionId);
+  const { data: agents } = useAgents();
   const [inputValue, setInputValue] = useState("");
+  const [addressedParticipantId, setAddressedParticipantId] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [voiceError, setVoiceError] = useState<VoiceErrorState | null>(null);
   const [voiceState, setVoiceState] = useState<"idle" | "connecting" | "connected">("idle");
@@ -254,11 +268,13 @@ export function ChatPanel() {
       text,
       images,
       controls,
+      addressedParticipantId: addressed,
     }: {
       text: string;
       images: Array<{ imageId: string; filename?: string }>;
       controls?: Controls;
-    }) => sendUserMessageWithImages(sessionId, text, images, controls),
+      addressedParticipantId?: string | null;
+    }) => sendUserMessageWithImages(sessionId, text, images, controls, addressed),
   });
   const executeCommand = useMutation({
     mutationFn: async ({
@@ -450,6 +466,41 @@ export function ChatPanel() {
     [executeCommand, persistSelection, setInputValue],
   );
 
+  // Addressing: a compact selector lets the user route a turn to a specific
+  // guest agent. Only surfaced when the session has ≥2 active agent
+  // participants; the default (none) preserves host-responds behavior.
+  const agentNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const agent of agents ?? []) {
+      map.set(agent.id, getDisplayName(agent));
+    }
+    return map;
+  }, [agents]);
+
+  const activeAgentParticipants = useMemo(
+    () => (participants ?? []).filter((p) => !p.left_at && p.kind === "agent"),
+    [participants],
+  );
+  const addressableParticipants = useMemo(
+    () => activeAgentParticipants.filter((p) => p.role !== "host"),
+    [activeAgentParticipants],
+  );
+  const showAddressing = activeAgentParticipants.length >= 2 && addressableParticipants.length > 0;
+
+  // Drop a stale selection if the addressed participant leaves or the session
+  // changes, so a departed guest can't silently keep receiving turns.
+  useEffect(() => {
+    if (
+      addressedParticipantId &&
+      !addressableParticipants.some((p) => p.id === addressedParticipantId)
+    ) {
+      setAddressedParticipantId(null);
+    }
+  }, [addressableParticipants, addressedParticipantId]);
+
+  const addressedParticipantLabel = (p: (typeof addressableParticipants)[number]): string =>
+    (p.agent_id && agentNameById.get(p.agent_id)) || "Agent";
+
   const submitMessage = async (controls?: Controls) => {
     if (!canSubmit) return;
     setSubmitError(null);
@@ -472,6 +523,7 @@ export function ChatPanel() {
           text: inputValue.trim(),
           images: uploadedImageIds,
           controls,
+          addressedParticipantId,
         });
         clearImages();
       } else {
@@ -479,6 +531,7 @@ export function ChatPanel() {
           sessionId,
           content: inputValue.trim(),
           controls,
+          addressedParticipantId,
         });
       }
 
@@ -511,134 +564,175 @@ export function ChatPanel() {
 
   return (
     <>
-      <div className="relative flex min-h-0 flex-1 flex-col">
-        <div
-          ref={scrollContainerRef}
-          onScroll={handleScrollUp}
-          className={cn(
-            "relative flex-1 overflow-y-auto bg-background bg-brand-dots px-3 py-4 sm:px-4",
-            !eventsLoading && chatEvents.length === 0 && "flex flex-col justify-end",
-          )}
-        >
-          <ChatMessageList
-            events={events}
-            chatEvents={chatEvents}
+      <div className="flex min-h-0 flex-1">
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <div
+              ref={scrollContainerRef}
+              onScroll={handleScrollUp}
+              className={cn(
+                "relative flex-1 overflow-y-auto bg-background bg-brand-dots px-3 py-4 sm:px-4",
+                !eventsLoading && chatEvents.length === 0 && "flex flex-col justify-end",
+              )}
+            >
+              <ChatMessageList
+                events={events}
+                chatEvents={chatEvents}
+                sessionId={sessionId}
+                toolResultsMap={toolResultsMap}
+                toolProgressMap={toolProgressMap}
+                toolOutputMap={toolOutputMap}
+                eventsLoading={eventsLoading}
+                hasMoreEvents={hasMoreEvents}
+                loadingOlderEvents={loadingOlderEvents}
+                getMessageText={getMessageText}
+                getToolCalls={getToolCalls}
+                participants={participants}
+              />
+
+              {(isThinking || streamingText) && (
+                <div className="mt-4 flex justify-start">
+                  <div className={chatSurfaceStyles.agentMessageRow}>
+                    <div className={chatSurfaceStyles.agentIcon}>
+                      <Bot className="h-3 w-3" />
+                    </div>
+                    <div className={chatSurfaceStyles.agentMessage}>
+                      {streamingIteration && streamingIteration > 1 && (
+                        <div className="mb-1 text-xs text-muted-foreground">
+                          {t("iteration", { value: streamingIteration })}
+                        </div>
+                      )}
+                      {isThinking && !streamingText ? (
+                        <ThinkingIndicator />
+                      ) : streamingText ? (
+                        <StreamingMessage text={streamingText} />
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {submitError && (
+                <div className="mt-4">
+                  <ChatErrorAlert message={submitError} />
+                </div>
+              )}
+
+              {voiceError && (
+                <div className="mt-4">
+                  <ChatErrorAlert
+                    message={voiceError.message}
+                    description={voiceError.description}
+                  />
+                </div>
+              )}
+
+              <div ref={messagesEndRef} />
+
+              {hasNewMessages && (
+                <button
+                  type="button"
+                  onClick={dismissNewMessages}
+                  className={chatSurfaceStyles.floatingNotice}
+                >
+                  <ArrowDown className="h-3 w-3" />
+                  {t("new_messages")}
+                </button>
+              )}
+            </div>
+
+            <ChatNavRail
+              anchors={navAnchors}
+              currentAnchorId={currentAnchorId}
+              onJump={scrollToAnchor}
+            />
+          </div>
+
+          <SessionTaskChips
             sessionId={sessionId}
-            toolResultsMap={toolResultsMap}
-            toolProgressMap={toolProgressMap}
-            toolOutputMap={toolOutputMap}
-            eventsLoading={eventsLoading}
-            hasMoreEvents={hasMoreEvents}
-            loadingOlderEvents={loadingOlderEvents}
-            getMessageText={getMessageText}
-            getToolCalls={getToolCalls}
+            basePath={sessionBasePath}
+            hasTasksFeature={hasTasksFeature}
           />
 
-          {(isThinking || streamingText) && (
-            <div className="mt-4 flex justify-start">
-              <div className={chatSurfaceStyles.agentMessageRow}>
-                <div className={chatSurfaceStyles.agentIcon}>
-                  <Bot className="h-3 w-3" />
-                </div>
-                <div className={chatSurfaceStyles.agentMessage}>
-                  {streamingIteration && streamingIteration > 1 && (
-                    <div className="mb-1 text-xs text-muted-foreground">
-                      {t("iteration", { value: streamingIteration })}
-                    </div>
-                  )}
-                  {isThinking && !streamingText ? (
-                    <ThinkingIndicator />
-                  ) : streamingText ? (
-                    <StreamingMessage text={streamingText} />
-                  ) : null}
-                </div>
-              </div>
+          {showAddressing && (
+            <div className="flex items-center gap-2 px-3 pt-2 sm:px-4">
+              <span className="text-xs text-muted-foreground">Address</span>
+              <Select
+                value={addressedParticipantId ?? "__host__"}
+                onValueChange={(value) =>
+                  setAddressedParticipantId(value === "__host__" ? null : value)
+                }
+              >
+                <SelectTrigger size="sm" className="h-7 w-auto min-w-40">
+                  <SelectValue>
+                    {addressedParticipantId
+                      ? addressedParticipantLabel(
+                          addressableParticipants.find((p) => p.id === addressedParticipantId) ??
+                            addressableParticipants[0],
+                        )
+                      : "Session host (default)"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__host__">Session host (default)</SelectItem>
+                  {addressableParticipants.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {addressedParticipantLabel(p)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           )}
 
-          {submitError && (
-            <div className="mt-4">
-              <ChatErrorAlert message={submitError} />
-            </div>
-          )}
-
-          {voiceError && (
-            <div className="mt-4">
-              <ChatErrorAlert message={voiceError.message} description={voiceError.description} />
-            </div>
-          )}
-
-          <div ref={messagesEndRef} />
-
-          {hasNewMessages && (
-            <button
-              type="button"
-              onClick={dismissNewMessages}
-              className={chatSurfaceStyles.floatingNotice}
-            >
-              <ArrowDown className="h-3 w-3" />
-              {t("new_messages")}
-            </button>
-          )}
+          <ChatComposer
+            commands={commands}
+            models={models}
+            inputValue={inputValue}
+            onInputChange={setInputValue}
+            onSubmit={submitMessage}
+            onCommandSelect={handleCommandSelect}
+            pendingImages={pendingImages}
+            hasImages={hasImages}
+            removeImage={removeImage}
+            addFiles={addFiles}
+            isDraggingOver={isDraggingOver}
+            dropZoneProps={dropZoneProps}
+            handlePaste={handlePaste}
+            selectedModelId={selectedModelId}
+            recentModels={recentModels}
+            onModelChange={handleModelChange}
+            modelTriggerLabel={modelTriggerLabel}
+            defaultModelOptionLabel={defaultModelOptionLabel}
+            supportsReasoning={supportsReasoning}
+            reasoningEffort={reasoningEffort}
+            reasoningEffortConfig={reasoningEffortConfig}
+            defaultEffortName={defaultEffortName}
+            getReasoningEffortName={getReasoningEffortName}
+            onReasoningEffortChange={(value) => setReasoningEffort(value as typeof reasoningEffort)}
+            supportsVerbosity={supportsVerbosity}
+            verbosity={verbosity}
+            verbosityConfig={verbosityConfig}
+            defaultVerbosityName={defaultVerbosityName}
+            getVerbosityName={getVerbosityName}
+            onVerbosityChange={(value) => setVerbosity(value as typeof verbosity)}
+            isActive={isActive}
+            cancelCurrentTurn={cancelCurrentTurn}
+            canSubmit={canSubmit}
+            isUploading={isUploading}
+            sendPending={
+              sendMessage.isPending || sendMessageWithImages.isPending || executeCommand.isPending
+            }
+            textareaRef={textareaRef}
+            voiceEnabled={voiceAvailable}
+            voiceActive={voiceState === "connected"}
+            voicePending={voiceState === "connecting"}
+            onToggleVoice={toggleVoice}
+          />
         </div>
 
-        <ChatNavRail
-          anchors={navAnchors}
-          currentAnchorId={currentAnchorId}
-          onJump={scrollToAnchor}
-        />
+        <SessionParticipantsRail sessionId={sessionId} />
       </div>
-
-      <SessionTaskChips
-        sessionId={sessionId}
-        basePath={sessionBasePath}
-        hasTasksFeature={hasTasksFeature}
-      />
-
-      <ChatComposer
-        commands={commands}
-        models={models}
-        inputValue={inputValue}
-        onInputChange={setInputValue}
-        onSubmit={submitMessage}
-        onCommandSelect={handleCommandSelect}
-        pendingImages={pendingImages}
-        hasImages={hasImages}
-        removeImage={removeImage}
-        addFiles={addFiles}
-        isDraggingOver={isDraggingOver}
-        dropZoneProps={dropZoneProps}
-        handlePaste={handlePaste}
-        selectedModelId={selectedModelId}
-        recentModels={recentModels}
-        onModelChange={handleModelChange}
-        modelTriggerLabel={modelTriggerLabel}
-        defaultModelOptionLabel={defaultModelOptionLabel}
-        supportsReasoning={supportsReasoning}
-        reasoningEffort={reasoningEffort}
-        reasoningEffortConfig={reasoningEffortConfig}
-        defaultEffortName={defaultEffortName}
-        getReasoningEffortName={getReasoningEffortName}
-        onReasoningEffortChange={(value) => setReasoningEffort(value as typeof reasoningEffort)}
-        supportsVerbosity={supportsVerbosity}
-        verbosity={verbosity}
-        verbosityConfig={verbosityConfig}
-        defaultVerbosityName={defaultVerbosityName}
-        getVerbosityName={getVerbosityName}
-        onVerbosityChange={(value) => setVerbosity(value as typeof verbosity)}
-        isActive={isActive}
-        cancelCurrentTurn={cancelCurrentTurn}
-        canSubmit={canSubmit}
-        isUploading={isUploading}
-        sendPending={
-          sendMessage.isPending || sendMessageWithImages.isPending || executeCommand.isPending
-        }
-        textareaRef={textareaRef}
-        voiceEnabled={voiceAvailable}
-        voiceActive={voiceState === "connected"}
-        voicePending={voiceState === "connecting"}
-        onToggleVoice={toggleVoice}
-      />
 
       <Dialog open={!!btwOverlay} onOpenChange={(open) => !open && closeBtwOverlay()}>
         <DialogContent className="sm:max-w-2xl">

--- a/apps/ui/src/components/session/session-participants-rail.tsx
+++ b/apps/ui/src/components/session/session-participants-rail.tsx
@@ -1,0 +1,211 @@
+/**
+ * "In this session" rail (EVE-759, area F) — lists the active participants of a
+ * multi-party session with role/kind badges, an Invite-agent control, and a
+ * per-member Leave control.
+ *
+ * Guarded: an ordinary 1:1 session (host only, nobody has left) renders nothing,
+ * so single-host sessions look exactly as before. Hidden below `lg` like the
+ * ChatNavRail so narrow viewports keep the full transcript width.
+ */
+"use client";
+
+import { useMemo, useState } from "react";
+import { Bot, Loader2, LogOut, User, UserPlus } from "lucide-react";
+import type { SessionParticipant } from "@/lib/api/types";
+import {
+  useAddSessionParticipant,
+  useAgents,
+  useLeaveSessionParticipant,
+  useSessionParticipants,
+} from "@/hooks";
+import { getDisplayName } from "@/lib/entity-lifecycle";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface SessionParticipantsRailProps {
+  sessionId: string;
+  className?: string;
+}
+
+export function SessionParticipantsRail({ sessionId, className }: SessionParticipantsRailProps) {
+  const { data: participants } = useSessionParticipants(sessionId);
+  const { data: agents } = useAgents();
+  const addParticipant = useAddSessionParticipant(sessionId);
+  const leaveParticipant = useLeaveSessionParticipant(sessionId);
+  const [inviteOpen, setInviteOpen] = useState(false);
+
+  const agentNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const agent of agents ?? []) {
+      map.set(agent.id, getDisplayName(agent));
+    }
+    return map;
+  }, [agents]);
+
+  const active = useMemo(() => (participants ?? []).filter((p) => !p.left_at), [participants]);
+  const left = useMemo(() => (participants ?? []).filter((p) => p.left_at), [participants]);
+
+  const activeAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const p of active) {
+      if (p.kind === "agent" && p.agent_id) ids.add(p.agent_id);
+    }
+    return ids;
+  }, [active]);
+
+  const invitableAgents = useMemo(
+    () => (agents ?? []).filter((agent) => !activeAgentIds.has(agent.id)),
+    [agents, activeAgentIds],
+  );
+
+  // Guard: keep ordinary 1:1 sessions (host only) untouched.
+  if (active.length < 2 && left.length === 0) return null;
+
+  const participantLabel = (p: SessionParticipant): string => {
+    if (p.kind === "agent") {
+      return (p.agent_id && agentNameById.get(p.agent_id)) || "Agent";
+    }
+    return "Participant";
+  };
+
+  const handleInvite = async (agentId: string) => {
+    try {
+      await addParticipant.mutateAsync({ kind: "agent", agent_id: agentId, role: "member" });
+      setInviteOpen(false);
+    } catch (error) {
+      console.error("Failed to invite agent:", error);
+    }
+  };
+
+  const renderRow = (p: SessionParticipant, isLeft: boolean) => {
+    const isHost = p.role === "host";
+    const isAgent = p.kind === "agent";
+    return (
+      <li
+        key={p.id}
+        className={cn(
+          "flex items-start gap-2 border border-border/60 bg-card/60 px-2 py-2",
+          isLeft && "opacity-50",
+        )}
+      >
+        <Avatar className="size-6 rounded-none">
+          <AvatarFallback className="rounded-none bg-muted text-muted-foreground">
+            {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-medium text-foreground">{participantLabel(p)}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-1">
+            <Badge variant={isHost ? "accent" : "outline"}>{isHost ? "Host" : "Member"}</Badge>
+            <Badge variant="secondary">{isAgent ? "Agent" : "User"}</Badge>
+          </div>
+        </div>
+        {!isHost && !isLeft && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            title="Remove from session"
+            aria-label={`Remove ${participantLabel(p)} from session`}
+            disabled={leaveParticipant.isPending}
+            onClick={() => leaveParticipant.mutate(p.id)}
+          >
+            <LogOut className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </li>
+    );
+  };
+
+  return (
+    <aside
+      className={cn(
+        "hidden w-64 shrink-0 flex-col border-l border-border bg-background lg:flex",
+        className,
+      )}
+      aria-label="Session participants"
+    >
+      <div className="flex items-center justify-between border-b border-border px-3 py-2.5">
+        <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          In this session
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          title="Invite agent"
+          aria-label="Invite agent"
+          onClick={() => setInviteOpen(true)}
+        >
+          <UserPlus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        <ul className="space-y-2">{active.map((p) => renderRow(p, false))}</ul>
+        {left.length > 0 && (
+          <>
+            <div className="mt-4 mb-2 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              Left
+            </div>
+            <ul className="space-y-2">{left.map((p) => renderRow(p, true))}</ul>
+          </>
+        )}
+      </div>
+
+      <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Invite agent</DialogTitle>
+            <DialogDescription>
+              Add an agent as a member of this session. Members can be addressed for a turn.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-72 space-y-1 overflow-y-auto">
+            {invitableAgents.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                No other agents available to invite.
+              </p>
+            ) : (
+              invitableAgents.map((agent) => (
+                <button
+                  key={agent.id}
+                  type="button"
+                  disabled={addParticipant.isPending}
+                  onClick={() => handleInvite(agent.id)}
+                  className="flex w-full items-center gap-2 border border-transparent px-2 py-2 text-left text-sm transition-colors hover:border-border/70 hover:bg-muted disabled:opacity-50"
+                >
+                  <Bot className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                  <span className="truncate">{getDisplayName(agent)}</span>
+                </button>
+              ))
+            )}
+          </div>
+
+          <DialogFooter>
+            {addParticipant.isPending && (
+              <span className="mr-auto inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Inviting…
+              </span>
+            )}
+            <Button type="button" variant="outline" onClick={() => setInviteOpen(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </aside>
+  );
+}

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -12,6 +12,7 @@ export * from "./use-auth";
 export * from "./use-durable";
 export * from "./use-image-attachments";
 export * from "./use-session-resources";
+export * from "./use-session-participants";
 export * from "./use-session-tasks";
 export * from "./use-session-schedules";
 export * from "./use-global-chat";

--- a/apps/ui/src/hooks/use-session-participants.ts
+++ b/apps/ui/src/hooks/use-session-participants.ts
@@ -1,0 +1,64 @@
+// Session participant hooks (EVE-759, area F)
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  addSessionParticipant,
+  leaveSessionParticipant,
+  listSessionParticipants,
+} from "@/lib/api/session-participants";
+import { queryKeys } from "@/lib/query-keys";
+import type { AddSessionParticipantRequest } from "@/lib/api/types";
+import { useOrg } from "@/providers/org-provider";
+
+/**
+ * Fetch the participants of a session. Gated on org + sessionId so single-org
+ * loads don't fire before the org cookie is set.
+ */
+export function useSessionParticipants(sessionId: string | undefined) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: queryKeys.sessions.participants(org, sessionId),
+    queryFn: () => listSessionParticipants(sessionId!),
+    enabled: !!org && !!sessionId,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+/** Add a member participant to a session, invalidating the participants query. */
+export function useAddSessionParticipant(sessionId: string) {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: (body: AddSessionParticipantRequest) => addSessionParticipant(sessionId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.participants(org, sessionId),
+      });
+    },
+  });
+}
+
+/** Remove a participant from a session, invalidating the participants query. */
+export function useLeaveSessionParticipant(sessionId: string) {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: (participantId: string) => leaveSessionParticipant(sessionId, participantId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sessions.participants(org, sessionId),
+      });
+    },
+  });
+}

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -208,11 +208,13 @@ export function useSendMessage() {
       sessionId,
       content,
       controls,
+      addressedParticipantId,
     }: {
       sessionId: string;
       content: string;
       controls?: Controls;
-    }) => sendUserMessage(sessionId, content, controls),
+      addressedParticipantId?: string | null;
+    }) => sendUserMessage(sessionId, content, controls, addressedParticipantId),
     onSuccess: (_, { sessionId }) => {
       // Invalidate events query to refresh the message list
       queryClient.invalidateQueries({

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -3090,6 +3090,9 @@ export interface CreateMessageRequest {
   controls?: Controls;
   metadata?: Record<string, unknown>;
   tags?: string[];
+  // Optional active agent participant to address for this turn. When omitted,
+  // the session host remains the responder (default 1:1 behavior).
+  addressed_participant_id?: string | null;
 }
 
 // Helper function to create a simple text message request

--- a/apps/ui/src/lib/api/messages.ts
+++ b/apps/ui/src/lib/api/messages.ts
@@ -17,11 +17,15 @@ export async function listMessages(sessionId: string): Promise<Message[]> {
   return response.data.data;
 }
 
-// Send a user message to a session (triggers workflow)
+// Send a user message to a session (triggers workflow).
+//
+// `addressedParticipantId` optionally targets an active agent participant for
+// this turn; when omitted the session host responds (unchanged default).
 export async function sendUserMessage(
   sessionId: string,
   content: string,
   controls?: Controls,
+  addressedParticipantId?: string | null,
 ): Promise<Message> {
   return createMessage(sessionId, {
     message: {
@@ -29,6 +33,7 @@ export async function sendUserMessage(
       content: [{ type: "text", text: content }],
     },
     controls,
+    ...(addressedParticipantId ? { addressed_participant_id: addressedParticipantId } : {}),
   });
 }
 
@@ -46,6 +51,7 @@ export async function sendUserMessageWithImages(
   text: string,
   images: ImageAttachment[],
   controls?: Controls,
+  addressedParticipantId?: string | null,
 ): Promise<Message> {
   const content: Array<
     { type: "text"; text: string } | { type: "image_file"; image_id: string; filename?: string }
@@ -71,5 +77,6 @@ export async function sendUserMessageWithImages(
       content,
     },
     controls,
+    ...(addressedParticipantId ? { addressed_participant_id: addressedParticipantId } : {}),
   });
 }

--- a/apps/ui/src/lib/api/session-participants.ts
+++ b/apps/ui/src/lib/api/session-participants.ts
@@ -1,0 +1,40 @@
+// Session participant API functions
+// Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
+
+import { api } from "./client";
+import type { SessionParticipant, AddSessionParticipantRequest } from "./types";
+
+/** List participants for a session (active and left). */
+export async function listSessionParticipants(sessionId: string): Promise<SessionParticipant[]> {
+  const response = await api.get<SessionParticipant[]>(`/v1/sessions/${sessionId}/participants`);
+  return response.data;
+}
+
+/**
+ * Add a participant to a session. Only members can be added — the server
+ * rejects `role: "host"`. Agent participants require `agent_id`.
+ */
+export async function addSessionParticipant(
+  sessionId: string,
+  body: AddSessionParticipantRequest,
+): Promise<SessionParticipant> {
+  const response = await api.post<SessionParticipant>(
+    `/v1/sessions/${sessionId}/participants`,
+    body,
+  );
+  return response.data;
+}
+
+/**
+ * Remove a participant from a session (sets `left_at`). The server returns 409
+ * when attempting to remove the host.
+ */
+export async function leaveSessionParticipant(
+  sessionId: string,
+  participantId: string,
+): Promise<SessionParticipant> {
+  const response = await api.delete<SessionParticipant>(
+    `/v1/sessions/${sessionId}/participants/${participantId}`,
+  );
+  return response.data;
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -52,6 +52,8 @@ export const queryKeys = {
     detail: (org?: string, sessionId?: string) => ["session", org, sessionId] as const,
     contextReport: (org?: string, sessionId?: string) =>
       ["session", org, sessionId, "context-report"] as const,
+    participants: (org?: string, sessionId?: string) =>
+      ["session", org, sessionId, "participants"] as const,
     stats: (org?: string) => ["sessions", "stats", org] as const,
   },
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -54,6 +54,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/agent-reliability-tests.md` - Agent execution reliability tests
 - `specs/subagents.md` - Subagent orchestration
 - `specs/session-tasks.md` - Session task registry for background work
+- `specs/session-participants.md` - Session participants (host/member agents and users, addressed-turn routing, invite-mode handoff)
 - `specs/session-resources.md` - Session resource registry
 - `specs/leased-resources.md` - Generic lease primitive
 - `specs/session-sandbox.md` - Managed session-owned sandbox capability and lifecycle

--- a/specs/session-participants.md
+++ b/specs/session-participants.md
@@ -1,0 +1,104 @@
+# Session Participants
+
+## Abstract
+
+A session is a shared space that more than one actor can occupy. **Session
+participants** record which agents and users are attached to a session, in what
+role, and for which interval. Participants make multi-actor sessions
+first-class: a host agent that supplies the execution environment, invited guest
+agents that can be addressed for individual turns, and the users watching or
+driving the conversation.
+
+This spec captures the durable model and its invariants. Field-level shapes,
+enum variants, and SQL live in code — see `crates/core/src/session.rs`
+(`SessionParticipant`, `SessionParticipantKind`, `SessionParticipantRole`), the
+command layer in `crates/server/src/domains/sessions/commands.rs`, and migrations
+`095_session_participants.sql` / `098_session_participant_user_identity.sql`.
+
+## Model
+
+Each participant row binds a principal to a session:
+
+- **kind** — `agent` or `user`. Agent participants carry an `agent_id` (and,
+  when known, the immutable `agent_version_id`); user participants do not.
+- **role** — `host` or `member`. The host anchors the session; members are
+  ordinary participants (invited guest agents, additional users).
+- **principal_id** — the principal that joined. This is the provenance anchor:
+  turns, resources, and audit attribute back to the participant's principal
+  rather than to `system`.
+- **joined_at / left_at** — the participation interval. `left_at = null` means
+  the participant is still active; a set `left_at` marks a past membership that
+  is retained for history.
+
+Participant ids use the `part_` prefix (see `specs/id-schema.md`).
+
+## Invariants
+
+- **One active host.** At most one active agent participant may hold the `host`
+  role (`specs/concepts.md`). The host is established when the session is created
+  and cannot leave through the ordinary leave path.
+- **Host supplies the harness.** The session runs on the host agent's harness
+  (the agent-owns-harness foundation from P1). Invited members overlay behavior
+  only — see routing below — and do not replace the host's execution
+  environment.
+- **Membership history is append-only in spirit.** Leaving sets `left_at`; rows
+  are not deleted, so provenance and the join/leave timeline stay reconstructable.
+- **User membership is idempotent.** A user acting in a session is ensured as an
+  active member participant exactly once
+  (`ensure_active_user_session_participant`), rather than creating a row per
+  turn.
+
+## API
+
+Participants are managed under a session
+(`crates/server/src/api/sessions.rs`):
+
+- `GET /v1/sessions/{session_id}/participants` — full participant history
+  (active and left), ordered by `joined_at`. Policy `SESSION_VIEW`.
+- `POST /v1/sessions/{session_id}/participants` — add a **member**. Body carries
+  `kind` and, for agents, `agent_id`; `role` defaults to `member` and an
+  explicit `host` is rejected (the host is owned by session creation). Policy
+  `SESSION_MANAGE`.
+- `DELETE /v1/sessions/{session_id}/participants/{participant_id}` — leave: sets
+  `left_at`. An active host cannot leave through this endpoint (`409`). Policy
+  `SESSION_MANAGE`.
+
+There is no participant join/leave event on the SSE stream; consumers that want a
+join/leave timeline derive it from `joined_at` / `left_at`.
+
+## Turn routing
+
+By default a user turn is answered by the session **host**. A turn may instead
+be **addressed** to a specific participant by setting
+`addressed_participant_id` on the create-message request
+(`POST /v1/sessions/{session_id}/messages`). Resolution
+(`resolve_responder_agent_id` in
+`crates/server/src/domains/messages/commands.rs`):
+
+- omitted → the session's default (host) agent responds;
+- the addressed participant must exist, still be active (`409` if it already
+  left), and be an agent (`400` otherwise);
+- the turn is then routed to that participant's `agent_id`, and the reply is
+  attributed to that participant for provenance.
+
+This makes a single session support several addressable agents while keeping the
+host as the default responder.
+
+## Invite-mode handoff
+
+Guest agents most commonly join through **invite-mode handoff**: an agent with
+the `agent_handoff` capability calls `spawn_agent` with `mode = invite`, which
+adds the configured target agent as a **member** participant in the current
+session instead of creating a child session. Addressed turns then route to that
+member. The invited agent contributes only a behavioral overlay during addressed
+turns (prompt, capabilities, model defaults, client tools); its own harness stays
+reserved for child-session modes. See `specs/agent-handoff.md` for the full
+handoff contract and the `invite` vs `background`/`foreground` mode split.
+
+## Surfacing
+
+The session view surfaces participants as an "in this session" rail (roles and
+kinds as badges, with invite/leave controls) and derives join/leave system lines
+in the transcript from `joined_at` / `left_at`. Because no participant SSE event
+exists, this surface is a read/derive over the participants API and does not
+change the session or message contracts.


### PR DESCRIPTION
## What changed
Surfaces **session participants** in the session view and adds the `specs/session-participants.md` spec — the two areas of P2 (EVE-692) that shipped their backend but were never delivered (EVE-759).

Functionally, a multi-party session now shows:
- An **"In this session" rail** listing active participants with **host/member** and **agent/user** badges, an **invite-agent** control, and a per-member **leave/remove** control.
- **Join/leave system lines** in the transcript, derived client-side from each participant's `joined_at`/`left_at` (there is no participant SSE event), interleaved by timestamp.
- An **addressing selector** by the composer that routes a turn to a specific guest agent via `addressed_participant_id` (default = session host responds, unchanged).

Plus the durable spec (`specs/session-participants.md`) documenting the participant model, the one-active-host invariant, host-supplies-harness, addressed-turn routing, provenance anchoring, and invite-mode handoff; cross-linked from `specs/README.md`. `specs/agent-handoff.md` already documents `mode = invite`.

No backend, schema, API, or generated-OpenAPI changes — this is UI + docs over the already-merged participant API.

## Why
The backend exposes `/v1/sessions/{id}/participants`, addressed-turn routing, and invite-mode handoff, but there was no participant surface in the UI (only generated types referenced it) and no dedicated spec. This closes that gap so multi-agent/multi-user sessions are visible and steerable.

## Before / After
Verified locally against `apps/ui`:
- `pnpm run typecheck` (tsgo --noEmit) → clean.
- `pnpm run lint` (oxlint) → clean, exit 0.
- `pnpm run test` (jest) → 130 suites, **1132 tests, 0 failures** (incl. updated `chat-panel.test.tsx`).
- `pnpm run format:check` → all files correctly formatted.
- `pnpm run build` → production build completes.

**Guarded so ordinary 1:1 sessions are byte-identical:** session creation records exactly one host participant, and the acting user is not added as a participant on normal web sends (only the Slack flow does). So a normal session has a single participant, and every surface is gated off:
- Rail returns `null` when `active.length < 2 && left.length === 0`.
- Join/leave markers are produced only when `participants.length >= 2`, and the host's own join is suppressed.
- The addressing selector shows only with ≥2 active agent participants; when no guest is selected the send payload omits `addressed_participant_id` entirely, so the request is unchanged.

The feature only lights up once a member is added (e.g. invite-mode handoff).

## Risk
- **Low.** Additive, UI + docs only; no backend/schema/API change. The transcript change is a logic-preserving refactor (the existing per-event render is wrapped so markers can be prepended); single-participant transcripts render exactly as before.
- Full end-to-end stack smoke (server+worker+infra+browser) was not run in this environment; coverage is the production build, full jest suite, and CI's UI Playwright smoke, plus the additive/guarded design.

## Security
- Threat categories reviewed: **TM-WEB**, **TM-API**, **TM-AUTHZ**.
- Participant list/add/leave and addressed turns call **existing** endpoints whose server-side policies (`SESSION_VIEW`/`SESSION_MANAGE`) and `addressed_participant_id` validation (participant must be active + an agent) are unchanged — the UI cannot bypass them. Labels render as React-escaped text (no `dangerouslySetInnerHTML`); no new dependencies; existing cookie-auth API client.
- Findings and resolutions: **None.** No new security-relevant surface.

## Follow-ups
No follow-ups. Area F and area G of EVE-759 are both delivered; `agent-handoff.md` already covered invite mode.

## Checklist
- [x] Tests added or updated (chat-panel test updated; full jest suite green)
- [x] Backward compatibility considered (guarded; 1:1 sessions unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SewsULJeGVpzQ5opXAv6GT)_