### PR TITLE
feat(agents): agent_triggers data model + storage (EVE-757 A)

### DIFF
--- a/crates/core/src/agent_trigger.rs
+++ b/crates/core/src/agent_trigger.rs
@@ -1,0 +1,109 @@
+// Agent trigger domain types
+//
+// Design Decision:
+// - AgentTrigger is an org-scoped, agent-owned entity that describes how an
+//   agent gets invoked autonomously (e.g. on a schedule). It mirrors the
+//   AgentIdentity CRUD shape (see `agent_identity.rs`).
+// - The concrete per-type configuration lives in `config` (JSONB). Typed
+//   accessors parse it on demand, mirroring `AppChannel::schedule_config()`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// Reuse the app-side invocation/schedule config so schedule triggers and
+// schedule channels share one shape. Do not duplicate these.
+use crate::app::InvocationSessionMode;
+use crate::typed_id::{AgentId, TriggerId};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// The kind of event that fires an agent trigger. Only scheduled triggers exist
+/// today; the enum leaves room for webhook/event triggers later.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum AgentTriggerType {
+    /// Cron-driven schedule trigger.
+    #[default]
+    Schedule,
+}
+
+impl std::fmt::Display for AgentTriggerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AgentTriggerType::Schedule => write!(f, "schedule"),
+        }
+    }
+}
+
+impl From<&str> for AgentTriggerType {
+    fn from(_value: &str) -> Self {
+        // Only one variant exists today; every stored value maps to Schedule.
+        Self::Schedule
+    }
+}
+
+/// Typed configuration for a `Schedule` trigger.
+///
+/// `message` is also the template body. `{{path.to.value}}` placeholders are
+/// expanded at invocation time. Mirrors `app::ScheduleChannelConfig`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ScheduleTriggerConfig {
+    /// Cron expression that drives the durable schedule.
+    pub cron_expression: String,
+    /// IANA timezone identifier for cron evaluation.
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
+    /// Whether invocations reuse a stable session or create a new one.
+    #[serde(default)]
+    pub session_mode: InvocationSessionMode,
+    /// Message content or template sent when the schedule fires.
+    pub message: String,
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
+/// AgentTrigger is a durable, agent-owned invocation trigger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct AgentTrigger {
+    /// External identifier (trg_<32-hex>). Shown as `id` in API.
+    #[serde(rename = "id")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "trg_01933b5a000070008000000000000001"))]
+    pub id: TriggerId,
+    /// Agent that owns this trigger.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a000070008000000000000001"))]
+    pub agent_id: AgentId,
+    /// The kind of event that fires this trigger.
+    pub trigger_type: AgentTriggerType,
+    /// Type-specific configuration (parsed via typed accessors).
+    pub config: serde_json::Value,
+    /// Whether the trigger is currently active.
+    pub enabled: bool,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp.
+    pub updated_at: DateTime<Utc>,
+    /// Archive timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+    /// Delete timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl AgentTrigger {
+    /// Parse `config` as [`ScheduleTriggerConfig`]. Errors if this is not a
+    /// schedule trigger or the config is malformed. Mirrors
+    /// `AppChannel::schedule_config()`.
+    pub fn schedule_config(&self) -> anyhow::Result<ScheduleTriggerConfig> {
+        if self.trigger_type != AgentTriggerType::Schedule {
+            anyhow::bail!("agent trigger {} is not a schedule trigger", self.id);
+        }
+        Ok(serde_json::from_value(self.config.clone())?)
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -84,6 +84,7 @@ pub mod budget;
 // These are DB-agnostic entity types used by both API and worker
 pub mod agent;
 pub mod agent_identity;
+pub mod agent_trigger;
 pub mod app;
 pub mod ard_attachment;
 pub mod capability_dto;
@@ -420,6 +421,7 @@ pub use agent::{
     generate_agent_public_id, validate_addressable_name, validate_agent_public_id,
 };
 pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
+pub use agent_trigger::{AgentTrigger, AgentTriggerType, ScheduleTriggerConfig};
 pub use app::{
     A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, AgentVersionPolicy,
     ApiEndpointChannelConfig, App, AppChannel, AppEndpointAuthConfig, AppEndpointAuthMode,
@@ -526,7 +528,7 @@ pub use typed_id::{
     IdParseError, ImageId, KnowledgeBaseId, KnowledgeEntryId, LeasedResourceId, McpServerId,
     MemoryId, MessageId, ModelId, NotificationId, OrgId, PaymentAccountId, PaymentAttemptId,
     PaymentPolicyId, PluginInstallId, PluginMarketplaceId, PrincipalId, ProviderId, ScheduleId,
-    SessionId, SessionParticipantId, SkillId, TurnId, TypedId, WorkspaceId,
+    SessionId, SessionParticipantId, SkillId, TriggerId, TurnId, TypedId, WorkspaceId,
 };
 pub use wake_queue::{PendingWake, SessionWakeQueue, wake_text_for};
 

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -322,6 +322,13 @@ impl IdMarker for AgentIdentityIdMarker {
     const PREFIX: &'static str = "identity";
 }
 
+/// Marker for agent trigger IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TriggerIdMarker;
+impl IdMarker for TriggerIdMarker {
+    const PREFIX: &'static str = "trg";
+}
+
 /// Marker for principal IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct PrincipalIdMarker;
@@ -624,6 +631,8 @@ pub type AgentVersionId = TypedId<AgentVersionIdMarker>;
 pub type HarnessId = TypedId<HarnessIdMarker>;
 /// Agent identity ID
 pub type AgentIdentityId = TypedId<AgentIdentityIdMarker>;
+/// Agent trigger ID
+pub type TriggerId = TypedId<TriggerIdMarker>;
 /// Principal ID
 pub type PrincipalId = TypedId<PrincipalIdMarker>;
 /// Session ID

--- a/crates/server/migrations/104_agent_triggers.sql
+++ b/crates/server/migrations/104_agent_triggers.sql
@@ -1,0 +1,32 @@
+-- Agent triggers: org-scoped, agent-owned autonomous invocation triggers.
+--
+-- Mirrors the agent_identities CRUD shape (see 008_v0.8.7.sql). The concrete
+-- per-type configuration lives in `config` (JSONB); `durable_schedule_id`
+-- optionally binds a schedule trigger to a durable_schedules row, matching the
+-- app_channels durable-schedule binding (see 021).
+
+CREATE TABLE agent_triggers (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id) DEFAULT 1,
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    trigger_type VARCHAR(50) NOT NULL DEFAULT 'schedule',
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    durable_schedule_id UUID REFERENCES durable_schedules(id) ON DELETE SET NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived', 'deleted')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    archived_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_agent_triggers_org_id ON agent_triggers(org_id);
+CREATE INDEX idx_agent_triggers_agent_id ON agent_triggers(agent_id);
+
+-- At most one trigger may bind a given durable schedule (cf. app_channels, 021).
+CREATE UNIQUE INDEX agent_triggers_durable_schedule_id_idx
+    ON agent_triggers (durable_schedule_id)
+    WHERE durable_schedule_id IS NOT NULL;
+
+CREATE TRIGGER update_agent_triggers_updated_at BEFORE UPDATE ON agent_triggers
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -10,7 +10,7 @@ use everruns_core::message_filter::MessageQuery;
 use everruns_core::typed_id::{
     AgentId, AgentIdentityId, EventId, HarnessId, KnowledgeBaseId, KnowledgeEntryId,
     KnowledgeIndexId, LeasedResourceId, MemoryId, MessageId, NotificationId, PrincipalId,
-    ScheduleId, SessionId, SessionParticipantId, WorkspaceId,
+    ScheduleId, SessionId, SessionParticipantId, TriggerId, WorkspaceId,
 };
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -833,6 +833,68 @@ impl StorageBackend {
 
     pub async fn destroy_agent_identity(&self, org_id: i64, id: AgentIdentityId) -> Result<bool> {
         dispatch!(self, destroy_agent_identity, org_id, id)
+    }
+
+    // ============================================
+    // Agent triggers
+    // ============================================
+
+    pub async fn create_agent_trigger(
+        &self,
+        input: CreateAgentTriggerRow,
+    ) -> Result<AgentTriggerRow> {
+        dispatch!(self, create_agent_trigger, input)
+    }
+
+    pub async fn get_agent_trigger(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+    ) -> Result<Option<AgentTriggerRow>> {
+        dispatch!(self, get_agent_trigger, org_id, id)
+    }
+
+    pub async fn list_agent_triggers(
+        &self,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+        include_archived: bool,
+    ) -> Result<Vec<AgentTriggerRow>> {
+        dispatch!(
+            self,
+            list_agent_triggers,
+            org_id,
+            agent_id,
+            include_archived
+        )
+    }
+
+    pub async fn update_agent_trigger(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+        input: UpdateAgentTrigger,
+    ) -> Result<Option<AgentTriggerRow>> {
+        dispatch!(self, update_agent_trigger, org_id, id, input)
+    }
+
+    pub async fn set_agent_trigger_durable_schedule_id(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+        durable_schedule_id: Option<Uuid>,
+    ) -> Result<Option<AgentTriggerRow>> {
+        dispatch!(
+            self,
+            set_agent_trigger_durable_schedule_id,
+            org_id,
+            id,
+            durable_schedule_id
+        )
+    }
+
+    pub async fn delete_agent_trigger(&self, org_id: i64, id: TriggerId) -> Result<bool> {
+        dispatch!(self, delete_agent_trigger, org_id, id)
     }
 
     // ============================================

--- a/crates/server/src/storage/memory/agent_triggers.rs
+++ b/crates/server/src/storage/memory/agent_triggers.rs
@@ -1,0 +1,133 @@
+// In-memory storage: Agent Trigger CRUD
+
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::Result;
+use everruns_core::{AgentId, TriggerId};
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    // ============================================
+    // Agent Trigger CRUD
+    // ============================================
+
+    pub async fn create_agent_trigger(
+        &self,
+        input: CreateAgentTriggerRow,
+    ) -> Result<AgentTriggerRow> {
+        let row = AgentTriggerRow {
+            id: input.id,
+            org_id: input.org_id,
+            agent_id: input.agent_id,
+            trigger_type: input.trigger_type,
+            config: input.config,
+            enabled: input.enabled,
+            durable_schedule_id: input.durable_schedule_id,
+            status: "active".to_string(),
+            created_at: Self::now(),
+            updated_at: Self::now(),
+            archived_at: None,
+            deleted_at: None,
+        };
+        self.agent_triggers.write().insert(row.id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_agent_trigger(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+    ) -> Result<Option<AgentTriggerRow>> {
+        Ok(self
+            .agent_triggers
+            .read()
+            .get(&id)
+            .filter(|row| row.org_id == org_id)
+            .cloned())
+    }
+
+    pub async fn list_agent_triggers(
+        &self,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+        include_archived: bool,
+    ) -> Result<Vec<AgentTriggerRow>> {
+        let mut rows: Vec<_> = self
+            .agent_triggers
+            .read()
+            .values()
+            .filter(|row| row.org_id == org_id)
+            .filter(|row| row.status != "deleted")
+            .filter(|row| include_archived || row.status != "archived")
+            .filter(|row| agent_id.is_none_or(|aid| row.agent_id == aid))
+            .cloned()
+            .collect();
+        rows.sort_by_key(|row| std::cmp::Reverse(row.created_at));
+        Ok(rows)
+    }
+
+    pub async fn update_agent_trigger(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+        input: UpdateAgentTrigger,
+    ) -> Result<Option<AgentTriggerRow>> {
+        let mut rows = self.agent_triggers.write();
+        let Some(row) = rows.get_mut(&id) else {
+            return Ok(None);
+        };
+        if row.org_id != org_id {
+            return Ok(None);
+        }
+        if let Some(trigger_type) = input.trigger_type {
+            row.trigger_type = trigger_type;
+        }
+        if let Some(config) = input.config {
+            row.config = config;
+        }
+        if let Some(enabled) = input.enabled {
+            row.enabled = enabled;
+        }
+        input
+            .durable_schedule_id
+            .apply(&mut row.durable_schedule_id);
+        if let Some(status) = input.status {
+            row.status = status;
+        }
+        row.updated_at = Self::now();
+        Ok(Some(row.clone()))
+    }
+
+    /// Bind (or clear) the durable schedule backing a trigger.
+    pub async fn set_agent_trigger_durable_schedule_id(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+        durable_schedule_id: Option<Uuid>,
+    ) -> Result<Option<AgentTriggerRow>> {
+        let mut rows = self.agent_triggers.write();
+        let Some(row) = rows.get_mut(&id) else {
+            return Ok(None);
+        };
+        if row.org_id != org_id {
+            return Ok(None);
+        }
+        row.durable_schedule_id = durable_schedule_id;
+        row.updated_at = Self::now();
+        Ok(Some(row.clone()))
+    }
+
+    pub async fn delete_agent_trigger(&self, org_id: i64, id: TriggerId) -> Result<bool> {
+        let mut rows = self.agent_triggers.write();
+        let Some(row) = rows.get_mut(&id) else {
+            return Ok(false);
+        };
+        if row.org_id != org_id || row.status != "active" {
+            return Ok(false);
+        }
+        row.status = "archived".to_string();
+        row.archived_at = Some(Self::now());
+        row.updated_at = Self::now();
+        Ok(true)
+    }
+}

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -11,6 +11,7 @@ mod agent_check_rules;
 mod agent_health_checks;
 mod agent_identities;
 mod agent_identity_connections;
+mod agent_triggers;
 mod agents;
 mod app_channels;
 mod apps;
@@ -57,7 +58,7 @@ use everruns_core::{
     AgentId, AgentIdentityId, AgentVersionId, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, EventId,
     HarnessId, ImageId, LeasedResourceId, McpServerId, MessageId, ModelId, NotificationId,
     PluginMarketplaceId, PrincipalId, ProviderId, ScheduleId, SessionId, SessionParticipantId,
-    SkillId,
+    SkillId, TriggerId,
 };
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -155,6 +156,8 @@ pub struct InMemoryDatabase {
     app_channels: RwLock<HashMap<Uuid, AppChannelRow>>,
     // Agent identities (virtual principals)
     agent_identities: RwLock<HashMap<AgentIdentityId, AgentIdentityRow>>,
+    // Agent triggers (agent-owned invocation triggers)
+    agent_triggers: RwLock<HashMap<TriggerId, AgentTriggerRow>>,
     principals: RwLock<HashMap<PrincipalId, PrincipalRow>>,
     // Agent identity connections (identity-scoped external accounts)
     agent_identity_connections: RwLock<HashMap<Uuid, AgentIdentityConnectionRow>>,
@@ -302,6 +305,7 @@ impl Default for InMemoryDatabase {
             apps: RwLock::new(HashMap::new()),
             app_channels: RwLock::new(HashMap::new()),
             agent_identities: RwLock::new(HashMap::new()),
+            agent_triggers: RwLock::new(HashMap::new()),
             principals: RwLock::new(HashMap::new()),
             agent_identity_connections: RwLock::new(HashMap::new()),
             org_settings: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -3862,3 +3862,197 @@ fn test_normalize_email_trims_and_lowercases() {
     assert_eq!(normalize_email("alice@example.com"), "alice@example.com");
     assert_eq!(normalize_email("\tBob@X.io\n"), "bob@x.io");
 }
+
+// ============================================
+// Agent trigger round-trips (EVE-757)
+// ============================================
+
+fn schedule_trigger_input(agent_id: AgentId) -> CreateAgentTriggerRow {
+    CreateAgentTriggerRow {
+        org_id: DEFAULT_ORG_ID,
+        id: everruns_core::TriggerId::new(),
+        agent_id,
+        trigger_type: "schedule".to_string(),
+        config: serde_json::json!({
+            "cron_expression": "0 0 * * * *",
+            "timezone": "UTC",
+            "session_mode": "shared_session",
+            "message": "hello",
+        }),
+        enabled: true,
+        durable_schedule_id: None,
+    }
+}
+
+#[tokio::test]
+async fn test_agent_trigger_create_get_list_update_delete_round_trip() {
+    let db = InMemoryDatabase::new();
+    let agent_id = AgentId::new();
+
+    // Create
+    let created = db
+        .create_agent_trigger(schedule_trigger_input(agent_id))
+        .await
+        .unwrap();
+    assert_eq!(created.status, "active");
+    assert_eq!(created.trigger_type, "schedule");
+    assert!(created.enabled);
+    assert_eq!(created.agent_id, agent_id);
+
+    // Config round-trips into the typed core accessor.
+    let trigger = everruns_core::AgentTrigger {
+        id: created.id,
+        agent_id: created.agent_id,
+        trigger_type: created.trigger_type.as_str().into(),
+        config: created.config.clone(),
+        enabled: created.enabled,
+        created_at: created.created_at,
+        updated_at: created.updated_at,
+        archived_at: created.archived_at,
+        deleted_at: created.deleted_at,
+    };
+    let schedule = trigger.schedule_config().unwrap();
+    assert_eq!(schedule.cron_expression, "0 0 * * * *");
+    assert_eq!(schedule.message, "hello");
+
+    // Get
+    let fetched = db
+        .get_agent_trigger(DEFAULT_ORG_ID, created.id)
+        .await
+        .unwrap()
+        .expect("trigger exists");
+    assert_eq!(fetched.id, created.id);
+
+    // Cross-org isolation.
+    assert!(
+        db.get_agent_trigger(999, created.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // List
+    let listed = db
+        .list_agent_triggers(DEFAULT_ORG_ID, None, false)
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+
+    // Update
+    let updated = db
+        .update_agent_trigger(
+            DEFAULT_ORG_ID,
+            created.id,
+            UpdateAgentTrigger {
+                enabled: Some(false),
+                config: Some(serde_json::json!({
+                    "cron_expression": "0 5 * * * *",
+                    "message": "updated",
+                })),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .expect("update returns row");
+    assert!(!updated.enabled);
+    assert_eq!(updated.config["message"], serde_json::json!("updated"));
+
+    // Soft delete (archive)
+    assert!(
+        db.delete_agent_trigger(DEFAULT_ORG_ID, created.id)
+            .await
+            .unwrap()
+    );
+    let after_delete = db
+        .get_agent_trigger(DEFAULT_ORG_ID, created.id)
+        .await
+        .unwrap()
+        .expect("row still present after soft delete");
+    assert_eq!(after_delete.status, "archived");
+    assert!(after_delete.archived_at.is_some());
+
+    // Archived rows are excluded unless include_archived.
+    assert!(
+        db.list_agent_triggers(DEFAULT_ORG_ID, None, false)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        db.list_agent_triggers(DEFAULT_ORG_ID, None, true)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Second delete is a no-op (already archived, not active).
+    assert!(
+        !db.delete_agent_trigger(DEFAULT_ORG_ID, created.id)
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_agent_trigger_set_durable_schedule_id() {
+    let db = InMemoryDatabase::new();
+    let created = db
+        .create_agent_trigger(schedule_trigger_input(AgentId::new()))
+        .await
+        .unwrap();
+    assert!(created.durable_schedule_id.is_none());
+
+    let schedule_id = uuid::Uuid::now_v7();
+    let bound = db
+        .set_agent_trigger_durable_schedule_id(DEFAULT_ORG_ID, created.id, Some(schedule_id))
+        .await
+        .unwrap()
+        .expect("bind returns row");
+    assert_eq!(bound.durable_schedule_id, Some(schedule_id));
+
+    // Clearing the binding works too.
+    let cleared = db
+        .set_agent_trigger_durable_schedule_id(DEFAULT_ORG_ID, created.id, None)
+        .await
+        .unwrap()
+        .expect("clear returns row");
+    assert!(cleared.durable_schedule_id.is_none());
+}
+
+#[tokio::test]
+async fn test_agent_trigger_list_filters_by_agent() {
+    let db = InMemoryDatabase::new();
+    let agent_a = AgentId::new();
+    let agent_b = AgentId::new();
+
+    db.create_agent_trigger(schedule_trigger_input(agent_a))
+        .await
+        .unwrap();
+    db.create_agent_trigger(schedule_trigger_input(agent_a))
+        .await
+        .unwrap();
+    db.create_agent_trigger(schedule_trigger_input(agent_b))
+        .await
+        .unwrap();
+
+    let for_a = db
+        .list_agent_triggers(DEFAULT_ORG_ID, Some(agent_a), false)
+        .await
+        .unwrap();
+    assert_eq!(for_a.len(), 2);
+    assert!(for_a.iter().all(|t| t.agent_id == agent_a));
+
+    let for_b = db
+        .list_agent_triggers(DEFAULT_ORG_ID, Some(agent_b), false)
+        .await
+        .unwrap();
+    assert_eq!(for_b.len(), 1);
+
+    let all = db
+        .list_agent_triggers(DEFAULT_ORG_ID, None, false)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 3);
+}

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -5,7 +5,7 @@ use everruns_core::{
     AgentId, AgentIdentityId, EventId, HarnessId, ImageId, LeasedResourceId, McpServerId,
     MessageId, ModelId, NotificationId, PrincipalId, ProviderId, ScheduleId, ServiceKind,
     SessionId, SessionParticipant, SessionParticipantId, SessionParticipantKind,
-    SessionParticipantRole, SkillId,
+    SessionParticipantRole, SkillId, TriggerId,
 };
 use everruns_durable::UpdateField;
 use sqlx::FromRow;
@@ -2445,6 +2445,46 @@ pub struct UpdateAgentIdentity {
     pub avatar_url: UpdateField<String>,
     pub locale: UpdateField<String>,
     pub timezone: UpdateField<String>,
+    pub status: Option<String>,
+}
+
+// ============================================
+// Agent trigger models (agent-owned invocation triggers)
+// ============================================
+
+#[derive(Debug, Clone, FromRow)]
+pub struct AgentTriggerRow {
+    pub id: TriggerId,
+    pub org_id: i64,
+    pub agent_id: AgentId,
+    pub trigger_type: String,
+    pub config: serde_json::Value,
+    pub enabled: bool,
+    pub durable_schedule_id: Option<Uuid>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub archived_at: Option<DateTime<Utc>>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateAgentTriggerRow {
+    pub org_id: i64,
+    pub id: TriggerId,
+    pub agent_id: AgentId,
+    pub trigger_type: String,
+    pub config: serde_json::Value,
+    pub enabled: bool,
+    pub durable_schedule_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UpdateAgentTrigger {
+    pub trigger_type: Option<String>,
+    pub config: Option<serde_json::Value>,
+    pub enabled: Option<bool>,
+    pub durable_schedule_id: UpdateField<Uuid>,
     pub status: Option<String>,
 }
 

--- a/crates/server/src/storage/repositories/agent_triggers.rs
+++ b/crates/server/src/storage/repositories/agent_triggers.rs
@@ -1,0 +1,156 @@
+// PostgreSQL repository: Agent Trigger CRUD
+
+use super::super::models::*;
+use super::Database;
+use anyhow::Result;
+use everruns_core::{AgentId, TriggerId};
+use uuid::Uuid;
+
+const COLUMNS: &str = "id, org_id, agent_id, trigger_type, config, enabled, durable_schedule_id, status, created_at, updated_at, archived_at, deleted_at";
+
+impl Database {
+    // ============================================
+    // Agent Trigger CRUD
+    // ============================================
+
+    pub async fn create_agent_trigger(
+        &self,
+        input: CreateAgentTriggerRow,
+    ) -> Result<AgentTriggerRow> {
+        let row = sqlx::query_as::<_, AgentTriggerRow>(
+            r#"
+            INSERT INTO agent_triggers (org_id, id, agent_id, trigger_type, config, enabled, durable_schedule_id, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, 'active')
+            RETURNING id, org_id, agent_id, trigger_type, config, enabled, durable_schedule_id, status, created_at, updated_at, archived_at, deleted_at
+            "#,
+        )
+        .bind(input.org_id)
+        .bind(input.id)
+        .bind(input.agent_id)
+        .bind(&input.trigger_type)
+        .bind(&input.config)
+        .bind(input.enabled)
+        .bind(input.durable_schedule_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_agent_trigger(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+    ) -> Result<Option<AgentTriggerRow>> {
+        let sql = format!("SELECT {COLUMNS} FROM agent_triggers WHERE org_id = $1 AND id = $2");
+        let row = sqlx::query_as::<_, AgentTriggerRow>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(org_id)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_agent_triggers(
+        &self,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+        include_archived: bool,
+    ) -> Result<Vec<AgentTriggerRow>> {
+        let status_sql = if include_archived {
+            " AND status != 'deleted'"
+        } else {
+            " AND status NOT IN ('archived', 'deleted')"
+        };
+        let agent_sql = if agent_id.is_some() {
+            " AND agent_id = $2"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "SELECT {COLUMNS} FROM agent_triggers WHERE org_id = $1{status_sql}{agent_sql} ORDER BY created_at DESC"
+        );
+        let mut query =
+            sqlx::query_as::<_, AgentTriggerRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        if let Some(agent_id) = agent_id {
+            query = query.bind(agent_id);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
+    }
+
+    pub async fn update_agent_trigger(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+        input: UpdateAgentTrigger,
+    ) -> Result<Option<AgentTriggerRow>> {
+        let row = sqlx::query_as::<_, AgentTriggerRow>(
+            r#"
+            UPDATE agent_triggers
+            SET
+                trigger_type = COALESCE($3, trigger_type),
+                config = COALESCE($4, config),
+                enabled = COALESCE($5, enabled),
+                durable_schedule_id = CASE WHEN $6 THEN $7 ELSE durable_schedule_id END,
+                status = COALESCE($8, status),
+                updated_at = NOW()
+            WHERE org_id = $1 AND id = $2
+            RETURNING id, org_id, agent_id, trigger_type, config, enabled, durable_schedule_id, status, created_at, updated_at, archived_at, deleted_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .bind(&input.trigger_type)
+        .bind(&input.config)
+        .bind(input.enabled)
+        .bind(input.durable_schedule_id.is_changed())
+        .bind(input.durable_schedule_id.into_value())
+        .bind(&input.status)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Bind (or clear) the durable schedule backing a trigger. Mirrors the
+    /// app_channel durable-schedule binding update.
+    pub async fn set_agent_trigger_durable_schedule_id(
+        &self,
+        org_id: i64,
+        id: TriggerId,
+        durable_schedule_id: Option<Uuid>,
+    ) -> Result<Option<AgentTriggerRow>> {
+        let row = sqlx::query_as::<_, AgentTriggerRow>(
+            r#"
+            UPDATE agent_triggers
+            SET durable_schedule_id = $3, updated_at = NOW()
+            WHERE org_id = $1 AND id = $2
+            RETURNING id, org_id, agent_id, trigger_type, config, enabled, durable_schedule_id, status, created_at, updated_at, archived_at, deleted_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .bind(durable_schedule_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn delete_agent_trigger(&self, org_id: i64, id: TriggerId) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE agent_triggers
+            SET status = 'archived', archived_at = COALESCE(archived_at, NOW()), updated_at = NOW()
+            WHERE org_id = $1 AND id = $2 AND status = 'active'
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -5,6 +5,7 @@ mod agent_check_rules;
 mod agent_health_checks;
 mod agent_identities;
 mod agent_identity_connections;
+mod agent_triggers;
 mod agents;
 mod app_channels;
 mod apps;

--- a/crates/server/tests/repository_conformance_test.rs
+++ b/crates/server/tests/repository_conformance_test.rs
@@ -9,13 +9,14 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use everruns_core::TriggerId;
 use everruns_core::message_filter::MessageQuery;
 use everruns_core::{AgentId, DEFAULT_ORG_ID, HarnessId, PrincipalId};
 use everruns_server::org_init;
 use everruns_server::storage::{
-    CreateAgentRow, CreateBudgetRow, CreateEventRow, CreatePrincipalRow, CreateProviderRow,
-    CreateSessionRow, CreateUsageJournalRow, CreateUsageLedgerRow, Database, MESSAGE_SAFETY_LIMIT,
-    Repository, StorageBackend,
+    CreateAgentRow, CreateAgentTriggerRow, CreateBudgetRow, CreateEventRow, CreatePrincipalRow,
+    CreateProviderRow, CreateSessionRow, CreateUsageJournalRow, CreateUsageLedgerRow, Database,
+    MESSAGE_SAFETY_LIMIT, Repository, StorageBackend, UpdateAgentTrigger,
 };
 use test_harness::get_database_url;
 
@@ -309,11 +310,108 @@ async fn run_repository_conformance(repo: &dyn Repository, label: &str, harness_
     );
 }
 
+/// Dual-backend round-trip for agent triggers (EVE-757): create -> get -> list
+/// (with agent filter) -> update -> bind durable schedule -> soft delete. Runs
+/// against both the in-memory and PostgreSQL backends via `StorageBackend`.
+async fn run_agent_trigger_conformance(
+    backend: &StorageBackend,
+    label: &str,
+    harness_id: HarnessId,
+) {
+    // A real agent is required so the PostgreSQL FK is satisfied.
+    let (agent, _) = backend
+        .upsert_agent_by_name(
+            DEFAULT_ORG_ID,
+            agent_input(format!("trigger-owner-{label}"), harness_id),
+        )
+        .await
+        .expect("create agent");
+
+    let created = backend
+        .create_agent_trigger(CreateAgentTriggerRow {
+            org_id: DEFAULT_ORG_ID,
+            id: TriggerId::new(),
+            agent_id: agent.id,
+            trigger_type: "schedule".to_string(),
+            config: json!({
+                "cron_expression": "0 0 * * * *",
+                "timezone": "UTC",
+                "session_mode": "shared_session",
+                "message": "hello",
+            }),
+            enabled: true,
+            durable_schedule_id: None,
+        })
+        .await
+        .expect("create agent trigger");
+    assert_eq!(created.status, "active");
+    assert_eq!(created.agent_id, agent.id);
+
+    let fetched = backend
+        .get_agent_trigger(DEFAULT_ORG_ID, created.id)
+        .await
+        .expect("get agent trigger")
+        .expect("trigger exists");
+    assert_eq!(fetched.id, created.id);
+
+    let by_agent = backend
+        .list_agent_triggers(DEFAULT_ORG_ID, Some(agent.id), false)
+        .await
+        .expect("list by agent");
+    assert!(by_agent.iter().any(|t| t.id == created.id));
+    assert!(by_agent.iter().all(|t| t.agent_id == agent.id));
+
+    let updated = backend
+        .update_agent_trigger(
+            DEFAULT_ORG_ID,
+            created.id,
+            UpdateAgentTrigger {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update agent trigger")
+        .expect("update returns row");
+    assert!(!updated.enabled);
+
+    // Clearing the durable schedule binding round-trips (a NULL binding avoids
+    // needing a real durable_schedules row for the FK).
+    let cleared = backend
+        .set_agent_trigger_durable_schedule_id(DEFAULT_ORG_ID, created.id, None)
+        .await
+        .expect("clear durable schedule")
+        .expect("returns row");
+    assert!(cleared.durable_schedule_id.is_none());
+
+    assert!(
+        backend
+            .delete_agent_trigger(DEFAULT_ORG_ID, created.id)
+            .await
+            .expect("soft delete")
+    );
+    let archived = backend
+        .get_agent_trigger(DEFAULT_ORG_ID, created.id)
+        .await
+        .expect("get after delete")
+        .expect("row present after soft delete");
+    assert_eq!(archived.status, "archived");
+    assert!(
+        !backend
+            .list_agent_triggers(DEFAULT_ORG_ID, None, false)
+            .await
+            .expect("list active")
+            .iter()
+            .any(|t| t.id == created.id)
+    );
+}
+
 #[tokio::test]
 async fn in_memory_repository_conformance() {
     let backend = StorageBackend::in_memory();
     let harness_id = HarnessId::from_uuid(Uuid::nil());
     run_repository_conformance(&backend, "memory", harness_id).await;
+    run_agent_trigger_conformance(&backend, "memory", harness_id).await;
 }
 
 #[tokio::test]
@@ -326,4 +424,5 @@ async fn postgres_repository_conformance() {
         .await
         .expect("generic harness id");
     run_repository_conformance(&backend, "postgres", harness_id).await;
+    run_agent_trigger_conformance(&backend, "postgres", harness_id).await;
 }


### PR DESCRIPTION
## What changed
First slice (**sub-task A**) of the **P4 agent-triggers epic (EVE-757)** — the purely-additive **data layer** for an agent-owned, org-scoped autonomous invocation trigger. It introduces the `agent_triggers` entity end-to-end through storage, with **no** API routes, durable-scheduler binding, or App changes yet (those land in follow-up sub-PRs B/C/D). Nothing calls this code at runtime, so there is no behavior change.

- **`TriggerId`** (`trg_`) typed id.
- **Core domain type** `AgentTrigger` + `AgentTriggerType` (`schedule`) + `ScheduleTriggerConfig` (`cron_expression`, `timezone`, `session_mode`, `message`) — reuses `app::InvocationSessionMode` (no duplication) — with a `schedule_config()` accessor mirroring `AppChannel::schedule_config()`.
- **Migration `104_agent_triggers`** — org-scoped table with `agent_id` FK (`ON DELETE CASCADE`), JSONB `config`, `enabled`, `durable_schedule_id` binding (unique partial index, cf. `app_channels`/`021`), and `status` lifecycle. Mirrors the `agent_identities` shape.
- **Storage parity (Postgres + in-memory)** for create / get / list (optionally by agent) / update / soft-delete / `set_durable_schedule_id`, exposed through the `StorageBackend` dispatch enum.

## Why
P4 makes an Agent proactive (wakes itself on a schedule). This is the foundation the rest of the epic builds on: sub-task B adds the CRUD API + durable-schedule binding, C adds the `invoke_agent_trigger` execution activity. Landing the additive data layer first keeps each PR small, reviewable, and low-risk (the epic explicitly lists A–F as individually landable).

## Before / After
- **Before:** no `agent_triggers` table/type.
- **After:** the entity round-trips on both storage backends. Verified locally:
  - `cargo clippy -p everruns-core -p everruns-server --all-targets --all-features -- -D warnings` → clean (exit 0).
  - `cargo test -p everruns-server --lib storage::memory::tests` → 88 passed / 0 failed (incl. 3 new `agent_trigger` round-trip tests: CRUD, cross-org isolation, `include_archived`, durable-schedule bind/clear, agent filtering).
  - `cargo fmt --check` → clean; `bash scripts/lib/check-migration-ordering.sh` → `001..104` sequential.
  - The Postgres conformance/integration path compiles; its live execution is covered by CI's **Integration Tests (PostgreSQL)** job (no local DB available in this environment).

## Risk
- **Low.** Additive only — new id, new table, new storage methods; nothing invokes them yet. No existing schema, API, or behavior touched. New migration `104` is the next sequential number with no collisions on `main`.

## Security
- Threat categories reviewed: **TM-TENANT**, **TM-SQL**.
- Every query is org-scoped (`WHERE org_id = $1 ...`), and cross-org isolation is unit-tested. All SQL is parameterized; the only dynamically-assembled SQL is a fixed column list and constant status-filter fragments (no user input concatenated). No auth surface yet (added with the API in sub-task B).
- Findings and resolutions: **None.**

## Follow-ups
- **EVE-757 B** — CRUD API `/v1/agents/{agent_id}/triggers` + durable-schedule binding lifecycle + manual trigger endpoint.
- **EVE-757 C** — `invoke_agent_trigger` execution activity (renders the template, creates/reuses a session per `session_mode`, owned by the agent identity principal).
- **EVE-757 D/E/F** — App schedule-channel migration (gated on the epic's open decisions), UI Triggers tab, and specs.
These are tracked on EVE-757; the epic stays In Progress until its acceptance is met.

## Checklist
- [x] Tests added or updated (in-memory round-trips + dual-backend conformance)
- [x] Backward compatibility considered (purely additive; nothing wired yet)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SewsULJeGVpzQ5opXAv6GT)_