### PR TITLE
fix(ci): free runner disk in pure unit-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # This job builds the most of any single CI job: provider crates, the full
+      # runtime, the CLI, and all integration crates share one target/ dir. Their
+      # rlibs plus the linker's temporary output exhausted the runner's disk mid-
+      # link (`ld terminated with signal 7 [Bus error]`, 36 MB free). Reclaim the
+      # ~25 GB of preinstalled tooling this job never uses before building.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
+            /usr/local/share/chromium /usr/local/lib/node_modules
+          df -h /
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
 


### PR DESCRIPTION
## What changed
The `Unit Tests (Pure)` CI job now frees the runner's preinstalled tooling before it builds. No product behavior changes — this only affects CI infrastructure.

## Why
Main CI went red (run [#9063](https://github.com/everruns/everruns/actions/runs/29297812306), commit `c0626457`) with a linker crash, **not** a test or code failure:

```
##[warning]You are running out of disk space. Free space left: 36 MB
error: linking with `cc` failed
collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
error: could not compile `everruns-integrations-ard` (test "tool_integration")
```

`Unit Tests (Pure)` is the heaviest single CI job: it builds the provider crates, the full runtime, the CLI, and all integration crates into one shared `target/` dir. Every test passed — the runner simply ran out of disk *during linking* of the last crate, so `ld` died with a bus error. The dev profile already minimizes debug info (`debug = "line-tables-only"`), so reclaiming disk is the remaining lever.

## Before / After
- **Before:** the job accumulates `target/` artifacts across every `cargo test` invocation until the runner's default ~14 GB free is exhausted mid-link (36 MB free observed → `ld` bus error → red main).
- **After:** a `Free disk space` step removes ~25 GB of preinstalled tooling the job never uses (dotnet, Android SDK, GHC, CodeQL, PowerShell, bundled Chromium/node) and prints `df -h /`, giving the linker headroom.
- **Proof:** on this PR's run, the `everruns-integrations-ard` crate — the exact crate whose link crashed on main — compiled and passed all 38 tests (`Finished test profile in 3.37s`; 33 lib + 5 `tool_integration` tests ok). The whole `Unit Tests (Pure)` job is green with the disk-free step in place, so the fix is validated directly rather than relying on a lucky fresh runner.

## Risk
- Low
- The only failure mode is a future runner-image change renaming one of the removed paths; `rm -rf` on a missing path is a no-op, so a stale entry cannot break the job. No third-party action is introduced (inline shell only — no new supply-chain surface). No product code, API, or migration is touched.

## Security
- Threat categories reviewed: none of the product threat-model categories (`TM-*`) apply — this changes CI infrastructure only, not runtime code, auth, data paths, or trust boundaries.
- Findings and resolutions: None. The step runs `sudo rm -rf` against a fixed allowlist of well-known runner-preinstalled directories on the ephemeral runner; no untrusted input is interpolated, no secrets are read or exposed, and no marketplace action is added.

## Follow-ups
- The other heavy Rust jobs (`Worker Tests`, PostgreSQL integration) build less than this job and have not hit the limit, but if disk pressure spreads, factor this step into a shared composite action rather than duplicating it. Deferred because those jobs are currently healthy and premature extraction would add indirection with no present payoff.

## Checklist
- [x] Tests added or updated — N/A (CI-config-only change; the job's own run is the test)
- [x] Backward compatibility considered — no runtime/API surface touched
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)