### PR TITLE
refactor(core): unify spawn agent modes

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -12,7 +12,7 @@ use super::delegation_result::{
 };
 use super::{
     Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SESSION_TASKS_CAPABILITY_ID,
-    SystemPromptContext,
+    SpawnMode, SystemPromptContext,
 };
 use crate::network_access::NetworkAccessList;
 use crate::session_task::{
@@ -287,7 +287,7 @@ impl Capability for A2aAgentDelegationCapability {
         Some(format!(
             "<capability id=\"{}\">\n\
 Delegate work to configured external A2A agents with spawn_agent.\n\
-Use mode=\"background\" for long-running work; use wait_task (from session_tasks) later for results.\n\
+Use mode=\"background\" for long-running work and wait_task (from session_tasks) later for results; use mode=\"foreground\" when blocked on the result.\n\
 Use message_task for follow-up input or input_required tasks; use cancel_task to stop a remote task.\n\
 Available external agents:\n{}\n\
 </capability>",
@@ -502,25 +502,6 @@ impl From<&TaskState> for AgentRunStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum AgentRunMode {
-    Wait,
-    Background,
-}
-
-impl AgentRunMode {
-    fn parse(value: Option<&str>) -> std::result::Result<Self, String> {
-        match value.unwrap_or("wait") {
-            "wait" => Ok(Self::Wait),
-            "background" => Ok(Self::Background),
-            other => Err(format!(
-                "Invalid mode: {other}. Expected wait or background"
-            )),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct AgentRunRecord {
     run_id: String,
@@ -529,7 +510,7 @@ struct AgentRunRecord {
     external_agent_name: String,
     #[serde(alias = "task")]
     instructions: String,
-    mode: AgentRunMode,
+    mode: SpawnMode,
     status: AgentRunStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     remote_task_id: Option<String>,
@@ -572,7 +553,7 @@ impl AgentRunRecord {
         run_id: String,
         agent: &ExternalA2aAgentConfig,
         instructions: String,
-        mode: AgentRunMode,
+        mode: SpawnMode,
         wake_on_completion: bool,
         result_schema: Option<Value>,
     ) -> Self {
@@ -1345,7 +1326,7 @@ impl Tool for SpawnAgentTool {
     }
 
     fn description(&self) -> &str {
-        "Delegate a task to a configured external A2A agent. Supports wait and background modes."
+        "Delegate a task to a configured external A2A agent in foreground or background mode."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1357,12 +1338,13 @@ impl Tool for SpawnAgentTool {
                     "type": "object",
                     "properties": {
                         "type": {"type": "string", "enum": ["external_a2a"]},
-                        "external_agent_id": {"type": "string"}
+                        "id": {"type": "string", "description": "Configured external A2A agent id."},
+                        "external_agent_id": {"type": "string", "description": "Deprecated provider-specific spelling; prefer target.id."}
                     },
-                    "required": ["type", "external_agent_id"],
+                    "required": ["type"],
                     "additionalProperties": false
                 },
-                "mode": {"type": "string", "enum": ["wait", "background"], "default": "wait"},
+                "mode": {"type": "string", "enum": ["background", "foreground"], "default": "foreground"},
                 "wait_timeout_secs": {"type": "integer", "minimum": 1, "maximum": 86400},
                 "wake_on_completion": {"type": "boolean", "default": true},
                 "result_schema": {"type": "object", "description": "JSON Schema for a required structured result artifact from the external agent."},
@@ -1411,16 +1393,15 @@ impl Tool for SpawnAgentTool {
             );
         }
         let external_agent_id = match target
-            .get("external_agent_id")
+            .get("id")
+            .or_else(|| target.get("external_agent_id"))
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
             Some(id) => id,
             None => {
-                return ToolExecutionResult::tool_error(
-                    "Missing required parameter: target.external_agent_id",
-                );
+                return ToolExecutionResult::tool_error("Missing required parameter: target.id");
             }
         };
         let Some(agent) = self.config.agent(external_agent_id).cloned() else {
@@ -1428,9 +1409,14 @@ impl Tool for SpawnAgentTool {
                 "Unknown external A2A agent: {external_agent_id}"
             ));
         };
-        let mode = match AgentRunMode::parse(arguments.get("mode").and_then(Value::as_str)) {
-            Ok(mode) => mode,
-            Err(e) => return ToolExecutionResult::tool_error(e),
+        let mode = match arguments.get("mode").and_then(Value::as_str) {
+            None => SpawnMode::Foreground,
+            Some(value) if let Some(mode) = SpawnMode::parse(value) => mode,
+            Some(other) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid mode: {other}. Expected background, foreground"
+                ));
+            }
         };
         let timeout_secs = arguments
             .get("wait_timeout_secs")
@@ -1464,7 +1450,7 @@ impl Tool for SpawnAgentTool {
             run_id.clone(),
             &agent,
             instructions.clone(),
-            mode.clone(),
+            mode,
             wake_on_completion,
             result_schema.clone(),
         );
@@ -1491,14 +1477,14 @@ impl Tool for SpawnAgentTool {
                         state: SessionTaskState::Queued,
                         links: TaskLinks::default(),
                         wake_policy: match mode {
-                            AgentRunMode::Background => TaskWakePolicy::OnTerminal,
-                            AgentRunMode::Wait => TaskWakePolicy::Silent,
+                            SpawnMode::Background => TaskWakePolicy::OnTerminal,
+                            SpawnMode::Foreground => TaskWakePolicy::Silent,
                         },
                     })
                     .await
                 {
                     Ok(created) => record.task_id = Some(created.id),
-                    Err(e) if mode == AgentRunMode::Background || result_schema.is_some() => {
+                    Err(e) if mode == SpawnMode::Background || result_schema.is_some() => {
                         // Background runs must be task-backed before remote work
                         // starts; surface this as a user-facing tool error (per
                         // the capability contract) rather than an internal error,
@@ -1511,7 +1497,7 @@ impl Tool for SpawnAgentTool {
                     Err(_) => {}
                 }
             }
-            None if mode == AgentRunMode::Background => {
+            None if mode == SpawnMode::Background => {
                 return ToolExecutionResult::tool_error(
                     "Background spawn_agent requires session_task_registry context so the run can be controlled with wait_task/message_task/cancel_task",
                 );
@@ -1530,7 +1516,7 @@ impl Tool for SpawnAgentTool {
             return ToolExecutionResult::success(record.public_json());
         }
         match mode {
-            AgentRunMode::Background => {
+            SpawnMode::Background => {
                 let context = context.clone();
                 // Capture the attempt at spawn time (1 for a fresh spawn).
                 // The heartbeat loop uses this to fence stale writes from any
@@ -1549,7 +1535,7 @@ impl Tool for SpawnAgentTool {
                 });
                 ToolExecutionResult::success(record.public_json())
             }
-            AgentRunMode::Wait => {
+            SpawnMode::Foreground => {
                 // Foreground wait: the tool executor owns the call stack so no
                 // separate heartbeat thread is needed; pass None.
                 match wait_for_run(context, &agent, record, timeout_secs, None).await {
@@ -2124,7 +2110,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_agent_wait_calls_real_a2a_agent() {
+    async fn spawn_agent_foreground_calls_real_a2a_agent_with_target_id_alias() {
         let base_url = spawn_real_a2a_agent().await;
         let config = configured_capability(base_url);
         let tool = SpawnAgentTool::new(config);
@@ -2136,8 +2122,8 @@ mod tests {
             .execute_with_context(
                 json!({
                     "instructions": "hello",
-                    "target": {"type": "external_a2a", "external_agent_id": "echo"},
-                    "mode": "wait",
+                    "target": {"type": "external_a2a", "id": "echo"},
+                    "mode": "foreground",
                     "wait_timeout_secs": 5
                 }),
                 &ctx,
@@ -2153,7 +2139,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_agent_wait_validates_a2a_data_artifact_and_writes_task_result() {
+    async fn spawn_agent_rejects_legacy_wait_mode() {
+        let tool = SpawnAgentTool::new(configured_capability("http://127.0.0.1:1".to_string()));
+        let ctx = context(
+            Arc::new(TestStorageStore::default()),
+            Arc::new(TestFileStore::default()),
+        );
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "instructions": "never sent",
+                    "target": {"type": "external_a2a", "external_agent_id": "echo"},
+                    "mode": "wait"
+                }),
+                &ctx,
+            )
+            .await;
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("expected legacy mode rejection: {result:?}");
+        };
+        assert!(message.contains("background, foreground"));
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_foreground_validates_a2a_data_artifact_and_writes_task_result() {
         let tool = SpawnAgentTool::new(configured_capability(spawn_real_a2a_agent().await));
         let storage_store = Arc::new(TestStorageStore::default());
         let file_store = Arc::new(TestFileStore::default());
@@ -2166,7 +2175,7 @@ mod tests {
                 json!({
                     "instructions": "structured",
                     "target": {"type": "external_a2a", "external_agent_id": "echo"},
-                    "mode": "wait",
+                    "mode": "foreground",
                     "wait_timeout_secs": 5,
                     "result_schema": {
                         "type": "object",
@@ -2207,7 +2216,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_agent_wait_marks_a2a_schema_mismatch_failed() {
+    async fn spawn_agent_foreground_marks_a2a_schema_mismatch_failed() {
         let tool = SpawnAgentTool::new(configured_capability(spawn_real_a2a_agent().await));
         let storage_store = Arc::new(TestStorageStore::default());
         let file_store = Arc::new(TestFileStore::default());
@@ -2219,7 +2228,7 @@ mod tests {
                 json!({
                     "instructions": "structured",
                     "target": {"type": "external_a2a", "external_agent_id": "echo"},
-                    "mode": "wait",
+                    "mode": "foreground",
                     "wait_timeout_secs": 5,
                     "result_schema": {
                         "type": "object",
@@ -2317,6 +2326,13 @@ mod tests {
             }))
             .is_err()
         );
+
+        let tool_schema = SpawnAgentTool::new(A2aDelegationConfig::default()).parameters_schema();
+        assert_eq!(
+            tool_schema["properties"]["mode"]["enum"],
+            json!(["background", "foreground"])
+        );
+        assert!(tool_schema["properties"]["target"]["properties"]["id"].is_object());
     }
 
     #[test]
@@ -2347,7 +2363,7 @@ mod tests {
             "run-policy".to_string(),
             &config,
             "instructions".to_string(),
-            AgentRunMode::Background,
+            SpawnMode::Background,
             false,
             None,
         );
@@ -2761,7 +2777,7 @@ mod tests {
             run_id.clone(),
             &config,
             "instructions".to_string(),
-            AgentRunMode::Background,
+            SpawnMode::Background,
             false,
             None,
         );
@@ -2864,7 +2880,7 @@ mod tests {
             run_id.clone(),
             &config,
             "instructions".to_string(),
-            AgentRunMode::Background,
+            SpawnMode::Background,
             false,
             None,
         );
@@ -2961,7 +2977,7 @@ mod tests {
             run_id.clone(),
             &config,
             "instructions".to_string(),
-            AgentRunMode::Background,
+            SpawnMode::Background,
             false,
             None,
         );
@@ -3000,7 +3016,7 @@ mod tests {
             "external_agent_id": "echo",
             "external_agent_name": "Echo",
             "task": "legacy instructions",
-            "mode": "wait",
+            "mode": "foreground",
             "status": "submitted"
         });
 
@@ -3036,7 +3052,7 @@ mod tests {
             run_id.clone(),
             &config,
             "do something".to_string(),
-            AgentRunMode::Wait,
+            SpawnMode::Foreground,
             false,
             None,
         );

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -11,7 +11,9 @@ use super::delegation_result::{
     normalize_result_schema, required_result_is_missing, result_value_for_task,
 };
 use super::util::{get_platform_store, require_str_nonblank as require_str};
-use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SystemPromptContext};
+use super::{
+    Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SpawnMode, SystemPromptContext,
+};
 use crate::config_layer::{AgentConfigOverlay, normalize_initial_file_path};
 use crate::harness::Harness;
 use crate::platform_store::PlatformCreateSessionRequest;
@@ -375,11 +377,9 @@ impl AgentHandoffTargetConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SpawnAgentHandoffMode {
-    Background,
-    Foreground,
+    Spawn(SpawnMode),
     Invite,
 }
 
@@ -387,8 +387,7 @@ impl SpawnAgentHandoffMode {
     fn parse(value: Option<&str>, context: &ToolContext) -> std::result::Result<Self, String> {
         let explicit = match value.map(str::trim).filter(|s| !s.is_empty()) {
             None => None,
-            Some("background") => Some(Self::Background),
-            Some("foreground") => Some(Self::Foreground),
+            Some(value) if let Some(mode) = SpawnMode::parse(value) => Some(Self::Spawn(mode)),
             Some("invite") => Some(Self::Invite),
             Some(other) => {
                 return Err(format!(
@@ -398,22 +397,25 @@ impl SpawnAgentHandoffMode {
         };
         let has_registry = context.session_task_registry.is_some();
         match explicit {
-            Some(Self::Background) if !has_registry => Err(
+            Some(Self::Spawn(SpawnMode::Background)) if !has_registry => Err(
                 "Background mode requires a session task registry, which is not available in this environment. Use mode: \"foreground\" instead."
                     .to_string(),
             ),
             Some(mode) => Ok(mode),
-            None if has_registry => Ok(Self::Background),
-            None => Ok(Self::Foreground),
+            None if has_registry => Ok(Self::Spawn(SpawnMode::Background)),
+            None => Ok(Self::Spawn(SpawnMode::Foreground)),
         }
     }
 
     fn as_str(self) -> &'static str {
         match self {
-            Self::Background => "background",
-            Self::Foreground => "foreground",
+            Self::Spawn(mode) => mode.as_str(),
             Self::Invite => "invite",
         }
+    }
+
+    fn is_invite(self) -> bool {
+        self == Self::Invite
     }
 }
 
@@ -945,9 +947,7 @@ impl Tool for SpawnAgentHandoffTool {
             Ok(schema) => schema,
             Err(error) => return error,
         };
-        if mode == SpawnAgentHandoffMode::Invite
-            && (result_schema.is_some() || message_schema.is_some())
-        {
+        if mode.is_invite() && (result_schema.is_some() || message_schema.is_some()) {
             return ToolExecutionResult::tool_error(
                 "result_schema and message_schema require a child task and are not valid for invite-mode agent handoffs.",
             );
@@ -959,7 +959,7 @@ impl Tool for SpawnAgentHandoffTool {
                 "result_schema and message_schema require session_task_registry context for agent handoffs.",
             );
         }
-        if lifetime == HandoffLifetime::Detached && mode == SpawnAgentHandoffMode::Invite {
+        if lifetime == HandoffLifetime::Detached && mode.is_invite() {
             return ToolExecutionResult::tool_error(
                 "lifetime=\"detached\" is only valid for agent handoffs that create a new session; invite mode joins the current session.",
             );
@@ -987,7 +987,7 @@ impl Tool for SpawnAgentHandoffTool {
             );
         }
 
-        if mode == SpawnAgentHandoffMode::Invite {
+        if mode.is_invite() {
             let (host_overlay, guest_overlay) =
                 match invite_mode_overlays(store, &parent_session, target).await {
                     Ok(overlays) => overlays,
@@ -1078,15 +1078,21 @@ impl Tool for SpawnAgentHandoffTool {
                     },
                     wake_policy: match (lifetime, mode, message_schema.is_some()) {
                         (HandoffLifetime::Detached, _, _) => TaskWakePolicy::Silent,
-                        (HandoffLifetime::Linked, SpawnAgentHandoffMode::Background, true) => {
-                            TaskWakePolicy::OnActivity
-                        }
-                        (HandoffLifetime::Linked, SpawnAgentHandoffMode::Background, false) => {
-                            TaskWakePolicy::OnTerminal
-                        }
-                        (HandoffLifetime::Linked, SpawnAgentHandoffMode::Foreground, _) => {
-                            TaskWakePolicy::Silent
-                        }
+                        (
+                            HandoffLifetime::Linked,
+                            SpawnAgentHandoffMode::Spawn(SpawnMode::Background),
+                            true,
+                        ) => TaskWakePolicy::OnActivity,
+                        (
+                            HandoffLifetime::Linked,
+                            SpawnAgentHandoffMode::Spawn(SpawnMode::Background),
+                            false,
+                        ) => TaskWakePolicy::OnTerminal,
+                        (
+                            HandoffLifetime::Linked,
+                            SpawnAgentHandoffMode::Spawn(SpawnMode::Foreground),
+                            _,
+                        ) => TaskWakePolicy::Silent,
                         (HandoffLifetime::Linked, SpawnAgentHandoffMode::Invite, _) => {
                             unreachable!("invite mode returns before child-session task creation")
                         }
@@ -1099,7 +1105,7 @@ impl Tool for SpawnAgentHandoffTool {
                     task_id = Some(task.id);
                 }
                 Err(error)
-                    if mode == SpawnAgentHandoffMode::Background
+                    if mode == SpawnAgentHandoffMode::Spawn(SpawnMode::Background)
                         || result_schema.is_some()
                         || message_schema.is_some() =>
                 {
@@ -1112,7 +1118,7 @@ impl Tool for SpawnAgentHandoffTool {
         }
 
         match mode {
-            SpawnAgentHandoffMode::Background => {
+            SpawnAgentHandoffMode::Spawn(SpawnMode::Background) => {
                 let Some(task_id) = task_id else {
                     return ToolExecutionResult::tool_error(
                         "Background spawn_agent requires session_task_registry context so the handoff can be controlled with wait_task/message_task/cancel_task",
@@ -1135,7 +1141,7 @@ impl Tool for SpawnAgentHandoffTool {
                     "mode": "background",
                 }))
             }
-            SpawnAgentHandoffMode::Foreground => {
+            SpawnAgentHandoffMode::Spawn(SpawnMode::Foreground) => {
                 if let Err(error) = store.send_message(child_session.id, &handoff_task).await {
                     finish_handoff_task(
                         context,

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1785,6 +1785,31 @@ struct SpawnAgentTargetProvider {
     tool: Box<dyn Tool>,
 }
 
+/// Shared execution mode accepted natively by every `spawn_agent` provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SpawnMode {
+    Background,
+    Foreground,
+}
+
+impl SpawnMode {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "background" => Some(Self::Background),
+            "foreground" => Some(Self::Foreground),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Background => "background",
+            Self::Foreground => "foreground",
+        }
+    }
+}
+
 struct UnifiedSpawnAgentTool {
     providers: Vec<SpawnAgentTargetProvider>,
 }
@@ -1810,34 +1835,6 @@ impl UnifiedSpawnAgentTool {
                     .any(|provider| provider.target_type == *target_type)
             })
             .collect()
-    }
-
-    fn normalize_arguments(&self, mut arguments: serde_json::Value) -> serde_json::Value {
-        let target_type = arguments
-            .get("target")
-            .and_then(|target| target.get("type"))
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default();
-
-        if target_type == "external_a2a" {
-            if let Some(target) = arguments
-                .get_mut("target")
-                .and_then(serde_json::Value::as_object_mut)
-                && !target.contains_key("external_agent_id")
-                && let Some(id) = target.get("id").cloned()
-            {
-                target.insert("external_agent_id".to_string(), id);
-            }
-            if arguments.get("mode").and_then(serde_json::Value::as_str) == Some("foreground") {
-                arguments["mode"] = serde_json::Value::String("wait".to_string());
-            }
-        } else if matches!(target_type, "subagent" | "agent")
-            && arguments.get("mode").and_then(serde_json::Value::as_str) == Some("wait")
-        {
-            arguments["mode"] = serde_json::Value::String("foreground".to_string());
-        }
-
-        arguments
     }
 }
 
@@ -1909,7 +1906,7 @@ impl Tool for UnifiedSpawnAgentTool {
                         },
                         "id": {
                             "type": "string",
-                            "description": "Configured first-party handoff target id. Also accepted as an alias for external_a2a target.external_agent_id."
+                            "description": "Configured target id for first-party handoffs or external A2A agents."
                         },
                         "external_agent_id": {
                             "type": "string",
@@ -1921,8 +1918,8 @@ impl Tool for UnifiedSpawnAgentTool {
                 },
                 "mode": {
                     "type": "string",
-                    "enum": ["background", "foreground", "wait"],
-                    "description": "Execution mode. Use background to return immediately with a task_id. Use foreground to block for local targets; external_a2a also accepts legacy wait."
+                    "enum": ["background", "foreground"],
+                    "description": "Execution mode. Use background to return immediately with a task_id, or foreground to block until the delegated work reaches a terminal state or timeout."
                 },
                 "blueprint": {
                     "type": "string",
@@ -1948,7 +1945,7 @@ impl Tool for UnifiedSpawnAgentTool {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 86400,
-                    "description": "External-A2A-only foreground/wait timeout."
+                    "description": "External-A2A-only foreground timeout."
                 },
                 "wake_on_completion": {
                     "type": "boolean",
@@ -2016,9 +2013,7 @@ impl Tool for UnifiedSpawnAgentTool {
             );
         }
 
-        provider
-            .execute_with_context(self.normalize_arguments(arguments), context)
-            .await
+        provider.execute_with_context(arguments, context).await
     }
 
     fn requires_context(&self) -> bool {
@@ -5303,6 +5298,16 @@ mod tests {
         assert_eq!(
             spawn_agent_defs[0].parameters()["properties"]["target"]["properties"]["type"]["enum"],
             serde_json::json!(["subagent", "external_a2a"])
+        );
+        assert_eq!(
+            spawn_agent_defs[0].parameters()["properties"]["mode"]["enum"],
+            serde_json::json!(["background", "foreground"])
+        );
+        assert!(
+            !spawn_agent_defs[0].parameters()["properties"]["mode"]["description"]
+                .as_str()
+                .expect("mode description")
+                .contains("wait")
         );
     }
 

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -25,7 +25,7 @@ use super::delegation_result::{
 };
 #[cfg(test)]
 use super::delegation_result::{ReportResultTool, ReportTaskProgressTool};
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
+use super::{Capability, CapabilityLocalization, CapabilityStatus, SpawnMode};
 use crate::platform_store::{PlatformCreateSessionRequest, PlatformStore};
 use crate::session::SessionSeedMode;
 use crate::session_task::{
@@ -179,25 +179,6 @@ const SUBAGENT_SYSTEM_PROMPT: &str = "Spawn subagents for independent parallel w
 const PUSH_CONFIGS_SPEC_KEY: &str = "push_configs";
 /// Valid `event_filter` members for a per-task push config.
 const VALID_PUSH_EVENT_FILTERS: [&str; 3] = ["terminal", "awaiting_input", "message"];
-
-/// Execution mode for subagent delegation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SpawnMode {
-    /// Return immediately; a detached watcher settles the task and the
-    /// OnTerminal wake policy notifies the parent when the child finishes.
-    Background,
-    /// Block until the child idles and return its result inline.
-    Foreground,
-}
-
-impl SpawnMode {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Background => "background",
-            Self::Foreground => "foreground",
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SpawnLifetime {
@@ -733,8 +714,7 @@ fn resolve_spawn_mode(
         .filter(|s| !s.is_empty())
     {
         None => None,
-        Some("background") => Some(SpawnMode::Background),
-        Some("foreground") => Some(SpawnMode::Foreground),
+        Some(value) if let Some(mode) = SpawnMode::parse(value) => Some(mode),
         Some(other) => {
             return Err(ToolExecutionResult::tool_error(format!(
                 "Invalid mode: \"{other}\". Valid modes: background, foreground."

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -339,7 +339,7 @@ async fn spawn_background_against_local_a2a(config: Value) -> (Arc<TestStorageSt
         .execute_with_context(
             json!({
                 "instructions": "hello from outbound delegation",
-                "target": {"type": "external_a2a", "external_agent_id": "local_app"},
+                "target": {"type": "external_a2a", "id": "local_app"},
                 "mode": "background",
                 "wait_timeout_secs": 5,
                 "wake_on_completion": false

--- a/specs/a2a-capability.md
+++ b/specs/a2a-capability.md
@@ -21,7 +21,8 @@ V1 supports:
 
 - AgentCard discovery from configured external A2A agents.
 - JSON-RPC and HTTP+JSON transport negotiation through the official Rust A2A client.
-- `spawn_agent` in `wait` or `background` mode.
+- `spawn_agent` in `foreground` or `background` mode, using the same execution
+  vocabulary as local delegation providers.
 - `wait_task` for pending runs (generic session task tool).
 - `message_task` for follow-up or `input_required` runs (generic session task tool).
 - `cancel_task` for remote task cancellation (generic session task tool).
@@ -113,9 +114,9 @@ Parameters:
 
 - `instructions` required
 - `target.type = external_a2a`
-- `target.external_agent_id`
-- `mode = wait | background`; the shared dispatcher also accepts `foreground`
-  as an alias for `wait`.
+- `target.id` (the A2A provider also accepts its provider-specific
+  `target.external_agent_id` spelling)
+- `mode = foreground | background`
 - `wait_timeout_secs`
 - `wake_on_completion`
 - `result_schema`: optional JSON Schema for a required terminal structured
@@ -124,7 +125,10 @@ Parameters:
   spawn error; Everruns cannot inject `report_task_progress` into a remote
   agent.
 
-`mode = wait` blocks until the remote task reaches a terminal state or timeout. `mode = background` returns an `agent_run_id` immediately and monitors completion in a detached task.
+`mode = foreground` blocks until the remote task reaches a terminal state or
+timeout. `mode = background` returns an `agent_run_id` immediately and monitors
+completion in a detached task. The provider parses these values directly; the
+shared dispatcher does not translate provider-specific mode dialects.
 
 When `result_schema` is present, a completed remote task succeeds only if its
 first structured data artifact conforms. A valid value is written to
@@ -204,7 +208,8 @@ Required mitigations:
 Integration tests use the official Rust `a2a-server-lf` crate to start a real local A2A agent over JSON-RPC. Tests cover:
 
 - AgentCard discovery.
-- `spawn_agent` wait mode.
+- `spawn_agent` foreground mode and terminal/timeout parity with the former
+  blocking behavior.
 - Structured artifact validation and task-result persistence.
 - Schema mismatch settlement and explicit `message_schema` rejection.
 - Background mode (background spawn).

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -308,6 +308,9 @@ providers (`subagent`, `agent`, and/or `external_a2a`). Every spawn creates a
 task and returns its `task_id`. Blocking
 (foreground) spawns also create task records: same object, and the UI shows it
 live while the parent turn waits; background is a mode, not a different entity.
+All delegation providers parse the shared `background | foreground` execution
+vocabulary natively; the dispatcher owns one model-facing enum and performs no
+provider-specific mode translation.
 
 Naming cleanup: `task` parameters that carry instruction text were renamed to
 `instructions` so "task" unambiguously means the lifecycle object. The

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -94,6 +94,8 @@ execution. The dispatcher can advertise other active known delegation providers
 alongside `subagent` (for example first-party handoff or external A2A).
 
 The retired direct creation entry point is no longer advertised to models.
+`background` and `foreground` are the native shared execution-mode vocabulary
+for every delegation provider; the dispatcher does not rewrite them per target.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|


### PR DESCRIPTION
## What changed
`spawn_agent` now exposes and accepts one native execution vocabulary across subagents, first-party handoffs, and external A2A agents: `background | foreground`. A2A parses `target.id` itself and `foreground` keeps the former blocking-to-terminal-or-timeout behavior. The shared dispatcher no longer rewrites provider arguments.

Specs and the A2A capability prompt now describe the shared vocabulary. Unit and integration coverage prove provider schemas, legacy model-facing `wait` rejection, A2A foreground behavior, and target-id parsing.

## Why
The unified tool previously advertised three mode values and silently translated `foreground` to A2A's private `wait` dialect. That made the model-facing contract differ from provider contracts and left provider-specific argument surgery in the shared dispatcher.

## Before / After
Before: the merged schema advertised `background | foreground | wait`; the wrapper rewrote A2A `foreground` to `wait` and copied `target.id` to `target.external_agent_id`.

After: the merged schema advertises exactly `background | foreground`; all three providers consume the shared enum natively, A2A owns its target-id parsing, and `wait` is rejected. Proof: 30 focused `spawn_agent` tests pass, including a real local A2A foreground call; the server's local A2A discovery-card integration smoke also passes.

## Risk
- Low
- Internal model-authored calls using A2A `mode: wait` now fail intentionally; prompts/specs/tests are updated to `foreground`. Background behavior, timeout limits, configured-target lookup, and A2A egress controls are unchanged.

## Security
- Threat categories reviewed: TM-TOOL, TM-AGENT, TM-A2A, TM-DOS
- Findings and resolutions: No new trust boundary or external input source. Configured-agent lookup still gates target IDs; URL validation/network ACL enforcement is unchanged; foreground timeout remains bounded. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)