### PR TITLE
test(storage): stabilize message index plan check

### DIFF
--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1413,6 +1413,18 @@ async fn test_long_message_history_reads_are_bounded_and_index_supported() {
     );
 
     let pool = backend.pool().expect("postgres pool");
+    let message_index: (String,) = sqlx::query_as(
+        "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() AND indexname = 'idx_events_messages'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("message events partial index should exist");
+    assert!(
+        message_index.0.contains("WHERE"),
+        "idx_events_messages should remain a partial index: {}",
+        message_index.0
+    );
+
     let plan_rows: Vec<(String,)> = sqlx::query_as(
         r#"
         EXPLAIN (ANALYZE, BUFFERS)
@@ -1437,10 +1449,6 @@ async fn test_long_message_history_reads_are_bounded_and_index_supported() {
         .map(|row| row.0)
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(
-        plan.contains("idx_events_messages"),
-        "message history query should use idx_events_messages:\n{plan}"
-    );
     assert!(
         !plan.contains("Seq Scan on events"),
         "message history query should not seq-scan events:\n{plan}"


### PR DESCRIPTION
## What changed
The long-history PostgreSQL regression test now verifies the message partial index exists independently from the query plan, while retaining the performance invariant that the bounded query must not sequentially scan events.

## Why
Main CI after #2726 selected the valid general session/sequence index instead of the partial message index twice. The query remained indexed and completed in 3.26 ms, but the test incorrectly required one specific planner choice.

## Before / After
Before: main CI failed when PostgreSQL chose idx_events_session_sequence.

After: the focused PostgreSQL test passes, confirms idx_events_messages remains partial, and confirms the bounded query uses an index rather than a sequential scan.

## Risk
- Low
- Test-only change; a missing partial index or sequential scan still fails the test.

## Security
- Threat categories reviewed: No security-relevant production code changes; test-only database plan assertions.
- Findings and resolutions: No findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)