### PR TITLE
fix(core): make cancel_task cancel detached peer sessions

### DIFF
--- a/crates/core/src/capabilities/session_tasks.rs
+++ b/crates/core/src/capabilities/session_tasks.rs
@@ -458,7 +458,7 @@ impl Tool for CancelTaskTool {
     }
 
     fn description(&self) -> &str {
-        "Request cooperative cancellation of a task. The task winds down and may still end succeeded or failed."
+        "Request cooperative cancellation of a task. The task winds down and may still end succeeded or failed. For a detached `session` task this also cancels the peer session (not just the tracking chip)."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -1651,8 +1651,12 @@ inventory::submit! {
     }
 }
 
-/// Control plane for detached peer-session tracking tasks. Cancellation only
-/// detaches the tracking chip; the peer session owns its own lifecycle.
+/// Control plane for detached peer-session tracking tasks. `cancel` means
+/// cancel everywhere (EVE-766): it cooperatively requests the peer session to
+/// stop via the standard session cancel path, then settles the tracking task
+/// `canceled`. The peer is a same-org session (inherited via fork lineage), so
+/// the cooperative-cancel message routes through the ordinary send path — the
+/// same mechanism linked subagents use.
 pub struct DetachedSessionTaskExecutor;
 
 #[async_trait]
@@ -1665,16 +1669,31 @@ impl TaskExecutor for DetachedSessionTaskExecutor {
         let Some(registry) = context.session_task_registry.as_ref() else {
             return Ok(());
         };
+        // Option A (EVE-766): cancel actually cancels. Deliver a cooperative
+        // stop to the peer session first; only settle the tracking task once
+        // the request is in flight, so a delivery failure surfaces to the
+        // caller instead of silently claiming the peer was canceled.
+        let summary = match (context.platform_store.as_ref(), task.links.child_session_id) {
+            (Some(store), Some(peer_id)) => {
+                store
+                    .send_message(
+                        peer_id,
+                        "Cancellation requested by the session that spawned you. Stop work, wind down, and end your run.",
+                    )
+                    .await?;
+                "Peer session cancellation requested; tracking settled canceled.".to_string()
+            }
+            // No peer link to signal (e.g. never wired): nothing to stop, just
+            // settle the tracking task so the intent is honored.
+            _ => "Detached session tracking canceled; no peer session link to signal.".to_string(),
+        };
         registry
             .update(
                 task.session_id,
                 &task.id,
                 SessionTaskUpdate {
                     state: Some(SessionTaskState::Canceled),
-                    summary: Some(
-                        "Detached session tracking canceled; peer session left running."
-                            .to_string(),
-                    ),
+                    summary: Some(summary),
                     ..Default::default()
                 },
             )
@@ -2205,7 +2224,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn detached_session_task_cancel_detaches_tracking_only() {
+    async fn detached_session_task_cancel_requests_peer_cancellation() {
+        // EVE-766: cancel_task on a detached-session task must cooperatively
+        // cancel the peer session, not just detach the tracking chip.
         let store = Arc::new(MockPlatformStore::new());
         let registry = Arc::new(InMemorySessionTaskRegistry::default());
         let context = spawn_context(&store, Some(registry.clone()));
@@ -2232,6 +2253,21 @@ mod tests {
             .await
             .unwrap();
 
+        // The peer session was signaled to stop via the standard send path.
+        let sent = store.sent_messages.lock().unwrap().clone();
+        assert_eq!(
+            sent.len(),
+            1,
+            "exactly one cooperative-cancel message expected, got {sent:?}"
+        );
+        assert_eq!(sent[0].0, child_id, "cancel must target the peer session");
+        assert!(
+            sent[0].1.contains("Cancellation requested"),
+            "cancel message should ask the peer to stop, got {:?}",
+            sent[0].1
+        );
+
+        // The tracking task settles canceled and keeps its peer link.
         let updated = registry
             .get(context.session_id, &task.id)
             .await
@@ -2241,7 +2277,46 @@ mod tests {
         assert_eq!(updated.links.child_session_id, Some(child_id));
         assert_eq!(
             updated.summary.as_deref(),
-            Some("Detached session tracking canceled; peer session left running.")
+            Some("Peer session cancellation requested; tracking settled canceled.")
+        );
+    }
+
+    #[tokio::test]
+    async fn detached_session_task_cancel_without_peer_link_still_settles() {
+        // Defensive: a session-kind task with no peer link has nothing to
+        // signal, but the cancel intent must still be honored.
+        let store = Arc::new(MockPlatformStore::new());
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let context = spawn_context(&store, Some(registry.clone()));
+        let task = registry
+            .create(CreateSessionTask {
+                session_id: context.session_id,
+                id: None,
+                kind: TASK_KIND_SESSION.to_string(),
+                display_name: "Peer".to_string(),
+                spec: json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        DetachedSessionTaskExecutor
+            .cancel(&task, &context)
+            .await
+            .unwrap();
+
+        assert!(store.sent_messages.lock().unwrap().is_empty());
+        let updated = registry
+            .get(context.session_id, &task.id)
+            .await
+            .unwrap()
+            .expect("task should remain present");
+        assert_eq!(updated.state, SessionTaskState::Canceled);
+        assert_eq!(
+            updated.summary.as_deref(),
+            Some("Detached session tracking canceled; no peer session link to signal.")
         );
     }
 

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -337,6 +337,10 @@ pub mod tests {
         /// Status returned by `wait_for_idle` ("idle" by default). Tests set
         /// a terminal turn status (e.g. "completed") to exercise settle paths.
         pub wait_for_idle_status: std::sync::Mutex<String>,
+        /// Records every `send_message` call as `(session_id, content)` so
+        /// tests can assert which session was signaled (e.g. a detached peer
+        /// receiving a cooperative-cancel message).
+        pub sent_messages: std::sync::Mutex<Vec<(SessionId, String)>>,
     }
 
     impl Default for MockPlatformStore {
@@ -486,6 +490,7 @@ pub mod tests {
                 joined_participants: std::sync::Mutex::new(Vec::new()),
                 created_session_harness_ids: std::sync::Mutex::new(Vec::new()),
                 wait_for_idle_status: std::sync::Mutex::new("idle".to_string()),
+                sent_messages: std::sync::Mutex::new(Vec::new()),
             }
         }
     }
@@ -826,7 +831,11 @@ pub mod tests {
         async fn delete_session(&self, _id: SessionId) -> Result<()> {
             Ok(())
         }
-        async fn send_message(&self, _id: SessionId, _content: &str) -> Result<()> {
+        async fn send_message(&self, id: SessionId, content: &str) -> Result<()> {
+            self.sent_messages
+                .lock()
+                .unwrap()
+                .push((id, content.to_string()));
             Ok(())
         }
         async fn get_messages(

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -29,8 +29,9 @@ pub type TaskProgress = crate::background::BackgroundProgress;
 /// Well-known task kinds. Kind stays a free-form string; these constants
 /// cover the built-in executors.
 pub const TASK_KIND_SUBAGENT: &str = "subagent";
-/// Detached peer session tracked for visibility only. Canceling this task
-/// detaches tracking; it does not stop the peer session.
+/// Detached peer session. Canceling this task cooperatively cancels the peer
+/// session (standard send/cancel path) and settles the tracking task
+/// `canceled` — cancel means cancel, not detach-only (EVE-766).
 pub const TASK_KIND_SESSION: &str = "session";
 /// Cross-agent handoff to a different configured Agent in the same harness.
 /// Distinct from `subagent` so `list_tasks(kind="subagent")` returns only

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -161,7 +161,7 @@ update); `post` and `output` are content (thread and stream). This keeps
 | `subagent` | create child session, send instructions | `send_message(child)` | child question → `request_input`; final message → `post` + terminal state |
 | `external_agent` | A2A `message/send` | `message/send` with `remote_task_id` | `reconcile` polls `tasks/get`; remote artifacts → `artifact` |
 | `background_tool` | run `execute_background` with the sink | rarely used | direct sink calls (existing `BackgroundEventSink` is a strict subset) |
-| `session` | create a detached peer session | n/a | visibility-only task; cancel detaches tracking and never stops the peer session |
+| `session` | create a detached peer session | n/a | `cancel` cooperatively cancels the peer session (standard send/cancel path) and settles the tracking task `canceled` — cancel means cancel, not detach-only (EVE-766) |
 | `monitor` | created by `spawn_background` with a `schedule` arg | n/a (schedule-driven) | schedule fire → probe runs (or placeholder message); one-shot → `succeeded`; recurring stays `running` |
 
 A monitor is a long-lived task (`running` until canceled or exhausted).


### PR DESCRIPTION
## What changed
`cancel_task` on a **detached `session`** task now cooperatively cancels the peer session instead of silently detaching only the tracking chip. Previously the tracking task settled `canceled` while the peer session kept running — so `cancel_task` meant "cancel the work" for subagent/background/handoff/A2A kinds but "stop watching, work continues" for detached sessions, with no signal to the caller. Now cancel means cancel everywhere: `DetachedSessionTaskExecutor::cancel` delivers a cooperative stop to the peer via the standard send path, then settles the tracking task `canceled`. Fixes EVE-766.

## Why
Same tool, opposite outcome across kinds is a correctness/trust hole. A model or user that calls `cancel_task` on a detached spawn reasonably expects the work to stop — and it didn't. EVE-766 Option A (recommended) makes the generic contract honest.

## Before / After
- **Before:** `cancel_task(detached-session)` → tracking task `canceled`, summary "peer session left running", peer session untouched and still burning turns/budget.
- **After:** `cancel_task(detached-session)` → cooperative-cancel message delivered to the peer session (the same mechanism linked subagents use), then tracking task settles `canceled` with summary "Peer session cancellation requested; tracking settled canceled." A delivery failure surfaces to the caller instead of silently claiming success.

Evidence (executor-level, deterministic — `MockPlatformStore` now records `send_message`):
- `detached_session_task_cancel_requests_peer_cancellation` — asserts exactly one cancel message targeted the peer session id, and the tracking task settled `canceled`.
- `detached_session_task_cancel_without_peer_link_still_settles` — defensive: no peer link → nothing signaled, cancel intent still honored.
- All other kinds unchanged (regression); `just pre-push` green (fmt, clippy `-D warnings`, lockfile, migrations, enumeration, specs index, attribution).

## Risk
- Low
- The peer session is a same-org session (inherited via fork lineage), so the cooperative-cancel routes through the ordinary send path with existing org scoping. The only behavior change is that a detached peer now receives a stop message on cancel; other task kinds are untouched.

## Security
- Threat categories reviewed: **TM-TENANT** (cross-tenant boundaries) — peer session id comes from `task.links.child_session_id` set at spawn time (trusted, internal); `send_message` uses the standard path that enforces org scoping, and the peer is same-org by construction. **TM-AUTHZ** — cancel already runs in the owning session's `ToolContext`; no new endpoint, no new input parsing, message body is a fixed string (no injection surface).
- Findings and resolutions: none.

## Follow-ups
No follow-ups. Option A fully replaces the detach-only behavior; a separate explicit "detach without cancel" affordance is not currently needed (deleting the tracking task remains available if that need arises).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal task semantics; no migration, no API contract change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)