### PR TITLE
feat(core): random public message IDs (drop uuidv7 from MessageId)

### DIFF
--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -4,7 +4,8 @@
 // Design decisions:
 // - Uses marker traits to differentiate ID types at compile time
 // - Stores IDs as prefixed strings (e.g., "agent_01933b5a...")
-// - Uses UUIDv7 for time-ordering benefits
+// - Uses UUIDv7 for DB-backed ids (time-ordering) and UUIDv4 for random-public
+//   ids (e.g. MessageId) — dispatched per class via IdMarker::generate_uuid()
 // - Supports serde, sqlx, and utoipa for full integration
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -45,6 +46,17 @@ impl std::error::Error for IdParseError {}
 pub trait IdMarker: Clone + Copy + Send + Sync + 'static {
     /// The prefix for this ID type (e.g., "agt" for agents)
     const PREFIX: &'static str;
+
+    /// Generate a fresh UUID for a new id of this class.
+    ///
+    /// Defaults to UUIDv7, whose time-ordering gives DB-backed keys B-tree
+    /// locality and sortability (events, sessions, agents, …). Id classes that
+    /// are purely *public/correlation* identifiers with no DB sort/index
+    /// dependency override this to a random UUIDv4 so no creation timestamp
+    /// leaks into a client-visible id. See `specs/id-schema.md`.
+    fn generate_uuid() -> Uuid {
+        Uuid::now_v7()
+    }
 }
 
 /// A type-safe identifier with a specific prefix
@@ -55,10 +67,24 @@ pub struct TypedId<T: IdMarker> {
 }
 
 impl<T: IdMarker> TypedId<T> {
-    /// Create a new ID with a random UUIDv7
+    /// Create a new ID using this id class's generation strategy
+    /// ([`IdMarker::generate_uuid`] — UUIDv7 by default, UUIDv4 for
+    /// random-public id classes such as [`MessageId`]).
     pub fn new() -> Self {
         Self {
-            uuid: Uuid::now_v7(),
+            uuid: T::generate_uuid(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a new ID with a random (non-time-ordered) UUIDv4.
+    ///
+    /// Use for public/correlation ids that must not embed a creation
+    /// timestamp. The wire format is unchanged (`prefix_{32-hex}`), so parsing,
+    /// validation, and persistence are identical to a UUIDv7-backed id.
+    pub fn new_random() -> Self {
+        Self {
+            uuid: Uuid::new_v4(),
             _marker: PhantomData,
         }
     }
@@ -355,6 +381,16 @@ impl IdMarker for SessionParticipantIdMarker {
 pub struct MessageIdMarker;
 impl IdMarker for MessageIdMarker {
     const PREFIX: &'static str = "message";
+
+    // Messages are not DB entities — they live embedded in `events.data` JSONB
+    // with no table, FK, index, or sort dependency on their id, and the id is
+    // the *public* identifier serialized to clients (`output.message.completed`,
+    // `EventContext.input_message_id`). UUIDv7's time-ordering does no work here
+    // and would leak a creation timestamp into a client-visible id, so message
+    // ids are random UUIDv4. See EVE-771 and `specs/id-schema.md`.
+    fn generate_uuid() -> Uuid {
+        Uuid::new_v4()
+    }
 }
 
 /// Marker for Event IDs
@@ -833,5 +869,51 @@ mod tests {
         assert_eq!(set.len(), 2);
         set.insert(id1);
         assert_eq!(set.len(), 2); // No duplicate
+    }
+
+    #[test]
+    fn test_message_id_is_random_v4() {
+        // MessageId is a random-public id class: new() and new_random() must
+        // both yield UUIDv4, unlike the default UUIDv7 classes.
+        let id = MessageId::new();
+        assert_eq!(
+            id.uuid().get_version_num(),
+            4,
+            "MessageId::new() must be v4"
+        );
+        assert_eq!(
+            MessageId::new_random().uuid().get_version_num(),
+            4,
+            "MessageId::new_random() must be v4"
+        );
+        // Format is unchanged: message_ + 32 lowercase hex, still parseable.
+        let s = id.to_string();
+        assert!(s.starts_with("message_"));
+        assert_eq!(s.len(), "message_".len() + 32);
+        assert_eq!(MessageId::parse(&s).unwrap(), id);
+    }
+
+    #[test]
+    fn test_default_id_class_stays_v7() {
+        // DB-backed classes keep UUIDv7 for B-tree locality / sortability.
+        assert_eq!(AgentId::new().uuid().get_version_num(), 7);
+        assert_eq!(SessionId::new().uuid().get_version_num(), 7);
+        assert_eq!(EventId::new().uuid().get_version_num(), 7);
+        // TurnId decision (EVE-771): stays UUIDv7 — turn ordering is used by
+        // durable execution and its public AG-UI exposure is being removed by
+        // the streaming message_id work (EVE-773), so it is not changed here.
+        assert_eq!(TurnId::new().uuid().get_version_num(), 7);
+    }
+
+    #[test]
+    fn test_message_id_parse_compat_legacy_and_random() {
+        // Legacy message ids were UUIDv7; new ones are UUIDv4. Both must parse
+        // identically — the wire format did not change, so no migration.
+        let legacy_v7 = format!("message_{}", Uuid::now_v7().simple());
+        let new_v4 = format!("message_{}", Uuid::new_v4().simple());
+        for s in [legacy_v7, new_v4] {
+            let parsed = MessageId::parse(&s).expect("both id vintages must parse");
+            assert_eq!(parsed.to_string(), s);
+        }
     }
 }

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-This document defines the standardized identifier schema for all entity types in Everruns. All external-facing identifiers use **Stripe-style prefixed IDs with UUIDv7** for type safety, debuggability, and consistency.
+This document defines the standardized identifier schema for all entity types in Everruns. All external-facing identifiers use **Stripe-style prefixed IDs backed by a UUID** (UUIDv7 for DB-backed keys, UUIDv4 for random-public ids — see [ID classes](#id-classes-time-ordered-vs-random-public)) for type safety, debuggability, and consistency.
 
 This pattern was popularized by Stripe (`cus_`, `sub_`, `pi_`) and formalized by the [TypeID spec](https://github.com/jetpack-io/typeid). Our implementation uses hex encoding (32 chars) rather than TypeID's base32 (26 chars) for simpler debugging and UUID compatibility.
 
@@ -19,7 +19,7 @@ All entity identifiers follow a consistent prefixed format:
 Where:
 - `{prefix}` - A descriptive lowercase string identifying the entity type
 - `_` - Underscore separator
-- `{32-hex-chars}` - UUIDv7 in simple format (lowercase hex, no dashes)
+- `{32-hex-chars}` - a UUID in simple format (lowercase hex, no dashes); UUIDv7 or UUIDv4 depending on the [id class](#id-classes-time-ordered-vs-random-public)
 
 **Example:** `agent_01933b5a00007000800000000000001`
 
@@ -33,15 +33,25 @@ Agent version IDs use the `agentver_` prefix.
 
 ### ID Generation
 
-- IDs are generated using UUIDv7 for time-ordering benefits
-- The UUID is formatted as lowercase hex without dashes (32 chars)
-- The prefix is prepended with an underscore separator
+- The UUID is formatted as lowercase hex without dashes (32 chars); the prefix is prepended with an underscore separator
+- The UUID *version* depends on the id class (see below). The wire format (`{prefix}_{32-hex}`) and validation regex are identical for every class, so version is an internal generation detail — never a parse or storage concern
 
 ```rust
-// Example generation
+// Example generation (time-ordered, default)
 let uuid = Uuid::now_v7();
 let id = format!("agent_{}", uuid.simple()); // agent_0193...
 ```
+
+#### ID classes: time-ordered vs random-public
+
+`TypedId::new()` dispatches on the id class via `IdMarker::generate_uuid()`:
+
+| Class | UUID version | Rationale |
+|-------|--------------|-----------|
+| **Time-ordered** (default) — DB-backed keys: `agent`, `session`, `event`, `turn`, `org`, and all other entities with a table/PK/index | UUIDv7 | Time-ordering gives B-tree insert locality and lets the id double as a sort key. |
+| **Random-public** — `message` | UUIDv4 (`TypedId::new_random()`) | Messages are **not** DB entities: they live embedded in `events.data` JSONB with no table, FK, index, or sort dependency on the id, and the id is the *public* identifier serialized to clients (`output.message.completed`, `EventContext.input_message_id`). UUIDv7's time-ordering does no work here and would leak a creation timestamp into a client-visible id, so message ids are random. Same wire format → no migration; legacy UUIDv7 message ids keep parsing. |
+
+`TurnId` stays UUIDv7: turn ordering is used by durable execution, and the raw turn UUID's current public exposure via AG-UI is being removed by the streaming `message_id` work rather than by re-randomizing the turn id. To make a new id class random, override `generate_uuid()` on its marker in `crates/core/src/typed_id.rs`.
 
 ### ID Validation
 
@@ -96,7 +106,8 @@ For the full list of well-known IDs and range allocations, see `crates/core/src/
 | Question | Decision |
 |----------|----------|
 | Why prefixed IDs? | Type safety, debuggability, prevents mixing ID types |
-| Why UUIDv7? | Time-ordering benefits, sortable, globally unique |
+| Why UUIDv7 for DB-backed ids? | Time-ordering gives B-tree insert locality + sortability; globally unique |
+| Why UUIDv4 for message ids? | Messages are not DB entities (embedded in `events.data` JSONB, no index/sort on the id) and the id is client-visible; v7 would leak a creation timestamp with no benefit — see the ID-class table |
 | Why dual-ID? | Internal UUID PK for FK integrity; external public_id for client-facing API, client-supplied IDs, upsert |
 | Why not expose UUID? | Decouples internal PK from API contract; allows client-supplied IDs |
 | Why lowercase hex? | Consistency, case-insensitive matching, URL-safe |


### PR DESCRIPTION
## What changed
`MessageId` is now generated as a random **UUIDv4** instead of a time-ordered **UUIDv7**. The wire format (`message_{32-hex}`), validation regex, serialization, and persistence are all unchanged, so this is behaviorally invisible to clients except that a message id no longer embeds a creation timestamp. Legacy uuidv7 message ids keep parsing — no migration.

Mechanism: generation is now dispatched per id-class via a new `IdMarker::generate_uuid()` (UUIDv7 by default). `MessageIdMarker` overrides it to UUIDv4, so every `MessageId::new()` / `MessageId::default()` — in production, tests, and any future call site — is random by construction. A public `TypedId::new_random()` helper is also added. Every other id class (`agent`, `session`, `event`, `turn`, …) is unchanged.

## Why
Messages are not DB entities: they live embedded in `events.data` JSONB with no table, FK, index, or sort dependency on their id, and the id is the *public* identifier serialized to clients (`output.message.completed`, `EventContext.input_message_id`). UUIDv7's time-ordering does zero work here; its only observable effect is leaking a creation timestamp into a client-visible identifier. This is also required groundwork for the EVE-768 streaming `message_id` series — it must land before the streaming lifecycle starts broadcasting message ids, otherwise those ids would carry uuidv7 timestamps.

Rather than mechanically switching ~50 `MessageId::new()` call sites (leak-prone — a missed site silently stays uuidv7, and future code using `MessageId::new()` would regress), generation is fixed at the marker level so the id class is random by definition.

## Before / After
- **Before:** `MessageId::new()` → `message_01933b5a…` (UUIDv7, version nibble `7`, encodes a timestamp).
- **After:** `MessageId::new()` → `message_4f3c…` (UUIDv4, version nibble `4`, no timestamp). Same `message_{32-hex}` format; `MessageId::parse` accepts both vintages.
- New tests assert `MessageId::new()`/`new_random()` are v4, that `agent`/`session`/`event`/`turn` stay v7, and that legacy-v7 and new-v4 message-id strings both round-trip through parse.

## Risk
- **Low.** Additive trait method with a uuidv7 default (no other id class changes) plus one behavioral change to the `message` class. No public API signature change, no format/regex change, no migration. Verified nothing sorts or derives from message-id timestamps (`grep` for message-id ordering in Rust/SQL: none — ids are correlation-only).

## Security
- Threat categories reviewed: **TM-API** (client-visible identifier). Finding: switching to UUIDv4 *removes* a minor information leak (creation timestamp embedded in a public id); it does not weaken uniqueness (both are 122-bit random-backed for collision purposes). No new threat surface. No other security-relevant code touched.

## Follow-ups
- **TurnId decision (recorded, not applied):** `TurnId` stays UUIDv7. Turn ordering is used by durable execution, and the raw turn UUID's current public exposure via AG-UI (`ag_ui.rs`) is being removed by the streaming `message_id` work (EVE-773) rather than by re-randomizing the turn id. Documented in `specs/id-schema.md` and a `typed_id.rs` test comment.
- Otherwise: No follow-ups.

## Checklist
- [x] Tests added or updated (3 new: v4-for-message, v7-for-default-classes, parse-compat legacy+random)
- [x] Backward compatibility considered (format unchanged; legacy uuidv7 ids still parse; no migration)
- [x] Security review performed against relevant threat model categories (TM-API)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLejHF8ctj1pjdAPWgrsXX)_