### PR TITLE
fix(web-fetch): validate save destinations

### DIFF
--- a/crates/core/src/capabilities/web_fetch/mod.rs
+++ b/crates/core/src/capabilities/web_fetch/mod.rs
@@ -321,9 +321,51 @@ struct SessionFileSaver {
     session_id: SessionId,
 }
 
+impl SessionFileSaver {
+    async fn resolve_destination(&self, path: &str) -> Result<String, FileSaveError> {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(FileSaveError::PathNotAllowed(
+                "Destination path must name a file".to_string(),
+            ));
+        }
+
+        // SessionFileSystem is the path authority: this preserves mount routing,
+        // host-backed display identity, and backend containment policy.
+        let resolved = self.file_store.resolve_path(path);
+        let root = self.file_store.resolve_path("");
+        if resolved == root || resolved == "/" {
+            return Err(FileSaveError::PathNotAllowed(format!(
+                "Destination resolves to the workspace root: {resolved}"
+            )));
+        }
+
+        let existing = self
+            .file_store
+            .stat_file(self.session_id, &resolved)
+            .await
+            .map_err(|error| {
+                FileSaveError::Other(format!(
+                    "Could not inspect destination path {resolved}: {error}"
+                ))
+            })?;
+        if existing.is_some_and(|entry| entry.is_directory) {
+            return Err(FileSaveError::PathNotAllowed(format!(
+                "Destination is an existing directory: {resolved}"
+            )));
+        }
+
+        Ok(resolved)
+    }
+}
+
 #[async_trait]
 impl FileSaver for SessionFileSaver {
     async fn save(&self, path: &str, bytes: &[u8]) -> Result<SaveResult, FileSaveError> {
+        // Revisit after upgrading fetchkit beyond 0.4.1: confirm upstream calls
+        // validate_path before network I/O. Keep this save-time check as defense
+        // in depth unless the FileSaver contract guarantees the path is unchanged.
+        let path = self.resolve_destination(path).await?;
         let (content, encoding) = match std::str::from_utf8(bytes) {
             Ok(text) => (text.to_string(), "text"),
             Err(_) => {
@@ -334,7 +376,7 @@ impl FileSaver for SessionFileSaver {
 
         let file = self
             .file_store
-            .write_file(self.session_id, path, &content, encoding)
+            .write_file(self.session_id, &path, &content, encoding)
             .await
             .map_err(|e| FileSaveError::Other(e.to_string()))?;
 
@@ -342,6 +384,10 @@ impl FileSaver for SessionFileSaver {
             path: file.path,
             bytes_written: bytes.len() as u64,
         })
+    }
+
+    async fn validate_path(&self, path: &str) -> Result<(), FileSaveError> {
+        self.resolve_destination(path).await.map(|_| ())
     }
 }
 
@@ -460,10 +506,14 @@ impl WebFetchTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        // Revisit after fetchkit publishes a nonblank save_to_file schema:
+        // retain boundary normalization for callers that bypass schema validation.
         let save_to_file = arguments
             .get("save_to_file")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(str::to_string);
 
         Ok(FetchRequest {
             url,
@@ -1757,13 +1807,22 @@ mod tests {
     /// In-memory SessionFileSystem for testing file downloads
     struct MockFileStore {
         files: tokio::sync::Mutex<std::collections::HashMap<(SessionId, String), (String, String)>>,
+        directories: tokio::sync::Mutex<std::collections::HashSet<(SessionId, String)>>,
     }
 
     impl MockFileStore {
         fn new() -> Self {
             Self {
                 files: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+                directories: tokio::sync::Mutex::new(std::collections::HashSet::new()),
             }
+        }
+
+        async fn add_directory(&self, session_id: SessionId, path: &str) {
+            self.directories
+                .lock()
+                .await
+                .insert((session_id, path.to_string()));
         }
 
         async fn get_file(&self, session_id: SessionId, path: &str) -> Option<(String, String)> {
@@ -1851,9 +1910,25 @@ mod tests {
 
         async fn stat_file(
             &self,
-            _session_id: SessionId,
-            _path: &str,
+            session_id: SessionId,
+            path: &str,
         ) -> crate::error::Result<Option<crate::session_file::FileStat>> {
+            if self
+                .directories
+                .lock()
+                .await
+                .contains(&(session_id, path.to_string()))
+            {
+                return Ok(Some(crate::session_file::FileStat {
+                    path: path.to_string(),
+                    name: path.rsplit('/').next().unwrap_or(path).to_string(),
+                    is_directory: true,
+                    is_readonly: false,
+                    size_bytes: 0,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                }));
+            }
             Ok(None)
         }
 
@@ -1898,6 +1973,58 @@ mod tests {
     fn test_web_fetch_tool_requires_context() {
         let tool = WebFetchTool::default();
         assert!(tool.requires_context());
+    }
+
+    #[test]
+    fn test_save_to_file_is_trimmed_and_blank_is_absent() {
+        let blank = WebFetchTool::parse_request(&serde_json::json!({
+            "url": "https://example.com",
+            "save_to_file": "  \n\t "
+        }))
+        .unwrap();
+        assert_eq!(blank.save_to_file, None);
+
+        let path = WebFetchTool::parse_request(&serde_json::json!({
+            "url": "https://example.com",
+            "save_to_file": "  /downloads/file.txt  "
+        }))
+        .unwrap();
+        assert_eq!(path.save_to_file.as_deref(), Some("/downloads/file.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_blank_save_to_file_fetches_inline_without_file_store() {
+        let tool = WebFetchTool::new(false, None);
+        let mut context = ToolContext::new(SessionId::new());
+        context.egress_service = Some(Arc::new(CannedEgress));
+
+        let result = tool
+            .execute_with_context(
+                serde_json::json!({
+                    "url": "http://93.184.216.34/file.txt",
+                    "save_to_file": "  \n "
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("blank save_to_file should fetch inline: {result:?}");
+        };
+        assert_eq!(value["content"], "pong from egress");
+        assert!(value.get("saved_path").is_none() || value["saved_path"].is_null());
+    }
+
+    #[test]
+    fn test_save_error_remains_distinct_from_http_errors() {
+        let result = WebFetchTool::map_error(FetchError::SaveError(
+            "Path not allowed: Destination is an existing directory: /downloads".to_string(),
+        ));
+        assert!(matches!(
+            result,
+            ToolExecutionResult::ToolError(message)
+                if message == "Failed to save file: Path not allowed: Destination is an existing directory: /downloads"
+        ));
     }
 
     #[test]
@@ -1989,6 +2116,54 @@ mod tests {
         } else {
             panic!("Expected successful response, got: {:?}", result);
         }
+    }
+
+    #[tokio::test]
+    async fn test_session_file_saver_rejects_workspace_roots_and_directories() {
+        let file_store = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        file_store.add_directory(session_id, "/downloads").await;
+        let saver = SessionFileSaver {
+            file_store,
+            session_id,
+        };
+
+        for path in ["", "   ", "/", "/workspace", "/workspace/"] {
+            let error = saver.validate_path(path).await.unwrap_err();
+            assert!(
+                matches!(error, FileSaveError::PathNotAllowed(_)),
+                "root destination {path:?} should be a path error: {error}"
+            );
+        }
+
+        let error = saver.validate_path("/downloads").await.unwrap_err();
+        assert!(
+            matches!(error, FileSaveError::PathNotAllowed(ref message) if message.contains("directory")),
+            "directory destination should be a precise path error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_session_file_saver_resolves_and_saves_valid_path() {
+        let file_store = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        let saver = SessionFileSaver {
+            file_store: file_store.clone(),
+            session_id,
+        };
+
+        saver.validate_path("downloads/file.txt").await.unwrap();
+        let saved = saver
+            .save("downloads/file.txt", b"downloaded")
+            .await
+            .unwrap();
+
+        assert_eq!(saved.path, "/downloads/file.txt");
+        assert_eq!(saved.bytes_written, 10);
+        assert_eq!(
+            file_store.get_file(session_id, "/downloads/file.txt").await,
+            Some(("downloaded".to_string(), "text".to_string()))
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -676,22 +676,34 @@ pub fn narrate_write_todos(phase: ToolNarrationPhase, locale: Option<&str>) -> S
     }
 }
 
-/// `web_fetch` narration (English-only for now; UK falls back to English).
+/// `web_fetch` narration, distinguishing inline fetches from file downloads.
 pub fn narrate_web_fetch(
     arguments: &Value,
     phase: ToolNarrationPhase,
     locale: Option<&str>,
 ) -> String {
     let value = safe_arg_str(arguments, &["url", "uri"]).map(url_display);
-    let verbs = pick(
-        locale,
-        ("Fetch URL", "Fetched URL", "Could not fetch URL"),
-        (
-            "Завантажую URL",
-            "Завантажив URL",
-            "Не вдалося завантажити URL",
-        ),
-    );
+    let is_download = arguments
+        .get("save_to_file")
+        .and_then(Value::as_str)
+        .is_some_and(|path| !path.trim().is_empty());
+    let verbs = if is_download {
+        pick(
+            locale,
+            ("Download URL", "Downloaded URL", "Could not download URL"),
+            (
+                "Завантажую URL",
+                "Завантажив URL",
+                "Не вдалося завантажити URL",
+            ),
+        )
+    } else {
+        pick(
+            locale,
+            ("Fetch URL", "Fetched URL", "Could not fetch URL"),
+            ("Отримую URL", "Отримав URL", "Не вдалося отримати URL"),
+        )
+    };
     labeled_phrase(verbs.0, verbs.1, verbs.2, value, phase)
 }
 
@@ -1052,7 +1064,40 @@ mod tests {
         // Ukrainian locale must not fall back to English (no mixed-language UI).
         assert_eq!(
             narrate_web_fetch(&a, ToolNarrationPhase::Completed, Some("uk")),
-            "Завантажив URL: example.com/page"
+            "Отримав URL: example.com/page"
+        );
+    }
+
+    #[test]
+    fn web_fetch_helper_narrates_download_when_save_path_is_present() {
+        let a = args(json!({
+            "url": "https://example.com/file?token=abc",
+            "save_to_file": "/downloads/file"
+        }));
+        assert_eq!(
+            narrate_web_fetch(&a, ToolNarrationPhase::Started, None),
+            "Download URL: example.com/file"
+        );
+        assert_eq!(
+            narrate_web_fetch(&a, ToolNarrationPhase::Completed, None),
+            "Downloaded URL: example.com/file"
+        );
+        assert_eq!(
+            narrate_web_fetch(&a, ToolNarrationPhase::Failed, None),
+            "Could not download URL: example.com/file"
+        );
+        assert_eq!(
+            narrate_web_fetch(&a, ToolNarrationPhase::Completed, Some("uk")),
+            "Завантажив URL: example.com/file"
+        );
+
+        let blank = args(json!({
+            "url": "https://example.com/file",
+            "save_to_file": "   "
+        }));
+        assert_eq!(
+            narrate_web_fetch(&blank, ToolNarrationPhase::Completed, None),
+            "Fetched URL: example.com/file"
         );
     }
 


### PR DESCRIPTION
## What changed
Web fetch now trims `save_to_file`, treats blank values as an inline fetch, validates destinations through the session filesystem, and rejects workspace roots or existing directories with precise persistence errors. Download requests use distinct localized narration.

## Why
Blank optional values previously resolved to the workspace root, and invalid save destinations were not rejected by the Everruns filesystem adapter. This made persistence failures ambiguous and risked targeting directory roots.

## Before / After
Before: whitespace-only `save_to_file` entered the save path and could resolve to the workspace root; narration always said Fetch URL.

After: focused tests prove blank values return inline content, root and directory destinations return path-specific save errors, valid destinations preserve filesystem path identity, and saved requests narrate Download URL / Downloaded URL / Could not download URL. The local dev API also returned `200 OK` from `/health` on the final branch.

## Risk
- Low
- The change is limited to web-fetch argument normalization, session file-save validation, and narration. Existing valid save paths remain supported.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL, TM-AGENT
- Findings and resolutions: Path resolution remains delegated to `SessionFileSystem`, preserving mount routing, session isolation, host containment, and TM-FS-001/TM-FS-013 mitigations. Save validation is repeated at write time as defense in depth. No dependency or egress-policy changes.

## Follow-ups
- After fetchkit publishes the sibling preflight/schema changes, bump the pinned release and verify `FileSaver::validate_path` runs before HTTP I/O and `save_to_file` rejects blank strings at schema validation. Revisit comments are placed at both compatibility boundaries.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
