### PR TITLE
fix(api): restrict structured task results

### DIFF
--- a/crates/server/src/domains/session_tasks/result.rs
+++ b/crates/server/src/domains/session_tasks/result.rs
@@ -13,6 +13,7 @@
 // `specs/a2a-channel.md` / `specs/mcp.md`.
 
 use everruns_core::SessionId;
+use everruns_core::session_task::{SessionTask, TASK_KIND_SUBAGENT, task_result_path};
 use serde_json::Value;
 
 use crate::storage::StorageBackend;
@@ -48,14 +49,11 @@ pub async fn read_structured_task_result(
         return Ok(None);
     };
 
-    // Owned tasks that reported a structured result. `result_path` is only ever
-    // set by `report_result`, which requires a declared `result_schema`, so its
-    // presence alone is a sufficient marker — no need to re-inspect the spec.
     let rows = db.list_session_tasks(session_id, None, None).await?;
-    let mut best: Option<everruns_core::SessionTask> = None;
+    let mut best: Option<SessionTask> = None;
     for row in &rows {
         let task = row.to_task()?;
-        if task.result_path.is_none() {
+        if !is_structured_result_task(&task) {
             continue;
         }
         match &best {
@@ -80,4 +78,13 @@ pub async fn read_structured_task_result(
     };
     let value = serde_json::from_slice::<Value>(&bytes)?;
     Ok(Some(value))
+}
+
+fn is_structured_result_task(task: &SessionTask) -> bool {
+    task.kind == TASK_KIND_SUBAGENT
+        && task.spec.get("result_schema").is_some_and(Value::is_object)
+        && task
+            .result_path
+            .as_deref()
+            .is_some_and(|path| path == task_result_path(&task.id))
 }

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -1031,6 +1031,67 @@ async fn seed_structured_result(server: &TestServer, session_id: &str, result: V
         .expect("write result file");
 }
 
+async fn seed_non_schema_result_path(server: &TestServer, session_id: &str, result: Value) {
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, SessionTaskUpdate, new_session_task,
+    };
+    use everruns_server::storage::models::CreateSessionFileRow;
+
+    let sid = session_id.parse::<SessionId>().expect("valid session id");
+    let session = server
+        .db
+        .get_session(DEFAULT_ORG_ID, sid)
+        .await
+        .expect("get_session")
+        .expect("session exists");
+
+    let task = new_session_task(
+        CreateSessionTask {
+            session_id: sid,
+            id: None,
+            kind: "background_tool".to_string(),
+            display_name: "background result".to_string(),
+            spec: json!({ "tool": "internal_scan" }),
+            state: SessionTaskState::Running,
+            links: Default::default(),
+            wake_policy: Default::default(),
+        },
+        chrono::Utc::now(),
+    );
+    server
+        .db
+        .create_session_task(&task)
+        .await
+        .expect("create non-schema task");
+
+    let path = format!("/.background/{}/result.json", task.id);
+    server
+        .db
+        .update_session_task(
+            sid,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                result_path: Some(path.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("set non-schema result_path");
+
+    server
+        .db
+        .create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(session.workspace_id),
+            path,
+            content: Some(serde_json::to_vec(&result).unwrap()),
+            is_directory: false,
+            is_readonly: false,
+        })
+        .await
+        .expect("write non-schema result file");
+}
+
 /// A task that reported a schema-bound `result.json` (EVE-678) exposes it as an
 /// A2A `tasks/get` artifact `DataPart`, not just last-message / status text.
 #[tokio::test]
@@ -1087,6 +1148,43 @@ async fn a2a_tasks_get_surfaces_structured_result_artifact() {
     let parts = artifacts[0]["parts"].as_array().expect("artifact parts");
     assert_eq!(parts[0]["kind"], "data");
     assert_eq!(parts[0]["data"], expected);
+}
+
+#[tokio::test]
+async fn a2a_tasks_get_ignores_non_schema_result_path_artifact() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) =
+        create_app_with_a2a(&server, "a2a-non-schema-result", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    let send = a2a_rpc(
+        &server,
+        app_id,
+        channel_id,
+        &api_key,
+        "message/send",
+        json!({ "message": { "role": "user", "parts": [{ "kind": "text", "text": "triage" }] } }),
+    )
+    .await;
+    let task_id = send["result"]["id"].as_str().unwrap().to_string();
+
+    seed_non_schema_result_path(&server, &task_id, json!({ "internal": "tool-output" })).await;
+
+    let resp = a2a_rpc(
+        &server,
+        app_id,
+        channel_id,
+        &api_key,
+        "tasks/get",
+        json!({ "id": task_id }),
+    )
+    .await;
+    assert!(
+        resp["result"].get("artifacts").is_none(),
+        "non-schema result_path leaked as artifact: {resp}"
+    );
 }
 
 /// Tenant isolation: a second channel's API key must not receive another

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -3613,6 +3613,67 @@ async fn seed_structured_result(server: &TestServer, session_id: &str, result: V
         .expect("write result file");
 }
 
+async fn seed_non_schema_result_path(server: &TestServer, session_id: &str, result: Value) {
+    use everruns_core::session_task::{
+        CreateSessionTask, SessionTaskState, SessionTaskUpdate, new_session_task,
+    };
+    use everruns_server::storage::models::CreateSessionFileRow;
+
+    let sid = session_id.parse::<SessionId>().expect("valid session id");
+    let session = server
+        .db
+        .get_session(DEFAULT_ORG_ID, sid)
+        .await
+        .expect("get_session")
+        .expect("session exists");
+
+    let task = new_session_task(
+        CreateSessionTask {
+            session_id: sid,
+            id: None,
+            kind: "background_tool".to_string(),
+            display_name: "background result".to_string(),
+            spec: json!({ "tool": "internal_scan" }),
+            state: SessionTaskState::Running,
+            links: Default::default(),
+            wake_policy: Default::default(),
+        },
+        chrono::Utc::now(),
+    );
+    server
+        .db
+        .create_session_task(&task)
+        .await
+        .expect("create non-schema task");
+
+    let path = format!("/.background/{}/result.json", task.id);
+    server
+        .db
+        .update_session_task(
+            sid,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                result_path: Some(path.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("set non-schema result_path");
+
+    server
+        .db
+        .create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(session.workspace_id),
+            path,
+            content: Some(serde_json::to_vec(&result).unwrap()),
+            is_directory: false,
+            is_readonly: false,
+        })
+        .await
+        .expect("write non-schema result file");
+}
+
 /// EVE-728: when a task reported a schema-bound `result.json`, `tasks/get`
 /// surfaces it under `result.structured_result` for Tasks clients — not just
 /// the last-message / status snapshot.
@@ -3651,6 +3712,29 @@ async fn test_mcp_tasks_get_surfaces_structured_result() {
 
     assert_eq!(resp["result"]["taskId"].as_str(), Some(task_id.as_str()));
     assert_eq!(resp["result"]["result"]["structured_result"], expected);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tasks_get_ignores_non_schema_result_path() {
+    let server = TestServer::in_memory().await;
+
+    let run = mcp_task_tool_call(&server, "agent_run", json!({ "message": "task result" })).await;
+    let task_id = run["result"]["taskId"].as_str().unwrap().to_string();
+
+    seed_non_schema_result_path(&server, &task_id, json!({ "internal": "tool-output" })).await;
+
+    let resp = mcp_call_with_headers(
+        &server,
+        "tasks/get",
+        json!({ "taskId": task_id }),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_2026)],
+    )
+    .await;
+
+    assert!(
+        resp["result"]["result"].get("structured_result").is_none(),
+        "non-schema result_path leaked as structured_result: {resp}"
+    );
 }
 
 /// tasks/get for 2025-* is method_not_found (extension doesn't exist there).


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of non-schema task artifacts via A2A/MCP `tasks/get` by tightening the structured-result selection logic which previously picked any task with a `result_path`.
- The previous behavior could surface internal `background_tool` or delegated-agent JSON as a session-level structured result, leaking internal/tool outputs to callers that only poll task status.

### Description
- Require the task to be a subagent with an object `result_schema` and the canonical `/.tasks/{task_id}/result.json` path before treating a task as a structured result by adding `is_structured_result_task` and applying it in `read_structured_task_result`.
- Replace the broad `result_path`-only selection with the above predicate so only intended schema-bound results are read and returned.
- Add regression helpers `seed_non_schema_result_path` and tests `a2a_tasks_get_ignores_non_schema_result_path_artifact` and `test_mcp_tasks_get_ignores_non_schema_result_path` to assert non-schema `result_path` artifacts are not exposed via A2A artifacts or MCP `result.structured_result`.
- Small, focused edits to `crates/server/src/domains/session_tasks/result.rs` and test files under `crates/server/tests/` implementing the checks and test cases.

### Testing
- Ran `cargo fmt --check` which succeeded.  
- Ran the focused A2A regression: `cargo test -p everruns-server --test app_a2a_integration_test a2a_tasks_get_ignores_non_schema_result_path_artifact -- --exact --nocapture` and it passed.  
- Ran the focused MCP regression: `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_tasks_get_ignores_non_schema_result_path -- --exact --nocapture` and it passed after switching the test harness to `TestServer::in_memory()` to avoid an external Postgres dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51eb223778832ba49200c98c649e88)