### PR TITLE
fix(auth): preserve zero-org auth state

### DIFF
--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -7,9 +7,7 @@
 
 use async_trait::async_trait;
 use axum::Router;
-use everruns_core::{
-    DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, PlatformDefinition,
-};
+use everruns_core::{OrgMembership, OrgRole, PlatformDefinition};
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,7 +35,8 @@ const PAT_CACHE_MAX_CAPACITY: u64 = 10_000;
 /// This is the default for OSS deployments.
 ///
 /// HARNESS-SEED SAFETY NET (see also `specs/authentication.md`):
-/// `register` and `oauth_callback` both add new users to `DEFAULT_ORG_ID`.
+/// When default-org auto-join is enabled, `register` and `oauth_callback`
+/// add new users to `DEFAULT_ORG_ID`.
 /// The background seed task (see `seed::spawn_seed_task_with_platform_definition`)
 /// provisions built-in harnesses for that org, but it runs asynchronously
 /// with a 500 ms initial delay — so a user who signs up during the startup
@@ -252,17 +251,9 @@ impl BuiltinAuthBackend {
             return Err(AuthError::unauthorized("Invalid or expired token"));
         };
 
-        // Fetch organization memberships for the user
+        // Fetch real organization memberships for the user. A zero-org user must
+        // stay zero-org so onboarding can create an isolated tenant-owned org.
         let organizations = fetch_user_organizations(&self.db, user_id).await?;
-
-        // If user has no organizations, fall back to default organization
-        if organizations.is_empty() {
-            tracing::warn!(
-                user_id = %user_id,
-                "User has no organizations, falling back to default org"
-            );
-        }
-        let organizations = organizations_or_default(organizations);
 
         let roles: Vec<String> = serde_json::from_value(user.roles).map_err(|e| {
             tracing::error!(user_id = %user_id, error = %e, "Failed to decode JWT user roles");
@@ -431,20 +422,6 @@ pub(super) async fn fetch_user_organizations(
             role: row.role.parse::<OrgRole>().unwrap_or(OrgRole::Member),
         })
         .collect())
-}
-
-/// Return organizations as-is, or fall back to default org membership if empty
-pub(super) fn organizations_or_default(organizations: Vec<OrgMembership>) -> Vec<OrgMembership> {
-    if organizations.is_empty() {
-        vec![OrgMembership {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-            role: OrgRole::Member,
-        }]
-    } else {
-        organizations
-    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -654,7 +654,7 @@ pub async fn login(
             .as_array()
             .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
-        organizations: builtin::organizations_or_default(organizations),
+        organizations,
     };
 
     audit::emit(
@@ -902,7 +902,7 @@ pub async fn register(
         roles: vec!["user".to_string()],
         is_platform_user: false,
         auth_method: AuthMethod::Jwt,
-        organizations: builtin::organizations_or_default(organizations),
+        organizations,
     };
 
     audit::emit(
@@ -994,7 +994,7 @@ pub async fn refresh_token(
             .as_array()
             .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
-        organizations: builtin::organizations_or_default(organizations),
+        organizations,
     };
 
     audit::emit(
@@ -1487,7 +1487,7 @@ async fn oauth_callback_inner(
             .as_array()
             .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
-        organizations: builtin::organizations_or_default(organizations),
+        organizations,
     };
 
     audit::emit(
@@ -1782,7 +1782,7 @@ pub async fn verify_email(
                 roles,
                 is_platform_user: false,
                 auth_method: AuthMethod::Jwt,
-                organizations: builtin::organizations_or_default(organizations),
+                organizations,
             };
             match generate_token_response(&state, jar.clone(), &auth_user).await {
                 Ok((jar, _json)) => jar,
@@ -2028,7 +2028,7 @@ async fn get_or_create_admin_user(
             .as_array()
             .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
-        organizations: builtin::organizations_or_default(organizations),
+        organizations,
     })
 }
 
@@ -2421,6 +2421,7 @@ mod oauth_state_tests {
     // Password reset + email verification
     // ========================================================================
 
+    use crate::auth::backend::AuthBackend;
     use crate::auth::config::AuthConfig;
     use crate::storage::StorageBackend;
     use crate::storage::models::CreateUserRow;
@@ -2545,7 +2546,7 @@ mod oauth_state_tests {
     async fn register_does_not_join_default_org_by_default() {
         let state = full_mode_backend();
         let db = state.db.clone();
-        register(
+        let outcome = register(
             State(state.clone()),
             None,
             HeaderMap::new(),
@@ -2559,6 +2560,25 @@ mod oauth_state_tests {
         )
         .await
         .expect("register should succeed");
+
+        let RegisterOutcome::Session(status, jar, Json(tokens)) = outcome else {
+            panic!("default mode must return an instant session");
+        };
+        assert_eq!(status, StatusCode::CREATED);
+        assert!(
+            jar.get(ORG_COOKIE_NAME).is_none(),
+            "zero-org signup must not receive a synthetic org cookie"
+        );
+
+        let auth_user = state
+            .validate_token(&tokens.access_token)
+            .await
+            .expect("issued access token should validate");
+        assert!(
+            auth_user.organizations.is_empty(),
+            "issued token must preserve zero-org memberships, got {:?}",
+            auth_user.organizations
+        );
 
         let user = db
             .get_user_by_email("solo@example.com")


### PR DESCRIPTION
### Motivation

- New signups in multi-tenant deployments must remain zero-org so the zero-org onboarding flow can create an isolated tenant, but the auth code was synthesizing `DEFAULT_ORG_ID` for empty membership lists and leaking that into tokens and cookies.

### Description

- Removed the synthetic default-org fallback during auth-user construction and JWT validation so `AuthUser.organizations` reflects only real DB memberships (changes in `crates/server/src/auth/builtin.rs`).
- Stopped calling `organizations_or_default` when building `AuthUser` in login/register/refresh/oauth/verify/admin flows and instead propagate the real `organizations` list (changes in `crates/server/src/auth/routes.rs`).
- Deleted the synthetic `organizations_or_default` fallback helper and updated comments to state the intended safety-net behavior remains gated by the `auto_join_default_org` flag.
- Added regression assertions in the registration test to verify a zero-org signup receives no org cookie and that the issued bearer token validates to an `AuthUser` with an empty organization list (`crates/server/src/auth/routes.rs` tests). 

### Testing

- Ran formatting check with `cargo fmt --check` which passed.
- Ran focused lib tests with `cargo test -p everruns-server --lib register_ -- --nocapture` and the updated registration tests passed (10 auth/register unit tests passed).
- A broader filtered `cargo test` run compiled and ran unit tests successfully but an unrelated integration test (`mcp_endpoint_test`) failed due to PostgreSQL not running (`PoolTimedOut`), unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5069367924832b95cf1ea0d8a55172)