### PR TITLE
fix(auth): stop email verification from signing in

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -879,8 +879,8 @@ pub async fn register(
     issue_verification_email(&state, user.id, &user.email).await;
 
     if state.config.signup_email_confirm {
-        // No session until the emailed confirmation link is clicked — the
-        // verify-email endpoint mints it (see `verify_email`).
+        // No session is minted during confirm-mode signup. The emailed link
+        // only verifies the address; users sign in explicitly afterward.
         audit::emit(
             state.db.clone(),
             DEFAULT_ORG_ID,
@@ -1737,9 +1737,8 @@ pub async fn reset_password(
 /// POST /v1/auth/verify-email - Mark the user's email verified.
 pub async fn verify_email(
     State(state): State<BuiltinAuthBackend>,
-    jar: CookieJar,
     Json(req): Json<VerifyEmailRequest>,
-) -> Result<(CookieJar, Json<OkResponse>), AuthError> {
+) -> Result<Json<OkResponse>, AuthError> {
     let token_hash = crate::api::org_invitations::hash_invite_token(&req.token);
     let user_id = state
         .db
@@ -1766,37 +1765,7 @@ pub async fn verify_email(
             AuthError::internal("Email verification failed")
         })?;
 
-    // The single-use token proves control of the mailbox, so the confirmation
-    // link doubles as sign-in (required by confirm-mode signup, where no
-    // session exists before this point; harmless otherwise). Best-effort: a
-    // session failure must not fail verification itself.
-    let jar = match state.db.get_user(user_id).await {
-        Ok(Some(user)) => {
-            let organizations = builtin::fetch_user_organizations(&state.db, user.id)
-                .await
-                .unwrap_or_default();
-            let roles: Vec<String> = serde_json::from_value(user.roles.clone()).unwrap_or_default();
-            let auth_user = AuthUser {
-                id: user.id,
-                email: user.email,
-                name: user.name,
-                roles,
-                is_platform_user: false,
-                auth_method: AuthMethod::Jwt,
-                organizations,
-            };
-            match generate_token_response(&state, jar.clone(), &auth_user).await {
-                Ok((jar, _json)) => jar,
-                Err(err) => {
-                    tracing::warn!(error = %err.error, "verify-email session mint failed");
-                    jar
-                }
-            }
-        }
-        _ => jar,
-    };
-
-    Ok((jar, OkResponse::ok()))
+    Ok(OkResponse::ok())
 }
 
 /// POST /v1/auth/resend-verification - Re-send a verification email.
@@ -2926,13 +2895,9 @@ mod oauth_state_tests {
             .create_email_verification_token(user_id, &hash, Utc::now() - Duration::minutes(1))
             .await
             .unwrap();
-        let err = verify_email(
-            State(state),
-            CookieJar::new(),
-            Json(VerifyEmailRequest { token: raw }),
-        )
-        .await
-        .expect_err("expired token must be rejected");
+        let err = verify_email(State(state), Json(VerifyEmailRequest { token: raw }))
+            .await
+            .expect_err("expired token must be rejected");
         assert_eq!(err.status, StatusCode::BAD_REQUEST);
     }
 
@@ -2963,20 +2928,14 @@ mod oauth_state_tests {
             .await
             .unwrap();
 
-        let (jar, _ok) = verify_email(
+        let _ = verify_email(
             State(state.clone()),
-            CookieJar::new(),
             Json(VerifyEmailRequest { token: raw }),
         )
         .await
         .expect("verify should succeed");
 
         assert!(db.get_user(user_id).await.unwrap().unwrap().email_verified);
-        // The confirmation link doubles as sign-in: session cookies are set.
-        assert!(
-            jar.get("access_token").is_some(),
-            "verify must mint a session"
-        );
     }
 
     #[tokio::test]
@@ -2984,7 +2943,6 @@ mod oauth_state_tests {
         let state = test_backend();
         let err = verify_email(
             State(state),
-            CookieJar::new(),
             Json(VerifyEmailRequest {
                 token: "bad".to_string(),
             }),

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -219,10 +219,10 @@ email/password signup is an explicit, enumeration-safe two-step flow:
   address sends a "you already have an account" email instead. Both cases
   return the same `200 { "ok": true }` — the emailed body is the only place
   the two outcomes diverge.
-- `POST /v1/auth/verify-email` consumes the single-use token, marks the email
-  verified, and (best-effort) mints a session — the confirmation link doubles
-  as sign-in. Session minting on verify applies in all modes; the token
-  proves control of the mailbox.
+- `POST /v1/auth/verify-email` consumes the single-use token and marks the
+  email verified. It does not mint a session; after confirmation the user signs
+  in explicitly so verification links cannot overwrite another browser's
+  existing session.
 - `/v1/auth/config` advertises `signup_email_confirm` so the UI renders the
   "Check your email" landing (identical copy for new and existing addresses)
   instead of expecting tokens.


### PR DESCRIPTION
### Motivation
- Prevent a login CSRF / session-fixation issue where `POST /v1/auth/verify-email` consumed an attacker-controlled verification token and minted browser session cookies for the token owner.
- Treat verification as mailbox control only; verification links must not overwrite an existing browser session.

### Description
- Removed implicit session minting from `POST /v1/auth/verify-email` by dropping the `CookieJar` parameter and no longer calling the token/cookie generation path; the handler now consumes the token, sets `email_verified = true`, and returns a plain OK. (`crates/server/src/auth/routes.rs`).
- Clarified confirm-mode signup documentation and comments to state that the emailed link only verifies the address and does not sign the user in. (`crates/server/src/auth/routes.rs` and `specs/authentication.md`).
- Updated unit tests to stop asserting on session cookies and instead assert only that `email_verified` is set; adjusted test call sites to match the new `verify_email` signature. (`crates/server/src/auth/routes.rs` tests).

### Testing
- Ran `cargo fmt` and focused unit tests via `cargo test -p everruns-server --lib verify_email -- --nocapture`, which executed the `verify_email` test group and reported: `3 passed; 0 failed`.
- Verified `git diff --check` and committed the changes as `fix(auth): stop email verification from signing in`.
- Note: `git fetch origin main` failed in this worktree because `origin` is not configured, so changes were made and tested against the current HEAD.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca14671cc832baaad085cc1ae6c70)