### PR TITLE
fix(agent-triggers): return public agent IDs

### DIFF
--- a/crates/server/src/domains/agent_triggers/commands.rs
+++ b/crates/server/src/domains/agent_triggers/commands.rs
@@ -167,7 +167,14 @@ pub(crate) async fn sync_agent_trigger_binding(
     ctx: &Ctx,
     trigger_row: &AgentTriggerRow,
 ) -> Result<(), CommandError> {
-    let trigger = q::row_to_trigger(trigger_row.clone());
+    let agent = ctx
+        .db
+        .get_agent(ctx.org_id(), trigger_row.agent_id)
+        .await
+        .map_err(classify_anyhow)?
+        .ok_or_else(|| CommandError::not_found("Agent"))?;
+    let agent_public_id = parse_agent_id(&agent.public_id)?;
+    let trigger = q::row_to_trigger(trigger_row.clone(), agent_public_id);
     if trigger.trigger_type != AgentTriggerType::Schedule {
         return Ok(());
     }
@@ -180,12 +187,6 @@ pub(crate) async fn sync_agent_trigger_binding(
 
     // The durable target must name the agent by its user-facing public id so the
     // invocation activity can resolve it.
-    let agent = ctx
-        .db
-        .get_agent(ctx.org_id(), trigger_row.agent_id)
-        .await
-        .map_err(classify_anyhow)?
-        .ok_or_else(|| CommandError::not_found("Agent"))?;
     let target_input = build_trigger_target_input(ctx.org_id(), &agent.public_id, trigger_row.id);
     let description = format!(
         "Agent schedule trigger {} for {}",
@@ -413,7 +414,7 @@ impl Command for CreateAgentTrigger {
         let row = q::get_by_id(&ctx.db, ctx.org_id(), row.id)
             .await?
             .unwrap_or(row);
-        Ok(q::row_to_trigger(row))
+        Ok(q::row_to_trigger(row, agent_public))
     }
 }
 
@@ -460,7 +461,10 @@ impl Command for ListAgentTriggers {
             .list_agent_triggers(ctx.org_id(), Some(agent.id), self.include_archived)
             .await
             .map_err(classify_anyhow)?;
-        Ok(rows.into_iter().map(q::row_to_trigger).collect())
+        Ok(rows
+            .into_iter()
+            .map(|row| q::row_to_trigger(row, agent_public))
+            .collect())
     }
 }
 
@@ -495,8 +499,10 @@ impl Command for GetAgentTrigger {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<AgentTrigger, CommandError> {
-        let (_, trigger) = resolve_trigger_for_agent(ctx, &self.agent_id, &self.trigger_id).await?;
-        Ok(q::row_to_trigger(trigger))
+        let (agent, trigger) =
+            resolve_trigger_for_agent(ctx, &self.agent_id, &self.trigger_id).await?;
+        let agent_public = parse_agent_id(&agent.public_id)?;
+        Ok(q::row_to_trigger(trigger, agent_public))
     }
 }
 
@@ -538,7 +544,7 @@ impl Command for UpdateAgentTriggerCmd {
         let req = self.req;
 
         // Merge onto the stored schedule config.
-        let mut config = q::row_to_trigger(existing.clone())
+        let mut config = q::row_to_trigger(existing.clone(), parse_agent_id(&self.agent_id)?)
             .schedule_config()
             .map_err(|_| CommandError::bad_request("Invalid stored schedule configuration"))?;
         if let Some(cron) = req.cron_expression {
@@ -591,7 +597,7 @@ impl Command for UpdateAgentTriggerCmd {
         let row = q::get_by_id(&ctx.db, ctx.org_id(), row.id)
             .await?
             .unwrap_or(row);
-        Ok(q::row_to_trigger(row))
+        Ok(q::row_to_trigger(row, parse_agent_id(&self.agent_id)?))
     }
 }
 
@@ -756,7 +762,7 @@ pub async fn invoke_agent_trigger(
         return Err(CommandError::not_found("Agent trigger"));
     }
 
-    let trigger = q::row_to_trigger(trigger_row.clone());
+    let trigger = q::row_to_trigger(trigger_row.clone(), parse_agent_id(&agent.public_id)?);
     let config = trigger
         .schedule_config()
         .map_err(|_| CommandError::bad_request("Invalid schedule trigger configuration"))?;

--- a/crates/server/src/domains/agent_triggers/queries.rs
+++ b/crates/server/src/domains/agent_triggers/queries.rs
@@ -9,10 +9,13 @@ use everruns_core::{AgentTrigger, AgentTriggerType};
 use std::sync::Arc;
 
 /// Map a storage row into the core [`AgentTrigger`].
-pub fn row_to_trigger(row: AgentTriggerRow) -> AgentTrigger {
+///
+/// `AgentTriggerRow.agent_id` is the internal agent FK; API DTOs must carry
+/// the caller-facing agent public id.
+pub fn row_to_trigger(row: AgentTriggerRow, agent_public_id: AgentId) -> AgentTrigger {
     AgentTrigger {
         id: row.id,
-        agent_id: row.agent_id,
+        agent_id: agent_public_id,
         trigger_type: AgentTriggerType::from(row.trigger_type.as_str()),
         config: row.config,
         enabled: row.enabled,

--- a/crates/server/src/domains/agent_triggers/tests.rs
+++ b/crates/server/src/domains/agent_triggers/tests.rs
@@ -148,6 +148,53 @@ async fn create_enforces_per_org_enabled_cap() {
     unsafe { std::env::remove_var("AGENT_TRIGGER_MAX_PER_ORG") };
 }
 
+#[tokio::test]
+async fn responses_use_public_agent_id_not_internal_fk() {
+    let db = Arc::new(StorageBackend::in_memory());
+    let store = Arc::new(InMemoryWorkflowEventStore::new());
+    let ctx = test_ctx(db.clone(), store);
+    let (agent_id, _) = seed_agent(&db).await;
+    let public_agent_id: AgentId = agent_id.parse().expect("public agent id parses");
+    let internal_agent_id = db
+        .get_agent_by_public_id(DEFAULT_ORG_ID, &agent_id)
+        .await
+        .unwrap()
+        .expect("agent row")
+        .id;
+    assert_ne!(
+        public_agent_id, internal_agent_id,
+        "test must exercise distinct public and internal agent IDs"
+    );
+
+    let created = CreateAgentTrigger {
+        agent_id: agent_id.clone(),
+        req: create_req("0 9 * * *", "hello", true),
+    }
+    .execute(&ctx)
+    .await
+    .expect("create trigger");
+    assert_eq!(created.agent_id, public_agent_id);
+
+    let listed = ListAgentTriggers {
+        agent_id: agent_id.clone(),
+        include_archived: false,
+    }
+    .execute(&ctx)
+    .await
+    .expect("list triggers");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].agent_id, public_agent_id);
+
+    let fetched = GetAgentTrigger {
+        agent_id,
+        trigger_id: created.id.to_string(),
+    }
+    .execute(&ctx)
+    .await
+    .expect("get trigger");
+    assert_eq!(fetched.agent_id, public_agent_id);
+}
+
 // ---- durable binding create / teardown ----------------------------------
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Close an information-disclosure bug where `AgentTrigger.agent_id` used the internal agent FK from storage instead of the API-facing `agent_*` public id, violating the dual-ID boundary. 
- Preserve internal FK storage for DB relations while ensuring API DTOs only expose public identifiers.

### Description
- Change the trigger mapper to accept a public `AgentId` and populate `AgentTrigger.agent_id` from that public id instead of the internal FK by updating `row_to_trigger` signature. 
- Hydrate the agent's public id at call sites and pass it into the mapper from create/list/get/update, durable-binding sync, and invocation paths (`crates/server/src/domains/agent_triggers/commands.rs` and `queries.rs`).
- Keep storage and FK usage unchanged (`agent_id` remains the internal DB FK in trigger rows). 
- Add a regression test `responses_use_public_agent_id_not_internal_fk` that asserts create/list/get responses return the public agent id and not the internal FK (`crates/server/src/domains/agent_triggers/tests.rs`).

### Testing
- Ran `cargo test -p everruns-server --lib domains::agent_triggers` and all tests passed: `10 passed / 0 failed` (includes the new regression test). 
- Ran `cargo fmt --check` and `git diff --check` with no formatting or diff-check errors. 
- Verified the small, targeted diff and included the PR body describing the change and security rationale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c6ad70832b8cd3f9d74ae16c50)