### PR TITLE
fix(core): enforce full result JSON schema validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1137,12 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -2230,6 +2256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2612,7 @@ dependencies = [
  "include_dir",
  "insta",
  "inventory",
+ "jsonschema",
  "llmsim",
  "mlua",
  "opentelemetry",
@@ -3445,6 +3481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,6 +3542,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -4739,6 +4796,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5191,6 +5284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,12 +5593,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -5526,6 +5654,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -6943,6 +7092,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -9071,6 +9237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9243,6 +9415,16 @@ dependencies = [
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ futures.workspace = true
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
+jsonschema = { version = "0.47.0", default-features = false }
 serde_yaml.workspace = true
 toml = "1.1"
 

--- a/crates/core/src/capabilities/delegation_result.rs
+++ b/crates/core/src/capabilities/delegation_result.rs
@@ -51,84 +51,27 @@ pub(crate) fn normalize_message_schema(
     normalize_optional_schema(arguments, MESSAGE_SCHEMA_SPEC_KEY)
 }
 
-fn json_schema_type_matches(expected: &str, value: &Value) -> bool {
-    match expected {
-        "object" => value.is_object(),
-        "array" => value.is_array(),
-        "string" => value.is_string(),
-        "boolean" => value.is_boolean(),
-        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
-        "number" => value.is_number(),
-        "null" => value.is_null(),
-        _ => true,
-    }
-}
-
-fn validate_against_schema(schema: &Value, value: &Value, path: &str, errors: &mut Vec<String>) {
-    if let Some(enum_values) = schema.get("enum").and_then(Value::as_array)
-        && !enum_values.iter().any(|candidate| candidate == value)
-    {
-        errors.push(format!("{path} is not one of the allowed enum values"));
-    }
-    if let Some(const_value) = schema.get("const")
-        && const_value != value
-    {
-        errors.push(format!("{path} does not match the required const value"));
-    }
-    if let Some(type_value) = schema.get("type") {
-        let matches = match type_value {
-            Value::String(expected) => json_schema_type_matches(expected, value),
-            Value::Array(types) => types
-                .iter()
-                .filter_map(Value::as_str)
-                .any(|expected| json_schema_type_matches(expected, value)),
-            _ => true,
-        };
-        if !matches {
-            errors.push(format!("{path} has the wrong JSON type"));
-            return;
-        }
-    }
-    if let (Some(object), Some(properties)) = (
-        value.as_object(),
-        schema.get("properties").and_then(Value::as_object),
-    ) {
-        if let Some(required) = schema.get("required").and_then(Value::as_array) {
-            for key in required.iter().filter_map(Value::as_str) {
-                if !object.contains_key(key) {
-                    errors.push(format!("{path}.{key} is required"));
-                }
-            }
-        }
-        if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
-            for key in object.keys() {
-                if !properties.contains_key(key) {
-                    errors.push(format!("{path}.{key} is not allowed"));
-                }
-            }
-        }
-        for (key, property_schema) in properties {
-            if let Some(property_value) = object.get(key) {
-                validate_against_schema(
-                    property_schema,
-                    property_value,
-                    &format!("{path}.{key}"),
-                    errors,
-                );
-            }
-        }
-    }
-    if let (Some(array), Some(item_schema)) = (value.as_array(), schema.get("items")) {
-        for (index, item) in array.iter().enumerate() {
-            validate_against_schema(item_schema, item, &format!("{path}[{index}]"), errors);
-        }
-    }
-}
-
 pub(crate) fn schema_validation_errors(schema: &Value, value: &Value) -> Vec<String> {
-    let mut errors = Vec::new();
-    validate_against_schema(schema, value, "$", &mut errors);
-    errors
+    let validator = match jsonschema::draft202012::options()
+        .should_validate_formats(true)
+        .build(schema)
+    {
+        Ok(validator) => validator,
+        Err(error) => return vec![format!("result schema is invalid: {error}")],
+    };
+
+    validator
+        .iter_errors(value)
+        .map(|error| {
+            let path = error.instance_path().to_string();
+            let path = if path.is_empty() {
+                "$".to_string()
+            } else {
+                path
+            };
+            format!("{path} {error}")
+        })
+        .collect()
 }
 
 const MAX_TASK_SUMMARY_CHARS: usize = 2_048;
@@ -480,13 +423,70 @@ mod tests {
         });
         let errors =
             schema_validation_errors(&schema, &json!({"count": "not-an-integer", "extra": true}));
-        assert!(errors.iter().any(|error| error == "$.answer is required"));
         assert!(
             errors
                 .iter()
-                .any(|error| error == "$.count has the wrong JSON type")
+                .any(|error| error.contains("answer") && error.contains("required"))
         );
-        assert!(errors.iter().any(|error| error == "$.extra is not allowed"));
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("count") && error.contains("integer"))
+        );
+        assert!(errors.iter().any(|error| error.contains("extra")
+            && (error.contains("additional") || error.contains("not allowed"))));
+    }
+
+    #[test]
+    fn shared_validator_enforces_full_json_schema_constraints() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "echo": {"type": "string", "pattern": "^[0-9]+$", "minLength": 2},
+                "score": {"type": "integer", "minimum": 0},
+                "tags": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {"type": "string"}
+                },
+                "choice": {
+                    "oneOf": [
+                        {"const": "alpha"},
+                        {"const": "beta"}
+                    ]
+                }
+            },
+            "required": ["echo", "score", "tags", "choice"],
+            "additionalProperties": false
+        });
+
+        let errors = schema_validation_errors(
+            &schema,
+            &json!({
+                "echo": "x",
+                "score": -5,
+                "tags": ["solo"],
+                "choice": "gamma"
+            }),
+        );
+
+        assert!(errors.iter().any(|error| error.contains("echo")
+            && (error.contains("pattern") || error.contains("^[0-9]+$"))));
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("score") && error.contains("0"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("tags") && error.contains("2"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("choice") && error.contains("oneOf"))
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -3068,8 +3068,15 @@ mod tests {
         let ToolExecutionResult::ToolError(message) = result else {
             panic!("expected validation error, got {result:?}");
         };
-        assert!(message.contains("$.answer is required"), "got: {message}");
-        assert!(message.contains("$.extra is not allowed"), "got: {message}");
+        assert!(
+            message.contains("answer") && message.contains("required"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("extra")
+                && (message.contains("additional") || message.contains("not allowed")),
+            "got: {message}"
+        );
     }
 
     #[tokio::test]
@@ -3186,10 +3193,14 @@ mod tests {
             panic!("expected validation error, got {result:?}");
         };
         assert!(
-            message.contains("$.step has the wrong JSON type"),
+            message.contains("step") && message.contains("string"),
             "got: {message}"
         );
-        assert!(message.contains("$.extra is not allowed"), "got: {message}");
+        assert!(
+            message.contains("extra")
+                && (message.contains("additional") || message.contains("not allowed")),
+            "got: {message}"
+        );
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,7 @@ allow = [
     "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
+    "MIT-0",
     "OpenSSL",
     "Unicode-3.0",
     "Zlib",


### PR DESCRIPTION
### Motivation

- External A2A structured results were being accepted after a limited in-repo JSON Schema check, which ignored many common keywords and allowed untrusted remote data to be persisted as successful task results.

### Description

- Replace the hand-rolled subset validator with the `jsonschema` crate's Draft 2020-12 validator and fail-closed on schema compilation errors. 
- Add `jsonschema = { version = "0.47.0", default-features = false }` to `crates/core/Cargo.toml` so HTTP/file `$ref` resolution features are not enabled. 
- Surface full validator errors (instance path + message) from `schema_validation_errors()` and preserve server-side result-path behavior. 
- Update existing tests and add a regression test that exercises `pattern`, `minimum`, `minItems`, and `oneOf` constraints.

### Testing

- Ran `cargo fmt --check` and applied formatting fixes, which passed. 
- Ran `cargo test -p everruns-core shared_validator --all-features -- --nocapture`, and the focused validator tests (including the new regression) passed. 
- Verified dependency feature surface with `cargo tree -p everruns-core -e features -i jsonschema` to confirm no HTTP/file resolver features were enabled. 
- Attempted `cargo test -p everruns-core ... --no-default-features` but the run failed due to a pre-existing, unrelated feature-gating compile error in `tool_search` when `web-fetch` is disabled (kept as informational evidence).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c64c3c832bae47b32572d1ca5b)