### PR TITLE
fix(ui): cap Work view SSE subscriptions

### DIFF
--- a/apps/ui/src/__tests__/use-org-tasks.test.tsx
+++ b/apps/ui/src/__tests__/use-org-tasks.test.tsx
@@ -5,21 +5,31 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import type { SessionTask } from "@/lib/api/types";
-import { useOrgTasks } from "@/hooks/use-org-tasks";
+import {
+  ORG_TASKS_LIST_LIMIT,
+  ORG_TASKS_LIVE_SESSION_LIMIT,
+  liveOrgTaskSessionIds,
+  useOrgTasks,
+} from "@/hooks/use-org-tasks";
 
 // Capture SSE listeners the hook registers so the test can push events.
 const mockSseListeners: Record<string, Array<(e: MessageEvent) => void>> = {};
+const mockStreams: Array<{ close: jest.Mock }> = [];
 
 jest.mock("@/lib/event-stream", () => ({
-  createEventStream: jest.fn(() => ({
-    addEventListener: (type: string, listener: (e: MessageEvent) => void) => {
-      (mockSseListeners[type] ||= []).push(listener);
-    },
-    removeEventListener: () => {},
-    close: jest.fn(),
-    onopen: null,
-    onerror: null,
-  })),
+  createEventStream: jest.fn(() => {
+    const stream = {
+      addEventListener: (type: string, listener: (e: MessageEvent) => void) => {
+        (mockSseListeners[type] ||= []).push(listener);
+      },
+      removeEventListener: () => {},
+      close: jest.fn(),
+      onopen: null,
+      onerror: null,
+    };
+    mockStreams.push(stream);
+    return stream;
+  }),
 }));
 
 const initialTask: SessionTask = {
@@ -35,10 +45,10 @@ const initialTask: SessionTask = {
   updated_at: new Date().toISOString(),
 } as unknown as SessionTask;
 
-const mockListOrgTasks = jest.fn(async () => [initialTask]);
+const mockListOrgTasks = jest.fn(async (_options?: unknown) => [initialTask]);
 
 jest.mock("@/lib/api/session-tasks", () => ({
-  listOrgTasks: () => mockListOrgTasks(),
+  listOrgTasks: (options?: unknown) => mockListOrgTasks(options),
 }));
 
 jest.mock("@/lib/api/events", () => ({
@@ -65,6 +75,7 @@ describe("useOrgTasks SSE reconciliation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockStreams.length = 0;
     for (const key of Object.keys(mockSseListeners)) delete mockSseListeners[key];
   });
 
@@ -93,6 +104,7 @@ describe("useOrgTasks SSE reconciliation", () => {
     expect(result.current.data).toHaveLength(1);
     // No second snapshot fetch was needed to reflect the delta.
     expect(mockListOrgTasks).toHaveBeenCalledTimes(1);
+    expect(mockListOrgTasks).toHaveBeenCalledWith({ limit: ORG_TASKS_LIST_LIMIT });
   });
 
   it("appends a newly created task from a task.created snapshot", async () => {
@@ -108,5 +120,56 @@ describe("useOrgTasks SSE reconciliation", () => {
 
     await waitFor(() => expect(result.current.data).toHaveLength(2));
     expect(result.current.data?.map((t) => t.id)).toEqual(["task_1", "task_2"]);
+  });
+
+  describe("subscription limits", () => {
+    it("keeps only a capped newest-session live window", () => {
+      const tasks = Array.from({ length: ORG_TASKS_LIVE_SESSION_LIMIT + 5 }, (_, index) => ({
+        ...initialTask,
+        id: `task_${index}`,
+        session_id: `session-${String(index).padStart(2, "0")}`,
+      })) as SessionTask[];
+
+      expect(liveOrgTaskSessionIds(tasks)).toHaveLength(ORG_TASKS_LIVE_SESSION_LIMIT);
+      expect(liveOrgTaskSessionIds(tasks)).not.toContain(
+        `session-${String(ORG_TASKS_LIVE_SESSION_LIMIT + 1).padStart(2, "0")}`,
+      );
+    });
+
+    it("opens at most the capped number of session streams for a large snapshot", async () => {
+      mockListOrgTasks.mockResolvedValueOnce(
+        Array.from({ length: ORG_TASKS_LIVE_SESSION_LIMIT + 10 }, (_, index) => ({
+          ...initialTask,
+          id: `task_${index}`,
+          session_id: `session-${index}`,
+        })) as SessionTask[],
+      );
+
+      renderHook(() => useOrgTasks(), { wrapper });
+
+      await waitFor(() => expect(mockStreams).toHaveLength(ORG_TASKS_LIVE_SESSION_LIMIT));
+    });
+
+    it("coalesces connected invalidations from multiple session streams", async () => {
+      const invalidateQueries = jest.spyOn(queryClient, "invalidateQueries");
+      mockListOrgTasks.mockResolvedValueOnce(
+        Array.from({ length: 3 }, (_, index) => ({
+          ...initialTask,
+          id: `task_${index}`,
+          session_id: `session-${index}`,
+        })) as SessionTask[],
+      );
+
+      renderHook(() => useOrgTasks(), { wrapper });
+      await waitFor(() => expect(mockSseListeners.connected).toHaveLength(3));
+
+      act(() => {
+        for (const handler of mockSseListeners.connected ?? []) {
+          handler({ data: "{}" } as MessageEvent);
+        }
+      });
+
+      await waitFor(() => expect(invalidateQueries).toHaveBeenCalledTimes(1));
+    });
   });
 });

--- a/apps/ui/src/hooks/use-org-tasks.ts
+++ b/apps/ui/src/hooks/use-org-tasks.ts
@@ -4,12 +4,10 @@
 // task_id — identical to `useSessionTasks`, but fanned out across sessions.
 //
 // There is no org-wide SSE endpoint; the event stream is per-session
-// (`/v1/sessions/{id}/sse`). So this hook opens one stream per distinct owning
-// session present in the current snapshot and reconciles `task.created` /
-// `task.updated` (full snapshots) into the single org task cache by task_id.
-// When the set of sessions changes, the streams are torn down and reopened.
-// Brand-new sessions not yet in the snapshot are picked up on the next
-// snapshot refetch (each stream re-invalidates on `connected`).
+// (`/v1/sessions/{id}/sse`). To avoid turning an org-wide task snapshot into
+// unbounded persistent streams, this hook subscribes only to a capped newest-task
+// session window and reconciles `task.created` / `task.updated` (full snapshots)
+// into the single org task cache by task_id.
 "use client";
 
 import { useEffect, useMemo } from "react";
@@ -22,6 +20,29 @@ import { createReconnectTracker } from "@/lib/sse-reconnect";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
 import type { SessionTask } from "@/lib/api/types";
+
+export const ORG_TASKS_LIVE_SESSION_LIMIT = 20;
+export const ORG_TASKS_LIST_LIMIT = 100;
+
+const connectedInvalidationTimers = new WeakMap<QueryClient, ReturnType<typeof setTimeout>>();
+
+function invalidateOrgTasksSoon(queryClient: QueryClient) {
+  if (connectedInvalidationTimers.has(queryClient)) return;
+  const timer = setTimeout(() => {
+    connectedInvalidationTimers.delete(queryClient);
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgTasks.list() });
+  }, 0);
+  connectedInvalidationTimers.set(queryClient, timer);
+}
+
+export function liveOrgTaskSessionIds(tasks: SessionTask[]): string[] {
+  const ids = new Set<string>();
+  for (const task of tasks) {
+    ids.add(task.session_id);
+    if (ids.size >= ORG_TASKS_LIVE_SESSION_LIMIT) break;
+  }
+  return Array.from(ids).sort();
+}
 
 /** Subscribe to one session's SSE stream, reconciling task snapshots into the
  *  shared org task cache. Returns a disposer that stops reconnects and closes
@@ -47,9 +68,8 @@ function subscribeSession(sessionId: string, queryClient: QueryClient): () => vo
 
     source.addEventListener("connected", () => {
       tracker.reset();
-      // Close the fetch-then-subscribe gap and pick up tasks from sessions that
-      // were not yet in the snapshot when we subscribed.
-      queryClient.invalidateQueries({ queryKey: queryKeys.orgTasks.list() });
+      // Close the fetch-then-subscribe gap without refetching once per stream.
+      invalidateOrgTasksSoon(queryClient);
     });
 
     source.addEventListener("disconnecting", (messageEvent) => {
@@ -125,17 +145,16 @@ export function useOrgTasks() {
 
   const query = useQuery({
     queryKey: queryKeys.orgTasks.list(),
-    queryFn: () => listOrgTasks(),
+    queryFn: () => listOrgTasks({ limit: ORG_TASKS_LIST_LIMIT }),
     enabled,
   });
 
-  // Distinct owning sessions in the snapshot, as a stable key so the effect only
-  // re-subscribes when the session set actually changes (not on every patch).
-  const sessionIdsKey = useMemo(() => {
-    const ids = new Set<string>();
-    for (const task of query.data ?? []) ids.add(task.session_id);
-    return Array.from(ids).sort().join(",");
-  }, [query.data]);
+  // Capped owning sessions in the newest-first snapshot, as a stable key so the
+  // effect only re-subscribes when the live session window actually changes.
+  const sessionIdsKey = useMemo(
+    () => liveOrgTaskSessionIds(query.data ?? []).join(","),
+    [query.data],
+  );
 
   useEffect(() => {
     if (!enabled || !sessionIdsKey) return;


### PR DESCRIPTION
### Motivation

- The Work view opened a persistent per-session SSE stream for every distinct session in the org task snapshot, which could fan out to dozens of EventSource connections and create availability/reconnect/refetch storms against server SSE limits. 
- Introduce a lightweight client-side mitigation that preserves functionality while preventing unbounded connection fan-out.

### Description

- Limit live per-session SSE subscriptions to a newest-task window using `ORG_TASKS_LIVE_SESSION_LIMIT` and compute that window with the new `liveOrgTaskSessionIds` helper in `apps/ui/src/hooks/use-org-tasks.ts`.
- Keep the org snapshot size explicit by calling `listOrgTasks({ limit: ORG_TASKS_LIST_LIMIT })` so the client-side cap is aligned with the returned page size.
- Coalesce `connected` event-driven invalidations into a single tick-per-`QueryClient` via `invalidateOrgTasksSoon` backed by a `WeakMap` to avoid one refetch per stream when many streams connect simultaneously.
- Add and update regression tests in `apps/ui/src/__tests__/use-org-tasks.test.tsx` to cover live reconciliation, the capped session selection, capped stream creation for large snapshots, and the coalesced `connected` invalidation behavior.

### Testing

- Formatting ran via `oxfmt` on the modified files and completed successfully.
- Linting with `oxlint` completed successfully with no errors.
- Type checking with `tsgo --noEmit` completed successfully with no errors.
- Focused unit tests `pnpm test -- --runInBand src/__tests__/use-org-tasks.test.tsx` ran and passed (1 test suite, 5 tests), including the new coverage for the subscription cap and coalesced invalidations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c68448832bb7d71fa0cd1a42ca)