### PR TITLE
fix(core): enforce auto-continue schedule limits

### DIFF
--- a/crates/core/src/capabilities/usage_limit_auto_continue.rs
+++ b/crates/core/src/capabilities/usage_limit_auto_continue.rs
@@ -218,7 +218,7 @@ impl LlmErrorHook for UsageLimitAutoContinueHook {
         let scheduled_at = (reset_time + delay).max(now + delay);
 
         match store
-            .create_schedule(
+            .create_schedule_enforcing_limits(
                 ctx.session_id,
                 cfg.prompt.clone(),
                 None,
@@ -238,11 +238,10 @@ impl LlmErrorHook for UsageLimitAutoContinueHook {
                 // now that a continuation was actually scheduled.
                 LlmErrorHookOutcome::noop().with_error_field("auto_continue", true)
             }
-            Err(e) => {
+            Err(_) => {
                 tracing::warn!(
                     session_id = %ctx.session_id,
-                    error = %e,
-                    "usage_limit_auto_continue: failed to schedule continuation"
+                    "usage_limit_auto_continue: failed to schedule continuation within schedule limits"
                 );
                 LlmErrorHookOutcome::noop()
             }
@@ -329,6 +328,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingScheduleStore {
         created: Mutex<Vec<(String, Option<chrono::DateTime<chrono::Utc>>)>>,
+        active_schedules: u32,
     }
 
     #[async_trait]
@@ -385,7 +385,7 @@ mod tests {
             &self,
             _session_id: SessionId,
         ) -> crate::error::Result<u32> {
-            Ok(0)
+            Ok(self.active_schedules)
         }
 
         async fn count_active_org_schedules(&self) -> crate::error::Result<u32> {
@@ -428,6 +428,31 @@ mod tests {
             outcome.extra_error_fields.get("auto_continue"),
             Some(&json!(true))
         );
+    }
+
+    #[tokio::test]
+    async fn handler_enforces_schedule_limits_before_auto_continue() {
+        let store = Arc::new(RecordingScheduleStore {
+            active_schedules: crate::session_schedule::MAX_ACTIVE_SCHEDULES_PER_SESSION,
+            ..Default::default()
+        });
+        let services = LlmErrorHookServices {
+            schedule_store: Some(store.clone()),
+        };
+        let fields = usage_limit_fields(1_783_767_823);
+        let config = json!({});
+        let ctx = LlmErrorContext {
+            session_id: SessionId::new(),
+            error_code: user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED,
+            error_fields: &fields,
+            config: &config,
+            services: &services,
+        };
+
+        let outcome = UsageLimitAutoContinueHook.on_llm_error(&ctx).await;
+
+        assert!(store.created.lock().unwrap().is_empty());
+        assert_eq!(outcome, LlmErrorHookOutcome::noop());
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation

- The usage-limit auto-continue hook previously created continuation schedules via the raw store API and bypassed the platform's per-session and per-org active-schedule caps, risking worker amplification and DB growth.

### Description

- Route auto-continue creation through `create_schedule_enforcing_limits` instead of the raw `create_schedule` so store-side per-session and per-org caps are enforced atomically.
- Avoid logging the store error value directly (the shared `ScheduleLimitError` lacks Display/Debug) and emit a generic warning when scheduling is rejected by limits.
- Add a regression test `handler_enforces_schedule_limits_before_auto_continue` that simulates the session active-schedule cap and asserts no schedule is created and no `auto_continue` promise is returned.
- Extend the test `RecordingScheduleStore` to model `active_schedules` and return it from `count_active_schedules` for the new regression case.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p everruns-core usage_limit_auto_continue --all-features` and all focused tests passed (9 passed, 0 failed).
- Added unit test `handler_enforces_schedule_limits_before_auto_continue` which passed in the focused test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c56ca0832bb37a0e53a1329d21)