### PR TITLE
fix(export): validate ATIF subagent links

### DIFF
--- a/crates/server/src/atif.rs
+++ b/crates/server/src/atif.rs
@@ -29,6 +29,7 @@ use everruns_core::events::{
 };
 use everruns_core::message::{ContentPart, Message};
 use serde_json::{Map, Value, json};
+use std::collections::HashMap;
 
 use crate::domains::evals::dataset::{REDACTED, sanitize_value};
 
@@ -265,6 +266,10 @@ fn fold_messages(messages: &[Message], redact: bool) -> Vec<Value> {
     let mut steps: Vec<Value> = Vec::new();
     // Index of the agent step that trailing tool results attach observations to.
     let mut open_agent: Option<usize> = None;
+    // Model-view tool result messages carry only a call id. Preserve the
+    // originating tool name from prior assistant messages so structural
+    // subagent links are only emitted for real spawn_agent results.
+    let mut tool_names_by_call_id: HashMap<String, String> = HashMap::new();
 
     for message in messages {
         let ts = json!(message.created_at.to_rfc3339());
@@ -308,6 +313,7 @@ fn fold_messages(messages: &[Message], redact: bool) -> Vec<Value> {
                     .tool_calls()
                     .iter()
                     .map(|tc| {
+                        tool_names_by_call_id.insert(tc.id.clone(), tc.name.clone());
                         json!({
                             "tool_call_id": tc.id,
                             "function_name": tc.name,
@@ -332,8 +338,13 @@ fn fold_messages(messages: &[Message], redact: bool) -> Vec<Value> {
             }
             MessageRole::ToolResult => {
                 let mut omitted = Vec::new();
+                let tool_name = message.tool_result_content().and_then(|tr| {
+                    tool_names_by_call_id
+                        .get(&tr.tool_call_id)
+                        .map(String::as_str)
+                });
                 let Some(observation) =
-                    message_tool_result_observation(message, redact, &mut omitted)
+                    message_tool_result_observation(message, redact, &mut omitted, tool_name)
                 else {
                     continue;
                 };
@@ -396,6 +407,7 @@ fn message_tool_result_observation(
     message: &Message,
     redact: bool,
     omitted: &mut Vec<Value>,
+    tool_name: Option<&str>,
 ) -> Option<Value> {
     let tr = message.tool_result_content()?;
     let base = if let Some(err) = &tr.error {
@@ -447,9 +459,12 @@ fn message_tool_result_observation(
         }),
     );
     obs.insert("extra".to_string(), Value::Object(extra));
-    // Subagent linkage parity with the event fold: a spawn result carries the
-    // child session id under `subagent_id`.
-    if let Some(res) = &tr.result
+    // Subagent linkage parity with the event fold: only spawn_agent results
+    // treat `subagent_id` as structural metadata. Other tools may return a
+    // user-controlled field with that name, which must remain content and
+    // therefore be redacted with the observation body.
+    if tool_name == Some("spawn_agent")
+        && let Some(res) = &tr.result
         && let Some(id) = res.get("subagent_id").and_then(Value::as_str)
         && !id.is_empty()
     {
@@ -2413,6 +2428,49 @@ mod tests {
         assert_eq!(
             redacted["steps"][1]["tool_calls"][0]["function_name"],
             json!("spawn_agent")
+        );
+    }
+
+    #[test]
+    fn message_fold_does_not_link_non_spawn_subagent_ids() {
+        let session = SessionId::new();
+        let (run, result) = sample_run_and_result(session);
+        let fake_child = "patient-alice@example.internal";
+
+        let lookup_call = ToolCall {
+            id: "call_lookup".to_string(),
+            name: "lookup_patient".to_string(),
+            arguments: json!({"patient": "alice"}),
+        };
+        let messages = vec![
+            Message::user("lookup alice"),
+            Message::assistant_with_tools("checking", vec![lookup_call]),
+            Message::tool_result(
+                "call_lookup",
+                Some(json!({"subagent_id": fake_child, "status": "matched"})),
+                None,
+            ),
+        ];
+
+        let redacted = build_case_record_from_messages(
+            &run,
+            &result,
+            &messages,
+            AtifOptions {
+                redact_content: true,
+            },
+        );
+        let observation = &redacted["steps"][1]["observation"]["results"][0];
+        assert_eq!(observation["content"], json!(REDACTED));
+        assert!(
+            observation.get("subagent_trajectory_ref").is_none(),
+            "non-spawn tool result subagent_id stays redacted content, not a structural link"
+        );
+        assert!(
+            !serde_json::to_string(&redacted)
+                .unwrap()
+                .contains(fake_child),
+            "redacted ATIF output must not leak non-spawn subagent_id content"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a redaction bypass in ATIF model-view exports where any tool-result JSON with a top-level `subagent_id` became a structural `subagent_trajectory_ref` even when the result did not come from `spawn_agent`.
- Ensure exported training rows reflect only structural subagent links produced by real `spawn_agent` tool calls while keeping non-structural `subagent_id` values subject to redaction.

### Description
- Preserve a `tool_call_id -> tool_name` map while folding model-view messages by recording tool names from assistant `tool_calls` in `fold_messages` and storing it in a `HashMap` in `crates/server/src/atif.rs`.
- Resolve the originating tool name for each model-view `ToolResult` and pass it into `message_tool_result_observation`, restricting `subagent_trajectory_ref` emission to `tool_name == "spawn_agent"` so non-spawn `subagent_id` values remain redacted content.
- Add a focused regression test `message_fold_does_not_link_non_spawn_subagent_ids` that asserts a redacted non-`spawn_agent` tool result containing `subagent_id` does not produce a structural subagent link and the identifier is not present in the exported ATIF document.
- Minor formatting applied (`cargo fmt`) and committed as part of the change in `crates/server/src/atif.rs`.

### Testing
- Ran `cargo fmt --check` and formatting completed successfully after applying `cargo fmt` where needed.
- Ran the focused unit tests with `cargo test -p everruns-server --lib atif::tests::message_fold` and all 4 ATIF model-view fold tests passed, including the new regression (`4 passed; 0 failed`).
- Ran `git diff --check` to validate the working tree and diff sanity, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52980d245c832bab1f99fd8270cd58)