### PR TITLE
fix(agent-handoff): check inherited invite conflicts

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -15,7 +15,6 @@ use super::{
     Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SpawnMode, SystemPromptContext,
 };
 use crate::config_layer::{AgentConfigOverlay, normalize_initial_file_path};
-use crate::harness::Harness;
 use crate::platform_store::PlatformCreateSessionRequest;
 use crate::session::{SessionSeedMode, SubagentStatus};
 use crate::session_task::{
@@ -472,18 +471,22 @@ fn invite_conflict_message(
         .or_else(|| mcp_conflict_message(host, guest))
 }
 
-async fn harness_overlay(
+async fn harness_chain_overlay(
     store: &dyn crate::platform_store::PlatformStore,
     harness_id: HarnessId,
 ) -> Result<AgentConfigOverlay, ToolExecutionResult> {
-    let harness = store
-        .get_harness(harness_id)
+    let chain = store
+        .get_harness_chain(harness_id)
         .await
-        .map_err(ToolExecutionResult::internal_error)?
-        .ok_or_else(|| {
-            ToolExecutionResult::tool_error(format!("Harness not found: {harness_id}"))
-        })?;
-    Ok(AgentConfigOverlay::from(&harness))
+        .map_err(ToolExecutionResult::internal_error)?;
+    if chain.is_empty() {
+        return Err(ToolExecutionResult::tool_error(format!(
+            "Harness not found: {harness_id}"
+        )));
+    }
+    Ok(AgentConfigOverlay::fold(
+        chain.iter().map(AgentConfigOverlay::from),
+    ))
 }
 
 async fn invite_mode_overlays(
@@ -491,7 +494,7 @@ async fn invite_mode_overlays(
     parent_session: &crate::session::Session,
     target: &AgentHandoffTargetConfig,
 ) -> Result<(AgentConfigOverlay, AgentConfigOverlay), ToolExecutionResult> {
-    let mut host_layers = vec![harness_overlay(store, parent_session.harness_id).await?];
+    let mut host_layers = vec![harness_chain_overlay(store, parent_session.harness_id).await?];
     if let Some(agent_id) = parent_session.agent_id {
         let host_agent = store
             .get_agent_by_id(agent_id)
@@ -504,13 +507,6 @@ async fn invite_mode_overlays(
     }
     host_layers.push(AgentConfigOverlay::from(parent_session));
 
-    let target_harness: Harness = store
-        .get_harness(target.harness_id)
-        .await
-        .map_err(ToolExecutionResult::internal_error)?
-        .ok_or_else(|| {
-            ToolExecutionResult::tool_error(format!("Harness not found: {}", target.harness_id))
-        })?;
     let target_agent = store
         .get_agent_by_id(target.agent_id)
         .await
@@ -522,7 +518,7 @@ async fn invite_mode_overlays(
     Ok((
         AgentConfigOverlay::fold(host_layers),
         AgentConfigOverlay::fold([
-            AgentConfigOverlay::from(&target_harness),
+            harness_chain_overlay(store, target.harness_id).await?,
             AgentConfigOverlay::from(&target_agent),
         ]),
     ))
@@ -1795,6 +1791,63 @@ mod tests {
         assert_eq!(
             participants[0].role,
             crate::session::SessionParticipantRole::Member
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_handoff_invite_rejects_inherited_harness_capability_conflict() {
+        let mut store_value = MockPlatformStore::new();
+        let parent_harness_id = HarnessId::new();
+        let child_harness_id = HarnessId::new();
+        let mut parent_harness = store_value.harness.clone();
+        parent_harness.id = parent_harness_id;
+        parent_harness.parent_harness_id = None;
+        parent_harness.capabilities = vec![crate::AgentCapabilityConfig::with_config(
+            "web_fetch",
+            json!({"max_bytes": 1024}),
+        )];
+        let mut child_harness = store_value.harness.clone();
+        child_harness.id = child_harness_id;
+        child_harness.parent_harness_id = Some(parent_harness_id);
+        child_harness.capabilities = vec![];
+        store_value.session.harness_id = child_harness_id;
+        store_value.agent.capabilities = vec![crate::AgentCapabilityConfig::with_config(
+            "web_fetch",
+            json!({"max_bytes": 2048}),
+        )];
+        {
+            let mut harnesses = store_value.extra_harnesses.lock().unwrap();
+            harnesses.insert(parent_harness_id, parent_harness);
+            harnesses.insert(child_harness_id, child_harness);
+        }
+        let store = Arc::new(store_value);
+        let config = target_config(store.agent.public_id, child_harness_id, vec![]);
+        let tool = spawn_agent_tool(&config);
+        let context = context(store.clone(), None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "name": "AWS Operator Invite",
+                    "instructions": "Join this incident session",
+                    "target": { "type": "agent", "id": "aws_operator" },
+                    "mode": "invite"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(matches!(result, ToolExecutionResult::ToolError(message)
+                if message.contains("Invite-mode handoff cannot join target")
+                    && message.contains("capability `web_fetch`")
+                    && message.contains("Use background or foreground mode")));
+        assert!(
+            store
+                .joined_participants
+                .lock()
+                .expect("participants lock")
+                .is_empty(),
+            "conflicting inherited harness invite must not join the participant"
         );
     }
 

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -16,6 +16,7 @@ use crate::typed_id::{AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// Simplified message representation for platform management tools.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +60,33 @@ pub trait PlatformStore: Send + Sync {
 
     /// Get a harness by ID.
     async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>>;
+
+    /// Get the effective harness chain from root to the requested harness.
+    ///
+    /// Platform management lookups return the raw harness row. Runtime assembly
+    /// applies inherited parent harnesses first, so security-sensitive
+    /// compatibility checks must use this chain rather than a single raw row.
+    async fn get_harness_chain(&self, id: HarnessId) -> Result<Vec<Harness>> {
+        let mut chain = Vec::new();
+        let mut current_id = Some(id);
+        let mut seen = HashSet::new();
+
+        while let Some(harness_id) = current_id {
+            if !seen.insert(harness_id) {
+                return Err(crate::error::AgentLoopError::tool(format!(
+                    "Harness inheritance cycle detected at {harness_id}"
+                )));
+            }
+            let Some(harness) = self.get_harness(harness_id).await? else {
+                return Ok(Vec::new());
+            };
+            current_id = harness.parent_harness_id;
+            chain.push(harness);
+        }
+
+        chain.reverse();
+        Ok(chain)
+    }
 
     /// Create a new harness.
     ///
@@ -328,6 +356,7 @@ pub mod tests {
     /// registered but the store is not passed through.
     pub struct MockPlatformStore {
         pub harness: Harness,
+        pub extra_harnesses: std::sync::Mutex<std::collections::HashMap<HarnessId, Harness>>,
         pub agent: Agent,
         pub app: App,
         pub app_channel: AppChannel,
@@ -380,6 +409,7 @@ pub mod tests {
                     archived_at: None,
                     deleted_at: None,
                 },
+                extra_harnesses: std::sync::Mutex::new(std::collections::HashMap::new()),
                 agent: Agent {
                     public_id: crate::typed_id::AgentId::new(),
                     internal_id: uuid::Uuid::now_v7(),
@@ -507,7 +537,10 @@ pub mod tests {
         async fn list_harnesses(&self) -> Result<Vec<Harness>> {
             Ok(vec![self.harness.clone()])
         }
-        async fn get_harness(&self, _id: HarnessId) -> Result<Option<Harness>> {
+        async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>> {
+            if let Some(harness) = self.extra_harnesses.lock().unwrap().get(&id).cloned() {
+                return Ok(Some(harness));
+            }
             Ok(Some(self.harness.clone()))
         }
         async fn create_harness(


### PR DESCRIPTION
### Motivation
- Invite-mode handoff compared only raw harness rows and could miss capabilities inherited from parent harnesses, allowing a guest to override host restrictions at runtime.
- Prevent same-session privilege/configuration bypass by ensuring invite compatibility checks consider the effective harness chain used at runtime.

### Description
- Add a default `PlatformStore::get_harness_chain` (root-to-leaf traversal with cycle detection) so callers can obtain the effective harness chain rather than a single raw row.
- Change invite overlay construction in `agent_handoff` to fold the full harness chain for both host and target (`harness_chain_overlay`) before running conflict checks, so inherited capabilities are considered.
- Extend the `MockPlatformStore` test helper to model multiple harnesses (`extra_harnesses`) so inheritance scenarios can be exercised in unit tests.
- Add a regression test `spawn_agent_handoff_invite_rejects_inherited_harness_capability_conflict` that verifies invite-mode rejects a guest whose capability would override a parent-harness restriction.

### Testing
- `cargo fmt --check`: passed.
- `cargo test -p everruns-core spawn_agent_handoff_invite --lib --all-features`: focused tests passed (3 passed, 0 failed).
- `cargo check -p everruns-core --all-features`: passed.
- `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings`: passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c5f180832b92d5ae3a9290602e)