### PR TITLE
fix(subagents): gate session overrides as high risk

### DIFF
--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -25,7 +25,7 @@ use super::delegation_result::{
 };
 #[cfg(test)]
 use super::delegation_result::{ReportResultTool, ReportTaskProgressTool};
-use super::{Capability, CapabilityLocalization, CapabilityStatus, SpawnMode};
+use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SpawnMode};
 use crate::platform_store::{PlatformCreateSessionRequest, PlatformStore};
 use crate::session::SessionSeedMode;
 use crate::session_task::{
@@ -78,6 +78,12 @@ impl Capability for SubagentCapability {
 
     fn category(&self) -> Option<&str> {
         Some("Core")
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        // Subagent recursion controls bound org cost/DoS exposure; keep
+        // caller-supplied session capability overrides behind the admin gate.
+        RiskLevel::High
     }
 
     fn features(&self) -> Vec<&'static str> {
@@ -1921,6 +1927,11 @@ mod tests {
 
         let agent = org.with_agent_override(Some(1));
         assert_eq!(agent.max_subagent_depth(), 1);
+    }
+
+    #[test]
+    fn subagent_capability_is_high_risk() {
+        assert_eq!(SubagentCapability.risk_level(), RiskLevel::High);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent unprivileged session creators from raising the effective subagent recursion/task caps by submitting session-level `subagents` configs that override operator/admin harness or agent settings, which weakens the DoS/cost-control boundary.

### Description
- Classify the built-in subagents capability as high risk by adding `fn risk_level(&self) -> RiskLevel { RiskLevel::High }` in `crates/core/src/capabilities/subagents.rs` and add a focused unit test `subagent_capability_is_high_risk` to prevent regressions.

### Testing
- Ran `cargo fmt --check` and `cargo test -p everruns-core capabilities::subagents::tests::subagent_capability_is_high_risk --lib --all-features`, and the focused test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a0378df8832bbfd37524629c52f7)