### PR TITLE
fix(subagents): cap background watcher concurrency

### DIFF
--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -34,7 +34,9 @@ use crate::session_task::{
     TaskMessage, TaskWakePolicy, task_message_text,
 };
 use crate::tool_types::ToolHints;
-use crate::tools::{Tool, ToolExecutionResult};
+use crate::tools::{
+    BackgroundRunPermit, Tool, ToolExecutionResult, try_acquire_background_run_permit,
+};
 use crate::traits::{SessionStore, SpawnClaimResult, ToolContext};
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
@@ -1027,6 +1029,13 @@ async fn spawn_agent_subagent_impl(
                         .await);
                     }
                     SpawnMode::Background => {
+                        let background_run_permit =
+                            match try_acquire_background_run_permit(context.session_id) {
+                                Ok(permit) => permit,
+                                Err(message) => {
+                                    return Ok(ToolExecutionResult::tool_error(message));
+                                }
+                            };
                         // Re-arm the detached watcher so the task still settles;
                         // the instructions were already sent on the first claim.
                         spawn_background_watcher(
@@ -1037,6 +1046,7 @@ async fn spawn_agent_subagent_impl(
                             task_id.clone(),
                             task_attempt,
                             Some(stored_claim_token),
+                            background_run_permit,
                         );
                         return Ok(background_running_result(
                             child_session_id,
@@ -1158,6 +1168,15 @@ async fn spawn_create_and_wait(
         uuid::Uuid,
     )>,
 ) -> ToolExecutionResult {
+    let background_run_permit = if mode == SpawnMode::Background {
+        match try_acquire_background_run_permit(context.session_id) {
+            Ok(permit) => Some(permit),
+            Err(message) => return ToolExecutionResult::tool_error(message),
+        }
+    } else {
+        None
+    };
+
     let Some(session_store) = context.session_store.as_ref() else {
         return ToolExecutionResult::tool_error("Subagent spawn requires session_store context");
     };
@@ -1331,6 +1350,7 @@ async fn spawn_create_and_wait(
             task_id.clone(),
             task_attempt,
             wait_settle_ctx.map(|(_, _, claim_token)| claim_token),
+            background_run_permit.expect("background permit acquired for background mode"),
         );
         return background_running_result(child_session.id, name, &task_id, blueprint_param);
     }
@@ -1518,10 +1538,12 @@ fn spawn_background_watcher(
     task_id: Option<String>,
     task_attempt: i32,
     claim_token: Option<uuid::Uuid>,
+    background_run_permit: BackgroundRunPermit,
 ) {
     let context = context.clone();
     let name = name.to_string();
     tokio::spawn(async move {
+        let _background_run_permit = background_run_permit;
         let Some(store) = context.platform_store.clone() else {
             // Callers only enter background mode with a platform store wired.
             return;
@@ -3314,6 +3336,42 @@ mod tests {
         assert_eq!(task.spec["mode"], "background");
         // Summary carries the child's last agent message.
         assert_eq!(task.summary.as_deref(), Some("Hi!"));
+    }
+
+    #[tokio::test]
+    async fn background_spawn_rejects_when_session_active_run_limit_reached() {
+        let store = Arc::new(MockPlatformStore::new());
+        *store.wait_for_idle_status.lock().unwrap() = "paused".to_string();
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let context = spawn_context(&store, Some(registry));
+
+        for index in 0..crate::tools::MAX_ACTIVE_BACKGROUND_RUNS_PER_SESSION {
+            let result = spawn(
+                &context,
+                json!({
+                    "name": format!("Runner {index}"),
+                    "instructions": "go",
+                }),
+            )
+            .await;
+            let ToolExecutionResult::Success(value) = result else {
+                panic!("background spawn below the session limit should start: {result:?}");
+            };
+            assert_eq!(value["status"], "running");
+        }
+
+        let result = spawn(
+            &context,
+            json!({
+                "name": "Runner over limit",
+                "instructions": "go",
+            }),
+        )
+        .await;
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("background spawn should reject once the session limit is reached: {result:?}");
+        };
+        assert!(message.contains("active background runs per session"));
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -1530,6 +1530,7 @@ async fn settle_subagent_outcome(
 /// reaper can detect worker loss, wait for the child's terminal turn status,
 /// then settle the task and spawn handle. The task's OnTerminal wake policy
 /// notifies the parent session at the registry level.
+#[allow(clippy::too_many_arguments)]
 fn spawn_background_watcher(
     context: &ToolContext,
     child_id: crate::typed_id::SessionId,

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -58,6 +58,15 @@ struct SessionBackgroundPermit {
     permit: Option<OwnedSemaphorePermit>,
 }
 
+/// Active background run permit held for the lifetime of detached work.
+///
+/// This combines the worker-wide guard with the per-session guard so all
+/// background execution paths share the same admission control.
+pub(crate) struct BackgroundRunPermit {
+    _worker: tokio::sync::SemaphorePermit<'static>,
+    _session: SessionBackgroundPermit,
+}
+
 impl Drop for SessionBackgroundPermit {
     fn drop(&mut self) {
         drop(self.permit.take());
@@ -92,6 +101,31 @@ fn try_acquire_session_background_permit(
         session_id,
         semaphore,
         permit: Some(permit),
+    })
+}
+
+pub(crate) fn try_acquire_background_run_permit(
+    session_id: SessionId,
+) -> std::result::Result<BackgroundRunPermit, String> {
+    let worker = ACTIVE_BACKGROUND_RUNS_PER_WORKER.try_acquire().map_err(|_| {
+        format!(
+            "Worker is already running the maximum {MAX_ACTIVE_BACKGROUND_RUNS_PER_WORKER} active background runs. Try again after an existing run finishes."
+        )
+    })?;
+
+    let session = match try_acquire_session_background_permit(session_id) {
+        Ok(permit) => permit,
+        Err(_) => {
+            drop(worker);
+            return Err(format!(
+                "Maximum {MAX_ACTIVE_BACKGROUND_RUNS_PER_SESSION} active background runs per session. Wait for an existing run to finish before starting another."
+            ));
+        }
+    };
+
+    Ok(BackgroundRunPermit {
+        _worker: worker,
+        _session: session,
     })
 }
 
@@ -1258,22 +1292,9 @@ impl Tool for SpawnBackgroundTool {
             );
         }
 
-        let background_run_permit = match ACTIVE_BACKGROUND_RUNS_PER_WORKER.try_acquire() {
+        let background_run_permit = match try_acquire_background_run_permit(context.session_id) {
             Ok(permit) => permit,
-            Err(_) => {
-                return ToolExecutionResult::tool_error(format!(
-                    "Worker is already running the maximum {MAX_ACTIVE_BACKGROUND_RUNS_PER_WORKER} active background runs. Try again after an existing run finishes."
-                ));
-            }
-        };
-
-        let session_run_permit = match try_acquire_session_background_permit(context.session_id) {
-            Ok(permit) => permit,
-            Err(_) => {
-                return ToolExecutionResult::tool_error(format!(
-                    "Maximum {MAX_ACTIVE_BACKGROUND_RUNS_PER_SESSION} active background runs per session. Wait for an existing run to finish before starting another."
-                ));
-            }
+            Err(message) => return ToolExecutionResult::tool_error(message),
         };
 
         let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
@@ -1337,7 +1358,6 @@ impl Tool for SpawnBackgroundTool {
 
         tokio::spawn(async move {
             let _background_run_permit = background_run_permit;
-            let _session_run_permit = session_run_permit;
             let _ = sink.status("Starting").await;
 
             // Run the tool future inside a select! against a cancel-watch loop
@@ -1841,19 +1861,8 @@ pub(crate) async fn reattach_background_run(
 
     // Enforce the same concurrency caps as spawn_background so many concurrent
     // re-attaches cannot exhaust worker or session limits.
-    let background_run_permit = ACTIVE_BACKGROUND_RUNS_PER_WORKER
-        .try_acquire()
-        .map_err(|_| {
-            crate::error::AgentLoopError::tool(
-                "worker background run limit reached; re-attach deferred",
-            )
-        })?;
-    let session_run_permit =
-        try_acquire_session_background_permit(task.session_id).map_err(|_| {
-            crate::error::AgentLoopError::tool(
-                "session background run limit reached; re-attach deferred",
-            )
-        })?;
+    let background_run_permit = try_acquire_background_run_permit(task.session_id)
+        .map_err(crate::error::AgentLoopError::tool)?;
 
     // Restore original signaling behavior; default true for tasks created before
     // this field was persisted.
@@ -1890,7 +1899,6 @@ pub(crate) async fn reattach_background_run(
     tokio::spawn(async move {
         // Hold permits for the duration of the re-attached run.
         let _background_run_permit = background_run_permit;
-        let _session_run_permit = session_run_permit;
         let _ = sink.status("Re-attaching").await;
 
         let outcome: std::result::Result<BackgroundOutcome, ToolExecutionResult> =


### PR DESCRIPTION
### Motivation
- Background subagent watchers were spawned detached without acquiring the existing per-worker / per-session background-run permits, enabling an authenticated model or prompt-injected actor to start many long-lived watchers and cause resource exhaustion (DoS).

### Description
- Add a `BackgroundRunPermit` type and `try_acquire_background_run_permit` helper that composes the worker-wide and per-session semaphores to centralize admission control (`crates/core/src/tools.rs`).
- Acquire the shared permit before creating fresh background subagent sessions/tasks and before re-arming reclaims, and pass/hold the permit for the lifetime of the detached watcher (`crates/core/src/capabilities/subagents.rs`).
- Reuse the new helper from existing `spawn_background` and reattach code paths so all detached background work uses the same guards (`crates/core/src/tools.rs`).
- Add a regression test that verifies the per-session background limit rejects the (N+1)th concurrent background subagent while N watchers are active (`crates/core/src/capabilities/subagents.rs`).

### Testing
- Ran `cargo fmt` and formatting check; formatting completed successfully.
- Ran the targeted regression: `cargo test -p everruns-core capabilities::subagents::tests::background_spawn_rejects_when_session_active_run_limit_reached` and it passed.
- Ran the broader subagent test filter: `cargo test -p everruns-core capabilities::subagents::tests::` and all subagent tests passed (19 passed, 0 failed).
- No automated test failures observed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d7458301c832babd88e9c2d56af79)