### PR TITLE
fix(mcp): restore endpoint feature gate

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -85,7 +85,15 @@ jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => ({
     global_chat: true,
     notifications: true,
+    evals: true,
+    app_budgets: true,
+    agent_versions: true,
+    voice: true,
+    agent_delegation: true,
+    observers: true,
+    mcp_endpoint: true,
   }),
+  useFeatureFlag: (flag: string) => flag === "mcp_endpoint" || flag === "notifications",
 }));
 
 /// Mock LLM providers hook (default: providers configured, no warning)

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
 
 export type SidebarUserMenuUser = {
   name?: string | null;
@@ -62,6 +63,7 @@ export function SidebarUserMenu({
 }) {
   const router = useRouter();
   const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
+  const mcpEndpointEnabled = useFeatureFlag("mcp_endpoint");
   const navigate = (href: string) => router.push(href);
 
   const handleLogout = async () => {
@@ -105,7 +107,9 @@ export function SidebarUserMenu({
                 <Key className="icon-sharp mr-2 h-4 w-4" />
                 Personal access tokens
               </DropdownMenuItem>
-              <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />
+              {mcpEndpointEnabled && (
+                <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />
+              )}
               {renderExtraItems?.({ user, navigate })}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
@@ -116,7 +120,9 @@ export function SidebarUserMenu({
           </DropdownMenuContent>
         </DropdownMenuPositioner>
       </DropdownMenu>
-      <McpConnectDialog open={mcpDialogOpen} onOpenChange={setMcpDialogOpen} />
+      {mcpEndpointEnabled && (
+        <McpConnectDialog open={mcpDialogOpen} onOpenChange={setMcpDialogOpen} />
+      )}
     </>
   );
 }

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -107,9 +107,7 @@ export function SidebarUserMenu({
                 <Key className="icon-sharp mr-2 h-4 w-4" />
                 Personal access tokens
               </DropdownMenuItem>
-              {mcpEndpointEnabled && (
-                <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />
-              )}
+              {mcpEndpointEnabled && <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />}
               {renderExtraItems?.({ user, navigate })}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -784,6 +784,8 @@ export interface FeatureFlags {
   observers: boolean;
   /** Public Chat (isolated public-facing chat web app + `public_chat` channel). Experimental. */
   public_chat: boolean;
+  /** First-party MCP server endpoint (`POST /mcp`). Experimental. */
+  mcp_endpoint: boolean;
 }
 
 export interface OrgFeatureFlagSetting {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -22,6 +22,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   agent_delegation: false,
   observers: false,
   public_chat: false,
+  mcp_endpoint: false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -53,6 +53,10 @@ pub struct FeatureFlags {
     /// channel). Experimental. Gates the public endpoints, channel creation,
     /// the builder UI, and the public web route. See `specs/public-chat.md`.
     pub public_chat: bool,
+    /// First-party MCP server endpoint (`POST /mcp`) and OAuth-minted MCP tokens.
+    /// Experimental remote-control surface; requires both deployment enablement
+    /// and per-org opt-in.
+    pub mcp_endpoint: bool,
 }
 
 /// Untyped API representation of feature flags: a generic `{ "<flag>": bool }` map.
@@ -156,6 +160,14 @@ pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
         description: "Isolated, public-facing chat web app and the public_chat channel.",
         experimental: true,
     },
+    FeatureFlagDefinition {
+        name: "mcp_endpoint",
+        label: "MCP endpoint",
+        description: "Exposes the first-party MCP server at POST /mcp for authenticated MCP \
+             clients. This remote-control surface can list and invoke MCP tools, including \
+             side-effecting operations within the caller's permissions.",
+        experimental: true,
+    },
 ];
 
 impl FeatureFlags {
@@ -177,6 +189,7 @@ impl FeatureFlags {
             agent_delegation: opt_in("agent_delegation", system.agent_delegation),
             observers: opt_in("observers", system.observers),
             public_chat: opt_in("public_chat", system.public_chat),
+            mcp_endpoint: opt_in("mcp_endpoint", system.mcp_endpoint),
         }
     }
 
@@ -192,6 +205,7 @@ impl FeatureFlags {
             agent_delegation: experimental_flag("FEATURE_AGENT_DELEGATION", grade),
             observers: experimental_flag("FEATURE_OBSERVERS", grade),
             public_chat: experimental_flag("FEATURE_PUBLIC_CHAT", grade),
+            mcp_endpoint: experimental_flag("FEATURE_MCP_ENDPOINT", grade),
         }
     }
 
@@ -218,6 +232,7 @@ impl FeatureFlags {
             ("agent_delegation".to_string(), self.agent_delegation),
             ("observers".to_string(), self.observers),
             ("public_chat".to_string(), self.public_chat),
+            ("mcp_endpoint".to_string(), self.mcp_endpoint),
         ]))
     }
 
@@ -233,6 +248,7 @@ impl FeatureFlags {
             "agent_delegation" => self.agent_delegation,
             "observers" => self.observers,
             "public_chat" => self.public_chat,
+            "mcp_endpoint" => self.mcp_endpoint,
             _ => false,
         }
     }
@@ -250,6 +266,7 @@ impl FeatureFlags {
             agent_delegation: true,
             observers: true,
             public_chat: true,
+            mcp_endpoint: true,
         }
     }
 }
@@ -407,6 +424,7 @@ mod tests {
             agent_delegation: true,
             observers: true,
             public_chat: true,
+            mcp_endpoint: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("notifications"));
@@ -417,6 +435,7 @@ mod tests {
         assert!(flags.is_enabled("agent_delegation"));
         assert!(flags.is_enabled("observers"));
         assert!(flags.is_enabled("public_chat"));
+        assert!(flags.is_enabled("mcp_endpoint"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -432,6 +451,7 @@ mod tests {
             agent_delegation: true,
             observers: true,
             public_chat: true,
+            mcp_endpoint: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -539,6 +539,10 @@ async fn handle_mcp(
     headers: HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> Response {
+    if !org.feature_flags.mcp_endpoint {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
     let protocol_version = if req.method == "initialize" {
         None
     } else {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1583,9 +1583,9 @@ impl ServerAppBuilder {
 
         let mut root_routes = Router::new();
 
-        // MCP endpoint (POST /mcp) is always available; access is gated per-request
-        // by authentication, not a feature flag.
-        root_routes = root_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
+        if feature_flags.mcp_endpoint {
+            root_routes = root_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
+        }
 
         if let Some(public_routes) = auth_backend.public_routes() {
             root_routes = root_routes.merge(public_routes);

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -98,6 +98,20 @@ async fn mcp_request_raw(
         .await
 }
 
+#[tokio::test]
+async fn test_mcp_returns_404_when_org_not_opted_in() {
+    let server = TestServer::in_memory().await;
+    let disabled_flags = std::collections::HashMap::from([("mcp_endpoint".to_string(), false)]);
+    server
+        .db
+        .replace_org_feature_flags(everruns_core::DEFAULT_ORG_ID, &disabled_flags)
+        .await
+        .expect("disable MCP endpoint flag");
+
+    let resp = mcp_request_raw(&server, "initialize", json!({}), vec![]).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
 /// Call tools/call with a given tool name and arguments.
 async fn mcp_tool_call(server: &TestServer, tool: &str, arguments: Value) -> Value {
     mcp_call(

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -2036,6 +2036,23 @@ async fn test_mcp_adversarial_tool_chain_cannot_escape_org_scope() {
         .assert_status(StatusCode::OK);
     let org2_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
 
+    // The MCP endpoint is feature-gated per org; opt the freshly-created org2
+    // in so this test exercises org-scope isolation rather than the 404 gate.
+    server
+        .db
+        .replace_org_feature_flags(
+            server
+                .db
+                .get_organization_by_public_id(&org2_id)
+                .await
+                .expect("lookup org2")
+                .expect("org2 exists")
+                .org_id,
+            &std::collections::HashMap::from([("mcp_endpoint".to_string(), true)]),
+        )
+        .await
+        .expect("opt org2 into mcp_endpoint");
+
     let create_agent_resp = mcp_tool_call_with_headers(
         &server,
         "execute",
@@ -2279,6 +2296,23 @@ async fn test_mcp_resources_read_cannot_escape_org_scope() {
         .await
         .assert_status(StatusCode::OK);
     let org2_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    // The MCP endpoint is feature-gated per org; opt the freshly-created org2
+    // in so this test exercises org-scope isolation rather than the 404 gate.
+    server
+        .db
+        .replace_org_feature_flags(
+            server
+                .db
+                .get_organization_by_public_id(&org2_id)
+                .await
+                .expect("lookup org2")
+                .expect("org2 exists")
+                .org_id,
+            &std::collections::HashMap::from([("mcp_endpoint".to_string(), true)]),
+        )
+        .await
+        .expect("opt org2 into mcp_endpoint");
 
     let create_agent_resp = mcp_tool_call_with_headers(
         &server,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -280,6 +280,7 @@ impl TestServer {
         feature_flags.agent_versions = true;
         feature_flags.app_budgets = true;
         feature_flags.global_chat = true;
+        feature_flags.mcp_endpoint = true;
 
         // Org-effective flags are `system && org-opt-in`, so opt the default
         // test org into the experimental flags whose runtime gates now consult
@@ -294,6 +295,7 @@ impl TestServer {
             "agent_versions",
             "app_budgets",
             "global_chat",
+            "mcp_endpoint",
         ]
         .into_iter()
         .map(|name| (name.to_string(), true))


### PR DESCRIPTION
### Motivation
- A recent change removed the `mcp_endpoint` deployment/org opt-in gates which unintentionally exposed the authenticated MCP tool surface (including destructive `execute`) even when deployments or orgs had not opted in.

### Description
- Reintroduced `mcp_endpoint` into `FeatureFlags` (env key: `FEATURE_MCP_ENDPOINT`) and restored its API metadata, serialization, and dynamic lookup in `crates/core/src/feature_flags.rs`.
- Gate the `/mcp` route mount on the deployment-level flag in `crates/server/src/app_builder.rs` so the endpoint is only registered when the deployment enables it.
- Return `404 Not Found` at the start of `handle_mcp` when the resolved organization's effective `mcp_endpoint` flag is not enabled in `crates/server/src/api/mcp_endpoint/mod.rs`.
- Added a focused regression test `test_mcp_returns_404_when_org_not_opted_in` and updated the test harness defaults to opt the test org into MCP where existing MCP tests depend on it (`crates/server/tests/*`).
- Synced frontend types/defaults and gating: added `mcp_endpoint` to UI `FeatureFlags` types and defaults and gated the MCP connect menu/dialog in `apps/ui` on the effective flag.

### Testing
- Ran `cargo test -p everruns-core feature_flags` and all feature-flag unit tests passed.
- Ran the focused server tests: `cargo test -p everruns-server --test mcp_endpoint_test` including the new `test_mcp_returns_404_when_org_not_opted_in` and existing `mcp` initialization tests, and they passed.
- Ran `cargo fmt --check` (after applying `cargo fmt`) and formatting checks passed.
- Frontend unit test `pnpm test -- sidebar.test.tsx` could not run in the environment because `node_modules`/`jest` were not installed (`jest: not found`), so UI tests should be validated in CI or a dev environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a406390e77c832ba700169309d37557)