### PR TITLE
fix(core): preserve workspace display paths

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -527,6 +527,14 @@ fn fs_display_path(file_store: &dyn SessionFileSystem, path: &str) -> String {
     file_store.display_path(path)
 }
 
+fn fs_input_display_path(file_store: &dyn SessionFileSystem, path: &str) -> String {
+    if file_store.is_mount_resolver() {
+        file_store.resolve_path(path)
+    } else {
+        file_store.display_path(path)
+    }
+}
+
 fn file_content_hash(content: &str, encoding: &str) -> crate::error::Result<String> {
     let bytes = SessionFile::decode_content(content, encoding)
         .map_err(|error| anyhow::anyhow!("failed to decode file content for hashing: {error}"))?;
@@ -980,13 +988,16 @@ impl Tool for ReadFileTool {
         // The store (MountFs in production) is the sole resolver: hand it the
         // raw path and it routes `/workspace`, the root mount, and relatives.
         let normalized_path = path.to_string();
-        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
+        let display_path = fs_input_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .read_file(context.session_id, &normalized_path)
             .await
         {
             Ok(Some(file)) => {
+                let resolved_path = file.path.as_str();
+                let display_path = fs_display_path(file_store.as_ref(), resolved_path);
+
                 if file.is_directory {
                     return ToolExecutionResult::tool_error(format!(
                         "Path '{}' is a directory, not a file. Use list_directory instead.",
@@ -995,7 +1006,7 @@ impl Tool for ReadFileTool {
                 }
 
                 // Check if this is an image file that should be returned as native image content
-                if let Some(media_type) = image_media_type(&normalized_path) {
+                if let Some(media_type) = image_media_type(resolved_path) {
                     // For base64-encoded files, return as image
                     if file.encoding == "base64"
                         && let Some(ref content) = file.content
@@ -1041,8 +1052,8 @@ impl Tool for ReadFileTool {
 
                 // Apply content-type-aware defaults (EVE-249)
                 let (ct_limit, read_mode) =
-                    effective_read_defaults(&normalized_path, explicit_offset, explicit_limit);
-                let content_type = content_type_from_extension(&normalized_path);
+                    effective_read_defaults(resolved_path, explicit_offset, explicit_limit);
+                let content_type = content_type_from_extension(resolved_path);
 
                 // Metadata-only for known binary extensions
                 if read_mode == ReadMode::MetadataOnly {
@@ -1089,7 +1100,7 @@ impl Tool for ReadFileTool {
                 // Generate structural outline for unread portions (EVE-248)
                 let mut formatted = if truncated && start_line > 0 {
                     let outline_items =
-                        crate::outline::generate_outline(raw_content, &normalized_path);
+                        crate::outline::generate_outline(raw_content, resolved_path);
                     if let Some(outline_text) = crate::outline::format_outline(
                         &outline_items,
                         start_line,
@@ -1273,7 +1284,7 @@ impl Tool for WriteFileTool {
         // The store (MountFs in production) is the sole resolver: hand it the
         // raw path and it routes `/workspace`, the root mount, and relatives.
         let normalized_path = path.to_string();
-        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
+        let display_path = fs_input_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .write_file(context.session_id, &normalized_path, content, encoding)
@@ -1401,7 +1412,7 @@ impl Tool for EditFileTool {
         // The store (MountFs in production) is the sole resolver: hand it the
         // raw path and it routes `/workspace`, the root mount, and relatives.
         let normalized_path = path.to_string();
-        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
+        let display_path = fs_input_display_path(file_store.as_ref(), &normalized_path);
 
         let existing = match file_store
             .read_file(context.session_id, &normalized_path)
@@ -1620,7 +1631,7 @@ impl Tool for ListDirectoryTool {
         // The store (MountFs in production) is the sole resolver: hand it the
         // raw path and it routes `/workspace`, the root mount, and relatives.
         let normalized_path = path.to_string();
-        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
+        let display_path = fs_input_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .list_directory(context.session_id, &normalized_path)
@@ -1976,7 +1987,7 @@ impl Tool for DeleteFileTool {
         // The store (MountFs in production) is the sole resolver: hand it the
         // raw path and it routes `/workspace`, the root mount, and relatives.
         let normalized_path = path.to_string();
-        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
+        let display_path = fs_input_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .delete_file(context.session_id, &normalized_path, recursive)
@@ -2083,7 +2094,7 @@ impl Tool for StatFileTool {
         // The store (MountFs in production) is the sole resolver: hand it the
         // raw path and it routes `/workspace`, the root mount, and relatives.
         let normalized_path = path.to_string();
-        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
+        let display_path = fs_input_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .stat_file(context.session_id, &normalized_path)

--- a/crates/core/src/mount_fs.rs
+++ b/crates/core/src/mount_fs.rs
@@ -330,6 +330,18 @@ fn join_backend_path(backend_root: &str, rest: &str) -> String {
     format!("{backend_root}{rest}")
 }
 
+/// Render a canonical backend key literally under that backend's display root.
+fn display_backend_path(display_root: &str, path: &str) -> String {
+    let normalized = normalize_virtual(path, "/");
+    if normalized == "/" {
+        display_root.to_string()
+    } else if display_root == "/" {
+        normalized
+    } else {
+        format!("{}{normalized}", display_root.trim_end_matches('/'))
+    }
+}
+
 #[async_trait]
 impl SessionFileSystem for MountFs {
     fn display_root(&self) -> String {
@@ -341,19 +353,34 @@ impl SessionFileSystem for MountFs {
     }
 
     fn resolve_path(&self, input: &str) -> String {
-        // Keep the model-facing namespace stable and host-agnostic. Real-disk
-        // backends may expose host paths directly, but MountFs is the boundary
-        // used by agent-visible file tools and bash.
-        self.display_path(input)
+        // Resolve the raw input through the mount table, then render the
+        // resolved backend key literally under the host-agnostic /workspace
+        // namespace. Prefixing the backend key (instead of re-stripping the
+        // mount) keeps a literal `workspace/…` backend segment distinct from
+        // the `/workspace` mount alias, so a displayed path round-trips to the
+        // same backend key. Using WORKSPACE_MOUNT — not a backend-derived
+        // display root — keeps this independent of real-disk host paths (#2776).
+        let virtual_path = normalize_virtual(input, &self.cwd());
+        match self.resolve(&virtual_path) {
+            Ok(resolved) if resolved.primary_workspace => {
+                display_backend_path(WORKSPACE_MOUNT, &resolved.backend_path)
+            }
+            _ => virtual_path,
+        }
     }
 
     fn display_path(&self, path: &str) -> String {
-        let virtual_path = normalize_virtual(path, &self.cwd());
+        // `path` here is an already-canonical virtual output path (a resolved
+        // `file.path`, i.e. a backend key in the primary namespace, or a named
+        // mount's virtual path). Normalize at root — NOT cwd — so we treat it as
+        // a canonical key and don't inject the `/workspace` cwd alias. Then:
+        //  - named mounts: return as-is (already in their mounted namespace),
+        //  - primary: prefix literally under /workspace so a literal `workspace/…`
+        //    backend segment stays distinct from the mount alias and round-trips.
+        let virtual_path = normalize_virtual(path, "/");
         match self.resolve(&virtual_path) {
-            Ok(resolved) if resolved.primary_workspace => {
-                crate::session_path::to_display_path(&resolved.backend_path)
-            }
-            _ => virtual_path,
+            Ok(resolved) if !resolved.primary_workspace => virtual_path,
+            _ => display_backend_path(WORKSPACE_MOUNT, &virtual_path),
         }
     }
 
@@ -784,6 +811,31 @@ mod tests {
         assert_eq!(fs.display_path("/src/lib.rs"), "/workspace/src/lib.rs");
         assert_eq!(fs.display_path("/"), "/workspace");
         assert_eq!(fs.resolve_path("src/lib.rs"), "/workspace/src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn display_preserves_literal_backend_workspace_segment() {
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore::default());
+        backend
+            .write_file(sid(), "/workspace/collide.txt", "literal", "text")
+            .await
+            .unwrap();
+        backend
+            .write_file(sid(), "/collide.txt", "alias", "text")
+            .await
+            .unwrap();
+        let fs = MountFs::new(backend);
+
+        let literal = fs
+            .read_file(sid(), "workspace/collide.txt")
+            .await
+            .unwrap()
+            .unwrap();
+        let display_path = fs.display_path(&literal.path);
+        assert_eq!(display_path, "/workspace/workspace/collide.txt");
+
+        let round_trip = fs.read_file(sid(), &display_path).await.unwrap().unwrap();
+        assert_eq!(round_trip.content.as_deref(), Some("literal"));
     }
 
     #[tokio::test]

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -32,8 +32,8 @@ pub enum ToolNarrationPhase {
 
 /// Optional execution context for path-bearing tool narration.
 ///
-/// When a [`SessionFileSystem`] is present, path-bearing helpers render through
-/// its `display_path` contract so narration matches tool results.
+/// When a [`SessionFileSystem`] is present, path-bearing helpers resolve input
+/// through its path contract so narration matches tool results.
 #[derive(Clone, Copy, Default)]
 pub struct ToolNarrationContext<'a> {
     pub file_store: Option<&'a dyn SessionFileSystem>,
@@ -236,7 +236,11 @@ pub fn present_filesystem_path(
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or(WORKSPACE_PREFIX);
-        return store.display_path(raw);
+        return if store.is_mount_resolver() {
+            store.resolve_path(raw)
+        } else {
+            store.display_path(raw)
+        };
     }
     location_phrase_from_raw(input, locale)
 }


### PR DESCRIPTION
## What changed

Filesystem outputs now preserve literal backend paths that begin with `workspace/` without colliding with the model-facing `/workspace` mount alias. A backend key such as `/workspace/foo` is presented as `/workspace/workspace/foo`, and that displayed path resolves back to the same file.

`MountFs::resolve_path` (raw input) now resolves the input through the mount table and renders the resolved backend key *literally* under the `/workspace` namespace via `display_backend_path(WORKSPACE_MOUNT, …)`; `display_path` (an already-canonical `file.path`) prefixes literally without re-resolving the mount. Input-path narration and file-tool echoes go through `resolve_path`; the post-read canonical path goes through `display_path`. Named secondary mounts keep their mounted namespace.

**Rebase note (reconciled with #2776):** `#2776` ("keep mounted display paths host-agnostic") reworked these same functions to stop leaking real-disk host paths, hardcoding the `/workspace` namespace. This branch was rebased on top of that: the collision fix keeps `#2776`'s host-agnostic behavior by prefixing with the `WORKSPACE_MOUNT` constant instead of any backend-derived display root, and drops the earlier `primary.display_path` shortcut. So real-disk primary backends stay under `/workspace` (host-agnostic), and the literal-`workspace/` collision is still fixed.

## Why

A backend key that literally began with `/workspace` could previously be displayed as `/workspace/foo`, the same spelling used for backend key `/foo`. Tool output could therefore direct a later read to a different file than the one listed. (Verified still reproducible on `main` after #2776.)

## Before / After

Before:

```text
backend /workspace/collide.txt -> displayed /workspace/collide.txt -> reads backend /collide.txt
```

After:

```text
backend /workspace/collide.txt -> displayed /workspace/workspace/collide.txt -> reads backend /workspace/collide.txt
```

Evidence (post-rebase):

```text
cargo test -p everruns-core --lib                                        # 2802 passed; 0 failed
cargo fmt --check -p everruns-core                                       # clean
cargo clippy -p everruns-core --all-targets --all-features -- -D warnings # clean
```

Key traced tests: `display_preserves_literal_backend_workspace_segment` (collision fixed), `test_write_file_returns_content_hash` (was failing pre-rebase, now `/workspace/new.txt`), `read_file_uses_mountfs_workspace_display_path` + `display_uses_workspace_alias_for_primary` (#2776 host-agnostic behavior preserved).

## Risk

- Medium
- Changes the displayed spelling only for backend keys that would otherwise collide with the `/workspace` mount alias. VFS, host-agnostic real-disk, and named-mount identity suites pass.

## Security

- Threat categories reviewed: TM-FS, TM-TOOL
- Findings and resolutions: path presentation is not a containment boundary. Traversal rejection, registered-root containment, symlink checks, and session scoping are unchanged. Displayed paths are pure string transforms over the `/workspace` constant (no backend host paths leak — preserves #2776). Regression coverage verifies the displayed path round-trips to the same backend key.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
