### PR TITLE
fix(auth): clear signup return_to after instant auth

### DIFF
--- a/apps/ui/src/__tests__/auth-redirect.test.ts
+++ b/apps/ui/src/__tests__/auth-redirect.test.ts
@@ -3,6 +3,7 @@ import {
   buildSignupHref,
   consumeReturnTo,
   getLoginRedirectPath,
+  getPostAuthTarget,
   isFullPageLoginRedirect,
   navigateToLogin,
   persistReturnTo,
@@ -152,5 +153,29 @@ describe("return_to session storage", () => {
     persistReturnTo("//evil.com");
     expect(sessionStorage.getItem(RETURN_TO_STORAGE_KEY)).toBeNull();
     expect(consumeReturnTo()).toBeNull();
+  });
+});
+
+describe("getPostAuthTarget", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("uses the URL return_to and clears any stored one-shot redirect", () => {
+    persistReturnTo("/invite/token123");
+
+    expect(getPostAuthTarget("/invite/token123")).toBe("/invite/token123");
+    expect(sessionStorage.getItem(RETURN_TO_STORAGE_KEY)).toBeNull();
+  });
+
+  it("falls back to the stored return_to when the URL has none", () => {
+    persistReturnTo("/settings/providers");
+
+    expect(getPostAuthTarget(null)).toBe("/settings/providers");
+    expect(sessionStorage.getItem(RETURN_TO_STORAGE_KEY)).toBeNull();
+  });
+
+  it("falls back to dashboard when no safe target exists", () => {
+    expect(getPostAuthTarget("https://evil.com")).toBe("/dashboard");
   });
 });

--- a/apps/ui/src/__tests__/signup-password-policy.test.tsx
+++ b/apps/ui/src/__tests__/signup-password-policy.test.tsx
@@ -32,6 +32,7 @@ jest.mock("@/lib/api/auth", () => ({ getOAuthUrl: jest.fn(() => "/oauth") }));
 jest.mock("@/lib/auth-redirect", () => ({
   buildLoginHref: () => "/login",
   consumeReturnTo: () => null,
+  getPostAuthTarget: () => "/dashboard",
   isBackendNavigationPath: () => false,
   persistReturnTo: jest.fn(),
   sanitizeReturnTo: () => "",

--- a/apps/ui/src/app/(auth)/signup/page.tsx
+++ b/apps/ui/src/app/(auth)/signup/page.tsx
@@ -21,7 +21,7 @@ import { useAuthConfig, useRegister } from "@/hooks/use-auth";
 import { getOAuthUrl } from "@/lib/api/auth";
 import {
   buildLoginHref,
-  consumeReturnTo,
+  getPostAuthTarget,
   isBackendNavigationPath,
   persistReturnTo,
   sanitizeReturnTo,
@@ -56,10 +56,6 @@ export default function SignupPage() {
   useEffect(() => {
     persistReturnTo(returnTo);
   }, [returnTo]);
-
-  const getPostAuthTarget = (): string => {
-    return returnTo || consumeReturnTo() || "/dashboard";
-  };
 
   const navigateAfterAuth = (target: string) => {
     if (isBackendNavigationPath(target)) {
@@ -101,7 +97,7 @@ export default function SignupPage() {
         // Confirm mode: no session yet — the emailed link signs you in.
         setSubmittedEmail(email);
       } else {
-        navigateAfterAuth(getPostAuthTarget());
+        navigateAfterAuth(getPostAuthTarget(returnTo));
       }
     } catch {
       if (config?.signup_email_confirm) {

--- a/apps/ui/src/lib/auth-redirect.ts
+++ b/apps/ui/src/lib/auth-redirect.ts
@@ -156,3 +156,10 @@ export function consumeReturnTo(): string | null {
   sessionStorage.removeItem(RETURN_TO_STORAGE_KEY);
   return stored;
 }
+
+/** Resolve a post-auth target while clearing any stored one-shot redirect. */
+export function getPostAuthTarget(returnTo: string | null | undefined): string {
+  const sanitized = sanitizeReturnTo(returnTo);
+  const stored = consumeReturnTo();
+  return sanitized || stored || "/dashboard";
+}


### PR DESCRIPTION
### Motivation
- Signup could navigate immediately to a URL `return_to` without consuming the one-shot `everruns_return_to` stored in `sessionStorage`, which allowed stale post-auth redirects to be replayed later when entering the main app layout.
- The change ensures instant-signup preserves the intended deep-link continuation while clearing any stored one-shot redirect to avoid confusing repeat navigation.

### Description
- Added `getPostAuthTarget(returnTo)` in `apps/ui/src/lib/auth-redirect.ts` to sanitize the URL `return_to`, consume and clear any stored `everruns_return_to`, and return the resolved target or `"/dashboard"` as a fallback.
- Updated the instant-signup path in `apps/ui/src/app/(auth)/signup/page.tsx` to call `getPostAuthTarget(returnTo)` so the stored redirect is cleared before navigation.
- Extended `apps/ui/src/__tests__/auth-redirect.test.ts` with unit tests that cover URL-priority behavior, stored-fallback behavior, and unsafe-target fallback.

### Testing
- Ran the focused unit tests with `pnpm test src/__tests__/auth-redirect.test.ts`, which passed (`23` tests passed).
- Ran formatting and lint checks with `pnpm run format:check` and `pnpm run lint`, which completed cleanly.
- Executed repository pre-push checks via `just pre-push`, which failed on unrelated repository environment checks (Rust formatting, clippy, `Cargo.lock` freshness, and migration immutability due to `origin/main` not being configured), while UI-specific checks within pre-push passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c5e768832bae02eb39c1634163)