### PR TITLE
fix(server): scope AG-UI messageId to the message, not the turn

### DIFF
--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -979,20 +979,21 @@ fn is_terminal_public_output_message(
     assistant_emitted_delta || !public_content_parts_to_string(&message.content).is_empty()
 }
 
-fn ensure_assistant_message_id(
-    state: &mut AgUiStreamState,
-    event: &everruns_core::Event,
-) -> AgUiMessageId {
+/// Returns the AG-UI `messageId` for the assistant message currently being
+/// streamed, allocating a fresh id the first time a message scope opens.
+///
+/// The id is message-scoped, not turn-scoped: `close_assistant_text_without_finishing`
+/// clears the cached id at every non-terminal message boundary, so a commentary
+/// message and the final answer within one turn receive distinct ids. The id is a
+/// random public identifier and is never derived from `turn_id`, so the internal
+/// turn uuid is never exposed on the public AG-UI transport.
+///
+/// Once EVE-772 lands `message_id` on the streaming lifecycle events, this should
+/// key off the streamed `message_id` so the AG-UI id equals the stored `Message.id`.
+fn ensure_assistant_message_id(state: &mut AgUiStreamState) -> AgUiMessageId {
     state
         .assistant_message_id
-        .get_or_insert_with(|| {
-            event
-                .context
-                .turn_id
-                .as_ref()
-                .map(|id| AgUiMessageId::from(id.uuid()))
-                .unwrap_or_else(AgUiMessageId::random)
-        })
+        .get_or_insert_with(AgUiMessageId::random)
         .clone()
 }
 
@@ -1107,7 +1108,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
     match event.event_type.as_str() {
         "output.message.delta" => {
             if let Ok(data) = parse_event_data::<OutputMessageDeltaData>(event) {
-                let message_id = ensure_assistant_message_id(state, event);
+                let message_id = ensure_assistant_message_id(state);
                 if !state.assistant_content_started {
                     state
                         .queue
@@ -1132,7 +1133,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                     close_assistant_text_without_finishing(state);
                     return;
                 }
-                let message_id = ensure_assistant_message_id(state, event);
+                let message_id = ensure_assistant_message_id(state);
                 if !state.assistant_content_started {
                     state
                         .queue
@@ -1221,7 +1222,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             state.public_tool_activity_opened_thinking = false;
         }
         "tool.started" if parse_event_data::<ToolStartedData>(event).is_ok() => {
-            ensure_assistant_message_id(state, event);
+            ensure_assistant_message_id(state);
             state.active_tool_activity_count += 1;
             match state.tool_visibility {
                 AgUiToolVisibility::None => {}
@@ -1237,7 +1238,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             }
         }
         "tool.completed" if parse_event_data::<ToolCompletedData>(event).is_ok() => {
-            ensure_assistant_message_id(state, event);
+            ensure_assistant_message_id(state);
             state.active_tool_activity_count = state.active_tool_activity_count.saturating_sub(1);
             push_public_tool_activity_end(state);
         }
@@ -1732,6 +1733,26 @@ mod tests {
             "The Base harness is the default execution wrapper."
         );
         assert!(state.finished);
+
+        // EVE-773: the commentary message and the final answer are distinct AG-UI
+        // messages, so they must carry distinct message-scoped ids, and neither may
+        // leak the raw turn uuid onto the public transport.
+        let start_ids: Vec<&AgUiMessageId> = state
+            .queue
+            .iter()
+            .filter_map(|event| match event {
+                AgUiEvent::TextMessageStart(event) => Some(&event.message_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(start_ids.len(), 2);
+        assert_ne!(
+            start_ids[0], start_ids[1],
+            "commentary and final answer must have distinct messageIds"
+        );
+        let turn_message_id = AgUiMessageId::from(turn_id.uuid());
+        assert_ne!(*start_ids[0], turn_message_id);
+        assert_ne!(*start_ids[1], turn_message_id);
     }
 
     #[tokio::test]
@@ -1921,9 +1942,12 @@ mod tests {
         );
         translate_event(&mut state, &output_completed);
 
-        let expected_message_id = AgUiMessageId::from(turn_id.uuid());
+        // The public messageId is message-scoped and must never be the raw turn uuid.
+        let turn_message_id = AgUiMessageId::from(turn_id.uuid());
         match &state.queue[5] {
-            AgUiEvent::TextMessageStart(event) => assert_eq!(event.message_id, expected_message_id),
+            AgUiEvent::TextMessageStart(event) => {
+                assert_ne!(event.message_id, turn_message_id);
+            }
             _ => panic!("expected text start event"),
         }
     }


### PR DESCRIPTION
## What changed
AG-UI assistant `messageId` is now message-scoped instead of turn-scoped. Previously `ensure_assistant_message_id` derived a single id from `turn_id.uuid()` and cached it for the whole turn, so within one turn a commentary message and the final answer emitted two `TEXT_MESSAGE_START/END` cycles under the **same** `messageId`, and the raw internal `turn_id` uuid was exposed on the public AG-UI SSE transport.

The function now allocates a fresh random public id per message scope. The cached id is already cleared at every non-terminal message boundary (`close_assistant_text_without_finishing`), so commentary and final-answer messages now get **distinct** ids, and the internal turn uuid is never placed on the wire.

## Why
Per EVE-773, AG-UI message identity should be message-scoped, not turn-scoped. Two assistant messages in one turn sharing a `messageId` is questionable per AG-UI semantics, and leaking the turn uuid on a public transport is undesirable.

## Before / After
Behavior of the EVE-448 scenario (commentary -> tool calls -> final answer), asserted by unit tests:

- Before: commentary `TextMessageStart` and final-answer `TextMessageStart` carried the same id, equal to `AgUiMessageId::from(turn_id.uuid())`.
- After: the two `TextMessageStart` ids are distinct, and neither equals the turn uuid.

Test proof:
```
running 24 tests
test api::ag_ui::tests::test_commentary_delta_tool_completion_does_not_hide_final_answer ... ok
test api::ag_ui::tests::test_generic_tool_activity_hides_public_tool_details ... ok
test api::ag_ui::tests::test_tool_call_completion_does_not_finish_before_final_answer ... ok
...
test result: ok. 24 passed; 0 failed
```
AG-UI integration suite: `14 passed; 0 failed`. `cargo fmt --check` clean. `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` clean.

## Scope note / deviation from the issue
EVE-773 proposes keying `AgUiMessageId` off the **streamed `message_id`** from EVE-772. EVE-772 (`message_id` on the output-message streaming lifecycle) is still **In Progress** and has not landed on `main` — `output.message.delta`/`started` events carry only `turn_id`, so the streamed message id is not yet available during streaming. This PR delivers the achievable, in-scope outcome for `crates/server/src/api/ag_ui.rs`: message-scoped ids with no turn-uuid leak, satisfying the AG-UI portion of the acceptance criteria. A code comment marks where to switch to the real streamed `message_id` once EVE-772 lands.

## Risk
- Low.
- Behavioral change is limited to the public AG-UI transport's assistant `messageId` values, which are opaque per-stream identifiers. No consumer in-tree correlates them with the stored turn/message id. The change strictly reduces information exposure.

## Security
- Threat categories reviewed: TM-API / TM-WEB (public AG-UI SSE transport). No auth/authz, input parsing, or query surface touched.
- Findings and resolutions: The change removes exposure of the internal `turn_id` uuid on the public stream, replacing it with a random public id (via the existing `AgUiMessageId::random()`). This is a net reduction in internal-identifier disclosure; no new threat surface introduced.

## Follow-ups
- Key AG-UI `messageId` off the streamed `message_id` so the AG-UI id equals the stored `Message.id`, once **EVE-772** lands. (Blocked; comment left in code.)
- Sweep the remaining streaming consumers named in EVE-773 to group by `message_id` (`examples/coding-cli/src/session_log.rs`, `apps/ui` streaming components) and audit the other in-tree projections (`fcp.rs`, `app_api.rs`, `voice.rs`, `durable.rs`, `notifications.rs`). These depend on EVE-772's streamed `message_id` and are out of scope for this AG-UI-focused change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal transport; no external contract on the opaque id)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Refs EVE-773.


---
_Generated by [Claude Code](https://claude.ai/code)_