### PR TITLE
fix(ci): run workflow tests against real gRPC control-plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -998,10 +998,16 @@ jobs:
       API_BASE_URL: http://localhost:9000
       WORKER_GRPC_AUTH_TOKEN: test-grpc-token-for-ci
       RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
-      # This job boots the server in no-auth mode for workflow tests. Since
-      # EVE-621, AUTH_MODE=none is only permitted in dev deployments, so the
-      # dev grade must be set explicitly (matching the other server-boot jobs).
-      DEV_MODE: "true"
+      # This job exercises the real durable topology: the server owns Postgres
+      # state and exposes the gRPC control-plane on :9001, and a separate
+      # everruns-worker binary connects to it. That path only runs when the
+      # server is NOT in DEV_MODE (DEV_MODE=true forces in-memory storage and
+      # disables the gRPC control-plane — see app_builder.rs), which would leave
+      # the external worker unable to connect. AUTH_MODE=none still requires a
+      # dev deployment grade (EVE-621), so opt in via DEPLOYMENT_GRADE=dev
+      # instead of DEV_MODE, satisfying the auth gate without touching the
+      # storage/gRPC wiring.
+      DEPLOYMENT_GRADE: dev
       AUTH_MODE: none
 
     steps:


### PR DESCRIPTION
## What &amp; why

Main CI has been red on every push: the **Workflow Tests (Server + Worker)** job fails in the "Run workflow tests" step with:

```
Error: Failed to connect durable task store
    Failed to connect to control-plane at 127.0.0.1:9001 after 31.2s (20 attempts): transport error
```

### Root cause

That job boots the API server and a **separate** `everruns-worker` binary. The worker connects to the server's gRPC control-plane on `:9001`. The server only starts that control-plane when it is **not** in `DEV_MODE` — `DEV_MODE=true` forces in-memory storage and disables the gRPC server (`crates/server/src/app_builder.rs`, `if !self.config.dev_mode`). So with `DEV_MODE=true`:

- storage silently switches to in-memory (the Postgres service + `sqlx migrate run` become dead weight), and
- the gRPC control-plane never binds `:9001`, so the external worker retries for 31s, panics, and the whole test step fails.

`DEV_MODE=true` was only there to satisfy `AUTH_MODE=none`, which since EVE-621 requires a dev deployment grade.

### Fix

Opt into the dev grade with `DEPLOYMENT_GRADE=dev` instead of `DEV_MODE=true`. This satisfies the `AUTH_MODE=none` gate (`grade.is_dev()`) **without** setting `config.dev_mode`, so the server keeps Postgres storage and the gRPC control-plane, and the external worker connects — the real durable topology this job is meant to exercise. Provider/LlmSim seeding and no-auth behavior are grade-driven, so they are unchanged from before.

## Before / After

- **Before:** worker panics `Failed to connect to control-plane at 127.0.0.1:9001`; job red on every push to main.
- **After:** server exposes gRPC on `:9001` against Postgres; worker connects; `workflow_test` runs.

Note: the Workflow Tests job is gated to `push` events (it runs PR-built binaries with live API keys, so it must not run on PRs), so this fix **cannot be verified by PR CI** — it skips here by design. Verification comes from the first push to main after merge. The fix is corroborated by code reading: `dev_mode` is read only from `DEV_MODE` (`crates/server/src/server.rs`), the `AUTH_MODE=none` gate only requires `grade.is_dev()` (`crates/server/src/auth/config.rs`), and seeding/event-delivery paths work without NATS or dev mode.

## Test plan

- PR CI green (Workflow Tests skips on PRs by design).
- After merge: confirm **Workflow Tests (Server + Worker)** goes green on the main push run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyLEX1yn8wAvL8z5wFzHrc)_