### PR TITLE
fix(runtime): honor grep files regex contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,6 +3075,7 @@ dependencies = [
  "everruns-openai",
  "futures",
  "ignore",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -517,10 +517,12 @@ pub trait SessionFileSystem: Send + Sync {
     /// Get file metadata
     async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>>;
 
-    /// Search file contents, optionally filtering canonical paths by glob.
+    /// Search file contents with Rust regex syntax, optionally filtering canonical paths by glob.
     ///
-    /// Basename-only globs match at any depth. Non-glob path filters retain
-    /// legacy substring matching; see `specs/file-store.md`.
+    /// Implementations compile the content pattern once before scanning and
+    /// return an error for invalid regex. Basename-only globs match at any
+    /// depth. Non-glob path filters retain legacy substring matching; see
+    /// `specs/file-store.md`.
     async fn grep_files(
         &self,
         session_id: SessionId,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -34,6 +34,7 @@ async-trait.workspace = true
 chrono.workspace = true
 futures.workspace = true
 ignore.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -12,6 +12,7 @@ use everruns_core::traits::{
     SessionFileSystemFactoryContext, SessionMutator, SessionStorageStore, SessionStore,
 };
 use everruns_core::typed_id::SessionId;
+use regex::Regex;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -364,6 +365,8 @@ impl SessionFileSystem for InMemorySessionFileStore {
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
+        let regex = Regex::new(pattern)
+            .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))?;
         let path_pattern = path_pattern
             .map(everruns_core::session_path::GrepPathPattern::new)
             .transpose()?;
@@ -385,7 +388,7 @@ impl SessionFileSystem for InMemorySessionFileStore {
             };
 
             for (idx, line) in content.lines().enumerate() {
-                if line.contains(pattern) {
+                if regex.is_match(line) {
                     matches.push(GrepMatch {
                         path: path.clone(),
                         line_number: idx + 1,

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -19,6 +19,7 @@ use everruns_core::traits::{
 use everruns_core::typed_id::SessionId;
 use everruns_core::{MountFs, WorkspaceRootSet};
 use ignore::WalkBuilder;
+use regex::Regex;
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -511,7 +512,8 @@ impl SessionFileSystem for RealDiskFileStore {
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
         let root = self.root();
-        let pattern = pattern.to_string();
+        let regex = Regex::new(pattern)
+            .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))?;
         let path_pattern = match path_pattern {
             Some(path) => Some(everruns_core::session_path::GrepPathPattern::new(
                 self.paths.parse_input(path)?.as_relative(),
@@ -588,7 +590,7 @@ impl SessionFileSystem for RealDiskFileStore {
                 };
                 let canonical_path = format!("/{rel_str}");
                 for (idx, line) in text.lines().enumerate() {
-                    if line.contains(&pattern) {
+                    if regex.is_match(line) {
                         out.push(GrepMatch {
                             path: canonical_path.clone(),
                             line_number: idx + 1,

--- a/crates/runtime/tests/file_store_grep_conformance_test.rs
+++ b/crates/runtime/tests/file_store_grep_conformance_test.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use everruns_core::traits::SessionFileSystem;
+use everruns_core::typed_id::SessionId;
+use everruns_runtime::{InMemorySessionFileStore, RealDiskFileStore};
+use tempfile::TempDir;
+
+async fn assert_regex_contract(store: Arc<dyn SessionFileSystem>) {
+    let session = SessionId::from_seed(776);
+
+    let error = store
+        .grep_files(session, "[invalid", None)
+        .await
+        .expect_err("invalid regex must fail before scanning");
+    assert!(
+        error.to_string().contains("Invalid regex pattern"),
+        "unexpected error: {error}"
+    );
+
+    for (path, content) in [
+        (
+            "/src/app.log",
+            "Error: code 42\nall good\ntimeout after 120s",
+        ),
+        ("/src/worker.log", "request failed with code 7"),
+        ("/docs/readme.md", "Error handling guide 99"),
+    ] {
+        store
+            .write_file(session, path, content, "text")
+            .await
+            .unwrap();
+    }
+
+    let mut alternatives: Vec<_> = store
+        .grep_files(session, "Error|failed|timeout", Some("src/**/*.log"))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|hit| (hit.path, hit.line_number))
+        .collect();
+    alternatives.sort();
+    assert_eq!(
+        alternatives,
+        vec![
+            ("/src/app.log".to_string(), 1),
+            ("/src/app.log".to_string(), 3),
+            ("/src/worker.log".to_string(), 1),
+        ]
+    );
+
+    let mut repeated_digits: Vec<_> = store
+        .grep_files(session, r"\d{2,}", None)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|hit| (hit.path, hit.line_number))
+        .collect();
+    repeated_digits.sort();
+    assert_eq!(
+        repeated_digits,
+        vec![
+            ("/docs/readme.md".to_string(), 1),
+            ("/src/app.log".to_string(), 1),
+            ("/src/app.log".to_string(), 3),
+        ]
+    );
+
+    let literal = store
+        .grep_files(session, "all good", Some("src/app.log"))
+        .await
+        .unwrap();
+    assert_eq!(literal.len(), 1);
+    assert_eq!(literal[0].path, "/src/app.log");
+    assert_eq!(literal[0].line_number, 2);
+}
+
+#[tokio::test]
+async fn in_memory_store_honors_grep_regex_contract() {
+    assert_regex_contract(Arc::new(InMemorySessionFileStore::new())).await;
+}
+
+#[tokio::test]
+async fn real_disk_store_honors_grep_regex_contract() {
+    let root = TempDir::new().unwrap();
+    let store = Arc::new(RealDiskFileStore::new(root.path()).unwrap());
+    assert_regex_contract(store).await;
+}

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -291,9 +291,11 @@ The following behaviors hold across all implementations:
    itself MUST fail with an error, not return `Ok(false)`.
 4. **`stat_file` on root** returns a synthetic directory entry; the root
    always exists.
-5. **`grep_files`** searches text files only. Implementations are free to
-   skip binary content, oversized files, and explicitly excluded
-   directories. `path_pattern` filters canonical workspace paths using globs:
+5. **`grep_files`** searches text files only. The content `pattern` uses Rust
+   [`regex`](https://docs.rs/regex) syntax and is compiled once before scanning;
+   an invalid pattern returns an explicit error. Implementations are free to
+   skip binary content, oversized files, and explicitly excluded directories.
+   `path_pattern` filters canonical workspace paths using globs:
    `*` and `?` match within one path segment, `**` crosses directories, and
    bracket classes and brace alternation are supported. A basename-only glob
    such as `*.txt` matches at any depth. `/workspace` and supported host-absolute


### PR DESCRIPTION
## What changed
Runtime-backed `grep_files` now interprets content patterns with Rust regex syntax in both the in-memory and real-disk stores. Invalid expressions fail before scanning, while path filtering keeps its existing glob and substring semantics.

A shared conformance test covers both stores, and the public trait/spec now state the regex contract.

## Why
The tool schema promised regex matching, but runtime stores used literal substring matching while server-backed stores compiled regexes. Embedded runtimes therefore behaved differently for patterns such as alternation and repetition.

Resolves EVE-776.

## Before / After
Before: `Error|failed|timeout` and `\d{2,}` were treated as literal text by runtime stores, and `[invalid` returned an empty successful result.

After: both runtime stores match alternation and repeated digit classes, reject invalid expressions before scanning, preserve literal searches, and retain existing `path_pattern` behavior.

Proof:
- `cargo test -p everruns-runtime --test file_store_grep_conformance_test`
- `cargo test -p everruns-runtime --all-features`
- `cargo clippy -p everruns-runtime --all-targets --all-features -- -D warnings`
- `just pre-push`
- GitHub Actions: all applicable checks passed

## Risk
- Low
- Existing callers that relied on regex metacharacters being literal will now receive the documented regex behavior. Literal patterns without metacharacters remain unchanged. Path filtering is untouched.

## Security
- Threat categories reviewed: TM-FS, TM-DOS
- Findings and resolutions: path normalization, containment, and path-pattern filtering are unchanged. Rust's `regex` engine provides linear-time matching with bounded compilation; each request compiles once before scanning, preserving the ReDoS posture. No new third-party version was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)