### PR TITLE
feat(server): project reason.item summaries to reasoning channel

### DIFF
--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -46,9 +46,9 @@ use axum::{
 };
 use axum_extra::extract::Multipart;
 use everruns_core::events::{
-    OutputMessageCompletedData, OutputMessageDeltaData, ReasonThinkingCompletedData,
-    ReasonThinkingDeltaData, ReasonThinkingStartedData, ToolCompletedData, ToolStartedData,
-    TurnFailedData,
+    OutputMessageCompletedData, OutputMessageDeltaData, ReasonItemData,
+    ReasonThinkingCompletedData, ReasonThinkingDeltaData, ReasonThinkingStartedData,
+    ToolCompletedData, ToolStartedData, TurnFailedData,
 };
 use everruns_core::message::ExecutionPhase;
 use everruns_core::message_retriever::InputMessage as StoredInputMessage;
@@ -1104,6 +1104,76 @@ fn push_public_tool_activity_end(state: &mut AgUiStreamState) {
     }
 }
 
+/// Project a provider `reason.item` summary onto the AG-UI reasoning (thinking)
+/// channel. Per the EVE-768 design note the provider-authored summary is a
+/// reasoning artifact: it must render on the reasoning channel and is never
+/// relabeled as an assistant answer. Only the curated `summary` segments are
+/// surfaced here — opaque/encrypted reasoning content is never emitted.
+///
+/// If a reasoning block is already open (an active `reason.thinking` stream),
+/// the summary is appended within it rather than opening a nested block;
+/// otherwise a self-contained `THINKING_*` block is emitted for the summary.
+fn push_reasoning_summary(state: &mut AgUiStreamState, summary: &[String]) {
+    let text = summary
+        .iter()
+        .map(|segment| segment.trim())
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.is_empty() {
+        return;
+    }
+
+    // Append to an already-open reasoning text message so the summary joins the
+    // active thinking stream instead of opening a nested/duplicate block.
+    if state.thinking_started && state.thinking_text_started {
+        state.queue.push_back(AgUiEvent::ThinkingTextMessageContent(
+            AgUiThinkingTextMessageContentEvent {
+                base: agui_base_event(),
+                delta: format!("\n{text}"),
+            },
+        ));
+        return;
+    }
+
+    // Otherwise emit a self-contained reasoning block. Only open a fresh
+    // `ThinkingStart` when no reasoning block (thinking or tool-activity) is
+    // currently open, and close only what we opened.
+    let thinking_block_open = state.thinking_started || state.public_tool_activity_opened_thinking;
+    let opened_thinking = !thinking_block_open;
+    if opened_thinking {
+        state
+            .queue
+            .push_back(AgUiEvent::ThinkingStart(AgUiThinkingStartEvent {
+                base: agui_base_event(),
+                title: None,
+            }));
+    }
+    state.queue.push_back(AgUiEvent::ThinkingTextMessageStart(
+        AgUiThinkingTextMessageStartEvent {
+            base: agui_base_event(),
+        },
+    ));
+    state.queue.push_back(AgUiEvent::ThinkingTextMessageContent(
+        AgUiThinkingTextMessageContentEvent {
+            base: agui_base_event(),
+            delta: text,
+        },
+    ));
+    state.queue.push_back(AgUiEvent::ThinkingTextMessageEnd(
+        AgUiThinkingTextMessageEndEvent {
+            base: agui_base_event(),
+        },
+    ));
+    if opened_thinking {
+        state
+            .queue
+            .push_back(AgUiEvent::ThinkingEnd(AgUiThinkingEndEvent {
+                base: agui_base_event(),
+            }));
+    }
+}
+
 fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
     match event.event_type.as_str() {
         "output.message.delta" => {
@@ -1220,6 +1290,16 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             state.thinking_started = false;
             state.thinking_text_started = false;
             state.public_tool_activity_opened_thinking = false;
+        }
+        // EVE-775: a provider `reason.item` summary is a *reasoning artifact*
+        // (EVE-768 design note), so it renders on the AG-UI reasoning channel
+        // (`THINKING_*` / `REASONING_*`) — never on the assistant-text channel.
+        // Only the provider-curated `summary` segments are surfaced; the opaque
+        // `encrypted_content` reasoning context is never emitted to a consumer.
+        "reason.item" => {
+            if let Ok(data) = parse_event_data::<ReasonItemData>(event) {
+                push_reasoning_summary(state, &data.summary);
+            }
         }
         "tool.started" if parse_event_data::<ToolStartedData>(event).is_ok() => {
             ensure_assistant_message_id(state);
@@ -1753,6 +1833,218 @@ mod tests {
         let turn_message_id = AgUiMessageId::from(turn_id.uuid());
         assert_ne!(*start_ids[0], turn_message_id);
         assert_ne!(*start_ids[1], turn_message_id);
+    }
+
+    // EVE-775: a provider `reason.item` summary is a reasoning artifact and must
+    // project onto the AG-UI reasoning channel (THINKING_*), never the
+    // assistant-text channel, and never leak opaque reasoning content.
+    #[tokio::test]
+    async fn test_reason_item_summary_projects_to_reasoning_channel() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let event = Event::new(
+            SessionId::from_uuid(state.session_id),
+            EventContext::turn(turn_id, input_message_id),
+            ReasonItemData {
+                turn_id,
+                provider: "openai".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                item_id: "rs_1".to_string(),
+                encrypted_content: Some("OPAQUE-DO-NOT-LEAK".to_string()),
+                summary: vec!["Considered the file layout.".to_string()],
+                token_count: Some(42),
+            },
+        );
+
+        translate_event(&mut state, &event);
+
+        let event_types: Vec<AgUiEventType> =
+            state.queue.iter().map(AgUiEvent::event_type).collect();
+        assert_eq!(
+            event_types,
+            vec![
+                AgUiEventType::ThinkingStart,
+                AgUiEventType::ThinkingTextMessageStart,
+                AgUiEventType::ThinkingTextMessageContent,
+                AgUiEventType::ThinkingTextMessageEnd,
+                AgUiEventType::ThinkingEnd,
+            ]
+        );
+        // The reasoning summary must never appear on the assistant-text channel.
+        assert!(!state.queue.iter().any(|event| matches!(
+            event,
+            AgUiEvent::TextMessageStart(_)
+                | AgUiEvent::TextMessageContent(_)
+                | AgUiEvent::TextMessageEnd(_)
+        )));
+        match &state.queue[2] {
+            AgUiEvent::ThinkingTextMessageContent(event) => {
+                assert_eq!(event.delta, "Considered the file layout.");
+            }
+            other => panic!("expected thinking content, got {other:?}"),
+        }
+        // Hidden/opaque reasoning content is never exposed anywhere on the wire.
+        let serialized: String = state
+            .queue
+            .iter()
+            .map(|event| serde_json::to_string(event).unwrap())
+            .collect();
+        assert!(
+            !serialized.contains("OPAQUE-DO-NOT-LEAK"),
+            "opaque reasoning must never reach the AG-UI wire: {serialized}"
+        );
+        // A reasoning summary does not end the run — the final answer still follows.
+        assert!(!state.finished);
+    }
+
+    #[tokio::test]
+    async fn test_reason_item_empty_summary_emits_nothing() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let event = Event::new(
+            SessionId::from_uuid(state.session_id),
+            EventContext::turn(turn_id, input_message_id),
+            ReasonItemData {
+                turn_id,
+                provider: "openai".to_string(),
+                model: None,
+                item_id: "rs_empty".to_string(),
+                encrypted_content: Some("OPAQUE".to_string()),
+                summary: vec![String::new(), "   ".to_string()],
+                token_count: None,
+            },
+        );
+        translate_event(&mut state, &event);
+        assert!(state.queue.is_empty());
+    }
+
+    // EVE-768 AC#7: reasoning summary vs commentary channel separation. Commentary
+    // is deliberate user-facing assistant text; the provider reasoning summary is a
+    // reasoning artifact. They must land on different channels and never mix.
+    #[tokio::test]
+    async fn test_reason_summary_and_commentary_use_separate_channels() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let context = EventContext::turn(turn_id, input_message_id);
+        let session_id = SessionId::from_uuid(state.session_id);
+
+        let commentary_delta = Event::new(
+            session_id,
+            context.clone(),
+            OutputMessageDeltaData {
+                turn_id,
+                delta: "Let me look into that.".to_string(),
+                accumulated: "Let me look into that.".to_string(),
+            },
+        );
+        translate_event(&mut state, &commentary_delta);
+
+        let reason_item = Event::new(
+            session_id,
+            context,
+            ReasonItemData {
+                turn_id,
+                provider: "openai".to_string(),
+                model: None,
+                item_id: "rs_sep".to_string(),
+                encrypted_content: None,
+                summary: vec!["Summarized the plan.".to_string()],
+                token_count: None,
+            },
+        );
+        translate_event(&mut state, &reason_item);
+
+        // Assistant-text channel carries only the commentary.
+        let text_deltas: Vec<&str> = state
+            .queue
+            .iter()
+            .filter_map(|event| match event {
+                AgUiEvent::TextMessageContent(event) => Some(event.delta.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text_deltas, vec!["Let me look into that."]);
+
+        // Reasoning channel carries only the summary.
+        let thinking_deltas: Vec<&str> = state
+            .queue
+            .iter()
+            .filter_map(|event| match event {
+                AgUiEvent::ThinkingTextMessageContent(event) => Some(event.delta.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(thinking_deltas, vec!["Summarized the plan."]);
+    }
+
+    #[tokio::test]
+    async fn test_reason_item_summary_appends_to_active_thinking_block() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let context = EventContext::turn(turn_id, input_message_id);
+        let session_id = SessionId::from_uuid(state.session_id);
+
+        let thinking_started = Event::new(
+            session_id,
+            context.clone(),
+            ReasonThinkingStartedData {
+                turn_id,
+                model: None,
+            },
+        );
+        translate_event(&mut state, &thinking_started);
+        let thinking_delta = Event::new(
+            session_id,
+            context.clone(),
+            ReasonThinkingDeltaData {
+                turn_id,
+                delta: "Reasoning...".to_string(),
+                accumulated: "Reasoning...".to_string(),
+            },
+        );
+        translate_event(&mut state, &thinking_delta);
+
+        let reason_item = Event::new(
+            session_id,
+            context,
+            ReasonItemData {
+                turn_id,
+                provider: "openai".to_string(),
+                model: None,
+                item_id: "rs_app".to_string(),
+                encrypted_content: None,
+                summary: vec!["Summary tail.".to_string()],
+                token_count: None,
+            },
+        );
+        translate_event(&mut state, &reason_item);
+
+        let event_types: Vec<AgUiEventType> =
+            state.queue.iter().map(AgUiEvent::event_type).collect();
+        // The summary appends into the open reasoning block — no duplicate start.
+        assert_eq!(
+            event_types
+                .iter()
+                .filter(|event_type| **event_type == AgUiEventType::ThinkingStart)
+                .count(),
+            1
+        );
+        assert!(
+            !state
+                .queue
+                .iter()
+                .any(|event| matches!(event, AgUiEvent::TextMessageContent(_)))
+        );
+        match state.queue.back().unwrap() {
+            AgUiEvent::ThinkingTextMessageContent(event) => {
+                assert_eq!(event.delta, "\nSummary tail.");
+            }
+            other => panic!("expected appended thinking content, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -29,6 +29,9 @@ use tokio::sync::{mpsc, oneshot};
 pub enum Author {
     User,
     Assistant,
+    // EVE-775: provider reasoning-summary artifacts render on their own
+    // dimmed reasoning channel — a secondary detail, never the assistant answer.
+    Reasoning,
     Tool,
     ToolDetail,
     Diff,
@@ -40,6 +43,7 @@ impl Author {
         match self {
             Author::User => "you",
             Author::Assistant => "agent",
+            Author::Reasoning => "reasoning",
             Author::Tool => "tool",
             Author::ToolDetail => "",
             Author::Diff => "diff",
@@ -50,6 +54,7 @@ impl Author {
         match self {
             Author::User => ACCENT_BLUE,
             Author::Assistant => ACCENT_GOLD,
+            Author::Reasoning => TEXT_DIM,
             Author::Tool => TEXT_MUTED,
             Author::ToolDetail => TEXT_MUTED,
             Author::Diff => ACCENT_BLUE,
@@ -774,13 +779,17 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
                 Vec::new()
             }
         }
+        // EVE-775: a `reason.item` summary is a reasoning artifact (EVE-768
+        // design note), so it renders on the dimmed reasoning channel as a
+        // secondary detail — never as an assistant answer. Only the curated
+        // `summary` segments are shown; opaque `encrypted_content` is not.
         EventData::ReasonItem(data) => data
             .summary
             .iter()
             .filter_map(|segment| {
                 let trimmed = segment.trim();
                 (!trimmed.is_empty()).then(|| ChatLine {
-                    author: Author::Assistant,
+                    author: Author::Reasoning,
                     text: trimmed.to_string(),
                 })
             })
@@ -1993,9 +2002,40 @@ mod tests {
         let lines = lines_for_event(&event);
 
         assert_eq!(lines.len(), 2, "blank summary segments are dropped");
-        assert!(matches!(lines[0].author, Author::Assistant));
+        // EVE-775: reasoning summaries render on the reasoning channel, never as
+        // an assistant answer, and never expose opaque `encrypted_content`.
+        assert!(matches!(lines[0].author, Author::Reasoning));
+        assert!(matches!(lines[1].author, Author::Reasoning));
         assert_eq!(lines[0].text, "Considering file layout");
         assert_eq!(lines[1].text, "Plan the read order");
+        assert!(lines.iter().all(|line| !line.text.contains("opaque")));
+    }
+
+    // EVE-768 AC#7: replay reconstruction keeps a reasoning summary on the
+    // reasoning channel, never reclassifying it as an assistant answer.
+    #[test]
+    fn lines_for_replayed_event_keeps_reason_summary_on_reasoning_channel() {
+        use everruns_core::events::ReasonItemData;
+
+        let event = RuntimeEvent::new(
+            SessionId::new(),
+            EventContext::empty(),
+            ReasonItemData {
+                turn_id: TurnId::new(),
+                provider: "openai".to_string(),
+                model: None,
+                item_id: "rs_replay".to_string(),
+                encrypted_content: Some("opaque".to_string()),
+                summary: vec!["Summarized the change".to_string()],
+                token_count: None,
+            },
+        );
+
+        let lines = lines_for_replayed_event(&event);
+
+        assert_eq!(lines.len(), 1);
+        assert!(matches!(lines[0].author, Author::Reasoning));
+        assert_eq!(lines[0].text, "Summarized the change");
     }
 
     #[test]

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -399,6 +399,15 @@ fn print_transcript_line(line: &app::ChatLine, color: bool) {
         app::Author::Assistant => {
             println!("{} {}", paint(color, "90", "•"), line.text);
         }
+        app::Author::Reasoning => {
+            // Reasoning summary: dimmed secondary detail on its own channel.
+            println!(
+                "{} {} {}",
+                paint(color, "90", "◦"),
+                paint(color, "90", line.author.label()),
+                paint(color, "90", &line.text)
+            );
+        }
         app::Author::Tool => {
             println!(
                 "{} {} {}",

--- a/specs/events.md
+++ b/specs/events.md
@@ -1191,6 +1191,7 @@ Durable record of an opaque assistant reasoning response item, distinct from `re
 - `summary` carries only provider-curated summary text (e.g., OpenAI `summary_text` parts). Other content variants are dropped.
 - `encrypted_content` and `token_count` are optional; not every provider supplies them.
 - User-visible thinking streams continue to flow through `reason.thinking.*`; `reason.item` is the durable record for opaque artifacts that cannot be safely streamed as plaintext.
+- **Projection:** the curated `summary` is a reasoning artifact and projects onto the reasoning channel (AG-UI `REASONING_*`/`THINKING_*`, ACP `agent_thought_chunk`) — visible by default, never the assistant-text channel. `encrypted_content` is never surfaced to a consumer. See the Channel Projection Matrix below.
 
 **Extended Thinking Timeline Example:**
 
@@ -1223,6 +1224,69 @@ output.message.delta  output.message.delta  ← UI shows streaming text
   │ output.message.completed │  ← UI shows final message
   └──────────────────────────┘
 ```
+
+### Channel Projection Matrix (commentary vs. reasoning vs. tool)
+
+Downstream transports (AG-UI, ACP, the terminal example) render the runtime
+event stream onto a small set of **channels**. The load-bearing rule — the one
+that fixes the EVE-448 class of bug where deliberate progress was labeled
+"Thinking" — is that each runtime concept maps to exactly one channel, and a
+projection must never move an item across channels to fake a phase. See
+`proposals/commentary-in-runtime-event-model.md` (EVE-768) for the full design
+rationale and the non-overlapping definitions.
+
+**Definitions (non-overlapping):**
+
+- **Commentary** — deliberate, user-visible assistant *text* produced as
+  progress/preamble before or between tool calls; does not end the turn
+  (`Message.phase = commentary`).
+- **Final answer** — the durable, turn-ending assistant *text*
+  (`Message.phase = final_answer`).
+- **Thinking** — model reasoning the provider *explicitly exposes* as
+  displayable reasoning, streamed via `reason.thinking.*`. Never inferred; raw
+  hidden chain-of-thought is never persisted or exposed.
+- **Reasoning summary** — the provider-curated safe summary carried on
+  `reason.item` (`summary`), alongside opaque/encrypted continuation state. The
+  summary is a *reasoning artifact*, surfaced on the reasoning channel by
+  default — never relabeled as an assistant answer. The opaque
+  `encrypted_content` is never surfaced to a consumer.
+- **Tool activity** — narration/progress/output scoped to a `tool_call` id; its
+  own channel, never merged into the assistant-message channel.
+
+**Projection + fallback matrix:**
+
+| Runtime concept | Source event(s) | Assistant-text channel | Reasoning channel | Tool channel |
+|---|---|---|---|---|
+| Commentary | `output.message.delta` / `output.message.completed` (`phase = commentary`) | AG-UI `TEXT_MESSAGE_*`; ACP `agent_message_chunk` | — | — |
+| Final answer | `output.message.completed` (`phase = final_answer`) | AG-UI `TEXT_MESSAGE_*`; ACP `agent_message_chunk` | — | — |
+| Thinking | `reason.thinking.*` | — | AG-UI `REASONING_*` / `THINKING_*`; ACP `agent_thought_chunk` | — |
+| Reasoning summary | `reason.item` (`summary`) | — | AG-UI `REASONING_*` / `THINKING_*` (visible by default; policy may omit); ACP `agent_thought_chunk` | — |
+| Tool narration/progress/output | `tool.started` / `tool.completed` | — | — | AG-UI `TOOL_CALL_*`; ACP `tool_call` / `tool_call_update` |
+
+**HARD fallback rule:** when a message's phase is missing or unknown (e.g. a
+stream that died before `output.message.completed`, or a transport with no phase
+concept), it falls back to the **assistant-text** channel — shown in order as
+ordinary assistant text. A missing/unknown phase must **NEVER** fall back to the
+thinking/reasoning channel. Only `reason.thinking.*` and the `reason.item`
+`summary` are ever routed to the reasoning channel; assistant messages never are,
+regardless of phase.
+
+**ACP mapping (spec-level contract).** No ACP adapter exists in-tree yet; when
+one lands it must honor this contract: commentary and final answer map to
+`session/update → agent_message_chunk` (role assistant); thinking and reasoning
+summaries map to `agent_thought_chunk`. Routing commentary to
+`agent_thought_chunk` is exactly the mis-projection that makes clients label
+progress "Thinking" and is prohibited.
+
+**Graceful degradation.** AG-UI and ACP have no native commentary/final `phase`,
+so commentary and final answer both render on the assistant-text channel and are
+simply shown in order — the transcript stays correct; only the "this was a
+preamble" affordance is lost. Replay reconstructs boundaries from the durable
+`output.message.*` lifecycle and classification from the authoritative
+`output.message.completed` `Message.phase`; a reasoning summary replayed from
+`reason.item` stays on the reasoning channel and is never reclassified as an
+assistant answer. AG-UI projection lives in `crates/server/src/api/ag_ui.rs`;
+the terminal example is `examples/coding-cli`.
 
 **Real-time Usage Tracking Pattern:**
 


### PR DESCRIPTION
Closes EVE-775.

## What changed
Provider `reason.item` reasoning summaries (`ReasonItemData.summary`, persisted per EVE-485) are now projected to consumers on the **reasoning channel** instead of being dropped. Previously `ag_ui.rs::translate_event` had no `reason.item` case, so these summaries never reached AG-UI at all, and the terminal example rendered them as `Author::Assistant` — exactly the mislabeling the EVE-768 design note forbids.

- **AG-UI** (`crates/server/src/api/ag_ui.rs`): new `"reason.item"` handler + `push_reasoning_summary` helper. The curated `summary` is emitted as `THINKING_*` (reasoning) events — appended into an already-open reasoning block when one is active, otherwise a self-contained block. Opaque `encrypted_content` is **never** emitted; empty/whitespace summaries emit nothing; a summary never ends the run.
- **Terminal** (`examples/coding-cli`): added a dimmed `Author::Reasoning` channel and routed the summary there as secondary detail (was previously shown as an assistant answer).
- **Spec** (`specs/events.md`): added a "Channel Projection Matrix" — commentary/final → assistant-text; thinking + reasoning summaries → reasoning; tool activity → tool — plus the hard fallback rule (missing/unknown phase → assistant text, never thinking/reasoning) and the ACP contract (`agent_message_chunk` for commentary/final, `agent_thought_chunk` for thinking/summaries; no in-tree adapter yet). Closes EVE-768 AC#6.

## Before / After
- **Before:** `reason.item` summaries invisible in AG-UI; rendered as an assistant answer in the terminal.
- **After:** summaries render on the reasoning channel in both surfaces; opaque content never leaves the server.

Evidence (local, disk-limited):
```
cargo test -p everruns-server --lib ag_ui   → 28 passed, 0 failed (incl. 4 new)
examples/coding-cli reason tests            → pass
cargo clippy -p everruns-server --lib / -p everruns-coding-cli --all-features → clean
```
Full `just pre-push` / integration-test binaries deferred to CI (local ENOSPC); CI runs the complete suite.

## Risk
- Low. Additive projection + docs + an internal `Author` enum variant. No serialized event shapes changed (no `openapi.json` / UI-type regeneration needed). New string match arm in `translate_event` — no exhaustiveness impact.

## Security
- Threat categories reviewed: TM-DATA / reasoning-exposure. This change **strengthens** the boundary: only the provider-curated `summary` is surfaced; opaque `encrypted_content` (raw chain-of-thought) is explicitly never emitted, and a test asserts the opaque marker is absent from the serialized wire. No auth, input-parsing, or secret-handling surface touched.
- Findings and resolutions: None.

## Follow-ups
- EVE-774 (streamed phase hint) and EVE-778 (read-once/contextual-search guidance) are separate EVE-768-series slices.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xcs5JEA9waush1UxMXS86C)_