### PR TITLE
feat(core): streamed phase hint on output.message started/delta

### DIFF
--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -11533,6 +11533,7 @@ export interface components {
       accumulated: string;
       /** @description The new text chunk */
       delta: string;
+      phase?: null | components["schemas"]["ExecutionPhase"];
       /**
        * @description Turn ID this delta belongs to
        * @example turn_01933b5a00007000800000000000001
@@ -11583,6 +11584,7 @@ export interface components {
       iteration?: number | null;
       /** @description Optional model name being used */
       model?: string | null;
+      phase?: null | components["schemas"]["ExecutionPhase"];
       /**
        * @description Turn ID this output belongs to
        * @example turn_01933b5a00007000800000000000001

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -351,7 +351,9 @@ fn stream_event_advances_stall_deadline(event: &LlmStreamEvent) -> bool {
                 || token_count.is_some_and(|count| count > 0)
         }
         LlmStreamEvent::ToolCalls(calls) => !calls.is_empty(),
-        LlmStreamEvent::ThinkingSignature(_)
+        // MessagePhase is a metadata hint, not assistant output progress.
+        LlmStreamEvent::MessagePhase(_)
+        | LlmStreamEvent::ThinkingSignature(_)
         | LlmStreamEvent::Done(_)
         | LlmStreamEvent::Error(_) => false,
     }
@@ -1758,6 +1760,9 @@ impl ReasonAtom {
                     turn_id: context.turn_id,
                     model: Some(runtime_agent.model.clone()),
                     iteration: Some(iteration),
+                    // Emitted before the LLM call — phase is not yet known, so the
+                    // streamed hint starts `None` (treat as assistant text).
+                    phase: None,
                 },
             ))
             .await
@@ -1955,6 +1960,11 @@ impl ReasonAtom {
         const DELTA_BATCH_INTERVAL_MS: u64 = 100;
         let retry_config = LlmRetryConfig::default();
         let mut stream_retry_metadata = RetryMetadata::default();
+        // Best-effort streamed phase hint (EVE-774). Starts `None` ("not yet
+        // classified — treat as assistant text") and is refined monotonically
+        // once a provider reveals a native phase mid-stream. Declared outside the
+        // retry loop so it is available to the post-loop guarded delta emission.
+        let mut streamed_phase: Option<crate::message::ExecutionPhase> = None;
         let (
             text,
             thinking,
@@ -2459,6 +2469,7 @@ impl ReasonAtom {
                                         turn_id: context.turn_id,
                                         delta: pending_delta.clone(),
                                         accumulated: text.clone(),
+                                        phase: streamed_phase,
                                     },
                                 ))
                                 .await
@@ -2590,6 +2601,20 @@ impl ReasonAtom {
                         stream_has_output |= !calls.is_empty();
                         tool_calls = calls;
                     }
+                    LlmStreamEvent::MessagePhase(phase) => {
+                        // Provider revealed a native phase for the current
+                        // assistant message mid-stream. Refine the streamed hint
+                        // monotonically (never flip-flop, never back to None);
+                        // subsequent output.message.delta events carry it. This is
+                        // a hint only — it is NOT a completion signal and does not
+                        // count as stream output. The completed Message.phase stays
+                        // authoritative, and the hint is deliberately not derived
+                        // from later tool-call presence (EVE-448 anti-pattern).
+                        streamed_phase = crate::message::ExecutionPhase::refine_streamed_hint(
+                            streamed_phase,
+                            phase,
+                        );
+                    }
                     LlmStreamEvent::Done(metadata) => {
                         // Emit any remaining pending delta before completing,
                         // unless a post-generation guardrail must first inspect
@@ -2605,6 +2630,7 @@ impl ReasonAtom {
                                         turn_id: context.turn_id,
                                         delta: pending_delta.clone(),
                                         accumulated: text.clone(),
+                                        phase: streamed_phase,
                                     },
                                 ))
                                 .await
@@ -2797,6 +2823,7 @@ impl ReasonAtom {
                         turn_id: context.turn_id,
                         delta: pending_delta.clone(),
                         accumulated: text.clone(),
+                        phase: streamed_phase,
                     },
                 ))
                 .await
@@ -3104,6 +3131,9 @@ impl ReasonAtom {
                     turn_id,
                     model: None,
                     iteration: Some(iteration),
+                    // Recovery/finalize path reconstructs the started signal only;
+                    // the streamed phase hint is unavailable here (None).
+                    phase: None,
                 },
             ))
             .await;

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -141,6 +141,16 @@ pub enum LlmStreamEvent {
     },
     /// Tool calls from the LLM
     ToolCalls(Vec<ToolCall>),
+    /// Provider-native execution phase for the current assistant message,
+    /// surfaced mid-stream before completion (EVE-774).
+    ///
+    /// Only emitted by providers whose stream carries a native phase ahead of
+    /// the terminal `Done` metadata (OpenAI Responses exposes it on
+    /// `response.output_item.added`). Consumers use it as a best-effort hint to
+    /// classify streamed assistant text as commentary vs final answer; the
+    /// authoritative value is still the completed `Message.phase`. Other
+    /// providers never emit this and stay unclassified until completion.
+    MessagePhase(crate::message::ExecutionPhase),
     /// Streaming completed
     Done(Box<LlmCompletionMetadata>),
     /// Error during streaming
@@ -288,6 +298,9 @@ pub trait ChatDriver: Send + Sync {
                     }
                 }
                 LlmStreamEvent::ToolCalls(calls) => tool_calls = calls,
+                // Streamed phase hint is a mid-stream refinement only; the
+                // non-streaming collector relies on the terminal Done metadata.
+                LlmStreamEvent::MessagePhase(_) => {}
                 LlmStreamEvent::Done(meta) => metadata = *meta,
                 LlmStreamEvent::Error(err) => {
                     return Err(crate::error::AgentLoopError::llm_kind(

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -507,7 +507,7 @@ impl Event {
 // Input/Output Event Data Types
 // ============================================================================
 
-use crate::message::{ContentPart, Message};
+use crate::message::{ContentPart, ExecutionPhase, Message};
 use crate::tool_narration::{
     ToolNarrationPhase, render_group_headline_with_locale, render_tool_narration_with_locale,
 };
@@ -771,6 +771,18 @@ pub struct OutputMessageStartedData {
     /// Useful for UI to show progress during multi-step tool-calling flows.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iteration: Option<u32>,
+
+    /// Best-effort streamed phase hint (EVE-774).
+    ///
+    /// `None` means "not yet classified — treat as ordinary assistant text",
+    /// NEVER "thinking". A missing/unknown phase must fall back to the
+    /// assistant-text channel, never the reasoning channel. Only populated when
+    /// the provider stream reveals a native phase before this event is emitted;
+    /// today `output.message.started` is emitted before the LLM call, so this is
+    /// generally `None` at start. The authoritative classification remains the
+    /// completed `Message.phase`. See `specs/events.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<ExecutionPhase>,
 }
 
 /// Data for output.message.delta event
@@ -789,6 +801,19 @@ pub struct OutputMessageDeltaData {
 
     /// Accumulated text so far
     pub accumulated: String,
+
+    /// Best-effort streamed phase hint (EVE-774).
+    ///
+    /// `None` means "not yet classified — treat as ordinary assistant text",
+    /// NEVER "thinking". Refinement is monotonic: once a stream reveals a native
+    /// phase (`Commentary` or `FinalAnswer`) it stays fixed for the rest of the
+    /// message — it never flip-flops and never reverts to `None`
+    /// (see `ExecutionPhase::refine_streamed_hint`). Providers without native
+    /// mid-stream phase (Anthropic, Gemini, …) leave this `None` until
+    /// completion. The authoritative classification remains the completed
+    /// `Message.phase`. See `specs/events.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<ExecutionPhase>,
 }
 
 /// Data for output.message.completed event
@@ -3264,6 +3289,7 @@ mod tests {
                 turn_id,
                 delta: "hel".to_string(),
                 accumulated: "hel".to_string(),
+                phase: None,
             },
         );
         assert!(output_delta.is_ephemeral());
@@ -3354,6 +3380,7 @@ mod tests {
             turn_id,
             model: Some("claude-4-opus".to_string()),
             iteration: None,
+            phase: None,
         };
 
         let event_data: EventData = data.into();
@@ -3372,6 +3399,7 @@ mod tests {
             turn_id,
             model: None,
             iteration: None,
+            phase: None,
         };
 
         // Model should be skipped when None
@@ -3439,6 +3467,7 @@ mod tests {
             turn_id,
             delta: "Hello".to_string(),
             accumulated: "Hello".to_string(),
+            phase: None,
         };
 
         let event_data: EventData = data.into();
@@ -3452,6 +3481,50 @@ mod tests {
     }
 
     #[test]
+    fn test_output_message_phase_hint_serde() {
+        // EVE-774: the streamed phase hint is skipped when None (so existing
+        // consumers see no new field) and serialized as the provider wire value
+        // when present, on both started and delta events.
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
+
+        let started_none = OutputMessageStartedData {
+            turn_id,
+            model: None,
+            iteration: None,
+            phase: None,
+        };
+        assert!(
+            !serde_json::to_string(&started_none)
+                .unwrap()
+                .contains("phase")
+        );
+
+        let delta_commentary = OutputMessageDeltaData {
+            turn_id,
+            delta: "one moment".to_string(),
+            accumulated: "one moment".to_string(),
+            phase: Some(crate::message::ExecutionPhase::Commentary),
+        };
+        let json = serde_json::to_value(&delta_commentary).unwrap();
+        assert_eq!(json["phase"], "commentary");
+
+        // Round-trips back to the same phase.
+        let back: OutputMessageDeltaData = serde_json::from_value(json).unwrap();
+        assert_eq!(back.phase, Some(crate::message::ExecutionPhase::Commentary));
+
+        let delta_final = OutputMessageDeltaData {
+            turn_id,
+            delta: "done".to_string(),
+            accumulated: "done".to_string(),
+            phase: Some(crate::message::ExecutionPhase::FinalAnswer),
+        };
+        assert_eq!(
+            serde_json::to_value(&delta_final).unwrap()["phase"],
+            "final_answer"
+        );
+    }
+
+    #[test]
     fn test_output_message_delta_deserialization_preserves_fields() {
         // Verify OutputMessageDelta decodes with all fields preserved through the
         // type-driven dispatcher (regression guard for field-dropping decode bugs).
@@ -3460,6 +3533,7 @@ mod tests {
             turn_id,
             delta: "Hello world".to_string(),
             accumulated: "Hello world".to_string(),
+            phase: None,
         };
 
         // Serialize to JSON
@@ -3486,6 +3560,7 @@ mod tests {
             turn_id,
             model: Some("claude-3".to_string()),
             iteration: None,
+            phase: None,
         };
 
         // Serialize to JSON
@@ -3887,6 +3962,7 @@ mod contract_tests {
             turn_id: test_turn_id(),
             model: Some("gpt-4o".to_string()),
             iteration: None,
+            phase: None,
         };
         with_settings!({
             sort_maps => true,
@@ -3901,6 +3977,7 @@ mod contract_tests {
             turn_id: test_turn_id(),
             delta: "Hello".to_string(),
             accumulated: "Hello".to_string(),
+            phase: None,
         };
         with_settings!({
             sort_maps => true,
@@ -4443,6 +4520,7 @@ mod contract_tests {
                     turn_id: test_turn_id(),
                     model: None,
                     iteration: None,
+                    phase: None,
                 }
                 .into(),
             ),
@@ -4452,6 +4530,7 @@ mod contract_tests {
                     turn_id: test_turn_id(),
                     delta: "x".to_string(),
                     accumulated: "x".to_string(),
+                    phase: None,
                 }
                 .into(),
             ),

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -67,6 +67,19 @@ impl ExecutionPhase {
             Self::FinalAnswer => "final_answer",
         }
     }
+
+    /// Monotonic refinement for the streamed phase *hint* on
+    /// `output.message.started` / `output.message.delta`.
+    ///
+    /// The hint may advance `None -> Commentary | FinalAnswer` exactly once and
+    /// then never changes: it never flip-flops between variants and never
+    /// reverts to `None`. Once a message has been classified mid-stream that
+    /// classification stays put; the authoritative value remains the completed
+    /// `Message.phase`. Returns the (possibly unchanged) refined hint.
+    pub fn refine_streamed_hint(current: Option<Self>, incoming: Self) -> Option<Self> {
+        // First classification wins; a later hint cannot overwrite it.
+        Some(current.unwrap_or(incoming))
+    }
 }
 
 impl std::fmt::Display for ExecutionPhase {
@@ -1384,6 +1397,35 @@ mod tests {
         assert_eq!(
             ExecutionPhase::from_has_tool_calls(false),
             ExecutionPhase::FinalAnswer
+        );
+    }
+
+    #[test]
+    fn test_execution_phase_refine_streamed_hint_monotonic() {
+        use ExecutionPhase::{Commentary, FinalAnswer};
+        // None advances to the first observed value.
+        assert_eq!(
+            ExecutionPhase::refine_streamed_hint(None, Commentary),
+            Some(Commentary)
+        );
+        assert_eq!(
+            ExecutionPhase::refine_streamed_hint(None, FinalAnswer),
+            Some(FinalAnswer)
+        );
+        // First classification wins: a later hint never flips it...
+        assert_eq!(
+            ExecutionPhase::refine_streamed_hint(Some(Commentary), FinalAnswer),
+            Some(Commentary)
+        );
+        assert_eq!(
+            ExecutionPhase::refine_streamed_hint(Some(FinalAnswer), Commentary),
+            Some(FinalAnswer)
+        );
+        // ...and never reverts to None (the input is never None-valued, but a
+        // repeated identical hint is a no-op).
+        assert_eq!(
+            ExecutionPhase::refine_streamed_hint(Some(Commentary), Commentary),
+            Some(Commentary)
         );
     }
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -1219,11 +1219,15 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                                     }
 
                                     Some("response.output_item.added") => {
-                                        // New output item added - may be function call
-                                        if let Some(item) = json.get("item")
-                                            && item.get("type").and_then(|t| t.as_str())
-                                                == Some("function_call")
-                                        {
+                                        // New output item added - may be a function
+                                        // call or an assistant message carrying a
+                                        // native phase.
+                                        let item_type = json
+                                            .get("item")
+                                            .and_then(|i| i.get("type"))
+                                            .and_then(|t| t.as_str());
+                                        if item_type == Some("function_call") {
+                                            let item = json.get("item").unwrap();
                                             let id = item
                                                 .get("id")
                                                 .and_then(|c| c.as_str())
@@ -1251,6 +1255,21 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                                                     name,
                                                     arguments: String::new(),
                                                 });
+                                            }
+                                        } else if item_type == Some("message") {
+                                            // Surface the assistant item's native
+                                            // phase mid-stream as a best-effort hint
+                                            // (EVE-774); Done metadata stays
+                                            // authoritative.
+                                            if let Some(phase) = json
+                                                .get("item")
+                                                .and_then(|i| i.get("phase"))
+                                                .and_then(|p| p.as_str())
+                                                .and_then(
+                                                    crate::message::ExecutionPhase::from_provider_str,
+                                                )
+                                            {
+                                                return Ok(LlmStreamEvent::MessagePhase(phase));
                                             }
                                         }
                                         Ok(LlmStreamEvent::TextDelta(String::new()))
@@ -1532,24 +1551,38 @@ fn handle_streaming_event(
         }
 
         StreamingEvent::OutputItemAdded { item, .. } => {
-            if let Some(types::OutputItem::FunctionCall {
-                id, call_id, name, ..
-            }) = item
-            {
-                let mut acc = accumulated_tool_calls.lock().unwrap();
-                if let Some(tc) = acc.iter_mut().find(|t| t.id == id) {
-                    tc.name = name;
-                    tc.call_id = call_id;
-                } else {
-                    acc.push(ToolCallAccumulator {
-                        id,
-                        call_id,
-                        name,
-                        arguments: String::new(),
-                    });
+            match item {
+                Some(types::OutputItem::FunctionCall {
+                    id, call_id, name, ..
+                }) => {
+                    let mut acc = accumulated_tool_calls.lock().unwrap();
+                    if let Some(tc) = acc.iter_mut().find(|t| t.id == id) {
+                        tc.name = name;
+                        tc.call_id = call_id;
+                    } else {
+                        acc.push(ToolCallAccumulator {
+                            id,
+                            call_id,
+                            name,
+                            arguments: String::new(),
+                        });
+                    }
+                    LlmStreamEvent::TextDelta(String::new())
                 }
+                // OpenAI Responses stamps the assistant item's phase on
+                // `response.output_item.added`, i.e. before any text delta of
+                // that item. Surface it as a best-effort streamed hint (EVE-774)
+                // so consumers can classify commentary vs final answer while
+                // streaming; the terminal Done metadata stays authoritative.
+                Some(types::OutputItem::Message {
+                    phase: Some(phase_str),
+                    ..
+                }) => match crate::message::ExecutionPhase::from_provider_str(&phase_str) {
+                    Some(phase) => LlmStreamEvent::MessagePhase(phase),
+                    None => LlmStreamEvent::TextDelta(String::new()),
+                },
+                _ => LlmStreamEvent::TextDelta(String::new()),
             }
-            LlmStreamEvent::TextDelta(String::new())
         }
 
         StreamingEvent::OutputItemDone { item, .. } => {
@@ -4051,6 +4084,87 @@ mod tests {
                 assert!(token_count.is_none());
             }
             other => panic!("Expected ReasonItem event, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn output_item_added_message_surfaces_native_phase_hint() {
+        use std::sync::Mutex;
+
+        // EVE-774: OpenAI Responses stamps the assistant item's phase on
+        // `response.output_item.added` (before any text delta). The driver must
+        // surface it as a mid-stream `MessagePhase` hint.
+        for (wire, expected) in [
+            ("commentary", crate::message::ExecutionPhase::Commentary),
+            ("final_answer", crate::message::ExecutionPhase::FinalAnswer),
+        ] {
+            let event: StreamingEvent = serde_json::from_value(serde_json::json!({
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "id": "msg_001",
+                    "status": "in_progress",
+                    "role": "assistant",
+                    "content": [],
+                    "phase": wire,
+                }
+            }))
+            .expect("output_item.added should deserialize");
+
+            let result = handle_streaming_event(
+                event,
+                &Mutex::new(0),
+                &Mutex::new(0),
+                &Mutex::new(None),
+                &Mutex::new(Vec::new()),
+                &Mutex::new(None),
+                "gpt-5".to_string(),
+                None,
+            );
+
+            match result {
+                LlmStreamEvent::MessagePhase(phase) => assert_eq!(phase, expected),
+                other => panic!("Expected MessagePhase({expected:?}), got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn output_item_added_message_without_phase_is_noop() {
+        use std::sync::Mutex;
+
+        // A message item that carries no phase yields no hint (empty text delta),
+        // never a fabricated phase.
+        let event: StreamingEvent = serde_json::from_value(serde_json::json!({
+            "type": "response.output_item.added",
+            "sequence_number": 1,
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "id": "msg_002",
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            }
+        }))
+        .expect("output_item.added should deserialize");
+
+        let result = handle_streaming_event(
+            event,
+            &Mutex::new(0),
+            &Mutex::new(0),
+            &Mutex::new(None),
+            &Mutex::new(Vec::new()),
+            &Mutex::new(None),
+            "gpt-5".to_string(),
+            None,
+        );
+
+        match result {
+            LlmStreamEvent::TextDelta(d) => assert!(d.is_empty()),
+            other => panic!("Expected empty TextDelta, got {other:?}"),
         }
     }
 

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -1691,6 +1691,7 @@ mod tests {
                 turn_id,
                 delta: "Hello".to_string(),
                 accumulated: "Hello".to_string(),
+                phase: None,
             },
         );
         translate_event(&mut state, &delta_event);
@@ -1741,6 +1742,7 @@ mod tests {
                 turn_id,
                 delta: "Let me check that.".to_string(),
                 accumulated: "Let me check that.".to_string(),
+                phase: None,
             },
         );
         translate_event(&mut state, &delta_event);
@@ -1938,6 +1940,7 @@ mod tests {
                 turn_id,
                 delta: "Let me look into that.".to_string(),
                 accumulated: "Let me look into that.".to_string(),
+                phase: None,
             },
         );
         translate_event(&mut state, &commentary_delta);

--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -1636,6 +1636,7 @@ mod tests {
             turn_id: TurnId::new(),
             model: None,
             iteration: None,
+            phase: None,
         });
         assert!(translate_session_event(&data, "t", "c").is_none());
     }

--- a/crates/server/src/event_delivery.rs
+++ b/crates/server/src/event_delivery.rs
@@ -310,6 +310,7 @@ mod tests {
                 turn_id: TurnId::new(),
                 delta: "hello".to_string(),
                 accumulated: "hello".to_string(),
+                phase: None,
             }),
             metadata: None,
             tags: None,

--- a/crates/server/src/storage/repositories/tests.rs
+++ b/crates/server/src/storage/repositories/tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+/// `database_pool_config_*` tests mutate process-global `DATABASE_POOL_*` env
+/// vars. `cargo test` runs a binary's tests multi-threaded, so without a shared
+/// lock they race — one test's `set_var`/`remove_var` is observed by another
+/// mid-read (e.g. the invalid-value test's `"not_a_number"` leaking into the
+/// from-env test as a fallback-to-default 50 instead of 100). Serialize them.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn database_pool_config_defaults() {
     let config = DatabasePoolConfig::default();
@@ -11,7 +18,8 @@ fn database_pool_config_defaults() {
 
 #[test]
 fn database_pool_config_from_env() {
-    // SAFETY: test is run single-threaded (--test-threads=1)
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: env access is serialized by ENV_LOCK for the critical section.
     unsafe {
         std::env::set_var("DATABASE_POOL_MAX", "100");
         std::env::set_var("DATABASE_POOL_MIN", "10");
@@ -35,7 +43,8 @@ fn database_pool_config_from_env() {
 
 #[test]
 fn database_pool_config_invalid_values_use_defaults() {
-    // SAFETY: test is run single-threaded (--test-threads=1)
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: env access is serialized by ENV_LOCK for the critical section.
     unsafe {
         std::env::set_var("DATABASE_POOL_MAX", "not_a_number");
     }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -29059,6 +29059,17 @@
             "type": "string",
             "description": "The new text chunk"
           },
+          "phase": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ExecutionPhase",
+                "description": "Best-effort streamed phase hint (EVE-774).\n\n`None` means \"not yet classified — treat as ordinary assistant text\",\nNEVER \"thinking\". Refinement is monotonic: once a stream reveals a native\nphase (`Commentary` or `FinalAnswer`) it stays fixed for the rest of the\nmessage — it never flip-flops and never reverts to `None`\n(see `ExecutionPhase::refine_streamed_hint`). Providers without native\nmid-stream phase (Anthropic, Gemini, …) leave this `None` until\ncompletion. The authoritative classification remains the completed\n`Message.phase`. See `specs/events.md`."
+              }
+            ]
+          },
           "turn_id": {
             "type": "string",
             "description": "Turn ID this delta belongs to",
@@ -29122,6 +29133,17 @@
               "null"
             ],
             "description": "Optional model name being used"
+          },
+          "phase": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ExecutionPhase",
+                "description": "Best-effort streamed phase hint (EVE-774).\n\n`None` means \"not yet classified — treat as ordinary assistant text\",\nNEVER \"thinking\". A missing/unknown phase must fall back to the\nassistant-text channel, never the reasoning channel. Only populated when\nthe provider stream reveals a native phase before this event is emitted;\ntoday `output.message.started` is emitted before the LLM call, so this is\ngenerally `None` at start. The authoritative classification remains the\ncompleted `Message.phase`. See `specs/events.md`."
+              }
+            ]
           },
           "turn_id": {
             "type": "string",

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -2071,6 +2071,7 @@ mod tests {
                 turn_id: TurnId::new(),
                 model: None,
                 iteration: Some(3),
+                phase: None,
             },
         );
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -291,6 +291,8 @@ Emitted when the LLM starts generating a response. UI can show a "thinking" indi
 
 **`iteration`** (optional, u32): 1-based iteration number within the current turn. Lets the UI show which iteration the agent is on during multi-step tool-calling flows. Only displayed when > 1.
 
+**`phase`** (optional, string — `"commentary"` | `"final_answer"`): best-effort streamed phase hint (EVE-774). This event is emitted *before* the LLM call, so `phase` is generally absent here. When absent it means **"not yet classified — treat as ordinary assistant text"**, NEVER "thinking". See the shared hint semantics under `output.message.delta`.
+
 #### `output.message.delta`
 
 Streaming text update during LLM generation. Events are batched (~100ms) to reduce volume while providing real-time feedback. UI should accumulate deltas or use the `accumulated` field until `output.message.completed` arrives with the final text.
@@ -308,10 +310,18 @@ Streaming text update during LLM generation. Events are batched (~100ms) to redu
   "data": {
     "turn_id": "...",
     "delta": "Hello, ",
-    "accumulated": "Hello, "
+    "accumulated": "Hello, ",
+    "phase": "commentary"
   }
 }
 ```
+
+**`phase`** (optional, string — `"commentary"` | `"final_answer"`): best-effort streamed phase hint (EVE-774) letting consumers classify streamed assistant text as commentary vs final answer *before* `output.message.completed` arrives.
+
+- **Absent = "not yet classified — treat as ordinary assistant text", NEVER "thinking".** A missing/unknown phase must fall back to the assistant-text channel, never the reasoning/thinking channel (the EVE-448 class of bug).
+- **Monotonic refinement only.** Within a single message the hint advances `absent → "commentary" | "final_answer"` at most once and then never changes: it never flip-flops between the two values and never reverts to absent (`ExecutionPhase::refine_streamed_hint` enforces this).
+- **Best-effort, not authoritative.** Only providers whose stream carries a native phase populate it mid-stream — OpenAI Responses exposes it on `response.output_item.added` and the driver surfaces it as a mid-stream stream event. Other providers (Anthropic, Gemini, …) leave it absent until completion. The authoritative classification is always the completed `output.message.completed` `Message.phase`; a consumer that needs certainty waits for that event (unchanged behavior) but may now render optimistically meanwhile.
+- **Not derived from later tool calls.** The streamed hint is never inferred from the subsequent presence of tool calls (the EVE-448 anti-pattern); `ExecutionPhase::from_has_tool_calls` stays a completion-time fallback only.
 
 #### `output.message.replaced`
 


### PR DESCRIPTION
Closes EVE-774.

## What changed
Streaming consumers can now receive a best-effort **phase hint** (`commentary` vs `final_answer`) mid-stream instead of waiting for `output.message.completed`. The hint is layered on message identity and never substitutes for correct channel routing (per the EVE-768 design note).

- **`crates/core/src/events.rs`**: added `phase: Option<ExecutionPhase>` to `OutputMessageStartedData` and `OutputMessageDeltaData` (serde `default` + `skip_serializing_if`). `None` = "not yet classified — treat as assistant text", **never** thinking.
- **`crates/core/src/message.rs`**: `ExecutionPhase::refine_streamed_hint` — first classification wins, so the hint advances `None → commentary|final_answer` at most once, never flip-flops, never reverts to `None`. Completed `Message.phase` stays authoritative.
- **`crates/core/src/driver_registry.rs`**: new `LlmStreamEvent::MessagePhase(ExecutionPhase)` variant carrying item-level phase mid-stream (the missing protocol primitive). The non-streaming collector ignores it.
- **`crates/core/src/openresponses_protocol.rs`**: the OpenAI Responses driver surfaces the assistant item's native phase from `response.output_item.added` (both structured + fallback paths). Other providers emit `None` until completion.
- **`crates/core/src/atoms/reason.rs`**: tracks a monotonically-refined `streamed_phase` and attaches it to emitted `output.message.delta` events. `started` stays `None` (emitted before the LLM call). Explicitly **not** derived from later tool-call presence (EVE-448 anti-pattern); `from_has_tool_calls` remains a completion-time fallback only.
- **`specs/events.md`**: documents the hint, `None`-fallback semantics, monotonic refinement, and the "not from tool calls" rule.
- **`docs/api/openapi.json`** regenerated via the `export-openapi` binary; **`apps/ui/.../generated/openapi.ts`** regenerated. Event snapshots unchanged (`phase: None` is skipped in serialization).

## Before / After
- **Before:** phase unknowable until `output.message.completed`; no stream primitive carried item-level phase.
- **After:** OpenAI Responses populates the hint mid-stream; other providers stay `None` until completion; refinement is monotonic and never reclassifies already-shown assistant text.

Evidence:
```
cargo test -p everruns-core --lib (events / message / openresponses / atoms::reason) → 220 + 28 passed
new tests: execution_phase_refine (monotonic), output_message_phase_hint, output_item_added → pass
cargo clippy -p everruns-core --all-targets --all-features -- -D warnings → clean
apps/ui: node scripts/generate-api-types.mjs --check → PASS (byte-exact)
```

## Risk
- Low–Medium. Additive optional field + a new `LlmStreamEvent` variant (all provider stream matches have catch-all arms). Serialized shape changes are additive (skip-if-none) → snapshots unchanged; openapi.json + UI types regenerated. Full-workspace `just pre-push` deferred to CI (local disk limit).

## Security
- Threat categories reviewed: TM-DATA / reasoning-exposure. The hint only distinguishes commentary vs final_answer on assistant text; it is explicitly **never** "thinking" and the `None` fallback routes to assistant text, so it cannot cause already-shown assistant output to be reclassified as reasoning. No auth/secret/input-parsing surface touched.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. (EVE-775 reasoning-summary projection already merged; EVE-778 read-economy guidance is a separate slice, blocked on EVE-777.)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xcs5JEA9waush1UxMXS86C)_