### PR TITLE
perf(agent): teach shared hints single-read/contextual-search policy

### DIFF
--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -92,21 +92,27 @@ pub fn output_verbosity_schema() -> serde_json::Value {
     })
 }
 
-/// System prompt hint for exec tool capabilities (EVE-223, EVE-236, EVE-489).
+/// System prompt hint for exec tool capabilities (EVE-223, EVE-236, EVE-489, EVE-778).
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
-/// the LLM toward less verbose command usage.
+/// the LLM toward less verbose command usage and a single-read/contextual-search
+/// policy for persisted output.
 pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** The `output` parameter shapes command output (default: `auto` — compact summary on success, ~8 KiB diagnostic window on failure). \
 Persistence-enabled tools save full output to `/outputs/{tool_call_id}.stdout`/`.stderr`; oversized results include an `output_files` array of paths to `read_file` with offset/limit.\n\
 Modes: `auto` (default), `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
-`auto` is usually sufficient — check `exit_code` first; use `verbose` or read the persisted files when more detail is needed.";
+`auto` is usually sufficient — check `exit_code` first; use `verbose` or read the persisted files when more detail is needed.\n\
+When the needed filter is known before running a command, apply it in the command itself (e.g. pipe through `grep`) instead of post-filtering persisted output. \
+Read a persisted log at most once: ≤200 lines or ≤64 KiB fits one `read_file` with an ample `limit`; anything larger is one `grep_files` search with context. \
+Never reconstruct a file through sequential or overlapping reads — stop once you have enough diagnostic evidence.";
 
-/// System prompt hint for file reading economy (EVE-244).
+/// System prompt hint for file reading economy (EVE-244, EVE-778).
 /// Appended to the FileSystem capability's `system_prompt_addition()` to guide
-/// the LLM toward efficient file reading with offset/limit pagination.
+/// the LLM toward efficient file reading with offset/limit pagination and a
+/// single complete read for small files.
 pub const READ_ECONOMY_HINT: &str = "\n\n**File reading economy:** `read_file` returns at most 2000 lines by default.\n\
 - Locate the relevant region first with `grep_files`, then read that section with `read_file` using `offset` and `limit`.\n\
 - Use `list_directory` to understand file structure before reading.\n\
-- When a read is truncated, check `total_lines` to see how much remains and continue from `lines_shown.end` on the next call.";
+- When a read is truncated, check `total_lines` to see how much remains and continue from `lines_shown.end` on the next call.\n\
+- Read small files (≤200 lines or ≤64 KiB — most persisted `/outputs/` logs) once with an ample `limit`; search larger ones with a single contextual `grep_files` (`before_context`/`after_context`). Never rebuild a file from sequential or overlapping windows — stop once you have the evidence you need.";
 
 /// Strip ANSI escape sequences from text.
 ///
@@ -1351,6 +1357,49 @@ mod tests {
             output_verbosity_budget("auto"),
             Some(AUTO_SUCCESS_BUDGET),
             "bare `auto` should resolve to the tight success budget, not silently widen to concise"
+        );
+    }
+
+    // ====================================================================
+    // Shared prompt hints (EVE-223, EVE-244, EVE-778)
+    // ====================================================================
+
+    #[test]
+    fn test_exec_output_hint_single_read_policy() {
+        // EVE-778: pre-filter at the source, read persisted output at most
+        // once, never reconstruct via repeated windows, stop on evidence.
+        assert!(EXEC_OUTPUT_HINT.contains("apply it in the command itself"));
+        assert!(EXEC_OUTPUT_HINT.contains("at most once"));
+        assert!(EXEC_OUTPUT_HINT.contains("≤200 lines or ≤64 KiB"));
+        assert!(EXEC_OUTPUT_HINT.contains("`grep_files` search with context"));
+        assert!(EXEC_OUTPUT_HINT.contains("sequential or overlapping reads"));
+        assert!(EXEC_OUTPUT_HINT.contains("stop once you have enough diagnostic evidence"));
+    }
+
+    #[test]
+    fn test_read_economy_hint_single_read_policy() {
+        // EVE-778: one complete read for small files, one contextual grep
+        // for large ones, no window-by-window reconstruction.
+        assert!(READ_ECONOMY_HINT.contains("≤200 lines or ≤64 KiB"));
+        assert!(READ_ECONOMY_HINT.contains("once with an ample `limit`"));
+        assert!(READ_ECONOMY_HINT.contains("`before_context`/`after_context`"));
+        assert!(READ_ECONOMY_HINT.contains("sequential or overlapping windows"));
+    }
+
+    #[test]
+    fn test_prompt_hints_stay_concise() {
+        // The hints ride along in every harness prompt that exposes exec or
+        // filesystem tools; keep them bounded. Ratchet deliberately, in the
+        // same PR that grows them.
+        assert!(
+            EXEC_OUTPUT_HINT.len() <= 1100,
+            "EXEC_OUTPUT_HINT is {} bytes",
+            EXEC_OUTPUT_HINT.len()
+        );
+        assert!(
+            READ_ECONOMY_HINT.len() <= 750,
+            "READ_ECONOMY_HINT is {} bytes",
+            READ_ECONOMY_HINT.len()
         );
     }
 

--- a/crates/core/tests/prompt_budget.rs
+++ b/crates/core/tests/prompt_budget.rs
@@ -42,7 +42,13 @@ async fn stateless_todo_list_prompt_within_budget() {
 
 #[tokio::test]
 async fn file_system_prompt_within_budget() {
-    assert_contribution_under(&FileSystemCapability, 950).await;
+    // Bumped 950 → 1000: EVE-778 added the single-read/contextual-search
+    // policy for persisted output to READ_ECONOMY_HINT (read small files
+    // once, one contextual grep_files for large ones), taking the
+    // contribution to 961 bytes. The bullet exists to eliminate repeated
+    // overlapping reads of `/outputs/` logs, so it pays for itself in
+    // tool-result bytes; ratchet the cap up per this file's policy.
+    assert_contribution_under(&FileSystemCapability, 1000).await;
 }
 
 #[tokio::test]

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -366,7 +366,10 @@ mod tests {
         let cap = DaytonaCapability;
         let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
         let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
-        assert!(prompt.len() <= 1300, "prompt is {} bytes", prompt.len());
+        // Bumped 1300 → 1600: EVE-778 grew the shared EXEC_OUTPUT_HINT with the
+        // single-read/contextual-search policy (+438 bytes), taking this
+        // contribution to 1567 bytes.
+        assert!(prompt.len() <= 1600, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -165,6 +165,9 @@ mod tests {
             everruns_core::SessionId::new(),
         );
         let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
-        assert!(prompt.len() <= 1000, "prompt is {} bytes", prompt.len());
+        // Bumped 1000 → 1300: EVE-778 grew the shared EXEC_OUTPUT_HINT with the
+        // single-read/contextual-search policy (+438 bytes), taking this
+        // contribution to 1256 bytes.
+        assert!(prompt.len() <= 1300, "prompt is {} bytes", prompt.len());
     }
 }

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -1126,7 +1126,10 @@ mod tests {
             everruns_core::SessionId::new(),
         );
         let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
-        assert!(prompt.len() <= 1150, "prompt is {} bytes", prompt.len());
+        // Bumped 1150 → 1500: EVE-778 grew the shared EXEC_OUTPUT_HINT with the
+        // single-read/contextual-search policy (+438 bytes), taking this
+        // contribution to 1324 bytes.
+        assert!(prompt.len() <= 1500, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -175,6 +175,9 @@ mod tests {
             everruns_core::SessionId::new(),
         );
         let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
-        assert!(prompt.len() <= 1000, "prompt is {} bytes", prompt.len());
+        // Bumped 1000 → 1300: EVE-778 grew the shared EXEC_OUTPUT_HINT with the
+        // single-read/contextual-search policy (+438 bytes), taking this
+        // contribution to 1255 bytes.
+        assert!(prompt.len() <= 1300, "prompt is {} bytes", prompt.len());
     }
 }

--- a/integrations/sprites/src/lib.rs
+++ b/integrations/sprites/src/lib.rs
@@ -198,7 +198,10 @@ mod tests {
             everruns_core::SessionId::new(),
         );
         let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
-        assert!(prompt.len() <= 1200, "prompt is {} bytes", prompt.len());
+        // Bumped 1200 → 1400: EVE-778 grew the shared EXEC_OUTPUT_HINT with the
+        // single-read/contextual-search policy (+438 bytes), taking this
+        // contribution to 1361 bytes.
+        assert!(prompt.len() <= 1400, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -175,6 +175,8 @@ Default is `auto`. In `auto` mode, the resolved budget depends on the process ex
 
 Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and the files are readable with `read_file`. The persisted files are the source of truth for full logs; the inline payload is sized for next-step reasoning. See `crates/core/src/tool_output_sanitizer.rs` for budget constants, `output_verbosity_budget()`, and `resolve_auto_mode()`.
 
+The shared prompt hints (`EXEC_OUTPUT_HINT`, `READ_ECONOMY_HINT` in `tool_output_sanitizer.rs`) also carry a single-read/contextual-search policy for persisted output (EVE-778): pre-filter in the originating command when the filter is known, read a small persisted log (≤200 lines or ≤64 KiB) once with an ample `limit`, search larger ones with one contextual `grep_files` call, never reconstruct a file through sequential or overlapping read windows, and stop once diagnostic evidence suffices. Both constants are appended by every harness surface that exposes output persistence and filesystem tools (bashkit, sandbox integrations, the FileSystem capability).
+
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 
 ### Structured Exec Result Contract


### PR DESCRIPTION
## What changed
The two shared prompt hints that ride along in every harness that exposes exec/output-persistence and filesystem tools — `EXEC_OUTPUT_HINT` and `READ_ECONOMY_HINT` (`crates/core/src/tool_output_sanitizer.rs`) — now tell the model *when to read once versus search with context* for persisted command output:

- Pre-filter in the originating exec command when the filter is known (e.g. pipe through `grep`), instead of persisting a large log and post-filtering it.
- Read a small persisted log (≤200 lines or ≤64 KiB — the shape of most `/outputs/` logs) **once** with an ample `read_file` `limit`.
- For larger output, use **one** contextual `grep_files` call (`before_context`/`after_context`, landed in EVE-777 / #2802).
- Never reconstruct a file through sequential or overlapping read windows; stop once diagnostic evidence suffices.

Because the change is to the shared constants, every consumer inherits it automatically: bashkit, the six sandbox integrations (docker, e2b, deno, daytona, sprites, container-sandbox), and the FileSystem capability. Existing output modes, truncation, and pagination behavior are untouched.

## Why
When an exec result is persisted under `/outputs/`, agents can reconstruct a small log through multiple overlapping `read_file` windows. In an observed Yolop run an 81-line, ~11 KiB GitHub Actions log triggered one ineffective grep followed by three reads of the same persisted stdout file — wasted round trips, tokens, and wall time. The existing hints explained persistence and pagination but never stated the single-read/contextual-search policy. This is the guidance half of the work; EVE-777 (#2802) added the `grep_files` context capability the large-output path relies on. (EVE-778)

## Before / After
This change adds static guidance text to system prompts; there is no runtime code path, so the observable effect is the assembled prompt contribution.

**Before** — `READ_ECONOMY_HINT` ended at pagination guidance; `EXEC_OUTPUT_HINT` ended at "use `verbose` or read the persisted files when more detail is needed." Neither said read-once-vs-search.

**After** — both carry the policy. Assembled FileSystem capability contribution measured at **961 bytes** (~240 tokens) by `prompt_budget.rs`, within the ratcheted 1000-byte cap.

Evidence:
- `cargo test -p everruns-core --lib tool_output_sanitizer` — 59 passed (incl. new `test_exec_output_hint_single_read_policy`, `test_read_economy_hint_single_read_policy`, `test_prompt_hints_stay_concise`).
- `cargo test -p everruns-core --test prompt_budget` — 12 passed (assembled contribution measured at 961 B against the new 1000 B cap).
- `cargo test -p everruns-core --lib capabilities::file_system` — 78 passed; `cargo test -p everruns-core --lib bashkit` — 82 passed.
- `pre-push.sh` — all 10 checks pass (fmt, clippy, lockfile, migration ordering, specs coverage, author attribution).

## Risk
- Low
- Only static prompt-string constants, their unit tests, one prompt-budget cap, and one spec paragraph change. No runtime logic, tool schema, parsing, or output-truncation behavior is altered. Worst case is prompt guidance the model may or may not follow; the live-model search-efficiency regression is tracked downstream in Yolop per the issue's validation plan.

## Security
- Threat categories reviewed: TM-LLM (prompt construction), TM-TOOL (tool-usage guidance).
- Findings and resolutions: The change appends fixed, non-templated guidance text to system prompts. No user/tenant input flows into the constants, no new parsing, endpoints, credentials, file paths, or logging surface. No secret or data-exposure vector introduced; no `THREAT[...]` mitigations touched. No threat-model update required.

## Follow-ups
No follow-ups. (Live-model search-efficiency evaluation is downstream in Yolop's existing persisted-output-reread trajectory metrics, per the issue's validation section, and is not part of this repo.)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Fixes EVE-778

https://claude.ai/code/session_014WBP8qCH64gnic3B8AQNxr

---
_Generated by [Claude Code](https://claude.ai/code/session_014WBP8qCH64gnic3B8AQNxr)_