### PR TITLE
fix(core): keep spawn_agent schema free of top-level oneOf

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -561,6 +561,26 @@ impl AnthropicChatDriver {
         (system_prompt, converted)
     }
 
+    /// Anthropic rejects `oneOf`, `allOf`, and `anyOf` at the top level of a
+    /// tool `input_schema` (nested composition is accepted). Tool schemas can
+    /// be caller-supplied JSON Schema (e.g. a spawn_agent `result_schema`
+    /// becomes the child's `report_result` schema verbatim), so drop the
+    /// keywords here instead of failing the whole request with a 400. This
+    /// only loosens what the model sees; execute-time validation still
+    /// enforces the full schema and rejects non-conforming calls.
+    fn sanitize_input_schema(mut schema: Value) -> Value {
+        if let Value::Object(obj) = &mut schema {
+            let mut had_composition = false;
+            for key in ["oneOf", "allOf", "anyOf"] {
+                had_composition |= obj.remove(key).is_some();
+            }
+            if had_composition && !obj.contains_key("type") {
+                obj.insert("type".to_string(), Value::String("object".to_string()));
+            }
+        }
+        schema
+    }
+
     fn convert_tools(
         tools: &[ToolDefinition],
         prompt_cache_enabled: bool,
@@ -573,7 +593,7 @@ impl AnthropicChatDriver {
                 AnthropicToolEntry::Function(AnthropicTool {
                     name: tool.name().to_string(),
                     description: tool.description().to_string(),
-                    input_schema: tool.parameters().clone(),
+                    input_schema: Self::sanitize_input_schema(tool.parameters().clone()),
                     cache_control: (prompt_cache_enabled && index == last_index)
                         .then(AnthropicCacheControl::ephemeral),
                     defer_loading: None,
@@ -631,7 +651,7 @@ impl AnthropicChatDriver {
             entries.push(AnthropicToolEntry::Function(AnthropicTool {
                 name: tool.name().to_string(),
                 description: tool.description().to_string(),
-                input_schema: tool.parameters().clone(),
+                input_schema: Self::sanitize_input_schema(tool.parameters().clone()),
                 cache_control: None,
                 defer_loading: should_defer.then_some(true),
             }));
@@ -2187,6 +2207,62 @@ mod tests {
         assert!(json[0].get("cache_control").is_none());
         assert!(json[1].get("cache_control").is_none());
         assert_eq!(json[2]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn test_convert_tools_strips_top_level_composition_keywords() {
+        let make_tool = |name: &str, parameters: Value| {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: name.to_string(),
+                display_name: None,
+                description: "test tool".to_string(),
+                parameters,
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default(),
+                full_parameters: None,
+            })
+        };
+        let tools = vec![
+            make_tool(
+                "top_level_one_of",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "object",
+                            // Nested composition is accepted by Anthropic and
+                            // must survive.
+                            "oneOf": [{"required": ["id"]}]
+                        }
+                    },
+                    "required": ["target"],
+                    "oneOf": [{"required": ["name"]}],
+                    "anyOf": [{"required": ["name"]}],
+                    "allOf": [{"required": ["name"]}]
+                }),
+            ),
+            // Degenerate caller-supplied schema: nothing but composition.
+            make_tool("bare_any_of", json!({"anyOf": [{"type": "object"}]})),
+        ];
+
+        let converted = AnthropicChatDriver::convert_tools(&tools, false);
+        let json = serde_json::to_value(&converted).unwrap();
+
+        let schema = &json[0]["input_schema"];
+        assert!(schema.get("oneOf").is_none());
+        assert!(schema.get("anyOf").is_none());
+        assert!(schema.get("allOf").is_none());
+        assert_eq!(schema["required"], json!(["target"]));
+        assert_eq!(
+            schema["properties"]["target"]["oneOf"],
+            json!([{"required": ["id"]}])
+        );
+
+        let bare = &json[1]["input_schema"];
+        assert!(bare.get("anyOf").is_none());
+        assert_eq!(bare["type"], "object");
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1837,48 +1837,48 @@ impl UnifiedSpawnAgentTool {
             .collect()
     }
 
-    fn target_requirement_branches(&self) -> Vec<serde_json::Value> {
+    /// Per-`target.type` constraint branches, nested inside the `target`
+    /// property. Anthropic rejects `oneOf`/`allOf`/`anyOf` at the top level
+    /// of a tool `input_schema`, so provider-specific requirements must live
+    /// below the root (nested composition is accepted).
+    fn target_constraint_branches(&self) -> Vec<serde_json::Value> {
         self.target_types()
             .into_iter()
             .filter_map(|target_type| match target_type {
                 "subagent" => Some(serde_json::json!({
                     "properties": {
-                        "target": {
-                            "properties": {
-                                "type": {"const": "subagent"}
-                            }
-                        }
-                    },
-                    "required": ["name"]
+                        "type": {"const": "subagent"}
+                    }
                 })),
                 "agent" => Some(serde_json::json!({
                     "properties": {
-                        "target": {
-                            "properties": {
-                                "type": {"const": "agent"}
-                            },
-                            "required": ["type", "id"]
-                        }
+                        "type": {"const": "agent"}
                     },
-                    "required": ["name"]
+                    "required": ["type", "id"]
                 })),
                 "external_a2a" => Some(serde_json::json!({
                     "properties": {
-                        "target": {
-                            "properties": {
-                                "type": {"const": "external_a2a"}
-                            },
-                            "anyOf": [
-                                {"required": ["id"]},
-                                {"required": ["external_agent_id"]}
-                            ]
-                        }
-                    }
+                        "type": {"const": "external_a2a"}
+                    },
+                    "anyOf": [
+                        {"required": ["id"]},
+                        {"required": ["external_agent_id"]}
+                    ]
                 })),
                 _ => None,
             })
             .collect()
     }
+
+    // NOTE: subagent and agent providers require `name` at execution
+    // (`require_str`), while external_a2a ignores it. A schema that required
+    // `name` only for the local targets would need a top-level
+    // `oneOf`/`if`/`allOf`, which Anthropic rejects in a tool `input_schema`.
+    // `name` is therefore required at the root unconditionally: requiring a
+    // field external_a2a merely ignores is safe (the schema never permits a
+    // call execution would reject), whereas omitting it would let a
+    // `name`-less subagent call pass validation and then fail at dispatch —
+    // exactly the mismatch #2787 set out to close.
 }
 
 #[async_trait]
@@ -1917,7 +1917,7 @@ impl Tool for UnifiedSpawnAgentTool {
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Human-readable name for local subagent or first-party handoff runs. Optional for external A2A targets."
+                    "description": "Human-readable name for the delegated run (subagent, first-party handoff, or external delegation). Used as the task label."
                 },
                 "instructions": {
                     "type": "string",
@@ -1957,6 +1957,7 @@ impl Tool for UnifiedSpawnAgentTool {
                         }
                     },
                     "required": ["type"],
+                    "oneOf": self.target_constraint_branches(),
                     "additionalProperties": false
                 },
                 "mode": {
@@ -1995,8 +1996,7 @@ impl Tool for UnifiedSpawnAgentTool {
                     "description": "External-A2A-only control for background completion wake-ups."
                 }
             },
-            "required": ["instructions", "target"],
-            "oneOf": self.target_requirement_branches(),
+            "required": ["name", "instructions", "target"],
             "additionalProperties": false
         })
     }
@@ -5306,25 +5306,24 @@ mod tests {
             schema["properties"]["target"]["properties"]["type"]["enum"],
             serde_json::json!(["subagent", "agent"])
         );
+        // Anthropic rejects top-level oneOf/allOf/anyOf in input_schema, so
+        // the per-target constraints must live inside the target property.
+        assert!(schema.get("oneOf").is_none());
+        assert!(schema.get("anyOf").is_none());
+        assert!(schema.get("allOf").is_none());
         assert_eq!(
-            schema["oneOf"],
+            schema["required"],
+            serde_json::json!(["name", "instructions", "target"])
+        );
+        assert_eq!(
+            schema["properties"]["target"]["oneOf"],
             serde_json::json!([
                 {
-                    "properties": {
-                        "target": {
-                            "properties": {"type": {"const": "subagent"}}
-                        }
-                    },
-                    "required": ["name"]
+                    "properties": {"type": {"const": "subagent"}}
                 },
                 {
-                    "properties": {
-                        "target": {
-                            "properties": {"type": {"const": "agent"}},
-                            "required": ["type", "id"]
-                        }
-                    },
-                    "required": ["name"]
+                    "properties": {"type": {"const": "agent"}},
+                    "required": ["type", "id"]
                 }
             ])
         );
@@ -5376,27 +5375,27 @@ mod tests {
                 .expect("mode description")
                 .contains("wait")
         );
+        let schema = spawn_agent_defs[0].parameters();
+        assert!(schema.get("oneOf").is_none());
+        // name is required at the root even with external_a2a present: the
+        // local providers demand it and requiring a field external_a2a ignores
+        // is safe, whereas top-level conditional requirements are rejected.
         assert_eq!(
-            spawn_agent_defs[0].parameters()["oneOf"],
+            schema["required"],
+            serde_json::json!(["name", "instructions", "target"])
+        );
+        assert_eq!(
+            schema["properties"]["target"]["oneOf"],
             serde_json::json!([
                 {
-                    "properties": {
-                        "target": {
-                            "properties": {"type": {"const": "subagent"}}
-                        }
-                    },
-                    "required": ["name"]
+                    "properties": {"type": {"const": "subagent"}}
                 },
                 {
-                    "properties": {
-                        "target": {
-                            "properties": {"type": {"const": "external_a2a"}},
-                            "anyOf": [
-                                {"required": ["id"]},
-                                {"required": ["external_agent_id"]}
-                            ]
-                        }
-                    }
+                    "properties": {"type": {"const": "external_a2a"}},
+                    "anyOf": [
+                        {"required": ["id"]},
+                        {"required": ["external_agent_id"]}
+                    ]
                 }
             ])
         );


### PR DESCRIPTION
## What changed
Restores green CI on `main`. The unified `spawn_agent` tool advertised a JSON Schema with a top-level `oneOf` (added in #2787 to encode per-target requirements). Anthropic's Messages API rejects `oneOf`/`allOf`/`anyOf` at the top level of a tool `input_schema`, so every parent turn that offered `spawn_agent` failed with a `400 invalid_request_error`, which is what the live subagent integration test hits on each push.

Two changes:
- **Move the per-target constraints down a level.** The `agent`/`external_a2a` requirement branches now live inside `properties.target.oneOf` (nested composition is accepted). `name` — which the subagent and agent providers require at execution — is now required at the root unconditionally. A schema that required `name` only for the local targets would itself need a top-level `oneOf`/`if`; requiring a field that `external_a2a` merely ignores is safe, whereas omitting it would let a `name`-less subagent call pass validation and fail at dispatch (the exact mismatch #2787 set out to close).
- **Add a driver-level backstop.** The Anthropic driver's `convert_tools`/`convert_tools_with_search` now strip top-level `oneOf`/`allOf`/`anyOf` from every tool `input_schema` before sending. This matters beyond `spawn_agent`: `report_result`/`report_task_progress` embed caller-supplied JSON Schemas verbatim as `input_schema`, so one user schema with top-level composition would otherwise 400 the whole request. Stripping only loosens the model-facing hint — execute-time validation still enforces the full schema (including any `oneOf`) and rejects non-conforming calls.

## Why
`main` has been red since #2787. Root cause is the top-level `oneOf` on the model-visible `spawn_agent` schema.

## Before / After
The originally failing live test, run against the real Anthropic API:

Before (on `main`):
```
test background_spawn_agent_subagent_live_end_to_end ... FAILED
parent turn failed: Some("LLM error: Anthropic API error (400 Bad Request):
  ...input_schema does not support oneOf, allOf, or anyOf at the top level...")
```

After (this branch):
```
test background_spawn_agent_subagent_live_end_to_end ... ok
test result: ok. 3 passed; 0 failed
```

Also verified live against Anthropic (Haiku): `test_basic_completion`, `test_tool_call`, and `test_file_system_tool_schemas_accepted` all pass — confirming ordinary tool schemas pass through the sanitizer intact.

## Risk
- Low
- Blast radius is the `spawn_agent` model-visible schema and the Anthropic tool-serialization path. The nested constraints preserve #2787's intent (invalid target calls are still rejected pre-dispatch); execution-time validation is unchanged. The driver strip only removes keywords Anthropic already refuses to accept.

## Security
- Threat categories reviewed: **TM-TOOL**, **TM-LLM**.
- Findings and resolutions:
  - The driver sanitizer only alters the model-facing schema, not the stored `result_schema`/`message_schema` used by `schema_validation_errors`, so a subagent's `report_result` payload is still validated against the full (composition-bearing) schema at execution. No validation is weakened.
  - Verified the relaxed root `name` requirement does not reintroduce the #2787 execution-mismatch: the `external_a2a` provider never reads `name`, while `subagent`/`agent` providers require it and the schema now requires it universally.
  - No auth, tenancy, input-parsing, or data-exposure surface touched.

## Follow-ups
- The OpenAI Responses driver has no equivalent top-level-composition strip, so a caller-supplied `result_schema`/`message_schema` containing top-level `oneOf` would still be rejected by OpenAI (pre-existing; not what reddened `main`). `normalize_optional_schema` deliberately preserves such schemas verbatim because they drive real validation, so the correct fix is a driver-level strip mirroring this PR's Anthropic change. Worth a separate PR if structured subagent results start being used with OpenAI models.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01A9oQJQ2KFmWWwhY4maK845

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9oQJQ2KFmWWwhY4maK845)_