### PR TITLE
perf(ui): scope sidebar prefetch to intent

### DIFF
--- a/apps/ui/e2e/navigation-prefetch.spec.ts
+++ b/apps/ui/e2e/navigation-prefetch.spec.ts
@@ -62,7 +62,33 @@ function isSettingsRscRequest(request: Request) {
   return request.headers().rsc === "1" && url.pathname.startsWith("/settings");
 }
 
-test.describe("Settings navigation prefetch", () => {
+function isRscRequest(request: Request) {
+  return request.headers().rsc === "1";
+}
+
+const DASHBOARD_API_ALLOWLIST = new Set([
+  "/api/v1/auth/config",
+  "/api/v1/auth/me",
+  "/api/v1/agents",
+  "/api/v1/capabilities",
+  "/api/v1/models",
+  "/api/v1/providers",
+  "/api/v1/sessions",
+  "/api/v1/sessions/stats",
+  "/api/v1/feature-flags",
+  "/api/v1/users/me/switch-org",
+  "/api/v1/user/preferences/ui.early_access_banner.dismissed",
+  "/api/v1/durable/config",
+]);
+
+function isDashboardApi(pathname: string) {
+  return (
+    DASHBOARD_API_ALLOWLIST.has(pathname) ||
+    /^\/api\/v1\/orgs\/[^/]+(?:\/feature-flags)?$/.test(pathname)
+  );
+}
+
+test.describe("Sidebar navigation prefetch", () => {
   test.use({ viewport: { width: 1440, height: 2000 } });
 
   test.beforeEach(async ({ context, page, baseURL }) => {
@@ -78,7 +104,35 @@ test.describe("Settings navigation prefetch", () => {
     await mockAppApi(page);
   });
 
-  test("normal pages and Settings navigation avoid Settings route fan-out", async ({ page }) => {
+  test("Dashboard startup does not prefetch unrelated sidebar routes or APIs", async ({ page }) => {
+    const requests: Request[] = [];
+    page.on("request", (request) => requests.push(request));
+
+    await page.goto("/dashboard");
+    await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    const unrelatedRscRequests = requests.filter((request) => {
+      const pathname = new URL(request.url()).pathname;
+      return isRscRequest(request) && pathname !== "/dashboard";
+    });
+    expect(unrelatedRscRequests).toHaveLength(0);
+
+    const unrelatedApiRequests = requests.filter((request) => {
+      const pathname = new URL(request.url()).pathname;
+      return pathname.startsWith("/api/v1/") && !isDashboardApi(pathname);
+    });
+    expect(unrelatedApiRequests.map((request) => new URL(request.url()).pathname)).toEqual([]);
+  });
+
+  test("sidebar click navigation works without broad route prefetch", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByRole("link", { name: "Sessions" })).toBeVisible();
+    await page.getByRole("link", { name: "Sessions" }).click();
+    await expect(page).toHaveURL(/\/sessions$/);
+  });
+
+  test("Settings navigation avoids child route fan-out", async ({ page }) => {
     const settingsRequests: Request[] = [];
     page.on("request", (request) => {
       if (isSettingsRscRequest(request)) settingsRequests.push(request);
@@ -87,8 +141,6 @@ test.describe("Settings navigation prefetch", () => {
     await page.goto("/dashboard");
     await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
     await page.waitForLoadState("networkidle");
-
-    expect(settingsRequests).toHaveLength(0);
 
     settingsRequests.length = 0;
     await page.getByRole("link", { name: "Settings" }).click();

--- a/apps/ui/scripts/benchmark-sidebar-prefetch.mjs
+++ b/apps/ui/scripts/benchmark-sidebar-prefetch.mjs
@@ -1,0 +1,162 @@
+import { chromium } from "@playwright/test";
+
+const baseURL = process.env.BENCHMARK_BASE_URL ?? "http://localhost:9100";
+const orgId = "org_00000000000000000000000000000001";
+const targets = [
+  { name: "Sessions", pathname: "/sessions", heading: "Sessions" },
+  { name: "Agents", pathname: "/agents", heading: "Agents" },
+  { name: "Settings", pathname: "/settings/organization", heading: "Organization" },
+];
+
+function percentile(samples, quantile) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  return sorted[Math.ceil(quantile * sorted.length) - 1];
+}
+
+function summarize(samples) {
+  return {
+    samples_ms: samples,
+    median_ms: percentile(samples, 0.5),
+    p95_ms: percentile(samples, 0.95),
+  };
+}
+
+async function mockApi(page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    let json;
+
+    if (pathname === "/api/v1/auth/config") {
+      json = {
+        mode: "full",
+        password_auth_enabled: true,
+        oauth_providers: [],
+        signup_enabled: true,
+      };
+    } else if (pathname === "/api/v1/auth/me") {
+      json = {
+        id: "user-1",
+        email: "benchmark@example.com",
+        name: "Benchmark User",
+        roles: [],
+        email_verified: true,
+        organizations: [{ public_id: orgId, name: "Benchmark Org", role: "owner" }],
+      };
+    } else if (pathname === `/api/v1/orgs/${orgId}`) {
+      json = {
+        id: orgId,
+        public_id: orgId,
+        name: "Benchmark Org",
+        role: "owner",
+        onboarding_completed_at: "2026-07-15T00:00:00Z",
+      };
+    } else if (pathname.endsWith("/feature-flags") || pathname === "/api/v1/feature-flags") {
+      json = {
+        global_chat: false,
+        notifications: false,
+        evals: false,
+        app_budgets: false,
+        agent_versions: false,
+        voice: false,
+        agent_delegation: false,
+        observers: false,
+        public_chat: false,
+      };
+    } else if (pathname.endsWith("/switch-org")) {
+      json = { success: true, org_id: orgId };
+    } else if (pathname.endsWith("/config")) {
+      json = { policies: {} };
+    } else {
+      json = { data: [], has_more: false, total: 0 };
+    }
+
+    await route.fulfill({ json });
+  });
+}
+
+async function waitForReady(page, heading) {
+  await page.getByRole("heading", { name: heading, exact: true }).first().waitFor();
+  await page.waitForLoadState("networkidle");
+}
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ viewport: { width: 1440, height: 2000 } });
+await context.addCookies([
+  {
+    name: "access_token",
+    value: "benchmark-only",
+    url: baseURL,
+  },
+]);
+const page = await context.newPage();
+await mockApi(page);
+
+const startupRequests = [];
+page.on("request", (request) => startupRequests.push(request));
+const dashboardStarted = performance.now();
+await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
+await waitForReady(page, "Dashboard");
+const dashboardReadinessMs = Math.round(performance.now() - dashboardStarted);
+
+const measuredRequests = startupRequests.filter((request) => {
+  const url = new URL(request.url());
+  return (
+    url.pathname.startsWith("/api/v1/") ||
+    request.resourceType() === "document" ||
+    request.headers().rsc === "1"
+  );
+});
+const pageRequests = measuredRequests.filter(
+  (request) => request.resourceType() === "document" || request.headers().rsc === "1",
+);
+const apiRequests = measuredRequests.filter((request) =>
+  new URL(request.url()).pathname.startsWith("/api/v1/"),
+);
+const uniqueRoutes = new Set(measuredRequests.map((request) => new URL(request.url()).pathname));
+
+const navigation = {};
+for (const target of targets) {
+  const samples = [];
+  for (let sample = 0; sample < 5; sample += 1) {
+    await page.goto(`${baseURL}/dashboard`, { waitUntil: "domcontentloaded" });
+    await waitForReady(page, "Dashboard");
+    const link = page.getByRole("link", { name: target.name, exact: true });
+    if ((await link.count()) === 0) {
+      throw new Error(
+        `Missing ${target.name} sidebar link at ${page.url()}; links=${JSON.stringify(await page.getByRole("link").allTextContents())}`,
+      );
+    }
+    await link.waitFor();
+    await link.hover();
+    await page.waitForTimeout(150);
+    const started = performance.now();
+    await link.click();
+    await page.waitForURL((url) => url.pathname === target.pathname);
+    await waitForReady(page, target.heading);
+    samples.push(Math.round(performance.now() - started));
+  }
+  navigation[target.name] = summarize(samples);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      environment: baseURL,
+      methodology:
+        "Chromium 1440x2000; mocked authenticated user/API; DOM heading plus network idle; 150ms hover intent before click",
+      dashboard: {
+        total_requests: measuredRequests.length,
+        page_rsc_requests: pageRequests.length,
+        api_requests: apiRequests.length,
+        unique_routes: uniqueRoutes.size,
+        readiness_ms: dashboardReadinessMs,
+        routes: [...uniqueRoutes].sort(),
+      },
+      navigation,
+    },
+    null,
+    2,
+  ),
+);
+
+await browser.close();

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -20,10 +20,12 @@ jest.mock("next/link", () => ({
 // Mock next/navigation
 const mockPathname = jest.fn();
 const mockPush = jest.fn();
+const mockPrefetch = jest.fn();
 jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname(),
   useRouter: () => ({
     push: mockPush,
+    prefetch: mockPrefetch,
     replace: jest.fn(),
     back: jest.fn(),
   }),
@@ -111,6 +113,7 @@ describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");
     mockPush.mockClear();
+    mockPrefetch.mockClear();
     mockUsePolicies.mockReturnValue({
       data: { policies: { "durable.view": true } },
       can: (policyId: string) => policyId === "durable.view",
@@ -224,19 +227,37 @@ describe("Sidebar", () => {
     expect(settingsLink).toHaveAttribute("href", "/settings/organization");
   });
 
-  it("disables prefetch only for the top-level Settings link", () => {
+  it("disables automatic viewport prefetch for every sidebar navigation link", () => {
     render(<Sidebar />);
 
+    expect(screen.getByAltText("Everruns").closest("a")).toHaveAttribute("data-prefetch", "false");
     const navigation = screen.getByRole("navigation");
     const links = within(navigation).getAllByRole("link");
-    const settingsLink = within(navigation).getByRole("link", { name: "Settings" });
-
-    expect(settingsLink).toHaveAttribute("data-prefetch", "false");
     for (const link of links) {
-      if (link !== settingsLink) {
-        expect(link).not.toHaveAttribute("data-prefetch");
-      }
+      expect(link).toHaveAttribute("data-prefetch", "false");
     }
+  });
+
+  it("prefetches only the intended link on hover or keyboard focus", () => {
+    render(<Sidebar />);
+
+    fireEvent.mouseEnter(screen.getByRole("link", { name: "Sessions" }));
+    expect(mockPrefetch).toHaveBeenCalledTimes(1);
+    expect(mockPrefetch).toHaveBeenLastCalledWith("/sessions");
+
+    fireEvent.focus(screen.getByRole("link", { name: "Agents" }));
+    expect(mockPrefetch).toHaveBeenCalledTimes(2);
+    expect(mockPrefetch).toHaveBeenLastCalledWith("/agents");
+  });
+
+  it("preserves Settings no-prefetch behavior on hover and focus", () => {
+    render(<Sidebar />);
+
+    const settingsLink = screen.getByRole("link", { name: "Settings" });
+    fireEvent.mouseEnter(settingsLink);
+    fireEvent.focus(settingsLink);
+
+    expect(mockPrefetch).not.toHaveBeenCalled();
   });
 
   it("does not render legacy navigation items", () => {
@@ -375,6 +396,10 @@ describe("Sidebar with config", () => {
     // Default items should not appear
     expect(screen.queryByText("Building Blocks")).not.toBeInTheDocument();
     expect(screen.queryByText("Durable Execution")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Custom Page" })).toHaveAttribute(
+      "data-prefetch",
+      "false",
+    );
   });
 
   it("appends extraSections after default navigation", () => {

--- a/apps/ui/src/components/layout/sidebar-navigation.tsx
+++ b/apps/ui/src/components/layout/sidebar-navigation.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { FeatureFlags } from "@/lib/api/types";
@@ -25,6 +26,7 @@ function NavLink({
   pathname: string;
   featureFlags: FeatureFlags;
 }) {
+  const router = useRouter();
   if (item.flag && !featureFlags[item.flag]) return null;
 
   const activePath = item.activePrefix ?? item.href;
@@ -35,7 +37,9 @@ function NavLink({
   return (
     <Link
       href={item.href}
-      prefetch={item.prefetch}
+      prefetch={false}
+      onMouseEnter={item.prefetch === false ? undefined : () => router.prefetch(item.href)}
+      onFocus={item.prefetch === false ? undefined : () => router.prefetch(item.href)}
       className={cn(
         "flex items-center gap-2.5 border-l-2 px-3 py-1.5 text-[13px] font-semibold leading-5 transition-colors",
         isActive

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -63,6 +63,7 @@ export type NavigationItem = {
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   activePrefix?: string;
+  /** Set false to disable the shared hover/focus prefetch in addition to automatic prefetch. */
   prefetch?: boolean;
   flag?: keyof FeatureFlags;
   exact?: boolean;
@@ -197,7 +198,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   return (
     <div className="flex h-full w-60 flex-col border-r border-border/70 bg-background">
       <div className="flex h-14 items-center justify-between border-b border-border/70 bg-card px-4">
-        <Link href="/dashboard" className="flex items-center gap-2">
+        <Link href="/dashboard" prefetch={false} className="flex items-center gap-2">
           <Image src="/logo.svg" alt="Everruns" width={28} height={28} />
           <span className="text-base font-semibold tracking-[-0.02em]">Everruns</span>
         </Link>

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -11177,9 +11177,9 @@ export interface components {
        */
       cache_read?: number | null;
       /**
-       * @description Tiered pricing that applies above certain context thresholds.
-       *     When present, the base cost fields apply up to the tier threshold,
-       *     and each tier's costs apply for tokens beyond that threshold.
+       * @description Tiered pricing that applies when prompt tokens exceed context thresholds.
+       *     When present, the highest matching tier replaces the base rates for the
+       *     whole request.
        */
       cost_tiers?: components["schemas"]["CostTier"][];
       /**

--- a/test_cases/ui/navigation_prefetch/TC001_sidebar_prefetch_policy.md
+++ b/test_cases/ui/navigation_prefetch/TC001_sidebar_prefetch_policy.md
@@ -1,0 +1,39 @@
+# Sidebar Prefetch Policy
+
+## Description
+
+Verify that authenticated app startup does not automatically prefetch visible sidebar destinations, while intent and click navigation remain responsive and Settings does not fan out to child routes.
+
+## Preconditions
+
+- The app is running with authentication enabled.
+- A user is signed in and belongs to an organization.
+- The browser network log is empty before each measured step.
+- Use the same browser, viewport, environment, data, and readiness signal for before/after measurements.
+
+## Test Data
+
+| Input | Value |
+| --- | --- |
+| Startup route | `/dashboard` |
+| Warm navigation targets | `/sessions`, `/agents`, `/settings/organization` |
+| Samples per target | 5 |
+
+## Steps
+
+1. Load Dashboard directly and wait for Dashboard content and network idle.
+2. Inspect page/RSC and API requests made since navigation began.
+3. Hover Sessions, then use keyboard focus on Agents, inspecting requests after each intent.
+4. Click Sessions and verify its page content and data render correctly.
+5. Return to Dashboard and repeat five warm-navigation samples for Sessions, Agents, and Settings.
+6. Return to Dashboard, click Settings, wait for `/settings/organization`, and inspect Settings page/RSC requests.
+
+## Expected Result
+
+- Dashboard startup makes no page/RSC or API request attributable only to an unrelated sidebar destination.
+- Every sidebar `Link` disables automatic viewport prefetch.
+- Hover or keyboard focus may prefetch only the intended destination; Settings remains fully opted out of intent prefetch.
+- Click navigation, active state, feature-flag visibility, development-only sections, and keyboard accessibility remain correct.
+- Settings loads only `/settings/organization`; no Settings child route is prefetched.
+- Record total requests, page/RSC requests, API requests, unique routes, Dashboard readiness, and all five samples per target.
+- On a stable environment, warm-navigation median is below 500 ms and p95 is below 800 ms; otherwise report the observed external or environment latency without hiding it.


### PR DESCRIPTION
## What changed

Shared sidebar links now opt out of Next.js automatic viewport prefetch. Visible links retain responsiveness through narrowly scoped hover/focus prefetch of only their own destination; Settings preserves its existing full prefetch opt-out. Click navigation, active states, feature flags, development-only sections, custom navigation, and keyboard accessibility are unchanged.

Adds deterministic unit/E2E coverage, a repeatable production-mode benchmark harness, and the OSS manual performance contract.

Fixes [EVE-780](https://linear.app/everruns/issue/EVE-780/perfui-stop-automatic-sidebar-route-prefetch-fan-out).

## Why

An authenticated Dashboard render caused every visible sidebar destination to prefetch. Those page/RSC loads created broad startup network fan-out unrelated to Dashboard.

## Before / After

Same-method production-mode Chromium benchmark: 1440×2000 viewport, mocked authenticated user/API, DOM heading plus network-idle readiness, 150 ms hover intent before click, five samples per target.

| Metric | Before | After |
| --- | ---: | ---: |
| Dynamic requests | 48 | 19 |
| Page/RSC requests | 32 | 3 |
| API requests | 16 | 16 |
| Unique routes | 30 | 16 |
| Dashboard readiness | 665 ms | 699 ms |

The after run has zero unrelated sidebar page/RSC or API prefetches. Its only non-Dashboard page route is `/agents/new`, owned by the Dashboard Quick Actions link. All 16 APIs are Dashboard, auth, organization, or sidebar policy dependencies.

Warm navigation after the fix:

| Target | Samples (ms) | Median | p95 |
| --- | --- | ---: | ---: |
| Sessions | 112, 71, 38, 59, 41 | 59 ms | 112 ms |
| Agents | 84, 79, 102, 95, 78 | 84 ms | 102 ms |
| Settings | 66, 67, 61, 76, 71 | 67 ms | 76 ms |

Settings child-route prefetch remains zero. Focused browser tests also verify Dashboard startup isolation, click navigation, and canonical Settings navigation.

Validation:
- `just pre-push` after latest-main rebase
- focused sidebar and Settings unit tests: 54 passed
- focused Playwright navigation-prefetch suite: 3 passed
- UI format, lint, typecheck, and production build
- migration ordering: 001..105

## Risk

- Low
- Intent prefetch depends on hover/focus events; direct clicks still use normal Next.js navigation. The exported `prefetch: false` item option continues to disable all prefetch for Settings and other explicit opt-outs.

## Security

- Threat categories reviewed: TM-WEB
- Findings and resolutions: no new trust boundary, user-controlled destination, auth/authz behavior, data exposure, dependency, or unbounded work. Prefetch uses the same code-defined `href` already used by navigation and reduces startup requests. No threat-model update required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)