### PR TITLE
feat(ui): expand global search coverage

### DIFF
--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -2,8 +2,9 @@ import { act, renderHook } from "@testing-library/react";
 import { useGlobalSearch } from "@/hooks/use-global-search";
 import type { OrganizationMembership } from "@/lib/api/types";
 
+const mockUseAgents = jest.fn((_options?: { enabled?: boolean }) => ({ data: [] }));
 jest.mock("@/hooks/use-agents", () => ({
-  useAgents: () => ({ data: [] }),
+  useAgents: (options?: { enabled?: boolean }) => mockUseAgents(options),
 }));
 jest.mock("@/hooks/use-sessions", () => ({
   useSessions: () => ({ data: { data: [] } }),
@@ -31,9 +32,67 @@ jest.mock("@/hooks/use-apps", () => ({
 jest.mock("@/hooks/use-agent-identities", () => ({
   useAgentIdentities: () => ({ data: [] }),
 }));
-let mockEvalsFlag = false;
+jest.mock("@/hooks/use-memory", () => ({
+  useMemories: () => ({
+    data: [
+      {
+        id: "mem_product",
+        name: "Product Notes",
+        description: "Product decisions",
+      },
+    ],
+  }),
+}));
+jest.mock("@/hooks/use-knowledge-indexes", () => ({
+  useKnowledgeIndexes: () => ({
+    data: [
+      {
+        id: "kidx_docs",
+        name: "Documentation Index",
+        description: "Published documentation",
+      },
+    ],
+  }),
+}));
+jest.mock("@/hooks/use-plugins", () => ({
+  useInstalledPlugins: () => ({
+    data: [
+      {
+        id: "plugin_email",
+        name: "email-service",
+        display_name: "Email Service",
+        description: "Transactional email",
+      },
+    ],
+  }),
+}));
+jest.mock("@/hooks/use-observers", () => ({
+  useObservers: () => ({
+    data: [
+      {
+        id: "observer_quality",
+        name: "Answer Quality",
+        description: "Scores production answers",
+      },
+    ],
+  }),
+}));
+const mockUseSavedReports = jest.fn((_enabled?: boolean) => ({
+  data: [
+    {
+      id: "report_weekly",
+      name: "Weekly Usage",
+      description: "Usage by week",
+    },
+  ],
+}));
+jest.mock("@/hooks/use-reporting", () => ({
+  useSavedReports: (enabled?: boolean) => mockUseSavedReports(enabled),
+}));
+
+const mockFeatureFlags = { evals: false, observers: true };
 jest.mock("@/providers/feature-flags-provider", () => ({
-  useFeatureFlag: () => mockEvalsFlag,
+  useFeatureFlag: (flag: keyof typeof mockFeatureFlags) => mockFeatureFlags[flag],
 }));
 
 const mockSetCurrentOrg = jest.fn();
@@ -61,8 +120,11 @@ jest.mock("@/providers/org-provider", () => ({
 describe("useGlobalSearch", () => {
   beforeEach(() => {
     mockSetCurrentOrg.mockClear();
+    mockUseAgents.mockClear();
     mockUseEvals.mockClear();
-    mockEvalsFlag = false;
+    mockUseSavedReports.mockClear();
+    mockFeatureFlags.evals = false;
+    mockFeatureFlags.observers = true;
   });
 
   it("defers the evals fetch when the feature flag is off", () => {
@@ -71,9 +133,16 @@ describe("useGlobalSearch", () => {
   });
 
   it("enables the evals fetch when the feature flag is on", () => {
-    mockEvalsFlag = true;
-    renderHook(() => useGlobalSearch(""));
+    mockFeatureFlags.evals = true;
+    renderHook(() => useGlobalSearch("eval"));
     expect(mockUseEvals).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it("does not enable entity fetches before the user enters a query", () => {
+    renderHook(() => useGlobalSearch(""));
+
+    expect(mockUseAgents).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseSavedReports).toHaveBeenCalledWith(false);
   });
 
   it("finds organizations and switches to the selected organization", () => {
@@ -112,5 +181,33 @@ describe("useGlobalSearch", () => {
       subtitle: "Current organization > org_current",
     });
     expect(orgResult?.onSelect).toBeUndefined();
+  });
+
+  it.each([
+    ["reports", "/reports"],
+    ["work", "/work"],
+    ["knowledge indexes", "/knowledge-indexes"],
+    ["plugins", "/plugins"],
+    ["observers", "/observers"],
+    ["payments", "/settings/payments"],
+    ["circuit breakers", "/durable/circuit-breakers"],
+  ])("finds the %s navigation page", (query, href) => {
+    const { result } = renderHook(() => useGlobalSearch(query));
+
+    expect(result.current).toContainEqual(
+      expect.objectContaining({ category: "navigation", href }),
+    );
+  });
+
+  it.each([
+    ["product notes", "memory:mem_product", "/memory/mem_product"],
+    ["documentation index", "knowledge-index:kidx_docs", "/knowledge-indexes/kidx_docs"],
+    ["email service", "plugin:plugin_email", "/plugins"],
+    ["answer quality", "observer:observer_quality", "/observers/observer_quality"],
+    ["weekly usage", "report:report_weekly", "/reports"],
+  ])("finds the %s entity", (query, id, href) => {
+    const { result } = renderHook(() => useGlobalSearch(query));
+
+    expect(result.current).toContainEqual(expect.objectContaining({ id, href }));
   });
 });

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -30,6 +30,11 @@ const CATEGORY_LABELS: Record<SearchResultCategory, string> = {
   mcp_server: "MCP Servers",
   app: "Apps",
   eval: "Evals",
+  memory: "Memory",
+  knowledge_index: "Knowledge Indexes",
+  plugin: "Plugins",
+  observer: "Observers",
+  report: "Reports",
   organization: "Organizations",
   id: "Go to",
 };
@@ -47,6 +52,11 @@ const CATEGORY_ORDER: SearchResultCategory[] = [
   "mcp_server",
   "app",
   "eval",
+  "memory",
+  "knowledge_index",
+  "plugin",
+  "observer",
+  "report",
 ];
 
 function groupResults(

--- a/apps/ui/src/hooks/use-agent-identities.ts
+++ b/apps/ui/src/hooks/use-agent-identities.ts
@@ -19,14 +19,14 @@ const agentIdentityKeys = {
   detail: (id: string) => ["agent-identities", "detail", id] as const,
 };
 
-export function useAgentIdentities(options: { includeArchived?: boolean } = {}) {
+export function useAgentIdentities(options: { includeArchived?: boolean; enabled?: boolean } = {}) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const includeArchived = options.includeArchived ?? false;
   const org = currentOrg?.public_id;
   const query = useQuery({
     queryKey: [...agentIdentityKeys.list(includeArchived), org],
     queryFn: () => listAgentIdentities(includeArchived),
-    enabled: !!org,
+    enabled: !!org && (options.enabled ?? true),
   });
   return { ...query, isLoading: orgLoading || query.isLoading };
 }

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -23,14 +23,14 @@ import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
 import { useResourceOrgFallback } from "./use-resource-org-fallback";
 
-export function useCapabilities() {
+export function useCapabilities(options: { enabled?: boolean } = {}) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
     queryKey: ["capabilities", org],
     queryFn: () => listCapabilities(),
-    enabled: !!org,
+    enabled: !!org && (options.enabled ?? true),
   });
 
   // Include org loading state so pages show skeleton while org initializes
@@ -63,14 +63,14 @@ export function useCapability(capabilityId: CapabilityId | undefined) {
   };
 }
 
-export function useDeclarativeCapabilities() {
+export function useDeclarativeCapabilities(options: { enabled?: boolean } = {}) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
     queryKey: [...queryKeys.declarativeCapabilities.list(), org],
     queryFn: () => listDeclarativeCapabilities(),
-    enabled: !!org,
+    enabled: !!org && (options.enabled ?? true),
   });
 
   return {

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -14,6 +14,7 @@
  * 10. Evals (client-side filter over cached list)
  * 11. Apps (client-side filter over cached list)
  * 12. Agent Identities (client-side filter over cached list)
+ * 13. Memories, knowledge indexes, plugins, observers, and saved reports
  *
  * All entity searches are client-side over already-fetched React Query data.
  * Backend search endpoints are available for server-side filtering when needed.
@@ -41,6 +42,12 @@ import {
   Cpu,
   HardDrive,
   Building2,
+  ChartColumn,
+  Waypoints,
+  Library,
+  Telescope,
+  WalletCards,
+  CircuitBoard,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAgents } from "@/hooks/use-agents";
@@ -52,6 +59,11 @@ import { useCapabilities, useDeclarativeCapabilities } from "@/hooks/use-capabil
 import { useEvals } from "@/hooks/use-evals";
 import { useApps } from "@/hooks/use-apps";
 import { useAgentIdentities } from "@/hooks/use-agent-identities";
+import { useMemories } from "@/hooks/use-memory";
+import { useKnowledgeIndexes } from "@/hooks/use-knowledge-indexes";
+import { useInstalledPlugins } from "@/hooks/use-plugins";
+import { useObservers } from "@/hooks/use-observers";
+import { useSavedReports } from "@/hooks/use-reporting";
 import { getDisplayName } from "@/lib/entity-lifecycle";
 import { localizedCapabilityName } from "@/lib/capability-localization";
 import { useLocale } from "@/providers/locale-provider";
@@ -69,6 +81,11 @@ export type SearchResultCategory =
   | "capability"
   | "app"
   | "eval"
+  | "memory"
+  | "knowledge_index"
+  | "plugin"
+  | "observer"
+  | "report"
   | "organization"
   | "id";
 
@@ -102,6 +119,18 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     href: "/sessions",
     icon: MessageSquare,
     keywords: ["chat", "conversation"],
+  },
+  {
+    title: "Reports",
+    href: "/reports",
+    icon: ChartColumn,
+    keywords: ["analytics", "saved report"],
+  },
+  {
+    title: "Work",
+    href: "/work",
+    icon: Waypoints,
+    keywords: ["tasks", "delegation"],
   },
   {
     title: "Chat",
@@ -140,12 +169,24 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     keywords: ["workspace", "files", "storage"],
   },
   {
+    title: "Knowledge Indexes",
+    href: "/knowledge-indexes",
+    icon: Library,
+    keywords: ["knowledge", "index", "search", "retrieval"],
+  },
+  {
     title: "Models",
     href: "/models",
     icon: Cpu,
     keywords: ["llm", "openai", "anthropic", "default model"],
   },
   { title: "Capabilities", href: "/capabilities", icon: Puzzle },
+  {
+    title: "Plugins",
+    href: "/plugins",
+    icon: Puzzle,
+    keywords: ["marketplace", "extension", "integration"],
+  },
   {
     title: "Apps",
     href: "/apps",
@@ -157,6 +198,12 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     href: "/evals",
     icon: FlaskConical,
     keywords: ["evaluation", "test", "benchmark", "score"],
+  },
+  {
+    title: "Observers",
+    href: "/observers",
+    icon: Telescope,
+    keywords: ["monitor", "score", "production eval"],
   },
   {
     title: "MCP Servers",
@@ -221,6 +268,12 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     keywords: ["feature", "flags", "experimental", "opt-in", "beta"],
   },
   {
+    title: "Settings > Payments",
+    href: "/settings/payments",
+    icon: WalletCards,
+    keywords: ["wallet", "spend", "billing"],
+  },
+  {
     title: "Durable Execution",
     href: "/durable",
     icon: Cog,
@@ -230,23 +283,42 @@ const NAVIGATION_PAGES: NavigationPage[] = [
   { title: "Durable > Workflows", href: "/durable/workflows", icon: Workflow },
   { title: "Durable > Queues", href: "/durable/queues", icon: ListTodo },
   { title: "Durable > Schedules", href: "/durable/schedules", icon: Calendar },
+  {
+    title: "Durable > Circuit Breakers",
+    href: "/durable/circuit-breakers",
+    icon: CircuitBoard,
+    keywords: ["failure", "resilience"],
+  },
   { title: "Dev Tools", href: "/dev", icon: FlaskConical },
 ];
 
 /** Known ID prefixes and where they resolve. */
 const ID_PREFIX_MAP: Record<
   string,
-  { category: SearchResultCategory; label: string; path: string }
+  { category: SearchResultCategory; label: string; path: string; listOnly?: boolean }
 > = {
   agent_: { category: "agent", label: "Agent", path: "/agents" },
   session_: { category: "session", label: "Session", path: "/sessions" },
   harness_: { category: "harness", label: "Harness", path: "/harnesses" },
   skill_: { category: "skill", label: "Skill", path: "/skills" },
-  mcp_: { category: "mcp_server", label: "MCP Server", path: "/mcp-servers" },
-  cap_: { category: "capability", label: "Declarative Capability", path: "/capabilities" },
+  mcp_: {
+    category: "mcp_server",
+    label: "MCP Server",
+    path: "/mcp-servers",
+    listOnly: true,
+  },
+  cap_: {
+    category: "capability",
+    label: "Declarative Capability",
+    path: "/capabilities",
+    listOnly: true,
+  },
   eval_: { category: "eval", label: "Eval", path: "/evals" },
   app_: { category: "app", label: "App", path: "/apps" },
   mem_: { category: "id", label: "Memory", path: "/memory" },
+  kidx_: { category: "knowledge_index", label: "Knowledge Index", path: "/knowledge-indexes" },
+  plugin_: { category: "plugin", label: "Plugin", path: "/plugins", listOnly: true },
+  observer_: { category: "observer", label: "Observer", path: "/observers" },
   identity_: {
     category: "agent_identity",
     label: "Agent Identity",
@@ -273,19 +345,34 @@ const EMPTY_ARRAY: never[] = [];
 export function useGlobalSearch(query: string) {
   const { locale } = useLocale();
   const { currentOrg, organizations, setCurrentOrg } = useOrg();
-  const { data: agentsData } = useAgents();
-  const { data: sessionsData } = useSessions(undefined, { limit: 100 });
-  const { data: harnessesData } = useHarnesses();
-  const { data: skillsData } = useSkills();
-  const { data: mcpServersData } = useMcpServers();
-  const { data: capabilitiesData } = useCapabilities();
-  const { data: declarativeCapabilitiesData } = useDeclarativeCapabilities();
+  const entitySearchEnabled = query.trim().length > 0;
+  const { data: agentsData } = useAgents({ enabled: entitySearchEnabled });
+  const { data: sessionsData } = useSessions(
+    undefined,
+    { limit: 100 },
+    { enabled: entitySearchEnabled },
+  );
+  const { data: harnessesData } = useHarnesses({ enabled: entitySearchEnabled });
+  const { data: skillsData } = useSkills({ enabled: entitySearchEnabled });
+  const { data: mcpServersData } = useMcpServers({ enabled: entitySearchEnabled });
+  const { data: capabilitiesData } = useCapabilities({ enabled: entitySearchEnabled });
+  const { data: declarativeCapabilitiesData } = useDeclarativeCapabilities({
+    enabled: entitySearchEnabled,
+  });
   // Evals is an experimental, flag-gated feature; only fetch when enabled to
   // avoid a 404 on every palette open for orgs without the flag.
   const evalsEnabled = useFeatureFlag("evals");
-  const { data: evalsData } = useEvals({ enabled: evalsEnabled });
-  const { data: appsData } = useApps();
-  const { data: agentIdentitiesData } = useAgentIdentities();
+  const { data: evalsData } = useEvals({ enabled: evalsEnabled && entitySearchEnabled });
+  const { data: appsData } = useApps({ enabled: entitySearchEnabled });
+  const { data: agentIdentitiesData } = useAgentIdentities({ enabled: entitySearchEnabled });
+  const { data: memoriesData } = useMemories({ enabled: entitySearchEnabled });
+  const { data: knowledgeIndexesData } = useKnowledgeIndexes({ enabled: entitySearchEnabled });
+  const { data: installedPluginsData } = useInstalledPlugins({ enabled: entitySearchEnabled });
+  const observersEnabled = useFeatureFlag("observers");
+  const { data: observersData } = useObservers({
+    enabled: observersEnabled && entitySearchEnabled,
+  });
+  const { data: savedReportsData } = useSavedReports(entitySearchEnabled);
 
   const agents = agentsData ?? EMPTY_ARRAY;
   const sessions = sessionsData?.data ?? EMPTY_ARRAY;
@@ -297,6 +384,11 @@ export function useGlobalSearch(query: string) {
   const evals = evalsData ?? EMPTY_ARRAY;
   const apps = appsData ?? EMPTY_ARRAY;
   const agentIdentities = agentIdentitiesData ?? EMPTY_ARRAY;
+  const memories = memoriesData ?? EMPTY_ARRAY;
+  const knowledgeIndexes = knowledgeIndexesData ?? EMPTY_ARRAY;
+  const installedPlugins = installedPluginsData ?? EMPTY_ARRAY;
+  const observers = observersData ?? EMPTY_ARRAY;
+  const savedReports = savedReportsData ?? EMPTY_ARRAY;
 
   return useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -346,6 +438,15 @@ export function useGlobalSearch(query: string) {
           resolvedName = apps.find((a) => a.id === idValue)?.name;
         } else if (prefix === "identity_") {
           resolvedName = agentIdentities.find((ai) => ai.id === idValue)?.name;
+        } else if (prefix === "mem_") {
+          resolvedName = memories.find((memory) => memory.id === idValue)?.name;
+        } else if (prefix === "kidx_") {
+          resolvedName = knowledgeIndexes.find((index) => index.id === idValue)?.name;
+        } else if (prefix === "plugin_") {
+          const plugin = installedPlugins.find((candidate) => candidate.id === idValue);
+          resolvedName = plugin?.display_name ?? plugin?.name;
+        } else if (prefix === "observer_") {
+          resolvedName = observers.find((observer) => observer.id === idValue)?.name;
         }
 
         results.push({
@@ -354,7 +455,7 @@ export function useGlobalSearch(query: string) {
           icon: Boxes,
           title: resolvedName ? `${meta.label}: ${resolvedName}` : `Go to ${meta.label}`,
           subtitle: idValue,
-          href: prefix === "cap_" ? meta.path : `${meta.path}/${idValue}`,
+          href: meta.listOnly ? meta.path : `${meta.path}/${idValue}`,
         });
       }
     }
@@ -617,6 +718,94 @@ export function useGlobalSearch(query: string) {
       }
     }
 
+    // 13. Memories
+    let memoryCount = 0;
+    for (const memory of memories) {
+      if (memoryCount >= MAX_PER_CATEGORY) break;
+      if (matchesTokens(tokens, memory.name, memory.description, memory.id, "memory")) {
+        results.push({
+          id: `memory:${memory.id}`,
+          category: "memory",
+          icon: HardDrive,
+          title: memory.name,
+          subtitle: `Memory > ${memory.name}`,
+          href: `/memory/${memory.id}`,
+        });
+        memoryCount++;
+      }
+    }
+
+    // 14. Knowledge indexes
+    let knowledgeIndexCount = 0;
+    for (const index of knowledgeIndexes) {
+      if (knowledgeIndexCount >= MAX_PER_CATEGORY) break;
+      if (
+        matchesTokens(tokens, index.name, index.description, index.id, "knowledge index retrieval")
+      ) {
+        results.push({
+          id: `knowledge-index:${index.id}`,
+          category: "knowledge_index",
+          icon: Library,
+          title: index.name,
+          subtitle: `Knowledge Indexes > ${index.name}`,
+          href: `/knowledge-indexes/${index.id}`,
+        });
+        knowledgeIndexCount++;
+      }
+    }
+
+    // 15. Installed plugins
+    let pluginCount = 0;
+    for (const plugin of installedPlugins) {
+      if (pluginCount >= MAX_PER_CATEGORY) break;
+      const title = plugin.display_name ?? plugin.name;
+      if (matchesTokens(tokens, plugin.name, title, plugin.description, plugin.id, "plugin")) {
+        results.push({
+          id: `plugin:${plugin.id}`,
+          category: "plugin",
+          icon: Puzzle,
+          title,
+          subtitle: `Plugins > ${title}`,
+          href: "/plugins",
+        });
+        pluginCount++;
+      }
+    }
+
+    // 16. Observers
+    let observerCount = 0;
+    for (const observer of observers) {
+      if (observerCount >= MAX_PER_CATEGORY) break;
+      if (matchesTokens(tokens, observer.name, observer.description, observer.id, "observer")) {
+        results.push({
+          id: `observer:${observer.id}`,
+          category: "observer",
+          icon: Telescope,
+          title: observer.name,
+          subtitle: `Observers > ${observer.name}`,
+          href: `/observers/${observer.id}`,
+        });
+        observerCount++;
+      }
+    }
+
+    // 17. Saved reports
+    let reportCount = 0;
+    for (const report of savedReports) {
+      if (reportCount >= MAX_PER_CATEGORY) break;
+      if (matchesTokens(tokens, report.name, report.description, report.id, "saved report")) {
+        results.push({
+          id: `report:${report.id}`,
+          category: "report",
+          icon: ChartColumn,
+          title: report.name,
+          subtitle: `Reports > ${report.name}`,
+          href: "/reports",
+        });
+        reportCount++;
+      }
+    }
+
     return results;
   }, [
     query,
@@ -634,5 +823,10 @@ export function useGlobalSearch(query: string) {
     evals,
     apps,
     agentIdentities,
+    memories,
+    knowledgeIndexes,
+    installedPlugins,
+    observers,
+    savedReports,
   ]);
 }

--- a/apps/ui/src/hooks/use-knowledge-indexes.ts
+++ b/apps/ui/src/hooks/use-knowledge-indexes.ts
@@ -40,13 +40,16 @@ function invalidateIndexQueries(queryClient: QueryClient, indexId?: string) {
   }
 }
 
-export function useKnowledgeIndexes(options: ListKnowledgeIndexesParams = {}) {
+export function useKnowledgeIndexes(
+  options: ListKnowledgeIndexesParams & { enabled?: boolean } = {},
+) {
   const includeArchived = options.includeArchived ?? false;
   const search = options.search?.trim() ?? "";
 
   return useOrgScopedQuery({
     queryKey: queryKeys.knowledgeIndexes.list(includeArchived, search),
     queryFn: () => listKnowledgeIndexes({ includeArchived, search }),
+    enabled: options.enabled ?? true,
   });
 }
 

--- a/apps/ui/src/hooks/use-memory.ts
+++ b/apps/ui/src/hooks/use-memory.ts
@@ -38,13 +38,14 @@ function invalidateMemoryQueries(queryClient: QueryClient, memoryId?: string) {
   }
 }
 
-export function useMemories(options: ListMemoriesParams = {}) {
+export function useMemories(options: ListMemoriesParams & { enabled?: boolean } = {}) {
   const includeArchived = options.includeArchived ?? false;
   const search = options.search?.trim() ?? "";
 
   return useOrgScopedQuery({
     queryKey: queryKeys.memory.list(includeArchived, search),
     queryFn: () => listMemories({ includeArchived, search }),
+    enabled: options.enabled ?? true,
   });
 }
 

--- a/apps/ui/src/hooks/use-reporting.ts
+++ b/apps/ui/src/hooks/use-reporting.ts
@@ -40,14 +40,14 @@ export function useReportQuery(query: ReportQuery | undefined) {
   });
 }
 
-export function useSavedReports() {
+export function useSavedReports(enabled = true) {
   const { currentOrg } = useOrg();
   const org = currentOrg?.public_id;
 
   return useQuery({
     queryKey: queryKeys.reporting.saved(org),
     queryFn: listSavedReports,
-    enabled: !!org,
+    enabled: !!org && enabled,
   });
 }
 

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -35,14 +35,18 @@ import { useResourceOrgFallback } from "./use-resource-org-fallback";
  * Optionally filter by agentId.
  * Returns { data, total, offset, limit } for pagination controls.
  */
-export function useSessions(agentId?: string, params?: PaginationParams) {
+export function useSessions(
+  agentId?: string,
+  params?: PaginationParams,
+  options: { enabled?: boolean } = {},
+) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
     queryKey: queryKeys.sessions.list(org, agentId, params?.offset ?? 0, params?.limit ?? 20),
     queryFn: () => listSessions({ ...params, agentId }),
-    enabled: !!org,
+    enabled: !!org && (options.enabled ?? true),
   });
 
   // Include org loading state so pages show skeleton while org initializes


### PR DESCRIPTION
## What changed

Global search now exposes every primary product destination, including Reports, Work, Knowledge Indexes, Plugins, Observers, Payments, and Circuit Breakers. It also finds Memories, Knowledge Indexes, installed Plugins, Observers, and saved Reports by name or ID where supported.

Entity queries stay disabled until the user enters a non-empty search term. Command-palette navigation remains button-driven and performs no route prefetching.

## Why

Several important destinations and resource types were reachable through navigation but missing from global search, leaving search coverage out of sync with the product surface.

## Before / After

Before: searches for `reports`, `work`, `knowledge indexes`, `plugins`, `observers`, `payments`, or `circuit breakers` returned no matching page. Memory and other newly covered resources could not be found by name.

After: agent-browser verified all seven destinations appear for matching queries. Selecting Circuit Breakers navigated to `/durable/circuit-breakers`. A newly created `Search Smoke Memory` appeared as a Memory result and navigated to its `/memory/{id}` detail page.

Validation:

- `just pre-push`
- `cd apps/ui && pnpm exec jest --runInBand` — 132 suites, 1,164 tests passed
- `cd apps/ui && pnpm run build`
- Focused global-search tests — 21 tests passed
- Manual command-palette smoke test on the in-memory dev stack with `PORT_PREFIX=284`

## Risk

- Low
- Search result grouping and query enablement could regress; unit tests cover every added page/entity and the no-prefetch query gate, while the production build and manual navigation flow passed.

## Security

- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: Result labels remain React-escaped and all new navigation targets are static internal paths. No authentication, authorization, tenant, API, or dependency boundary changed. Entity list requests are gated behind a non-empty query and results remain capped per category. No threat-model update is required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
