### PR TITLE
perf(api): compress non-streaming responses

### DIFF
--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -228,6 +228,25 @@ configs:
       # SDK reconnects transparently (no retry budget cost).
       :9300 {
         handle /api/* {
+          # Compress only buffered, text-based responses. The explicit allowlist keeps
+          # text/event-stream out of the encoder so SSE events flush immediately.
+          encode zstd gzip {
+            minimum_length 1024
+            match {
+              header Content-Type application/json*
+              header Content-Type application/*+json
+              header Content-Type text/plain*
+              header Content-Type text/html*
+              header Content-Type text/css*
+              header Content-Type text/csv*
+              header Content-Type text/javascript*
+              header Content-Type text/markdown*
+              header Content-Type application/javascript*
+              header Content-Type application/xml*
+              header Content-Type application/*+xml
+              header Content-Type image/svg+xml*
+            }
+          }
           reverse_proxy server:9000 {
             # Disable response buffering for SSE streaming
             flush_interval -1

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -26,6 +26,25 @@
 #   - SDK reconnects transparently on disconnecting events (no retry budget cost)
 :{$PROXY_PORT:9300} {
 	handle /api/* {
+		# Compress only buffered, text-based responses. The explicit allowlist keeps
+		# text/event-stream out of the encoder so SSE events flush immediately.
+		encode zstd gzip {
+			minimum_length 1024
+			match {
+				header Content-Type application/json*
+				header Content-Type application/*+json
+				header Content-Type text/plain*
+				header Content-Type text/html*
+				header Content-Type text/css*
+				header Content-Type text/csv*
+				header Content-Type text/javascript*
+				header Content-Type text/markdown*
+				header Content-Type application/javascript*
+				header Content-Type application/xml*
+				header Content-Type application/*+xml
+				header Content-Type image/svg+xml*
+			}
+		}
 		reverse_proxy localhost:{$API_PORT:9301} {
 			# Disable response buffering for SSE streaming
 			flush_interval -1

--- a/scripts/test-caddy-api-compression.sh
+++ b/scripts/test-caddy-api-compression.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+if ! command -v caddy >/dev/null 2>&1; then
+  echo "SKIP: caddy not installed"
+  exit 0
+fi
+
+python3 - "$PROJECT_ROOT" <<'PY'
+from __future__ import annotations
+
+import gzip
+import http.client
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+PROJECT_ROOT = Path(sys.argv[1])
+CAPABILITIES_BODY = b'{"data":"' + (b"a" * (232_755 - 11)) + b'"}'
+ERROR_BODY = json.dumps({"error": "invalid request", "detail": "x" * 2_048}).encode()
+ALREADY_COMPRESSED_BODY = gzip.compress(b'{"data":"' + (b"b" * 2_048) + b'"}')
+FIRST_EVENT_SENT = threading.Event()
+FINISH_STREAM = threading.Event()
+
+
+class ApiFixture(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:
+        if self.path == "/api/v1/capabilities":
+            self._send(200, "application/json", CAPABILITIES_BODY)
+        elif self.path == "/api/v1/small":
+            self._send(200, "application/json", b'{"ok":true}')
+        elif self.path == "/api/v1/already-compressed":
+            self._send(
+                200,
+                "application/json",
+                ALREADY_COMPRESSED_BODY,
+                {"Content-Encoding": "gzip"},
+            )
+        elif self.path == "/api/v1/error":
+            self._send(400, "application/json", ERROR_BODY)
+        elif self.path == "/api/v1/events":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            self.wfile.write(b"event: first\ndata: {}\n\n")
+            self.wfile.flush()
+            FIRST_EVENT_SENT.set()
+            FINISH_STREAM.wait(timeout=5)
+            self.wfile.write(b"event: second\ndata: {}\n\n")
+            self.wfile.flush()
+        else:
+            self._send(404, "application/json", b'{"error":"not found"}')
+
+    def _send(
+        self,
+        status: int,
+        content_type: str,
+        body: bytes,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: object) -> None:
+        pass
+
+
+class QuietThreadingHTTPServer(ThreadingHTTPServer):
+    def handle_error(self, _request: object, _client_address: object) -> None:
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def request(port: int, path: str, accept_encoding: str = "gzip") -> tuple[int, dict[str, str], bytes]:
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    connection.request("GET", path, headers={"Accept-Encoding": accept_encoding})
+    response = connection.getresponse()
+    result = response.status, {name.lower(): value for name, value in response.getheaders()}, response.read()
+    connection.close()
+    return result
+
+
+api_port, proxy_port, admin_port, ui_port = (free_port() for _ in range(4))
+server = QuietThreadingHTTPServer(("127.0.0.1", api_port), ApiFixture)
+server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+server_thread.start()
+
+environment = os.environ.copy()
+environment.update(
+    API_PORT=str(api_port),
+    PROXY_PORT=str(proxy_port),
+    CADDY_ADMIN_PORT=str(admin_port),
+    UI_PORT=str(ui_port),
+)
+caddy = subprocess.Popen(
+    ["caddy", "run", "--config", str(PROJECT_ROOT / "local/Caddyfile"), "--adapter", "caddyfile"],
+    env=environment,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+
+try:
+    deadline = time.monotonic() + 5
+    while True:
+        if caddy.poll() is not None:
+            raise AssertionError(f"caddy exited during startup: {caddy.stderr.read()}")
+        try:
+            request(proxy_port, "/api/v1/small", "identity")
+            break
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise AssertionError("caddy did not become ready")
+            time.sleep(0.05)
+
+    status, headers, compressed_body = request(proxy_port, "/api/v1/capabilities")
+    assert status == 200
+    assert headers.get("content-encoding") == "gzip", headers
+    assert "accept-encoding" in headers.get("vary", "").lower(), headers
+    assert gzip.decompress(compressed_body) == CAPABILITIES_BODY
+    assert len(compressed_body) < len(CAPABILITIES_BODY) // 10
+
+    _, small_headers, small_body = request(proxy_port, "/api/v1/small")
+    assert "content-encoding" not in small_headers, small_headers
+    assert small_body == b'{"ok":true}'
+
+    _, encoded_headers, encoded_body = request(proxy_port, "/api/v1/already-compressed")
+    assert encoded_headers.get("content-encoding") == "gzip", encoded_headers
+    assert encoded_body == ALREADY_COMPRESSED_BODY
+    assert gzip.decompress(encoded_body).startswith(b'{"data":"')
+
+    error_status, error_headers, error_body = request(proxy_port, "/api/v1/error")
+    assert error_status == 400
+    assert error_headers.get("content-encoding") == "gzip", error_headers
+    assert json.loads(gzip.decompress(error_body))["error"] == "invalid request"
+
+    connection = http.client.HTTPConnection("127.0.0.1", proxy_port, timeout=2)
+    connection.request("GET", "/api/v1/events", headers={"Accept-Encoding": "gzip"})
+    response = connection.getresponse()
+    assert response.status == 200
+    sse_headers = {name.lower(): value for name, value in response.getheaders()}
+    assert "content-encoding" not in sse_headers, sse_headers
+    started = time.monotonic()
+    assert response.readline() == b"event: first\n"
+    assert time.monotonic() - started < 1
+    assert FIRST_EVENT_SENT.is_set()
+    assert not FINISH_STREAM.is_set()
+    FINISH_STREAM.set()
+    assert response.readline() == b"data: {}\n"
+    connection.close()
+
+    print(
+        "caddy API compression checks passed "
+        f"(capabilities wire bytes: {len(CAPABILITIES_BODY)} -> {len(compressed_body)})"
+    )
+finally:
+    FINISH_STREAM.set()
+    caddy.terminate()
+    try:
+        caddy.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        caddy.kill()
+        caddy.wait(timeout=3)
+    server.shutdown()
+    server.server_close()
+PY

--- a/scripts/test-port-layout.sh
+++ b/scripts/test-port-layout.sh
@@ -70,6 +70,7 @@ check_example_ports() {
   rg -q 'PORT: "9305"' "$compose_file"
   rg -q 'reverse_proxy server:9000' "$compose_file"
   rg -q 'reverse_proxy ui:9305' "$compose_file"
+  rg -q 'encode zstd gzip' "$compose_file"
   rg -q '\$\{EXAMPLE_PROXY_PORT:-9300\}:9300' "$compose_file"
 }
 

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -109,7 +109,11 @@ Do not rewrite `/mcp` under `/api`. Do not rewrite `/.well-known/*` under `/api`
 ### Transport Requirements
 
 - TLS/HTTPS required for public traffic
+- Compress eligible non-streaming API responses with content negotiation and a
+  minimum-size threshold; do not recompress already encoded payloads
 - Disable proxy buffering for SSE responses under `/api/*`
+- Exclude `text/event-stream` from response compression so events remain
+  observable before stream completion
 - Preserve Host and standard forwarding headers, including `X-Request-ID` (pass through unchanged)
 - Keep gRPC worker traffic off the public ingress path
 


### PR DESCRIPTION
## What changed
Large JSON and text responses under `/api/*` now negotiate zstd or gzip at the shared OSS Caddy boundary. Compression starts at 1 KiB, preserves already encoded payloads, and explicitly excludes `text/event-stream` so SSE remains incremental.

The local production proxy example and full Docker Compose example use the same policy. A black-box Caddy regression covers compressed JSON, `Vary: Accept-Encoding`, small and already compressed responses, readable JSON errors, and first-event SSE delivery before stream completion.

Resolves EVE-781.

## Why
The OSS proxy disabled buffering for SSE but did not configure response encoding, so large API catalogs crossed the wire uncompressed. Compression needs to reduce cold-load bandwidth without turning the shared streaming route into a buffered response path.

## Before / After
- Reported production-mode baseline: `/api/v1/capabilities` transferred 232,755 bytes with `Accept-Encoding: gzip, br`, no `Content-Encoding`, and no `Vary: Accept-Encoding`.
- Real-stack smoke after the change: the current `/api/v1/capabilities` payload was 231,832 identity bytes and 60,262 gzip wire bytes (74% reduction), with `Content-Encoding: gzip` and `Vary: Accept-Encoding`.
- Deterministic proxy regression: 232,755 bytes became 1,843 gzip wire bytes for the highly repetitive fixture payload.
- Typed error smoke: `GET /api/v1/capabilities/no-such-capability` remained a readable 404 `application/problem+json` response (`{"title":"Not Found","status":404,"detail":"Capability not found"}`), correctly uncompressed at 66 bytes.
- SSE regression: `text/event-stream` has no `Content-Encoding`; the first event is observed while the upstream stream is still open and before its second event.

Validation:
- `./scripts/run-shell-tests.sh`
- `just pre-push`
- Real server + actual `local/Caddyfile` smoke on isolated ports
- `caddy validate --config local/Caddyfile --adapter caddyfile`

## Risk
- Medium. The change affects response framing at the shared API proxy boundary.
- Mitigations: explicit content-type allowlist excludes SSE and binary media; a 1 KiB threshold avoids small-response overhead; Caddy skips existing `Content-Encoding`; black-box tests cover negotiation, exclusions, error readability, and incremental streaming.

## Security
- Threat categories reviewed: TM-API and TM-DOS.
- Findings and resolutions: authentication, authorization, input parsing, and error disclosure are unchanged. Compression is limited to finite allowlisted text responses above 1 KiB; small, already encoded, binary, and SSE responses are excluded. No new dependency or secret surface was introduced. The existing SSE connection-exhaustion and cycling mitigations remain intact. No threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)