### PR TITLE
chore(release): prepare v0.17.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.10] - 2026-07-16
+
+### Highlights
+
+- **Expanded global search** — Global search now covers more of the workspace, so results surface across more session and content types ([#2810](https://github.com/everruns/everruns/pull/2810)).
+- **Resend email plugin & plugin MCP OAuth** — New Resend OAuth email plugin, plus OAuth support for plugin-provided MCP servers ([#2808](https://github.com/everruns/everruns/pull/2808)).
+- **Web fetch on fetchkit 0.5** — The web-fetch tool adopts fetchkit 0.5 capabilities ([#2807](https://github.com/everruns/everruns/pull/2807)).
+- **Live reasoning stream** — Streamed phase hints on message start/delta and projected `reason.item` summaries into the reasoning channel make in-progress model reasoning more visible ([#2804](https://github.com/everruns/everruns/pull/2804), [#2803](https://github.com/everruns/everruns/pull/2803)).
+
+### What's Changed
+
+- feat(ui): expand global search coverage ([#2810](https://github.com/everruns/everruns/pull/2810)) by [@chaliy](https://github.com/chaliy)
+- feat(plugins): Resend OAuth email plugin + plugin MCP OAuth support ([#2808](https://github.com/everruns/everruns/pull/2808)) by [@chaliy](https://github.com/chaliy)
+- feat(web-fetch): adopt fetchkit 0.5 features ([#2807](https://github.com/everruns/everruns/pull/2807)) by [@chaliy](https://github.com/chaliy)
+- feat(core): streamed phase hint on output.message started/delta ([#2804](https://github.com/everruns/everruns/pull/2804)) by [@chaliy](https://github.com/chaliy)
+- feat(server): project reason.item summaries to reasoning channel ([#2803](https://github.com/everruns/everruns/pull/2803)) by [@chaliy](https://github.com/chaliy)
+- feat(filesystem): return bounded grep context by [@chaliy](https://github.com/chaliy)
+- perf(api): compress non-streaming responses ([#2811](https://github.com/everruns/everruns/pull/2811)) by [@chaliy](https://github.com/chaliy)
+- perf(ui): scope sidebar prefetch to intent ([#2809](https://github.com/everruns/everruns/pull/2809)) by [@chaliy](https://github.com/chaliy)
+- perf(agent): teach shared hints single-read/contextual-search policy ([#2805](https://github.com/everruns/everruns/pull/2805)) by [@chaliy](https://github.com/chaliy)
+- fix(session-files): keep grep available by redacting private memory ([#2801](https://github.com/everruns/everruns/pull/2801)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): honor grep files regex contract ([#2800](https://github.com/everruns/everruns/pull/2800)) by [@chaliy](https://github.com/chaliy)
+- fix(agents): restore harness on version rollback ([#2797](https://github.com/everruns/everruns/pull/2797)) by [@chaliy](https://github.com/chaliy)
+- fix(subagents): guard report_result task finalization ([#2796](https://github.com/everruns/everruns/pull/2796)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): validate KB embedding provider service ([#2795](https://github.com/everruns/everruns/pull/2795)) by [@chaliy](https://github.com/chaliy)
+- fix(session-tasks): restrict scheduled probe tools ([#2794](https://github.com/everruns/everruns/pull/2794)) by [@chaliy](https://github.com/chaliy)
+- fix(harnesses): bound embedder metadata ([#2793](https://github.com/everruns/everruns/pull/2793)) by [@chaliy](https://github.com/chaliy)
+- fix(core): reject malformed legacy edit scalars ([#2792](https://github.com/everruns/everruns/pull/2792)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve accumulator effective cost ([#2791](https://github.com/everruns/everruns/pull/2791)) by [@chaliy](https://github.com/chaliy)
+- fix(server): reconcile canceled one-shot monitors ([#2790](https://github.com/everruns/everruns/pull/2790)) by [@chaliy](https://github.com/chaliy)
+- test(durable): make counter reset atomic ([#2789](https://github.com/everruns/everruns/pull/2789)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): require tasks opt-in for task methods ([#2788](https://github.com/everruns/everruns/pull/2788)) by [@chaliy](https://github.com/chaliy)
+- fix(core): require spawn_agent target fields ([#2787](https://github.com/everruns/everruns/pull/2787)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): seed participant agent versions ([#2786](https://github.com/everruns/everruns/pull/2786)) by [@chaliy](https://github.com/chaliy)
+- fix(reporting): guard malformed usage records ([#2785](https://github.com/everruns/everruns/pull/2785)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): clear signup return_to after instant auth ([#2784](https://github.com/everruns/everruns/pull/2784)) by [@chaliy](https://github.com/chaliy)
+- fix(llm): enforce model speed tier support ([#2783](https://github.com/everruns/everruns/pull/2783)) by [@chaliy](https://github.com/chaliy)
+- fix(worker): preserve non-wake durable signals ([#2782](https://github.com/everruns/everruns/pull/2782)) by [@chaliy](https://github.com/chaliy)
+- fix(core): accept legacy A2A wait run records ([#2781](https://github.com/everruns/everruns/pull/2781)) by [@chaliy](https://github.com/chaliy)
+- fix(server): remove org feature flag read cache ([#2780](https://github.com/everruns/everruns/pull/2780)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): validate imported attribution urls ([#2777](https://github.com/everruns/everruns/pull/2777)) by [@chaliy](https://github.com/chaliy)
+- fix(fs): keep mounted display paths host-agnostic ([#2776](https://github.com/everruns/everruns/pull/2776)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): block unsafe trace links ([#2775](https://github.com/everruns/everruns/pull/2775)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): restore endpoint feature gate ([#2774](https://github.com/everruns/everruns/pull/2774)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): pin design lint dependency ([#2773](https://github.com/everruns/everruns/pull/2773)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): reject duplicate routing headers ([#2772](https://github.com/everruns/everruns/pull/2772)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): avoid deleting reusable file blob keys ([#2771](https://github.com/everruns/everruns/pull/2771)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): scope HTTP negotiation cache ([#2770](https://github.com/everruns/everruns/pull/2770)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): bound eval run comparison inputs ([#2768](https://github.com/everruns/everruns/pull/2768)) by [@chaliy](https://github.com/chaliy)
+- fix(core): prevent host-scope symlink escapes ([#2767](https://github.com/everruns/everruns/pull/2767)) by [@chaliy](https://github.com/chaliy)
+- fix(public-chat): bind sessions to visitor identity ([#2766](https://github.com/everruns/everruns/pull/2766)) by [@chaliy](https://github.com/chaliy)
+- fix(subagents): cap background watcher concurrency ([#2765](https://github.com/everruns/everruns/pull/2765)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): reject future cron bursts ([#2764](https://github.com/everruns/everruns/pull/2764)) by [@chaliy](https://github.com/chaliy)
+- fix(bashkit): stream capped HTTP responses ([#2763](https://github.com/everruns/everruns/pull/2763)) by [@chaliy](https://github.com/chaliy)
+- fix(drivers): bound streaming reconnect first item wait ([#2762](https://github.com/everruns/everruns/pull/2762)) by [@chaliy](https://github.com/chaliy)
+- fix(core): fence subagent progress attempts ([#2761](https://github.com/everruns/everruns/pull/2761)) by [@chaliy](https://github.com/chaliy)
+- fix(subagents): gate session overrides as high risk ([#2760](https://github.com/everruns/everruns/pull/2760)) by [@chaliy](https://github.com/chaliy)
+- fix(subagents): serialize spawn admission ([#2759](https://github.com/everruns/everruns/pull/2759)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): require agent permission for agent sessions ([#2757](https://github.com/everruns/everruns/pull/2757)) by [@chaliy](https://github.com/chaliy)
+- fix(models): apply tiered cost estimates ([#2755](https://github.com/everruns/everruns/pull/2755)) by [@chaliy](https://github.com/chaliy)
+- fix(core): keep spawn_agent schema free of top-level oneOf ([#2806](https://github.com/everruns/everruns/pull/2806)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.9] - 2026-07-14
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
  "webpki-roots 1.0.8",
 ]
 
@@ -39,7 +39,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ dependencies = [
  "tower",
  "tower-http 0.6.11",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -838,7 +838,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "clap",
  "ed25519-dalek 2.2.0",
@@ -981,9 +981,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -1104,7 +1104,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 2.0.18",
 ]
 
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1301,7 +1301,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1503,7 +1503,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1755,7 +1755,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -1845,7 +1845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1916,7 +1916,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1939,7 +1939,7 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1950,7 +1950,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2010,7 +2010,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2074,7 +2074,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2087,7 +2087,7 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2153,7 +2153,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -2165,7 +2165,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.9"
+version = "0.17.10"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2717,13 +2717,13 @@ dependencies = [
  "tree-sitter-typescript",
  "url",
  "utoipa",
- "uuid 1.23.5",
+ "uuid 1.24.0",
  "wiremock",
 ]
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,12 +2743,12 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2897,12 +2897,12 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3003,12 +3003,12 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3027,12 +3027,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
 name = "everruns-local"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3050,12 +3050,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3097,13 +3097,13 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
  "wiremock",
 ]
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3138,11 +3138,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.9"
+version = "0.17.10"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3158,7 +3158,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3273,14 +3273,14 @@ dependencies = [
  "url",
  "urlencoding",
  "utoipa",
- "uuid 1.23.5",
+ "uuid 1.24.0",
  "wiremock",
  "zip",
 ]
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3292,12 +3292,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3354,7 +3354,7 @@ dependencies = [
  "tonic",
  "tracing",
  "turmoil",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -3670,7 +3670,7 @@ checksum = "1458c6e22d36d61507034d5afecc64f105c1d39712b7ac6ec3b352c423f715cc"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3762,7 +3762,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3901,7 +3901,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3915,9 +3915,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -4175,7 +4175,7 @@ dependencies = [
  "markup5ever 0.12.1",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4575,7 +4575,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4637,7 +4637,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -4694,7 +4694,7 @@ dependencies = [
  "indoc",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4829,7 +4829,7 @@ checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4874,7 +4874,7 @@ dependencies = [
  "quote 1.0.46",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4893,7 +4893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5036,7 +5036,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -5134,7 +5134,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5219,7 +5219,7 @@ dependencies = [
  "quote 1.0.46",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5233,7 +5233,7 @@ dependencies = [
  "quote 1.0.46",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5473,7 +5473,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5589,7 +5589,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -5660,7 +5660,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5673,7 +5673,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5716,7 +5716,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify",
  "kqueue",
  "libc",
@@ -5733,7 +5733,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5816,7 +5816,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5888,7 +5888,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5915,7 +5915,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -5932,7 +5932,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -5959,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -6046,7 +6046,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -6062,7 +6062,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6215,7 +6215,7 @@ dependencies = [
  "by_address",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6243,7 +6243,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6397,7 +6397,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6500,7 +6500,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6513,7 +6513,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6560,7 +6560,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6597,7 +6597,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6678,7 +6678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2 1.0.106",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6711,7 +6711,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -6738,7 +6738,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -6774,7 +6774,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -6788,7 +6788,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6909,7 +6909,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -6952,9 +6952,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -7214,7 +7214,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
@@ -7292,7 +7292,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -7312,7 +7312,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -7335,7 +7335,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -7366,7 +7366,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7388,9 +7388,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7400,9 +7400,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7645,7 +7645,7 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "rquickjs-core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7692,7 +7692,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -7702,7 +7702,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -7738,7 +7738,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -7882,7 +7882,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7916,7 +7916,7 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7988,7 +7988,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -8011,7 +8011,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more 2.1.1",
  "log",
@@ -8073,7 +8073,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8084,7 +8084,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8155,7 +8155,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8335,9 +8335,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -8548,7 +8548,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.23.5",
+ "uuid 1.24.0",
  "webpki-roots 1.0.8",
 ]
 
@@ -8562,7 +8562,7 @@ dependencies = [
  "quote 1.0.46",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8585,7 +8585,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -8597,7 +8597,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -8616,7 +8616,7 @@ dependencies = [
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -8627,7 +8627,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -8652,7 +8652,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "uuid 1.23.5",
+ "uuid 1.24.0",
  "whoami",
 ]
 
@@ -8679,7 +8679,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -8794,7 +8794,7 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "rustversion",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8806,7 +8806,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8839,9 +8839,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
@@ -8865,7 +8865,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8889,7 +8889,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8966,7 +8966,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -9002,7 +9002,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -9073,7 +9073,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9084,7 +9084,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9187,7 +9187,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9315,9 +9315,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -9379,7 +9379,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9404,7 +9404,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -9435,7 +9435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -9457,7 +9457,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "http 1.4.2",
  "http-body 1.1.0",
@@ -9500,7 +9500,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9899,8 +9899,8 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "regex",
- "syn 2.0.118",
- "uuid 1.23.5",
+ "syn 2.0.119",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -9915,9 +9915,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -10046,7 +10046,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -10186,7 +10186,7 @@ dependencies = [
  "mac_address",
  "sha2 0.10.9",
  "thiserror 1.0.69",
- "uuid 1.23.5",
+ "uuid 1.24.0",
 ]
 
 [[package]]
@@ -10240,9 +10240,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -10343,7 +10343,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10354,7 +10354,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10678,7 +10678,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -10699,7 +10699,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10719,7 +10719,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -10740,7 +10740,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10773,7 +10773,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.46",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.9"
+version = "0.17.10"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -150,11 +150,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.9" }
+everruns-core = { path = "crates/core", version = "0.17.10" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.9" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.10" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.9" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.10" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.9",
+  "version": "0.17.10",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.9", default-features = false }
+everruns-core = { path = "../core", version = "0.17.10", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.9", default-features = false }
+everruns-core = { path = "../core", version = "0.17.10", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -127,10 +127,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.9", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.10", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.9", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.10", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.9", default-features = false }
+everruns-core = { path = "../core", version = "0.17.10", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.9", default-features = false }
+everruns-core = { path = "../core", version = "0.17.10", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.9", default-features = false }
+everruns-core = { path = "../core", version = "0.17.10", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What changed

Prepares the **v0.17.10** release (patch bump from 0.17.9). All 50 commits since the 0.17.9 tag ship together: 6 features, 3 perf improvements, 40 fixes, and 1 test hardening. See `CHANGELOG.md` for the full list and highlights.

Following the project's established convention, feature-bearing regular releases are cut as **patch** bumps (0.17.7 / 0.17.8 / 0.17.9 all shipped `feat` commits as patch releases); the minor digit is reserved for larger milestones.

Highlights:
- Expanded global search coverage ([#2810](https://github.com/everruns/everruns/pull/2810))
- Resend OAuth email plugin + plugin MCP OAuth support ([#2808](https://github.com/everruns/everruns/pull/2808))
- Web-fetch adopts fetchkit 0.5 ([#2807](https://github.com/everruns/everruns/pull/2807))
- Live reasoning stream: phase hints + `reason.item` summaries ([#2804](https://github.com/everruns/everruns/pull/2804), [#2803](https://github.com/everruns/everruns/pull/2803))

## Why

Cut a new release so the accumulated fixes and features on `main` are tagged, published, and available downstream (Docker/CLI/crates/Homebrew) and to the SaaS wrapper.

## Before / After

Version-only change; no runtime behavior changes in this PR.

- **Before:** workspace version `0.17.9`
- **After:** workspace version `0.17.10` (`Cargo.toml`, `apps/ui/package.json`), new `CHANGELOG.md` section, refreshed `Cargo.lock`.

Mechanical evidence:
- `python3 scripts/sync-publish-pin-versions.py --check` → `all path-dep pins at 0.17.10`
- Migrations sequential (001..105); `just pre-push` green (fmt, clippy, lock freshness, migration ordering/immutability, test enumeration, specs index, attribution).
- Release backstop reviewed: latest **Integration Live Sweep** on `main` is green (2026-07-13).

## Risk

- Low — version/changelog/lockfile only; no source changes.
- Post-merge, the Release workflow auto-creates tag `v0.17.10`, the GitHub Release from `CHANGELOG.md`, and dispatches Docker / CLI binaries / crates.io / Homebrew tap.

## Security

- Threat categories reviewed: No security-relevant code changes — version/changelog/lockfile only.
- Findings and resolutions: None.

## Follow-ups

No follow-ups. SaaS OSS submodule will be bumped to `v0.17.10` after this merges.

## Checklist
- [x] Tests added or updated — N/A (release prep)
- [x] Backward compatibility considered — no operator-visible migration caveats
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)