### PR TITLE
perf(ui): eliminate duplicate dashboard agent-list requests

### DIFF
--- a/apps/ui/src/__tests__/dashboard-agent-requests.test.tsx
+++ b/apps/ui/src/__tests__/dashboard-agent-requests.test.tsx
@@ -1,0 +1,146 @@
+// Regression test for EVE-784: a cold dashboard load must issue each distinct
+// agent-list query exactly once, and a window focus/visibility event must not
+// immediately repeat those (still-fresh) requests.
+//
+// Root cause guarded here: org-scoped CRUD queries used to pass an explicit
+// `staleTime: undefined`, which overwrote the QueryClient default (60_000) and
+// left every agent-list query immediately stale. With `refetchOnWindowFocus`,
+// the first focus/visibilitychange after load (e.g. CDP/DevTools attaching)
+// duplicated the whole agent-list fetch pair.
+
+import { render, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { QueryClientProvider, focusManager } from "@tanstack/react-query";
+import { createAppQueryClient } from "@/lib/query-client";
+import { OrgProvider, useOrg } from "@/providers/org-provider";
+import { useAgents } from "@/hooks/use-agents";
+import type { OrganizationMembership } from "@/lib/api/types";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  usePathname: () => "/dashboard",
+}));
+
+const mockSwitchOrg = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/lib/api/users", () => ({
+  switchOrg: (...args: unknown[]) => mockSwitchOrg(...args),
+}));
+
+const ORG: OrganizationMembership = {
+  public_id: "org_00000000000000000000000000000001",
+  name: "Default Org",
+  role: "owner",
+};
+
+// Real OrgProvider is used; only the auth source is stubbed.
+jest.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: { organizations: [ORG] }, isLoading: false }),
+}));
+
+let agentCalls: string[] = [];
+
+beforeEach(() => {
+  agentCalls = [];
+  mockSwitchOrg.mockClear().mockResolvedValue(undefined);
+  jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+  jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {});
+  global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/v1/agents")) agentCalls.push(url);
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => JSON.stringify({ data: [] }),
+    } as Response;
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+// The dashboard asks for the active agent list and the archived-inclusive
+// reference list — two distinct queries that should each run once.
+function DashboardAgents() {
+  useAgents();
+  useAgents({ includeArchived: true });
+  return <div>dashboard</div>;
+}
+
+// Mirror MainLayout: children mount only after org bootstrap finishes.
+function Gate({ children }: { children: ReactNode }) {
+  const { isLoading } = useOrg();
+  return isLoading ? <div>loading</div> : <>{children}</>;
+}
+
+function renderDashboard() {
+  const client = createAppQueryClient();
+  render(<DashboardAgents />, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>
+        <OrgProvider initialOrgId={null}>
+          <Gate>{children}</Gate>
+        </OrgProvider>
+      </QueryClientProvider>
+    ),
+  });
+  return client;
+}
+
+const plainCalls = () => agentCalls.filter((u) => !u.includes("include_archived"));
+const archivedCalls = () => agentCalls.filter((u) => u.includes("include_archived"));
+
+describe("dashboard agent-list requests (EVE-784)", () => {
+  it("cold load issues each distinct agent-list query exactly once", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(plainCalls()).toHaveLength(1);
+      expect(archivedCalls()).toHaveLength(1);
+    });
+
+    // Allow any stray refetch to settle, then confirm still exactly one each.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(plainCalls()).toHaveLength(1);
+    expect(archivedCalls()).toHaveLength(1);
+  });
+
+  it("a window focus regain does not repeat the fresh agent-list requests", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(plainCalls()).toHaveLength(1);
+      expect(archivedCalls()).toHaveLength(1);
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Simulate the browser regaining focus shortly after the cold load.
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Data is fresh (60s client default), so focus must not refetch.
+    expect(plainCalls()).toHaveLength(1);
+    expect(archivedCalls()).toHaveLength(1);
+  });
+
+  it("explicit invalidation still refetches despite the fresh-data window", async () => {
+    const client = renderDashboard();
+
+    await waitFor(() => {
+      expect(plainCalls()).toHaveLength(1);
+      expect(archivedCalls()).toHaveLength(1);
+    });
+
+    // The staleTime fix must not suppress legitimate refetches: an
+    // invalidation (as fired after agent create/update/archive, or on org
+    // switch) marks queries stale regardless of staleTime and refetches.
+    await client.invalidateQueries({ queryKey: ["agents"] });
+
+    await waitFor(() => {
+      expect(plainCalls()).toHaveLength(2);
+      expect(archivedCalls()).toHaveLength(2);
+    });
+  });
+});

--- a/apps/ui/src/hooks/create-crud-hooks.ts
+++ b/apps/ui/src/hooks/create-crud-hooks.ts
@@ -42,11 +42,20 @@ export function useOrgScopedQuery<TData>({
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
+  // Only include `staleTime` when the caller specified one. React Query's
+  // `defaultQueryOptions` merges options over the client defaults by object
+  // spread, so an explicit `staleTime: undefined` key OVERWRITES the client
+  // default (`staleTime: 60_000`) with `undefined` (→ 0), marking the query
+  // immediately stale. With `refetchOnWindowFocus: true`, the first focus or
+  // visibilitychange after a cold load (fired by tab focus, or by CDP/DevTools
+  // attaching ~18 ms in) then refetches every org-scoped query, producing the
+  // duplicate dashboard agent-list request pair reported in EVE-784. Omitting
+  // the key lets the intended 60s client default apply. (EVE-784)
   const query = useQuery({
     queryKey: [...queryKey, org],
     queryFn,
     enabled: enabled && !!org,
-    staleTime,
+    ...(staleTime !== undefined ? { staleTime } : {}),
   });
 
   return {


### PR DESCRIPTION
## What changed
Org-scoped React Query hooks (agents, and every other CRUD list/detail via `useOrgScopedQuery`) now respect the app's intended 60s `staleTime` instead of being treated as immediately stale. As a result a cold dashboard load issues each distinct agent-list query exactly once, and route navigation / window focus no longer re-fire those still-fresh requests.

Root cause: `useOrgScopedQuery` always spread `staleTime` into the `useQuery` options object, even when it was `undefined`. React Query's `defaultQueryOptions` merges options over the client defaults by object spread, so an explicit `staleTime: undefined` key overwrote the client default (`staleTime: 60_000`) with `undefined` (→ 0). Every org-scoped query was therefore immediately stale, and with `refetchOnWindowFocus: true` the first focus/visibilitychange after a cold load refetched all of them. On the dashboard that meant `GET /api/v1/agents` and `GET /api/v1/agents?include_archived=true` each fired twice. The reporter's "second pair ~18ms later, same queryFn/onSubscribe initiator" matches a focus/visibility event fired right after load — notably by CDP/DevTools attaching during the very trace used to observe the bug.

Fix: only include `staleTime` in the query options when the caller actually specified one, so the client default applies. A code comment records the diagnosed trigger.

## Why
Duplicate agent-list fetches doubled the database/API work on every cold dashboard load, scaling with organization size (empty seeded responses hid it locally). EVE-784.

## Before / After
Deterministic reproduction via a production-like test (real `OrgProvider` + `useAgents`, instrumented `fetch`, focus simulated through React Query's `focusManager`):

Before (reverting only the one-line fix), on a window focus regain after cold load:
```
Received length: 2
Received array:  ["/api/v1/agents", "/api/v1/agents"]   // duplicated
```

After (fix in place):
```
cold load:        plain=1, archived=1
focus regain:     plain=1, archived=1   // no duplicate
invalidation:     plain=2, archived=2   // legitimate refetch still works

Tests: 3 passed  (dashboard-agent-requests.test.tsx)
```

Full UI suite: 1166 passed / 133 suites. `just pre-push` green. `pnpm run build` succeeds.

## Risk
- Low
- Behavioral change is limited to org-scoped CRUD queries now honoring the 60s freshness window that was always intended by the QueryClient default. Explicit `invalidateQueries` (agent create/update/archive, and the org-switch invalidate-all) bypasses `staleTime`, so legitimate refetches are unaffected — covered by a test. The `org` segment in the query key is unchanged, so org data stays isolated across switches.

## Security
- Threat categories reviewed: TM-WEB (frontend caching/refetch behavior), TM-TENANT (org data isolation).
- Findings and resolutions: None. The query key still includes the org `public_id`, so per-org cache entries remain separate; org switch invalidates all queries (invalidation ignores `staleTime`), so no other org's agent data can be displayed or reused. No auth, endpoints, inputs, or data-exposure surface touched. The change reduces request volume.

## Follow-ups
No follow-ups. The fix is in the shared `useOrgScopedQuery` helper, so all org-scoped list/detail queries (harnesses, apps, skills, evals, observers, etc.) benefit from the same correctness fix, not just agents.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01KFkPKBCM3B94V1vgwyj3uu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFkPKBCM3B94V1vgwyj3uu)_