### PR TITLE
perf(ui): avoid dashboard capability and model overfetch

### DIFF
--- a/apps/ui/src/__tests__/dashboard-catalog-requests.test.tsx
+++ b/apps/ui/src/__tests__/dashboard-catalog-requests.test.tsx
@@ -1,0 +1,214 @@
+// Regression test for EVE-783: the dashboard must not overfetch the capability
+// and model catalogs when the rendered state cannot display them.
+//
+// Root cause guarded here: the dashboard called useCapabilities() and
+// useModels() unconditionally, so an empty org downloaded ~228 KB of
+// capabilities and ~78 KB of models that nothing could render. The fix gates
+// each catalog query on the data that actually consumes it:
+//   - capabilities: enabled only when a displayed active agent references one
+//   - models: enabled only when a recent session references a model
+//
+// These tests render the real dashboard page against a fetch stub and assert
+// the exact catalog request set for empty, agents-only, sessions-only, and
+// populated dashboards.
+
+import { render, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createAppQueryClient } from "@/lib/query-client";
+import { OrgProvider, useOrg } from "@/providers/org-provider";
+import DashboardPage from "@/app/(main)/dashboard/page";
+import type { OrganizationMembership } from "@/lib/api/types";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  usePathname: () => "/dashboard",
+}));
+
+const mockSwitchOrg = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/lib/api/users", () => ({
+  switchOrg: (...args: unknown[]) => mockSwitchOrg(...args),
+}));
+
+const ORG: OrganizationMembership = {
+  public_id: "org_00000000000000000000000000000001",
+  name: "Default Org",
+  role: "owner",
+};
+
+// Real OrgProvider is used; only the auth source is stubbed.
+jest.mock("@/providers/auth-provider", () => ({
+  useAuth: () => ({ user: { organizations: [ORG] }, isLoading: false }),
+}));
+
+type Dataset = {
+  agents: unknown[];
+  sessions: unknown[];
+};
+
+let requested: string[] = [];
+let dataset: Dataset = { agents: [], sessions: [] };
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+beforeEach(() => {
+  requested = [];
+  dataset = { agents: [], sessions: [] };
+  mockSwitchOrg.mockClear().mockResolvedValue(undefined);
+  jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+  jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {});
+
+  global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    requested.push(url);
+
+    // Order matters: check the more specific paths first.
+    if (url.includes("/v1/capabilities")) return jsonResponse({ data: [] });
+    if (url.includes("/v1/models")) return jsonResponse({ data: [] });
+    if (url.includes("/v1/sessions/stats")) {
+      return jsonResponse({ total: dataset.sessions.length, active: 0, idle: 0 });
+    }
+    if (url.includes("/v1/sessions")) {
+      return jsonResponse({
+        data: dataset.sessions,
+        total: dataset.sessions.length,
+        offset: 0,
+        limit: 5,
+      });
+    }
+    if (url.includes("/v1/agents")) return jsonResponse({ data: dataset.agents });
+    return jsonResponse({ data: [] });
+  }) as unknown as typeof fetch;
+});
+
+// Mirror MainLayout: children mount only after org bootstrap finishes.
+function Gate({ children }: { children: ReactNode }) {
+  const { isLoading } = useOrg();
+  return isLoading ? <div>loading</div> : <>{children}</>;
+}
+
+function renderDashboard() {
+  const client = createAppQueryClient();
+  render(<DashboardPage />, {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>
+        <OrgProvider initialOrgId={null}>
+          <Gate>{children}</Gate>
+        </OrgProvider>
+      </QueryClientProvider>
+    ),
+  });
+  return client;
+}
+
+const capabilityCalls = () => requested.filter((u) => u.includes("/v1/capabilities"));
+const modelCalls = () => requested.filter((u) => u.includes("/v1/models"));
+const agentCalls = () => requested.filter((u) => u.includes("/v1/agents"));
+
+async function waitForAgentsLoaded() {
+  // The dashboard always fetches the agent lists; once they land the gating
+  // logic has run against real data.
+  await waitFor(() => expect(agentCalls().length).toBeGreaterThanOrEqual(2));
+  // Let any gated catalog query fire and settle.
+  await new Promise((r) => setTimeout(r, 60));
+}
+
+const agentWithCapability = {
+  id: "agent_1",
+  name: "Cap Agent",
+  status: "active",
+  capabilities: [{ ref: "cap_1" }],
+};
+
+const agentWithoutCapability = {
+  id: "agent_2",
+  name: "Plain Agent",
+  status: "active",
+  capabilities: [],
+};
+
+const sessionWithModel = {
+  id: "session_1",
+  status: "idle",
+  model_id: "model_1",
+  created_at: "2024-01-01T00:00:00Z",
+  usage: { input_tokens: 0, output_tokens: 0 },
+};
+
+const sessionWithoutModel = {
+  id: "session_2",
+  status: "idle",
+  model_id: null,
+  created_at: "2024-01-01T00:00:00Z",
+  usage: { input_tokens: 0, output_tokens: 0 },
+};
+
+describe("dashboard catalog requests (EVE-783)", () => {
+  it("empty dashboard requests neither capabilities nor models", async () => {
+    dataset = { agents: [], sessions: [] };
+    renderDashboard();
+    await waitForAgentsLoaded();
+
+    expect(capabilityCalls()).toHaveLength(0);
+    expect(modelCalls()).toHaveLength(0);
+  });
+
+  it("agents-only with a capability reference fetches capabilities once, no models", async () => {
+    dataset = { agents: [agentWithCapability], sessions: [] };
+    renderDashboard();
+    await waitForAgentsLoaded();
+
+    await waitFor(() => expect(capabilityCalls()).toHaveLength(1));
+    expect(modelCalls()).toHaveLength(0);
+  });
+
+  it("agents without capability references do not fetch the capability catalog", async () => {
+    dataset = { agents: [agentWithoutCapability], sessions: [] };
+    renderDashboard();
+    await waitForAgentsLoaded();
+
+    expect(capabilityCalls()).toHaveLength(0);
+    expect(modelCalls()).toHaveLength(0);
+  });
+
+  it("sessions-only with a model reference fetches models once, no capabilities", async () => {
+    dataset = { agents: [], sessions: [sessionWithModel] };
+    renderDashboard();
+    await waitForAgentsLoaded();
+
+    await waitFor(() => expect(modelCalls()).toHaveLength(1));
+    expect(capabilityCalls()).toHaveLength(0);
+  });
+
+  it("sessions without model references do not fetch the model catalog", async () => {
+    dataset = { agents: [], sessions: [sessionWithoutModel] };
+    renderDashboard();
+    await waitForAgentsLoaded();
+
+    expect(modelCalls()).toHaveLength(0);
+    expect(capabilityCalls()).toHaveLength(0);
+  });
+
+  it("populated dashboard fetches each catalog exactly once", async () => {
+    dataset = { agents: [agentWithCapability], sessions: [sessionWithModel] };
+    renderDashboard();
+    await waitForAgentsLoaded();
+
+    await waitFor(() => {
+      expect(capabilityCalls()).toHaveLength(1);
+      expect(modelCalls()).toHaveLength(1);
+    });
+
+    // Allow any stray refetch to settle, then confirm still exactly one each.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(capabilityCalls()).toHaveLength(1);
+    expect(modelCalls()).toHaveLength(1);
+  });
+});

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import { StatsCards } from "@/components/dashboard/stats-cards";
-import { AgentListWidget } from "@/components/dashboard/agent-list-widget";
+import { AgentListWidget, MAX_DISPLAYED_AGENTS } from "@/components/dashboard/agent-list-widget";
 import { RecentSessions } from "@/components/dashboard/recent-sessions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -35,12 +35,26 @@ export default function DashboardPage() {
   const router = useRouter();
   const { data: agents = [], isLoading: agentsLoading } = useAgents();
   const { data: agentsForReferences = [] } = useAgents({ includeArchived: true });
-  const { data: allCapabilities } = useCapabilities();
   const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(undefined, {
     limit: 5,
   });
   const { data: sessionStats } = useSessionStats();
-  const { data: models } = useModels();
+
+  const sessions = sessionsResponse?.data ?? [];
+
+  // Defer the catalog fetches until the rendered dashboard state actually needs
+  // them. On an empty org there are no capability-bearing agents and no
+  // model-bearing sessions, so both large catalogs (~228 KB + ~78 KB) are pure
+  // overfetch. The `enabled` gates flip on once the agent/session lists load
+  // with content that references those catalogs. See EVE-783.
+  const needsCapabilities = agents
+    .filter((a) => a.status === "active")
+    .slice(0, MAX_DISPLAYED_AGENTS)
+    .some((a) => (a.capabilities?.length ?? 0) > 0);
+  const needsModels = sessions.some((s) => !!s.model_id);
+
+  const { data: allCapabilities } = useCapabilities({ enabled: needsCapabilities });
+  const { data: models } = useModels({ enabled: needsModels });
   const createSession = useCreateSession();
 
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
@@ -101,8 +115,6 @@ export default function DashboardPage() {
       </PageContainer>
     );
   }
-
-  const sessions = sessionsResponse?.data ?? [];
 
   return (
     <>

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -18,11 +18,13 @@ interface AgentListWidgetProps {
   allCapabilities?: Capability[];
 }
 
-const MAX_DISPLAYED = 5;
+// Number of active agents rendered in the widget. Exported so the dashboard can
+// gate the capability-catalog fetch on exactly the agents it will display.
+export const MAX_DISPLAYED_AGENTS = 5;
 
 export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProps) {
   const { locale } = useLocale();
-  const activeAgents = agents.filter((a) => a.status === "active").slice(0, MAX_DISPLAYED);
+  const activeAgents = agents.filter((a) => a.status === "active").slice(0, MAX_DISPLAYED_AGENTS);
 
   const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);

--- a/apps/ui/src/hooks/use-providers.ts
+++ b/apps/ui/src/hooks/use-providers.ts
@@ -131,14 +131,14 @@ export function useSyncProviderModels() {
 }
 
 // Model hooks
-export function useModels() {
+export function useModels(options: { enabled?: boolean } = {}) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
     queryKey: [...queryKeys.models.list(), org],
     queryFn: () => getModels(),
-    enabled: !!org,
+    enabled: !!org && (options.enabled ?? true),
     staleTime: 30000,
   });
 


### PR DESCRIPTION
## What changed

The dashboard no longer fetches the capability and model catalogs when the rendered state cannot display them. Both `useCapabilities()` and `useModels()` were called unconditionally on every dashboard load; they are now gated on the data that actually consumes them:

- **Capabilities** load only when a displayed active agent references at least one capability (the catalog only decorates agent cards with capability icons/labels).
- **Models** load only when a recent session references a model (`model_id`); the catalog only renders the model name on recent-session rows.

`useModels()` gained an `{ enabled }` option (mirroring the existing `useCapabilities({ enabled })`) so callers can defer it. `MAX_DISPLAYED_AGENTS` is exported from the agent-list widget so the gate keys on exactly the agents the widget renders.

## Why

In an empty organization neither catalog can contribute visible content, yet together they dominated the cold-load payload (measured in the issue): `GET /api/v1/capabilities` ~228 KB and `GET /api/v1/models` ~78 KB, ~306 KB combined — about 40% of the ~760 KB dashboard transfer — downloaded and parsed for nothing, hurting LCP for remote users. Fixes EVE-783.

## Before / After

Cold dashboard load, request set for the two catalogs (from the new regression test that renders the real dashboard page against a fetch stub):

| Dashboard state | `/v1/capabilities` | `/v1/models` |
| --- | --- | --- |
| Empty org (no agents, no sessions) — **before** | 1 request (~228 KB) | 1 request (~78 KB) |
| Empty org (no agents, no sessions) — **after** | **0** | **0** |
| Agents with a capability ref, no sessions | 1 | 0 |
| Agents without capability refs | 0 | 0 |
| Sessions with a model ref, no agents | 0 | 1 |
| Sessions without model refs | 0 | 0 |
| Populated (both) | 1 | 1 |

Empty-org cold load drops ~306 KB / 2 requests. Populated dashboards still fetch each catalog exactly once and render agent capability icons and recent-session model names unchanged.

## Risk

- Low
- Deferring the catalogs introduces a small dependent fetch on populated dashboards (agents/sessions load, then the catalog). Impact is negligible: capabilities only add small inline icons and models only add a text label, so there is no meaningful layout shift / CLS or navigation-readiness regression. Loading/error states are already handled by the widgets (missing catalog entry renders nothing until data arrives), and org scoping on both queries is unchanged.

## Security

- Threat categories reviewed: **TM-WEB** (frontend data fetching) and **TM-TENANT** (org scoping). The change only reduces what the client fetches; both queries keep their existing `enabled: !!org` org guard, so tenant scoping is preserved. No new endpoints, inputs, auth, or rendering of untrusted data. No injection/exposure surface added.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. The issue also mentioned a browser-level request-budget assertion for the empty state; the added Jest test renders the real dashboard page and asserts the exact empty-state catalog request set (0/0), which covers that intent at the component-integration level without a full browser harness.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)