### PR TITLE
perf(ui): stop automatic /agents/new prefetch on dashboard startup

### DIFF
--- a/apps/ui/e2e/navigation-prefetch.spec.ts
+++ b/apps/ui/e2e/navigation-prefetch.spec.ts
@@ -125,6 +125,33 @@ test.describe("Sidebar navigation prefetch", () => {
     expect(unrelatedApiRequests.map((request) => new URL(request.url()).pathname)).toEqual([]);
   });
 
+  test("Dashboard startup does not prefetch the agent-creation route", async ({ page }) => {
+    // EVE-785: the empty dashboard shows three links to /agents/new. They must
+    // not eagerly prefetch the agent-creation RSC payload on startup — only on
+    // hover/focus intent or navigation.
+    const agentsNewRscRequests: Request[] = [];
+    page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname;
+      if (isRscRequest(request) && pathname === "/agents/new") {
+        agentsNewRscRequests.push(request);
+      }
+    });
+
+    await page.goto("/dashboard");
+    await expect(page.getByRole("link", { name: "Create your first agent" })).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    expect(agentsNewRscRequests).toHaveLength(0);
+  });
+
+  test("Create-agent link still navigates to /agents/new on click", async ({ page }) => {
+    await page.goto("/dashboard");
+    const createLink = page.getByRole("link", { name: "Create your first agent" });
+    await expect(createLink).toBeVisible();
+    await createLink.click();
+    await expect(page).toHaveURL(/\/agents\/new$/);
+  });
+
   test("sidebar click navigation works without broad route prefetch", async ({ page }) => {
     await page.goto("/dashboard");
     await expect(page.getByRole("link", { name: "Sessions" })).toBeVisible();

--- a/apps/ui/src/__tests__/dashboard-new-agent-prefetch.test.tsx
+++ b/apps/ui/src/__tests__/dashboard-new-agent-prefetch.test.tsx
@@ -1,0 +1,89 @@
+// Regression test for EVE-785: the empty dashboard renders three links to
+// `/agents/new` (Active Agents header, empty state, Quick Actions). With
+// Next.js default viewport prefetch these eagerly fetched the agent-creation
+// RSC payload on a cold production load, before any user intent. The links must
+// disable automatic prefetch and prefetch only on hover/focus intent — the same
+// policy EVE-780 applied to the sidebar — while still navigating on click.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AgentListWidget } from "@/components/dashboard/agent-list-widget";
+import { NewAgentLink } from "@/components/dashboard/new-agent-link";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    prefetch,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { prefetch?: boolean }) => (
+    <a {...props} data-prefetch={prefetch === undefined ? undefined : String(prefetch)}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockPrefetch = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    prefetch: mockPrefetch,
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+jest.mock("@/providers/locale-provider", () => ({
+  useLocale: () => ({ locale: "en" }),
+}));
+
+beforeEach(() => {
+  mockPrefetch.mockClear();
+});
+
+describe("dashboard /agents/new prefetch (EVE-785)", () => {
+  it("empty widget links to /agents/new with automatic prefetch disabled", () => {
+    render(<AgentListWidget agents={[]} />);
+
+    const links = screen
+      .getAllByRole("link")
+      .filter((link) => link.getAttribute("href") === "/agents/new");
+
+    // Active Agents header + empty-state call-to-action.
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute("data-prefetch", "false");
+    }
+  });
+
+  it("does not prefetch /agents/new on mount, only on hover/focus intent", () => {
+    render(<AgentListWidget agents={[]} />);
+
+    // No automatic prefetch fires from rendering the links.
+    expect(mockPrefetch).not.toHaveBeenCalled();
+
+    const link = screen
+      .getAllByRole("link")
+      .find((el) => el.getAttribute("href") === "/agents/new")!;
+
+    fireEvent.mouseEnter(link);
+    expect(mockPrefetch).toHaveBeenCalledWith("/agents/new");
+
+    mockPrefetch.mockClear();
+    fireEvent.focus(link);
+    expect(mockPrefetch).toHaveBeenCalledWith("/agents/new");
+
+    // The intent prefetch only ever targets the single agent-creation route,
+    // so repeated links never fan out to other destinations.
+    for (const call of mockPrefetch.mock.calls) {
+      expect(call).toEqual(["/agents/new"]);
+    }
+  });
+
+  it("NewAgentLink preserves click navigation to /agents/new", () => {
+    render(<NewAgentLink>Create</NewAgentLink>);
+
+    const link = screen.getByRole("link", { name: "Create" });
+    expect(link).toHaveAttribute("href", "/agents/new");
+    expect(link).toHaveAttribute("data-prefetch", "false");
+  });
+});

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -25,7 +25,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { AgentSelect } from "@/components/agent/agent-select";
-import Link from "next/link";
+import { NewAgentLink } from "@/components/dashboard/new-agent-link";
 import { Button } from "@/components/ui/button";
 import { Plus, LayoutDashboard } from "lucide-react";
 import { PageContainer, PageMasthead } from "@/components/layout";
@@ -139,12 +139,12 @@ export default function DashboardPage() {
                   New Session
                 </Button>
               )}
-              <Link href="/agents/new" className="block">
+              <NewAgentLink className="block">
                 <Button variant="outline" className="w-full justify-start">
                   <Plus className="h-4 w-4 mr-2" />
                   New Agent
                 </Button>
-              </Link>
+              </NewAgentLink>
             </CardContent>
           </Card>
         </div>

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { NewAgentLink } from "@/components/dashboard/new-agent-link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
@@ -33,21 +34,21 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>Active Agents</CardTitle>
-        <Link href="/agents/new">
+        <NewAgentLink>
           <Button variant="accent" size="sm">
             <Plus className="icon-sharp mr-1 h-4 w-4" />
             New Agent
           </Button>
-        </Link>
+        </NewAgentLink>
       </CardHeader>
       <CardContent>
         {activeAgents.length === 0 ? (
           <div className="text-center py-8">
             <Boxes className="icon-sharp mx-auto mb-2 h-12 w-12 text-muted-foreground" />
             <p className="text-muted-foreground">No agents yet.</p>
-            <Link href="/agents/new">
+            <NewAgentLink>
               <Button variant="link">Create your first agent</Button>
-            </Link>
+            </NewAgentLink>
           </div>
         ) : (
           <div className="space-y-3">

--- a/apps/ui/src/components/dashboard/new-agent-link.tsx
+++ b/apps/ui/src/components/dashboard/new-agent-link.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { ComponentProps, ReactNode } from "react";
+
+/**
+ * EVE-785: The empty dashboard renders three links to `/agents/new` (Active
+ * Agents header, empty state, Quick Actions). With Next.js default (viewport)
+ * prefetch, a cold production load eagerly fetched the agent-creation RSC
+ * payload before any user intent. Mirror the EVE-780 sidebar policy: disable
+ * automatic prefetch and prefetch once on hover/focus intent instead. Next.js
+ * dedupes `router.prefetch` per route, so repeated links never duplicate work.
+ */
+const NEW_AGENT_HREF = "/agents/new";
+
+type NewAgentLinkProps = Omit<ComponentProps<typeof Link>, "href" | "prefetch"> & {
+  children: ReactNode;
+};
+
+export function NewAgentLink({ children, onMouseEnter, onFocus, ...rest }: NewAgentLinkProps) {
+  const router = useRouter();
+
+  return (
+    <Link
+      href={NEW_AGENT_HREF}
+      prefetch={false}
+      onMouseEnter={(event) => {
+        router.prefetch(NEW_AGENT_HREF);
+        onMouseEnter?.(event);
+      }}
+      onFocus={(event) => {
+        router.prefetch(NEW_AGENT_HREF);
+        onFocus?.(event);
+      }}
+      {...rest}
+    >
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## What changed
The empty dashboard renders three links to `/agents/new` (Active Agents header, empty-state CTA, Quick Actions). They no longer eagerly prefetch the agent-creation route on startup. Instead they prefetch once on hover/focus intent — the same policy EVE-780 applied to the sidebar. Clicking any of the three entry points still navigates to `/agents/new` unchanged.

A shared `NewAgentLink` component encapsulates the behavior (`prefetch={false}` + `router.prefetch("/agents/new")` on `onMouseEnter`/`onFocus`), so all three links share one tested unit and the repeated links cannot fan out or duplicate work.

## Why
With Next.js default (viewport) prefetch, a cold **production** dashboard load fetched the agent-creation RSC payload twice before any user intent. The byte impact is small (~1.6 KB) but it violates the intended request-budget policy and grows as the destination changes. This is the dashboard-local counterpart to the sidebar prefetch fan-out fixed in EVE-780.

Note: Next.js only performs automatic `<Link>` prefetch in production builds, which is why this was observed on cold production loads and why the existing `next dev`-based e2e harness did not catch it.

## Before / After
Measured against a local **production build** (`next build` + `next start`) with the e2e request recorder, loading `/dashboard` (empty org) and waiting for network idle:

**Before** (origin/main):
```
Dashboard startup does not prefetch the agent-creation route
  Expected length: 0
  Received length: 2      <- two /agents/new?_rsc=... requests
```
Matches the issue report exactly (two `/agents/new` RSC requests on cold startup).

**After** (this branch):
```
✓ Dashboard startup does not prefetch the agent-creation route (0 requests)
✓ Create-agent link still navigates to /agents/new on click
```

Click-navigation timing: no regression — the click still triggers `router.prefetch` + navigation (intent prefetch fires slightly earlier now, on hover/focus). Keyboard focus and accessible names are unchanged (the anchor still wraps the same button/label).

Local validation: `pnpm run lint`, `pnpm run typecheck`, `pnpm test` (1176 passed incl. the new regression suite), `pnpm run build` all green. EVE-780 sidebar tests and expectations are untouched and still pass.

## Risk
- Low
- Only the three dashboard create-agent links change. If `router.prefetch` were unavailable navigation still works (the `Link` `href` is unchanged); worst case is losing intent prefetch, not broken navigation.

## Security
- Threat categories reviewed: TM-WEB. Frontend-only change to Next.js Link prefetch behavior. No auth, authz, data queries, endpoints, or user-controlled input involved — `router.prefetch` targets a single hardcoded static route (`/agents/new`). No new threat surface; the change reduces outbound requests.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. (The empty widget's `View all agents →` link to `/agents` still uses default prefetch, but that is out of scope for this issue and not part of the reported `/agents/new` regression.)

## Checklist
- [x] Tests added or updated (jsdom regression `dashboard-new-agent-prefetch.test.tsx` + e2e request-count case in `navigation-prefetch.spec.ts`)
- [x] Backward compatibility considered (internal UI; navigation behavior preserved)
- [x] Security review performed against relevant threat model categories (TM-WEB)
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFkPKBCM3B94V1vgwyj3uu)_