### PR TITLE
chore(release): prepare v0.17.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.11] - 2026-07-16
+
+### What's Changed
+
+- feat(core): MountFs display policy seam for host-native paths ([#2816](https://github.com/everruns/everruns/pull/2816)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): run workflow tests against real gRPC control-plane ([#2799](https://github.com/everruns/everruns/pull/2799)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.10] - 2026-07-16
 
 ### Highlights
@@ -70,6 +77,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(sessions): require agent permission for agent sessions ([#2757](https://github.com/everruns/everruns/pull/2757)) by [@chaliy](https://github.com/chaliy)
 - fix(models): apply tiered cost estimates ([#2755](https://github.com/everruns/everruns/pull/2755)) by [@chaliy](https://github.com/chaliy)
 - fix(core): keep spawn_agent schema free of top-level oneOf ([#2806](https://github.com/everruns/everruns/pull/2806)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve workspace display paths ([#2779](https://github.com/everruns/everruns/pull/2779)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): harden recovery endpoint timing ([#2769](https://github.com/everruns/everruns/pull/2769)) by [@chaliy](https://github.com/chaliy)
+- perf(ui): avoid dashboard capability and model overfetch ([#2814](https://github.com/everruns/everruns/pull/2814)) by [@chaliy](https://github.com/chaliy)
+- perf(ui): eliminate duplicate dashboard agent-list requests ([#2813](https://github.com/everruns/everruns/pull/2813)) by [@chaliy](https://github.com/chaliy)
+- perf(ui): stop automatic /agents/new prefetch on dashboard startup ([#2815](https://github.com/everruns/everruns/pull/2815)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.17.9] - 2026-07-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,9 +1210,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.10"
+version = "0.17.11"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-ard"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3138,11 +3138,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.10"
+version = "0.17.11"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.10"
+version = "0.17.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8026,9 +8026,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -9164,9 +9164,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.10"
+version = "0.17.11"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -150,11 +150,11 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.10" }
+everruns-core = { path = "crates/core", version = "0.17.11" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.10" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.11" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.10" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.11" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.10", default-features = false }
+everruns-core = { path = "../core", version = "0.17.11", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.10", default-features = false }
+everruns-core = { path = "../core", version = "0.17.11", default-features = false }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -127,10 +127,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.10", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.11", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.10", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.11", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.10", default-features = false }
+everruns-core = { path = "../core", version = "0.17.11", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -46,7 +46,7 @@ inventory.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-core = { path = "../core", version = "0.17.10", default-features = false }
+everruns-core = { path = "../core", version = "0.17.11", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-core = { path = "../core", version = "0.17.10", default-features = false }
+everruns-core = { path = "../core", version = "0.17.11", default-features = false }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures


### PR DESCRIPTION
## What changed

Prepares the **v0.17.11** patch release. Two commits landed on `main` since v0.17.10:

- feat(core): MountFs display policy seam for host-native paths ([#2816](https://github.com/everruns/everruns/pull/2816))
- fix(ci): run workflow tests against real gRPC control-plane ([#2799](https://github.com/everruns/everruns/pull/2799))

Also **backfills the v0.17.10 CHANGELOG section** with five commits that merged during the v0.17.10 release PR's CI window and landed inside the v0.17.10 tree, but were not itemized in its notes: #2779, #2769, #2814, #2813, #2815. They belong to 0.17.10 (they are ancestors of the tag), so they are documented there rather than under 0.17.11.

## Why

Cut a patch release for the new `main` commits, and correct the 0.17.10 changelog so every released commit is accounted for.

## Before / After

Version-only change; no runtime behavior changes in this PR.

- **Before:** workspace version `0.17.10`
- **After:** workspace version `0.17.11` (`Cargo.toml`, `apps/ui/package.json`), new `CHANGELOG.md` section + 0.17.10 backfill, refreshed `Cargo.lock`.

Mechanical evidence:
- `python3 scripts/sync-publish-pin-versions.py --check` → `all path-dep pins at 0.17.11`
- Migrations sequential (001..105); `just pre-push` green (fmt, clippy, lock freshness, migration ordering/immutability, test enumeration, specs index, attribution).

## Risk

- Low — version/changelog/lockfile only; no source changes.
- Post-merge, the Release workflow auto-creates tag `v0.17.11`, the GitHub Release from `CHANGELOG.md`, and dispatches Docker / CLI binaries / crates.io / Homebrew tap.

## Security

- Threat categories reviewed: No security-relevant code changes — version/changelog/lockfile only.
- Findings and resolutions: None.

## Follow-ups

No follow-ups. SaaS adoption of v0.17.11 is intentionally skipped for this release.

## Checklist
- [x] Tests added or updated — N/A (release prep)
- [x] Backward compatibility considered — no operator-visible migration caveats
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
