### PR TITLE
fix(core): keep embedder display policy in system-prompt file store

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -2825,6 +2825,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn system_prompt_backend_native_store_shows_host_root() {
+        // #258 end-to-end: a local embedder whose MountFs opted into
+        // backend-native display, wrapped by the same `scoped_prompt_file_store`
+        // helper the reason/executor paths use, must surface real host paths in
+        // the model-facing system prompt — not the `/workspace` alias.
+        let cap = FileSystemCapability;
+        let backend = Arc::new(MockFileStore::with_display_root("/host/repo"));
+        let embedder_store: Arc<dyn SessionFileSystem> =
+            Arc::new(crate::mount_fs::MountFs::new(backend).with_backend_display());
+        let prompt_store = crate::mount_fs::scoped_prompt_file_store(
+            embedder_store,
+            crate::typed_id::WorkspaceId::from_seed(7),
+        );
+        let ctx = SystemPromptContext {
+            session_id: SessionId::new(),
+            locale: None,
+            file_store: Some(prompt_store),
+            model: None,
+        };
+
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+
+        assert!(
+            prompt.contains("Workspace root: `/host/repo`"),
+            "system prompt should present the host root: {prompt}"
+        );
+        assert!(!prompt.contains("Workspace root: `/workspace`"));
+    }
+
+    #[tokio::test]
     async fn system_prompt_escapes_store_display_root_xml_text() {
         let cap = FileSystemCapability;
         let store = Arc::new(MockFileStore::with_display_root(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -221,7 +221,7 @@ pub use message_filter::{
     MessageFilterProvider, MessageQuery, PrependTransform,
 };
 pub use message_retriever::{InputMessage, MessageRetriever};
-pub use mount_fs::{DisplayPolicy, MountFs, WORKSPACE_MOUNT};
+pub use mount_fs::{DisplayPolicy, MountFs, WORKSPACE_MOUNT, scoped_prompt_file_store};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
 pub use runtime_context::{
     AssembledTurnContext, ResolvedRuntimeCapabilities, assemble_turn_context, inspect_turn_context,

--- a/crates/core/src/mount_fs.rs
+++ b/crates/core/src/mount_fs.rs
@@ -338,6 +338,41 @@ impl ResolvedMount {
     }
 }
 
+/// Wrap an embedder's file store for a model-facing [`SystemPromptContext`]:
+/// pin reads to the session's workspace, then guarantee a `/workspace` mount +
+/// cwd — WITHOUT discarding a display policy the embedder already configured.
+///
+/// This is the single, shared way the reason path
+/// ([`crate::runtime_context::assemble_turn_context`]) and the executor path
+/// (`everruns_runtime`'s `load_execution_capabilities`) build their prompt
+/// file store. Both used to inline `MountFs::wrap(WorkspaceScopedFileSystem::…)`
+/// separately; they drifted from the tool-execution (`act`) path — which wraps
+/// with [`MountFs::wrap_if_needed`] — so a local embedder's real host paths
+/// reached tool narration but were forced back to `/workspace` in the system
+/// prompt. Centralizing here keeps all three paths identical so presentation
+/// cannot drift again.
+///
+/// Why `wrap_if_needed` (not `wrap`): if `file_store` is already a [`MountFs`]
+/// (a local embedder that opted into [`DisplayPolicy::BackendNative`] via
+/// [`MountFs::with_backend_display`]), re-wrapping would bury it under a fresh
+/// default-`WorkspaceAlias` resolver and re-hide the host path — regressing
+/// EVE-660 / #258 host-path presentation. `wrap_if_needed` preserves the
+/// embedder's resolver (and its policy), and also avoids collapsing multi-root
+/// named mounts (see [`MountFs::wrap_if_needed`]).
+///
+/// Multi-tenant/server stores are unaffected: they are not mount resolvers, so
+/// they still get wrapped into the default `/workspace` alias, keeping host
+/// paths out of model-visible output (#2776, threat model TM-FS).
+pub fn scoped_prompt_file_store(
+    file_store: Arc<dyn SessionFileSystem>,
+    workspace_id: crate::typed_id::WorkspaceId,
+) -> Arc<dyn SessionFileSystem> {
+    MountFs::wrap_if_needed(crate::traits::WorkspaceScopedFileSystem::wrap(
+        file_store,
+        workspace_id,
+    ))
+}
+
 /// Normalize an input into an absolute virtual path: join cwd if relative, then
 /// collapse `.`/`..` segments (a leading `..` is clamped at root).
 fn normalize_virtual(input: &str, cwd: &str) -> String {
@@ -971,6 +1006,55 @@ mod tests {
         assert_eq!(
             fs.resolve_path("/workspace/src/lib.rs"),
             "/host/root/src/lib.rs"
+        );
+    }
+
+    #[test]
+    fn scoped_prompt_file_store_preserves_backend_native_policy() {
+        // The regression guard for #258: when the embedder hands in a MountFs
+        // that already opted into backend-native display, the shared prompt-store
+        // wrapper must NOT bury it under a fresh `/workspace`-alias resolver.
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore {
+            host_root: Some("/host/root".to_string()),
+            ..Default::default()
+        });
+        let embedder_store: Arc<dyn SessionFileSystem> =
+            Arc::new(MountFs::new(backend).with_backend_display());
+
+        let prompt_store =
+            scoped_prompt_file_store(embedder_store, crate::typed_id::WorkspaceId::from_seed(1));
+
+        // Host path survives all the way to what the system prompt would render.
+        assert_eq!(prompt_store.display_root(), "/host/root");
+        assert_eq!(
+            prompt_store.display_path("/src/lib.rs"),
+            "/host/root/src/lib.rs"
+        );
+        // Routing is unchanged: /workspace still resolves to the backend.
+        assert_eq!(
+            prompt_store.resolve_path("/workspace/src/lib.rs"),
+            "/host/root/src/lib.rs"
+        );
+    }
+
+    #[test]
+    fn scoped_prompt_file_store_defaults_plain_backend_to_workspace_alias() {
+        // A multi-tenant/server store is not a mount resolver, so the wrapper
+        // still mounts it under the host-agnostic `/workspace` alias — host paths
+        // must never leak into model-visible output (#2776, TM-FS).
+        let backend: Arc<dyn SessionFileSystem> = Arc::new(FlatStore {
+            host_root: Some("/host/root".to_string()),
+            ..Default::default()
+        });
+
+        let prompt_store =
+            scoped_prompt_file_store(backend, crate::typed_id::WorkspaceId::from_seed(2));
+
+        assert_eq!(prompt_store.display_root(), WORKSPACE_MOUNT);
+        assert!(
+            !prompt_store
+                .display_path("/src/lib.rs")
+                .contains("/host/root")
         );
     }
 

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -216,13 +216,12 @@ async fn assemble_turn_context_with_mode(
     // workspace so an attached shared workspace's instructions are used. For the
     // default 1:1 session this is a transparent pass-through. Then resolve model
     // paths through the mount resolver (EVE-660): `/workspace` is a mount + cwd,
-    // not a per-store prefix.
-    let file_store = file_store.map(|fs| {
-        crate::mount_fs::MountFs::wrap(crate::traits::WorkspaceScopedFileSystem::wrap(
-            fs,
-            session.workspace_id,
-        ))
-    });
+    // not a per-store prefix. `scoped_prompt_file_store` wraps with
+    // `wrap_if_needed`, so a local embedder's backend-native display policy
+    // survives into the system prompt (see its doc); server stores stay on the
+    // `/workspace` alias.
+    let file_store =
+        file_store.map(|fs| crate::mount_fs::scoped_prompt_file_store(fs, session.workspace_id));
     // The resolved model is known here, so model-adaptive capabilities (e.g.
     // `auto_tool_search`) can pick the right mechanism during collection in
     // `build_runtime_agent` below.

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -474,11 +474,12 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         // Pin system-prompt file reads to the session's workspace (the default
         // 1:1 case is a transparent pass-through), then resolve through the
         // mount resolver (EVE-660): `/workspace` is a mount + cwd.
-        file_store: Some(everruns_core::MountFs::wrap(
-            everruns_core::WorkspaceScopedFileSystem::wrap(
-                adapter.file_store(),
-                session.workspace_id,
-            ),
+        // `scoped_prompt_file_store` wraps with `wrap_if_needed` so a local
+        // embedder's backend-native display policy survives here too (it must
+        // match the reason path — see its doc); server stores stay on `/workspace`.
+        file_store: Some(everruns_core::scoped_prompt_file_store(
+            adapter.file_store(),
+            session.workspace_id,
         )),
         model: None,
     };


### PR DESCRIPTION
## What changed
Local single-user embedders (e.g. the yolop coding CLI) can once again present real host filesystem paths to the model. Previously, even when an embedder opted its `MountFs` into `DisplayPolicy::BackendNative`, the model-facing **system prompt** still described the workspace as `/workspace` — while tool narration and the shell showed the real checkout path. This restores one consistent path identity across the system prompt, tool narration, and shell.

Multi-tenant/server sessions are unchanged: they keep the host-agnostic `/workspace` alias.

## Why
`DisplayPolicy::BackendNative` (#2816) let an embedder opt into backend-native display, but only the tool-execution (`act`) path honored it — it wraps the store with `MountFs::wrap_if_needed`. The reason path (`assemble_turn_context`) and executor path (`load_execution_capabilities`) wrapped with `MountFs::wrap`, which builds a *fresh* `WorkspaceAlias` resolver on top of the embedder's store and forces `/workspace` back into the system prompt. So #2816 was necessary but not sufficient: it added the primitive but never wired it into the two system-prompt paths, leaving the file-tool-vs-shell path split that yolop's #258 fixed.

Root cause is drift: the three wrap sites duplicated the same `MountFs::wrap(WorkspaceScopedFileSystem::wrap(..))` logic and diverged (act got `wrap_if_needed`, the others did not). This centralizes them in one shared `scoped_prompt_file_store` helper so they cannot drift again.

## Before / After
Backend-native embedder (host root `/host/repo`), file-tool root guidance rendered into the system prompt:

Before:
```
Workspace root: `/workspace`. All file paths must start with `/workspace`.
```
After:
```
Workspace root: `/host/repo`. Paths may be relative to this root or absolute under it.
```

Proof: new test `system_prompt_backend_native_store_shows_host_root` asserts this end-to-end through the shared helper and the file-system capability. The server default (non-resolver store) stays `/workspace`, guarded by `scoped_prompt_file_store_defaults_plain_backend_to_workspace_alias`. Full `everruns-core` (2807) and `everruns-runtime` (61) lib suites pass; `just pre-push` is green.

## Risk
- Low
- Only stores that are already mount resolvers **and** opted into `BackendNative` change presentation. Server/in-memory stores are not mount resolvers, so behavior is byte-identical. The change also stops double-wrapping an embedder's existing `MountFs`, which is strictly more correct for multi-root named-mount display.

## Security
- Threat categories reviewed: **TM-FS** (host-path disclosure).
- Findings and resolutions: The #2776 default — never leak host paths to the model or persisted output on multi-tenant hosts — is preserved. Host paths surface only when an embedder explicitly constructs a `MountFs` and calls `with_backend_display()` in Rust; it is never request- or model-controlled. Directly guarded by `scoped_prompt_file_store_defaults_plain_backend_to_workspace_alias`.

## Follow-ups
- `hook_dispatch.rs` (`BashkitShellHookDispatcher::new`) still wraps with `MountFs::wrap`, so a backend-native embedder's hook scripts would see `/workspace` while its shell sees host paths. Deferred: it is a separate, more delicate payload-path surface and not part of the model-facing system-prompt regression. Worth a follow-up for full consistency.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01YFtzZ3VV8gi4JkSeY8ekkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFtzZ3VV8gi4JkSeY8ekkb)_