### PR TITLE
docs(runtime): reposition everruns-runtime as the agentic runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Run `/everruns-dev:whoami` and complete the OAuth flow on first use. See [`plugi
 
 ## Embed in your own app
 
-Need to run Everruns harnesses in-process? Use the embedded runtime crate (`everruns-runtime`) with `InProcessRuntimeBuilder` for in-memory sessions, filesystem, and storage. See the [Runtime](https://docs.everruns.com/features/runtime/) and [Embedding Everruns](https://docs.everruns.com/advanced/embedding-everruns/) guides.
+Need to build agents directly in Rust? `everruns-runtime` is the agentic runtime — the in-process entrypoint to the Everruns agentic framework. Use `InProcessRuntimeBuilder` for in-memory sessions, filesystem, and storage. See the [Runtime](https://docs.everruns.com/features/runtime/) and [Embedding Everruns](https://docs.everruns.com/advanced/embedding-everruns/) guides.
 
 A CLI (`everruns-cli`) is also available for scripting against a deployment — see the [CLI](https://docs.everruns.com/features/cli/) guide.
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,4 +1,4 @@
-# Public in-process runtime.
+# The agentic runtime: the in-process entrypoint to the Everruns agentic framework.
 # Decision: first public runtime is in-memory by default so embedders can run
 # harnesses in-process without the durable engine or control-plane services.
 
@@ -12,7 +12,7 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-runtime"
-description = "In-process Rust runtime for building local agentic systems — coding agents, personal agents, and more — by embedding Everruns agent harnesses"
+description = "The agentic runtime for Rust — the in-process entrypoint to the Everruns agentic framework, for building coding agents, personal agents, and more"
 readme = "README.md"
 keywords = ["agent", "agentic", "coding-agent", "llm", "ai"]
 categories = ["development-tools", "asynchronous"]

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -1,17 +1,18 @@
 # everruns-runtime
 
-> Embed Everruns agents directly in your Rust process — no server, worker, or database required.
+> The agentic runtime — build agents in Rust by embedding the Everruns agentic framework directly in your process. No server, worker, or database required.
 
 [![Crates.io](https://img.shields.io/crates/v/everruns-runtime.svg)](https://crates.io/crates/everruns-runtime)
 [![Documentation](https://docs.rs/everruns-runtime/badge.svg)](https://docs.rs/everruns-runtime)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-runtime` is the in-process entrypoint for embedding Everruns. It runs a
-harness entirely inside your own process — with in-memory stores by default —
-using the same `input → reason → act` loop as worker- and server-backed
-execution, but without the durable engine, gRPC worker boundary, or
-control-plane server. It is the recommended starting point for trying Everruns,
-writing tests, and embedding agents in your own application.
+`everruns-runtime` is the agentic runtime at the core of Everruns — the
+entrypoint to the Everruns agentic framework. It runs an agent harness entirely
+inside your own process — with in-memory stores by default — using the same
+`input → reason → act` loop as worker- and server-backed execution, but without
+the durable engine, gRPC worker boundary, or control-plane server. It is the
+recommended starting point for building agents, trying Everruns, and writing
+tests.
 
 Part of the [Everruns](https://everruns.com) ecosystem — the durable agentic
 harness engine for building unstoppable agents. The runtime builds on the

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,11 +1,12 @@
-//! Public in-process runtime for embedding Everruns.
+//! The agentic runtime — the in-process entrypoint to the Everruns agentic
+//! framework.
 //!
 //! The runtime crate exposes an in-memory execution surface that runs the same
 //! core atoms (`input`, `reason`, `act`) used elsewhere in the system, but
 //! without the durable engine, gRPC worker boundary, or control-plane server.
 //! It is part of the [Everruns](https://everruns.com) ecosystem.
 //!
-//! This is the intended public entrypoint for embedders who want to:
+//! This is the agentic framework entrypoint for embedders who want to:
 //!
 //! - run sessions in their own process
 //! - provide their own platform definition (capabilities, drivers, harnesses)

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -222,7 +222,7 @@ That means you can rename the harnesses freely. A platform can ship a base harne
 
 ## In-Process Runtime
 
-If you do not want PostgreSQL, the control-plane server, or the worker boundary, use the public `everruns-runtime` crate instead of embedding the full server/worker stack. See the [Runtime](/features/runtime/) page for a quickstart; this section covers how it fits the embedding story.
+If you do not want PostgreSQL, the control-plane server, or the worker boundary, use `everruns-runtime` — the agentic runtime, the in-process entrypoint to the Everruns agentic framework — instead of embedding the full server/worker stack. See the [Runtime](/features/runtime/) page for a quickstart; this section covers how it fits the embedding story.
 
 This path is for applications that want to:
 

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runtime
-description: Embed Everruns harnesses directly in your Rust process with the everruns-runtime crate — in-memory by default, no PostgreSQL, server, or worker required.
+description: The agentic runtime for Rust — the in-process entrypoint to the Everruns agentic framework. Embed agent harnesses directly in your process with the everruns-runtime crate; in-memory by default, no PostgreSQL, server, or worker required.
 # See features/sdk.mdx: explicit slug needed so links-validator resolves this
 # symlinked .mdx page's route. Keep equal to the file-derived route.
 slug: features/runtime
@@ -8,7 +8,7 @@ sidebar:
   label: Runtime
 ---
 
-The `everruns-runtime` crate runs an Everruns harness **entirely inside your own Rust process**. There is no PostgreSQL, no control-plane server, and no worker boundary — just the harness, your capabilities, and your code.
+`everruns-runtime` is **the agentic runtime** — the entrypoint to the Everruns agentic framework. It runs an agent harness **entirely inside your own Rust process**. There is no PostgreSQL, no control-plane server, and no worker boundary — just the harness, your capabilities, and your code.
 
 It is the Rust-native counterpart to the [SDKs](/features/sdk/): where the SDKs talk to a running Everruns server over HTTP, the runtime *is* the engine, linked straight into your binary.
 

--- a/skills/everruns-runtime/SKILL.md
+++ b/skills/everruns-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: everruns-runtime
-description: Embed the Everruns agent engine directly in a Rust process with the everruns-runtime crate — run harnesses in-process with no PostgreSQL, server, or worker. Use when building local agentic apps (coding agents, personal agents, CLIs), writing in-process agent tests, registering custom capabilities/drivers/backends, or wiring optional provider and integration crates (OpenAI, Anthropic, Daytona, E2B, …).
+description: The agentic runtime for Rust — the in-process entrypoint to the Everruns agentic framework, via the everruns-runtime crate. Run agent harnesses in-process with no PostgreSQL, server, or worker. Use when building local agentic apps (coding agents, personal agents, CLIs), writing in-process agent tests, registering custom capabilities/drivers/backends, or wiring optional provider and integration crates (OpenAI, Anthropic, Daytona, E2B, …).
 license: MIT
 compatibility: Rust 1.94+ (edition 2024)
 metadata:
@@ -14,13 +14,14 @@ metadata:
 
 # everruns-runtime
 
-> Embed Everruns agents directly in your Rust process — no server, worker, or database required.
+> The agentic runtime — build agents in Rust by embedding the Everruns agentic framework directly in your process. No server, worker, or database required.
 
-`everruns-runtime` is the public, in-process entrypoint for [Everruns](https://everruns.com),
-the open-source durable agentic harness engine. It runs an Everruns **harness**
-entirely inside your own binary, using the same `input → reason → act` loop as
-the worker- and server-backed runtime, but **in-memory by default** — no
-PostgreSQL, no control-plane server, no gRPC worker boundary.
+`everruns-runtime` is the agentic runtime for [Everruns](https://everruns.com) —
+the in-process entrypoint to the open-source Everruns agentic framework. It runs
+an agent **harness** entirely inside your own binary, using the same
+`input → reason → act` loop as the worker- and server-backed runtime, but
+**in-memory by default** — no PostgreSQL, no control-plane server, no gRPC worker
+boundary.
 
 It is the Rust-native counterpart to the [SDKs](https://docs.everruns.com/features/sdk/):
 where the SDKs talk to a *running* Everruns server over HTTP, the runtime **is**

--- a/skills/everruns-runtime/references/crates.md
+++ b/skills/everruns-runtime/references/crates.md
@@ -6,7 +6,7 @@ how to register them, and what they contribute.
 
 The two required crates are always:
 
-- `everruns-runtime` — the in-process engine ([docs.rs](https://docs.rs/everruns-runtime))
+- `everruns-runtime` — the agentic runtime; the in-process agentic-framework entrypoint ([docs.rs](https://docs.rs/everruns-runtime))
 - `everruns-core` — shared types (capabilities, drivers, models, `PlatformDefinition`)
 
 ## LLM provider crates (drivers)

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,7 +12,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/models.md` - Data models (Agent, Session, Message, etc.)
 - `specs/id-schema.md` - Standardized prefixed ID format
 - `specs/domains.md` - Domain modules: Command trait, feature-oriented structure, MCP catalog generation
-- `specs/runtime.md` - Public in-process runtime contract for embedded execution
+- `specs/runtime.md` - The agentic runtime: in-process agentic-framework entrypoint and embedded-execution contract
 - `specs/embedding.md` - Embedding contract and `PlatformDefinition`
 - `specs/providers.md` - Providers domain model: drivers, services, providers, models, model profiles
 - `specs/llm-drivers.md` - LLM driver trait, provider implementations

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -94,7 +94,7 @@ Production event routing therefore prefers:
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
    - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, egress service, internal system services, shared types)
-   - `runtime/` → `everruns-runtime` - Public in-process runtime plus reusable host-phase execution for embedded and durable/server-backed execution
+   - `runtime/` → `everruns-runtime` - The agentic runtime: in-process entrypoint to the agentic framework, plus reusable host-phase execution for embedded and durable/server-backed execution
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
    - `openai/` → `everruns-openai` - OpenAI LLM provider implementation

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -37,7 +37,8 @@ live filesystem.
 ## In-process Runtime
 
 Embedders that want to execute harnesses in their own process, without the
-durable engine or control-plane server, should use `everruns-runtime`.
+durable engine or control-plane server, should use `everruns-runtime` — the
+agentic runtime and in-process entrypoint to the agentic framework.
 
 `everruns-runtime` consumes the same `PlatformDefinition` type and uses the
 shared core atoms and turn state machine. This keeps embedded execution aligned

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -2,7 +2,8 @@
 
 ## Abstract
 
-`everruns-runtime` is the public execution crate for Everruns.
+`everruns-runtime` is the agentic runtime for Everruns — the public entrypoint
+to the Everruns agentic framework.
 
 It lets embedders run sessions inside their own process without the durable
 execution engine, gRPC worker boundary, or control-plane server. It also owns


### PR DESCRIPTION
## What changed
Repositions the `everruns-runtime` crate's messaging from "the in-process runtime for embedding Everruns" (an internal component) to **the agentic runtime** — the in-process entrypoint to the Everruns agentic framework. The crate now leads as the thing you reach for to build agents, with "in-process / in-memory / no server" demoted to supporting detail.

Prose updated across 12 files: crate description + header comment (`crates/runtime/Cargo.toml`), crate doc (`crates/runtime/src/lib.rs`), crate README tagline/opening, the `everruns-runtime` skill (`SKILL.md` frontmatter/tagline/opening + `references/crates.md`), docs (`features/runtime.mdx`, `advanced/embedding-everruns.md`), specs (`runtime.md` abstract, `architecture.md`, `embedding.md`, `README.md` index), and the root README "Embed in your own app" section.

Deliberately unchanged: the crate identifier `everruns-runtime`, `everruns_runtime` imports, `cargo run -p` invocations, docs.rs/crates.io URLs and badges (changing these would break the build and published-crate references); incidental usage mentions in example/eval/provider READMEs; and precise API doc comments on the `InProcessRuntime` struct/builder where "in-process" is an accurate type descriptor.

## Why
The runtime crate is the public front door for building agents in Rust, but its wording framed it as a subordinate piece of the Everruns platform rather than a runtime in its own right. Leading with "agentic runtime / agentic framework entrypoint" makes the positioning match how the crate is actually used.

## Before / After
Pure wording change — no runtime behavior changes. Representative example, `crates/runtime/Cargo.toml` `description`:

- **Before:** `In-process Rust runtime for building local agentic systems — coding agents, personal agents, and more — by embedding Everruns agent harnesses`
- **After:** `The agentic runtime for Rust — the in-process entrypoint to the Everruns agentic framework, for building coding agents, personal agents, and more`

Crate README opening:

- **Before:** `everruns-runtime` is the in-process entrypoint for embedding Everruns.
- **After:** `everruns-runtime` is the agentic runtime at the core of Everruns — the entrypoint to the Everruns agentic framework.

## Risk
- Low
- Documentation, comments, spec prose, and a Cargo `description` field only; no code paths, APIs, or runtime behavior change. `cargo fmt`/`clippy`/lockfile all still pass (the description string and doc comments do not affect compilation).

## Security
- Threat categories reviewed: No security-relevant code changes — the diff is docs, comments, spec prose, and crate metadata (`description`). No trust boundaries, inputs, auth, queries, or dependencies touched.
- Findings and resolutions: None.

## Follow-ups
- The shared ecosystem blurb "the durable agentic harness engine for building unstoppable agents" (in several crate READMEs) describes *Everruns the platform*, not the runtime crate, so it was left untouched. If we want the platform-level tagline aligned toward the "agentic framework" language too, that's a separate, broader messaging pass — safe to defer since it's out of scope for repositioning the runtime crate specifically.

## Checklist
- [x] Tests added or updated — N/A (docs/wording only; no behavior to test)
- [x] Backward compatibility considered — no API or identifier changes; crate name and imports preserved
- [x] Security review performed against relevant threat model categories — no security-relevant surface
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uab4VMRmvtvhsa2zczPbf3)_