### PR TITLE
docs(agents): document agent-first features

### DIFF
--- a/docs/advanced/memory-model.md
+++ b/docs/advanced/memory-model.md
@@ -10,6 +10,8 @@ Everruns separates **where the agent works** from **what the agent remembers acr
 
 These two tiers are intentional. Workspace is where an agent does its current task; Memory is where the org persists state it wants reused across tasks.
 
+For the shipped organization, agent, and user ownership tiers—including the private `/memory/user` and automatic `/memory/agent` mounts—see [Agent and user memory](/features/memory-scopes/).
+
 ## The two-axis grid
 
 Scope × surface, with the same surfaces appearing on both sides:
@@ -113,6 +115,7 @@ These exist in Everruns but live outside this model:
 
 ## Further reading
 
+- [Agent and user memory](/features/memory-scopes/) — scoped memory mounts, access, and privacy defaults
 - [`specs/memory.md`](https://github.com/everruns/everruns/blob/main/specs/memory.md) — durable design intent for the Memory tier
 - [`specs/workspace.md`](https://github.com/everruns/everruns/blob/main/specs/workspace.md) — Workspace specification (file surface, mount point, git VCS)
 - [`specs/knowledge-bases.md`](https://github.com/everruns/everruns/blob/main/specs/knowledge-bases.md) — curated org knowledge, the curation-first sibling of Memory

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -69,6 +69,6 @@ See [Events as the primary store](/explanation/events/) for the consequences.
 
 ## Apps connect agents to the outside world
 
-A bare agent has no way to receive messages from users. An **App** wires a harness + agent pair to a channel (Slack, webhook, schedule, AG-UI) and exposes a publish/unpublish lifecycle. The App owns the inbound auth, the session-routing strategy (per-thread, per-channel, per-user), and the channel-specific config.
+A bare agent has no way to receive messages from users. An **App** wires a harness + agent pair to an inbound channel (such as Slack, webhook, or AG-UI) and exposes a publish/unpublish lifecycle. The App owns the inbound auth, the session-routing strategy (per-thread, per-channel, per-user), and the channel-specific config. For proactive scheduled work, use [agent triggers](/features/agent-triggers/) instead of the deprecated App schedule channel.
 
 This is why apps are a separate concept from agents: the same agent can be deployed to multiple channels, and you want to publish and revoke those deployments independently.

--- a/docs/features/agent-triggers.md
+++ b/docs/features/agent-triggers.md
@@ -1,0 +1,68 @@
+---
+title: Agent Triggers
+description: Run an agent proactively on a recurring schedule, choose session reuse, test it immediately, and inspect recent outcomes.
+---
+
+Agent triggers let an agent start work on its own schedule. A trigger belongs to one agent, runs on that agent's harness, and sends a configured message when it fires. You do not need to put an App in front of the agent.
+
+Schedule triggers are the only trigger type currently available.
+
+## Create a trigger in the UI
+
+1. Open the agent.
+2. Select the **Triggers** tab.
+3. Select **Add trigger**.
+4. Choose a preset or enter a 5-field cron expression (or a 7-field expression whose year is `*`), then enter an IANA timezone. The editor shows the schedule in human-readable form and previews the next eight runs. The default timezone is `UTC`.
+5. Choose a session mode:
+   - **Shared session** reuses one durable session for this trigger. Use it when later runs should see the trigger's previous conversation.
+   - **New session per run** creates a fresh session every time. Use it when each run should be isolated.
+6. Enter the message that starts the run. Messages may use `{{...}}` template values from the agent, trigger, and invocation context.
+7. Leave **Enabled** on to activate the schedule, then select **Create trigger**.
+
+The trigger card shows the schedule in human-readable form, its timezone, message, session mode, enabled state, and recent run outcomes.
+
+## Operate and test a trigger
+
+From the **Triggers** tab you can:
+
+- enable or disable the recurring schedule;
+- edit its schedule, timezone, session mode, message, or enabled state;
+- select **Run now** to start one invocation immediately;
+- inspect the most recent durable execution outcomes; or
+- delete the trigger.
+
+**Run now** uses the same execution path as a scheduled run. The trigger must be enabled.
+
+## API
+
+Agent triggers are managed below `/v1/agents/{agent_id}/triggers`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/agents/{agent_id}/triggers` | List triggers |
+| `POST` | `/v1/agents/{agent_id}/triggers` | Create a schedule trigger |
+| `GET` | `/v1/agents/{agent_id}/triggers/{trigger_id}` | Get one trigger |
+| `PATCH` | `/v1/agents/{agent_id}/triggers/{trigger_id}` | Update provided fields |
+| `DELETE` | `/v1/agents/{agent_id}/triggers/{trigger_id}` | Delete a trigger |
+| `POST` | `/v1/agents/{agent_id}/triggers/{trigger_id}/trigger` | Run it now |
+| `GET` | `/v1/agents/{agent_id}/triggers/{trigger_id}/runs` | List recent outcomes |
+
+Create requests accept `cron_expression`, `timezone`, `session_mode`, `message`, and `enabled`. See the [API reference](/api/) for current request and response schemas.
+
+## Migrate from App schedule channels
+
+The App `schedule` channel is deprecated, and new schedule channels are rejected. Create a schedule trigger on the App's agent instead.
+
+Existing agent-bound App schedule channels are migrated automatically. Their cron expression, timezone, session mode, and message are preserved, and active schedules retain their durable execution identity and history. Existing Apps without an agent are grandfathered and are not migrated automatically.
+
+App webhook channels and session schedules solve different problems and are unchanged:
+
+- use an **agent trigger** when an agent should wake itself on a recurring schedule;
+- use an **App webhook channel** when an external HTTP request should invoke an App; and
+- use a **session schedule** when the current conversation should continue later.
+
+## See also
+
+- [Apps](/features/apps/) — publish agents to inbound channels.
+- [Session participants](/features/session-participants/) — understand the host agent used by a trigger-created session.
+- [API reference](/api/) — exact trigger schemas and responses.

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -1,11 +1,11 @@
 ---
 title: Everruns Apps for Agent Distribution Channels
-description: Apps bind a Harness and Agent to a distribution channel (Slack, webhook, schedule) and expose a publish/unpublish lifecycle.
+description: Apps bind a Harness and Agent to inbound distribution channels and expose a publish/unpublish lifecycle.
 sidebar:
   label: Apps
 ---
 
-An **App** turns a Harness + Agent pair into a deployed service that responds to external messages. The App owns the channel-specific binding (Slack, webhook, schedule, AG-UI), the inbound auth, the session-routing strategy, and the publish/unpublish lifecycle.
+An **App** turns a Harness + Agent pair into a deployed service that responds to external messages. The App owns the channel-specific binding (such as Slack, webhook, or AG-UI), the inbound auth, the session-routing strategy, and the publish/unpublish lifecycle.
 
 The same agent can back multiple apps (e.g., a Slack deployment and a webhook deployment), and each app's lifecycle is independent.
 
@@ -24,7 +24,7 @@ The same agent can back multiple apps (e.g., a Slack deployment and a webhook de
 |---|---|---|
 | Slack | Available | Deploy as a Slack bot |
 | AG-UI | Available | AG-UI inbound channel |
-| Schedule | Available | Cron-triggered invocation into an app-owned session |
+| Schedule | Deprecated | New channels are rejected; use [Agent triggers](/features/agent-triggers/) |
 | Webhook | Available | HTTP-triggered invocation |
 | WhatsApp | Planned | — |
 | Web Widget | Planned | — |
@@ -41,7 +41,13 @@ Each channel chooses how incoming messages map to sessions:
 | `per_channel` | One session per channel | Persistent channel assistant |
 | `per_user` | One session per user | Personal assistant |
 
-Schedule and webhook channels use their own routing model (shared session vs. per-invocation).
+Webhook channels use their own routing model (shared session vs. per-invocation). Agent triggers provide the same choice for scheduled runs.
+
+## Migrating App schedules
+
+Agent triggers are now the home for proactive scheduled execution. Existing agent-bound App schedule channels are migrated automatically with their cron expression, timezone, session mode, message, durable execution identity, and history preserved. Existing Apps without an agent are grandfathered and remain compatible.
+
+For new scheduled work, create a trigger from the agent's **Triggers** tab. See [Agent triggers](/features/agent-triggers/#migrate-from-app-schedule-channels) for the migration details and the distinction between agent triggers, App webhooks, and session schedules.
 
 ## Lifecycle
 
@@ -77,4 +83,5 @@ Full request/response schemas in the [API reference](/api/).
 ## See also
 
 - [Agent Versions](/features/agent-versions/) — pin an app to a specific agent version.
+- [Agent triggers](/features/agent-triggers/) — run an agent proactively without an App schedule channel.
 - [Concepts: Apps](/explanation/concepts/#apps-connect-agents-to-the-outside-world)

--- a/docs/features/memory-scopes.md
+++ b/docs/features/memory-scopes.md
@@ -1,0 +1,52 @@
+---
+title: Agent and User Memory
+description: Understand organization, agent, and user memory scopes, their automatic mount paths, and the privacy and access rules for each.
+---
+
+Memory keeps files available across sessions. Everruns provides three ownership scopes so shared organization knowledge, an agent's learned context, and a user's preferences do not have to share the same access boundary.
+
+## The three scopes
+
+| Scope | Lifetime and owner | How it enters a session | Access |
+|---|---|---|---|
+| Organization | A named store managed within one organization | Select it in the `memory` capability and choose a path under `/workspace` | Read-only by default; read-write must be selected explicitly |
+| Agent | One server-managed store per agent | Automatically mounted for sessions hosted by that agent at `/memory/agent` | Read-write in the hosted session |
+| User | One server-managed store per user | Automatically mounted in the owning user's private, default session workspace at `/memory/user` | Read-write for the owner and the agent working in that session |
+
+Organization memories are appropriate for shared references such as runbooks or product documentation. Agent memory follows one host agent across its sessions. User memory follows one user so preferences and personal context can persist across their sessions.
+
+## Privacy defaults
+
+**User memory is private by default.** Only the session owner may access `/memory/user` through user-facing session file APIs. Other users cannot read or mutate the subtree, and file searches redact matches from it. Internal runtime access lets the agent working for the owner read and update that memory.
+
+User memory is not mounted into caller-attached shared workspaces. Everruns waits to expose it there until mounts can be participant-local instead of visible to the entire workspace.
+
+Agent memory is separate from user memory. It is shared by sessions hosted by the same agent, so do not use `/memory/agent` for user-private data. A guest agent's private memory is not merged into a shared session's workspace-wide `/memory/agent` path.
+
+## How automatic mounts work
+
+When a session starts, Everruns lazily creates any missing scoped stores and mounts their current files:
+
+- `/memory/agent` contains the host agent's persistent files.
+- `/memory/user` contains the session owner's persistent files when the session uses the owner's private default workspace.
+
+Both automatic mounts are read-write. The regular file tools and Workspace UI traverse them alongside session files, and writes persist to the scoped memory for later sessions.
+
+The `/memory/*` namespace is reserved. You cannot use it for caller-supplied initial files or for mounts configured through the public `memory` capability.
+
+## Organization memory access
+
+Organization memories are created and managed through the Memory UI and `/v1/memories` API. Add the `memory` capability to select an active organization memory, its mount path, and its access mode.
+
+- Omitted access mode defaults to `readonly`.
+- A `readwrite` mount writes through to the durable organization memory.
+- Source-backed GitHub or Git memories are always read-only.
+- Agent- and user-scoped memories are server-managed and cannot be selected through `memory.mounts`.
+
+See [Memory model](/advanced/memory-model/) for the relationship between durable Memory and a session Workspace, or the [API reference](/api/) for current organization-memory schemas.
+
+## See also
+
+- [Memory model](/advanced/memory-model/) — Workspace and durable Memory architecture.
+- [Session participants](/features/session-participants/) — host and guest agent behavior in shared sessions.
+- [File System capability](/capabilities/file-system/) — tools that access session and mounted files.

--- a/docs/features/session-participants.md
+++ b/docs/features/session-participants.md
@@ -1,0 +1,61 @@
+---
+title: Session Participants
+description: Invite agents into a shared session, address a specific agent for a turn, and understand host, member, user, join, and leave behavior.
+---
+
+A session can include more than one agent and more than one user. Session participants record who is present, whether they are the host or a member, and when they joined or left.
+
+## Host and member roles
+
+An agent-backed session has one active host agent. The host supplies the session's harness and answers user turns by default.
+
+Other agents and users join as members:
+
+- an **agent member** can be addressed for an individual turn;
+- a **user member** records a person participating in the session, but cannot be addressed as an agent responder; and
+- a member that leaves remains in participant history with a leave time.
+
+Inviting a member agent does not replace the host or the host's harness. The invited agent contributes its behavior, model defaults, capabilities, and client tools only when a turn is addressed to it.
+
+## Invite an agent in the UI
+
+The session view shows multi-party membership in the **In this session** rail on desktop. It labels each participant as **Host** or **Member** and as **Agent** or **User**.
+
+To add an agent:
+
+1. Open **In this session**.
+2. Select **Invite agent**.
+3. Choose an agent that is not already active in the session.
+
+The agent joins as a member. The rail also shows participants who have left. Use the remove action on an active member to make it leave; the host cannot leave through the ordinary participant action.
+
+Agents can perform the same operation with invite-mode handoff. An agent with the `agent_handoff` capability calls `spawn_agent` with `mode = invite`. Unlike foreground or background handoff, invite mode joins the target agent to the current session instead of creating a child session.
+
+## Address an agent for one turn
+
+When at least one active member agent is available, the composer shows an **Address** selector:
+
+- **Session host (default)** sends the turn to the host agent.
+- Selecting a member agent sends that turn to the selected participant.
+
+Addressing is per turn. It does not change the session's host or default responder. A participant must still be active and must be an agent; requests that address a user or a participant who already left are rejected.
+
+## API
+
+Participant membership is managed below a session:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/sessions/{session_id}/participants` | List active and past participants in join order |
+| `POST` | `/v1/sessions/{session_id}/participants` | Add an agent or user member |
+| `DELETE` | `/v1/sessions/{session_id}/participants/{participant_id}` | Mark a member as having left |
+
+To address an agent, set `addressed_participant_id` when creating a message with `POST /v1/sessions/{session_id}/messages`. Omit it to use the host.
+
+The participant list is the source of truth for join and leave history. Join and leave do not emit dedicated participant events on the session SSE stream. See the [API reference](/api/) for current schemas and authorization requirements.
+
+## See also
+
+- [Agent triggers](/features/agent-triggers/) — proactive runs start sessions with the trigger's agent as host.
+- [Sub Agents capability](/capabilities/sub-agents/) — foreground, background, and invite handoff modes.
+- [Core concepts](/explanation/concepts/) — sessions, turns, and agents.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -87,3 +87,23 @@ The documentation is organised by what you're trying to do.
     href="/sre/environment-variables/"
   />
 </CardGrid>
+
+## Agent-first features
+
+<CardGrid>
+  <LinkCard
+    title="Agent triggers"
+    description="Wake an agent on a recurring schedule and inspect its runs."
+    href="/features/agent-triggers/"
+  />
+  <LinkCard
+    title="Session participants"
+    description="Invite agents into a shared session and address one for a turn."
+    href="/features/session-participants/"
+  />
+  <LinkCard
+    title="Agent and user memory"
+    description="Learn the persistence, mount paths, and privacy rules for scoped memory."
+    href="/features/memory-scopes/"
+  />
+</CardGrid>


### PR DESCRIPTION
## What changed
Added public, user-facing documentation for agent triggers, session participants, and agent/user memory scopes. The pages cover the shipped UI and API behavior, including trigger session modes and run history, participant invite/address/leave flows, scoped-memory access rules, `/memory/agent` and `/memory/user`, and the private-by-default user-memory boundary.

The docs homepage, generated feature navigation, and existing memory/App/concepts pages now link to the new material. App schedule channels are documented as deprecated, with the migration path to agent triggers.

## Why
EVE-789 identified three shipped agent-first capabilities that had specs and implementation but no public prose documentation. Existing App docs also still described schedule channels as available even though new schedule channels are rejected and agent-bound legacy schedules migrate to triggers.

## Before / After
Before: public docs had no prose pages for agent triggers, session participants, or scoped agent/user memory; the Apps page listed schedule channels as available.

After: the production docs build generates `/features/agent-triggers/`, `/features/session-participants/`, and `/features/memory-scopes/`; all internal links validate; the Apps documentation points scheduled work to agent triggers.

Evidence:
- `pnpm run check`: 0 errors
- `pnpm run build`: 459 pages built; all internal links valid; notebook verification passed
- `just pre-push`: all 10 repository checks passed
- Stale-language scan found no public prose saying a session selects/picks its harness or that App schedule channels are available

Runtime smoke testing was skipped because this PR changes documentation only and does not affect executable behavior.

## Risk
- Low
- Risk is limited to inaccurate or undiscoverable documentation. Claims were checked against the current specs, HTTP handlers, domain behavior, and shipped UI components; the production build validates routing and links.

## Security
- Threat categories reviewed: No security-relevant code changes; this PR changes public prose only.
- Findings and resolutions: Memory privacy wording was verified against the user-memory authorization/redaction boundary. No threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (not applicable for docs-only changes; docs check/build and repository pre-push validation passed)
- [x] Backward compatibility considered (documentation-only)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no reviewer comments or threads were posted)
