### PR TITLE
test(cases): UI test cases for session participants and scoped memory

### DIFF
--- a/test_cases/ui/memory/TC007_scoped_agent_and_user_memory.md
+++ b/test_cases/ui/memory/TC007_scoped_agent_and_user_memory.md
@@ -1,0 +1,40 @@
+# TC007 Scoped agent and user memory
+
+## Description
+
+Verify that agent-scoped and user-scoped memory automatically mount read-write at `/memory/agent` and `/memory/user`, persist across sessions of the same host agent and the same user, and that the `/memory/*` namespace is reserved. Distinct from the organization-memory pages covered by TC001–TC006.
+
+## Preconditions
+
+- A local (`AUTH_MODE=none`) or authenticated deployed Everruns UI is available
+- The tester is signed in and has access to the target organization when authentication is enabled
+- An active agent is available to host sessions
+- The tester can open the Workspace / file view of a session
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Host agent | Notetaker |
+| Agent memory file | `/memory/agent/known-issues.md` |
+| User memory file | `/memory/user/preferences.md` |
+| Content | `Prefer concise summaries` |
+
+## Steps
+
+1. Start a session hosted by the agent and open the Workspace / file view.
+2. Confirm `/memory/agent` is present and mounted read-write (its files show an agent-memory indicator).
+3. Create or edit a file under `/memory/agent` (for example `known-issues.md`), enter the content, and save.
+4. In the owner's private default session, confirm `/memory/user` is present and mounted read-write, then write a file under it (for example `preferences.md`) and save.
+5. Start a second, separate session hosted by the **same** agent.
+6. Verify the `/memory/agent` file written in step 3 is present with its content.
+7. In the owner's later private session, verify the `/memory/user` file written in step 4 is present with its content.
+8. Attempt to add a caller-supplied initial file, or configure a `memory` capability mount, under `/memory/` and confirm it is rejected.
+
+## Expected Result
+
+- `/memory/agent` and `/memory/user` mount automatically and read-write, with no manual capability configuration.
+- Files written to `/memory/agent` reappear in later sessions hosted by the same agent (agent memory follows the host agent).
+- Files written to `/memory/user` reappear in the same owner's later sessions (user memory follows the user).
+- The `/memory/*` namespace is reserved: caller-supplied initial files and public `memory` capability mounts under it are rejected.
+- User memory is private to the owner: `/memory/user` is not readable by other users and is redacted from their file searches. (Verify with a second user when available.)

--- a/test_cases/ui/session_participants/TC001_manage_session_participants.md
+++ b/test_cases/ui/session_participants/TC001_manage_session_participants.md
@@ -1,0 +1,41 @@
+# TC001 Manage session participants
+
+## Description
+
+Verify that the **In this session** rail shows host and member participants, supports inviting a member agent, addressing a member agent for a single turn, and removing a member, with correct host/member and agent/user labeling and join/leave history.
+
+## Preconditions
+
+- A local (`AUTH_MODE=none`) or authenticated deployed Everruns UI is available
+- The tester is signed in and has access to the target organization when authentication is enabled
+- Two active agents exist: one to host the session and one to invite as a member
+- A session hosted by the first agent is open and has at least one completed turn
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Host agent | Customer Support |
+| Member agent | Billing Specialist |
+| Addressed message | `Check the billing hold on this order` |
+
+## Steps
+
+1. Open a session hosted by the host agent and locate the **In this session** rail.
+2. Verify the rail lists the host agent labeled **Host** / **Agent** and the current user labeled **User**.
+3. Select **Invite agent** and choose the member agent (one not already active in the session).
+4. Verify the member agent appears in the rail labeled **Member** / **Agent** and the host is unchanged.
+5. In the composer, open the **Address** selector and confirm it defaults to **Session host (default)**.
+6. Select the member agent, send the addressed message, and confirm the reply is attributed to the member agent.
+7. Send a follow-up turn without changing the selector, and confirm the host answers (addressing is per turn).
+8. Use **Remove from session** on the member agent.
+9. Confirm the host cannot be removed through the ordinary participant action.
+
+## Expected Result
+
+- The rail lists all participants with **Host**/**Member** and **Agent**/**User** labels.
+- Inviting a member agent adds it as **Member** / **Agent** without replacing the host or the host's harness.
+- The **Address** selector routes a single turn to the selected member agent, and that turn's reply is attributed to the selected participant.
+- The next unaddressed turn is answered by the host (addressing does not change the default responder).
+- Removing a member marks it as having left; it remains visible in participant history and can no longer be addressed.
+- The host cannot leave through the ordinary participant remove action.


### PR DESCRIPTION
## What changed
Adds two manual UI test cases documenting expected behavior for two shipped agent-first features that lacked QA coverage:

- `test_cases/ui/session_participants/TC001_manage_session_participants.md` — the **In this session** rail: host/member + agent/user labeling, invite a member agent, address a member agent for one turn, remove a member (leave history), and host-cannot-leave.
- `test_cases/ui/memory/TC007_scoped_agent_and_user_memory.md` — scoped memory: `/memory/agent` and `/memory/user` auto-mount read-write, persist across sessions of the same host agent / same user, the reserved `/memory/*` namespace, and user-memory privacy.

Docs-only; no product code changes.

## Why
Coverage backfill from the agent-first rewrite audit (EVE-790). Agent triggers already had a manual test case (`ui/agent_triggers/TC001`); session participants and scoped memory did not. The features and their specs are already on `main`, and the product docs shipped in #2826.

## Before / After
No observable runtime behavior — this adds Markdown test cases only. Steps are grounded in the shipped UI: the rail's `In this session` / `Invite agent` / `Remove from session` controls, the composer's `Address` selector, and the `/memory/agent` + `/memory/user` mounts described in `docs/features/*` and `specs/`.

## Risk
- Low
- Documentation-only change; no code paths touched.

## Security
- Threat categories reviewed: No security-relevant code changes (manual test-case Markdown only).
- Findings and resolutions: None.

## Follow-ups
Remaining EVE-790 scope, intentionally not in this PR: CLI `triggers` / `participants` commands and SDK-compat exercising the new endpoints.

## Checklist
- [x] Tests added or updated (manual UI test cases)
- [x] Backward compatibility considered (docs-only)
- [x] Security review performed against relevant threat model categories (N/A — test-case docs)
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yY1Rv1sFELqPuMGewEgPu)_