### PR TITLE
feat(cli): add triggers and participants commands

### DIFF
--- a/.github/scripts/sdk-compat/test-python.sh
+++ b/.github/scripts/sdk-compat/test-python.sh
@@ -25,8 +25,24 @@ import inspect
 import os
 import random
 import string
+import json
+import urllib.request
 
 from everruns_sdk import Everruns
+
+
+def api_post(path: str, body: dict) -> dict:
+    request = urllib.request.Request(
+        f"{os.environ['EVERRUNS_BASE_URL'].rstrip('/')}{path}",
+        data=json.dumps(body).encode(),
+        headers={
+            "Authorization": f"Bearer {os.environ['EVERRUNS_API_KEY']}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request) as response:
+        return json.load(response)
 
 
 async def main() -> None:
@@ -69,6 +85,34 @@ async def main() -> None:
     if fetched_session.id != session.id:
         raise RuntimeError(f"session id mismatch: {fetched_session.id} != {session.id}")
     print("  session fetch verified")
+
+    # 5. Exercise newly generated trigger and participant API surfaces. Raw
+    # HTTP keeps older published SDK cohorts compatible with the current API.
+    trigger = api_post(
+        f"/v1/agents/{agent.id}/triggers",
+        {
+            "cron_expression": "0 0 * * *",
+            "timezone": "UTC",
+            "session_mode": "session_per_invocation",
+            "message": "SDK compatibility trigger",
+            "enabled": False,
+        },
+    )
+    if trigger.get("agent_id") != agent.id:
+        raise RuntimeError("created trigger has wrong agent")
+    print(f"  trigger created: {trigger['id']}")
+
+    guest = await client.agents.create(
+        name=f"sdk-compat-py-guest-{suffix}",
+        system_prompt="Compatibility guest agent",
+    )
+    participant = api_post(
+        f"/v1/sessions/{session.id}/participants",
+        {"kind": "agent", "agent_id": guest.id},
+    )
+    if participant.get("agent_id") != guest.id:
+        raise RuntimeError("created participant has wrong agent")
+    print(f"  participant added: {participant['id']}")
 
     print(f"ok python sdk {version}")
 

--- a/.github/scripts/sdk-compat/test-rust.sh
+++ b/.github/scripts/sdk-compat/test-rust.sh
@@ -25,7 +25,64 @@ edition = "2021"
 [dependencies]
 everruns-sdk = "=$version"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+reqwest = { version = "0.12", features = ["json"] }
+serde_json = "1"
 TOML
+
+cat > "$workdir/smoke/src/compat.rs" <<'RS'
+use everruns_sdk::Everruns;
+
+pub async fn exercise_new_surfaces(
+    client: &Everruns,
+    base_url: &str,
+    api_key: &str,
+    agent_id: &str,
+    session_id: &str,
+    suffix: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let http = reqwest::Client::new();
+    let trigger: serde_json::Value = http
+        .post(format!("{}/v1/agents/{agent_id}/triggers", base_url.trim_end_matches('/')))
+        .bearer_auth(api_key)
+        .json(&serde_json::json!({
+            "cron_expression": "0 0 * * *",
+            "timezone": "UTC",
+            "session_mode": "session_per_invocation",
+            "message": "SDK compatibility trigger",
+            "enabled": false
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(trigger["agent_id"], agent_id);
+    println!("  trigger created: {}", trigger["id"]);
+
+    let guest = client
+        .agents()
+        .create(
+            &format!("sdk-compat-rs-guest-{suffix}"),
+            "Compatibility guest agent",
+        )
+        .await?;
+    let participant: serde_json::Value = http
+        .post(format!(
+            "{}/v1/sessions/{session_id}/participants",
+            base_url.trim_end_matches('/')
+        ))
+        .bearer_auth(api_key)
+        .json(&serde_json::json!({ "kind": "agent", "agent_id": guest.id.clone() }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(participant["agent_id"], guest.id);
+    println!("  participant added: {}", participant["id"]);
+    Ok(())
+}
+RS
 
 # The SDK session API changed across versions:
 #   v0.1.0-v0.1.2: sessions().create(agent_id)
@@ -45,17 +102,19 @@ if version_cmp "$version" "0.1.4"; then
 # v0.1.4+: create() takes no args; use create_with_options() with builder
 cat > "$workdir/smoke/src/main.rs" <<'RS'
 use everruns_sdk::{Everruns, CreateSessionRequest};
+mod compat;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("EVERRUNS_API_KEY")?;
     let base_url = std::env::var("EVERRUNS_BASE_URL")?;
     let sdk_version = std::env::var("SDK_VERSION")?;
+    let suffix = format!("{}-{}", sdk_version.replace('.', "-"), std::process::id());
 
-    let client = Everruns::with_base_url(api_key, &base_url)?;
+    let client = Everruns::with_base_url(api_key.clone(), &base_url)?;
 
     // 1. Create agent
-    let agent = client.agents().create("sdk-compat-rs", "Compatibility test agent").await?;
+    let agent = client.agents().create(&format!("sdk-compat-rs-{suffix}"), "Compatibility test agent").await?;
     println!("  agent created: {}", agent.id);
 
     // 2. Fetch agent and verify
@@ -76,6 +135,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(fetched_session.id, session.id, "session id mismatch");
     println!("  session fetch verified");
 
+    // 5. Raw HTTP keeps older published SDK cohorts compatible while checking
+    // the current trigger and participant API surfaces.
+    compat::exercise_new_surfaces(
+        &client, &base_url, &api_key, &agent.id, &session.id, &suffix,
+    )
+    .await?;
+
     println!("ok rust sdk {}", sdk_version);
     Ok(())
 }
@@ -84,17 +150,19 @@ elif version_cmp "$version" "0.1.3"; then
 # v0.1.3: create(harness_id)
 cat > "$workdir/smoke/src/main.rs" <<'RS'
 use everruns_sdk::Everruns;
+mod compat;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("EVERRUNS_API_KEY")?;
     let base_url = std::env::var("EVERRUNS_BASE_URL")?;
     let sdk_version = std::env::var("SDK_VERSION")?;
+    let suffix = format!("{}-{}", sdk_version.replace('.', "-"), std::process::id());
 
-    let client = Everruns::with_base_url(api_key, &base_url)?;
+    let client = Everruns::with_base_url(api_key.clone(), &base_url)?;
 
     // 1. Create agent
-    let agent = client.agents().create("sdk-compat-rs", "Compatibility test agent").await?;
+    let agent = client.agents().create(&format!("sdk-compat-rs-{suffix}"), "Compatibility test agent").await?;
     println!("  agent created: {}", agent.id);
 
     // 2. Fetch agent and verify
@@ -112,6 +180,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(fetched_session.id, session.id, "session id mismatch");
     println!("  session fetch verified");
 
+    compat::exercise_new_surfaces(
+        &client, &base_url, &api_key, &agent.id, &session.id, &suffix,
+    )
+    .await?;
+
     println!("ok rust sdk {}", sdk_version);
     Ok(())
 }
@@ -120,17 +193,19 @@ else
 # v0.1.0-v0.1.2: create(agent_id)
 cat > "$workdir/smoke/src/main.rs" <<'RS'
 use everruns_sdk::Everruns;
+mod compat;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("EVERRUNS_API_KEY")?;
     let base_url = std::env::var("EVERRUNS_BASE_URL")?;
     let sdk_version = std::env::var("SDK_VERSION")?;
+    let suffix = format!("{}-{}", sdk_version.replace('.', "-"), std::process::id());
 
-    let client = Everruns::with_base_url(api_key, &base_url)?;
+    let client = Everruns::with_base_url(api_key.clone(), &base_url)?;
 
     // 1. Create agent
-    let agent = client.agents().create("sdk-compat-rs", "Compatibility test agent").await?;
+    let agent = client.agents().create(&format!("sdk-compat-rs-{suffix}"), "Compatibility test agent").await?;
     println!("  agent created: {}", agent.id);
 
     // 2. Fetch agent and verify
@@ -146,6 +221,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fetched_session = client.sessions().get(&session.id).await?;
     assert_eq!(fetched_session.id, session.id, "session id mismatch");
     println!("  session fetch verified");
+
+    compat::exercise_new_surfaces(
+        &client, &base_url, &api_key, &agent.id, &session.id, &suffix,
+    )
+    .await?;
 
     println!("ok rust sdk {}", sdk_version);
     Ok(())

--- a/.github/scripts/sdk-compat/test-typescript.sh
+++ b/.github/scripts/sdk-compat/test-typescript.sh
@@ -35,6 +35,21 @@ const client = new Everruns({
 
 const suffix = Math.random().toString(36).slice(2, 10);
 
+async function apiPost(path, body) {
+  const response = await fetch(`${process.env.EVERRUNS_BASE_URL.replace(/\/$/, "")}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.EVERRUNS_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`POST ${path} failed (${response.status}): ${await response.text()}`);
+  }
+  return response.json();
+}
+
 // 1. Create agent
 const agent = await client.agents.create({
   name: `sdk-compat-ts-${suffix}`,
@@ -61,6 +76,33 @@ if (fetchedSession.id !== session.id) {
   throw new Error(`session id mismatch: ${fetchedSession.id} != ${session.id}`);
 }
 console.log("  session fetch verified");
+
+// 5. Exercise newly generated trigger and participant API surfaces. Raw HTTP
+// keeps older published SDK cohorts compatible with the current API.
+const trigger = await apiPost(`/v1/agents/${agent.id}/triggers`, {
+  cron_expression: "0 0 * * *",
+  timezone: "UTC",
+  session_mode: "session_per_invocation",
+  message: "SDK compatibility trigger",
+  enabled: false,
+});
+if (trigger.agent_id !== agent.id) {
+  throw new Error("created trigger has wrong agent");
+}
+console.log(`  trigger created: ${trigger.id}`);
+
+const guest = await client.agents.create({
+  name: `sdk-compat-ts-guest-${suffix}`,
+  systemPrompt: "Compatibility guest agent",
+});
+const participant = await apiPost(`/v1/sessions/${session.id}/participants`, {
+  kind: "agent",
+  agent_id: guest.id,
+});
+if (participant.agent_id !== guest.id) {
+  throw new Error("created participant has wrong agent");
+}
+console.log(`  participant added: ${participant.id}`);
 
 console.log(`ok typescript sdk ${process.env.SDK_VERSION}`);
 JS

--- a/crates/cli/src/commands/api.rs
+++ b/crates/cli/src/commands/api.rs
@@ -1,0 +1,70 @@
+use anyhow::{Context, Result};
+use reqwest::Method;
+use serde_json::Value;
+
+pub struct ApiClient<'a> {
+    api_url: &'a str,
+    api_key: &'a str,
+    org_id: Option<&'a str>,
+    http: reqwest::Client,
+}
+
+impl<'a> ApiClient<'a> {
+    pub fn new(api_url: &'a str, api_key: &'a str, org_id: Option<&'a str>) -> Self {
+        Self {
+            api_url,
+            api_key,
+            org_id,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn get(&self, path: &str) -> Result<Value> {
+        self.send(Method::GET, path, None).await
+    }
+
+    pub async fn post(&self, path: &str, body: Option<&Value>) -> Result<Value> {
+        self.send(Method::POST, path, body).await
+    }
+
+    pub async fn patch(&self, path: &str, body: &Value) -> Result<Value> {
+        self.send(Method::PATCH, path, Some(body)).await
+    }
+
+    pub async fn delete(&self, path: &str) -> Result<Value> {
+        self.send(Method::DELETE, path, None).await
+    }
+
+    async fn send(&self, method: Method, path: &str, body: Option<&Value>) -> Result<Value> {
+        let url = format!("{}{}", self.api_url.trim_end_matches('/'), path);
+        let mut request = self
+            .http
+            .request(method.clone(), &url)
+            .header("Authorization", format!("Bearer {}", self.api_key));
+
+        let env_org = std::env::var("EVERRUNS_ORG_ID").ok();
+        if let Some(org_id) = self.org_id.or(env_org.as_deref()) {
+            request = request.header("X-Org-Id", org_id);
+        }
+        if let Some(body) = body {
+            request = request.json(body);
+        }
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("Failed to call {method} {path}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let response_body = response.text().await.unwrap_or_default();
+            anyhow::bail!("API request failed ({status}): {response_body}");
+        }
+        if status == reqwest::StatusCode::NO_CONTENT {
+            return Ok(Value::Null);
+        }
+        response
+            .json()
+            .await
+            .with_context(|| format!("Failed to parse response from {method} {path}"))
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod agents;
+pub mod api;
 pub mod capabilities;
 pub mod chat;
 pub mod connections;
@@ -6,5 +7,7 @@ pub mod files;
 pub mod login;
 pub mod logout;
 pub mod orgs;
+pub mod participants;
 pub mod sessions;
 pub mod status;
+pub mod triggers;

--- a/crates/cli/src/commands/participants.rs
+++ b/crates/cli/src/commands/participants.rs
@@ -1,0 +1,121 @@
+use crate::commands::api::ApiClient;
+use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde_json::{Value, json};
+
+#[derive(Subcommand, Debug)]
+pub enum ParticipantsCommand {
+    /// List current and past session participants
+    List,
+    /// Add (invite) an agent as a member
+    #[command(alias = "invite")]
+    Add {
+        /// Agent ID to invite
+        #[arg(long)]
+        agent: String,
+    },
+    /// Remove a participant from the session
+    Remove {
+        /// Participant ID (e.g. part_xxx)
+        participant: String,
+    },
+}
+
+pub async fn run(
+    command: ParticipantsCommand,
+    session_id: String,
+    api_url: &str,
+    api_key: &str,
+    org_id: Option<&str>,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    let api = ApiClient::new(api_url, api_key, org_id);
+    let collection = format!("/v1/sessions/{session_id}/participants");
+    match command {
+        ParticipantsCommand::List => {
+            let value = api.get(&collection).await?;
+            print_participant_list(&value, output)
+        }
+        ParticipantsCommand::Add { agent } => {
+            let value = api
+                .post(
+                    &collection,
+                    Some(&json!({ "kind": "agent", "agent_id": agent })),
+                )
+                .await?;
+            print_participant_action("Added", &value, output, quiet)
+        }
+        ParticipantsCommand::Remove { participant } => {
+            let value = api.delete(&format!("{collection}/{participant}")).await?;
+            print_participant_action("Removed", &value, output, quiet)
+        }
+    }
+}
+
+fn print_participant_list(value: &Value, output: OutputFormat) -> Result<()> {
+    if !output.is_text() {
+        output.print_value(value);
+        return Ok(());
+    }
+    let participants = value
+        .as_array()
+        .context("Expected participant list response")?;
+    if participants.is_empty() {
+        println!("No participants found.");
+        return Ok(());
+    }
+    print_table_header(&[
+        ("ID", 38),
+        ("KIND", 8),
+        ("ROLE", 8),
+        ("AGENT", 38),
+        ("STATUS", 8),
+    ]);
+    for participant in participants {
+        let status = if participant.get("left_at").is_some_and(|v| !v.is_null()) {
+            "left"
+        } else {
+            "active"
+        };
+        print_table_row(&[
+            (string_field(participant, "id"), 38),
+            (string_field(participant, "kind"), 8),
+            (string_field(participant, "role"), 8),
+            (string_field(participant, "agent_id"), 38),
+            (status, 8),
+        ]);
+    }
+    Ok(())
+}
+
+fn print_participant_action(
+    action: &str,
+    value: &Value,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    if !output.is_text() {
+        output.print_value(value);
+        return Ok(());
+    }
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .context("Participant response did not include id")?;
+    if quiet {
+        println!("{id}");
+    } else {
+        println!("{action} participant: {id}");
+        print_field("Role", string_field(value, "role"));
+        if let Some(agent_id) = value.get("agent_id").and_then(Value::as_str) {
+            print_field("Agent", agent_id);
+        }
+    }
+    Ok(())
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> &'a str {
+    value.get(key).and_then(Value::as_str).unwrap_or("-")
+}

--- a/crates/cli/src/commands/triggers.rs
+++ b/crates/cli/src/commands/triggers.rs
@@ -1,0 +1,316 @@
+use crate::commands::api::ApiClient;
+use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
+use anyhow::{Context, Result};
+use clap::{Subcommand, ValueEnum};
+use serde_json::{Value, json};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum SessionMode {
+    SharedSession,
+    SessionPerInvocation,
+}
+
+impl SessionMode {
+    fn as_api_value(self) -> &'static str {
+        match self {
+            Self::SharedSession => "shared_session",
+            Self::SessionPerInvocation => "session_per_invocation",
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TriggersCommand {
+    /// List schedule triggers
+    List,
+    /// Create a schedule trigger
+    Create {
+        /// Cron expression (5-field or 7-field)
+        #[arg(long = "cron", alias = "cron-expression")]
+        cron_expression: String,
+        /// IANA timezone for cron evaluation
+        #[arg(long, default_value = "UTC")]
+        timezone: String,
+        /// Whether runs reuse a session or create a new session
+        #[arg(long, value_enum, default_value = "shared-session")]
+        session_mode: SessionMode,
+        /// Message sent when the trigger fires
+        #[arg(long)]
+        message: String,
+        /// Create the trigger disabled
+        #[arg(long)]
+        disabled: bool,
+    },
+    /// Update a schedule trigger
+    Update {
+        /// Trigger ID (e.g. trg_xxx)
+        trigger: String,
+        #[arg(long = "cron", alias = "cron-expression")]
+        cron_expression: Option<String>,
+        #[arg(long)]
+        timezone: Option<String>,
+        #[arg(long, value_enum)]
+        session_mode: Option<SessionMode>,
+        #[arg(long)]
+        message: Option<String>,
+    },
+    /// Enable a schedule trigger
+    Enable { trigger: String },
+    /// Disable a schedule trigger
+    Disable { trigger: String },
+    /// Fire a schedule trigger immediately
+    RunNow { trigger: String },
+}
+
+pub async fn run(
+    command: TriggersCommand,
+    agent_id: String,
+    api_url: &str,
+    api_key: &str,
+    org_id: Option<&str>,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    let api = ApiClient::new(api_url, api_key, org_id);
+    let collection = format!("/v1/agents/{agent_id}/triggers");
+    match command {
+        TriggersCommand::List => {
+            let value = api.get(&collection).await?;
+            print_trigger_list(&value, output)
+        }
+        TriggersCommand::Create {
+            cron_expression,
+            timezone,
+            session_mode,
+            message,
+            disabled,
+        } => {
+            let body = create_body(cron_expression, timezone, session_mode, message, !disabled);
+            let value = api.post(&collection, Some(&body)).await?;
+            print_trigger_action("Created", &value, output, quiet)
+        }
+        TriggersCommand::Update {
+            trigger,
+            cron_expression,
+            timezone,
+            session_mode,
+            message,
+        } => {
+            let body = update_body(cron_expression, timezone, session_mode, message)?;
+            let value = api.patch(&format!("{collection}/{trigger}"), &body).await?;
+            print_trigger_action("Updated", &value, output, quiet)
+        }
+        TriggersCommand::Enable { trigger } => {
+            set_enabled(&api, &collection, &trigger, true, output, quiet).await
+        }
+        TriggersCommand::Disable { trigger } => {
+            set_enabled(&api, &collection, &trigger, false, output, quiet).await
+        }
+        TriggersCommand::RunNow { trigger } => {
+            let value = api
+                .post(&format!("{collection}/{trigger}/trigger"), None)
+                .await?;
+            if output.is_text() {
+                if quiet {
+                    if let Some(session_id) = value.get("session_id").and_then(Value::as_str) {
+                        println!("{session_id}");
+                    }
+                } else {
+                    println!("Triggered: {trigger}");
+                    for (label, key) in [("Session", "session_id"), ("Message", "message_id")] {
+                        if let Some(field) = value.get(key).and_then(Value::as_str) {
+                            print_field(label, field);
+                        }
+                    }
+                }
+            } else {
+                output.print_value(&value);
+            }
+            Ok(())
+        }
+    }
+}
+
+fn create_body(
+    cron_expression: String,
+    timezone: String,
+    session_mode: SessionMode,
+    message: String,
+    enabled: bool,
+) -> Value {
+    json!({
+        "cron_expression": cron_expression,
+        "timezone": timezone,
+        "session_mode": session_mode.as_api_value(),
+        "message": message,
+        "enabled": enabled,
+    })
+}
+
+fn update_body(
+    cron_expression: Option<String>,
+    timezone: Option<String>,
+    session_mode: Option<SessionMode>,
+    message: Option<String>,
+) -> Result<Value> {
+    let mut body = serde_json::Map::new();
+    if let Some(value) = cron_expression {
+        body.insert("cron_expression".into(), json!(value));
+    }
+    if let Some(value) = timezone {
+        body.insert("timezone".into(), json!(value));
+    }
+    if let Some(value) = session_mode {
+        body.insert("session_mode".into(), json!(value.as_api_value()));
+    }
+    if let Some(value) = message {
+        body.insert("message".into(), json!(value));
+    }
+    if body.is_empty() {
+        anyhow::bail!(
+            "update requires at least one of --cron, --timezone, --session-mode, or --message"
+        );
+    }
+    Ok(Value::Object(body))
+}
+
+async fn set_enabled(
+    api: &ApiClient<'_>,
+    collection: &str,
+    trigger: &str,
+    enabled: bool,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    let value = api
+        .patch(
+            &format!("{collection}/{trigger}"),
+            &json!({ "enabled": enabled }),
+        )
+        .await?;
+    print_trigger_action(
+        if enabled { "Enabled" } else { "Disabled" },
+        &value,
+        output,
+        quiet,
+    )
+}
+
+fn print_trigger_list(value: &Value, output: OutputFormat) -> Result<()> {
+    if !output.is_text() {
+        output.print_value(value);
+        return Ok(());
+    }
+    let triggers = value.as_array().context("Expected trigger list response")?;
+    if triggers.is_empty() {
+        println!("No triggers found.");
+        return Ok(());
+    }
+    print_table_header(&[("ID", 38), ("SCHEDULE", 48), ("MODE", 24), ("ENABLED", 7)]);
+    for trigger in triggers {
+        let id = string_field(trigger, "id");
+        let config = trigger.get("config").unwrap_or(&Value::Null);
+        let cron = string_field(config, "cron_expression");
+        let timezone = string_field(config, "timezone");
+        let schedule = human_cron(cron, timezone);
+        let mode = string_field(config, "session_mode");
+        let enabled = trigger
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            .to_string();
+        print_table_row(&[(id, 38), (&schedule, 48), (mode, 24), (&enabled, 7)]);
+    }
+    Ok(())
+}
+
+fn print_trigger_action(
+    action: &str,
+    value: &Value,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    if !output.is_text() {
+        output.print_value(value);
+        return Ok(());
+    }
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .context("Trigger response did not include id")?;
+    if quiet {
+        println!("{id}");
+        return Ok(());
+    }
+    println!("{action} trigger: {id}");
+    let config = value.get("config").unwrap_or(&Value::Null);
+    print_field(
+        "Schedule",
+        &human_cron(
+            string_field(config, "cron_expression"),
+            string_field(config, "timezone"),
+        ),
+    );
+    Ok(())
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> &'a str {
+    value.get(key).and_then(Value::as_str).unwrap_or("-")
+}
+
+pub(crate) fn human_cron(expression: &str, timezone: &str) -> String {
+    let fields: Vec<_> = expression.split_whitespace().collect();
+    let five = match fields.as_slice() {
+        [minute, hour, day, month, weekday] => Some((*minute, *hour, *day, *month, *weekday)),
+        ["0", minute, hour, day, month, weekday, "*"] => {
+            Some((*minute, *hour, *day, *month, *weekday))
+        }
+        _ => None,
+    };
+    let description = match five {
+        Some(("*", "*", "*", "*", "*")) => "Every minute".to_string(),
+        Some((minute, "*", "*", "*", "*")) if minute.parse::<u8>().is_ok() => {
+            format!("Every hour at :{:0>2}", minute)
+        }
+        Some((minute, hour, "*", "*", "*"))
+            if minute.parse::<u8>().is_ok() && hour.parse::<u8>().is_ok() =>
+        {
+            format!("Every day at {:0>2}:{:0>2}", hour, minute)
+        }
+        _ => format!("Cron {expression}"),
+    };
+    format!("{description} ({timezone})")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_common_five_and_seven_field_cron() {
+        assert_eq!(human_cron("30 * * * *", "UTC"), "Every hour at :30 (UTC)");
+        assert_eq!(
+            human_cron("0 30 * * * * *", "America/Chicago"),
+            "Every hour at :30 (America/Chicago)"
+        );
+        assert_eq!(human_cron("0 9 * * *", "UTC"), "Every day at 09:00 (UTC)");
+    }
+
+    #[test]
+    fn update_requires_a_change() {
+        assert!(update_body(None, None, None, None).is_err());
+    }
+
+    #[test]
+    fn create_serializes_api_shape() {
+        let body = create_body(
+            "0 9 * * *".into(),
+            "UTC".into(),
+            SessionMode::SessionPerInvocation,
+            "Daily report".into(),
+            true,
+        );
+        assert_eq!(body["session_mode"], "session_per_invocation");
+        assert_eq!(body["enabled"], true);
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -90,6 +90,24 @@ pub enum Commands {
         command: commands::sessions::SessionsCommand,
     },
 
+    /// Manage an agent's schedule triggers
+    Triggers {
+        /// Agent ID that owns the triggers
+        #[arg(long)]
+        agent: String,
+        #[command(subcommand)]
+        command: commands::triggers::TriggersCommand,
+    },
+
+    /// Manage a session's participants
+    Participants {
+        /// Session ID that owns the participants
+        #[arg(long)]
+        session: String,
+        #[command(subcommand)]
+        command: commands::participants::ParticipantsCommand,
+    },
+
     /// File sync and management
     Files {
         #[command(subcommand)]
@@ -212,6 +230,30 @@ async fn main() -> anyhow::Result<()> {
             commands::sessions::run(
                 command,
                 &client,
+                &api_url,
+                &api_key,
+                org_id.as_deref(),
+                output_format,
+                cli.quiet,
+            )
+            .await
+        }
+        Commands::Triggers { agent, command } => {
+            commands::triggers::run(
+                command,
+                agent,
+                &api_url,
+                &api_key,
+                org_id.as_deref(),
+                output_format,
+                cli.quiet,
+            )
+            .await
+        }
+        Commands::Participants { session, command } => {
+            commands::participants::run(
+                command,
+                session,
                 &api_url,
                 &api_key,
                 org_id.as_deref(),
@@ -398,6 +440,82 @@ mod tests {
             }
         } else {
             panic!("Expected Sessions command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_triggers_create() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "triggers",
+            "--agent",
+            "agent_abc",
+            "create",
+            "--cron",
+            "30 * * * *",
+            "--timezone",
+            "America/Chicago",
+            "--session-mode",
+            "session-per-invocation",
+            "--message",
+            "Prepare report",
+        ])
+        .unwrap();
+        if let Commands::Triggers { agent, command } = cli.command {
+            assert_eq!(agent, "agent_abc");
+            assert!(matches!(
+                command,
+                commands::triggers::TriggersCommand::Create {
+                    session_mode: commands::triggers::SessionMode::SessionPerInvocation,
+                    ..
+                }
+            ));
+        } else {
+            panic!("Expected Triggers command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_trigger_run_now() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "triggers",
+            "--agent",
+            "agent_abc",
+            "run-now",
+            "trg_abc",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Triggers {
+                command: commands::triggers::TriggersCommand::RunNow { .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_participants_add() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "participants",
+            "--session",
+            "session_abc",
+            "add",
+            "--agent",
+            "agent_guest",
+        ])
+        .unwrap();
+        if let Commands::Participants { session, command } = cli.command {
+            assert_eq!(session, "session_abc");
+            assert!(matches!(
+                command,
+                commands::participants::ParticipantsCommand::Add { agent }
+                    if agent == "agent_guest"
+            ));
+        } else {
+            panic!("Expected Participants command");
         }
     }
 

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -91,6 +91,43 @@ Session management.
 - `watch <id>` — stream session events in real time via SSE (like `kubectl logs -f`). Text mode: status/lifecycle events go to stderr, assistant message content goes to stdout (pipeable). JSON mode: each event as a JSON object to stdout. Exits cleanly on Ctrl+C.
 - `export <id> [-o <path>] [--format jsonl|atif]` — export session messages to a file (`-o`/`--output`) or stdout. `--format` defaults to `jsonl` (one message per line); `atif` emits an ATIF trajectory.
 
+### `everruns triggers`
+
+Manage schedule triggers scoped to an agent with `--agent <id>`.
+
+- `list` — list the agent's active triggers. Text output renders common cron schedules as a human-readable cadence with timezone; JSON and YAML retain the API response.
+- `create --cron <expression> --message <text> [--timezone <iana>] [--session-mode shared-session|session-per-invocation] [--disabled]`
+- `update <trigger-id> [--cron <expression>] [--message <text>] [--timezone <iana>] [--session-mode shared-session|session-per-invocation]`
+- `enable <trigger-id>`
+- `disable <trigger-id>`
+- `run-now <trigger-id>` — fire one invocation immediately.
+
+Examples:
+
+```bash
+everruns triggers --agent agent_... create \
+  --cron '30 * * * *' \
+  --timezone America/Chicago \
+  --session-mode session-per-invocation \
+  --message 'Prepare the hourly report'
+everruns triggers --agent agent_... list
+everruns triggers --agent agent_... run-now trg_...
+```
+
+### `everruns participants`
+
+Manage participants scoped to a session with `--session <id>`.
+
+- `list` — list active and past participants, including host/member role and leave status.
+- `add --agent <agent-id>` (alias: `invite`) — invite an agent as a member.
+- `remove <participant-id>` — mark an active member as having left. The session host cannot be removed.
+
+```bash
+everruns participants --session session_... add --agent agent_...
+everruns participants --session session_... list
+everruns participants --session session_... remove part_...
+```
+
 ### `everruns chat`
 
 Send message and poll for response.

--- a/test_cases/ui/memory/TC007_scoped_agent_and_user_memory.md
+++ b/test_cases/ui/memory/TC007_scoped_agent_and_user_memory.md
@@ -1,0 +1,42 @@
+# TC007 Scoped agent and user memory
+
+## Description
+
+Verify that host-agent memory is mounted at `/memory/agent` and persists across two sessions of the same agent, while user memory is mounted only in sessions where that user participates.
+
+## Preconditions
+
+- A local or authenticated Everruns stack with scoped memory enabled is available
+- The tester is signed in as User A
+- A second account, User B, can access the same organization
+- An active agent with workspace file tools is available
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Agent memory file | `/memory/agent/tc007-agent-note.txt` |
+| Agent memory content | `agent memory persists across sessions` |
+| User memory file | `/memory/user/tc007-user-note.txt` |
+| User memory content | `private to participating user` |
+
+## Steps
+
+1. As User A, create Session 1 hosted by the test agent.
+2. Ask the agent to list `/memory` and verify both `/memory/agent` and `/memory/user` are mounted.
+3. Ask the agent to write the agent and user test files with the specified contents.
+4. End Session 1 and create Session 2 with the same host agent as User A.
+5. Read `/memory/agent/tc007-agent-note.txt` and verify the content written in Session 1 persists.
+6. Read `/memory/user/tc007-user-note.txt` and verify User A's content persists in Session 2.
+7. As User B, create Session 3 with the same host agent without adding User A as a participant.
+8. Verify `/memory/agent/tc007-agent-note.txt` is present because the host agent is the same.
+9. Verify User A's `/memory/user/tc007-user-note.txt` is not mounted or readable in Session 3.
+10. Ask the agent to write `/memory/user/tc007-user-b-note.txt` in Session 3, then verify that file is visible to User B but not in either of User A's sessions.
+
+## Expected Result
+
+- The host agent's memory is automatically mounted read-write at `/memory/agent`.
+- Agent memory written in one session persists into a second session hosted by the same agent.
+- User A's memory is mounted at `/memory/user` in User A's sessions and persists for User A.
+- A session where User A does not participate cannot read or expose User A's scoped memory.
+- Each user's memory is mounted only in sessions where that user participates; another user's private memory is never merged into it.

--- a/test_cases/ui/session_participants/TC001_manage_session_participants.md
+++ b/test_cases/ui/session_participants/TC001_manage_session_participants.md
@@ -1,0 +1,38 @@
+# TC001 Manage session participants
+
+## Description
+
+Verify that the session participant rail identifies the host and members, supports inviting and addressing an agent member, attributes its reply, and renders a leave system line.
+
+## Preconditions
+
+- A local (`AUTH_MODE=none`) or authenticated deployed Everruns UI is available
+- The tester is signed in and has access to the target organization when authentication is enabled
+- Two active agents are available: a host agent and a guest agent with visibly different names
+- A session hosted by the host agent is open
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Host agent | `Participant Host` |
+| Guest agent | `Participant Specialist` |
+| Addressed message | `Reply with exactly: specialist reply` |
+
+## Steps
+
+1. Open the host agent's session and locate the **In this session** participant rail.
+2. Verify the host agent appears with the host role and the current user appears among the members.
+3. Use the invite control to add `Participant Specialist`.
+4. Verify the guest appears as an active agent member without replacing the host.
+5. Address `Participant Specialist` and send `Reply with exactly: specialist reply`.
+6. Wait for the response and verify the reply is attributed to `Participant Specialist`, not the host.
+7. Use the leave/remove control for `Participant Specialist`.
+8. Verify the participant rail no longer shows the guest as active and the transcript renders a system line recording that it left.
+
+## Expected Result
+
+- The participant rail distinguishes the host, user members, and invited agent members.
+- Inviting an agent adds it as a member while preserving the original host.
+- An addressed turn routes to the selected active agent and attributes its reply to that participant.
+- Removing the guest retains membership history and renders a leave system line in the transcript.


### PR DESCRIPTION
## What changed
Adds agent-scoped `everruns triggers` list/create/update/enable/disable/run-now commands and session-scoped `everruns participants` list/add/remove commands. Trigger text output renders common cron schedules as readable cadence plus timezone. Adds CLI/parser coverage, durable manual UI cases for participants and scoped memory, and SDK-compat smoke coverage for trigger creation and participant invitation across published SDK cohorts.

## Why
EVE-790 identified shipped agent-first API behavior that lacked CLI parity and regression coverage on manual UI and generated-SDK compatibility surfaces.

## Before / After
Before: the CLI exposed neither `/v1/agents/{id}/triggers` nor `/v1/sessions/{id}/participants`; participant/scoped-memory UI cases were absent; SDK-compat stopped after agent/session fetch.

After, live against an isolated in-memory API:

```text
ID                                      SCHEDULE                                          MODE
trg_...                                 Every hour at :30 (America/Chicago)                session_per_invocation
Triggered: trg_...
Session:       session_...

part_...  agent  host    agent_...  active
part_...  agent  member  agent_...  active
Removed participant: part_...
verified participant leave history
```

Python, TypeScript, and Rust SDK compatibility scripts created a disabled trigger and invited a guest participant successfully for current and prior cohorts; Rust branches for 0.1.0, 0.1.3, 0.1.10, and 0.2.0 were exercised locally.

## Risk
- Medium
- New CLI commands use direct authenticated HTTP for endpoints not yet available in published SDK clients. Risk is limited to request construction, output formatting, and compatibility-script fixture setup; server endpoint behavior is unchanged.

## Security
- Threat categories reviewed: TM-AUTH, TM-API, TM-TENANT, TM-DOS
- Findings and resolutions: API keys remain authorization-header-only and are never printed; existing org selection is forwarded through `X-Org-Id`; server-side validation and authorization remain authoritative; no unbounded client loops or repository dependency changes were added. No new threat-model entry is needed.

## Follow-ups
- Standalone participants/scoped-memory example deferred because it is optional; required behavior is covered by CLI docs and manual cases, and the existing weekend-concierge example already covers triggers.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

