### PR TITLE
feat(agents): own agent-trigger sessions by the agent's identity

### DIFF
--- a/crates/server/migrations/107_agent_identity_id_on_agents.sql
+++ b/crates/server/migrations/107_agent_identity_id_on_agents.sql
@@ -1,0 +1,15 @@
+-- Agent-owned identity: each agent gets a lazily-created agent_identity
+-- principal on its first unattended action (e.g. an agent trigger fire), so
+-- unattended sessions are owned by the agent acting as itself rather than the
+-- org system-owner. See specs/agent-triggers.md and specs/agent-identities.md.
+--
+-- Schema-only: nullable column plus a partial index. No data backfill and no
+-- retroactive rewrite of historical sessions.owner_principal_id — the identity
+-- is created on demand the next time an agent fires.
+
+ALTER TABLE agents
+    ADD COLUMN agent_identity_id UUID REFERENCES agent_identities(id);
+
+CREATE INDEX idx_agents_agent_identity_id
+    ON agents(agent_identity_id)
+    WHERE agent_identity_id IS NOT NULL;

--- a/crates/server/src/domains/agent_triggers/commands.rs
+++ b/crates/server/src/domains/agent_triggers/commands.rs
@@ -23,13 +23,14 @@ use crate::execution_metadata;
 use crate::services::PrincipalService;
 use crate::storage::StorageBackend;
 use crate::storage::models::{
-    AgentRow, AgentTriggerRow, CreateAgentTriggerRow, UpdateAgentTrigger,
+    AgentRow, AgentTriggerRow, CreateAgentIdentityRow, CreateAgentTriggerRow, PrincipalRow,
+    UpdateAgentTrigger,
 };
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, SessionId, TriggerId};
 use everruns_core::{
-    AgentAction, AgentTrigger, AgentTriggerType, AuditEvent, Caller, InvocationSessionMode, Policy,
-    ScheduleTriggerConfig,
+    AgentAction, AgentIdentityId, AgentTrigger, AgentTriggerType, AuditEvent, Caller,
+    InvocationSessionMode, Policy, ScheduleTriggerConfig,
 };
 use everruns_durable::{
     CreateScheduleRow, Pagination as DurablePagination, ScheduleExecutionFilter,
@@ -879,11 +880,12 @@ pub async fn invoke_agent_trigger(
         ));
     }
 
-    // Ownership: agents have no agent-identity layer, so the session is owned by
-    // the org's default owner principal (internal caller → system/human owner).
-    // Resolving it up front lets the shared-session reuse lookup key on it.
-    let owner = PrincipalService::new(db.clone())
-        .default_owner_principal(&Caller::internal(org_id), None)
+    // Ownership: the trigger session is owned by the agent's own identity
+    // principal, lazily created on this agent's first unattended action. The
+    // agent thus acts as itself; an explicitly-linked identity is never
+    // overridden. Resolving it up front lets the shared-session reuse lookup
+    // key on the (stable) identity principal.
+    let (agent_identity_id, owner) = ensure_identity_for_agent(db, org_id, &agent)
         .await
         .map_err(classify_anyhow)?;
 
@@ -894,6 +896,7 @@ pub async fn invoke_agent_trigger(
         &agent,
         trigger_id,
         config.session_mode,
+        agent_identity_id,
         owner.id,
         owner.resolved_user_id,
     )
@@ -926,6 +929,75 @@ pub async fn invoke_agent_trigger(
     })
 }
 
+/// Resolve the agent-identity principal that owns this agent's unattended work,
+/// lazily creating the identity on the agent's first fire (EVE-758).
+///
+/// - If the agent is already linked to an identity (explicitly or from a prior
+///   fire), that identity's principal is ensured and returned — it is NEVER
+///   overridden (`ensure_agent_identity_principal` also preserves the existing
+///   parent at the principal layer).
+/// - Otherwise a fresh `agent_identities` row is created, its principal is
+///   ensured (parented to the internal caller's system-owner, so the effective
+///   human/system owner is unchanged), and the agent is linked with a guarded
+///   set that only writes when the link is still NULL.
+///
+/// Returns the identity id and its principal row (the durable session owner).
+async fn ensure_identity_for_agent(
+    db: &Arc<StorageBackend>,
+    org_id: i64,
+    agent: &AgentRow,
+) -> anyhow::Result<(AgentIdentityId, PrincipalRow)> {
+    let principals = PrincipalService::new(db.clone());
+    let caller = Caller::internal(org_id);
+
+    // Already linked: ensure and return without ever creating a new identity.
+    if let Some(identity_id) = agent.agent_identity_id {
+        let principal = principals
+            .default_owner_principal(&caller, Some(identity_id))
+            .await?;
+        return Ok((identity_id, principal));
+    }
+
+    // First unattended action: create the agent's own identity.
+    let new_id = AgentIdentityId::new();
+    db.create_agent_identity(CreateAgentIdentityRow {
+        org_id,
+        id: new_id,
+        name: agent.name.clone(),
+        description: Some(format!("Identity for agent {}", agent.public_id)),
+        avatar_url: None,
+        locale: None,
+        timezone: None,
+    })
+    .await?;
+    let principal = principals
+        .default_owner_principal(&caller, Some(new_id))
+        .await?;
+
+    // Guarded link: only claims the agent when it is still unlinked. When a
+    // concurrent first-fire won the race this returns false; adopt the winner's
+    // identity and soft-archive our just-created orphan (best-effort).
+    if db.set_agent_identity_id(org_id, agent.id, new_id).await? {
+        return Ok((new_id, principal));
+    }
+
+    let winner = db
+        .get_agent(org_id, agent.id)
+        .await?
+        .and_then(|a| a.agent_identity_id)
+        .ok_or_else(|| anyhow::anyhow!("agent identity link missing after concurrent set"))?;
+    // Best-effort cleanup of the orphaned identity + its principal. Failure here
+    // is harmless: the orphan is an unreferenced, archivable row on a rare race.
+    let _ = db.delete_agent_identity(org_id, new_id).await;
+    let _ = principals
+        .sync_agent_identity_status(org_id, new_id, everruns_core::PrincipalStatus::Archived)
+        .await;
+    let winner_principal = principals
+        .default_owner_principal(&caller, Some(winner))
+        .await?;
+    Ok((winner, winner_principal))
+}
+
 fn trigger_session_tags(trigger_id: TriggerId) -> Vec<String> {
     vec![
         format!("agent_trigger:{trigger_id}"),
@@ -941,6 +1013,7 @@ async fn find_or_create_trigger_session(
     agent: &AgentRow,
     trigger_id: TriggerId,
     session_mode: InvocationSessionMode,
+    agent_identity_id: AgentIdentityId,
     owner_principal_id: everruns_core::PrincipalId,
     resolved_owner_user_id: Option<Uuid>,
 ) -> Result<(SessionId, bool), CommandError> {
@@ -979,7 +1052,7 @@ async fn find_or_create_trigger_session(
                 harness_name: None,
                 agent_id: Some(agent.id),
                 agent_name: None,
-                agent_identity_id: None,
+                agent_identity_id: Some(agent_identity_id),
                 title: Some(title),
                 goal: None,
                 locale: None,

--- a/crates/server/src/domains/agent_triggers/tests.rs
+++ b/crates/server/src/domains/agent_triggers/tests.rs
@@ -394,3 +394,109 @@ async fn binding_torn_down_on_delete() {
         "archived trigger excluded from active list"
     );
 }
+
+// ---- ensure_identity_for_agent (EVE-758) --------------------------------
+
+/// Full `AgentRow` for identity tests (the helper above returns only ids).
+async fn seed_agent_row(db: &Arc<StorageBackend>) -> crate::storage::models::AgentRow {
+    let (public_id, _) = seed_agent(db).await;
+    db.get_agent_by_public_id(DEFAULT_ORG_ID, &public_id)
+        .await
+        .unwrap()
+        .expect("seeded agent row")
+}
+
+#[tokio::test]
+async fn ensure_identity_for_agent_creates_and_links_when_none() {
+    let db = Arc::new(StorageBackend::in_memory());
+    let agent = seed_agent_row(&db).await;
+    assert!(agent.agent_identity_id.is_none());
+
+    let (identity_id, owner) = ensure_identity_for_agent(&db, DEFAULT_ORG_ID, &agent)
+        .await
+        .expect("lazily create identity");
+
+    // The trigger session owner is the agent's own identity principal.
+    assert_eq!(owner.kind, "agent_identity");
+    // The agent row is now linked to the freshly-created identity.
+    let linked = db
+        .get_agent(DEFAULT_ORG_ID, agent.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(linked.agent_identity_id, Some(identity_id));
+}
+
+#[tokio::test]
+async fn ensure_identity_for_agent_is_idempotent_across_fires() {
+    let db = Arc::new(StorageBackend::in_memory());
+    let agent = seed_agent_row(&db).await;
+
+    let (first, _) = ensure_identity_for_agent(&db, DEFAULT_ORG_ID, &agent)
+        .await
+        .expect("first fire");
+    // Second fire re-reads the (now linked) agent, mirroring the real path.
+    let agent = db
+        .get_agent(DEFAULT_ORG_ID, agent.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let (second, _) = ensure_identity_for_agent(&db, DEFAULT_ORG_ID, &agent)
+        .await
+        .expect("second fire");
+
+    assert_eq!(first, second, "same identity reused on subsequent fires");
+}
+
+#[tokio::test]
+async fn ensure_identity_for_agent_never_overrides_explicit_identity() {
+    use crate::storage::models::CreateAgentIdentityRow;
+    use everruns_core::AgentIdentityId;
+
+    let db = Arc::new(StorageBackend::in_memory());
+    let mut agent = seed_agent_row(&db).await;
+
+    let explicit = AgentIdentityId::new();
+    db.create_agent_identity(CreateAgentIdentityRow {
+        org_id: DEFAULT_ORG_ID,
+        id: explicit,
+        name: "Explicit".to_string(),
+        description: None,
+        avatar_url: None,
+        locale: None,
+        timezone: None,
+    })
+    .await
+    .unwrap();
+    assert!(
+        db.set_agent_identity_id(DEFAULT_ORG_ID, agent.id, explicit)
+            .await
+            .unwrap()
+    );
+    agent.agent_identity_id = Some(explicit);
+
+    let (identity_id, owner) = ensure_identity_for_agent(&db, DEFAULT_ORG_ID, &agent)
+        .await
+        .expect("resolve explicit identity");
+
+    assert_eq!(identity_id, explicit, "explicit identity is returned as-is");
+    assert_eq!(owner.kind, "agent_identity");
+    let linked = db
+        .get_agent(DEFAULT_ORG_ID, agent.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        linked.agent_identity_id,
+        Some(explicit),
+        "explicit identity is never overridden"
+    );
+
+    // A guarded set on an already-linked agent is a no-op.
+    assert!(
+        !db.set_agent_identity_id(DEFAULT_ORG_ID, agent.id, AgentIdentityId::new())
+            .await
+            .unwrap(),
+        "set_agent_identity_id refuses to override an existing link"
+    );
+}

--- a/crates/server/src/services/principal.rs
+++ b/crates/server/src/services/principal.rs
@@ -188,7 +188,7 @@ impl PrincipalService {
                 kind: "agent_identity".to_string(),
                 subject_id: Some(agent_identity_id.uuid()),
                 parent_principal_id: Some(parent.id),
-                resolved_user_id: Some(resolved_user_id),
+                resolved_user_id,
                 metadata,
             })
             .await
@@ -304,7 +304,17 @@ impl PrincipalService {
         Ok(())
     }
 
-    async fn resolve_user_from_lineage(&self, org_id: i64, start: &PrincipalRow) -> Result<Uuid> {
+    /// Walk a principal's parent chain to the human user that ultimately owns
+    /// it, if any. Returns `None` when the lineage terminates at the org's
+    /// system principal: a system-owned (unattended) principal has no resolved
+    /// human user. This lets an agent-identity principal be parented to the
+    /// org system-owner — e.g. a lazily-created agent-trigger identity (EVE-758)
+    /// — resolving to "no user" (system-owned) rather than erroring.
+    async fn resolve_user_from_lineage(
+        &self,
+        org_id: i64,
+        start: &PrincipalRow,
+    ) -> Result<Option<Uuid>> {
         let mut current = start.clone();
         for _ in 0..MAX_PRINCIPAL_DEPTH {
             if current.org_id != org_id {
@@ -315,11 +325,17 @@ impl PrincipalService {
                 return current
                     .subject_id
                     .or(current.resolved_user_id)
-                    .ok_or_else(|| anyhow!("User principal missing subject"));
+                    .ok_or_else(|| anyhow!("User principal missing subject"))
+                    .map(Some);
             }
 
             if let Some(user_id) = current.resolved_user_id {
-                return Ok(user_id);
+                return Ok(Some(user_id));
+            }
+
+            // The org system-owner is a terminal root with no human behind it.
+            if current.kind == "system" {
+                return Ok(None);
             }
 
             let parent_id = current

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -612,6 +612,15 @@ impl StorageBackend {
         dispatch!(self, update_agent, org_id, id, input)
     }
 
+    pub async fn set_agent_identity_id(
+        &self,
+        org_id: i64,
+        id: AgentId,
+        agent_identity_id: AgentIdentityId,
+    ) -> Result<bool> {
+        dispatch!(self, set_agent_identity_id, org_id, id, agent_identity_id)
+    }
+
     pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         dispatch!(self, delete_agent, org_id, id)
     }

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -4,7 +4,7 @@ use super::super::models::*;
 use super::InMemoryDatabase;
 use super::matches_search_tokens;
 use anyhow::Result;
-use everruns_core::AgentId;
+use everruns_core::{AgentId, AgentIdentityId};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -26,6 +26,7 @@ impl InMemoryDatabase {
             system_prompt: input.system_prompt,
             default_model_id: input.default_model_id,
             harness_id: input.harness_id,
+            agent_identity_id: None,
             default_version_id: None,
             forked_from_agent_id: None,
             forked_from_version_id: None,
@@ -108,6 +109,7 @@ impl InMemoryDatabase {
             system_prompt: input.system_prompt,
             default_model_id: input.default_model_id,
             harness_id: input.harness_id,
+            agent_identity_id: None,
             default_version_id: None,
             forked_from_agent_id: None,
             forked_from_version_id: None,
@@ -306,6 +308,27 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
+    /// Link an agent to its lazily-created identity, only when not already
+    /// linked (EVE-758). Returns `true` when this call set the link, `false`
+    /// when it was already linked — never overrides an existing link.
+    pub async fn set_agent_identity_id(
+        &self,
+        org_id: i64,
+        id: AgentId,
+        agent_identity_id: AgentIdentityId,
+    ) -> Result<bool> {
+        let mut agents = self.agents.write();
+        if let Some(agent) = agents.get_mut(&id).filter(|a| a.org_id == org_id) {
+            if agent.agent_identity_id.is_some() {
+                return Ok(false);
+            }
+            agent.agent_identity_id = Some(agent_identity_id);
+            agent.updated_at = Self::now();
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         let mut agents = self.agents.write();
         if let Some(agent) = agents.get_mut(&id) {
@@ -376,6 +399,7 @@ impl InMemoryDatabase {
                 system_prompt: input.system_prompt,
                 default_model_id: input.default_model_id,
                 harness_id: input.harness_id,
+                agent_identity_id: None,
                 default_version_id: None,
                 forked_from_agent_id: None,
                 forked_from_version_id: None,
@@ -447,6 +471,7 @@ impl InMemoryDatabase {
                 system_prompt: input.system_prompt,
                 default_model_id: input.default_model_id,
                 harness_id: input.harness_id,
+                agent_identity_id: None,
                 default_version_id: None,
                 forked_from_agent_id: None,
                 forked_from_version_id: None,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -456,6 +456,13 @@ pub struct AgentRow {
     pub system_prompt: String,
     pub default_model_id: Option<ModelId>,
     pub harness_id: HarnessId,
+    /// Lazily-created identity principal subject for this agent (EVE-758).
+    /// NULL until the agent first acts unattended (e.g. an agent trigger fire),
+    /// at which point an `agent_identities` row is created and linked so the
+    /// agent owns its unattended sessions as itself. Storage-only: intentionally
+    /// not surfaced on the public `everruns_core::Agent` API.
+    #[sqlx(default)]
+    pub agent_identity_id: Option<AgentIdentityId>,
     #[sqlx(default)]
     pub default_version_id: Option<everruns_core::AgentVersionId>,
     #[sqlx(default)]

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -4,6 +4,7 @@ use super::super::models::*;
 use super::Database;
 use super::build_search_sql;
 use anyhow::Result;
+use everruns_core::AgentIdentityId;
 use everruns_core::typed_id::AgentId;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -18,7 +19,7 @@ impl Database {
             r#"
             INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, status)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, 'active')
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -82,7 +83,7 @@ impl Database {
                 OR agents.network_access IS DISTINCT FROM EXCLUDED.network_access
                 OR agents.max_iterations IS DISTINCT FROM EXCLUDED.max_iterations
                 OR agents.parallel_tool_calls IS DISTINCT FROM EXCLUDED.parallel_tool_calls
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -111,7 +112,7 @@ impl Database {
     pub async fn get_agent(&self, org_id: i64, id: AgentId) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND id = $2
@@ -129,7 +130,7 @@ impl Database {
         let ids: Vec<Uuid> = ids.iter().map(|id| id.uuid()).collect();
         Ok(sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND id = ANY($2)
@@ -161,7 +162,7 @@ impl Database {
     ) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND public_id = $2
@@ -209,7 +210,7 @@ impl Database {
         let limit_idx = param_idx + 1;
         let offset_idx = param_idx + 2;
         let sql = format!(
-            r#"SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            r#"SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                        total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
                 FROM agents
                 WHERE org_id = $1{status_sql}{search_sql}
@@ -244,7 +245,7 @@ impl Database {
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND name = $2 AND status != 'deleted'
@@ -288,7 +289,7 @@ impl Database {
                 parallel_tool_calls = CASE WHEN $22 THEN $23 ELSE parallel_tool_calls END,
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -319,6 +320,33 @@ impl Database {
         .await?;
 
         Ok(row)
+    }
+
+    /// Link an agent to its lazily-created identity, but only when it is not
+    /// already linked (EVE-758). Returns `true` when this call performed the
+    /// assignment and `false` when the agent was already linked (e.g. a
+    /// concurrent first-fire won the race, or an identity was set explicitly),
+    /// so callers never override an existing link.
+    pub async fn set_agent_identity_id(
+        &self,
+        org_id: i64,
+        id: AgentId,
+        agent_identity_id: AgentIdentityId,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE agents
+            SET agent_identity_id = $3, updated_at = NOW()
+            WHERE org_id = $1 AND id = $2 AND agent_identity_id IS NULL
+            "#,
+        )
+        .bind(org_id)
+        .bind(id.uuid())
+        .bind(agent_identity_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
@@ -384,7 +412,7 @@ impl Database {
                 parallel_tool_calls = EXCLUDED.parallel_tool_calls,
                 status = 'active',
                 updated_at = NOW()
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -436,7 +464,7 @@ impl Database {
                 parallel_tool_calls = EXCLUDED.parallel_tool_calls,
                 status = 'active',
                 updated_at = NOW()
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )

--- a/crates/server/tests/agent_trigger_invocation_integration_test.rs
+++ b/crates/server/tests/agent_trigger_invocation_integration_test.rs
@@ -140,6 +140,46 @@ async fn agent_trigger_binds_schedule_and_invokes_shared_session() {
     );
     assert!(session.agent_id.is_some(), "session is hosted by the agent");
 
+    // Ownership (EVE-758): the trigger session is owned by the agent's own
+    // lazily-created identity principal, and the agent row is now linked to it.
+    let agent_row = server
+        .db
+        .get_agent(DEFAULT_ORG_ID, session.agent_id.expect("agent id"))
+        .await
+        .expect("get agent")
+        .expect("agent exists");
+    let identity_id = agent_row
+        .agent_identity_id
+        .expect("agent linked to a lazily-created identity on first fire");
+    let owner = server
+        .db
+        .get_principal(DEFAULT_ORG_ID, session.owner_principal_id)
+        .await
+        .expect("get owner principal")
+        .expect("owner principal exists");
+    assert_eq!(
+        owner.kind, "agent_identity",
+        "trigger session is owned by the agent's identity principal"
+    );
+    assert_eq!(
+        session.agent_identity_id,
+        Some(identity_id),
+        "session records the agent's identity"
+    );
+
+    // The second (shared) fire reuses the same identity and the same session.
+    let agent_after_second = server
+        .db
+        .get_agent(DEFAULT_ORG_ID, agent_row.id)
+        .await
+        .expect("get agent")
+        .expect("agent exists");
+    assert_eq!(
+        agent_after_second.agent_identity_id,
+        Some(identity_id),
+        "shared-mode reuse keeps the same identity (no re-link)"
+    );
+
     // The rendered template reached the session as a user message, twice.
     let texts = list_user_message_texts(&server, &first.session_id.to_string()).await;
     assert!(

--- a/specs/agent-identities.md
+++ b/specs/agent-identities.md
@@ -32,6 +32,26 @@ Agent identities also participate in durable ownership through the principal gra
 - that principal keeps its existing parent/effective user when the identity is edited
 - sessions and apps that reference the identity can use the identity principal as their durable owner without losing the effective human owner
 
+### Identity per agent (lazy default)
+
+Agent identities can be created and managed standalone (the CRUD API above), but
+an agent also gets one **lazily, on demand**: the first time an agent acts
+unattended (currently an agent-trigger fire — see `specs/agent-triggers.md`) it
+is given its own `agent_identity` so it owns that work as itself.
+
+- The link lives on `agents.agent_identity_id` (storage-only; not on the public
+  `Agent` API). It is nullable and created on first unattended action.
+- Creation is idempotent and never overrides an existing link: an identity
+  attached explicitly, or from a prior fire, is reused. The guarded link write
+  only sets `agent_identity_id` while it is still NULL, so a concurrent
+  first-fire race resolves to a single winner (the loser's orphan identity is
+  soft-archived best-effort).
+- The lazily-created identity's principal is parented to the org system-owner,
+  so the effective human/system owner and budgeting are unchanged; the agent
+  simply acts as itself.
+- No retroactive rewrite: existing agents and their historical sessions are left
+  as-is and pick up an identity on their next unattended action.
+
 ### Scheduling
 
 `SessionSchedule` does not own a separate identity field. Schedules inherit the resident identity from their session at execution time.

--- a/specs/agent-triggers.md
+++ b/specs/agent-triggers.md
@@ -84,13 +84,17 @@ the durable schedule id.
 
 ## Ownership and provenance
 
-Agents do not yet carry their own identity principal, so trigger sessions are
-owned by the **org's default owner principal** (resolved via
-`PrincipalService::default_owner_principal` for an internal caller). This keeps
-unattended runs correctly attributed and budgeted, and is the stable key the
-`shared_session` reuse lookup matches on. Converging this onto a per-agent
-identity principal — so each agent acts as itself — is P5
-(`specs/agent-identities.md`); this spec will move to that owner when P5 lands.
+Trigger sessions are owned by the **agent's own `agent_identity` principal**, so
+each agent acts as itself on unattended runs. The identity is created lazily on
+the agent's first fire (`ensure_identity_for_agent`): an `agent_identities` row
+is created, its principal is ensured via
+`PrincipalService::default_owner_principal(internal_caller, Some(identity_id))`
+— parented to the org system-owner, so the effective owner/budget stays system,
+as before — and the agent row is linked through `agents.agent_identity_id` with
+a guarded write that only sets the link when it is still NULL. An
+explicitly-linked identity is never overridden, and subsequent fires reuse the
+same identity. That identity principal is the stable key the `shared_session`
+reuse lookup matches on. See `specs/agent-identities.md` for the identity model.
 
 ## Relationship to App schedule channels
 


### PR DESCRIPTION
## What changed

Agent-trigger sessions are now owned by the **agent's own identity principal** instead of the org system-owner. On an agent's first unattended action (an agent trigger fire), an `agent_identity` is created lazily and linked to the agent; every later fire reuses it. An explicitly-linked identity is never overridden. This is **Part A** of the P5 identity-convergence epic (EVE-758), scoped deliberately small.

- New nullable `agents.agent_identity_id` (migration 107, additive; partial index). No data backfill, no rewrite of historical session ownership.
- `invoke_agent_trigger` resolves/creates the agent's identity (idempotent, never-override) and owns the trigger session with the resulting `agent_identity` principal, which is parented to the org system-owner so the **effective human/system owner is unchanged**.
- Storage-only field on `AgentRow` — intentionally **not** surfaced on the public `everruns_core::Agent` API, so OpenAPI/UI are untouched.

## Why

P4 gave agents the ability to wake themselves on triggers, but their sessions were owned by the org's default (system) owner as an explicit interim (see the retired note in `specs/agent-triggers.md`). P5 converges ownership so an agent acts *as itself*. Part A lands the smallest safe slice: the lazy per-agent identity + the trigger (unattended) path.

## Before / After

- **Before:** a trigger fire created a session owned by the org `system-owner` principal; the agent had no identity of its own.
- **After:** the first fire lazily creates an `agent_identities` row + `agent_identity` principal, links it to the agent, and owns the session with it (`owner_principal.kind == "agent_identity"`); subsequent fires reuse the same identity/session. Effective owner (resolved human user) is unchanged (system-owned, `resolved_user_id = NULL`).

Evidence:
- `cargo fmt --check` clean; `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` clean.
- `cargo test -p everruns-server agent_trigger` → 18 lib + 2 integration passed (incl. 3 new `ensure_identity_for_agent_*` unit tests and the extended invocation test asserting `owner.kind == "agent_identity"`, agent linked, and shared-mode identity reuse); `principal` tests 5 passed.
- CI: **Integration Tests (PostgreSQL)** green — the full migration chain (`001..107`) applies via `sqlx` and the trigger/repo paths pass against real Postgres; **Migration Immutability** and **OpenAPI Spec Freshness** green (no API drift).

## Risk

- **Medium.** Localized to the agent-trigger path + additive schema. The hard invariants (idempotent principal upsert on `(org, kind, subject_id)`; never override an existing parent) are pre-existing and reused.
- One expected one-time behavior: existing **shared** trigger sessions were owned by the old system-owner principal; because shared-session reuse keys on the owner principal, the first post-deploy fire of a shared trigger starts a fresh shared session (prior history preserved on the old session). Session-per-invocation triggers are unaffected.
- `PrincipalService::resolve_user_from_lineage` now returns `Option<Uuid>` and yields `None` when lineage terminates at a `system` principal (previously it errored). Single caller (`ensure_agent_identity_principal`); user-parented identities are unaffected.

## Security

- Threat categories reviewed: **TM-AUTHZ**, **TM-TENANT**, **TM-DOS**.
- Every new path is org-scoped (`org_id` on `get_agent`, `set_agent_identity_id`, identity/principal create). The lazily-created identity is parented to the org system-owner (no human user), so it grants no user privileges and effective ownership/budgeting is identical to before. Guarded `set_agent_identity_id` (`WHERE agent_identity_id IS NULL`) prevents override/hijack of an existing link. One identity per agent bounds growth (TM-DOS). All queries are parameterized; no new endpoints, inputs, deps, or secrets. No THREAT comments affected; no threat-model change required.
- Findings and resolutions: none.

## Follow-ups

- **Part C / P2 participation** acting-principal switch (`messages/service.rs`) — the change that alters live interactive/multi-agent provenance; deliberately kept separate to contain blast radius.
- **Bulk backfill** of already-acted agents — intentionally omitted; lazy creation covers each agent on its next unattended action and historical `sessions.owner_principal_id` is left immutable. A one-time backfill, if desired, is a separate reviewed migration.
- **Other unattended entrypoints** (app/channel-driven, future workflows) still use existing ownership; converging them onto `ensure_identity_for_agent` is future work.
- First-fire concurrency race soft-archives the losing orphan identity best-effort; a deterministic concurrency test is deferred (hard to force with the in-memory backend).
- Parts B (identity facet resolution), D (`App.harness_id` removal), E (UI), F (full spec sweep) remain per the epic.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)