### PR TITLE
fix(agent-identities): block archived trigger owners

### DIFF
--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -282,6 +282,31 @@ impl Command for UpdateAgentIdentityCmd {
 
 inventory::submit! { CommandDescriptor::of::<UpdateAgentIdentityCmd>() }
 
+async fn ensure_no_live_references(
+    ctx: &Ctx,
+    identity_id: AgentIdentityId,
+) -> Result<(), CommandError> {
+    crate::domains::apps::queries::ensure_no_app_references_to_agent_identity(
+        &ctx.db,
+        ctx.org_id(),
+        identity_id.uuid(),
+    )
+    .await?;
+
+    if ctx
+        .db
+        .has_agent_with_identity(ctx.org_id(), identity_id)
+        .await
+        .map_err(classify_anyhow)?
+    {
+        return Err(CommandError::conflict(
+            "Cannot archive or delete agent identity while agents still reference it",
+        ));
+    }
+
+    Ok(())
+}
+
 // ============================================================================
 // DeleteAgentIdentity
 // ============================================================================
@@ -320,12 +345,7 @@ impl Command for DeleteAgentIdentity {
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid identity ID: {e}")))?;
 
-        crate::domains::apps::queries::ensure_no_app_references_to_agent_identity(
-            &ctx.db,
-            ctx.org_id(),
-            identity_id.uuid(),
-        )
-        .await?;
+        ensure_no_live_references(ctx, identity_id).await?;
 
         let deleted = ctx
             .db
@@ -385,12 +405,7 @@ impl Command for DestroyAgentIdentity {
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid identity ID: {e}")))?;
 
-        crate::domains::apps::queries::ensure_no_app_references_to_agent_identity(
-            &ctx.db,
-            ctx.org_id(),
-            identity_id.uuid(),
-        )
-        .await?;
+        ensure_no_live_references(ctx, identity_id).await?;
 
         let destroyed = ctx
             .db

--- a/crates/server/src/domains/agent_triggers/commands.rs
+++ b/crates/server/src/domains/agent_triggers/commands.rs
@@ -952,6 +952,16 @@ async fn ensure_identity_for_agent(
 
     // Already linked: ensure and return without ever creating a new identity.
     if let Some(identity_id) = agent.agent_identity_id {
+        let identity = db
+            .get_agent_identity(org_id, identity_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Agent identity not found"))?;
+        if identity.status != "active" {
+            anyhow::bail!(
+                "Agent identity {} is not active and cannot own new trigger sessions",
+                identity_id
+            );
+        }
         let principal = principals
             .default_owner_principal(&caller, Some(identity_id))
             .await?;

--- a/crates/server/src/domains/agent_triggers/tests.rs
+++ b/crates/server/src/domains/agent_triggers/tests.rs
@@ -500,3 +500,40 @@ async fn ensure_identity_for_agent_never_overrides_explicit_identity() {
         "set_agent_identity_id refuses to override an existing link"
     );
 }
+
+#[tokio::test]
+async fn ensure_identity_for_agent_rejects_archived_linked_identity() {
+    use crate::storage::models::CreateAgentIdentityRow;
+    use everruns_core::AgentIdentityId;
+
+    let db = Arc::new(StorageBackend::in_memory());
+    let mut agent = seed_agent_row(&db).await;
+
+    let identity_id = AgentIdentityId::new();
+    db.create_agent_identity(CreateAgentIdentityRow {
+        org_id: DEFAULT_ORG_ID,
+        id: identity_id,
+        name: "Archived".to_string(),
+        description: None,
+        avatar_url: None,
+        locale: None,
+        timezone: None,
+    })
+    .await
+    .unwrap();
+    db.set_agent_identity_id(DEFAULT_ORG_ID, agent.id, identity_id)
+        .await
+        .unwrap();
+    db.delete_agent_identity(DEFAULT_ORG_ID, identity_id)
+        .await
+        .unwrap();
+    agent.agent_identity_id = Some(identity_id);
+
+    let err = ensure_identity_for_agent(&db, DEFAULT_ORG_ID, &agent)
+        .await
+        .expect_err("archived identity must not own new trigger sessions");
+    assert!(
+        err.to_string().contains("is not active"),
+        "unexpected error: {err:#}"
+    );
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -621,6 +621,14 @@ impl StorageBackend {
         dispatch!(self, set_agent_identity_id, org_id, id, agent_identity_id)
     }
 
+    pub async fn has_agent_with_identity(
+        &self,
+        org_id: i64,
+        agent_identity_id: AgentIdentityId,
+    ) -> Result<bool> {
+        dispatch!(self, has_agent_with_identity, org_id, agent_identity_id)
+    }
+
     pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         dispatch!(self, delete_agent, org_id, id)
     }

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -329,6 +329,18 @@ impl InMemoryDatabase {
         Ok(false)
     }
 
+    pub async fn has_agent_with_identity(
+        &self,
+        org_id: i64,
+        agent_identity_id: AgentIdentityId,
+    ) -> Result<bool> {
+        Ok(self.agents.read().values().any(|agent| {
+            agent.org_id == org_id
+                && agent.agent_identity_id == Some(agent_identity_id)
+                && agent.status != "deleted"
+        }))
+    }
+
     pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         let mut agents = self.agents.write();
         if let Some(agent) = agents.get_mut(&id) {

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -349,6 +349,29 @@ impl Database {
         Ok(result.rows_affected() > 0)
     }
 
+    pub async fn has_agent_with_identity(
+        &self,
+        org_id: i64,
+        agent_identity_id: AgentIdentityId,
+    ) -> Result<bool> {
+        let exists: Option<(i32,)> = sqlx::query_as(
+            r#"
+            SELECT 1
+            FROM agents
+            WHERE org_id = $1
+              AND agent_identity_id = $2
+              AND status != 'deleted'
+            LIMIT 1
+            "#,
+        )
+        .bind(org_id)
+        .bind(agent_identity_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(exists.is_some())
+    }
+
     pub async fn delete_agent(&self, org_id: i64, id: AgentId) -> Result<bool> {
         // Archive instead of hard delete
         let result = sqlx::query(

--- a/crates/server/tests/agent_trigger_invocation_integration_test.rs
+++ b/crates/server/tests/agent_trigger_invocation_integration_test.rs
@@ -193,6 +193,11 @@ async fn agent_trigger_binds_schedule_and_invokes_shared_session() {
         2,
         "both fires dispatched into the shared session"
     );
+
+    server
+        .delete(&format!("/v1/agent-identities/{identity_id}"))
+        .await
+        .assert_status(StatusCode::CONFLICT);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation

- Prevent archived or deleted `agent_identities` from being newly assigned to trigger sessions via the new `agents.agent_identity_id` link.  
- Close the lifecycle-enforcement gap so admins can reliably revoke identity-owned credentials by archiving/destroying identities.  
- Align runtime behavior with `specs/agent-identities.md` which requires archived identities to be readable but not assignable to sessions/apps.

### Description

- Add `ensure_no_live_references` and call it from `DeleteAgentIdentity` and `DestroyAgentIdentity` so identity archive/destroy checks both app references and agent links.  
- Expose `has_agent_with_identity` on the `StorageBackend` and implement it in the Postgres repository (`crates/server/src/storage/repositories/agents.rs`) and the in-memory store (`crates/server/src/storage/memory/agents.rs`) using a parameterized, org-scoped query.  
- Harden trigger invocation in `ensure_identity_for_agent` to fetch the linked `agent_identity` and refuse to use it for new trigger sessions unless its `status` is `"active"`.  
- Add regression coverage: a unit test `ensure_identity_for_agent_rejects_archived_linked_identity` and an integration assertion that deleting a trigger-linked identity returns `CONFLICT` when the identity is still referenced by an agent.

### Testing

- Ran `cargo fmt --check`, which passed.  
- Ran `git diff --check`, which passed.  
- Added unit and integration tests under `crates/server` covering the new behavior, but a focused `cargo test -p everruns-server ensure_identity_for_agent` run in this environment was interrupted after lengthy first-time dependency/build steps and did not complete.  
- Attempted `cargo check -p everruns-server`, which progressed through dependency resolution and compilation in this container but was interrupted before finalization due to environment time limits; changes are formatted and compile-time checks were exercised locally as part of the attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b48daca50832bbca3a1496c83c3f4)