### PR TITLE
fix(mcp): enforce endpoint gate on org overrides

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -1341,6 +1341,12 @@ async fn resolve_org_by_id(
         )
     });
 
+    if !feature_flags.mcp_endpoint {
+        return Err(format!(
+            "MCP endpoint is not enabled for organization: {org_public_id}"
+        ));
+    }
+
     Ok(ResolvedOrg {
         org_id: org_row.org_id,
         public_id: org_row.public_id.clone(),

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -2003,6 +2003,56 @@ async fn test_mcp_execute_create_mcp_server() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_org_override_requires_target_org_opt_in() {
+    let server = TestServer::in_memory().await;
+
+    let org2: Value = server
+        .post(
+            "/v1/orgs",
+            json!({ "name": format!("MCP Disabled Override Target {}", unique_suffix()) }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let org2_id = org2["id"].as_str().expect("org2 id").to_string();
+
+    let switch_resp = server
+        .post("/v1/users/me/switch-org", json!({ "org_id": org2_id }))
+        .await
+        .assert_status(StatusCode::OK);
+    let org2_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    let direct_org2_resp = mcp_request_raw(
+        &server,
+        "initialize",
+        json!({}),
+        vec![("cookie", org2_cookie.as_str())],
+    )
+    .await;
+    assert_eq!(direct_org2_resp.status(), StatusCode::NOT_FOUND);
+
+    let override_resp = mcp_tool_call(
+        &server,
+        "execute",
+        json!({
+            "organization_id": org2_id,
+            "commands": "list_agents --limit 5",
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&override_resp),
+        "disabled target org override unexpectedly executed: {}",
+        tool_text(&override_resp)
+    );
+    assert!(
+        tool_text(&override_resp).contains("MCP endpoint is not enabled"),
+        "expected MCP feature-gate failure, got: {}",
+        tool_text(&override_resp)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_adversarial_tool_chain_cannot_escape_org_scope() {
     let server = TestServer::in_memory().await;
     let marker = format!("org2-agent-marker-{}", unique_suffix());


### PR DESCRIPTION
### Motivation
- The MCP entry-point previously checked the `mcp_endpoint` flag only for the initially resolved/default org, allowing an authenticated client to pass `arguments.organization_id` and target a different org that had not opted into MCP. 
- This allowed cross-org access to org-scoped tools (including destructive `execute`) despite a target org administrator opt-out, creating an authorization bypass.

### Description
- Enforce the organization-level MCP opt-in when resolving an `organization_id` override by returning an error if the resolved org's `feature_flags.mcp_endpoint` is false; change made in `crates/server/src/api/mcp_endpoint/mod.rs` inside `resolve_org_by_id`.
- Add a focused regression test `test_mcp_org_override_requires_target_org_opt_in` in `crates/server/tests/mcp_endpoint_test.rs` that creates a second org left opted-out and verifies direct `/mcp` returns `404` while a default-org `tools/call` with `organization_id` for the disabled org is rejected.
- Files changed: `crates/server/src/api/mcp_endpoint/mod.rs` and `crates/server/tests/mcp_endpoint_test.rs`.

### Testing
- Ran formatting: `cargo fmt` and `cargo fmt --check`, and formatting checks passed.
- Ran the focused server test: `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_org_override_requires_target_org_opt_in -- --test-threads=1`, and the new test passed.
- Verified `git diff --check` showed no whitespace errors after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5874693c58832ba852fb5f04ed1dd3)