### PR TITLE
fix(server): gate AG-UI reasoning summaries

### DIFF
--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -532,6 +532,7 @@ export interface AgUiChannelConfig {
   tool_visibility?: AgUiToolVisibility;
   /** Text shown while tools are running when tool_visibility is "generic". */
   generic_tool_text?: string;
+  reasoning_summary_visible?: boolean;
   auth?: AppEndpointAuthConfig;
 }
 

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -647,6 +647,11 @@ pub struct AgUiChannelConfig {
         skip_serializing_if = "is_default_ag_ui_generic_tool_text"
     )]
     pub generic_tool_text: String,
+    /// Whether provider-curated reasoning summaries may be emitted on public
+    /// AG-UI streams. Defaults off because published apps can be anonymous and
+    /// summaries may derive from private prompts, tools, or retrieved data.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub reasoning_summary_visible: bool,
     /// Optional inline auth config for this public endpoint. When omitted,
     /// legacy `anonymous` + `token` behavior applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -663,6 +668,10 @@ fn default_ag_ui_generic_tool_text() -> String {
 
 fn is_default_ag_ui_generic_tool_text(value: &str) -> bool {
     value == DEFAULT_AG_UI_GENERIC_TOOL_TEXT
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Default FCP handshake body. Returned by `GET` when the channel config does
@@ -995,6 +1004,7 @@ impl PublicChatChannelConfig {
             rate_limit_per_minute: self.rate_limit_per_minute,
             tool_visibility: self.tool_visibility,
             generic_tool_text: self.generic_tool_text.clone(),
+            reasoning_summary_visible: false,
             auth: self.auth.clone(),
         }
     }
@@ -1203,6 +1213,7 @@ mod tests {
         assert!(config.auth.is_none());
         assert_eq!(config.tool_visibility, AgUiToolVisibility::Generic);
         assert_eq!(config.generic_tool_text, DEFAULT_AG_UI_GENERIC_TOOL_TEXT);
+        assert!(!config.reasoning_summary_visible);
     }
 
     #[test]
@@ -1214,6 +1225,7 @@ mod tests {
             rate_limit_per_minute: Some(120),
             tool_visibility: AgUiToolVisibility::None,
             generic_tool_text: "Please wait".to_string(),
+            reasoning_summary_visible: true,
             auth: None,
         };
         let json = serde_json::to_string(&config).unwrap();
@@ -1224,6 +1236,7 @@ mod tests {
         assert_eq!(parsed.rate_limit_per_minute, Some(120));
         assert_eq!(parsed.tool_visibility, AgUiToolVisibility::None);
         assert_eq!(parsed.generic_tool_text, "Please wait");
+        assert!(parsed.reasoning_summary_visible);
     }
 
     #[test]
@@ -1242,6 +1255,7 @@ mod tests {
             rate_limit_per_minute: None,
             tool_visibility: AgUiToolVisibility::Generic,
             generic_tool_text: DEFAULT_AG_UI_GENERIC_TOOL_TEXT.to_string(),
+            reasoning_summary_visible: false,
             auth: None,
         };
         let json = serde_json::to_value(&config).unwrap();

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -552,6 +552,7 @@ pub(crate) async fn run_app_agent_stream(
         thinking_text_started: false,
         tool_visibility: channel_config.tool_visibility,
         generic_tool_text: channel_config.generic_tool_text.clone(),
+        reasoning_summary_visible: channel_config.reasoning_summary_visible,
         active_tool_activity_count: 0,
         public_tool_activity_started: false,
         public_tool_activity_opened_thinking: false,
@@ -1043,6 +1044,7 @@ struct AgUiStreamState {
     thinking_text_started: bool,
     tool_visibility: AgUiToolVisibility,
     generic_tool_text: String,
+    reasoning_summary_visible: bool,
     active_tool_activity_count: usize,
     public_tool_activity_started: bool,
     public_tool_activity_opened_thinking: bool,
@@ -1305,12 +1307,13 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             state.public_tool_activity_opened_thinking = false;
         }
         // EVE-775: a provider `reason.item` summary is a *reasoning artifact*
-        // (EVE-768 design note), so it renders on the AG-UI reasoning channel
-        // (`THINKING_*` / `REASONING_*`) — never on the assistant-text channel.
-        // Only the provider-curated `summary` segments are surfaced; the opaque
-        // `encrypted_content` reasoning context is never emitted to a consumer.
+        // (EVE-768 design note), so when channel policy opts in it renders on
+        // the AG-UI reasoning channel (`THINKING_*` / `REASONING_*`) — never on
+        // the assistant-text channel. Opaque `encrypted_content` is never emitted.
         "reason.item" => {
-            if let Ok(data) = parse_event_data::<ReasonItemData>(event) {
+            if state.reasoning_summary_visible
+                && let Ok(data) = parse_event_data::<ReasonItemData>(event)
+            {
                 push_reasoning_summary(state, &data.summary);
             }
         }
@@ -1584,6 +1587,7 @@ mod tests {
             thinking_text_started: false,
             tool_visibility: AgUiToolVisibility::Generic,
             generic_tool_text: "Working...".to_string(),
+            reasoning_summary_visible: false,
             active_tool_activity_count: 0,
             public_tool_activity_started: false,
             public_tool_activity_opened_thinking: false,
@@ -1850,12 +1854,38 @@ mod tests {
         assert_ne!(*start_ids[1], turn_message_id);
     }
 
+    #[tokio::test]
+    async fn test_reason_item_summary_hidden_by_default() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let event = Event::new(
+            SessionId::from_uuid(state.session_id),
+            EventContext::turn(turn_id, input_message_id),
+            ReasonItemData {
+                turn_id,
+                provider: "openai".to_string(),
+                model: Some("gpt-5.5".to_string()),
+                item_id: "rs_private".to_string(),
+                encrypted_content: Some("OPAQUE-DO-NOT-LEAK".to_string()),
+                summary: vec!["Looked up private CRM details.".to_string()],
+                token_count: Some(42),
+            },
+        );
+
+        translate_event(&mut state, &event);
+
+        assert!(state.queue.is_empty());
+        assert!(!state.finished);
+    }
+
     // EVE-775: a provider `reason.item` summary is a reasoning artifact and must
     // project onto the AG-UI reasoning channel (THINKING_*), never the
     // assistant-text channel, and never leak opaque reasoning content.
     #[tokio::test]
-    async fn test_reason_item_summary_projects_to_reasoning_channel() {
+    async fn test_reason_item_summary_projects_to_reasoning_channel_when_enabled() {
         let mut state = test_stream_state().await;
+        state.reasoning_summary_visible = true;
         let turn_id = TurnId::new();
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
         let event = Event::new(
@@ -1916,6 +1946,7 @@ mod tests {
     #[tokio::test]
     async fn test_reason_item_empty_summary_emits_nothing() {
         let mut state = test_stream_state().await;
+        state.reasoning_summary_visible = true;
         let turn_id = TurnId::new();
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
         let event = Event::new(
@@ -1941,6 +1972,7 @@ mod tests {
     #[tokio::test]
     async fn test_reason_summary_and_commentary_use_separate_channels() {
         let mut state = test_stream_state().await;
+        state.reasoning_summary_visible = true;
         let turn_id = TurnId::new();
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
         let context = EventContext::turn(turn_id, input_message_id);
@@ -1999,6 +2031,7 @@ mod tests {
     #[tokio::test]
     async fn test_reason_item_summary_appends_to_active_thinking_block() {
         let mut state = test_stream_state().await;
+        state.reasoning_summary_visible = true;
         let turn_id = TurnId::new();
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
         let context = EventContext::turn(turn_id, input_message_id);

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -72,7 +72,8 @@ Channel config is stored as JSONB and validated at the application layer per cha
   "session_expiration_seconds": 21600,
   "rate_limit_per_minute": 60,
   "tool_visibility": "generic",
-  "generic_tool_text": "Working..."
+  "generic_tool_text": "Working...",
+  "reasoning_summary_visible": false
 }
 ```
 
@@ -106,6 +107,7 @@ AG-UI uses an app-scoped anonymous ingress for the initial rollout:
   thread. Defaults to `21600` (6 hours). Set to `0` to disable expiration.
 - `rate_limit_per_minute` is an optional per-IP, per-app cap. `0` or absent disables the per-app cap and only the global API limit applies. Values above 1,000,000 are rejected at write time. Counters are shared across instances when `VALKEY_URL` is set; otherwise enforcement is per-instance.
 - Public tool activity is controlled by `tool_visibility`: `none` suppresses tool activity entirely, `generic` emits only `generic_tool_text` as transient activity, and `narrated` emits backend-authored narration. Public AG-UI streams never expose raw tool names, arguments, results, or internal tool call IDs.
+- Provider reasoning summaries are controlled separately by `reasoning_summary_visible` and default to hidden because anonymous/public apps may run over private prompts, tools, or retrieved data. Even when enabled, opaque `encrypted_content` is never exposed.
 
 ### App Endpoint Auth
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -1257,9 +1257,9 @@ rationale and the non-overlapping definitions.
   hidden chain-of-thought is never persisted or exposed.
 - **Reasoning summary** — the provider-curated safe summary carried on
   `reason.item` (`summary`), alongside opaque/encrypted continuation state. The
-  summary is a *reasoning artifact*, surfaced on the reasoning channel by
-  default — never relabeled as an assistant answer. The opaque
-  `encrypted_content` is never surfaced to a consumer.
+  summary is a *reasoning artifact* that may be surfaced on the reasoning
+  channel when a transport explicitly opts in — never relabeled as an assistant
+  answer. The opaque `encrypted_content` is never surfaced to a consumer.
 - **Tool activity** — narration/progress/output scoped to a `tool_call` id; its
   own channel, never merged into the assistant-message channel.
 
@@ -1270,7 +1270,7 @@ rationale and the non-overlapping definitions.
 | Commentary | `output.message.delta` / `output.message.completed` (`phase = commentary`) | AG-UI `TEXT_MESSAGE_*`; ACP `agent_message_chunk` | — | — |
 | Final answer | `output.message.completed` (`phase = final_answer`) | AG-UI `TEXT_MESSAGE_*`; ACP `agent_message_chunk` | — | — |
 | Thinking | `reason.thinking.*` | — | AG-UI `REASONING_*` / `THINKING_*`; ACP `agent_thought_chunk` | — |
-| Reasoning summary | `reason.item` (`summary`) | — | AG-UI `REASONING_*` / `THINKING_*` (visible by default; policy may omit); ACP `agent_thought_chunk` | — |
+| Reasoning summary | `reason.item` (`summary`) | — | AG-UI `REASONING_*` / `THINKING_*` (only when channel policy opts in); ACP `agent_thought_chunk` | — |
 | Tool narration/progress/output | `tool.started` / `tool.completed` | — | — | AG-UI `TOOL_CALL_*`; ACP `tool_call` / `tool_call_update` |
 
 **HARD fallback rule:** when a message's phase is missing or unknown (e.g. a


### PR DESCRIPTION
### Motivation
- Prevent provider-curated reasoning summaries from being emitted on anonymously reachable AG-UI streams by default because summaries may be derived from private prompts, tool results, or retrieved data and can leak sensitive information.
- Provide a secure, opt-in channel policy for reasoning summaries so consumers can enable the projection only when they intend to expose that information.

### Description
- Add a new `reasoning_summary_visible: bool` field to `AgUiChannelConfig` (default `false`) and expose it in the legacy UI types and specs documentation to document the opt-in policy.
- Wire `reasoning_summary_visible` into `AgUiStreamState` and gate `reason.item` handling in `translate_event` so `push_reasoning_summary` is only called when the channel policy opts in.
- Update `push_reasoning_summary` usage and add a new test asserting summaries are hidden by default plus updated/renamed existing tests to exercise the opt-in behavior.
- Update `specs/events.md`, `specs/apps.md`, and `apps/ui/src/lib/api/legacy-api-types.ts` to reflect the new policy and secure-default behavior.

### Testing
- Ran `cargo fmt --check` which completed successfully.
- Ran `cargo test -p everruns-core app::tests::test_ag_ui_channel_config` which passed.
- Ran focused server tests `cargo test -p everruns-server --lib reason_item` (including the new `test_reason_item_summary_hidden_by_default` and the enabled-case test), and all focused tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a587c4681b4832b9e2c665d5a9e0d7c)