### PR TITLE
fix(export): enforce session view on exports

### DIFF
--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -241,6 +241,10 @@ impl Command for ExportSessionMessages {
         Some("session_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ExportSessionJsonl, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::session_service(ctx)?

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -32,6 +32,7 @@ use everruns_server::domains::common::{
 use everruns_server::domains::evals::{CreateEvalRun, ListEvals};
 use everruns_server::domains::harnesses::types::CreateHarnessRequest;
 use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
+use everruns_server::domains::messages::{ExportSessionMessages, SessionExportFormat};
 use everruns_server::domains::session_files::{GetWorkspaceFile, ListWorkspaceFiles};
 use everruns_server::domains::session_tasks::{
     CancelSessionTask, GetSessionTask, ListSessionTasks, PostSessionTaskMessage,
@@ -231,6 +232,24 @@ async fn session_task_commands_honor_session_permissions_before_access() {
     .await
     .expect_err("cancel must require the session manage policy");
     assert_forbidden(cancel_err);
+}
+
+#[tokio::test]
+async fn session_export_requires_session_view_policy_before_lookup() {
+    // Regression for ATIF export RBAC: both export formats expose session data,
+    // so a resolver denying OrgSessionsManage must block before ID parsing or lookup.
+    let ctx = make_ctx(caller_with_role(OrgRole::Owner), Arc::new(DenyAllResolver));
+
+    for format in [SessionExportFormat::Jsonl, SessionExportFormat::Atif] {
+        let err = ExportSessionMessages {
+            session_id: "not-a-session-id".to_string(),
+            format,
+        }
+        .run(&ctx)
+        .await
+        .expect_err("session export must require SESSION_VIEW");
+        assert_forbidden(err);
+    }
 }
 
 fn assert_forbidden(err: CommandError) {


### PR DESCRIPTION
### Motivation
- The session export command exposed event-derived data without evaluating `SESSION_VIEW` because `ExportSessionMessages` did not declare a command-level `policy()`, allowing custom `PermissionResolver`s to bypass RBAC.

### Description
- Add `fn policy() -> Option<&'static everruns_core::Policy>` to `ExportSessionMessages` to require `SESSION_VIEW` before execution.
- Use the public `everruns_core::Policy` type in the command signature to fix visibility.
- Add a regression test `session_export_requires_session_view_policy_before_lookup` that asserts both `jsonl` and `atif` export formats are rejected when a deny-all `PermissionResolver` is installed.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p everruns-server --test command_policy_enforcement_test session_export_requires_session_view_policy_before_lookup` and it passed (test: `session_export_requires_session_view_policy_before_lookup` OK).
- The focused regression test ensures the new policy is consulted before ID parsing or session lookup for both export formats.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56a3c7eacc832b9c8ef0337143e6e5)