### PR TITLE
fix(mcp): fall back on unsupported RC versions

### DIFF
--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -240,6 +240,7 @@ async fn negotiate_and_send(
 
     // Auto fallback: a stateless attempt the server rejected because it wants a
     // session — handshake, then retry once.
+    let mut rejected_probe = None;
     let response = if mode == McpProtocolMode::Auto
         && !negotiated.stateful
         && !(200..300).contains(&response.status)
@@ -249,6 +250,7 @@ async fn negotiate_and_send(
             url = %url,
             "MCP stateless attempt rejected; falling back to stateful handshake"
         );
+        rejected_probe = Some((response.status, response.body.clone()));
         negotiated = do_handshake(
             egress,
             url,
@@ -257,7 +259,15 @@ async fn negotiate_and_send(
             protocol::DEFAULT_STATEFUL_VERSION,
             timeout,
         )
-        .await?;
+        .await
+        .map_err(|fallback_error| {
+            anyhow!(
+                "MCP RC probe failed: {} - {}; stable fallback failed: {}",
+                response.status,
+                response.body,
+                fallback_error
+            )
+        })?;
         send_op(
             egress,
             url,
@@ -269,12 +279,29 @@ async fn negotiate_and_send(
             op_body,
             timeout,
         )
-        .await?
+        .await
+        .map_err(|fallback_error| {
+            anyhow!(
+                "MCP RC probe failed: {} - {}; stable fallback request failed: {}",
+                response.status,
+                response.body,
+                fallback_error
+            )
+        })?
     } else {
         response
     };
 
     if !(200..300).contains(&response.status) {
+        if let Some((probe_status, probe_body)) = rejected_probe {
+            return Err(anyhow!(
+                "MCP RC probe failed: {} - {}; stable fallback failed: {} - {}",
+                probe_status,
+                probe_body,
+                response.status,
+                response.body
+            ));
+        }
         return Err(anyhow!(
             "MCP server returned error: {} - {}",
             response.status,

--- a/crates/mcp/src/protocol.rs
+++ b/crates/mcp/src/protocol.rs
@@ -144,6 +144,19 @@ pub fn looks_like_handshake_required(status: u16, body: &str) -> bool {
     {
         return true;
     }
+    // Some stable servers reject the optimistic RC header before they can
+    // report a session requirement. Keep this limited to explicit protocol
+    // version language so unrelated validation failures do not trigger a retry.
+    if status == 400
+        && (lower.contains("protocol version")
+            || lower.contains("protocol-version")
+            || lower.contains("protocolversion"))
+        && (lower.contains("unsupported")
+            || lower.contains("not supported")
+            || lower.contains("invalid"))
+    {
+        return true;
+    }
     // JSON-RPC-level signals (may arrive on a 200).
     lower.contains("server not initialized")
         || lower.contains("session required")
@@ -251,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn handshake_detection_triggers_on_session_signals_only() {
+    fn handshake_detection_requires_explicit_fallback_signals() {
         assert!(looks_like_handshake_required(
             400,
             "Bad Request: Mcp-Session-Id header is required"
@@ -260,8 +273,20 @@ mod tests {
             200,
             r#"{"error":{"code":-32600,"message":"Server not initialized"}}"#
         ));
+        assert!(looks_like_handshake_required(
+            400,
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Unsupported protocol version: 2026-07-28"}}"#
+        ));
+        assert!(looks_like_handshake_required(
+            400,
+            "Invalid MCP-Protocol-Version header"
+        ));
         assert!(!looks_like_handshake_required(500, "internal server error"));
         assert!(!looks_like_handshake_required(400, "invalid arguments"));
+        assert!(!looks_like_handshake_required(
+            400,
+            "unsupported tool argument"
+        ));
     }
 
     #[test]

--- a/crates/mcp/tests/protocol_negotiation.rs
+++ b/crates/mcp/tests/protocol_negotiation.rs
@@ -36,7 +36,13 @@ struct Recorded {
 #[derive(Clone, Copy, PartialEq)]
 enum ServerKind {
     StatelessRc,
-    Stateful { version: &'static str },
+    Stateful {
+        version: &'static str,
+    },
+    RejectsRc {
+        version: &'static str,
+        stable_failure: bool,
+    },
 }
 
 /// A scripted MCP server over the egress boundary.
@@ -117,34 +123,65 @@ impl EgressService for ScriptedEgress {
                 "tools/call" => Ok(Self::ok(call)),
                 _ => Ok(Self::ok(json!({ "jsonrpc": "2.0", "id": 1, "result": {} }))),
             },
-            ServerKind::Stateful { version } => match method.as_str() {
-                "initialize" => {
-                    let mut headers = BTreeMap::new();
-                    headers.insert("Mcp-Session-Id".to_string(), self.session_id.to_string());
-                    Ok(EgressResponse {
-                        status: 200,
-                        headers,
-                        body: serde_json::to_vec(&json!({
-                            "jsonrpc": "2.0", "id": 0,
-                            "result": { "protocolVersion": version, "capabilities": {} }
+            kind => {
+                let (version, stable_failure, stateless_rejection) = match kind {
+                    ServerKind::Stateful { version } => (
+                        version,
+                        false,
+                        b"Bad Request: Mcp-Session-Id header is required".to_vec(),
+                    ),
+                    ServerKind::RejectsRc {
+                        version,
+                        stable_failure,
+                    } => (
+                        version,
+                        stable_failure,
+                        serde_json::to_vec(&json!({
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "error": {
+                                "code": -32600,
+                                "message": "Bad Request: Unsupported protocol version: 2026-07-28 (supported versions include 2025-06-18)"
+                            }
                         }))
                         .unwrap(),
-                    })
+                    ),
+                    ServerKind::StatelessRc => unreachable!(),
+                };
+                match method.as_str() {
+                    "initialize" => {
+                        let mut headers = BTreeMap::new();
+                        headers.insert("Mcp-Session-Id".to_string(), self.session_id.to_string());
+                        Ok(EgressResponse {
+                            status: 200,
+                            headers,
+                            body: serde_json::to_vec(&json!({
+                                "jsonrpc": "2.0", "id": 0,
+                                "result": { "protocolVersion": version, "capabilities": {} }
+                            }))
+                            .unwrap(),
+                        })
+                    }
+                    "notifications/initialized" => Ok(EgressResponse {
+                        status: 202,
+                        headers: BTreeMap::new(),
+                        body: Vec::new(),
+                    }),
+                    "tools/list" | "tools/call" if !has_session => Ok(EgressResponse {
+                        status: 400,
+                        headers: BTreeMap::new(),
+                        body: stateless_rejection,
+                    }),
+                    "tools/list" | "tools/call" if stable_failure => Ok(EgressResponse {
+                        status: 400,
+                        headers: BTreeMap::new(),
+                        body: b"stable request rejected".to_vec(),
+                    }),
+                    "tools/list" => Ok(Self::ok(tools)),
+                    "tools/call" => Ok(Self::ok(call)),
+                    _ => Ok(Self::ok(json!({ "jsonrpc": "2.0", "id": 1, "result": {} }))),
                 }
-                "notifications/initialized" => Ok(EgressResponse {
-                    status: 202,
-                    headers: BTreeMap::new(),
-                    body: Vec::new(),
-                }),
-                "tools/list" | "tools/call" if !has_session => Ok(EgressResponse {
-                    status: 400,
-                    headers: BTreeMap::new(),
-                    body: b"Bad Request: Mcp-Session-Id header is required".to_vec(),
-                }),
-                "tools/list" => Ok(Self::ok(tools)),
-                "tools/call" => Ok(Self::ok(call)),
-                _ => Ok(Self::ok(json!({ "jsonrpc": "2.0", "id": 1, "result": {} }))),
-            },
+            }
         }
     }
 
@@ -205,6 +242,76 @@ async fn auto_falls_back_to_handshake_for_stateful_server() {
     // The first attempt had no session; the retry echoes the captured session.
     assert!(!log[0].has_session);
     assert!(log[3].has_session, "retried list must carry the session id");
+}
+
+#[tokio::test]
+async fn auto_falls_back_when_authenticated_server_rejects_rc_protocol_version() {
+    let (egress, log) = ScriptedEgress::new(ServerKind::RejectsRc {
+        version: "2025-06-18",
+        stable_failure: false,
+    });
+    let auth = StaticAuthProvider::new().with_bearer("linear", "linear-token");
+    let tools = McpClient::new(egress, Arc::new(auth))
+        .discover(&McpConnection::http("linear", URL))
+        .await
+        .unwrap();
+    assert_eq!(tools.len(), 1);
+
+    let log = log.lock().unwrap();
+    let methods: Vec<&str> = log.iter().map(|request| request.method.as_str()).collect();
+    assert_eq!(
+        methods,
+        vec![
+            "tools/list",
+            "initialize",
+            "notifications/initialized",
+            "tools/list"
+        ],
+        "the rejected RC probe must cause exactly one stateful retry"
+    );
+    assert!(
+        log.iter()
+            .all(|request| request.authorization.as_deref() == Some("Bearer linear-token")),
+        "authentication must be preserved across the fallback"
+    );
+    assert_eq!(log[0].protocol_header.as_deref(), Some("2026-07-28"));
+    assert_eq!(log[3].protocol_header.as_deref(), Some("2025-06-18"));
+    assert!(
+        log[3].has_session,
+        "the stable retry must carry the session id"
+    );
+}
+
+#[tokio::test]
+async fn auto_reports_rc_probe_and_stable_fallback_failures() {
+    let (egress, log) = ScriptedEgress::new(ServerKind::RejectsRc {
+        version: "2025-06-18",
+        stable_failure: true,
+    });
+    let error = client(egress)
+        .discover(&McpConnection::http("linear", URL))
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("MCP RC probe failed"));
+    assert!(error.contains("Unsupported protocol version: 2026-07-28"));
+    assert!(error.contains("stable fallback failed: 400 - stable request rejected"));
+    let log = log.lock().unwrap();
+    assert_eq!(
+        log.iter()
+            .filter(|request| request.method == "initialize")
+            .count(),
+        1,
+        "a failed fallback must not restart negotiation"
+    );
+    assert_eq!(
+        log.iter()
+            .filter(|request| request.method == "tools/list")
+            .count(),
+        2,
+        "the operation must be retried exactly once"
+    );
 }
 
 #[tokio::test]
@@ -282,6 +389,25 @@ async fn pinned_legacy_handshakes_first_without_a_stateless_probe() {
             .take_while(|r| r.method != "initialize")
             .any(|r| r.method == "tools/list"),
         "no stateless probe should precede the pinned handshake"
+    );
+}
+
+#[tokio::test]
+async fn pinned_stable_handshakes_first_without_a_stateless_probe() {
+    let (egress, log) = ScriptedEgress::new(ServerKind::Stateful {
+        version: "2025-06-18",
+    });
+    let connection = McpConnection::http("docs", URL).with_protocol_mode(McpProtocolMode::Stable);
+    client(egress).discover(&connection).await.unwrap();
+
+    let log = log.lock().unwrap();
+    assert_eq!(log[0].method, "initialize");
+    assert_eq!(log[0].protocol_header.as_deref(), Some("2025-06-18"));
+    assert_eq!(
+        log.iter()
+            .filter(|request| request.method == "initialize")
+            .count(),
+        1
     );
 }
 

--- a/specs/mcp-servers.md
+++ b/specs/mcp-servers.md
@@ -60,7 +60,7 @@ config when `auto`, so existing configuration is byte-identical.
 
 | Mode | Behavior |
 |------|----------|
-| `auto` (default) | Probe and adapt. Tries the stateless RC path first; on a response that signals the server needs a session (e.g. HTTP 400 mentioning `Mcp-Session-Id`, or a "not initialized" JSON-RPC error), transparently runs the handshake and retries. The verdict (era + session id) is cached per server for a short TTL so a `tools/list` + `tools/call` pair negotiates once. |
+| `auto` (default) | Probe and adapt. Tries the stateless RC path first; on a response that signals the server needs a session (e.g. HTTP 400 mentioning `Mcp-Session-Id`, a "not initialized" JSON-RPC error, or an explicit unsupported/invalid protocol-version rejection), transparently runs the stable handshake and retries once. The verdict (era + session id) is cached per server for a short TTL so a `tools/list` + `tools/call` pair negotiates once. If the fallback also fails, the error reports both failures. |
 | `legacy` | Pin `2025-03-26`; always handshake first. |
 | `stable` | Pin `2025-06-18`; always handshake first. |
 | `rc` | Pin `2026-07-28`; never handshake. |


### PR DESCRIPTION
## What changed
Auto-mode MCP connections now recognize explicit unsupported or invalid protocol-version rejections and retry once through the stable stateful handshake. Authenticated tool discovery can therefore interoperate with servers such as Linear that reject the optimistic 2026-07-28 RC probe while supporting 2025-06-18.

If both attempts fail, the returned error includes the RC probe failure and the stable fallback failure. Pinned legacy, stable, and RC modes retain their existing behavior.

## Why
Linear's authenticated Streamable HTTP endpoint returns HTTP 400 when Everruns probes `MCP-Protocol-Version: 2026-07-28`. The fallback classifier previously recognized only session and initialization signals, so Auto mode surfaced the rejection instead of negotiating the supported stable protocol.

## Before / After
Before: the new authenticated discovery regression failed with `MCP server returned error: 400` and the JSON-RPC message `Unsupported protocol version: 2026-07-28`.

After: the same integration flow discovers the tool catalog after exactly one stable handshake and one retried `tools/list`; the bearer credential and negotiated session are preserved. A negative-path test proves unrelated HTTP 400 argument failures do not trigger fallback, and a dual-failure test proves the error reports both attempts.

Validation:
- `cargo test -p everruns-mcp --all-features`
- `cargo clippy -p everruns-mcp --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `just pre-push`

Smoke test: `crates/mcp/tests/protocol_negotiation.rs` drives authenticated discovery end to end from `McpClient` through the egress boundary and scripted Linear response shape, covering RC rejection, stable initialization, initialized notification, and successful tool discovery. A live Linear smoke was not possible from this worktree because its Doppler project/credential context is unavailable; the repository `.mcp.json` uses a separate interactive SSE proxy rather than this HTTP transport.

## Risk
- Low / Medium
- The classifier could cause a wasted handshake if an unrelated HTTP 400 contains both explicit protocol-version and rejection language. It remains Auto-only, HTTP-400-only, and requires both signal classes; unrelated invalid tool arguments remain unchanged.

## Security
- Threat categories reviewed: TM-TOOL-002, TM-TOOL-004, TM-TOOL-007, TM-TOOL-018.
- Findings and resolutions: no new threat surface. Responses remain defensively parsed; fallback remains a single bounded retry under existing timeouts; credentials are reused without logging; and every probe, handshake, notification, and retry continues through DNS-pinned SSRF validation. No dependency or threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no comments or review threads were posted)
