### PR TITLE
perf(ui): eliminate Early Access banner layout shift

### DIFF
--- a/apps/ui/src/__tests__/early-access-banner.test.tsx
+++ b/apps/ui/src/__tests__/early-access-banner.test.tsx
@@ -1,0 +1,114 @@
+// Regression test for EVE-794: the early-access banner used to return null while
+// the dismissed preference loaded, then insert a 44px (h-11) row after the
+// request resolved — shifting the whole app shell (CLS ~0.024). The dismissal
+// decision is now seeded synchronously from a localStorage cache so first paint
+// is already correct: an undismissed user gets the banner as part of the initial
+// stable layout, and a dismissed user gets neither a flash nor a leftover gap.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { UserPreference } from "@/lib/api/user-preferences";
+
+const CACHE_KEY = "everruns:ui:early-access-banner-dismissed";
+
+// Controllable preference-query result. `undefined` models the still-loading
+// state; `null` an unset preference; an object a stored value.
+let preferenceData: UserPreference | null | undefined;
+const mockMutate = jest.fn();
+
+jest.mock("@/hooks/use-user-preferences", () => ({
+  useUserPreference: () => ({ data: preferenceData }),
+  useSetUserPreference: () => ({ mutate: mockMutate }),
+}));
+
+import { EarlyAccessBanner } from "@/components/layout/early-access-banner";
+
+function getBanner(): HTMLElement | null {
+  // The banner row carries the fixed 44px height; its absence means no shell gap.
+  return document.querySelector(".h-11");
+}
+
+beforeEach(() => {
+  preferenceData = undefined;
+  mockMutate.mockClear();
+  window.localStorage.clear();
+});
+
+describe("EarlyAccessBanner (EVE-794)", () => {
+  it("renders the banner during loading for a user with no cached dismissal", () => {
+    preferenceData = undefined; // query still loading
+    render(<EarlyAccessBanner />);
+
+    expect(getBanner()).not.toBeNull();
+    expect(screen.getByText("Early access.")).toBeInTheDocument();
+  });
+
+  it("does not render during loading when the local cache says dismissed", () => {
+    window.localStorage.setItem(CACHE_KEY, "true");
+    preferenceData = undefined; // query still loading
+    render(<EarlyAccessBanner />);
+
+    // No flash and no reserved gap for a dismissed user, even before the server
+    // preference resolves.
+    expect(getBanner()).toBeNull();
+  });
+
+  it("renders the banner when the preference is unset", () => {
+    preferenceData = null;
+    render(<EarlyAccessBanner />);
+
+    expect(getBanner()).not.toBeNull();
+    expect(screen.getByRole("link", { name: /Follow along on GitHub/i })).toHaveAttribute(
+      "href",
+      "https://github.com/everruns/everruns",
+    );
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
+  });
+
+  it("does not render (no gap) when the preference is dismissed", () => {
+    preferenceData = { key: "ui.early_access_banner.dismissed", value: true, updated_at: "" };
+    render(<EarlyAccessBanner />);
+
+    expect(getBanner()).toBeNull();
+    // The resolved server value reconciles the local cache for the next load.
+    expect(window.localStorage.getItem(CACHE_KEY)).toBe("true");
+  });
+
+  it("does not shift: an undismissed banner stays present as the query resolves", () => {
+    preferenceData = undefined;
+    const { rerender } = render(<EarlyAccessBanner />);
+    expect(getBanner()).not.toBeNull();
+
+    // Server resolves to unset — the banner must remain, no insert/collapse.
+    preferenceData = null;
+    rerender(<EarlyAccessBanner />);
+    expect(getBanner()).not.toBeNull();
+  });
+
+  it("does not shift: a cached-dismissed user stays hidden as the query resolves", () => {
+    window.localStorage.setItem(CACHE_KEY, "true");
+    preferenceData = undefined;
+    const { rerender } = render(<EarlyAccessBanner />);
+    expect(getBanner()).toBeNull();
+
+    preferenceData = { key: "ui.early_access_banner.dismissed", value: true, updated_at: "" };
+    rerender(<EarlyAccessBanner />);
+    expect(getBanner()).toBeNull();
+  });
+
+  it("hides immediately, caches, and persists the dismissal on click", () => {
+    preferenceData = null;
+    render(<EarlyAccessBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    // Hidden immediately, before the server write settles.
+    expect(getBanner()).toBeNull();
+    // Cached synchronously so a reload stays dismissed.
+    expect(window.localStorage.getItem(CACHE_KEY)).toBe("true");
+    // Persisted to the server preference (source of truth).
+    expect(mockMutate).toHaveBeenCalledWith({
+      key: "ui.early_access_banner.dismissed",
+      value: true,
+    });
+  });
+});

--- a/apps/ui/src/components/layout/early-access-banner.tsx
+++ b/apps/ui/src/components/layout/early-access-banner.tsx
@@ -3,31 +3,80 @@
 // Early-access banner shown above the app shell. Warns that Everruns is still
 // stabilizing and links to GitHub. Dismissal is persisted per-user via the
 // user-preferences key/value service, so it stays dismissed across devices.
-import { useState } from "react";
+//
+// EVE-794: the banner previously returned null while the dismissed preference
+// was loading, then inserted a 44px (h-11) row after the request resolved for
+// undismissed users — shifting the entire app shell down (CLS ~0.024). Reserving
+// the slot during loading and collapsing on resolve would instead shift the
+// shell for dismissed users, so neither half-measure is enough.
+//
+// Instead the dismissal decision is available synchronously at first paint: it
+// is seeded from a localStorage cache written whenever the banner is dismissed.
+// A dismissed user renders nothing from the first frame (no flash, no leftover
+// gap); an undismissed user renders the banner as part of the initial stable
+// layout. The server-side preference stays the source of truth and reconciles
+// the local cache once it resolves.
+import { useEffect, useState } from "react";
 import { FlaskConical, ArrowRight, X } from "lucide-react";
 
 import { GithubIcon } from "@/components/icons/github-icon";
 import { useUserPreference, useSetUserPreference } from "@/hooks/use-user-preferences";
 
 const BANNER_DISMISSED_KEY = "ui.early_access_banner.dismissed";
+// Synchronously-readable mirror of the dismissed preference, so first paint can
+// decide whether to show the banner without waiting for the server round-trip.
+const BANNER_DISMISSED_CACHE_KEY = "everruns:ui:early-access-banner-dismissed";
 const GITHUB_URL = "https://github.com/everruns/everruns";
 
+function readCachedDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(BANNER_DISMISSED_CACHE_KEY) === "true";
+  } catch {
+    // Storage may be unavailable (private mode, quota); treat as not dismissed.
+    return false;
+  }
+}
+
+function writeCachedDismissed(dismissed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (dismissed) {
+      window.localStorage.setItem(BANNER_DISMISSED_CACHE_KEY, "true");
+    } else {
+      window.localStorage.removeItem(BANNER_DISMISSED_CACHE_KEY);
+    }
+  } catch {
+    // Best-effort: the server preference remains authoritative.
+  }
+}
+
 export function EarlyAccessBanner() {
-  const { data: preference, isLoading } = useUserPreference(BANNER_DISMISSED_KEY);
+  const { data: preference } = useUserPreference(BANNER_DISMISSED_KEY);
   const setPreference = useSetUserPreference();
-  // Local flag hides the banner immediately on click, before the write settles.
-  const [dismissedLocally, setDismissedLocally] = useState(false);
+  // Seed synchronously from the local cache so the very first frame already
+  // knows whether to render the banner — no post-paint insert or collapse.
+  const [dismissed, setDismissed] = useState(readCachedDismissed);
 
-  const dismissed = dismissedLocally || preference?.value === true;
+  // Reconcile with the server once the preference resolves and keep the local
+  // cache in sync so the next cold load on this device is correct. `undefined`
+  // means the query is still loading — keep the cached decision until then.
+  useEffect(() => {
+    if (preference === undefined) return;
+    const serverDismissed = preference?.value === true;
+    setDismissed(serverDismissed);
+    writeCachedDismissed(serverDismissed);
+  }, [preference]);
 
-  // Wait for the stored state before first paint so the banner doesn't flash in
-  // for users who already dismissed it.
-  if (isLoading || dismissed) {
+  if (dismissed) {
     return null;
   }
 
   const handleDismiss = () => {
-    setDismissedLocally(true);
+    // Hide immediately and persist locally so a reload before the write settles
+    // still starts dismissed; the server write keeps cross-device state in sync.
+    setDismissed(true);
+    writeCachedDismissed(true);
     setPreference.mutate({ key: BANNER_DISMISSED_KEY, value: true });
   };
 


### PR DESCRIPTION
## What changed
The Early Access banner no longer shifts the app shell after first paint. The dismissal decision is now available synchronously at first paint via a `localStorage` mirror of the dismissed preference: a dismissed user renders nothing from the first frame (no flash, no leftover 44px gap), and an undismissed user renders the 44px banner as part of the initial stable layout. The server-side user preference remains the source of truth and reconciles the local cache once it resolves; dismissing hides immediately, writes the cache, and persists via the preference service.

## Why
Production-mode testing measured a repeatable ~0.024 CLS on cold `/dashboard` (and ~0.030 on `/agents`): the banner returned `null` while `useUserPreference("ui.early_access_banner.dismissed")` was loading, then inserted the 44px (`h-11`) row after the request resolved, pushing the whole shell from `y=0` to `y=44`. Reserving-then-collapsing the slot would only move the shift onto dismissed users, so the decision has to be known before paint.

## Before / After
- Before: shell moves `y=0 → y=44` ~137ms after paint; CLS ~0.024 (`/dashboard`), ~0.030 (`/agents`).
- After: no post-paint vertical movement on same-device cold loads — the render decision is made from the synchronous cache before paint. Covered by jest tests (7/7) for loading (cached-dismissed vs. no-cache), unset, dismissed (no gap + cache reconcile), no-shift transitions, and the dismiss mutation (immediate hide + cache write + server persist), plus accessible name / GitHub link / dismiss button.

## Risk
- Low
- The banner is rendered client-side only (behind the layout's auth/org loading gate + Suspense), so seeding state from `localStorage` does not introduce a server/client hydration mismatch. Storage-unavailable (private mode/quota) is handled by treating the banner as not-dismissed. Edge case: a user who dismissed on another device may briefly see the banner on a first cold load on a new device before the server preference resolves — unavoidable without SSR of the decision, and outside the measured same-device scenario.

## Security
- Threat categories reviewed: No security-relevant code changes (client-side rendering/caching of a non-sensitive UI dismissal flag).
- Findings and resolutions: None. The cached value is a boolean UI preference, not sensitive data.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (jest coverage for loading/unset/dismissed/dismiss-mutation states)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-794

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYwoGwNvVoXALAannYMsHT)_