### PR TITLE
fix(core): keep compacted tool exchanges atomic

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1386,6 +1386,8 @@ impl ReasonAtom {
 
         // 7. Create LLM driver using factory
         let chat_driver = self.create_chat_driver(&model_with_provider)?;
+        let stateful_response_continuation =
+            previous_response_id.is_some() && chat_driver.supports_stateful_responses();
 
         // 8. Resolve the reasoning effort for THIS LLM step.
         //    Source priority (re-evaluated on every step so mid-turn changes
@@ -1587,6 +1589,10 @@ impl ReasonAtom {
         };
         let mut context_messages =
             model_view_providers.apply_model_view(patched_messages, &model_view_context);
+        context_messages = crate::tool_call_integrity::retain_complete_message_tool_exchanges(
+            &context_messages,
+            stateful_response_continuation,
+        );
 
         // 9c. Append live dynamic facts (e.g. the current time) at the tail.
         // Collected fresh each request so values are current, and delivered as a
@@ -1668,6 +1674,15 @@ impl ReasonAtom {
                 "ReasonAtom: stripped error placeholder messages from LLM input"
             );
         }
+
+        // Context reducers operate on prompt-facing copies and may select only
+        // one side of a tool exchange at a window boundary. Stateless requests
+        // must be self-contained; stateful Responses requests may retain
+        // result-only deltas whose calls live behind `previous_response_id`.
+        llm_messages = crate::tool_call_integrity::retain_complete_llm_tool_exchanges_for_request(
+            llm_messages,
+            stateful_response_continuation,
+        );
 
         // 12. Build LLM call config with reasoning effort and metadata
         let mut llm_config_builder =
@@ -2146,7 +2161,10 @@ impl ReasonAtom {
                                     }
                                 }
 
-                                llm_messages_for_call = compacted_llm_messages;
+                                llm_messages_for_call =
+                                    crate::tool_call_integrity::retain_complete_llm_tool_exchanges(
+                                        compacted_llm_messages,
+                                    );
 
                                 let step_duration = step_start.elapsed().as_millis() as u64;
                                 strategies_used.push("native".to_string());
@@ -2176,7 +2194,7 @@ impl ReasonAtom {
                     // Only run if we haven't done native compaction (which already compressed everything)
                     if run_summarization && !strategies_used.contains(&"native".to_string()) {
                         use crate::capabilities::{
-                            build_summarization_prompt, build_summary_message,
+                            build_summarization_prompt, compose_summary_with_recent,
                             format_messages_for_summarization,
                         };
 
@@ -2246,15 +2264,13 @@ impl ReasonAtom {
                             {
                                 Ok(response) => {
                                     let summary_text = response.text;
-                                    let summary_msg = build_summary_message(&summary_text);
-
-                                    let mut new_messages = Vec::new();
-                                    if has_system_prompt {
-                                        new_messages.push(llm_messages_for_call[0].clone());
-                                    }
-                                    new_messages.push(summary_msg);
-                                    new_messages.extend_from_slice(recent);
-                                    llm_messages_for_call = new_messages;
+                                    let system_message =
+                                        has_system_prompt.then(|| llm_messages_for_call[0].clone());
+                                    llm_messages_for_call = compose_summary_with_recent(
+                                        system_message,
+                                        &summary_text,
+                                        recent,
+                                    );
 
                                     let step_duration = step_start.elapsed().as_millis() as u64;
                                     strategies_used.push("summarization".to_string());

--- a/crates/core/src/capabilities/compaction.rs
+++ b/crates/core/src/capabilities/compaction.rs
@@ -602,7 +602,7 @@ pub fn aggressive_trim(
         }
         kept.sort_by_key(|(i, _)| *i);
         result.extend(kept.into_iter().map(|(_, m)| m));
-        return result;
+        return crate::tool_call_integrity::retain_complete_llm_tool_exchanges(result);
     }
 
     token_budget -= protected_budget;
@@ -631,7 +631,7 @@ pub fn aggressive_trim(
     all_kept.sort_by_key(|(i, _)| *i);
 
     result.extend(all_kept.into_iter().map(|(_, m)| m));
-    result
+    crate::tool_call_integrity::retain_complete_llm_tool_exchanges(result)
 }
 
 // ============================================================================
@@ -806,7 +806,7 @@ pub fn apply_hierarchical_memory(
         result.extend_from_slice(&messages[hot_start..]);
     }
 
-    result
+    crate::tool_call_integrity::retain_complete_llm_tool_exchanges(result)
 }
 
 // ============================================================================
@@ -1633,6 +1633,25 @@ pub fn build_summary_message(summary_text: &str) -> LlmMessage {
     }
 }
 
+/// Compose a summary with the verbatim recent tail without splitting tool exchanges.
+///
+/// The summary replaces the older prefix, so a result retained at the boundary has
+/// no visible call unless that call is also in `recent_messages`. Incomplete pieces
+/// are removed from this prompt-facing view; stored history remains unchanged.
+pub fn compose_summary_with_recent(
+    system_message: Option<LlmMessage>,
+    summary_text: &str,
+    recent_messages: &[LlmMessage],
+) -> Vec<LlmMessage> {
+    let mut messages = Vec::with_capacity(recent_messages.len() + 2);
+    if let Some(system_message) = system_message {
+        messages.push(system_message);
+    }
+    messages.push(build_summary_message(summary_text));
+    messages.extend_from_slice(recent_messages);
+    crate::tool_call_integrity::retain_complete_llm_tool_exchanges(messages)
+}
+
 // ============================================================================
 // Compaction Step Tracking
 // ============================================================================
@@ -1657,6 +1676,19 @@ mod tests {
     use super::*;
     use crate::tool_types::ToolCall;
     use serde_json::json;
+
+    fn assert_complete_tool_exchanges(messages: &[LlmMessage]) {
+        let calls: std::collections::HashSet<_> = messages
+            .iter()
+            .flat_map(|message| message.tool_calls.iter().flatten())
+            .map(|call| call.id.as_str())
+            .collect();
+        let results: std::collections::HashSet<_> = messages
+            .iter()
+            .filter_map(|message| message.tool_call_id.as_deref())
+            .collect();
+        assert_eq!(calls, results, "tool calls and results must remain atomic");
+    }
 
     fn make_user_msg(text: &str) -> LlmMessage {
         LlmMessage {
@@ -1691,6 +1723,27 @@ mod tests {
                 name: tool_name.to_string(),
                 arguments: json!({"path": "src/main.rs"}),
             }]),
+            tool_call_id: None,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        }
+    }
+
+    fn make_assistant_with_tool_calls(calls: &[(&str, &str)]) -> LlmMessage {
+        LlmMessage {
+            role: LlmMessageRole::Assistant,
+            content: LlmMessageContent::Text(String::new()),
+            tool_calls: Some(
+                calls
+                    .iter()
+                    .map(|(call_id, tool_name)| ToolCall {
+                        id: (*call_id).to_string(),
+                        name: (*tool_name).to_string(),
+                        arguments: json!({}),
+                    })
+                    .collect(),
+            ),
             tool_call_id: None,
             phase: None,
             thinking: None,
@@ -3057,6 +3110,7 @@ mod tests {
             extract_text(&result.messages[3].content),
             "Skill 2 instructions"
         );
+        assert_complete_tool_exchanges(&result.messages);
     }
 
     #[test]
@@ -3096,6 +3150,89 @@ mod tests {
         assert!(
             has_skill_call,
             "Skill tool call must survive aggressive trim"
+        );
+    }
+
+    #[test]
+    fn aggressive_trim_keeps_parallel_tool_calls_atomic() {
+        let messages = vec![
+            make_user_msg("system"),
+            make_user_msg("original task"),
+            make_assistant_with_tool_calls(&[
+                ("call_skill", "activate_skill"),
+                ("call_bash", "bash"),
+            ]),
+            make_tool_result("call_skill", "Important skill instructions"),
+            make_tool_result("call_bash", &"output ".repeat(100)),
+            make_user_msg(&"recent user ".repeat(40)),
+            make_assistant_msg(&"recent answer ".repeat(40)),
+        ];
+
+        let result = aggressive_trim(&messages, 300, true);
+        let visible_calls: Vec<_> = result
+            .iter()
+            .flat_map(|message| message.tool_calls.iter().flatten())
+            .map(|call| call.id.as_str())
+            .collect();
+        let visible_results: Vec<_> = result
+            .iter()
+            .filter_map(|message| message.tool_call_id.as_deref())
+            .collect();
+
+        assert!(visible_calls.contains(&"call_skill"));
+        assert!(visible_results.contains(&"call_skill"));
+        assert_eq!(
+            visible_calls, visible_results,
+            "reduction must not expose a call without its result"
+        );
+        assert_complete_tool_exchanges(&result);
+    }
+
+    #[test]
+    fn hierarchical_memory_prunes_only_evicted_calls_from_a_protected_parallel_batch() {
+        let messages = vec![
+            make_assistant_with_tool_calls(&[
+                ("call_skill", "activate_skill"),
+                ("call_bash", "bash"),
+            ]),
+            make_tool_result("call_skill", "Important skill instructions"),
+            make_tool_result("call_bash", "ordinary output"),
+            make_user_msg("recent question"),
+            make_assistant_msg("recent answer"),
+        ];
+        let result = apply_hierarchical_memory(
+            &messages,
+            &HierarchicalMemoryConfig {
+                hot_messages: 2,
+                warm_messages: 0,
+            },
+            &ObservationMaskingConfig::default(),
+            Some("Summary of old work"),
+        );
+
+        assert_complete_tool_exchanges(&result);
+        let calls: Vec<_> = result
+            .iter()
+            .flat_map(|message| message.tool_calls.iter().flatten())
+            .map(|call| call.id.as_str())
+            .collect();
+        assert_eq!(calls, vec!["call_skill"]);
+    }
+
+    #[test]
+    fn summary_boundary_drops_a_recent_result_whose_call_was_summarized() {
+        let recent = vec![
+            make_tool_result("call_old", "old result"),
+            make_user_msg("continue"),
+        ];
+        let result = compose_summary_with_recent(None, "Earlier work", &recent);
+
+        assert_complete_tool_exchanges(&result);
+        assert!(result.iter().all(|message| message.tool_call_id.is_none()));
+        assert!(
+            result
+                .iter()
+                .any(|message| extract_text(&message.content) == "continue")
         );
     }
 

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -281,11 +281,30 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
         }
 
         let outcome = trim_messages_to_token_budget(messages, &config);
-        let total_excluded_count = existing_notice_count.saturating_add(outcome.hidden_count);
+        let mut total_excluded_count = existing_notice_count.saturating_add(outcome.hidden_count);
         if total_excluded_count > 0 {
+            // The reduction must not leave a visible call whose result was
+            // evicted. Result-only deltas remain eligible here because a
+            // stateful Responses request may reference their calls through
+            // `previous_response_id`; ReasonAtom resolves that distinction at
+            // the final runtime boundary.
+            let head_ids: std::collections::HashSet<String> = messages
+                .iter()
+                .take(outcome.head_len)
+                .map(|message| message.id.to_string())
+                .collect();
+            let count_before_integrity = messages.len();
+            *messages =
+                crate::tool_call_integrity::retain_complete_message_tool_exchanges(messages, true);
+            total_excluded_count = total_excluded_count
+                .saturating_add(count_before_integrity.saturating_sub(messages.len()));
+            let retained_head_len = messages
+                .iter()
+                .take_while(|message| head_ids.contains(&message.id.to_string()))
+                .count();
             // Place the notice right after the anchored head so the layout reads
             // [task anchor] -> [N hidden] -> [recent window].
-            insert_excluded_notice(messages, outcome.head_len, total_excluded_count);
+            insert_excluded_notice(messages, retained_head_len, total_excluded_count);
         }
     }
 
@@ -1372,6 +1391,65 @@ mod tests {
         assert!(
             messages.iter().any(|m| m.role == MessageRole::ToolResult),
             "locally unmatched tool result must be preserved until provider serialization"
+        );
+
+        let llm_messages = messages
+            .iter()
+            .map(crate::llm_conversions::llm_message_from_message)
+            .collect();
+        let stateless_view =
+            crate::tool_call_integrity::retain_complete_llm_tool_exchanges_for_request(
+                llm_messages,
+                false,
+            );
+        assert!(
+            stateless_view
+                .iter()
+                .all(|message| message.tool_call_id.is_none()),
+            "a stateless runtime view must drop a result whose call was trimmed"
+        );
+    }
+
+    #[test]
+    fn trim_removes_a_visible_call_when_its_result_is_evicted() {
+        use crate::tool_types::ToolCall;
+
+        let provider = InfinityContextFilterProvider;
+        let mut messages = vec![
+            Message::user("original task"),
+            Message::assistant_with_tools(
+                "calling tool",
+                vec![ToolCall {
+                    id: "call_old".to_string(),
+                    name: "bash".to_string(),
+                    arguments: serde_json::json!({}),
+                }],
+            ),
+            Message::tool_result(
+                "call_old",
+                Some(serde_json::json!("large result ".repeat(500))),
+                None,
+            ),
+            Message::user("recent question"),
+            Message::assistant("recent answer"),
+        ];
+
+        provider.post_load(
+            &mut messages,
+            &serde_json::json!({
+                "context_budget_tokens": 1,
+                "min_recent_messages": 2,
+                "keep_first_messages": 2
+            }),
+        );
+
+        assert!(
+            messages
+                .iter()
+                .flat_map(Message::tool_calls)
+                .next()
+                .is_none(),
+            "the anchored assistant message must not retain a call after its result is hidden"
         );
     }
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -193,8 +193,9 @@ pub use compaction::{
     MaskingSummaryFormat, MemoryTier, ObservationMaskingConfig, ObservationMaskingResult,
     SessionCompactionMetrics, SummarizationConfig, aggressive_trim, apply_cost_control_masking,
     apply_hierarchical_memory, apply_observation_masking, build_model_view_messages,
-    build_summarization_prompt, build_summary_message, classify_memory_tiers, estimate_tokens,
-    estimate_total_tokens, format_messages_for_summarization, should_compact_proactively,
+    build_summarization_prompt, build_summary_message, classify_memory_tiers,
+    compose_summary_with_recent, estimate_tokens, estimate_total_tokens,
+    format_messages_for_summarization, should_compact_proactively,
 };
 pub use current_time::{CURRENT_TIME_CAPABILITY_ID, CurrentTimeCapability, GetCurrentTimeTool};
 pub use data_knowledge::{DATA_KNOWLEDGE_CAPABILITY_ID, DataKnowledgeCapability};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -162,6 +162,7 @@ pub mod llm_conversions;
 pub mod message;
 pub mod message_filter;
 pub mod message_retriever;
+mod tool_call_integrity;
 pub use everruns_provider::openai_protocol;
 pub use everruns_provider::openresponses_protocol;
 pub use everruns_provider::openresponses_types;

--- a/crates/core/src/tool_call_integrity.rs
+++ b/crates/core/src/tool_call_integrity.rs
@@ -1,0 +1,225 @@
+//! Structural integrity helpers for reduced conversation histories.
+//!
+//! Session storage stays lossless. Reducers use these helpers only on prompt-facing
+//! copies so an assistant tool call is never exposed without its result, and a
+//! stateless request never exposes a result without its call.
+
+use crate::driver_registry::{LlmMessage, LlmMessageContent, LlmMessageRole};
+use crate::message::{ContentPart, Message};
+use std::collections::HashSet;
+
+/// Keep only complete tool-call/result exchanges in a prompt-facing `Message` view.
+///
+/// Stateful Responses requests may legitimately carry a result whose call lives in
+/// `previous_response_id`; `allow_unmatched_results` preserves that delta shape.
+/// Calls without visible results are always removed rather than synthesized.
+pub(crate) fn retain_complete_message_tool_exchanges(
+    messages: &[Message],
+    allow_unmatched_results: bool,
+) -> Vec<Message> {
+    let result_ids: HashSet<String> = messages
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .filter_map(|part| match part {
+            ContentPart::ToolResult(result) => Some(result.tool_call_id.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let calls_filtered: Vec<Message> = messages
+        .iter()
+        .filter_map(|message| {
+            let mut message = message.clone();
+            let had_calls = message
+                .content
+                .iter()
+                .any(|part| matches!(part, ContentPart::ToolCall(_)));
+            message.content.retain(|part| match part {
+                ContentPart::ToolCall(call) => result_ids.contains(call.id.as_str()),
+                _ => true,
+            });
+            (!had_calls || message_has_visible_content(&message)).then_some(message)
+        })
+        .collect();
+
+    let call_ids: HashSet<String> = calls_filtered
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .filter_map(|part| match part {
+            ContentPart::ToolCall(call) => Some(call.id.clone()),
+            _ => None,
+        })
+        .collect();
+
+    calls_filtered
+        .iter()
+        .filter_map(|message| {
+            let mut message = message.clone();
+            let had_results = message
+                .content
+                .iter()
+                .any(|part| matches!(part, ContentPart::ToolResult(_)));
+            message.content.retain(|part| match part {
+                ContentPart::ToolResult(result) => {
+                    call_ids.contains(result.tool_call_id.as_str()) || allow_unmatched_results
+                }
+                _ => true,
+            });
+            (!had_results || message_has_visible_content(&message)).then_some(message)
+        })
+        .collect()
+}
+
+/// Keep only complete tool-call/result exchanges in a reduced `LlmMessage` view.
+///
+/// This is strict because compaction operates on a self-contained transcript; it
+/// never synthesizes execution results and can only reduce the selected output.
+pub(crate) fn retain_complete_llm_tool_exchanges(messages: Vec<LlmMessage>) -> Vec<LlmMessage> {
+    retain_complete_llm_tool_exchanges_for_request(messages, false)
+}
+
+/// Enforce tool exchange integrity at the final runtime boundary.
+///
+/// `allow_unmatched_results` is reserved for stateful Responses continuations,
+/// where the matching call is stored behind `previous_response_id`.
+pub(crate) fn retain_complete_llm_tool_exchanges_for_request(
+    messages: Vec<LlmMessage>,
+    allow_unmatched_results: bool,
+) -> Vec<LlmMessage> {
+    let result_ids: HashSet<String> = messages
+        .iter()
+        .filter(|message| message.role == LlmMessageRole::Tool)
+        .filter_map(|message| message.tool_call_id.clone())
+        .collect();
+
+    let calls_filtered: Vec<LlmMessage> = messages
+        .into_iter()
+        .filter_map(|mut message| {
+            let had_calls = message.tool_calls.is_some();
+            if let Some(calls) = &mut message.tool_calls {
+                calls.retain(|call| result_ids.contains(call.id.as_str()));
+                if calls.is_empty() {
+                    message.tool_calls = None;
+                }
+            }
+            (!had_calls || llm_message_has_visible_content(&message)).then_some(message)
+        })
+        .collect();
+
+    let call_ids: HashSet<String> = calls_filtered
+        .iter()
+        .flat_map(|message| message.tool_calls.iter().flatten())
+        .map(|call| call.id.clone())
+        .collect();
+
+    calls_filtered
+        .into_iter()
+        .filter(|message| {
+            message.role != LlmMessageRole::Tool
+                || message
+                    .tool_call_id
+                    .as_deref()
+                    .is_some_and(|id| call_ids.contains(id) || allow_unmatched_results)
+        })
+        .collect()
+}
+
+fn message_has_visible_content(message: &Message) -> bool {
+    message.content.iter().any(|part| match part {
+        ContentPart::Text(text) => !text.text.is_empty(),
+        ContentPart::Image(_) | ContentPart::ImageFile(_) => true,
+        ContentPart::ToolCall(_) | ContentPart::ToolResult(_) => true,
+    })
+}
+
+fn llm_message_has_visible_content(message: &LlmMessage) -> bool {
+    let has_content = match &message.content {
+        LlmMessageContent::Text(text) => !text.is_empty(),
+        LlmMessageContent::Parts(parts) => !parts.is_empty(),
+    };
+    has_content
+        || message.tool_calls.is_some()
+        || message.thinking.is_some()
+        || message.thinking_signature.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver_registry::{LlmMessageContent, LlmMessageRole};
+    use crate::tool_types::ToolCall;
+    use serde_json::json;
+
+    fn assistant_batch() -> LlmMessage {
+        LlmMessage {
+            role: LlmMessageRole::Assistant,
+            content: LlmMessageContent::Text(String::new()),
+            tool_calls: Some(vec![
+                ToolCall {
+                    id: "call_skill".to_string(),
+                    name: "activate_skill".to_string(),
+                    arguments: json!({}),
+                },
+                ToolCall {
+                    id: "call_bash".to_string(),
+                    name: "bash".to_string(),
+                    arguments: json!({}),
+                },
+            ]),
+            tool_call_id: None,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        }
+    }
+
+    fn tool_result(id: &str) -> LlmMessage {
+        LlmMessage {
+            role: LlmMessageRole::Tool,
+            content: LlmMessageContent::Text("result".to_string()),
+            tool_calls: None,
+            tool_call_id: Some(id.to_string()),
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        }
+    }
+
+    #[test]
+    fn llm_reduction_prunes_only_the_unmatched_parallel_call() {
+        let reduced =
+            retain_complete_llm_tool_exchanges(vec![assistant_batch(), tool_result("call_skill")]);
+
+        let calls = reduced[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_skill");
+        assert_eq!(reduced[1].tool_call_id.as_deref(), Some("call_skill"));
+    }
+
+    #[test]
+    fn llm_reduction_drops_a_result_without_a_visible_call() {
+        let reduced = retain_complete_llm_tool_exchanges(vec![tool_result("call_bash")]);
+        assert!(reduced.is_empty());
+    }
+
+    #[test]
+    fn stateful_llm_request_keeps_a_result_delta_without_reintroducing_calls() {
+        let reduced =
+            retain_complete_llm_tool_exchanges_for_request(vec![tool_result("call_bash")], true);
+        assert_eq!(reduced.len(), 1);
+        assert_eq!(reduced[0].tool_call_id.as_deref(), Some("call_bash"));
+    }
+
+    #[test]
+    fn message_reduction_allows_stateful_result_deltas_only_when_requested() {
+        let result = Message::tool_result("call_bash", Some(json!("done")), None);
+
+        assert!(
+            retain_complete_message_tool_exchanges(std::slice::from_ref(&result), false).is_empty()
+        );
+        assert_eq!(
+            retain_complete_message_tool_exchanges(&[result], true).len(),
+            1
+        );
+    }
+}

--- a/crates/provider/src/driver_registry.rs
+++ b/crates/provider/src/driver_registry.rs
@@ -350,6 +350,15 @@ pub trait ChatDriver: Send + Sync {
         false
     }
 
+    /// Whether this driver persists Responses API state and can resolve tool
+    /// calls that are reachable only through `previous_response_id`.
+    ///
+    /// Stateless and custom drivers default to `false`; they must receive a
+    /// self-contained tool call/result transcript on every request.
+    fn supports_stateful_responses(&self) -> bool {
+        false
+    }
+
     /// Whether this driver can express the request-level `parallel_tool_calls`
     /// preference on the wire for `model`.
     ///
@@ -414,6 +423,10 @@ impl ChatDriver for Box<dyn ChatDriver> {
 
     fn supports_compact(&self) -> bool {
         (**self).supports_compact()
+    }
+
+    fn supports_stateful_responses(&self) -> bool {
+        (**self).supports_stateful_responses()
     }
 
     fn supports_parallel_tool_calls(&self, model: &str) -> bool {
@@ -2053,7 +2066,7 @@ mod tests {
     }
 
     #[test]
-    fn test_chat_driver_default_omits_parallel_tool_calls() {
+    fn test_chat_driver_defaults_are_conservative_and_boxed_capabilities_forward() {
         // Default trait impl is conservative: drivers opt in.
         struct DefaultDriver;
         #[async_trait]
@@ -2067,6 +2080,25 @@ mod tests {
             }
         }
         assert!(!DefaultDriver.supports_parallel_tool_calls("any-model"));
+        assert!(!DefaultDriver.supports_stateful_responses());
+
+        struct StatefulDriver;
+        #[async_trait]
+        impl ChatDriver for StatefulDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unreachable!()
+            }
+
+            fn supports_stateful_responses(&self) -> bool {
+                true
+            }
+        }
+        let boxed: BoxedChatDriver = Box::new(StatefulDriver);
+        assert!(boxed.supports_stateful_responses());
     }
 
     #[test]

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -984,6 +984,10 @@ fn endpoint_persists_responses(api_url: &str) -> bool {
 
 #[async_trait]
 impl ChatDriver for OpenResponsesProtocolChatDriver {
+    fn supports_stateful_responses(&self) -> bool {
+        endpoint_persists_responses(&self.api_url)
+    }
+
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -3345,6 +3349,7 @@ mod tests {
         assert!(endpoint_persists_responses(
             "https://my-resource.services.ai.azure.com/openai/v1/responses"
         ));
+        assert!(OpenResponsesProtocolChatDriver::new("test").supports_stateful_responses());
     }
 
     #[test]
@@ -3362,6 +3367,13 @@ mod tests {
         assert!(!endpoint_persists_responses(
             "https://api.openai.example.com/v1/responses"
         ));
+        assert!(
+            !OpenResponsesProtocolChatDriver::with_base_url(
+                "test",
+                "https://openrouter.ai/api/v1/responses"
+            )
+            .supports_stateful_responses()
+        );
     }
 
     /// End-to-end shape of the call path: against a stateless gateway, a request

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -20,6 +20,20 @@ The model view applies generic cost-control masking according to the configured 
 
 Provider cache telemetry feeds this same model-view step. If the previous call reports high uncached input or a low cache-read ratio, the model view may mask older tool results earlier so repeated full-history prompts do not keep paying for cache misses.
 
+### Tool-call structural integrity
+
+Prompt-facing reduction preserves tool calls and results as atomic protocol
+structure. If a reducer removes a result from a parallel batch, it also removes
+that call from the visible assistant call set while leaving complete protected
+pairs intact. A stateless model view likewise removes results whose calls are no
+longer visible. Stateful Responses continuations are the sole exception: a
+result-only delta may refer to a call held by `previous_response_id`.
+
+This invariant applies to proactive and reactive trimming, summary boundaries,
+hierarchical tiers, provider-compacted output, and infinity-context composition.
+Reducers only change prompt-facing copies: stored session history remains
+lossless, and reducers never invent successful tool results.
+
 ## Current State
 
 ### What Exists

--- a/specs/infinity-context.md
+++ b/specs/infinity-context.md
@@ -92,6 +92,11 @@ When searching history:
   **additional** to `max_recent_messages` (which caps only the recent tail) and is
   preserved outside the token budget when configured. The value is capped at 16 to
   bound the extra head fetch and the always-preserved prompt anchor.
+- Window boundaries MUST NOT expose a tool call after its result has been
+  excluded. Result-only deltas remain available until request assembly because
+  OpenAI Responses may keep the matching call behind `previous_response_id`;
+  stateless request assembly removes such unmatched results. This reduction is
+  prompt-only and never mutates the queryable stored history.
 
 ## Design
 


### PR DESCRIPTION
## What changed
Compaction and model-view reduction now preserve tool calls and results as atomic protocol structure across aggressive/reactive trimming, observation masking boundaries, hierarchical memory, summarization, native compaction output, and infinity-context windows.

When one result from a parallel assistant batch is evicted, only its matching call is pruned; complete protected pairs remain visible. Stateless drivers also drop orphan results, while verified stateful OpenAI/Azure Responses continuations may keep result-only deltas backed by `previous_response_id`. Stored session history remains lossless.

Fixes EVE-779.

## Why
A real session became permanently unrecoverable after proactive compaction retained a parallel assistant batch containing `activate_skill` and Bash calls, retained the skill result, and evicted the Bash result. The provider rejected every subsequent request because the visible Bash call had no output.

## Before / After
Before, the exact regression fixture reduced to visible calls `[call_skill, call_bash]` but results `[call_skill]`, producing a provider protocol error.

After, the same fixture reduces to calls/results `[call_skill]`: the complete protected skill pair survives and only the unmatched Bash call is removed. Focused regression tests cover aggressive, hierarchical, summary-boundary, infinity-context, stateless, stateful, and boxed-driver paths.

Validation:
- `cargo test -p everruns-core`: 2,345 unit tests plus integration/doc tests passed
- `cargo test -p everruns-provider`: 470 unit tests plus doc tests passed
- `just pre-push`: all checks passed
- `PORT_PREFIX=279 just start-dev --no-watch`: direct API and reverse-proxy `/health` returned `status: ok`

## Risk
- Medium
- Prompt-facing reduction can remove an unmatched protocol fragment that was previously sent to the model. This is intentional and limited to incomplete exchanges; complete pairs and durable history are preserved.
- Stateful result-only deltas are enabled only when the concrete driver confirms server-side Responses persistence. Custom and stateless drivers default to self-contained transcripts.

## Security
- Threat categories reviewed: TM-LLM, TM-AGENT-015, TM-DOS
- Findings and resolutions: no new credential, authorization, storage, or external-input boundary. The fix removes malformed prompt fragments without synthesizing successful tool output or mutating stored history. Integrity checks are bounded linear passes over the already-bounded model context; no new resource-amplification path was found. No threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)