### PR TITLE
fix(server): refresh expiring MCP OAuth tokens

### DIFF
--- a/crates/server/specs/user-connections.md
+++ b/crates/server/specs/user-connections.md
@@ -113,14 +113,22 @@ Connection tokens are resolved lazily at tool execution time via `UserConnection
 
 1. Tool (e.g. `git_clone`) requests token via `context.connection_resolver`
 2. For GitHub App: resolver reads `installation_id`, mints a fresh 1h token via GitHub API
-3. For legacy OAuth: resolver decrypts stored `access_token_encrypted`
-4. If no connection exists, tool returns guidance: "connect GitHub in Settings > Connections"
+3. For MCP OAuth: resolver returns an unexpired access token or lazily exchanges
+   the encrypted refresh token. A 60-second skew avoids racing expiry;
+   concurrent reads of one grant are coalesced, and rotated access/refresh
+   tokens are committed atomically. Session-scoped MCP grants take precedence
+   over the persistent user connection.
+4. For other legacy OAuth: resolver decrypts stored `access_token_encrypted`
+5. If no connection exists or an MCP refresh is rejected, tool returns the
+   provider-specific `connection_required` guidance.
 
 Benefits:
 - Tokens are always fresh (1h TTL, minted on demand)
 - Sessions created before connecting still get tokens
 - No long-lived secrets stored for GitHub
 - Token scope is limited to installed repos only
+- Short-lived MCP OAuth tokens remain fresh without reconnecting, while refresh
+  failures fail closed to reconnection
 
 The token value never appears in tool arguments, tool results, or message history.
 

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -9,6 +9,7 @@ use crate::auth::config::AuthConfig;
 use crate::auth::middleware::{AuthState, AuthUser};
 use crate::auth::oauth::GitHubAppService;
 use crate::domains::mcp_servers::{McpServerOAuthSettings, McpServerService, McpServerSettings};
+use crate::oauth_client::{egress_oauth_json, exchange_oauth_code};
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
     Json, Router,
@@ -24,9 +25,8 @@ use everruns_core::connector::{
     ConnectorFormSchema as CoreFormSchema, ConnectorRegistry, ConnectorType,
 };
 use everruns_core::{
-    Caller, EgressRequest, EgressRequestKind, EgressService, McpServerAuthMode, SessionId,
-    mcp_oauth_provider_id_for_uuid, mcp_oauth_session_secret_name, validate_safe_url,
-    validate_url_dns_pinned,
+    Caller, EgressService, McpServerAuthMode, SessionId, mcp_oauth_provider_id_for_uuid,
+    validate_safe_url,
 };
 use rand::RngExt;
 use reqwest::Url;
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use super::common::{impl_auth_state, sanitized_bad_gateway, sanitized_internal_error};
-use crate::storage::models::CreateUserConnectionRow;
+use crate::storage::models::{CreateUserConnectionRow, UpsertMcpOAuthSessionCredentials};
 
 /// App state for user connections routes
 #[derive(Clone)]
@@ -199,17 +199,6 @@ struct OAuthServerMetadata {
 struct OAuthClientRegistration {
     client_id: String,
     client_secret: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OAuthTokenResponse {
-    access_token: String,
-    #[serde(default)]
-    refresh_token: Option<String>,
-    #[serde(default)]
-    expires_in: Option<i64>,
-    #[serde(default)]
-    scope: Option<String>,
 }
 
 // ============================================================================
@@ -763,41 +752,25 @@ pub async fn connection_oauth_callback(
         ))?;
         state
             .db
-            .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
+            .upsert_mcp_oauth_session_credentials(UpsertMcpOAuthSessionCredentials {
                 session_id,
-                name: mcp_oauth_session_secret_name(server_id, "access_token"),
-                value_encrypted: encryption
+                server_id,
+                access_token_encrypted: encryption
                     .encrypt_string(&token.access_token)
+                    .map_err(|e| sanitized_internal_error("OAuth connection", &e))?,
+                refresh_token_encrypted: token
+                    .refresh_token
+                    .as_deref()
+                    .map(|value| encryption.encrypt_string(value))
+                    .transpose()
+                    .map_err(|e| sanitized_internal_error("OAuth connection", &e))?,
+                expires_at_encrypted: expires_at
+                    .map(|value| encryption.encrypt_string(&value.to_rfc3339()))
+                    .transpose()
                     .map_err(|e| sanitized_internal_error("OAuth connection", &e))?,
             })
             .await
             .map_err(|e| sanitized_internal_error("OAuth connection", &e))?;
-        if let Some(refresh_token) = &token.refresh_token {
-            state
-                .db
-                .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
-                    session_id,
-                    name: mcp_oauth_session_secret_name(server_id, "refresh_token"),
-                    value_encrypted: encryption
-                        .encrypt_string(refresh_token)
-                        .map_err(|e| sanitized_internal_error("OAuth connection", &e))?,
-                })
-                .await
-                .map_err(|e| sanitized_internal_error("OAuth connection", &e))?;
-        }
-        if let Some(expires_at) = expires_at {
-            state
-                .db
-                .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
-                    session_id,
-                    name: mcp_oauth_session_secret_name(server_id, "expires_at"),
-                    value_encrypted: encryption
-                        .encrypt_string(&expires_at.to_rfc3339())
-                        .map_err(|e| sanitized_internal_error("OAuth connection", &e))?,
-                })
-                .await
-                .map_err(|e| sanitized_internal_error("OAuth connection", &e))?;
-        }
     } else {
         let encryption = state.encryption.as_ref().ok_or((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1370,47 +1343,6 @@ async fn register_oauth_client(
     .await
 }
 
-async fn exchange_oauth_code(
-    egress: &dyn EgressService,
-    token_endpoint: &str,
-    client_id: &str,
-    client_secret: Option<&str>,
-    redirect_uri: &str,
-    code: &str,
-    code_verifier: &str,
-) -> Result<OAuthTokenResponse, (StatusCode, String)> {
-    validate_safe_url(token_endpoint).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Token endpoint blocked: {e}"),
-        )
-    })?;
-    let mut params = vec![
-        ("grant_type", "authorization_code".to_string()),
-        ("client_id", client_id.to_string()),
-        ("redirect_uri", redirect_uri.to_string()),
-        ("code", code.to_string()),
-        ("code_verifier", code_verifier.to_string()),
-    ];
-    if let Some(secret) = client_secret {
-        params.push(("client_secret", secret.to_string()));
-    }
-    let body = serde_urlencoded::to_string(&params)
-        .map_err(|e| sanitized_bad_gateway("OAuth token body", &e))?
-        .into_bytes();
-    egress_oauth_json(
-        egress,
-        "POST",
-        token_endpoint,
-        &[(
-            "Content-Type",
-            "application/x-www-form-urlencoded".to_string(),
-        )],
-        body,
-    )
-    .await
-}
-
 fn finalize_oauth_redirect(
     auth_config: &AuthConfig,
     return_to: &str,
@@ -1467,80 +1399,10 @@ fn parse_and_validate_url(url: &str) -> Result<Url, (StatusCode, String)> {
     Url::parse(url).map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid URL: {e}")))
 }
 
-/// Send an OAuth discovery/registration/token request through the host egress
-/// boundary with DNS pinning (TM-API-013, TM-MCP), parsing the JSON body.
-///
-/// These endpoints come from the attacker-controlled OAuth discovery response
-/// and were previously fetched with a bare `reqwest::Client::new()`, which
-/// follows redirects and does no DNS pinning — letting a URL that passed
-/// create-time `validate_safe_url` DNS-rebind or 302-redirect to a private/
-/// metadata address at request time (EVE-623). Routing through [`EgressService`]
-/// after `validate_url_dns_pinned` (pinning the connection to the validated IPs)
-/// reuses the egress hardening (redirects disabled, DNS-pinned connect) used by
-/// the MCP runtime and capabilities.
-async fn egress_oauth_json<T: serde::de::DeserializeOwned>(
-    egress: &dyn EgressService,
-    method: &str,
-    url: &str,
-    headers: &[(&str, String)],
-    body: Vec<u8>,
-) -> Result<T, (StatusCode, String)> {
-    // Resolve-and-pin before sending so the request connects to the exact IPs we
-    // validated, closing the DNS-rebind TOCTOU window.
-    let (parsed, pinned_addrs) = validate_url_dns_pinned(url)
-        .await
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Blocked URL: {e}")))?;
-    let host = parsed.host_str().unwrap_or("").to_string();
-
-    let mut request = EgressRequest::new(method, url, EgressRequestKind::Mcp);
-    for (name, value) in headers {
-        request = request.header(*name, value.clone());
-    }
-    if !body.is_empty() {
-        request = request.body(body);
-    }
-    if pinned_addrs.is_empty() {
-        // IP-literal URL: nothing to pin, but still demand boundary-side
-        // validation before connect.
-        request = request.require_dns_pinning();
-    } else {
-        request = request.pinned_addrs(host, pinned_addrs);
-    }
-
-    let response = egress
-        .send(request)
-        .await
-        .map_err(|e| sanitized_bad_gateway("OAuth external service", &e))?;
-
-    if !(200..300).contains(&response.status) {
-        let body_text = String::from_utf8_lossy(&response.body);
-        let truncated = truncate_utf8_for_log(&body_text, 512);
-        tracing::error!(
-            status = response.status,
-            body_len = response.body.len(),
-            "External service error: {truncated}"
-        );
-        return Err((StatusCode::BAD_GATEWAY, "Bad gateway".to_string()));
-    }
-
-    serde_json::from_slice(&response.body)
-        .map_err(|e| sanitized_bad_gateway("External service response parse", &e))
-}
-
-fn truncate_utf8_for_log(input: &str, max_bytes: usize) -> &str {
-    if input.len() <= max_bytes {
-        return input;
-    }
-    let mut end = max_bytes;
-    while end > 0 && !input.is_char_boundary(end) {
-        end -= 1;
-    }
-    &input[..end]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::EgressRequest;
 
     #[test]
     fn valid_state_accepted() {
@@ -1626,14 +1488,6 @@ mod tests {
         let query: GitHubInstallationCallbackQuery = serde_json::from_str(json).unwrap();
         assert_eq!(query.installation_id, 12345);
         assert_eq!(query.state, None);
-    }
-
-    #[test]
-    fn truncate_utf8_for_log_handles_multibyte_boundary() {
-        let value = format!("{}étail", "a".repeat(511));
-        let truncated = truncate_utf8_for_log(&value, 512);
-        assert_eq!(truncated, "a".repeat(511));
-        assert!(truncated.is_char_boundary(truncated.len()));
     }
 
     // =========================================================================

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -102,11 +102,13 @@ fn build_connection_resolver(
     db: &Arc<StorageBackend>,
     encryption: &Arc<EncryptionService>,
     auth_config: &auth::AuthConfig,
+    egress: Arc<dyn everruns_core::EgressService>,
 ) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {
     Arc::new(crate::storage::DbConnectionResolver::new(
         db.as_ref().clone(),
         encryption.as_ref().clone(),
         github_app_token_minter(auth_config),
+        egress,
     ))
 }
 
@@ -114,10 +116,11 @@ fn optional_connection_resolver(
     db: &Arc<StorageBackend>,
     encryption: &Option<Arc<EncryptionService>>,
     auth_config: &auth::AuthConfig,
+    egress: Arc<dyn everruns_core::EgressService>,
 ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
     encryption
         .as_ref()
-        .map(|enc| build_connection_resolver(db, enc, auth_config))
+        .map(|enc| build_connection_resolver(db, enc, auth_config, egress))
 }
 
 struct ServerTaskNotifier {
@@ -667,8 +670,12 @@ impl ServerAppBuilder {
                                 database.clone(),
                                 enc.as_ref().clone(),
                             ));
-                        let connection_resolver =
-                            Some(build_connection_resolver(&db, enc, &auth_config));
+                        let connection_resolver = Some(build_connection_resolver(
+                            &db,
+                            enc,
+                            &auth_config,
+                            platform_definition.egress_service(),
+                        ));
                         let service =
                             Arc::new(crate::domains::session_sandbox::SessionSandboxService::new(
                                 db.clone(),
@@ -690,8 +697,12 @@ impl ServerAppBuilder {
                     }
                 },
                 crate::storage::StorageBackend::InMemory(mem_db) => {
-                    let connection_resolver =
-                        optional_connection_resolver(&db, &encryption, &auth_config);
+                    let connection_resolver = optional_connection_resolver(
+                        &db,
+                        &encryption,
+                        &auth_config,
+                        platform_definition.egress_service(),
+                    );
                     let service =
                         Arc::new(crate::domains::session_sandbox::SessionSandboxService::new(
                             db.clone(),
@@ -2140,8 +2151,13 @@ impl ServerAppBuilder {
                 // slot empty — `runtime_host::connection_resolver()` always calls into the
                 // adapter at runtime and would otherwise panic.
                 let connection_resolver: Arc<dyn everruns_core::traits::UserConnectionResolver> =
-                    optional_connection_resolver(&db, &encryption, &auth_config)
-                        .unwrap_or_else(|| Arc::new(crate::storage::NoopConnectionResolver));
+                    optional_connection_resolver(
+                        &db,
+                        &encryption,
+                        &auth_config,
+                        platform_definition.egress_service(),
+                    )
+                    .unwrap_or_else(|| Arc::new(crate::storage::NoopConnectionResolver));
                 adapters = adapters.with_connection_resolver(connection_resolver);
 
                 let worker_config = TaskWorkerConfig::dev_mode();
@@ -2246,8 +2262,12 @@ impl ServerAppBuilder {
         );
 
         // -- Source-backed Memory sync (both prod and dev) --
-        let memory_connection_resolver =
-            optional_connection_resolver(&db, &encryption, &auth_config);
+        let memory_connection_resolver = optional_connection_resolver(
+            &db,
+            &encryption,
+            &auth_config,
+            platform_definition.egress_service(),
+        );
         supervisor.track_optional(
             "memory_source_sync",
             crate::domains::memory::source_sync::spawn_memory_source_sync_task(

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -625,6 +625,7 @@ impl WorkerServiceImpl {
                     db.as_ref().clone(),
                     enc.as_ref().clone(),
                     github_app_minter,
+                    platform_definition.egress_service(),
                 )) as Arc<dyn everruns_core::traits::UserConnectionResolver>
             });
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -52,6 +52,7 @@ pub use services::EventService;
 pub mod storage;
 
 // OpenAPI spec generation
+mod oauth_client;
 pub mod openapi;
 pub mod platform;
 pub use platform::{

--- a/crates/server/src/oauth_client.rs
+++ b/crates/server/src/oauth_client.rs
@@ -1,0 +1,178 @@
+//! Shared OAuth token-exchange client for MCP connection flows.
+
+use async_trait::async_trait;
+use axum::http::StatusCode;
+use everruns_core::{
+    EgressRequest, EgressRequestKind, EgressService, validate_safe_url, validate_url_dns_pinned,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::api::common::sanitized_bad_gateway;
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OAuthTokenResponse {
+    pub access_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[serde(default)]
+    pub expires_in: Option<i64>,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OAuthRefreshRequest {
+    pub token_endpoint: String,
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    pub refresh_token: String,
+}
+
+#[async_trait]
+pub(crate) trait OAuthRefreshExchange: Send + Sync {
+    async fn exchange(
+        &self,
+        request: OAuthRefreshRequest,
+    ) -> Result<OAuthTokenResponse, (StatusCode, String)>;
+}
+
+pub(crate) struct EgressOAuthRefreshExchange {
+    egress: Arc<dyn EgressService>,
+}
+
+impl EgressOAuthRefreshExchange {
+    pub fn new(egress: Arc<dyn EgressService>) -> Self {
+        Self { egress }
+    }
+}
+
+#[async_trait]
+impl OAuthRefreshExchange for EgressOAuthRefreshExchange {
+    async fn exchange(
+        &self,
+        request: OAuthRefreshRequest,
+    ) -> Result<OAuthTokenResponse, (StatusCode, String)> {
+        exchange_oauth_refresh_token(
+            self.egress.as_ref(),
+            &request.token_endpoint,
+            &request.client_id,
+            request.client_secret.as_deref(),
+            &request.refresh_token,
+        )
+        .await
+    }
+}
+
+pub(crate) async fn exchange_oauth_code(
+    egress: &dyn EgressService,
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    redirect_uri: &str,
+    code: &str,
+    code_verifier: &str,
+) -> Result<OAuthTokenResponse, (StatusCode, String)> {
+    let mut params = vec![
+        ("grant_type", "authorization_code".to_string()),
+        ("client_id", client_id.to_string()),
+        ("redirect_uri", redirect_uri.to_string()),
+        ("code", code.to_string()),
+        ("code_verifier", code_verifier.to_string()),
+    ];
+    if let Some(secret) = client_secret {
+        params.push(("client_secret", secret.to_string()));
+    }
+    exchange_oauth_token(egress, token_endpoint, params).await
+}
+
+async fn exchange_oauth_refresh_token(
+    egress: &dyn EgressService,
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    refresh_token: &str,
+) -> Result<OAuthTokenResponse, (StatusCode, String)> {
+    let mut params = vec![
+        ("grant_type", "refresh_token".to_string()),
+        ("client_id", client_id.to_string()),
+        ("refresh_token", refresh_token.to_string()),
+    ];
+    if let Some(secret) = client_secret {
+        params.push(("client_secret", secret.to_string()));
+    }
+    exchange_oauth_token(egress, token_endpoint, params).await
+}
+
+async fn exchange_oauth_token(
+    egress: &dyn EgressService,
+    token_endpoint: &str,
+    params: Vec<(&str, String)>,
+) -> Result<OAuthTokenResponse, (StatusCode, String)> {
+    validate_safe_url(token_endpoint).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Token endpoint blocked: {e}"),
+        )
+    })?;
+    let body = serde_urlencoded::to_string(&params)
+        .map_err(|e| sanitized_bad_gateway("OAuth token body", &e))?
+        .into_bytes();
+    egress_oauth_json(
+        egress,
+        "POST",
+        token_endpoint,
+        &[(
+            "Content-Type",
+            "application/x-www-form-urlencoded".to_string(),
+        )],
+        body,
+    )
+    .await
+}
+
+/// Send an OAuth request through the host egress boundary with DNS pinning.
+pub(crate) async fn egress_oauth_json<T: serde::de::DeserializeOwned>(
+    egress: &dyn EgressService,
+    method: &str,
+    url: &str,
+    headers: &[(&str, String)],
+    body: Vec<u8>,
+) -> Result<T, (StatusCode, String)> {
+    // THREAT[TM-TOOL-018]: bind the outbound connection to the IPs validated
+    // for this request, including token refreshes of long-lived credentials.
+    let (parsed, pinned_addrs) = validate_url_dns_pinned(url)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Blocked URL: {e}")))?;
+    let host = parsed.host_str().unwrap_or("").to_string();
+
+    let mut request = EgressRequest::new(method, url, EgressRequestKind::Mcp);
+    for (name, value) in headers {
+        request = request.header(*name, value.clone());
+    }
+    if !body.is_empty() {
+        request = request.body(body);
+    }
+    request = if pinned_addrs.is_empty() {
+        request.require_dns_pinning()
+    } else {
+        request.pinned_addrs(host, pinned_addrs)
+    };
+
+    let response = egress
+        .send(request)
+        .await
+        .map_err(|e| sanitized_bad_gateway("OAuth external service", &e))?;
+
+    if !(200..300).contains(&response.status) {
+        tracing::warn!(
+            status = response.status,
+            body_len = response.body.len(),
+            "OAuth external service rejected request"
+        );
+        return Err((StatusCode::BAD_GATEWAY, "Bad gateway".to_string()));
+    }
+
+    serde_json::from_slice(&response.body)
+        .map_err(|e| sanitized_bad_gateway("External service response parse", &e))
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3197,6 +3197,26 @@ impl StorageBackend {
         dispatch!(self, upsert_session_secret, input)
     }
 
+    pub async fn get_mcp_oauth_session_credentials(
+        &self,
+        session_id: SessionId,
+        server_id: Uuid,
+    ) -> Result<Option<McpOAuthSessionCredentialsRow>> {
+        dispatch!(
+            self,
+            get_mcp_oauth_session_credentials,
+            session_id,
+            server_id
+        )
+    }
+
+    pub async fn upsert_mcp_oauth_session_credentials(
+        &self,
+        input: UpsertMcpOAuthSessionCredentials,
+    ) -> Result<()> {
+        dispatch!(self, upsert_mcp_oauth_session_credentials, input)
+    }
+
     // ============================================
     // User Connections
     // ============================================
@@ -3218,6 +3238,13 @@ impl StorageBackend {
 
     pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         dispatch!(self, list_user_connections, user_id)
+    }
+
+    pub async fn update_user_connection_oauth_tokens(
+        &self,
+        input: UpdateUserConnectionOAuthTokens,
+    ) -> Result<Option<UserConnectionRow>> {
+        dispatch!(self, update_user_connection_oauth_tokens, input)
     }
 
     pub async fn delete_user_connection(&self, user_id: Uuid, provider: &str) -> Result<bool> {

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -10,14 +10,32 @@
 // Legacy OAuth connections: decrypts the stored token.
 
 use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use chrono::{DateTime, Duration, Utc};
 use everruns_core::traits::UserConnectionResolver;
 use everruns_core::typed_id::SessionId;
-use everruns_core::{AgentLoopError, Result};
+use everruns_core::{AgentLoopError, EgressService, McpServerAuthMode, Result};
+use moka::sync::Cache;
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use super::backend::StorageBackend;
 use super::encryption::EncryptionService;
+use super::models::{
+    McpOAuthSessionCredentialsRow, UpdateUserConnectionOAuthTokens,
+    UpsertMcpOAuthSessionCredentials, UserConnectionRow,
+};
 use crate::auth::oauth::GitHubAppService;
+use crate::domains::mcp_servers::{McpServerOAuthSettings, McpServerService};
+use crate::oauth_client::{
+    EgressOAuthRefreshExchange, OAuthRefreshExchange, OAuthRefreshRequest, OAuthTokenResponse,
+};
+
+const OAUTH_REFRESH_SKEW: Duration = Duration::seconds(60);
+const REFRESH_LOCK_MAX_CAPACITY: u64 = 10_000;
+const REFRESH_LOCK_IDLE_TTL: StdDuration = StdDuration::from_secs(10 * 60);
 
 /// Resolves connection tokens for tool execution.
 ///
@@ -33,6 +51,17 @@ pub struct DbConnectionResolver {
     encryption: EncryptionService,
     /// GitHub App service for minting installation tokens (None = legacy OAuth only)
     github_app: Option<GitHubAppTokenMinter>,
+    oauth_refresh: Arc<dyn OAuthRefreshExchange>,
+    // THREAT[TM-TOOL-025]: per-grant single-flight locks prevent refresh
+    // stampedes; the bounded idle cache prevents session-id memory exhaustion.
+    refresh_locks: Cache<String, Arc<Mutex<()>>>,
+}
+
+#[derive(Debug)]
+struct OAuthClientConfig {
+    token_endpoint: String,
+    client_id: String,
+    client_secret: Option<String>,
 }
 
 /// Handles GitHub App JWT signing and installation token minting.
@@ -75,12 +104,306 @@ impl DbConnectionResolver {
         db: StorageBackend,
         encryption: EncryptionService,
         github_app: Option<GitHubAppTokenMinter>,
+        egress: Arc<dyn EgressService>,
+    ) -> Self {
+        Self::with_oauth_refresh(
+            db,
+            encryption,
+            github_app,
+            Arc::new(EgressOAuthRefreshExchange::new(egress)),
+        )
+    }
+
+    fn with_oauth_refresh(
+        db: StorageBackend,
+        encryption: EncryptionService,
+        github_app: Option<GitHubAppTokenMinter>,
+        oauth_refresh: Arc<dyn OAuthRefreshExchange>,
     ) -> Self {
         Self {
             db,
             encryption,
             github_app,
+            oauth_refresh,
+            refresh_locks: Cache::builder()
+                .max_capacity(REFRESH_LOCK_MAX_CAPACITY)
+                .time_to_idle(REFRESH_LOCK_IDLE_TTL)
+                .build(),
         }
+    }
+
+    fn parse_mcp_oauth_provider(provider: &str) -> Option<Uuid> {
+        provider.strip_prefix("mcp_oauth_")?.parse().ok()
+    }
+
+    fn decrypt(&self, encrypted: &[u8], label: &str) -> Result<String> {
+        self.encryption
+            .decrypt_to_string(encrypted)
+            .map_err(|e| AgentLoopError::store(format!("Failed to decrypt {label}: {e}")))
+    }
+
+    fn needs_refresh(&self, expires_at_encrypted: Option<&[u8]>) -> Result<bool> {
+        let Some(encrypted) = expires_at_encrypted else {
+            return Ok(false);
+        };
+        let value = self.decrypt(encrypted, "OAuth token expiry")?;
+        let expires_at = DateTime::parse_from_rfc3339(&value)
+            .map_err(|e| AgentLoopError::store(format!("Invalid OAuth token expiry: {e}")))?
+            .with_timezone(&Utc);
+        Ok(expires_at <= Utc::now() + OAUTH_REFRESH_SKEW)
+    }
+
+    fn user_connection_needs_refresh(&self, row: &UserConnectionRow) -> bool {
+        row.expires_at
+            .is_some_and(|expires_at| expires_at <= Utc::now() + OAUTH_REFRESH_SKEW)
+    }
+
+    async fn oauth_client_config(
+        &self,
+        session_id: SessionId,
+        server_id: Uuid,
+    ) -> Result<Option<OAuthClientConfig>> {
+        // THREAT[TM-TENANT-001]: derive the org from the active session, then
+        // scope the OAuth server lookup to that org.
+        let session = self
+            .db
+            .get_session_unscoped(session_id)
+            .await
+            .map_err(|e| AgentLoopError::store(format!("Failed to resolve OAuth session: {e}")))?;
+        let Some(session) = session else {
+            return Ok(None);
+        };
+        let row = self
+            .db
+            .get_mcp_server(session.org_id, server_id)
+            .await
+            .map_err(|e| AgentLoopError::store(format!("Failed to resolve OAuth server: {e}")))?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let settings = McpServerService::settings_from_row(&row);
+        if settings.auth_mode != McpServerAuthMode::OAuth {
+            return Ok(None);
+        }
+        self.oauth_client_config_from_settings(settings.oauth.as_ref())
+    }
+
+    fn oauth_client_config_from_settings(
+        &self,
+        oauth: Option<&McpServerOAuthSettings>,
+    ) -> Result<Option<OAuthClientConfig>> {
+        let Some(oauth) = oauth else {
+            return Ok(None);
+        };
+        let (Some(token_endpoint), Some(client_id)) =
+            (oauth.token_endpoint.clone(), oauth.client_id.clone())
+        else {
+            return Ok(None);
+        };
+        let client_secret = oauth
+            .client_secret_encrypted
+            .as_deref()
+            .map(|value| {
+                let encrypted = BASE64_STANDARD.decode(value).map_err(|e| {
+                    AgentLoopError::store(format!("Invalid OAuth client secret encoding: {e}"))
+                })?;
+                self.decrypt(&encrypted, "OAuth client secret")
+            })
+            .transpose()?;
+        Ok(Some(OAuthClientConfig {
+            token_endpoint,
+            client_id,
+            client_secret,
+        }))
+    }
+
+    async fn exchange_refresh(
+        &self,
+        config: OAuthClientConfig,
+        refresh_token: String,
+    ) -> Option<OAuthTokenResponse> {
+        match self
+            .oauth_refresh
+            .exchange(OAuthRefreshRequest {
+                token_endpoint: config.token_endpoint,
+                client_id: config.client_id,
+                client_secret: config.client_secret,
+                refresh_token,
+            })
+            .await
+        {
+            Ok(token) => Some(token),
+            Err((status, _)) => {
+                // Do not expose provider responses or credentials. Returning no
+                // token preserves the existing connection_required behavior.
+                tracing::warn!(%status, "MCP OAuth token refresh failed");
+                None
+            }
+        }
+    }
+
+    fn expiry_from_response(token: &OAuthTokenResponse) -> Option<DateTime<Utc>> {
+        token
+            .expires_in
+            .map(|seconds| Utc::now() + Duration::seconds(seconds))
+    }
+
+    async fn resolve_session_oauth_token(
+        &self,
+        session_id: SessionId,
+        server_id: Uuid,
+        credentials: McpOAuthSessionCredentialsRow,
+    ) -> Result<Option<String>> {
+        if !self.needs_refresh(credentials.expires_at_encrypted.as_deref())? {
+            return self
+                .decrypt(&credentials.access_token_encrypted, "OAuth access token")
+                .map(Some);
+        }
+
+        let key = format!("session:{session_id}:{server_id}");
+        let lock = self
+            .refresh_locks
+            .get_with(key, || Arc::new(Mutex::new(())));
+        let _guard = lock.lock().await;
+
+        // Re-read after taking the lock: another waiter may have refreshed it.
+        let Some(credentials) = self
+            .db
+            .get_mcp_oauth_session_credentials(session_id, server_id)
+            .await
+            .map_err(|e| AgentLoopError::store(format!("Failed to resolve OAuth grant: {e}")))?
+        else {
+            return Ok(None);
+        };
+        if !self.needs_refresh(credentials.expires_at_encrypted.as_deref())? {
+            return self
+                .decrypt(&credentials.access_token_encrypted, "OAuth access token")
+                .map(Some);
+        }
+        let Some(refresh_token_encrypted) = credentials.refresh_token_encrypted else {
+            return Ok(None);
+        };
+        let refresh_token = self.decrypt(&refresh_token_encrypted, "OAuth refresh token")?;
+        let Some(config) = self.oauth_client_config(session_id, server_id).await? else {
+            return Ok(None);
+        };
+        let Some(token) = self.exchange_refresh(config, refresh_token.clone()).await else {
+            return Ok(None);
+        };
+        let rotated_refresh = token.refresh_token.as_deref().unwrap_or(&refresh_token);
+        let expires_at = Self::expiry_from_response(&token);
+        // THREAT[TM-TOOL-025]: replace the complete rotated grant in one
+        // storage transaction before exposing the new access token.
+        self.db
+            .upsert_mcp_oauth_session_credentials(UpsertMcpOAuthSessionCredentials {
+                session_id,
+                server_id,
+                access_token_encrypted: self
+                    .encryption
+                    .encrypt_string(&token.access_token)
+                    .map_err(|e| {
+                        AgentLoopError::store(format!("Failed to encrypt OAuth access token: {e}"))
+                    })?,
+                refresh_token_encrypted: Some(
+                    self.encryption
+                        .encrypt_string(rotated_refresh)
+                        .map_err(|e| {
+                            AgentLoopError::store(format!(
+                                "Failed to encrypt OAuth refresh token: {e}"
+                            ))
+                        })?,
+                ),
+                expires_at_encrypted: expires_at
+                    .map(|value| self.encryption.encrypt_string(&value.to_rfc3339()))
+                    .transpose()
+                    .map_err(|e| {
+                        AgentLoopError::store(format!("Failed to encrypt OAuth token expiry: {e}"))
+                    })?,
+            })
+            .await
+            .map_err(|e| {
+                AgentLoopError::store(format!("Failed to persist refreshed OAuth grant: {e}"))
+            })?;
+        Ok(Some(token.access_token))
+    }
+
+    async fn resolve_user_oauth_token(
+        &self,
+        session_id: SessionId,
+        server_id: Uuid,
+        user_id: Uuid,
+        row: UserConnectionRow,
+    ) -> Result<Option<String>> {
+        let Some(access_token_encrypted) = row.access_token_encrypted.as_deref() else {
+            return Ok(None);
+        };
+        if row.connection_type != "oauth" || !self.user_connection_needs_refresh(&row) {
+            return self
+                .decrypt(access_token_encrypted, "OAuth access token")
+                .map(Some);
+        }
+
+        let key = format!("user-connection:{}", row.id);
+        let lock = self
+            .refresh_locks
+            .get_with(key, || Arc::new(Mutex::new(())));
+        let _guard = lock.lock().await;
+        let Some(row) = self
+            .db
+            .get_user_connection(user_id, &row.provider)
+            .await
+            .map_err(|e| AgentLoopError::store(format!("Failed to resolve OAuth grant: {e}")))?
+        else {
+            return Ok(None);
+        };
+        let Some(access_token_encrypted) = row.access_token_encrypted.as_deref() else {
+            return Ok(None);
+        };
+        if !self.user_connection_needs_refresh(&row) {
+            return self
+                .decrypt(access_token_encrypted, "OAuth access token")
+                .map(Some);
+        }
+        let Some(refresh_token_encrypted) = row.refresh_token_encrypted.as_deref() else {
+            return Ok(None);
+        };
+        let refresh_token = self.decrypt(refresh_token_encrypted, "OAuth refresh token")?;
+        let Some(config) = self.oauth_client_config(session_id, server_id).await? else {
+            return Ok(None);
+        };
+        let Some(token) = self.exchange_refresh(config, refresh_token.clone()).await else {
+            return Ok(None);
+        };
+        let rotated_refresh = token.refresh_token.as_deref().unwrap_or(&refresh_token);
+        let fresh_access_token = token.access_token.clone();
+        // THREAT[TM-TOOL-025]: replace the complete rotated grant atomically
+        // before exposing the new access token.
+        let updated = self
+            .db
+            .update_user_connection_oauth_tokens(UpdateUserConnectionOAuthTokens {
+                connection_id: row.id,
+                access_token_encrypted: self
+                    .encryption
+                    .encrypt_string(&fresh_access_token)
+                    .map_err(|e| {
+                        AgentLoopError::store(format!("Failed to encrypt OAuth access token: {e}"))
+                    })?,
+                refresh_token_encrypted: self.encryption.encrypt_string(rotated_refresh).map_err(
+                    |e| {
+                        AgentLoopError::store(format!("Failed to encrypt OAuth refresh token: {e}"))
+                    },
+                )?,
+                expires_at: Self::expiry_from_response(&token),
+                scopes: token.scope,
+            })
+            .await
+            .map_err(|e| {
+                AgentLoopError::store(format!("Failed to persist refreshed OAuth grant: {e}"))
+            })?;
+        if updated.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(fresh_access_token))
     }
 }
 
@@ -106,6 +429,41 @@ impl UserConnectionResolver for DbConnectionResolver {
             if let Some(id) = installation_id {
                 let token = minter.mint_token(id).await.map_err(AgentLoopError::store)?;
                 return Ok(Some(token));
+            }
+        }
+
+        if let Some(server_id) = Self::parse_mcp_oauth_provider(provider) {
+            if let Some(credentials) = self
+                .db
+                .get_mcp_oauth_session_credentials(session_id, server_id)
+                .await
+                .map_err(|e| {
+                    AgentLoopError::store(format!("Failed to resolve session OAuth grant: {e}"))
+                })?
+            {
+                return self
+                    .resolve_session_oauth_token(session_id, server_id, credentials)
+                    .await;
+            }
+
+            if let Some(user_id) = self
+                .db
+                .get_connection_user_for_session(session_id, provider)
+                .await
+                .map_err(|e| {
+                    AgentLoopError::store(format!("Failed to resolve connection owner: {e}"))
+                })?
+                && let Some(row) = self
+                    .db
+                    .get_user_connection(user_id, provider)
+                    .await
+                    .map_err(|e| {
+                        AgentLoopError::store(format!("Failed to resolve connection: {e}"))
+                    })?
+            {
+                return self
+                    .resolve_user_oauth_token(session_id, server_id, user_id, row)
+                    .await;
             }
         }
 
@@ -211,5 +569,349 @@ impl UserConnectionResolver for NoopConnectionResolver {
         _provider: &str,
     ) -> Result<Option<String>> {
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::InMemoryDatabase;
+    use crate::storage::models::{CreateMcpServerRow, CreateSessionRow, CreateUserConnectionRow};
+    use everruns_core::traits::UserConnectionResolver;
+    use everruns_core::{DEFAULT_ORG_ID, PrincipalId};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const TEST_KEY: &str = "kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=";
+
+    struct FakeRefreshExchange {
+        calls: AtomicUsize,
+        delay: StdDuration,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl OAuthRefreshExchange for FakeRefreshExchange {
+        async fn exchange(
+            &self,
+            request: OAuthRefreshRequest,
+        ) -> std::result::Result<OAuthTokenResponse, (axum::http::StatusCode, String)> {
+            assert_eq!(request.refresh_token, "old-refresh");
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.delay).await;
+            if self.fail {
+                return Err((axum::http::StatusCode::BAD_GATEWAY, "provider error".into()));
+            }
+            Ok(OAuthTokenResponse {
+                access_token: "fresh-access".to_string(),
+                refresh_token: Some("rotated-refresh".to_string()),
+                expires_in: Some(3600),
+                scope: Some("email.send".to_string()),
+            })
+        }
+    }
+
+    fn encryption() -> EncryptionService {
+        EncryptionService::new(TEST_KEY, &[]).unwrap()
+    }
+
+    fn session_input(owner_user_id: Option<Uuid>) -> CreateSessionRow {
+        CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            workspace_id: None,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_version_id: None,
+            agent_config_hash: None,
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::from_seed(1),
+            resolved_owner_user_id: owner_user_id,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            budget_root_session_id: None,
+        }
+    }
+
+    async fn setup(
+        owner_user_id: Option<Uuid>,
+    ) -> (StorageBackend, EncryptionService, SessionId, Uuid, String) {
+        let memory = Arc::new(InMemoryDatabase::new());
+        let db = StorageBackend::InMemory(memory);
+        let server_id = Uuid::now_v7();
+        db.create_mcp_server_with_id(
+            DEFAULT_ORG_ID,
+            server_id,
+            CreateMcpServerRow {
+                name: "resend".to_string(),
+                description: None,
+                url: "https://mcp.resend.com/mcp".to_string(),
+                transport_type: "streamable_http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: Some(serde_json::json!({
+                    "auth_mode": "o_auth",
+                    "oauth": {
+                        "token_endpoint": "https://api.resend.com/oauth/token",
+                        "client_id": "test-client"
+                    }
+                })),
+            },
+        )
+        .await
+        .unwrap();
+        let session = db
+            .create_session(session_input(owner_user_id))
+            .await
+            .unwrap();
+        let server = db
+            .get_mcp_server(session.org_id, server_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let settings = McpServerService::settings_from_row(&server);
+        assert_eq!(settings.auth_mode, McpServerAuthMode::OAuth);
+        assert_eq!(
+            settings
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.client_id.as_deref()),
+            Some("test-client")
+        );
+        let provider = format!("mcp_oauth_{server_id}");
+        (db, encryption(), session.id, server_id, provider)
+    }
+
+    #[tokio::test]
+    async fn resend_connection_after_sixteen_minutes_refreshes_without_reconnect() {
+        let user_id = Uuid::now_v7();
+        let (db, encryption, session_id, _server_id, provider) = setup(Some(user_id)).await;
+        let connection = db
+            .upsert_user_connection(CreateUserConnectionRow {
+                user_id,
+                provider: provider.clone(),
+                connection_type: "oauth".to_string(),
+                provider_user_id: None,
+                provider_username: Some("Resend".to_string()),
+                access_token_encrypted: Some(encryption.encrypt_string("stale-access").unwrap()),
+                refresh_token_encrypted: Some(encryption.encrypt_string("old-refresh").unwrap()),
+                scopes: None,
+                expires_at: Some(Utc::now() - Duration::minutes(16)),
+                installation_id: None,
+                provider_metadata: None,
+            })
+            .await
+            .unwrap();
+        let exchange = Arc::new(FakeRefreshExchange {
+            calls: AtomicUsize::new(0),
+            delay: StdDuration::ZERO,
+            fail: false,
+        });
+        let resolver = DbConnectionResolver::with_oauth_refresh(
+            db.clone(),
+            encryption.clone(),
+            None,
+            exchange.clone(),
+        );
+
+        let token = resolver
+            .get_connection_token(session_id, &provider)
+            .await
+            .unwrap();
+
+        assert_eq!(token.as_deref(), Some("fresh-access"));
+        assert_eq!(exchange.calls.load(Ordering::SeqCst), 1);
+        let updated = db
+            .get_user_connection(user_id, &provider)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.id, connection.id);
+        assert_eq!(
+            encryption
+                .decrypt_to_string(updated.access_token_encrypted.as_deref().unwrap())
+                .unwrap(),
+            "fresh-access"
+        );
+        assert_eq!(
+            encryption
+                .decrypt_to_string(updated.refresh_token_encrypted.as_deref().unwrap())
+                .unwrap(),
+            "rotated-refresh"
+        );
+        assert_eq!(updated.scopes.as_deref(), Some("email.send"));
+        assert!(updated.expires_at.is_some_and(|value| value > Utc::now()));
+    }
+
+    #[tokio::test]
+    async fn expired_session_grant_refreshes_and_persists_rotated_grant() {
+        let (db, encryption, session_id, server_id, provider) = setup(None).await;
+        db.upsert_mcp_oauth_session_credentials(UpsertMcpOAuthSessionCredentials {
+            session_id,
+            server_id,
+            access_token_encrypted: encryption.encrypt_string("stale-access").unwrap(),
+            refresh_token_encrypted: Some(encryption.encrypt_string("old-refresh").unwrap()),
+            expires_at_encrypted: Some(
+                encryption
+                    .encrypt_string(&(Utc::now() - Duration::minutes(1)).to_rfc3339())
+                    .unwrap(),
+            ),
+        })
+        .await
+        .unwrap();
+        let exchange = Arc::new(FakeRefreshExchange {
+            calls: AtomicUsize::new(0),
+            delay: StdDuration::ZERO,
+            fail: false,
+        });
+        let resolver = DbConnectionResolver::with_oauth_refresh(
+            db.clone(),
+            encryption.clone(),
+            None,
+            exchange.clone(),
+        );
+
+        assert_eq!(
+            resolver
+                .get_connection_token(session_id, &provider)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("fresh-access")
+        );
+        let updated = db
+            .get_mcp_oauth_session_credentials(session_id, server_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            encryption
+                .decrypt_to_string(&updated.access_token_encrypted)
+                .unwrap(),
+            "fresh-access"
+        );
+        assert_eq!(
+            encryption
+                .decrypt_to_string(updated.refresh_token_encrypted.as_deref().unwrap())
+                .unwrap(),
+            "rotated-refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_expired_resolution_coalesces_refresh() {
+        let user_id = Uuid::now_v7();
+        let (db, encryption, session_id, _server_id, provider) = setup(Some(user_id)).await;
+        db.upsert_user_connection(CreateUserConnectionRow {
+            user_id,
+            provider: provider.clone(),
+            connection_type: "oauth".to_string(),
+            provider_user_id: None,
+            provider_username: Some("Resend".to_string()),
+            access_token_encrypted: Some(encryption.encrypt_string("stale-access").unwrap()),
+            refresh_token_encrypted: Some(encryption.encrypt_string("old-refresh").unwrap()),
+            scopes: None,
+            expires_at: Some(Utc::now() - Duration::minutes(1)),
+            installation_id: None,
+            provider_metadata: None,
+        })
+        .await
+        .unwrap();
+        let exchange = Arc::new(FakeRefreshExchange {
+            calls: AtomicUsize::new(0),
+            delay: StdDuration::from_millis(50),
+            fail: false,
+        });
+        let resolver = Arc::new(DbConnectionResolver::with_oauth_refresh(
+            db,
+            encryption,
+            None,
+            exchange.clone(),
+        ));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let resolver = resolver.clone();
+            let provider = provider.clone();
+            tasks.push(tokio::spawn(async move {
+                resolver
+                    .get_connection_token(session_id, &provider)
+                    .await
+                    .unwrap()
+            }));
+        }
+        for task in tasks {
+            assert_eq!(task.await.unwrap().as_deref(), Some("fresh-access"));
+        }
+        assert_eq!(exchange.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_fails_closed_and_preserves_existing_grant() {
+        let user_id = Uuid::now_v7();
+        let (db, encryption, session_id, _server_id, provider) = setup(Some(user_id)).await;
+        let original_access = encryption.encrypt_string("stale-access").unwrap();
+        let original_refresh = encryption.encrypt_string("old-refresh").unwrap();
+        db.upsert_user_connection(CreateUserConnectionRow {
+            user_id,
+            provider: provider.clone(),
+            connection_type: "oauth".to_string(),
+            provider_user_id: None,
+            provider_username: Some("Resend".to_string()),
+            access_token_encrypted: Some(original_access.clone()),
+            refresh_token_encrypted: Some(original_refresh.clone()),
+            scopes: None,
+            expires_at: Some(Utc::now() - Duration::minutes(1)),
+            installation_id: None,
+            provider_metadata: None,
+        })
+        .await
+        .unwrap();
+        let exchange = Arc::new(FakeRefreshExchange {
+            calls: AtomicUsize::new(0),
+            delay: StdDuration::ZERO,
+            fail: true,
+        });
+        let resolver = DbConnectionResolver::with_oauth_refresh(
+            db.clone(),
+            encryption,
+            None,
+            exchange.clone(),
+        );
+
+        assert_eq!(
+            resolver
+                .get_connection_token(session_id, &provider)
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(exchange.calls.load(Ordering::SeqCst), 1);
+        let unchanged = db
+            .get_user_connection(user_id, &provider)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            unchanged.access_token_encrypted.as_deref(),
+            Some(original_access.as_slice())
+        );
+        assert_eq!(
+            unchanged.refresh_token_encrypted.as_deref(),
+            Some(original_refresh.as_slice())
+        );
     }
 }

--- a/crates/server/src/storage/memory/session_storage.rs
+++ b/crates/server/src/storage/memory/session_storage.rs
@@ -127,6 +127,79 @@ impl InMemoryDatabase {
 
         Ok(row)
     }
+
+    pub async fn get_mcp_oauth_session_credentials(
+        &self,
+        session_id: SessionId,
+        server_id: uuid::Uuid,
+    ) -> Result<Option<McpOAuthSessionCredentialsRow>> {
+        let access_name = everruns_core::mcp_oauth_session_secret_name(server_id, "access_token");
+        let refresh_name = everruns_core::mcp_oauth_session_secret_name(server_id, "refresh_token");
+        let expires_name = everruns_core::mcp_oauth_session_secret_name(server_id, "expires_at");
+        let storage = self.session_secrets.read();
+        let access_token_encrypted = storage
+            .get(&(session_id, access_name))
+            .map(|row| row.value_encrypted.clone());
+
+        Ok(
+            access_token_encrypted.map(|access_token_encrypted| McpOAuthSessionCredentialsRow {
+                access_token_encrypted,
+                refresh_token_encrypted: storage
+                    .get(&(session_id, refresh_name))
+                    .map(|row| row.value_encrypted.clone()),
+                expires_at_encrypted: storage
+                    .get(&(session_id, expires_name))
+                    .map(|row| row.value_encrypted.clone()),
+            }),
+        )
+    }
+
+    pub async fn upsert_mcp_oauth_session_credentials(
+        &self,
+        input: UpsertMcpOAuthSessionCredentials,
+    ) -> Result<()> {
+        let now = Self::now();
+        let mut storage = self.session_secrets.write();
+        let names_and_values = [
+            (
+                everruns_core::mcp_oauth_session_secret_name(input.server_id, "access_token"),
+                Some(input.access_token_encrypted),
+            ),
+            (
+                everruns_core::mcp_oauth_session_secret_name(input.server_id, "refresh_token"),
+                input.refresh_token_encrypted,
+            ),
+            (
+                everruns_core::mcp_oauth_session_secret_name(input.server_id, "expires_at"),
+                input.expires_at_encrypted,
+            ),
+        ];
+
+        for (name, value_encrypted) in names_and_values {
+            let key = (input.session_id, name.clone());
+            if let Some(value_encrypted) = value_encrypted {
+                if let Some(existing) = storage.get_mut(&key) {
+                    existing.value_encrypted = value_encrypted;
+                    existing.updated_at = now;
+                } else {
+                    storage.insert(
+                        key,
+                        SessionSecretRow {
+                            id: uuid::Uuid::now_v7(),
+                            session_id: input.session_id,
+                            name,
+                            value_encrypted,
+                            created_at: now,
+                            updated_at: now,
+                        },
+                    );
+                }
+            } else {
+                storage.remove(&key);
+            }
+        }
+        Ok(())
+    }
 }
 
 // ============================================================================

--- a/crates/server/src/storage/memory/user_connections.rs
+++ b/crates/server/src/storage/memory/user_connections.rs
@@ -67,6 +67,27 @@ impl InMemoryDatabase {
         Ok(connections)
     }
 
+    pub async fn update_user_connection_oauth_tokens(
+        &self,
+        input: UpdateUserConnectionOAuthTokens,
+    ) -> Result<Option<UserConnectionRow>> {
+        let mut connections = self.user_connections.write();
+        let Some(connection) = connections.get_mut(&input.connection_id) else {
+            return Ok(None);
+        };
+        if connection.connection_type != "oauth" {
+            return Ok(None);
+        }
+        connection.access_token_encrypted = Some(input.access_token_encrypted);
+        connection.refresh_token_encrypted = Some(input.refresh_token_encrypted);
+        connection.expires_at = input.expires_at;
+        if input.scopes.is_some() {
+            connection.scopes = input.scopes;
+        }
+        connection.updated_at = Self::now();
+        Ok(Some(connection.clone()))
+    }
+
     /// Get encrypted connection token for a session.
     ///
     /// If the session has an `agent_identity_id`, checks `agent_identity_connections`

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2109,6 +2109,34 @@ pub struct CreateUserConnectionRow {
     pub provider_metadata: Option<serde_json::Value>,
 }
 
+/// Encrypted MCP OAuth credential bundle stored in session secrets.
+#[derive(Debug, Clone)]
+pub struct McpOAuthSessionCredentialsRow {
+    pub access_token_encrypted: Vec<u8>,
+    pub refresh_token_encrypted: Option<Vec<u8>>,
+    pub expires_at_encrypted: Option<Vec<u8>>,
+}
+
+/// Atomic replacement for a session-scoped MCP OAuth grant.
+#[derive(Debug, Clone)]
+pub struct UpsertMcpOAuthSessionCredentials {
+    pub session_id: SessionId,
+    pub server_id: Uuid,
+    pub access_token_encrypted: Vec<u8>,
+    pub refresh_token_encrypted: Option<Vec<u8>>,
+    pub expires_at_encrypted: Option<Vec<u8>>,
+}
+
+/// Atomic rotation of a persistent user OAuth connection.
+#[derive(Debug, Clone)]
+pub struct UpdateUserConnectionOAuthTokens {
+    pub connection_id: Uuid,
+    pub access_token_encrypted: Vec<u8>,
+    pub refresh_token_encrypted: Vec<u8>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub scopes: Option<String>,
+}
+
 // ============================================
 // Agent Identity Connection models
 // ============================================

--- a/crates/server/src/storage/repositories/session_storage.rs
+++ b/crates/server/src/storage/repositories/session_storage.rs
@@ -5,6 +5,13 @@ use super::Database;
 use anyhow::Result;
 use uuid::Uuid;
 
+#[derive(sqlx::FromRow)]
+struct McpOAuthSessionCredentialColumns {
+    access_token_encrypted: Option<Vec<u8>>,
+    refresh_token_encrypted: Option<Vec<u8>>,
+    expires_at_encrypted: Option<Vec<u8>>,
+}
+
 impl Database {
     // ============================================
     // Session Key/Value Storage
@@ -133,6 +140,87 @@ impl Database {
         .await?;
 
         Ok(row)
+    }
+
+    /// Read a session-scoped MCP OAuth grant as one database snapshot.
+    pub async fn get_mcp_oauth_session_credentials(
+        &self,
+        session_id: everruns_core::SessionId,
+        server_id: uuid::Uuid,
+    ) -> Result<Option<McpOAuthSessionCredentialsRow>> {
+        let access_name = everruns_core::mcp_oauth_session_secret_name(server_id, "access_token");
+        let refresh_name = everruns_core::mcp_oauth_session_secret_name(server_id, "refresh_token");
+        let expires_name = everruns_core::mcp_oauth_session_secret_name(server_id, "expires_at");
+        let row = sqlx::query_as::<_, McpOAuthSessionCredentialColumns>(
+            r#"
+            SELECT
+                (SELECT value_encrypted FROM session_secrets WHERE session_id = $1 AND name = $2)
+                    AS access_token_encrypted,
+                (SELECT value_encrypted FROM session_secrets WHERE session_id = $1 AND name = $3)
+                    AS refresh_token_encrypted,
+                (SELECT value_encrypted FROM session_secrets WHERE session_id = $1 AND name = $4)
+                    AS expires_at_encrypted
+            "#,
+        )
+        .bind(session_id)
+        .bind(access_name)
+        .bind(refresh_name)
+        .bind(expires_name)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row
+            .access_token_encrypted
+            .map(|access_token_encrypted| McpOAuthSessionCredentialsRow {
+                access_token_encrypted,
+                refresh_token_encrypted: row.refresh_token_encrypted,
+                expires_at_encrypted: row.expires_at_encrypted,
+            }))
+    }
+
+    /// Atomically replace all fields of a session-scoped MCP OAuth grant.
+    pub async fn upsert_mcp_oauth_session_credentials(
+        &self,
+        input: UpsertMcpOAuthSessionCredentials,
+    ) -> Result<()> {
+        let access_name =
+            everruns_core::mcp_oauth_session_secret_name(input.server_id, "access_token");
+        let refresh_name =
+            everruns_core::mcp_oauth_session_secret_name(input.server_id, "refresh_token");
+        let expires_name =
+            everruns_core::mcp_oauth_session_secret_name(input.server_id, "expires_at");
+        let mut tx = self.pool.begin().await?;
+
+        for (name, value) in [
+            (access_name, Some(input.access_token_encrypted)),
+            (refresh_name, input.refresh_token_encrypted),
+            (expires_name, input.expires_at_encrypted),
+        ] {
+            if let Some(value_encrypted) = value {
+                sqlx::query(
+                    r#"
+                    INSERT INTO session_secrets (session_id, name, value_encrypted)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (session_id, name) DO UPDATE
+                    SET value_encrypted = EXCLUDED.value_encrypted, updated_at = NOW()
+                    "#,
+                )
+                .bind(input.session_id)
+                .bind(&name)
+                .bind(value_encrypted)
+                .execute(&mut *tx)
+                .await?;
+            } else {
+                sqlx::query("DELETE FROM session_secrets WHERE session_id = $1 AND name = $2")
+                    .bind(input.session_id)
+                    .bind(&name)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+
+        tx.commit().await?;
+        Ok(())
     }
 
     /// List all secret names for a session (without encrypted values)

--- a/crates/server/src/storage/repositories/user_connections.rs
+++ b/crates/server/src/storage/repositories/user_connections.rs
@@ -88,6 +88,36 @@ impl Database {
         Ok(rows)
     }
 
+    /// Atomically persist a refreshed OAuth grant, including rotated refresh token.
+    pub async fn update_user_connection_oauth_tokens(
+        &self,
+        input: UpdateUserConnectionOAuthTokens,
+    ) -> Result<Option<UserConnectionRow>> {
+        let row = sqlx::query_as::<_, UserConnectionRow>(
+            r#"
+            UPDATE user_connections
+            SET access_token_encrypted = $2,
+                refresh_token_encrypted = $3,
+                expires_at = $4,
+                scopes = COALESCE($5, scopes),
+                updated_at = NOW()
+            WHERE id = $1 AND connection_type = 'oauth'
+            RETURNING id, user_id, provider, connection_type, provider_user_id,
+                      provider_username, access_token_encrypted, refresh_token_encrypted,
+                      scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
+            "#,
+        )
+        .bind(input.connection_id)
+        .bind(input.access_token_encrypted)
+        .bind(input.refresh_token_encrypted)
+        .bind(input.expires_at)
+        .bind(input.scopes)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     /// Get the encrypted connection token for a session.
     ///
     /// Resolution order:

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -119,13 +119,15 @@ Because the provider id is always assigned server-side from a host-created row,
 plugin content can never bind to another provider (e.g. `github`) and read
 tokens connected for it (`TM-PLUGIN-004`).
 
-**Token refresh (limitation).** Short-lived OAuth access tokens (Resend's are
-~15 min) are not yet auto-refreshed: the connection resolver returns the stored
-access token without exchanging the refresh token. This is a pre-existing
-limitation of the MCP-OAuth connection path (it applies to org-managed OAuth
-MCP servers too); until refresh lands, a user reconnects when the token
-expires. Refresh-token rotation in the connection resolver is the tracked
-follow-up.
+**Token refresh.** The connection resolver refreshes short-lived OAuth access
+tokens lazily when they are expired or within 60 seconds of expiry. Refreshes
+use the anchor's registered OAuth client through the host egress boundary;
+concurrent resolution of one grant is coalesced, and rotated access/refresh
+tokens are persisted atomically for both session-scoped and user-scoped
+connections. A rejected refresh fails closed to the standard
+`connection_required` reconnect flow. This applies equally to plugin anchors
+such as Resend (whose access tokens last about 15 minutes) and org-managed
+OAuth MCP servers.
 
 ## Marketplaces
 

--- a/specs/runtime-mcp.md
+++ b/specs/runtime-mcp.md
@@ -127,9 +127,11 @@ trait McpAuthProvider {
 }
 ```
 
-- The **server** keeps its current behavior by implementing the trait over the
-  existing session-secret + `UserConnectionResolver` web-OAuth resolution
-  (today's `McpToolExecutor::resolve_auth_header`). No behavior change.
+- The **server** implements the trait over the existing session-secret +
+  `UserConnectionResolver` web-OAuth resolution. Its resolver owns token
+  lifetime: it lazily refreshes near-expiry grants, coalesces concurrent
+  refreshes, and atomically persists refresh-token rotation before returning
+  the new access token.
 - The **runtime/coding-CLI** provides simpler implementations: a static
   bearer/header provider, an env-var provider, and (future) a device-code
   flow. The CLI does not require a browser redirect.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -477,6 +477,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids through `spawn_agent(target.type="agent")`, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/task metadata, records only non-secret target/provider/scope labels in `session_tasks`, and keeps invite-mode joins in the current session behind duplicate capability/mount conflict checks. Child-session follow-up control routes through `message_task` for the parent-owned task. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
 | TM-TOOL-022 | Cross-tenant MCP credential reach via guardrail `mcp` check | High | The guardrails `mcp` check (specs/guardrails.md) names a `server`/`tool` to call over the scoped-MCP client. The check resolves connections through the host's per-session `McpConnectionResolver`, which only resolves servers scoped to the current session/org; a tenant's guardrail config can only reach that tenant's servers and never another tenant's MCP credentials. A misconfigured/unknown server fails open (allow) rather than blocking. The verdict parser reads only `verdict`/`reason`, so a poisoned endpoint response cannot widen behavior beyond the fail-open baseline. | MITIGATED |
 | TM-TOOL-024 | WebFetch rendered-page JavaScript escapes egress controls or exhausts worker resources | High | Rendered fetch is explicitly request-opt-in (`render: "rakers"`) on an already admin-gated high-risk capability. FetchKit fetches the initial document through the normal DNS/egress/redirect/body-size policy, runs inline scripts with a per-script timeout, sends renderer subresource traffic to a local deny proxy, and caps rendered output before conversion. Everruns integration tests prove the backend is opt-in and returns rendered content; FetchKit upstream tests cover subresource denial, timeout, and output capping. | MITIGATED |
+| TM-TOOL-025 | MCP OAuth refresh-token theft, torn rotation, or refresh stampede | High | Refresh tokens stay envelope-encrypted and are never logged; token endpoints are revalidated and DNS-pinned through `EgressService` for every refresh (TM-TOOL-018); a bounded per-grant single-flight coalesces concurrent refreshes; access token, rotated refresh token, expiry, and scope are persisted atomically before the new access token is returned. Rejected or incomplete grants fail closed to `connection_required`. | MITIGATED |
 
 ### Mitigation Details
 
@@ -586,6 +587,10 @@ Validation runs for:
 MCP server URLs are validated twice:
 1. On create/update in the control plane — static check via `validate_safe_url` rejects unsafe schemes, loopback, RFC1918, link-local, and cloud metadata targets.
 2. At execution time (before each tool call and `tools/list` fetch) via `validate_url_dns_pinned` — performs the same static checks then resolves the hostname via `tokio::net::lookup_host` and verifies every returned IP against the blocked ranges. This closes the DNS-rebinding gap: an attacker cannot register a public hostname that initially resolves to a safe IP but later rebinds to an internal address, because the IP is re-checked on every outbound request.
+
+The same execution-time validation and DNS pinning applies to MCP OAuth token
+endpoint requests, including lazy refreshes; cached OAuth discovery metadata is
+never treated as permission to bypass the egress boundary.
 
 ## 8. LLM Integration (TM-LLM)
 


### PR DESCRIPTION
## What changed
MCP OAuth connections now refresh lazily when the access token is expired or within 60 seconds of expiry. Session-scoped and persistent user grants both persist refresh-token rotation atomically, and concurrent reads of one grant share a single exchange. Refresh failures fail closed to the existing reconnect path.

## Why
Short-lived MCP OAuth access tokens, including Resend tokens that expire after about 15 minutes, previously became stale until the user manually reconnected.

## Before / After
Before: the resolver returned the encrypted stored access token without consulting its expiry, so Resend tools stopped working after roughly 15 minutes.

After: `resend_connection_after_sixteen_minutes_refreshes_without_reconnect` simulates a Resend grant 16 minutes after connection and proves the resolver returns a fresh token while persisting the rotated refresh token. Focused evidence: 4 resolver refresh tests and 20 OAuth callback/egress tests pass; `just pre-push` passes.

## Risk
- Medium
- OAuth client metadata lookup, encrypted token rotation, and resolver wiring are affected. Failures deliberately return no token instead of exposing a stale credential.

## Security
- Threat categories reviewed: TM-TOOL-018, TM-TOOL-025, TM-TENANT, TM-CRYPTO, TM-OBS
- Findings and resolutions: token endpoints are validated and DNS-pinned on every exchange; refresh tokens remain envelope-encrypted and are never logged; complete grants rotate atomically; server metadata is scoped through the active session organization; single-flight locks use a bounded idle cache.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
