### PR TITLE
feat(events): correlate streaming message lifecycle

### DIFF
--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -11570,6 +11570,12 @@ export interface components {
       accumulated: string;
       /** @description The new text chunk */
       delta: string;
+      /**
+       * @description Stable public ID for this assistant message across its streaming lifecycle.
+       *     This is the same identifier as `OutputMessageCompletedData.message.id`.
+       * @example message_550e8400e29b41d4a716446655440000
+       */
+      message_id: string;
       phase?: null | components["schemas"]["ExecutionPhase"];
       /**
        * @description Turn ID this delta belongs to
@@ -11593,6 +11599,12 @@ export interface components {
       guardrail_capability_id: string;
       /** @description Stable ID of the guardrail itself (e.g. `"prompt_canary"`). */
       guardrail_id: string;
+      /**
+       * @description Stable public ID for the assistant message whose streamed text is replaced.
+       *     This is the same identifier as the subsequent completed `Message.id`.
+       * @example message_550e8400e29b41d4a716446655440000
+       */
+      message_id: string;
       /**
        * @description Stable machine-readable reason code (e.g. `"system_prompt_leak"`).
        *     Clients localize their copy from this rather than the human text.
@@ -11619,6 +11631,12 @@ export interface components {
        *     Useful for UI to show progress during multi-step tool-calling flows.
        */
       iteration?: number | null;
+      /**
+       * @description Stable public ID for this assistant message across its streaming lifecycle.
+       *     This is the same identifier as `OutputMessageCompletedData.message.id`.
+       * @example message_550e8400e29b41d4a716446655440000
+       */
+      message_id: string;
       /** @description Optional model name being used */
       model?: string | null;
       phase?: null | components["schemas"]["ExecutionPhase"];

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -57,7 +57,8 @@ use crate::runtime_context::{AssembledTurnContext, assemble_turn_context};
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::traits::{
     AgentStore, DurableToolCallStatus, DurableToolResultStore, EventEmitter, HarnessStore,
-    ImageResolver, PartialStreamStore, ProviderStore, ResolvedImage, ResolvedModel, SessionStore,
+    ImageResolver, PartialStreamState, PartialStreamStore, ProviderStore, ResolvedImage,
+    ResolvedModel, SessionStore,
 };
 use crate::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use crate::{ErrorDisclosure, UserFacingError, UserFacingErrorContext, user_facing_error_codes};
@@ -1517,7 +1518,7 @@ impl ReasonAtom {
                         .finalize_partial_stream(
                             session_id,
                             context,
-                            partial.accumulated,
+                            partial,
                             iteration,
                             runtime_agent.max_iterations,
                             &runtime_agent.tools,
@@ -1748,6 +1749,10 @@ impl ReasonAtom {
         // seam allows the finalized output so blocked tokens are never emitted
         // or persisted as output.message.delta events.
         let buffer_output_deltas = !post_output_providers.is_empty();
+        // Allocate the public message id before the first lifecycle event so
+        // started/delta/replaced/completed can be grouped without turn-level
+        // heuristics. Each reasoning iteration reaches this point separately.
+        let output_message_id = MessageId::new();
         tracing::info!(
             session_id = %session_id,
             turn_id = %context.turn_id,
@@ -1760,6 +1765,7 @@ impl ReasonAtom {
                 streaming_event_context.clone(),
                 OutputMessageStartedData {
                     turn_id: context.turn_id,
+                    message_id: output_message_id,
                     model: Some(runtime_agent.model.clone()),
                     iteration: Some(iteration),
                     // Emitted before the LLM call — phase is not yet known, so the
@@ -2469,6 +2475,7 @@ impl ReasonAtom {
                                     streaming_event_context.clone(),
                                     OutputMessageDeltaData {
                                         turn_id: context.turn_id,
+                                        message_id: output_message_id,
                                         delta: pending_delta.clone(),
                                         accumulated: text.clone(),
                                         phase: streamed_phase,
@@ -2630,6 +2637,7 @@ impl ReasonAtom {
                                     streaming_event_context.clone(),
                                     OutputMessageDeltaData {
                                         turn_id: context.turn_id,
+                                        message_id: output_message_id,
                                         delta: pending_delta.clone(),
                                         accumulated: text.clone(),
                                         phase: streamed_phase,
@@ -2823,6 +2831,7 @@ impl ReasonAtom {
                     streaming_event_context.clone(),
                     OutputMessageDeltaData {
                         turn_id: context.turn_id,
+                        message_id: output_message_id,
                         delta: pending_delta.clone(),
                         accumulated: text.clone(),
                         phase: streamed_phase,
@@ -2855,6 +2864,7 @@ impl ReasonAtom {
                     replaced_event_context,
                     OutputMessageReplacedData {
                         turn_id: context.turn_id,
+                        message_id: output_message_id,
                         guardrail_capability_id: t.capability_id.clone(),
                         guardrail_id: t.guardrail_id.clone(),
                         reason_code: t.block.reason_code.clone(),
@@ -3038,7 +3048,8 @@ impl ReasonAtom {
             Message::assistant_with_tools(&text, tool_calls.clone())
         } else {
             Message::assistant(&text)
-        };
+        }
+        .with_id(output_message_id);
         // Use the API-provided phase when available (preserving the provider's value),
         // otherwise derive from state: Commentary for intermediate iterations (with tool
         // calls), FinalAnswer for the completed response.
@@ -3058,8 +3069,6 @@ impl ReasonAtom {
             assistant_message.thinking = Some(thinking.clone());
             assistant_message.thinking_signature = thinking_signature.clone();
         }
-        let output_message_id = assistant_message.id;
-
         // Emit output.message.completed event (this stores the message as an event with proper turn context)
         // Include token usage for tracking (child of reason span)
         let message_event_context = EventContext::from_atom_context(context).with_span(
@@ -3115,13 +3124,14 @@ impl ReasonAtom {
         &self,
         session_id: SessionId,
         context: &AtomContext,
-        accumulated: String,
+        partial: PartialStreamState,
         iteration: u32,
         max_iterations: usize,
         tool_definitions: &[ToolDefinition],
     ) -> Result<ReasonResult> {
         let event_context = EventContext::from_atom_context(context);
         let turn_id = context.turn_id;
+        let message_id = partial.message_id;
 
         // Signal that output is starting (keeps the streaming protocol intact).
         let _ = self
@@ -3131,6 +3141,7 @@ impl ReasonAtom {
                 event_context.clone(),
                 OutputMessageStartedData {
                     turn_id,
+                    message_id,
                     model: None,
                     iteration: Some(iteration),
                     // Recovery/finalize path reconstructs the started signal only;
@@ -3142,9 +3153,10 @@ impl ReasonAtom {
 
         // Build the assistant message from accumulated text and persist via event.
         // Strip any echoed `[time …]` annotation the model produced (EVE-710).
-        let accumulated = crate::capabilities::strip_leading_timestamp_annotations(&accumulated);
-        let assistant_message = Message::assistant(&accumulated);
-        let output_message_id = assistant_message.id;
+        let accumulated =
+            crate::capabilities::strip_leading_timestamp_annotations(&partial.accumulated);
+        let assistant_message = Message::assistant(&accumulated).with_id(message_id);
+        let output_message_id = message_id;
         self.event_emitter
             .emit(EventRequest::new(
                 session_id,
@@ -3986,7 +3998,7 @@ mod tests {
 
     use crate::traits::{NoopPartialStreamStore, PartialStreamState, PartialStreamStore};
 
-    struct MockPartialStore(Option<String>);
+    struct MockPartialStore(Option<PartialStreamState>);
 
     #[async_trait::async_trait]
     impl PartialStreamStore for MockPartialStore {
@@ -3995,9 +4007,7 @@ mod tests {
             _session_id: crate::typed_id::SessionId,
             _turn_id: &str,
         ) -> crate::error::Result<Option<PartialStreamState>> {
-            Ok(self.0.as_deref().map(|s| PartialStreamState {
-                accumulated: s.to_string(),
-            }))
+            Ok(self.0.clone())
         }
     }
 
@@ -4013,17 +4023,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_stream_store_returns_accumulated_when_partial_exists() {
-        let store = MockPartialStore(Some("partial text so far".to_string()));
+        let message_id = MessageId::new();
+        let store = MockPartialStore(Some(PartialStreamState {
+            message_id,
+            accumulated: "partial text so far".to_string(),
+        }));
         let result = store
             .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
             .await
             .unwrap();
-        assert_eq!(result.unwrap().accumulated, "partial text so far");
+        let partial = result.unwrap();
+        assert_eq!(partial.message_id, message_id);
+        assert_eq!(partial.accumulated, "partial text so far");
     }
 
     #[tokio::test]
     async fn test_partial_stream_store_returns_empty_when_started_no_delta() {
-        let store = MockPartialStore(Some(String::new()));
+        let store = MockPartialStore(Some(PartialStreamState {
+            message_id: MessageId::new(),
+            accumulated: String::new(),
+        }));
         let result = store
             .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
             .await

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -763,6 +763,11 @@ pub struct OutputMessageStartedData {
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
     pub turn_id: TurnId,
 
+    /// Stable public ID for this assistant message across its streaming lifecycle.
+    /// This is the same identifier as `OutputMessageCompletedData.message.id`.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_550e8400e29b41d4a716446655440000"))]
+    pub message_id: MessageId,
+
     /// Optional model name being used
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -795,6 +800,11 @@ pub struct OutputMessageDeltaData {
     /// Turn ID this delta belongs to
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
     pub turn_id: TurnId,
+
+    /// Stable public ID for this assistant message across its streaming lifecycle.
+    /// This is the same identifier as `OutputMessageCompletedData.message.id`.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_550e8400e29b41d4a716446655440000"))]
+    pub message_id: MessageId,
 
     /// The new text chunk
     pub delta: String,
@@ -892,6 +902,11 @@ pub struct OutputMessageReplacedData {
     /// Turn ID this replacement belongs to.
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "turn_01933b5a00007000800000000000001"))]
     pub turn_id: TurnId,
+
+    /// Stable public ID for the assistant message whose streamed text is replaced.
+    /// This is the same identifier as the subsequent completed `Message.id`.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "message_550e8400e29b41d4a716446655440000"))]
+    pub message_id: MessageId,
 
     /// Stable ID of the capability that contributed the guardrail
     /// (e.g. `"prompt_canary_guardrail"`).
@@ -3287,6 +3302,7 @@ mod tests {
             EventContext::empty(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id: MessageId::new(),
                 delta: "hel".to_string(),
                 accumulated: "hel".to_string(),
                 phase: None,
@@ -3378,6 +3394,7 @@ mod tests {
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = OutputMessageStartedData {
             turn_id,
+            message_id: MessageId::new(),
             model: Some("claude-4-opus".to_string()),
             iteration: None,
             phase: None,
@@ -3397,6 +3414,7 @@ mod tests {
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = OutputMessageStartedData {
             turn_id,
+            message_id: MessageId::new(),
             model: None,
             iteration: None,
             phase: None,
@@ -3465,6 +3483,7 @@ mod tests {
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = OutputMessageDeltaData {
             turn_id,
+            message_id: MessageId::new(),
             delta: "Hello".to_string(),
             accumulated: "Hello".to_string(),
             phase: None,
@@ -3481,6 +3500,60 @@ mod tests {
     }
 
     #[test]
+    fn test_output_message_lifecycle_shares_message_id() {
+        let turn_id = TurnId::new();
+        let message_id = MessageId::new();
+        let next_message_id = MessageId::new();
+
+        let started = OutputMessageStartedData {
+            turn_id,
+            message_id,
+            model: None,
+            iteration: Some(1),
+            phase: None,
+        };
+        let next_started = OutputMessageStartedData {
+            turn_id,
+            message_id: next_message_id,
+            model: None,
+            iteration: Some(2),
+            phase: None,
+        };
+        let delta = OutputMessageDeltaData {
+            turn_id,
+            message_id,
+            delta: "Hello".to_string(),
+            accumulated: "Hello".to_string(),
+            phase: None,
+        };
+        let replaced = OutputMessageReplacedData {
+            turn_id,
+            message_id,
+            guardrail_capability_id: "guardrails".to_string(),
+            guardrail_id: "example".to_string(),
+            reason_code: "blocked".to_string(),
+            replacement: "Safe response".to_string(),
+        };
+        let completed = OutputMessageCompletedData::new(
+            Message::assistant("Safe response").with_id(message_id),
+        );
+
+        assert_eq!(started.message_id, message_id);
+        assert_eq!(delta.message_id, message_id);
+        assert_eq!(replaced.message_id, message_id);
+        assert_eq!(completed.message.id, message_id);
+        assert_ne!(started.message_id, next_started.message_id);
+
+        for value in [
+            serde_json::to_value(started).unwrap(),
+            serde_json::to_value(delta).unwrap(),
+            serde_json::to_value(replaced).unwrap(),
+        ] {
+            assert_eq!(value["message_id"], message_id.to_string());
+        }
+    }
+
+    #[test]
     fn test_output_message_phase_hint_serde() {
         // EVE-774: the streamed phase hint is skipped when None (so existing
         // consumers see no new field) and serialized as the provider wire value
@@ -3489,6 +3562,7 @@ mod tests {
 
         let started_none = OutputMessageStartedData {
             turn_id,
+            message_id: MessageId::new(),
             model: None,
             iteration: None,
             phase: None,
@@ -3501,6 +3575,7 @@ mod tests {
 
         let delta_commentary = OutputMessageDeltaData {
             turn_id,
+            message_id: MessageId::new(),
             delta: "one moment".to_string(),
             accumulated: "one moment".to_string(),
             phase: Some(crate::message::ExecutionPhase::Commentary),
@@ -3514,6 +3589,7 @@ mod tests {
 
         let delta_final = OutputMessageDeltaData {
             turn_id,
+            message_id: MessageId::new(),
             delta: "done".to_string(),
             accumulated: "done".to_string(),
             phase: Some(crate::message::ExecutionPhase::FinalAnswer),
@@ -3531,6 +3607,7 @@ mod tests {
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = OutputMessageDeltaData {
             turn_id,
+            message_id: MessageId::new(),
             delta: "Hello world".to_string(),
             accumulated: "Hello world".to_string(),
             phase: None,
@@ -3558,6 +3635,7 @@ mod tests {
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = OutputMessageStartedData {
             turn_id,
+            message_id: MessageId::new(),
             model: Some("claude-3".to_string()),
             iteration: None,
             phase: None,
@@ -3960,6 +4038,7 @@ mod contract_tests {
     fn snapshot_output_message_started() {
         let data = OutputMessageStartedData {
             turn_id: test_turn_id(),
+            message_id: test_message_id(),
             model: Some("gpt-4o".to_string()),
             iteration: None,
             phase: None,
@@ -3975,6 +4054,7 @@ mod contract_tests {
     fn snapshot_output_message_delta() {
         let data = OutputMessageDeltaData {
             turn_id: test_turn_id(),
+            message_id: test_message_id(),
             delta: "Hello".to_string(),
             accumulated: "Hello".to_string(),
             phase: None,
@@ -4518,6 +4598,7 @@ mod contract_tests {
                 OUTPUT_MESSAGE_STARTED,
                 OutputMessageStartedData {
                     turn_id: test_turn_id(),
+                    message_id: test_message_id(),
                     model: None,
                     iteration: None,
                     phase: None,
@@ -4528,6 +4609,7 @@ mod contract_tests {
                 OUTPUT_MESSAGE_DELTA,
                 OutputMessageDeltaData {
                     turn_id: test_turn_id(),
+                    message_id: test_message_id(),
                     delta: "x".to_string(),
                     accumulated: "x".to_string(),
                     phase: None,

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -579,6 +579,15 @@ impl InputContentPart {
 }
 
 impl Message {
+    /// Override the generated message id.
+    ///
+    /// Streaming producers use this to allocate a public id before emitting
+    /// `output.message.started`, then reuse it on the completed message.
+    pub fn with_id(mut self, id: MessageId) -> Self {
+        self.id = id;
+        self
+    }
+
     /// Create a new user message
     pub fn user(content: impl Into<String>) -> Self {
         Self {

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_output_message_delta.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_output_message_delta.snap
@@ -4,6 +4,7 @@ expression: data
 ---
 {
   "turn_id": "turn_00000000000000000000000000000002",
+  "message_id": "message_00000000000000000000000000000003",
   "delta": "Hello",
   "accumulated": "Hello"
 }

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_output_message_started.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_output_message_started.snap
@@ -4,5 +4,6 @@ expression: data
 ---
 {
   "turn_id": "turn_00000000000000000000000000000002",
+  "message_id": "message_00000000000000000000000000000003",
   "model": "gpt-4o"
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -12,7 +12,7 @@ use crate::session_file::{
     FileInfo, FileStat, GrepMatch, GrepOptions, GrepSearchResult, InitialFile, SessionFile,
 };
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::typed_id::{AgentId, HarnessId, ImageId, ModelId, SessionId, WorkspaceId};
+use crate::typed_id::{AgentId, HarnessId, ImageId, MessageId, ModelId, SessionId, WorkspaceId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::any::{Any, TypeId};
@@ -1556,6 +1556,9 @@ impl StreamHeartbeater for NoopStreamHeartbeater {
 /// State of a partially-streamed assistant message detected in the event log.
 #[derive(Debug, Clone)]
 pub struct PartialStreamState {
+    /// Stable public id from the latest `output.message.started` event.
+    pub message_id: MessageId,
+
     /// Accumulated text from the last `output.message.delta` for the turn.
     /// Empty when `output.message.started` was emitted but no delta arrived.
     pub accumulated: String,

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -1706,6 +1706,7 @@ mod tests {
             context.clone(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id: MessageId::new(),
                 delta: "Hello".to_string(),
                 accumulated: "Hello".to_string(),
                 phase: None,
@@ -1757,6 +1758,7 @@ mod tests {
             context.clone(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id: MessageId::new(),
                 delta: "Let me check that.".to_string(),
                 accumulated: "Let me check that.".to_string(),
                 phase: None,
@@ -1983,6 +1985,7 @@ mod tests {
             context.clone(),
             OutputMessageDeltaData {
                 turn_id,
+                message_id: MessageId::new(),
                 delta: "Let me look into that.".to_string(),
                 accumulated: "Let me look into that.".to_string(),
                 phase: None,

--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -1631,9 +1631,10 @@ mod tests {
     #[test]
     fn translate_unrelated_event_returns_none() {
         use everruns_core::events::OutputMessageStartedData;
-        use everruns_core::typed_id::TurnId;
+        use everruns_core::typed_id::{MessageId, TurnId};
         let data = EventData::OutputMessageStarted(OutputMessageStartedData {
             turn_id: TurnId::new(),
+            message_id: MessageId::new(),
             model: None,
             iteration: None,
             phase: None,

--- a/crates/server/src/event_delivery.rs
+++ b/crates/server/src/event_delivery.rs
@@ -297,7 +297,7 @@ impl NatsEventDelivery {
 mod tests {
     use super::*;
     use everruns_core::events::{EventData, OutputMessageDeltaData};
-    use everruns_core::typed_id::{EventId, SessionId, TurnId};
+    use everruns_core::typed_id::{EventId, MessageId, SessionId, TurnId};
 
     fn make_test_event(session_id: Uuid) -> Event {
         Event {
@@ -308,6 +308,7 @@ mod tests {
             context: Default::default(),
             data: EventData::OutputMessageDelta(OutputMessageDeltaData {
                 turn_id: TurnId::new(),
+                message_id: MessageId::new(),
                 delta: "hello".to_string(),
                 accumulated: "hello".to_string(),
                 phase: None,

--- a/crates/server/src/storage/partial_stream.rs
+++ b/crates/server/src/storage/partial_stream.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use everruns_core::error::AgentLoopError;
 use everruns_core::traits::{PartialStreamState, PartialStreamStore};
-use everruns_core::typed_id::SessionId;
+use everruns_core::typed_id::{MessageId, SessionId};
 use sqlx::PgPool;
 
 /// PostgreSQL-backed partial-stream store.
@@ -34,24 +34,37 @@ impl PartialStreamStore for PgPartialStreamStore {
         session_id: SessionId,
         turn_id: &str,
     ) -> Result<Option<PartialStreamState>, AgentLoopError> {
-        // Find the sequence of the latest output.message.started for this turn.
-        let started_seq: Option<i32> = sqlx::query_scalar(
+        // Find the latest output.message.started and carry its message id into
+        // recovery so the reconstructed lifecycle stays in one id scope.
+        let started: Option<(i32, Option<String>)> = sqlx::query_as(
             r#"
-            SELECT MAX(sequence)
+            SELECT sequence, data->>'message_id'
             FROM events
             WHERE session_id = $1
               AND context->>'turn_id' = $2
               AND event_type = 'output.message.started'
+            ORDER BY sequence DESC
+            LIMIT 1
             "#,
         )
         .bind(session_id.uuid())
         .bind(turn_id)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
         .map_err(|e| AgentLoopError::tool(format!("partial_stream started check: {e}")))?;
 
-        let Some(started_seq) = started_seq else {
+        let Some((started_seq, raw_message_id)) = started else {
             return Ok(None);
+        };
+        // A worker upgraded while an old-format stream is in flight may find a
+        // started event without message_id. Allocate an id for the recovery
+        // lifecycle in that one legacy case; all new emissions persist the id.
+        let legacy_stream = raw_message_id.is_none();
+        let message_id = match raw_message_id {
+            Some(raw) => MessageId::parse(&raw).map_err(|e| {
+                AgentLoopError::tool(format!("partial_stream invalid message_id: {e}"))
+            })?,
+            None => MessageId::new(),
         };
 
         // Check if a completion/replacement with sequence > started_seq exists.
@@ -62,14 +75,23 @@ impl PartialStreamStore for PgPartialStreamStore {
                 SELECT 1 FROM events
                 WHERE session_id = $1
                   AND context->>'turn_id' = $2
-                  AND event_type IN ('output.message.completed', 'output.message.replaced')
                   AND sequence > $3
+                  AND event_type IN ('output.message.completed', 'output.message.replaced')
+                  AND (
+                    $5
+                    OR (event_type = 'output.message.completed'
+                        AND data->'message'->>'id' = $4)
+                    OR (event_type = 'output.message.replaced'
+                        AND data->>'message_id' = $4)
+                  )
             )
             "#,
         )
         .bind(session_id.uuid())
         .bind(turn_id)
         .bind(started_seq)
+        .bind(message_id.to_string())
+        .bind(legacy_stream)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| AgentLoopError::tool(format!("partial_stream completed check: {e}")))?;
@@ -89,6 +111,7 @@ impl PartialStreamStore for PgPartialStreamStore {
               AND context->>'turn_id' = $2
               AND event_type = 'output.message.delta'
               AND sequence > $3
+              AND ($5 OR data->>'message_id' = $4)
             ORDER BY sequence DESC
             LIMIT 1
             "#,
@@ -96,12 +119,17 @@ impl PartialStreamStore for PgPartialStreamStore {
         .bind(session_id.uuid())
         .bind(turn_id)
         .bind(started_seq)
+        .bind(message_id.to_string())
+        .bind(legacy_stream)
         .fetch_optional(&self.pool)
         .await
         .map_err(|e| AgentLoopError::tool(format!("partial_stream delta fetch: {e}")))?
         .flatten()
         .unwrap_or_default();
 
-        Ok(Some(PartialStreamState { accumulated }))
+        Ok(Some(PartialStreamState {
+            message_id,
+            accumulated,
+        }))
     }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -29140,6 +29140,7 @@
         "description": "Data for output.message.delta event\n\nIncremental text update during LLM generation. Events are batched (~100ms)\nto reduce volume while providing real-time feedback.",
         "required": [
           "turn_id",
+          "message_id",
           "delta",
           "accumulated"
         ],
@@ -29151,6 +29152,11 @@
           "delta": {
             "type": "string",
             "description": "The new text chunk"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Stable public ID for this assistant message across its streaming lifecycle.\nThis is the same identifier as `OutputMessageCompletedData.message.id`.",
+            "example": "message_550e8400e29b41d4a716446655440000"
           },
           "phase": {
             "oneOf": [
@@ -29175,6 +29181,7 @@
         "description": "Data for `output.message.replaced` event.\n\nEmitted between the last (suppressed) `output.message.delta` and the final\n`output.message.completed`. Tells the client to discard everything it has\naccumulated for `turn_id` and use `replacement` as the assistant message\ntext. The original model output is never persisted or replayed.",
         "required": [
           "turn_id",
+          "message_id",
           "guardrail_capability_id",
           "guardrail_id",
           "reason_code",
@@ -29188,6 +29195,11 @@
           "guardrail_id": {
             "type": "string",
             "description": "Stable ID of the guardrail itself (e.g. `\"prompt_canary\"`)."
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Stable public ID for the assistant message whose streamed text is replaced.\nThis is the same identifier as the subsequent completed `Message.id`.",
+            "example": "message_550e8400e29b41d4a716446655440000"
           },
           "reason_code": {
             "type": "string",
@@ -29208,7 +29220,8 @@
         "type": "object",
         "description": "Data for output.message.started event\n\nEmitted when the LLM starts generating a response. UI can show a\n\"thinking\" indicator until output.message.delta or output.message.completed events arrive.",
         "required": [
-          "turn_id"
+          "turn_id",
+          "message_id"
         ],
         "properties": {
           "iteration": {
@@ -29219,6 +29232,11 @@
             "format": "int32",
             "description": "Current iteration number within this turn (1-based).\nUseful for UI to show progress during multi-step tool-calling flows.",
             "minimum": 0
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Stable public ID for this assistant message across its streaming lifecycle.\nThis is the same identifier as `OutputMessageCompletedData.message.id`.",
+            "example": "message_550e8400e29b41d4a716446655440000"
           },
           "model": {
             "type": [

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -1765,7 +1765,7 @@ mod tests {
     };
     use everruns_core::message::Message;
     use everruns_core::tool_types::ToolCall;
-    use everruns_core::{SessionId, TurnId};
+    use everruns_core::{MessageId, SessionId, TurnId};
 
     use everruns_core::command::{CommandArg, CommandDescriptor, CommandSource};
 
@@ -2069,6 +2069,7 @@ mod tests {
             EventContext::empty(),
             OutputMessageStartedData {
                 turn_id: TurnId::new(),
+                message_id: MessageId::new(),
                 model: None,
                 iteration: Some(3),
                 phase: None,

--- a/specs/events.md
+++ b/specs/events.md
@@ -283,6 +283,7 @@ Emitted when the LLM starts generating a response. UI can show a "thinking" indi
   },
   "data": {
     "turn_id": "...",
+    "message_id": "message_550e8400e29b41d4a716446655440000",
     "model": "gpt-4o",
     "iteration": 1
   }
@@ -290,6 +291,8 @@ Emitted when the LLM starts generating a response. UI can show a "thinking" indi
 ```
 
 **`iteration`** (optional, u32): 1-based iteration number within the current turn. Lets the UI show which iteration the agent is on during multi-step tool-calling flows. Only displayed when > 1.
+
+**`message_id`** (required, MessageId): stable random-public identifier allocated before generation begins. It scopes one assistant message within the turn and is reused by every `output.message.delta` / `output.message.replaced` event and by the completed `message.id`. This is the same public identifier, not a separate streaming id space.
 
 **`phase`** (optional, string — `"commentary"` | `"final_answer"`): best-effort streamed phase hint (EVE-774). This event is emitted *before* the LLM call, so `phase` is generally absent here. When absent it means **"not yet classified — treat as ordinary assistant text"**, NEVER "thinking". See the shared hint semantics under `output.message.delta`.
 
@@ -309,6 +312,7 @@ Streaming text update during LLM generation. Events are batched (~100ms) to redu
   },
   "data": {
     "turn_id": "...",
+    "message_id": "message_550e8400e29b41d4a716446655440000",
     "delta": "Hello, ",
     "accumulated": "Hello, ",
     "phase": "commentary"
@@ -317,6 +321,8 @@ Streaming text update during LLM generation. Events are batched (~100ms) to redu
 ```
 
 **`phase`** (optional, string — `"commentary"` | `"final_answer"`): best-effort streamed phase hint (EVE-774) letting consumers classify streamed assistant text as commentary vs final answer *before* `output.message.completed` arrives.
+
+Consumers group streamed assistant text by **`message_id`**, not `turn_id`: a multi-step turn may contain multiple assistant messages, each with a distinct id. All deltas for one generated message carry the id from its corresponding `output.message.started`.
 
 - **Absent = "not yet classified — treat as ordinary assistant text", NEVER "thinking".** A missing/unknown phase must fall back to the assistant-text channel, never the reasoning/thinking channel (the EVE-448 class of bug).
 - **Monotonic refinement only.** Within a single message the hint advances `absent → "commentary" | "final_answer"` at most once and then never changes: it never flip-flops between the two values and never reverts to absent (`ExecutionPhase::refine_streamed_hint` enforces this).
@@ -339,6 +345,7 @@ Streaming output was withheld by an output guardrail (see `specs/capabilities.md
   },
   "data": {
     "turn_id": "...",
+    "message_id": "message_550e8400e29b41d4a716446655440000",
     "guardrail_capability_id": "prompt_canary_guardrail",
     "guardrail_id": "prompt_canary",
     "reason_code": "system_prompt_leak",
@@ -350,6 +357,7 @@ Streaming output was withheld by an output guardrail (see `specs/capabilities.md
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `turn_id` | TurnId (string, prefixed UUIDv7 — e.g. `"turn_01933b5a..."`) | yes | Turn the replaced output belongs to |
+| `message_id` | MessageId (string, random-public prefixed UUIDv4) | yes | Assistant message being replaced; matches the started/delta and subsequent completed `message.id` |
 | `guardrail_capability_id` | string | yes | Capability that contributed the guardrail (e.g. `"prompt_canary_guardrail"`) |
 | `guardrail_id` | string | yes | Stable id of the guardrail itself (e.g. `"prompt_canary"`) |
 | `reason_code` | string | yes | Stable machine-readable reason (e.g. `"system_prompt_leak"`). Clients localize their copy from this rather than `replacement` |
@@ -411,6 +419,8 @@ Agent response message. Emitted when LLM generation completes.
   }
 }
 ```
+
+The completed **`message.id`** is the same `message_id` allocated by `output.message.started`. Replay reconstructs assistant-message boundaries by grouping started/delta/replaced/completed lifecycle events by this id. Partial-stream recovery preserves the persisted id when finalizing an interrupted message; a legacy in-flight start that predates this field begins a new recovery lifecycle with a freshly allocated random-public id.
 
 **`message.phase`** (optional, string): Execution phase — `"in_progress"` for intermediate messages with tool calls (agent is still working), `"completed"` for the final answer. Set by `ReasonAtom` based on whether tool calls are present. Sent as input to the OpenAI Responses API on assistant messages; other providers store it internally for consistent UI behavior. See `crates/core/src/atoms/reason.rs`.
 


### PR DESCRIPTION
## What changed
Streaming assistant lifecycle events now expose one stable public message ID from start through deltas, guardrail replacement, completion, replay, and partial-stream recovery. Consumers can group multiple assistant messages within one turn without relying on turn-level heuristics.

The OpenAPI contract, UI-generated types, event specification, and snapshots are updated with the required field.

## Why
EVE-772: started and delta events previously exposed only a turn ID, so consumers could not distinguish multiple assistant messages in one turn or reconstruct message boundaries during replay.

## Before / After
Before: output.message.started and output.message.delta had no message identity; the ID first appeared on output.message.completed.

After: a live llmsim SSE smoke produced started, delta, and completed events with the same message ID. Focused lifecycle and recovery-state tests also verify ID reuse and distinct IDs for successive messages.

## Risk
- Medium
- Adding a required event field changes the public streaming contract. All in-repo producers, generated clients, snapshots, replay grouping, and legacy in-flight recovery are covered.

## Security
- Threat categories reviewed: event-data disclosure, identifier exposure, tenant/replay isolation
- Findings and resolutions: no new secret, auth, or user-input surface. MessageId remains the specified random-public UUIDv4 identifier. Recovery queries remain session/turn scoped and now additionally message scoped, with a narrow legacy fallback for old in-flight starts.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Linear: https://linear.app/everruns/issue/EVE-772/featcore-message-id-on-output-message-streaming-lifecycle

