### PR TITLE
fix(streaming): project output by message id

### DIFF
--- a/apps/ui/src/__tests__/streaming-message-state.test.ts
+++ b/apps/ui/src/__tests__/streaming-message-state.test.ts
@@ -1,0 +1,79 @@
+import type { Event } from "@/lib/api/types";
+import { latestStreamingMessage } from "@/lib/streaming-message-state";
+
+function event(type: string, data: Record<string, unknown>): Event {
+  return {
+    id: `${type}-${String(data.message_id ?? "turn")}`,
+    type,
+    ts: "2026-07-18T00:00:00Z",
+    session_id: "session-1",
+    context: { turn_id: "turn-1" },
+    data,
+  };
+}
+
+describe("latestStreamingMessage", () => {
+  it("groups accumulated text by message_id within one turn", () => {
+    const events = [
+      event("output.message.started", {
+        turn_id: "turn-1",
+        message_id: "commentary",
+        iteration: 1,
+      }),
+      event("output.message.delta", {
+        turn_id: "turn-1",
+        message_id: "commentary",
+        delta: "Checking",
+        accumulated: "Checking",
+      }),
+      event("output.message.completed", {
+        message: { id: "commentary", role: "agent", content: [] },
+      }),
+      event("output.message.started", {
+        turn_id: "turn-1",
+        message_id: "final",
+        iteration: 2,
+      }),
+      event("output.message.delta", {
+        turn_id: "turn-1",
+        message_id: "final",
+        delta: "Done",
+        accumulated: "Done",
+      }),
+    ];
+
+    expect(latestStreamingMessage(events)).toEqual({
+      messageId: "final",
+      turnId: "turn-1",
+      text: "Done",
+      isThinking: false,
+      iteration: 2,
+    });
+  });
+
+  it("applies guardrail replacement only to its message lifecycle", () => {
+    const events = [
+      event("output.message.started", {
+        turn_id: "turn-1",
+        message_id: "message-1",
+      }),
+      event("output.message.delta", {
+        turn_id: "turn-1",
+        message_id: "message-1",
+        delta: "unsafe",
+        accumulated: "unsafe",
+      }),
+      event("output.message.replaced", {
+        turn_id: "turn-1",
+        message_id: "message-1",
+        guardrail_capability_id: "guardrail",
+        guardrail_id: "prompt-canary",
+        reason_code: "blocked",
+        replacement: "Safe replacement",
+      }),
+    ];
+
+    expect(latestStreamingMessage(events).text).toBe("Safe replacement");
+    expect(latestStreamingMessage(events).messageId).toBe("message-1");
+  });
+});

--- a/apps/ui/src/__tests__/streaming-message.test.tsx
+++ b/apps/ui/src/__tests__/streaming-message.test.tsx
@@ -21,7 +21,7 @@ describe("StreamingMessage", () => {
   });
 
   it("reveals accepted text incrementally instead of rendering a full chunk immediately", () => {
-    render(<StreamingMessage text="Hello" />);
+    render(<StreamingMessage messageId="message-1" text="Hello" />);
 
     expect(screen.getByTestId("message-content")).toHaveTextContent("H");
 
@@ -35,7 +35,7 @@ describe("StreamingMessage", () => {
   });
 
   it("reveals grapheme clusters without splitting combined glyphs", () => {
-    render(<StreamingMessage text="👩‍💻a" />);
+    render(<StreamingMessage messageId="message-1" text="👩‍💻a" />);
 
     expect(screen.getByTestId("message-content")).toHaveTextContent("👩‍💻");
 
@@ -44,13 +44,13 @@ describe("StreamingMessage", () => {
   });
 
   it("keeps typing from the visible prefix when a larger accumulated delta arrives", () => {
-    const { rerender } = render(<StreamingMessage text="Hel" />);
+    const { rerender } = render(<StreamingMessage messageId="message-1" text="Hel" />);
 
     advanceFrame();
     advanceFrame();
     expect(screen.getByTestId("message-content")).toHaveTextContent("Hel");
 
-    rerender(<StreamingMessage text="Hello world" />);
+    rerender(<StreamingMessage messageId="message-1" text="Hello world" />);
 
     expect(screen.getByTestId("message-content")).toHaveTextContent("Hel");
 
@@ -58,15 +58,18 @@ describe("StreamingMessage", () => {
     expect(screen.getByTestId("message-content")).toHaveTextContent("Hell");
   });
 
-  it("resets cleanly when the target text is replaced by a different turn", () => {
-    const { rerender } = render(<StreamingMessage text="Previous" />);
+  it("resets cleanly when a different message starts in the same turn", () => {
+    const { rerender } = render(
+      <StreamingMessage messageId="commentary-message" text="Previous" />,
+    );
 
     act(() => {
       jest.runOnlyPendingTimers();
     });
 
-    rerender(<StreamingMessage text="New" />);
+    rerender(<StreamingMessage messageId="final-message" text="Final" />);
 
-    expect(screen.getByTestId("message-content")).toHaveTextContent("N");
+    expect(screen.getByTestId("message-content")).toHaveTextContent("F");
+    expect(screen.getByTestId("message-content")).not.toHaveTextContent("Previous");
   });
 });

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -33,6 +33,7 @@ import type {
 } from "@/lib/api/types";
 import { getTextFromContent, isToolCallPart, getEventData } from "@/lib/api/types";
 import { getLocalizedOutputMessageText } from "@/lib/runtime-errors";
+import { latestStreamingMessage } from "@/lib/streaming-message-state";
 import type { UseMutationResult } from "@tanstack/react-query";
 
 /** Accumulated streamed output for a single tool call */
@@ -78,6 +79,7 @@ export interface SessionContextValue {
   isThinking: boolean;
   streamingText: string | null;
   streamingTurnId: string | null;
+  streamingMessageId: string | null;
   /** Current iteration number within the active turn (1-based) */
   streamingIteration: number | null;
   // Message sending
@@ -146,6 +148,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   const [isThinking, setIsThinking] = useState(false);
   const [streamingText, setStreamingText] = useState<string | null>(null);
   const [streamingTurnId, setStreamingTurnId] = useState<string | null>(null);
+  const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
   const [streamingIteration, setStreamingIteration] = useState<number | null>(null);
 
   // Optimistic events - shown immediately before SSE confirms
@@ -243,6 +246,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
         setIsThinking(false);
         setStreamingText(null);
         setStreamingTurnId(null);
+        setStreamingMessageId(null);
         break;
       }
       if (event.type === "turn.cancelled") {
@@ -251,6 +255,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
         setIsThinking(false);
         setStreamingText(null);
         setStreamingTurnId(null);
+        setStreamingMessageId(null);
         break;
       }
       if (event.type === "turn.failed") {
@@ -259,6 +264,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
         setIsThinking(false);
         setStreamingText(null);
         setStreamingTurnId(null);
+        setStreamingMessageId(null);
         setStreamingIteration(null);
         setLocalStatus("idle");
         break;
@@ -266,63 +272,16 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     }
   }, [events]);
 
-  // Update streaming state from SSE events (reason.thinking.started, output.message.delta, output.message.completed)
-  // This provides real-time feedback while the LLM generates text
+  // Project streaming state by message_id. A single turn may contain multiple
+  // commentary/final assistant messages, each with an independent lifecycle.
   useEffect(() => {
-    if (!events || events.length === 0) return;
-
-    // Process events from newest to oldest to find current streaming state
-    for (let i = events.length - 1; i >= 0; i--) {
-      const event = events[i];
-
-      // output.message.completed finalizes the response - stop streaming
-      if (event.type === "output.message.completed") {
-        const turnId = event.context?.turn_id;
-        // Only clear streaming if this message is for the current streaming turn
-        if (!streamingTurnId || turnId === streamingTurnId) {
-          setIsThinking(false);
-          setStreamingText(null);
-          setStreamingTurnId(null);
-          setStreamingIteration(null);
-        }
-        break;
-      }
-
-      // output.message.delta provides incremental text updates
-      {
-        const deltaData = getEventData(event, "output.message.delta");
-        if (deltaData) {
-          setIsThinking(false); // No longer just thinking, now we have text
-          setStreamingText(deltaData.accumulated);
-          setStreamingTurnId(deltaData.turn_id);
-          break;
-        }
-      }
-
-      // output.message.started tracks iteration number
-      {
-        const startedData = getEventData(event, "output.message.started");
-        if (startedData?.iteration) {
-          setStreamingIteration(startedData.iteration);
-        }
-        // Don't break - continue looking for delta/thinking events
-      }
-
-      // reason.thinking.started indicates LLM is generating (before first text)
-      {
-        const thinkData = getEventData(event, "reason.thinking.started");
-        if (thinkData) {
-          // Only set thinking if we don't already have streaming text for this turn
-          if (!streamingText || streamingTurnId !== thinkData.turn_id) {
-            setIsThinking(true);
-            setStreamingText(null);
-            setStreamingTurnId(thinkData.turn_id);
-          }
-          break;
-        }
-      }
-    }
-  }, [events, streamingTurnId, streamingText]);
+    const streaming = latestStreamingMessage(events ?? []);
+    setIsThinking(streaming.isThinking);
+    setStreamingText(streaming.text);
+    setStreamingTurnId(streaming.turnId);
+    setStreamingMessageId(streaming.messageId);
+    setStreamingIteration(streaming.iteration);
+  }, [events]);
 
   // Reset local status, optimistic events, and streaming state when session changes
   useEffect(() => {
@@ -331,6 +290,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     setIsThinking(false);
     setStreamingText(null);
     setStreamingTurnId(null);
+    setStreamingMessageId(null);
     setStreamingIteration(null);
   }, [sessionId]);
 
@@ -652,6 +612,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     isThinking,
     streamingText,
     streamingTurnId,
+    streamingMessageId,
     streamingIteration,
     sendMessage,
     cancelCurrentTurn,

--- a/apps/ui/src/app/dev/_components/dev-chat-runtime-preview.tsx
+++ b/apps/ui/src/app/dev/_components/dev-chat-runtime-preview.tsx
@@ -170,6 +170,7 @@ export function DevChatRuntimeScene({
         ? "Applying the runtime chat surface directly to this dev page."
         : null,
     streamingTurnId: scenario === "chat-components" ? "turn-dev-streaming" : null,
+    streamingMessageId: scenario === "chat-components" ? "message-dev-streaming" : null,
     streamingIteration: scenario === "chat-components" ? 2 : null,
     sendMessage,
     cancelCurrentTurn: createNoopCancelMutation(),

--- a/apps/ui/src/app/dev/markdown/page.tsx
+++ b/apps/ui/src/app/dev/markdown/page.tsx
@@ -214,7 +214,7 @@ function StreamingDemo() {
       <div className="border p-4 min-h-[400px] bg-background">
         {streamedText ? (
           isStreaming ? (
-            <StreamingMessage text={streamedText} />
+            <StreamingMessage messageId="dev-markdown-stream" text={streamedText} />
           ) : (
             <StreamdownMessage variant="inline">{streamedText}</StreamdownMessage>
           )

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -132,6 +132,7 @@ export function ChatPanel() {
     setIsWaitingForResponse,
     isThinking,
     streamingText,
+    streamingMessageId,
     streamingIteration,
     sendMessage,
     cancelCurrentTurn,
@@ -604,8 +605,8 @@ export function ChatPanel() {
                       )}
                       {isThinking && !streamingText ? (
                         <ThinkingIndicator />
-                      ) : streamingText ? (
-                        <StreamingMessage text={streamingText} />
+                      ) : streamingText && streamingMessageId ? (
+                        <StreamingMessage messageId={streamingMessageId} text={streamingText} />
                       ) : null}
                     </div>
                   </div>

--- a/apps/ui/src/components/streaming-message.tsx
+++ b/apps/ui/src/components/streaming-message.tsx
@@ -44,11 +44,18 @@ function charactersPerFrame(remaining: number): number {
   return 1;
 }
 
-function useSmoothedText(targetText: string): string {
+function useSmoothedText(targetText: string, messageId: string): string {
   const targetCharacters = useMemo(() => splitCharacters(targetText), [targetText]);
   const [visibleCharacters, setVisibleCharacters] = useState<string[]>(() =>
     targetCharacters.slice(0, Math.min(1, targetCharacters.length)),
   );
+
+  useEffect(() => {
+    setVisibleCharacters(targetCharacters.slice(0, Math.min(1, targetCharacters.length)));
+    // `messageId` is the lifecycle boundary. Accumulated text updates for the
+    // same message must preserve the visible prefix instead of restarting.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageId]);
 
   useEffect(() => {
     setVisibleCharacters((current) => {
@@ -80,12 +87,13 @@ function useSmoothedText(targetText: string): string {
 }
 
 interface StreamingMessageProps {
+  messageId: string;
   text: string;
   className?: string;
 }
 
-export function StreamingMessage({ text, className }: StreamingMessageProps) {
-  const visibleText = useSmoothedText(text);
+export function StreamingMessage({ messageId, text, className }: StreamingMessageProps) {
+  const visibleText = useSmoothedText(text, messageId);
 
   return (
     <div className={cn("relative", className)}>

--- a/apps/ui/src/components/trajectory/trajectory-view.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-view.tsx
@@ -100,7 +100,9 @@ export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
   const { locale } = useLocale();
   // Count structural events as a stable primitive memoization key.
   // This number only changes when a turn/reason/act/tool/message event arrives,
-  // NOT on every output.message.delta or reason.thinking.delta (which fire 10-30x/sec).
+  // NOT on every message-scoped output.message.delta or reason.thinking.delta
+  // (which fire 10-30x/sec). Trajectory nodes consume canonical completed
+  // messages, so no turn-level delta accumulator is needed here.
   const structuralCount = useMemo(() => countStructuralEvents(events), [events]);
 
   // Build nodes/edges/stats only when structural events change

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -237,6 +237,7 @@ const SSE_EVENT_TYPES = [
   "input.message",
   "output.message.started",
   "output.message.delta",
+  "output.message.replaced",
   "output.message.completed",
   "turn.started",
   "turn.completed",

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -11587,9 +11587,9 @@ export interface components {
      * @description Data for `output.message.replaced` event.
      *
      *     Emitted between the last (suppressed) `output.message.delta` and the final
-     *     `output.message.completed`. Tells the client to discard everything it has
-     *     accumulated for `turn_id` and use `replacement` as the assistant message
-     *     text. The original model output is never persisted or replayed.
+     *     `output.message.completed`. Tells the client to discard the text accumulated
+     *     for `message_id` and use `replacement` as that assistant message's text. The
+     *     original model output is never persisted or replayed.
      */
     OutputMessageReplacedData: {
       /**

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -2245,18 +2245,34 @@ export interface InputMessageData {
 /** Data for output.message.started event (LLM generation started) */
 export interface OutputMessageStartedData {
   turn_id: string;
+  /** Stable public ID for this assistant message across its streaming lifecycle */
+  message_id: string;
   model?: string;
   /** 1-based iteration number within the turn */
   iteration?: number;
+  phase?: "commentary" | "final_answer";
 }
 
 /** Data for output.message.delta event (streaming text update) */
 export interface OutputMessageDeltaData {
   turn_id: string;
+  /** Stable public ID for this assistant message across its streaming lifecycle */
+  message_id: string;
   /** The new text since last delta */
   delta: string;
   /** Accumulated text so far */
   accumulated: string;
+  phase?: "commentary" | "final_answer";
+}
+
+/** Data for output.message.replaced event (guardrail replacement) */
+export interface LegacyOutputMessageReplacedData {
+  turn_id: string;
+  message_id: string;
+  guardrail_capability_id: string;
+  guardrail_id: string;
+  reason_code: string;
+  replacement: string;
 }
 
 /** Data for output.message.completed event */
@@ -2563,6 +2579,7 @@ export type EventData =
   | InputMessageData
   | OutputMessageStartedData
   | OutputMessageDeltaData
+  | LegacyOutputMessageReplacedData
   | OutputMessageCompletedData
   | TurnStartedData
   | TurnCompletedData
@@ -2598,6 +2615,7 @@ export interface EventTypeMap {
   "input.message": InputMessageData;
   "output.message.started": OutputMessageStartedData;
   "output.message.delta": OutputMessageDeltaData;
+  "output.message.replaced": LegacyOutputMessageReplacedData;
   "output.message.completed": OutputMessageCompletedData;
   "turn.started": TurnStartedData;
   "turn.completed": TurnCompletedData;

--- a/apps/ui/src/lib/streaming-message-state.ts
+++ b/apps/ui/src/lib/streaming-message-state.ts
@@ -1,0 +1,104 @@
+import type { Event } from "@/lib/api/types";
+import { getEventData } from "@/lib/api/types";
+
+export interface StreamingMessageState {
+  messageId: string | null;
+  turnId: string | null;
+  text: string | null;
+  isThinking: boolean;
+  iteration: number | null;
+}
+
+const EMPTY_STREAMING_MESSAGE: StreamingMessageState = {
+  messageId: null,
+  turnId: null,
+  text: null,
+  isThinking: false,
+  iteration: null,
+};
+
+function startedForMessage(events: Event[], before: number, messageId: string) {
+  for (let i = before; i >= 0; i--) {
+    const started = getEventData(events[i], "output.message.started");
+    if (started?.message_id === messageId) return started;
+  }
+  return null;
+}
+
+function startedForTurn(events: Event[], before: number, turnId: string) {
+  for (let i = before; i >= 0; i--) {
+    const started = getEventData(events[i], "output.message.started");
+    if (started?.turn_id === turnId) return started;
+  }
+  return null;
+}
+
+/**
+ * Projects the latest active assistant-message lifecycle from an event stream.
+ * Message identity is the grouping key; a turn can contain multiple commentary
+ * and final-answer messages with independent accumulated text.
+ */
+export function latestStreamingMessage(events: Event[]): StreamingMessageState {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+
+    if (
+      event.type === "session.idled" ||
+      event.type === "turn.completed" ||
+      event.type === "turn.failed" ||
+      event.type === "turn.cancelled" ||
+      event.type === "output.message.completed"
+    ) {
+      return EMPTY_STREAMING_MESSAGE;
+    }
+
+    const replaced = getEventData(event, "output.message.replaced");
+    if (replaced) {
+      const started = startedForMessage(events, i - 1, replaced.message_id);
+      return {
+        messageId: replaced.message_id,
+        turnId: replaced.turn_id,
+        text: replaced.replacement,
+        isThinking: false,
+        iteration: started?.iteration ?? null,
+      };
+    }
+
+    const delta = getEventData(event, "output.message.delta");
+    if (delta) {
+      const started = startedForMessage(events, i - 1, delta.message_id);
+      return {
+        messageId: delta.message_id,
+        turnId: delta.turn_id,
+        text: delta.accumulated,
+        isThinking: false,
+        iteration: started?.iteration ?? null,
+      };
+    }
+
+    const started = getEventData(event, "output.message.started");
+    if (started) {
+      return {
+        messageId: started.message_id,
+        turnId: started.turn_id,
+        text: null,
+        isThinking: false,
+        iteration: started.iteration ?? null,
+      };
+    }
+
+    const thinking = getEventData(event, "reason.thinking.started");
+    if (thinking) {
+      const message = startedForTurn(events, i - 1, thinking.turn_id);
+      return {
+        messageId: message?.message_id ?? null,
+        turnId: thinking.turn_id,
+        text: null,
+        isThinking: true,
+        iteration: message?.iteration ?? null,
+      };
+    }
+  }
+
+  return EMPTY_STREAMING_MESSAGE;
+}

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -893,9 +893,9 @@ impl OutputMessageCompletedData {
 /// Data for `output.message.replaced` event.
 ///
 /// Emitted between the last (suppressed) `output.message.delta` and the final
-/// `output.message.completed`. Tells the client to discard everything it has
-/// accumulated for `turn_id` and use `replacement` as the assistant message
-/// text. The original model output is never persisted or replayed.
+/// `output.message.completed`. Tells the client to discard the text accumulated
+/// for `message_id` and use `replacement` as that assistant message's text. The
+/// original model output is never persisted or replayed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct OutputMessageReplacedData {

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -54,7 +54,7 @@ use everruns_core::message::ExecutionPhase;
 use everruns_core::message_retriever::InputMessage as StoredInputMessage;
 use everruns_core::{
     AgUiChannelConfig, AgUiToolVisibility, App, AppStatus, Caller, ContentPart, ExternalActor,
-    MessageRole, typed_id::ImageId,
+    MessageId, MessageRole, typed_id::ImageId,
 };
 use futures::{
     StreamExt,
@@ -993,22 +993,22 @@ fn is_terminal_public_output_message(
     assistant_emitted_delta || !public_content_parts_to_string(&message.content).is_empty()
 }
 
-/// Returns the AG-UI `messageId` for the assistant message currently being
-/// streamed, allocating a fresh id the first time a message scope opens.
+/// Projects the canonical streamed message id into AG-UI's message id space.
 ///
-/// The id is message-scoped, not turn-scoped: `close_assistant_text_without_finishing`
-/// clears the cached id at every non-terminal message boundary, so a commentary
-/// message and the final answer within one turn receive distinct ids. The id is a
-/// random public identifier and is never derived from `turn_id`, so the internal
-/// turn uuid is never exposed on the public AG-UI transport.
-///
-/// Once EVE-772 lands `message_id` on the streaming lifecycle events, this should
-/// key off the streamed `message_id` so the AG-UI id equals the stored `Message.id`.
-fn ensure_assistant_message_id(state: &mut AgUiStreamState) -> AgUiMessageId {
-    state
-        .assistant_message_id
-        .get_or_insert_with(AgUiMessageId::random)
-        .clone()
+/// A new lifecycle id closes any still-open assistant text before switching
+/// scopes. Normal streams close through `output.message.completed`; this guard
+/// also keeps replay/reconnect projections correct when a terminal event is
+/// missing.
+fn ensure_assistant_message_id(
+    state: &mut AgUiStreamState,
+    streamed_message_id: MessageId,
+) -> AgUiMessageId {
+    let projected = AgUiMessageId::from(streamed_message_id.uuid());
+    if state.assistant_message_id.as_ref() != Some(&projected) {
+        close_assistant_text_without_finishing(state);
+        state.assistant_message_id = Some(projected.clone());
+    }
+    projected
 }
 
 fn close_assistant_text_without_finishing(state: &mut AgUiStreamState) {
@@ -1193,7 +1193,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
     match event.event_type.as_str() {
         "output.message.delta" => {
             if let Ok(data) = parse_event_data::<OutputMessageDeltaData>(event) {
-                let message_id = ensure_assistant_message_id(state);
+                let message_id = ensure_assistant_message_id(state, data.message_id);
                 if !state.assistant_content_started {
                     state
                         .queue
@@ -1218,7 +1218,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                     close_assistant_text_without_finishing(state);
                     return;
                 }
-                let message_id = ensure_assistant_message_id(state);
+                let message_id = ensure_assistant_message_id(state, data.message.id);
                 if !state.assistant_content_started {
                     state
                         .queue
@@ -1318,7 +1318,6 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             }
         }
         "tool.started" if parse_event_data::<ToolStartedData>(event).is_ok() => {
-            ensure_assistant_message_id(state);
             state.active_tool_activity_count += 1;
             match state.tool_visibility {
                 AgUiToolVisibility::None => {}
@@ -1334,7 +1333,6 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             }
         }
         "tool.completed" if parse_event_data::<ToolCompletedData>(event).is_ok() => {
-            ensure_assistant_message_id(state);
             state.active_tool_activity_count = state.active_tool_activity_count.saturating_sub(1);
             push_public_tool_activity_end(state);
         }
@@ -1671,10 +1669,13 @@ mod tests {
         let mut state = test_stream_state().await;
         let turn_id = TurnId::new();
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let output_message_id = MessageId::new();
         let event = Event::new(
             SessionId::from_uuid(state.session_id),
             EventContext::turn(turn_id, input_message_id),
-            OutputMessageCompletedData::new(Message::assistant("Hello from AG-UI")),
+            OutputMessageCompletedData::new(
+                Message::assistant("Hello from AG-UI").with_id(output_message_id),
+            ),
         );
 
         translate_event(&mut state, &event);
@@ -1690,6 +1691,13 @@ mod tests {
                 AgUiEventType::RunFinished,
             ]
         );
+        match &state.queue[0] {
+            AgUiEvent::TextMessageStart(event) => assert_eq!(
+                event.message_id,
+                AgUiMessageId::from(output_message_id.uuid())
+            ),
+            _ => panic!("expected text start event"),
+        }
         assert!(state.finished);
     }
 
@@ -1700,13 +1708,14 @@ mod tests {
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
         let context = EventContext::turn(turn_id, input_message_id);
         let session_id = SessionId::from_uuid(state.session_id);
+        let streamed_message_id = MessageId::new();
 
         let delta_event = Event::new(
             session_id,
             context.clone(),
             OutputMessageDeltaData {
                 turn_id,
-                message_id: MessageId::new(),
+                message_id: streamed_message_id,
                 delta: "Hello".to_string(),
                 accumulated: "Hello".to_string(),
                 phase: None,
@@ -1717,7 +1726,9 @@ mod tests {
         let completed_event = Event::new(
             session_id,
             context,
-            OutputMessageCompletedData::new(Message::assistant("Hello from AG-UI")),
+            OutputMessageCompletedData::new(
+                Message::assistant("Hello from AG-UI").with_id(streamed_message_id),
+            ),
         );
         translate_event(&mut state, &completed_event);
 
@@ -1752,13 +1763,15 @@ mod tests {
         let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
         let context = EventContext::turn(turn_id, input_message_id);
         let session_id = SessionId::from_uuid(state.session_id);
+        let commentary_message_id = MessageId::new();
+        let final_message_id = MessageId::new();
 
         let delta_event = Event::new(
             session_id,
             context.clone(),
             OutputMessageDeltaData {
                 turn_id,
-                message_id: MessageId::new(),
+                message_id: commentary_message_id,
                 delta: "Let me check that.".to_string(),
                 accumulated: "Let me check that.".to_string(),
                 phase: None,
@@ -1778,6 +1791,7 @@ mod tests {
                         arguments: serde_json::json!({"query": "base harness"}),
                     }],
                 )
+                .with_id(commentary_message_id)
                 .with_phase(ExecutionPhase::Commentary),
             ),
         );
@@ -1800,6 +1814,7 @@ mod tests {
             context,
             OutputMessageCompletedData::new(
                 Message::assistant("The Base harness is the default execution wrapper.")
+                    .with_id(final_message_id)
                     .with_phase(ExecutionPhase::FinalAnswer),
             ),
         );
@@ -1835,9 +1850,8 @@ mod tests {
         );
         assert!(state.finished);
 
-        // EVE-773: the commentary message and the final answer are distinct AG-UI
-        // messages, so they must carry distinct message-scoped ids, and neither may
-        // leak the raw turn uuid onto the public transport.
+        // EVE-773: AG-UI projects the canonical streamed message ids, preserving
+        // the commentary/final boundary without exposing the turn uuid.
         let start_ids: Vec<&AgUiMessageId> = state
             .queue
             .iter()
@@ -1851,6 +1865,11 @@ mod tests {
             start_ids[0], start_ids[1],
             "commentary and final answer must have distinct messageIds"
         );
+        assert_eq!(
+            *start_ids[0],
+            AgUiMessageId::from(commentary_message_id.uuid())
+        );
+        assert_eq!(*start_ids[1], AgUiMessageId::from(final_message_id.uuid()));
         let turn_message_id = AgUiMessageId::from(turn_id.uuid());
         assert_ne!(*start_ids[0], turn_message_id);
         assert_ne!(*start_ids[1], turn_message_id);

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -29178,7 +29178,7 @@
       },
       "OutputMessageReplacedData": {
         "type": "object",
-        "description": "Data for `output.message.replaced` event.\n\nEmitted between the last (suppressed) `output.message.delta` and the final\n`output.message.completed`. Tells the client to discard everything it has\naccumulated for `turn_id` and use `replacement` as the assistant message\ntext. The original model output is never persisted or replayed.",
+        "description": "Data for `output.message.replaced` event.\n\nEmitted between the last (suppressed) `output.message.delta` and the final\n`output.message.completed`. Tells the client to discard the text accumulated\nfor `message_id` and use `replacement` as that assistant message's text. The\noriginal model output is never persisted or replayed.",
         "required": [
           "turn_id",
           "message_id",

--- a/examples/coding-cli/src/session_log.rs
+++ b/examples/coding-cli/src/session_log.rs
@@ -394,6 +394,9 @@ impl EventBus for JsonlEventEmitter {
 fn message_from_event(data: &EventData) -> Option<Message> {
     match data {
         EventData::InputMessage(d) => Some(d.message.clone()),
+        // Completed messages already carry the canonical message-scoped id.
+        // Streaming deltas are intentionally absent from the replay log, so
+        // preserving this id is the CLI projection's grouping boundary.
         EventData::OutputMessageCompleted(OutputMessageCompletedData { message, .. }) => {
             Some(message.clone())
         }
@@ -465,10 +468,27 @@ fn parse_structured_tool_result_text(text: &str) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::MessageId;
     use everruns_core::events::{
         EventContext, InputMessageData, OutputMessageCompletedData, ToolCompletedData,
     };
     use everruns_core::message::Message;
+
+    #[test]
+    fn completed_message_projection_preserves_message_scoped_ids() {
+        let commentary_id = MessageId::new();
+        let final_id = MessageId::new();
+        let commentary = EventData::OutputMessageCompleted(OutputMessageCompletedData::new(
+            Message::assistant("Checking").with_id(commentary_id),
+        ));
+        let final_answer = EventData::OutputMessageCompleted(OutputMessageCompletedData::new(
+            Message::assistant("Done").with_id(final_id),
+        ));
+
+        assert_eq!(message_from_event(&commentary).unwrap().id, commentary_id);
+        assert_eq!(message_from_event(&final_answer).unwrap().id, final_id);
+        assert_ne!(commentary_id, final_id);
+    }
 
     fn input_event(session_id: SessionId, text: &str) -> Event {
         Event::new(

--- a/specs/events.md
+++ b/specs/events.md
@@ -331,7 +331,7 @@ Consumers group streamed assistant text by **`message_id`**, not `turn_id`: a mu
 
 #### `output.message.replaced`
 
-Streaming output was withheld by an output guardrail (see `specs/capabilities.md` § Output Guardrails). Emitted between the last (suppressed) `output.message.delta` and the final `output.message.completed`. Clients should discard everything they accumulated for `turn_id` and use `replacement` as the assistant message text. The model's original tokens are never persisted or replayed on subsequent turns.
+Streaming output was withheld by an output guardrail (see `specs/capabilities.md` § Output Guardrails). Emitted between the last (suppressed) `output.message.delta` and the final `output.message.completed`. Clients should discard only the text accumulated for `message_id` and use `replacement` as that assistant message's text. The model's original tokens are never persisted or replayed on subsequent turns.
 
 ```json
 {


### PR DESCRIPTION
## What changed
Assistant streaming projections now use the canonical `message_id` lifecycle boundary across AG-UI, the web session UI, and the coding CLI. Commentary and final-answer messages in one turn stay distinct, while each message keeps the same ID from start/delta through completion.

AG-UI now publishes the canonical streamed message ID. The web UI groups accumulated and guardrail-replaced text by message ID and resets smoothing only when that identity changes. The coding CLI test confirms completed-message projections preserve distinct canonical IDs. Other audited consumers either intentionally consume completed messages only or do not build streaming projections.

## Why
Turn-scoped or locally generated projection IDs could collapse commentary and final-answer messages into one visible lifecycle. EVE-772 added canonical IDs to streaming events; this change makes all affected projections consume that identity.

## Before / After
Before: AG-UI generated an unrelated random ID, and the web UI cleared or grouped streaming state at the turn boundary.

After: projection tests prove commentary and final output in the same turn use separate canonical IDs. The AG-UI translator emits the exact streamed ID, and the UI retains only the latest active message lifecycle.

Validation:
- `just pre-push`
- 29 focused AG-UI unit tests
- 14 AG-UI integration tests
- 1 coding CLI projection test
- 1,189 UI tests
- UI generated API check, typecheck, formatting, lint, and production build
- Rust clippy for server and coding CLI with warnings denied

## Risk
- Medium
- Streaming UI state or public AG-UI message grouping could regress if event order or message identity differs from the documented lifecycle.

## Security
- Threat categories reviewed: TM-API and TM-WEB
- Findings and resolutions: no new authentication, authorization, input, persistence, dependency, or raw-HTML surface. Canonical message IDs are existing public random identifiers; the change avoids substituting turn IDs or unrelated projection IDs.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-773.