### PR TITLE
feat(runtime): reconfigure live capabilities

### DIFF
--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -144,6 +144,7 @@ impl<T: HarnessStore + ?Sized> HarnessStore for std::sync::Arc<T> {
 // SessionStore - For retrieving session information
 // ============================================================================
 
+use crate::capability_types::AgentCapabilityConfig;
 use crate::leased_resource::{LeasedResource, UpsertLeasedResource};
 use crate::session::Session;
 
@@ -170,12 +171,58 @@ impl<T: SessionStore + ?Sized> SessionStore for std::sync::Arc<T> {
 pub trait SessionMutator: Send + Sync {
     /// Update a session's human-readable title.
     async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session>;
+
+    /// Add or replace a session-scoped capability atomically.
+    ///
+    /// Session backends that support live capability reconfiguration override
+    /// this method. The default keeps existing backends source-compatible and
+    /// fails closed instead of pretending the capability was applied.
+    async fn upsert_session_capability(
+        &self,
+        _session_id: SessionId,
+        _capability: AgentCapabilityConfig,
+    ) -> Result<Session> {
+        Err(crate::error::AgentLoopError::store(
+            "session backend does not support live capability reconfiguration",
+        ))
+    }
+
+    /// Remove a session-scoped capability atomically.
+    async fn remove_session_capability(
+        &self,
+        _session_id: SessionId,
+        _capability_id: &str,
+    ) -> Result<Session> {
+        Err(crate::error::AgentLoopError::store(
+            "session backend does not support live capability reconfiguration",
+        ))
+    }
 }
 
 #[async_trait]
 impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
     async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
         (**self).update_session_title(session_id, title).await
+    }
+
+    async fn upsert_session_capability(
+        &self,
+        session_id: SessionId,
+        capability: AgentCapabilityConfig,
+    ) -> Result<Session> {
+        (**self)
+            .upsert_session_capability(session_id, capability)
+            .await
+    }
+
+    async fn remove_session_capability(
+        &self,
+        session_id: SessionId,
+        capability_id: &str,
+    ) -> Result<Session> {
+        (**self)
+            .remove_session_capability(session_id, capability_id)
+            .await
     }
 }
 

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -4,6 +4,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use everruns_core::AgentCapabilityConfig;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session::Session;
 use everruns_core::session_file::{
@@ -58,6 +59,44 @@ impl SessionMutator for InMemorySessionStore {
             .get_mut(&session_id)
             .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
         session.title = Some(title);
+        session.updated_at = Utc::now();
+        Ok(session.clone())
+    }
+
+    async fn upsert_session_capability(
+        &self,
+        session_id: SessionId,
+        capability: AgentCapabilityConfig,
+    ) -> Result<Session> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .get_mut(&session_id)
+            .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
+        if let Some(existing) = session
+            .capabilities
+            .iter_mut()
+            .find(|existing| existing.capability_id() == capability.capability_id())
+        {
+            *existing = capability;
+        } else {
+            session.capabilities.push(capability);
+        }
+        session.updated_at = Utc::now();
+        Ok(session.clone())
+    }
+
+    async fn remove_session_capability(
+        &self,
+        session_id: SessionId,
+        capability_id: &str,
+    ) -> Result<Session> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .get_mut(&session_id)
+            .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
+        session
+            .capabilities
+            .retain(|capability| capability.capability_id() != capability_id);
         session.updated_at = Utc::now();
         Ok(session.clone())
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -132,6 +132,7 @@ pub use in_memory::{
 };
 pub use real_disk::{RealDiskFileStore, RealDiskSessionFileSystemFactory, multi_root_file_system};
 pub use runtime::{
-    InProcessRuntime, InProcessRuntimeBuilder, TurnResult, in_process_internal_org_id,
+    CapabilityDelta, InProcessRuntime, InProcessRuntimeBuilder, TurnResult,
+    in_process_internal_org_id,
 };
 pub use turn_strategy::{RuntimeActPlan, RuntimeTurnPlan, RuntimeTurnState, plan_next_host_turn};

--- a/crates/runtime/src/mcp_cache.rs
+++ b/crates/runtime/src/mcp_cache.rs
@@ -127,6 +127,14 @@ impl McpDiscoveryCache {
         self.entries.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// Drop every cached discovery for a session after its live capability set
+    /// changes. Capability-contributed MCP servers may have been added,
+    /// removed, or replaced under an existing logical server name.
+    pub(crate) fn invalidate_session(&self, session_id: Uuid) {
+        self.entries()
+            .retain(|(cached_session_id, _), _| *cached_session_id != session_id);
+    }
+
     /// Classify the entry for `key` at `now`.
     fn classify(&self, key: &CacheKey, now: Instant) -> Freshness {
         match self.entries().get_mut(key) {

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -15,7 +15,10 @@ use crate::in_memory::{InMemorySessionFileStore, InMemorySessionFileSystemFactor
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
 use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput, ReasonInput};
-use everruns_core::capabilities::{Capability, CapabilityRegistry};
+use everruns_core::capabilities::{
+    Capability, CapabilityRegistry, CapabilityStatus, collect_capability_mcp_servers,
+    resolve_capability_configs,
+};
 use everruns_core::config_layer::AgentConfigOverlay;
 use everruns_core::driver_registry::{DriverId, DriverRegistry};
 use everruns_core::error::{AgentLoopError, Result};
@@ -39,8 +42,8 @@ use everruns_core::traits::{
 use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
 use everruns_core::typed_id::{AgentId, HarnessId, OrgId, SessionId};
 use everruns_core::{
-    AgentCapabilityConfig, InputMessage, MessageRetriever, SessionFileSystem,
-    SessionFileSystemFactoryContext, plugin_capability_id,
+    AgentCapabilityConfig, CapabilityId, InputMessage, MessageRetriever, SessionFileSystem,
+    SessionFileSystemFactoryContext, plugin_capability_id, resolve_runtime_capabilities,
 };
 use sha2::{Digest, Sha256};
 use std::path::Path;
@@ -115,6 +118,23 @@ pub struct TurnResult {
     pub error: Option<String>,
     /// Turn identifier used to correlate emitted events.
     pub turn_id: everruns_core::typed_id::TurnId,
+}
+
+/// Result of changing the session-scoped capability set of a live runtime.
+///
+/// A changed result is the refresh seam for embedders: every subsequent reason
+/// or act boundary reassembles model and execution surfaces from the updated
+/// session overlay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityDelta {
+    /// Canonical capability id.
+    pub capability_id: String,
+    /// Whether the session overlay changed.
+    pub changed: bool,
+    /// Whether the capability is active after the operation.
+    pub active: bool,
+    /// Whether prompt, tool, hook, command, or MCP surfaces must be refreshed.
+    pub surfaces_dirty: bool,
 }
 
 impl TurnResult {
@@ -641,7 +661,18 @@ impl InProcessRuntime {
             .get_harness_chain(session.harness_id)
             .await
             .unwrap_or_default();
-        crate::mcp::merge_session_scoped_servers(&harness_chain, agent, session)
+        let resolved = resolve_runtime_capabilities(
+            &harness_chain,
+            agent,
+            session,
+            self.platform_definition.capability_registry(),
+        );
+        let contributed = collect_capability_mcp_servers(
+            &resolved.resolved_capability_configs,
+            self.platform_definition.capability_registry(),
+        );
+        let explicit = crate::mcp::merge_session_scoped_servers(&harness_chain, agent, session);
+        everruns_core::merge_scoped_mcp_servers(&contributed, &explicit)
     }
     /// Create a builder for the in-process runtime.
     pub fn builder() -> InProcessRuntimeBuilder {
@@ -660,6 +691,127 @@ impl InProcessRuntime {
     /// [`InProcessRuntimeBuilder::with_plugin_dir`] is called.
     pub fn plugin_warnings(&self) -> &[String] {
         &self.plugin_warnings
+    }
+
+    /// Activate a registered capability on a running session.
+    ///
+    /// The capability is validated and dependency-resolved before the session
+    /// overlay changes. Conversation history and the session identity are
+    /// untouched. Re-activating an already-effective capability is a no-op.
+    pub async fn activate_capability(
+        &self,
+        session_id: SessionId,
+        capability: impl Into<AgentCapabilityConfig>,
+    ) -> Result<CapabilityDelta> {
+        let mut capability = capability.into();
+        let registry = self.platform_definition.capability_registry();
+        let registered = registry.get(capability.capability_id()).ok_or_else(|| {
+            AgentLoopError::config(format!(
+                "unknown capability: {}",
+                capability.capability_id()
+            ))
+        })?;
+        if registered.status() != CapabilityStatus::Available {
+            return Err(AgentLoopError::config(format!(
+                "capability is not available: {}",
+                capability.capability_id()
+            )));
+        }
+        registered
+            .validate_config(&capability.config)
+            .map_err(|error| {
+                AgentLoopError::config(format!("invalid capability config: {error}"))
+            })?;
+
+        let canonical_id = registered.id().to_string();
+        capability.capability_ref = CapabilityId::new(canonical_id.clone());
+        let context = self.load_context(session_id).await?;
+        if context
+            .resolved_capability_configs
+            .iter()
+            .any(|config| config.capability_id() == canonical_id)
+        {
+            return Ok(CapabilityDelta {
+                capability_id: canonical_id,
+                changed: false,
+                active: true,
+                surfaces_dirty: false,
+            });
+        }
+
+        let mut candidate = context.effective_overlay.capabilities;
+        candidate.push(capability.clone());
+        resolve_capability_configs(&candidate, registry)
+            .map_err(|error| AgentLoopError::config(error.to_string()))?;
+
+        self.session_store
+            .upsert_session_capability(session_id, capability)
+            .await?;
+        self.mcp_discovery_cache
+            .invalidate_session(session_id.uuid());
+        Ok(CapabilityDelta {
+            capability_id: canonical_id,
+            changed: true,
+            active: true,
+            surfaces_dirty: true,
+        })
+    }
+
+    /// Deactivate a capability previously activated on this running session.
+    ///
+    /// Capabilities inherited from the agent or harness cannot be removed by a
+    /// session-scoped operation; callers must change their owning layer.
+    pub async fn deactivate_capability(
+        &self,
+        session_id: SessionId,
+        capability_id: &str,
+    ) -> Result<CapabilityDelta> {
+        let registry = self.platform_definition.capability_registry();
+        let registered = registry.get(capability_id).ok_or_else(|| {
+            AgentLoopError::config(format!("unknown capability: {capability_id}"))
+        })?;
+        let canonical_id = registered.id().to_string();
+        let context = self.load_context(session_id).await?;
+        if !context
+            .resolved_capability_configs
+            .iter()
+            .any(|config| config.capability_id() == canonical_id)
+        {
+            return Ok(CapabilityDelta {
+                capability_id: canonical_id,
+                changed: false,
+                active: false,
+                surfaces_dirty: false,
+            });
+        }
+
+        let session_capability_id = context
+            .session
+            .capabilities
+            .iter()
+            .find(|config| {
+                registry
+                    .get(config.capability_id())
+                    .is_some_and(|capability| capability.id() == canonical_id)
+            })
+            .map(|config| config.capability_id().to_string())
+            .ok_or_else(|| {
+                AgentLoopError::config(format!(
+                    "capability {canonical_id} is inherited and cannot be deactivated at the session layer"
+                ))
+            })?;
+
+        self.session_store
+            .remove_session_capability(session_id, &session_capability_id)
+            .await?;
+        self.mcp_discovery_cache
+            .invalidate_session(session_id.uuid());
+        Ok(CapabilityDelta {
+            capability_id: canonical_id,
+            changed: true,
+            active: false,
+            surfaces_dirty: true,
+        })
     }
 
     /// Execute one turn for an existing session.

--- a/crates/runtime/tests/mcp_runtime_test.rs
+++ b/crates/runtime/tests/mcp_runtime_test.rs
@@ -8,15 +8,18 @@
 //! without resolving (and the fake egress never actually connects).
 
 use async_trait::async_trait;
+use everruns_core::command::{CommandDescriptor, CommandSource};
 use everruns_core::driver_registry::DriverRegistry;
-use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
 use everruns_core::{
-    CapabilityRegistry, DriverId, EgressRequest, EgressResponse, EgressResult, EgressService,
-    EgressStreamResponse, PlatformDefinition, ResolvedModel, ScopedMcpServer, ScopedMcpServers,
-    ToolCall,
+    AgentCapabilityConfig, Capability, CapabilityRegistry, CapabilityStatus, DriverId,
+    EgressRequest, EgressResponse, EgressResult, EgressService, EgressStreamResponse,
+    PlatformDefinition, ResolvedModel, ScopedMcpServer, ScopedMcpServers, Tool, ToolCall,
+    ToolContext, ToolExecutionResult, ToolResult,
 };
 use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
 use serde_json::{Value, json};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 /// A public, non-blocked IP literal: passes SSRF validation without DNS and is
@@ -105,6 +108,127 @@ fn platform_with_egress(traffic: Arc<Mutex<McpTraffic>>) -> PlatformDefinition {
         .build()
 }
 
+#[derive(Default)]
+struct HookCounts {
+    pre: AtomicUsize,
+    post: AtomicUsize,
+}
+
+struct LiveTool;
+
+#[async_trait]
+impl Tool for LiveTool {
+    fn name(&self) -> &str {
+        "live_echo"
+    }
+
+    fn description(&self) -> &str {
+        "Echo a value from a live capability."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": { "value": { "type": "string" } },
+            "required": ["value"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::success(json!({ "echo": arguments["value"] }))
+    }
+}
+
+struct CountingPreHook(Arc<HookCounts>);
+
+#[async_trait]
+impl everruns_core::atoms::PreToolUseHook for CountingPreHook {
+    async fn before_exec(
+        &self,
+        tool_call: ToolCall,
+        _tool_def: &everruns_core::ToolDefinition,
+        _context: &ToolContext,
+    ) -> everruns_core::atoms::PreToolUseDecision {
+        self.0.pre.fetch_add(1, Ordering::SeqCst);
+        everruns_core::atoms::PreToolUseDecision::Continue(tool_call)
+    }
+}
+
+struct CountingPostHook(Arc<HookCounts>);
+
+#[async_trait]
+impl everruns_core::atoms::PostToolExecHook for CountingPostHook {
+    async fn after_exec(
+        &self,
+        _tool_call: &ToolCall,
+        _tool_def: &everruns_core::ToolDefinition,
+        _result: &mut ToolResult,
+        _context: &ToolContext,
+    ) {
+        self.0.post.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct LiveCapability {
+    hooks: Arc<HookCounts>,
+}
+
+impl Capability for LiveCapability {
+    fn id(&self) -> &str {
+        "live_test"
+    }
+
+    fn name(&self) -> &str {
+        "Live Test"
+    }
+
+    fn description(&self) -> &str {
+        "Exercises every live capability surface."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some("LIVE_CAPABILITY_PROMPT")
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(LiveTool)]
+    }
+
+    fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> {
+        vec![Arc::new(CountingPreHook(self.hooks.clone()))]
+    }
+
+    fn post_tool_exec_hooks(&self) -> Vec<Arc<dyn everruns_core::atoms::PostToolExecHook>> {
+        vec![Arc::new(CountingPostHook(self.hooks.clone()))]
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "live".to_string(),
+            description: "Live command".to_string(),
+            args: vec![],
+            source: CommandSource::System,
+        }]
+    }
+
+    fn mcp_servers(&self) -> ScopedMcpServers {
+        scoped_servers()
+    }
+
+    fn validate_config(&self, config: &Value) -> std::result::Result<(), String> {
+        if config.get("enabled").and_then(Value::as_bool) == Some(true) {
+            Ok(())
+        } else {
+            Err("enabled must be true".to_string())
+        }
+    }
+}
+
 #[tokio::test]
 async fn runtime_discovers_and_executes_scoped_mcp_tool() {
     let traffic = Arc::new(Mutex::new(McpTraffic::default()));
@@ -170,4 +294,163 @@ async fn runtime_discovers_and_executes_scoped_mcp_tool() {
         vec!["echo".to_string()],
         "the mcp_docs__echo call should be routed out as a tools/call for 'echo'"
     );
+}
+
+#[tokio::test]
+async fn live_capability_activation_and_deactivation_refresh_every_surface() {
+    let traffic = Arc::new(Mutex::new(McpTraffic::default()));
+    let hooks = Arc::new(HookCounts::default());
+    let mut capabilities = CapabilityRegistry::with_builtins();
+    capabilities.register(LiveCapability {
+        hooks: hooks.clone(),
+    });
+    let platform = PlatformDefinition::builder()
+        .capability_registry(capabilities)
+        .driver_registry(DriverRegistry::new())
+        .egress_service(Arc::new(FakeMcpEgress {
+            traffic: traffic.clone(),
+        }))
+        .build();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .llm_sim(LlmSimConfig::scripted(vec![
+            SimTurn::Assistant("before activation".to_string()),
+            SimTurn::ToolCalls(vec![
+                SimToolCall {
+                    name: "live_echo".to_string(),
+                    arguments: json!({ "value": "hello" }),
+                    id: None,
+                },
+                SimToolCall {
+                    name: "mcp_docs__echo".to_string(),
+                    arguments: json!({ "message": "hi" }),
+                    id: None,
+                },
+            ]),
+            SimTurn::Assistant("after live tools".to_string()),
+            SimTurn::Assistant("after deactivation".to_string()),
+        ]))
+        .single_session(|session| {
+            session
+                .harness("live", "Base prompt")
+                .agent("live-agent", "Base agent prompt")
+                .agent_max_iterations(8)
+        })
+        .build()
+        .await
+        .expect("runtime builds");
+    let session_id = runtime.default_session_id().expect("session id");
+
+    runtime
+        .run_text_turn(session_id, "Before activation")
+        .await
+        .expect("initial turn runs");
+    let before = runtime.load_context(session_id).await.unwrap();
+    assert!(
+        !before
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+    assert!(
+        !before
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "live_echo")
+    );
+    assert!(runtime.list_commands(session_id).await.unwrap().is_empty());
+    assert_eq!(traffic.lock().unwrap().tools_list_calls, 0);
+
+    let invalid = runtime
+        .activate_capability(session_id, AgentCapabilityConfig::new("live_test"))
+        .await
+        .expect_err("invalid config must fail before mutation");
+    assert!(invalid.to_string().contains("enabled must be true"));
+
+    let delta = runtime
+        .activate_capability(
+            session_id,
+            AgentCapabilityConfig::with_config("live_test", json!({ "enabled": true })),
+        )
+        .await
+        .expect("activation succeeds");
+    assert!(delta.changed && delta.active && delta.surfaces_dirty);
+    let duplicate = runtime
+        .activate_capability(
+            session_id,
+            AgentCapabilityConfig::with_config("live_test", json!({ "enabled": true })),
+        )
+        .await
+        .expect("activation is idempotent");
+    assert!(!duplicate.changed && duplicate.active && !duplicate.surfaces_dirty);
+
+    let active = runtime.load_context(session_id).await.unwrap();
+    assert!(
+        active
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+    assert!(
+        active
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "live_echo")
+    );
+    assert_eq!(
+        runtime.list_commands(session_id).await.unwrap()[0].name,
+        "live"
+    );
+
+    let live_turn = runtime
+        .run_text_turn(session_id, "Use the live tools")
+        .await
+        .expect("live turn runs");
+    assert!(live_turn.success);
+    assert_eq!(traffic.lock().unwrap().tools_call_names, vec!["echo"]);
+    assert_eq!(hooks.pre.load(Ordering::SeqCst), 2);
+    assert_eq!(hooks.post.load(Ordering::SeqCst), 2);
+
+    let delta = runtime
+        .deactivate_capability(session_id, "live_test")
+        .await
+        .expect("deactivation succeeds");
+    assert!(delta.changed && !delta.active && delta.surfaces_dirty);
+    let duplicate = runtime
+        .deactivate_capability(session_id, "live_test")
+        .await
+        .expect("deactivation is idempotent");
+    assert!(!duplicate.changed && !duplicate.active && !duplicate.surfaces_dirty);
+
+    let inactive = runtime.load_context(session_id).await.unwrap();
+    assert!(
+        !inactive
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+    assert!(
+        !inactive
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "live_echo")
+    );
+    assert!(runtime.list_commands(session_id).await.unwrap().is_empty());
+    runtime
+        .run_text_turn(session_id, "After deactivation")
+        .await
+        .expect("post-deactivation turn runs");
+    assert_eq!(hooks.pre.load(Ordering::SeqCst), 2);
+    assert_eq!(hooks.post.load(Ordering::SeqCst), 2);
+    assert_eq!(traffic.lock().unwrap().tools_call_names, vec!["echo"]);
+
+    let unknown = runtime
+        .activate_capability(session_id, "does_not_exist")
+        .await
+        .expect_err("unknown capability must fail");
+    assert!(unknown.to_string().contains("unknown capability"));
 }

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -137,6 +137,34 @@ Capabilities are defined in **everruns-core** and resolved at the **API layer**:
 - The Agent Loop remains focused on execution
 - RuntimeAgent is built with merged system prompt and tools from capabilities
 
+### Live session reconfiguration
+
+The in-process runtime supports changing the session-scoped capability overlay
+without rebuilding the runtime or replacing the session:
+
+- `InProcessRuntime::activate_capability(session_id, config)` validates the
+  registered capability config, resolves the candidate dependency graph, and
+  atomically adds the canonical capability config to the session layer.
+- `InProcessRuntime::deactivate_capability(session_id, id)` atomically removes
+  a capability previously activated on the session layer.
+- Both methods return `CapabilityDelta`. `surfaces_dirty = true` is the
+  embedder refresh seam; the following reason/act boundary re-collects the
+  system prompt, model-visible tool definitions, executable tools, pre/post
+  tool hooks, tool-call hooks, commands, and capability-contributed MCP
+  servers from the updated source of truth.
+- Repeating an already-satisfied operation succeeds with `changed = false` and
+  `surfaces_dirty = false`. Unknown or unavailable capabilities, invalid
+  configs, dependency errors, and unsupported session backends fail before any
+  runtime surface changes.
+- The operation is intentionally session-scoped and non-durable. Embedders own
+  persisted enable/disable settings. A session operation cannot remove a
+  capability inherited from its harness or agent; that capability must be
+  changed at its owning layer.
+
+`SessionMutator::{upsert_session_capability, remove_session_capability}` is the
+host-storage seam. Its default implementation fails closed, while the bundled
+in-memory runtime store implements both mutations atomically.
+
 #### Deployment Availability (session creation)
 
 Some built-in capabilities are feature-gated (e.g. `container_sandbox` behind

--- a/specs/runtime-mcp.md
+++ b/specs/runtime-mcp.md
@@ -175,6 +175,15 @@ Both points hang off an optional adapter hook
 default `None`, so hosts that don't configure MCP pay nothing and behavior is
 unchanged.
 
+Capability-contributed MCP servers participate in the same runtime path. The
+runtime dependency-resolves the effective capability set, collects its MCP
+servers as defaults, then overlays explicit harness/agent/session servers by
+logical name. A live capability change invalidates that session's discovery
+cache, so activation discovers new servers on the next reason boundary and
+deactivation cannot retain stale tool definitions. Stdio transport remains
+per-invocation: each discovery/call tears down its child process, so removal
+leaves no persistent process to disconnect.
+
 > Historical note: an earlier design routed `mcp_*` calls through a separate
 > `CompositeToolExecutor` wrapper instead of registering MCP tools in the
 > registry. That kept MCP tools invisible to registry-introspecting tools and

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -207,6 +207,18 @@ embedded runtime needs for:
 - persisting assistant and tool-result messages from emitted events
 - configuring the runtime default model
 
+`RuntimeSessionStore` also inherits the live capability mutation methods from
+`SessionMutator`. A custom backend that wants to support
+`InProcessRuntime::{activate_capability, deactivate_capability}` implements
+atomic session-capability upsert/removal; backends that do not implement the
+methods return the default unsupported error.
+
+Live capability changes do not replace the `RuntimeAgent` in place. The session
+overlay is the source of truth, and the existing per-boundary assembly path
+rebuilds the prompt, definitions, executable registry, and hooks before the
+next reason/act step. This preserves session identity and conversation history
+and avoids two independently mutable copies of the runtime surface.
+
 Use `RuntimeBackends::in_memory()` for the all-in-memory default, then chain
 `.with_message_store(...)`, `.with_storage_store(...)`, etc. to override
 individual non-filesystem stores.


### PR DESCRIPTION
## What changed
The in-process runtime can now activate or deactivate a registered capability on a running session without replacing the session or losing conversation state. The returned `CapabilityDelta` tells embedders whether model/execution surfaces must refresh; the next reason/act boundary re-collects prompts, native tools, hooks, commands, and capability-contributed MCP servers.

The session storage contract now exposes fail-closed atomic capability upsert/removal methods, with the bundled in-memory store implementing them. MCP discovery now includes capability-contributed servers and invalidates a session's cache after live changes.

## Why
EVE-795 blocks embedders such as Yolop from enabling a newly authored extension in the current session. Capability-derived surfaces were assembled from a fixed effective set, and the in-process MCP path also ignored servers contributed by capabilities.

The implementation mutates the session overlay—the existing source of truth—instead of creating a second mutable `RuntimeAgent` copy. This keeps reason and act assembly aligned and preserves session/history state.

## Before / After
Before: a capability registered after session construction could not become active until a new session; its tool, prompt, hooks, command, and MCP server were absent.

After: the end-to-end runtime test activates a configured capability after an initial turn, observes its prompt/tool/command immediately in assembled context, then runs the next turn and executes both its native tool and MCP tool with pre/post hooks firing. Deactivation removes every surface, and a later turn no longer invokes either hook or MCP tool. Invalid configs and unknown IDs fail before mutation; repeated activation/removal is a no-op success.

Evidence:
- `cargo test -p everruns-runtime --all-features` — 142 unit/integration tests plus doc test passed.
- `cargo clippy -p everruns-runtime --all-targets --all-features -- -D warnings` — passed.
- `just pre-push` — all applicable repository checks passed.

## Risk
- Medium
- Custom `RuntimeSessionStore` implementations must override the new mutation methods to opt into live reconfiguration; the defaults fail closed.
- Deactivation is intentionally scoped to capabilities activated on the session layer. Harness/agent-owned capabilities remain controlled by their owning layer.
- MCP discovery behavior changes for capability-contributed servers in embedded runtimes; explicit harness/agent/session server definitions retain precedence by logical name.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-DOS.
- Findings and resolutions: capability IDs, availability, configs, and the bounded dependency graph are validated before mutation; unsupported stores fail closed; MCP traffic retains the existing DNS-pinned SSRF-safe egress path; session cache invalidation remains bounded. No auth boundary, secret handling, dependency, or genuinely new threat was introduced, so no threat-model entry changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
