### PR TITLE
fix(release): register everruns-provider in publish config; align docs

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -134,6 +134,7 @@ jobs:
               "crates/core/Cargo.toml": [
                   "everruns-openui",
                   "everruns-a2ui",
+                  "everruns-provider",
               ],
               "crates/mcp/Cargo.toml": [
                   "everruns-core",
@@ -146,19 +147,19 @@ jobs:
                   "everruns-runtime",
               ],
               "crates/openai/Cargo.toml": [
-                  "everruns-core",
+                  "everruns-provider",
               ],
               "crates/anthropic/Cargo.toml": [
-                  "everruns-core",
+                  "everruns-provider",
               ],
               "crates/openrouter/Cargo.toml": [
-                  "everruns-core",
+                  "everruns-provider",
               ],
               "crates/bedrock/Cargo.toml": [
-                  "everruns-core",
+                  "everruns-provider",
               ],
               "crates/gemini/Cargo.toml": [
-                  "everruns-core",
+                  "everruns-provider",
               ],
               "integrations/duckduckgo/Cargo.toml": [
                   "everruns-core",
@@ -225,6 +226,7 @@ jobs:
           CRATES=(
             everruns-openui
             everruns-a2ui
+            everruns-provider
             everruns-core
             everruns-mcp
             everruns-openai

--- a/crates/anthropic/README.md
+++ b/crates/anthropic/README.md
@@ -6,8 +6,8 @@
 [![Documentation](https://docs.rs/everruns-anthropic/badge.svg)](https://docs.rs/everruns-anthropic)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-anthropic` registers an Anthropic driver with
-[`everruns-core`](https://crates.io/crates/everruns-core) so the same Everruns
+`everruns-anthropic` registers an Anthropic driver into a `DriverRegistry` from
+[`everruns-provider`](https://crates.io/crates/everruns-provider) so the same Everruns
 agent loop can run against Claude models through the provider-neutral driver
 trait. It speaks the Claude Messages API with streaming, tool use, and reasoning,
 and maps provider errors onto Everruns runtime errors.
@@ -22,7 +22,7 @@ or run with no key at all using the built-in LLM simulator in
 
 ```rust
 use everruns_anthropic::{AnthropicChatDriver, register_driver};
-use everruns_core::DriverRegistry;
+use everruns_provider::DriverRegistry;
 
 let driver = AnthropicChatDriver::new("your-api-key");
 

--- a/crates/bedrock/README.md
+++ b/crates/bedrock/README.md
@@ -6,8 +6,8 @@
 [![Documentation](https://docs.rs/everruns-bedrock/badge.svg)](https://docs.rs/everruns-bedrock)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-bedrock` registers an AWS Bedrock driver with
-[`everruns-core`](https://crates.io/crates/everruns-core) so
+`everruns-bedrock` registers an AWS Bedrock driver into a `DriverRegistry` from
+[`everruns-provider`](https://crates.io/crates/everruns-provider) so
 the same Everruns agent loop can run against models hosted on Amazon Bedrock. It
 implements the provider-neutral `ChatDriver` contract using the Bedrock Runtime
 `ConverseStream` API, mapping Everruns' messages, tools, and reasoning onto the
@@ -24,7 +24,7 @@ backends, or run with no key using the built-in LLM simulator in
 
 ```rust
 use everruns_bedrock::{BedrockChatDriver, register_driver};
-use everruns_core::DriverRegistry;
+use everruns_provider::DriverRegistry;
 
 let mut registry = DriverRegistry::new();
 register_driver(&mut registry);

--- a/crates/fireworks/Cargo.toml
+++ b/crates/fireworks/Cargo.toml
@@ -36,7 +36,7 @@ chrono.workspace = true
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the dependency tree small. No version pin: this crate is not in
 # the publish set, so it follows the unpublished-crate convention (path only).
-everruns-provider = { path = "../provider", version = "0.17.12" }
+everruns-provider = { path = "../provider" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/fireworks/README.md
+++ b/crates/fireworks/README.md
@@ -6,8 +6,8 @@
 [![Documentation](https://docs.rs/everruns-fireworks/badge.svg)](https://docs.rs/everruns-fireworks)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-fireworks` registers the Fireworks AI driver with
-[`everruns-core`](https://crates.io/crates/everruns-core) so the same Everruns
+`everruns-fireworks` registers the Fireworks AI driver into a `DriverRegistry` from
+[`everruns-provider`](https://crates.io/crates/everruns-provider) so the same Everruns
 agent loop can run against [Fireworks AI](https://fireworks.ai/)'s open-model
 catalog (Llama, Qwen, DeepSeek, Kimi, GLM, gpt-oss, ...). Fireworks exposes an
 OpenAI-compatible Chat Completions API, so the driver wraps the core Chat

--- a/crates/gemini/README.md
+++ b/crates/gemini/README.md
@@ -6,8 +6,8 @@
 [![Documentation](https://docs.rs/everruns-gemini/badge.svg)](https://docs.rs/everruns-gemini)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-gemini` registers a Google Gemini driver with
-[`everruns-core`](https://crates.io/crates/everruns-core) so
+`everruns-gemini` registers a Google Gemini driver into a `DriverRegistry` from
+[`everruns-provider`](https://crates.io/crates/everruns-provider) so
 the same Everruns agent loop can run against Gemini models. It implements the
 provider-neutral `ChatDriver` contract and maps Everruns' messages, tools, and
 reasoning onto the Gemini API. Core has no knowledge of specific providers; hosts
@@ -24,7 +24,7 @@ backends, or run with no key using the built-in LLM simulator in
 
 ```rust
 use everruns_gemini::{GeminiChatDriver, register_driver};
-use everruns_core::DriverRegistry;
+use everruns_provider::DriverRegistry;
 
 let mut registry = DriverRegistry::new();
 register_driver(&mut registry);

--- a/crates/mai/Cargo.toml
+++ b/crates/mai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the dependency tree small. No version pin: this crate is not in
 # the publish set, so it follows the unpublished-crate convention (path only).
-everruns-provider = { path = "../provider", version = "0.17.12" }
+everruns-provider = { path = "../provider" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/mai/README.md
+++ b/crates/mai/README.md
@@ -5,7 +5,7 @@ Microsoft MAI provider driver for [Everruns](https://everruns.com).
 Microsoft MAI models (e.g. `MAI-Code-1-Flash`) are served via
 [Azure AI Foundry](https://ai.azure.com) behind an OpenAI-compatible Chat
 Completions API. `everruns-mai` implements the `ChatDriver` contract from
-[`everruns-core`](https://crates.io/crates/everruns-core) and registers the
+[`everruns-provider`](https://crates.io/crates/everruns-provider) and registers the
 `mai` driver into a `DriverRegistry`.
 
 ## Authentication
@@ -20,14 +20,14 @@ Two schemes are supported:
   cached, refreshed before expiry.
 
 The auth layer is built on the pluggable `AuthHeaderProvider` hook in
-`everruns-core`, so additional schemes (managed identity, workload identity
+`everruns-provider`, so additional schemes (managed identity, workload identity
 federation, ...) can be added by implementing the trait without changing the
 driver.
 
 ## Usage
 
 ```rust
-use everruns_core::DriverRegistry;
+use everruns_provider::DriverRegistry;
 use everruns_mai::{register_driver, MaiAuth, MaiChatDriver};
 
 // Register into a driver registry (the usual integration path):

--- a/crates/openai/README.md
+++ b/crates/openai/README.md
@@ -6,8 +6,8 @@
 [![Documentation](https://docs.rs/everruns-openai/badge.svg)](https://docs.rs/everruns-openai)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-openai` registers OpenAI drivers with
-[`everruns-core`](https://crates.io/crates/everruns-core) so the same Everruns
+`everruns-openai` registers OpenAI drivers into a `DriverRegistry` from
+[`everruns-provider`](https://crates.io/crates/everruns-provider) so the same Everruns
 agent loop can run against OpenAI models. It ships the recommended Responses API
 driver plus a Chat Completions compatibility driver for OpenAI-compatible
 endpoints, mapping Everruns' provider-neutral messages, tools, and reasoning

--- a/crates/openrouter/README.md
+++ b/crates/openrouter/README.md
@@ -6,8 +6,8 @@
 [![Documentation](https://docs.rs/everruns-openrouter/badge.svg)](https://docs.rs/everruns-openrouter)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-openrouter` registers the OpenRouter driver with
-[`everruns-core`](https://crates.io/crates/everruns-core) so the same Everruns
+`everruns-openrouter` registers the OpenRouter driver into a `DriverRegistry` from
+[`everruns-provider`](https://crates.io/crates/everruns-provider) so the same Everruns
 agent loop can run against OpenRouter's model catalog. OpenRouter exposes an
 OpenAI-compatible Responses API, so the driver wraps the core Open Responses
 protocol driver and parses OpenRouter's richer `/models` metadata into capability

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -11,7 +11,7 @@ Two modes:
 
 The pin set mirrors `dependency_versions` in
 `.github/workflows/publish-crates.yml` and `workspace.dependencies` in
-`Cargo.toml` (everruns-core).
+`Cargo.toml` (everruns-core, everruns-provider).
 """
 
 from __future__ import annotations
@@ -34,11 +34,11 @@ INNER_PINS: dict[str, list[str]] = {
     "crates/mcp/Cargo.toml": ["everruns-core"],
     "crates/runtime/Cargo.toml": ["everruns-core"],
     "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
-    "crates/openai/Cargo.toml": ["everruns-core"],
-    "crates/anthropic/Cargo.toml": ["everruns-core"],
-    "crates/openrouter/Cargo.toml": ["everruns-core"],
-    "crates/bedrock/Cargo.toml": ["everruns-core"],
-    "crates/gemini/Cargo.toml": ["everruns-core"],
+    "crates/openai/Cargo.toml": ["everruns-provider"],
+    "crates/anthropic/Cargo.toml": ["everruns-provider"],
+    "crates/openrouter/Cargo.toml": ["everruns-provider"],
+    "crates/bedrock/Cargo.toml": ["everruns-provider"],
+    "crates/gemini/Cargo.toml": ["everruns-provider"],
     "integrations/duckduckgo/Cargo.toml": ["everruns-core"],
     "integrations/github/Cargo.toml": ["everruns-core"],
     "integrations/daytona/Cargo.toml": ["everruns-core"],
@@ -53,7 +53,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-mcp", "everruns-runtime"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-provider", "everruns-mcp", "everruns-runtime"]
 
 
 def workspace_version() -> str:

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -93,7 +93,8 @@ Production event routing therefore prefers:
 2. **Crate Separation** (folder → package name):
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
-   - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, egress service, internal system services, shared types)
+   - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, egress service, internal system services, shared types). Depends on and re-exports `everruns-provider`.
+   - `provider/` → `everruns-provider` - LLM/provider abstraction that the provider crates depend on instead of core: `ChatDriver`, the shared OpenAI/OpenResponses protocol drivers, model profiles, retry/stream helpers, typed IDs, credential form schema, and the LLM error taxonomy
    - `runtime/` → `everruns-runtime` - The agentic runtime: in-process entrypoint to the agentic framework, plus reusable host-phase execution for embedded and durable/server-backed execution
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
@@ -119,6 +120,7 @@ everruns/
 │   ├── server/           # Control plane: HTTP API + gRPC server + storage
 │   ├── worker/           # Durable worker with gRPC client
 │   ├── core/             # Shared abstractions and types
+│   ├── provider/         # LLM/provider abstraction (ChatDriver, protocol drivers, model profiles)
 │   ├── runtime/          # Public in-process embedded runtime
 │   ├── internal-protocol/# gRPC protocol definitions
 │   ├── durable/          # Durable execution engine
@@ -426,7 +428,7 @@ The core crate provides DB-agnostic agent abstractions with pluggable backends:
 
 OpenAI-specific LLM provider implementation:
 
-1. **Implements Core Traits**: `ChatDriver` trait from `everruns-core`
+1. **Implements the driver trait**: `ChatDriver` trait from `everruns-provider`
 2. **OpenAI + Azure OpenAI Support**: Supports OpenAI-hosted and Azure-hosted OpenAI v1 endpoints
 3. **Streaming Support**: Full SSE streaming with tool call support
 4. **Native API Access**: Direct methods for OpenAI-specific functionality
@@ -445,7 +447,7 @@ a vendor-neutral, open-source API standard for multi-provider LLM interfaces.
 - **Better caching**: 40-80% better cache utilization vs Chat Completions API
 - **Provider-agnostic**: Events and responses follow a standardized format
 
-**Driver Selection**: `OpenAIChatDriver` (Responses API, recommended) or `OpenAICompletionsChatDriver` (Chat Completions). See `crates/openai/src/driver.rs` and the protocol implementations in `crates/core/src/`.
+**Driver Selection**: `OpenAIChatDriver` (Responses API, recommended) or `OpenAICompletionsChatDriver` (Chat Completions). See `crates/openai/src/driver.rs` and the protocol implementations in `crates/provider/src/`.
 
 ### LlmSim Driver (Testing)
 

--- a/specs/budgeting.md
+++ b/specs/budgeting.md
@@ -17,7 +17,7 @@ Key use cases:
 
 See source files for full definitions:
 - Core types: `crates/core/src/budget.rs`
-- Typed IDs: `crates/core/src/typed_id.rs` (`BudgetId`, `LedgerEntryId`)
+- Typed IDs: `crates/provider/src/typed_id.rs` (`BudgetId`, `LedgerEntryId`)
 - Events: `crates/core/src/events.rs` (budget event constants and `BudgetEventData`)
 - Storage: `crates/server/src/storage/repositories/budgets.rs`, `crates/server/src/storage/memory/budgets.rs`
 - Service: `crates/server/src/domains/budgets/service.rs`

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -53,19 +53,28 @@ badge-free header and omit docs.rs links.
 ### Crate dependency conventions
 
 Thin LLM provider crates (`openai`, `anthropic`, `gemini`, `bedrock`, `mai`,
-`fireworks`, `openrouter`) depend on `everruns-core` with
-`default-features = false`. Core's heavy subtrees (telemetry/OTLP, `a2a` gRPC,
-web-fetch/fetchkit, and the `llmsim` simulator driver) are opt-in features kept
-in core's `default`, so the application crates stay full while standalone
-provider builds shed them. Crates
-that pull in the runtime (e.g. `everruns-local` → `everruns-runtime`) cannot
-benefit — feature unification re-enables the subtrees — so they keep full
-defaults.
+`fireworks`, `openrouter`) depend on `everruns-provider`, **not**
+`everruns-core`. `everruns-provider` is the lean provider/LLM abstraction crate
+that owns the driver surface (`ChatDriver`, the shared OpenAI/OpenResponses
+protocol drivers, model profiles, retry/stream helpers, typed IDs, the
+credential form schema, and the LLM error taxonomy). It carries none of core's
+heavy subtrees (telemetry/OTLP, `a2a` gRPC, web-fetch/fetchkit, the `llmsim`
+simulator driver), so a standalone provider build never pulls them in. A
+provider is therefore a pure `ChatDriver` implementation with no dependency on
+core's agent-loop runtime; provider crates keep `everruns-core` only as a
+**dev-dependency** for integration tests that drive the in-memory runtime +
+`llmsim` harness.
+
+`everruns-core` depends on `everruns-provider` and re-exports every moved module
+at its original path (`everruns_core::driver_registry`, `::model_profiles`,
+`::error`, `::typed_id`, …), so application crates and embedders that import
+those paths are unaffected. Crates that pull in the runtime (e.g.
+`everruns-local` → `everruns-runtime`) still depend on full `everruns-core`.
 
 Two pin conventions follow from the publish set:
 
 - **Unpublished** crates reference path deps without a version
-  (`{ path = "../core", default-features = false }`), matching `server`/`worker`.
+  (`{ path = "../provider" }` for provider crates; `{ path = "../core", default-features = false }` for crates that do depend on core), matching `server`/`worker`.
 - **Published** crates that pin a sibling by exact version must be registered in
   *both* `.github/workflows/publish-crates.yml` (`dependency_versions`) and
   `scripts/sync-publish-pin-versions.py` (`INNER_PINS`). The release process

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -501,5 +501,5 @@ visibility rather than changing the capability ownership model.
 - `specs/infinity-context.md` — pull-based backstop capability; defers to compaction when both are enabled
 - `specs/events.md` — event schema
 - `specs/capabilities.md` — capability system
-- `crates/core/src/driver_registry.rs` — `ChatDriver` trait with `supports_compact()` / `compact()`
-- `crates/core/src/openresponses_protocol.rs` — `CompactRequest` / `CompactResponse` types
+- `crates/provider/src/driver_registry.rs` — `ChatDriver` trait with `supports_compact()` / `compact()`
+- `crates/provider/src/openresponses_protocol.rs` — `CompactRequest` / `CompactResponse` types

--- a/specs/error-disclosure.md
+++ b/specs/error-disclosure.md
@@ -9,7 +9,7 @@ on string parsing.
 
 LLM drivers classify provider failures at the provider boundary — where the
 HTTP status and response body are still available — into `LlmErrorKind`
-(`crates/core/src/error.rs`): authentication, quota exhaustion, rate limit,
+(`crates/provider/src/error.rs`): authentication, quota exhaustion, rate limit,
 provider unavailable, invalid request, or other. All drivers (OpenAI chat,
 OpenAI Responses, Anthropic, Gemini, Bedrock) attach a kind; `other` falls
 back to the legacy string classifier (`classify_runtime_error_message`), so

--- a/specs/execution-phases.md
+++ b/specs/execution-phases.md
@@ -37,7 +37,7 @@ Two variants: `Commentary` (intermediate, before/between tool calls) and `FinalA
 
 ## Model Profile Flag
 
-`supports_phases: bool` on `LlmModelProfile` — indicates whether the model accepts phase values in the provider API. Phase support is a model-level capability, not a driver-level one — the same OpenAI Responses API driver serves both phase-capable and non-phase models. See `crates/core/src/model_profiles.rs` for the per-model profile data and lookup logic.
+`supports_phases: bool` on `LlmModelProfile` — indicates whether the model accepts phase values in the provider API. Phase support is a model-level capability, not a driver-level one — the same OpenAI Responses API driver serves both phase-capable and non-phase models. See `crates/provider/src/model_profiles.rs` for the per-model profile data and lookup logic.
 
 ## Provider Mapping
 
@@ -49,7 +49,7 @@ The `phase` field is serialized as a string on assistant messages in the `input`
 
 For non-GPT-5.4 models on the same driver, the `phase` field is omitted from the wire format.
 
-See `crates/core/src/openresponses_protocol.rs` for the mapping.
+See `crates/provider/src/openresponses_protocol.rs` for the mapping.
 
 ### Anthropic / Gemini
 

--- a/specs/id-schema.md
+++ b/specs/id-schema.md
@@ -25,7 +25,7 @@ Where:
 
 ### Entity Prefixes
 
-For the full list of entity prefixes and type aliases, see `crates/core/src/typed_id.rs`.
+For the full list of entity prefixes and type aliases, see `crates/provider/src/typed_id.rs`.
 
 **Example:** `agent_01933b5a00007000800000000000002`
 
@@ -51,11 +51,11 @@ let id = format!("agent_{}", uuid.simple()); // agent_0193...
 | **Time-ordered** (default) — DB-backed keys: `agent`, `session`, `event`, `turn`, `org`, and all other entities with a table/PK/index | UUIDv7 | Time-ordering gives B-tree insert locality and lets the id double as a sort key. |
 | **Random-public** — `message` | UUIDv4 (`TypedId::new_random()`) | Messages are **not** DB entities: they live embedded in `events.data` JSONB with no table, FK, index, or sort dependency on the id, and the id is the *public* identifier serialized to clients (`output.message.completed`, `EventContext.input_message_id`). UUIDv7's time-ordering does no work here and would leak a creation timestamp into a client-visible id, so message ids are random. Same wire format → no migration; legacy UUIDv7 message ids keep parsing. |
 
-`TurnId` stays UUIDv7: turn ordering is used by durable execution, and the raw turn UUID's current public exposure via AG-UI is being removed by the streaming `message_id` work rather than by re-randomizing the turn id. To make a new id class random, override `generate_uuid()` on its marker in `crates/core/src/typed_id.rs`.
+`TurnId` stays UUIDv7: turn ordering is used by durable execution, and the raw turn UUID's current public exposure via AG-UI is being removed by the streaming `message_id` work rather than by re-randomizing the turn id. To make a new id class random, override `generate_uuid()` on its marker in `crates/provider/src/typed_id.rs`.
 
 ### ID Validation
 
-IDs must match `^{prefix}_[0-9a-f]{32}$`. See `TypedId` validation in `crates/core/src/typed_id.rs`.
+IDs must match `^{prefix}_[0-9a-f]{32}$`. See `TypedId` validation in `crates/provider/src/typed_id.rs`.
 
 ### Database Storage — Dual-ID Pattern
 
@@ -99,7 +99,7 @@ IDs are serialized as strings in JSON:
 
 ### Well-Known IDs
 
-For the full list of well-known IDs and range allocations, see `crates/core/src/typed_id.rs` and `crates/server/src/seed.rs`.
+For the full list of well-known IDs and range allocations, see `crates/provider/src/typed_id.rs` and `crates/server/src/seed.rs`.
 
 ## Design Decisions
 
@@ -122,6 +122,6 @@ Existing UUIDs are migrated to prefixed format:
 
 ## Type Implementation
 
-`TypedId<T>` provides type-safe ID handling with serde, sqlx, Display/Debug, and validation. See `crates/core/src/typed_id.rs` for the full implementation, type aliases, and usage patterns.
+`TypedId<T>` provides type-safe ID handling with serde, sqlx, Display/Debug, and validation. See `crates/provider/src/typed_id.rs` for the full implementation, type aliases, and usage patterns.
 
 **IMPORTANT: Typed IDs are mandatory throughout the codebase.** All code MUST use typed IDs (e.g., `SessionId`, `AgentId`) instead of raw `Uuid` for entity identifiers.

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -16,7 +16,7 @@ LLM drivers provide a provider-agnostic interface for interacting with Large Lan
 
 ```mermaid
 graph TD
-    subgraph Core [everruns-core]
+    subgraph Provider [everruns-provider]
         ChatDriver[ChatDriver Trait]
         Registry[DriverRegistry]
         Errors[AgentLoopError]
@@ -53,7 +53,7 @@ graph TD
 
 ### ChatDriver Trait
 
-1. **Trait Definition**: See `crates/core/src/driver_registry.rs` for `ChatDriver` trait, `LlmStreamEvent`, `ProviderType`, and `LlmCallConfig`.
+1. **Trait Definition**: See `crates/provider/src/driver_registry.rs` for `ChatDriver` trait, `LlmStreamEvent`, `ProviderType`, and `LlmCallConfig`.
 
 2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error). In-band provider failures use `LlmStreamError` so stable provider code and HTTP status survive the driver boundary.
 
@@ -86,7 +86,7 @@ name, declared `ServiceKind`s (see `specs/providers.md`), a credential form
 schema, and per-service factories (chat today). Chat drivers are created
 on-demand from `ProviderConfig`. All real built-in providers require API keys;
 `LlmSim` and `External` drivers are exempted (external drivers may authenticate
-via `ProviderMetadata`). See `crates/core/src/driver_registry.rs` for
+via `ProviderMetadata`). See `crates/provider/src/driver_registry.rs` for
 `DriverRegistry` and `DriverDescriptor`.
 
 ### Host-Owned Transport
@@ -158,7 +158,7 @@ Agents can override `max_tokens` via agent config. Cost guardrails should be con
 
 Extended thinking allows models to perform chain-of-thought reasoning before generating responses. Supported by both Anthropic Claude and OpenAI o-series/GPT-5 models.
 
-Anthropic has two thinking request forms, selected per model family by the driver. Recent Claude families (Fable 5, Opus 4.8/4.7, and the 4.6 family) take adaptive thinking (`thinking.type = "adaptive"` plus `output_config.effort`); the budget-based `budget_tokens` form is removed on Fable 5 and Opus 4.8/4.7 and returns 400 there. Older Claude models keep budget-based extended thinking. The family list lives in `crates/anthropic/src/driver.rs` and must stay in sync with the adaptive-thinking profiles in `crates/core/src/model_profiles.rs`.
+Anthropic has two thinking request forms, selected per model family by the driver. Recent Claude families (Fable 5, Opus 4.8/4.7, and the 4.6 family) take adaptive thinking (`thinking.type = "adaptive"` plus `output_config.effort`); the budget-based `budget_tokens` form is removed on Fable 5 and Opus 4.8/4.7 and returns 400 there. Older Claude models keep budget-based extended thinking. The family list lives in `crates/anthropic/src/driver.rs` and must stay in sync with the adaptive-thinking profiles in `crates/provider/src/model_profiles.rs`.
 
 #### Stream Events
 
@@ -291,11 +291,11 @@ sequenceDiagram
 
 | Component | Location |
 |-----------|----------|
-| ChatDriver trait | `crates/core/src/driver_registry.rs` |
-| AgentLoopError | `crates/core/src/error.rs` |
+| ChatDriver trait | `crates/provider/src/driver_registry.rs` |
+| AgentLoopError | `crates/provider/src/error.rs` |
 | OpenAI driver | `crates/openai/src/driver.rs` |
-| Open Responses protocol | `crates/core/src/openresponses_protocol.rs` |
-| Chat Completions protocol | `crates/core/src/openai_protocol.rs` |
+| Open Responses protocol | `crates/provider/src/openresponses_protocol.rs` |
+| Chat Completions protocol | `crates/provider/src/openai_protocol.rs` |
 | Anthropic driver | `crates/anthropic/src/driver.rs` |
 | Gemini driver | `crates/gemini/src/driver.rs` |
 | Bedrock driver | `crates/bedrock/src/driver.rs` |
@@ -330,9 +330,10 @@ gated by the resolved provider type.
 
 Microsoft MAI models (e.g. `mai-code-1-flash`) are served via Azure AI Foundry
 behind an OpenAI-compatible Chat Completions API. The `everruns-mai` crate is a
-standalone, crates.io-publishable provider crate that wraps the core
-`OpenAIProtocolChatDriver` and tags it with `DriverId::Mai`. Model ids resolve
-to the Microsoft-vendor profiles in `crates/core/src/model_profiles.rs` (the
+standalone, crates.io-publishable provider crate that wraps the shared
+`OpenAIProtocolChatDriver` (from `everruns-provider`) and tags it with
+`DriverId::Mai`. Model ids resolve
+to the Microsoft-vendor profiles in `crates/provider/src/model_profiles.rs` (the
 `MICROSOFT_MAI` surface).
 
 ### Model Discovery
@@ -382,7 +383,7 @@ generic, async `AuthHeaderProvider` hook
 (`OpenAIProtocolChatDriver::with_auth_provider` and
 `OpenResponsesProtocolChatDriver::with_auth_provider`); the trait is exported
 from one stable place (`everruns_core::AuthHeaderProvider`, defined in
-`crates/core/src/openai_protocol.rs`). When set, it overrides the default
+`crates/provider/src/openai_protocol.rs`). When set, it overrides the default
 host-keyed `api-key`/bearer logic and is awaited once per HTTP attempt — for the
 Open Responses driver this includes the streaming `/responses` call, every retry
 attempt, and the `/responses/compact` call — so providers can refresh short-lived
@@ -556,7 +557,7 @@ When a request to the OpenAI Responses API sets `previous_response_id`, the prov
 
 Invariant: **a request with `previous_response_id` only carries delta items in `input`** — typically tool results (`function_call_output`) for the prior assistant turn plus any fresh user messages. Prior assistant messages, reasoning items, and the assistant's own function calls are dropped because they live in server-side state. `instructions` (system message) is sent separately and is exempt. Empty `input` is allowed.
 
-`OpenResponsesProtocolChatDriver` enforces this by trimming `input` via `compute_delta_input_items` whenever `previous_response_id` is `Some(_)` (see `crates/core/src/openresponses_protocol.rs`).
+`OpenResponsesProtocolChatDriver` enforces this by trimming `input` via `compute_delta_input_items` whenever `previous_response_id` is `Some(_)` (see `crates/provider/src/openresponses_protocol.rs`).
 
 ### Stateless Gateways
 
@@ -621,7 +622,7 @@ Drivers parse provider-specific headers to determine retry timing:
 
 ### Retry Metadata
 
-On successful completion after retries, `LlmCompletionMetadata` includes retry info (attempts, total wait time, rate limit info). The `llm.generation` event also includes retry info. See `crates/core/src/driver_registry.rs` for `RetryMetadata`.
+On successful completion after retries, `LlmCompletionMetadata` includes retry info (attempts, total wait time, rate limit info). The `llm.generation` event also includes retry info. See `crates/provider/src/driver_registry.rs` for `RetryMetadata`.
 
 ### Implementation Details
 
@@ -643,7 +644,7 @@ The `/v1/responses/compact` endpoint is a context-compression feature for the Op
 
 ### ChatDriver Compact Methods
 
-The `ChatDriver` trait includes `supports_compact()` and `compact()` methods. See `crates/core/src/driver_registry.rs` for `CompactRequest`, `CompactInputItem`, `CompactResponse`, and `CompactOutputItem` types.
+The `ChatDriver` trait includes `supports_compact()` and `compact()` methods. See `crates/provider/src/driver_registry.rs` for `CompactRequest`, `CompactInputItem`, `CompactResponse`, and `CompactOutputItem` types.
 
 ### Provider Support
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -235,7 +235,7 @@ separate usage meanings (`configured`, `resolved`, `exposed`, `invoked`,
 
 ### LLM Provider
 
-Configuration for LLM API providers. See `crates/core/src/provider.rs` for full type definitions.
+Configuration for LLM API providers. See `crates/provider/src/provider.rs` for full type definitions.
 
 Key design points:
 - `provider_type` stored as plain string without CHECK constraint (forward compatibility)
@@ -250,7 +250,7 @@ Default providers and models seeded on startup. See `crates/server/src/seed.rs` 
 
 ### LLM Model
 
-Configuration for a specific model within a provider. See `crates/core/src/model.rs`.
+Configuration for a specific model within a provider. See `crates/provider/src/model.rs`.
 
 Key design points:
 - `source` enum: `manual` (user-added), `discovered` (from provider API), `predefined` (seeded)
@@ -267,7 +267,7 @@ Read-only metadata describing model capabilities, costs, and limits. Computed at
 
 **IMPORTANT:** Never guess or extrapolate profile data (pricing, limits, capabilities). Prefer models.dev when a model is listed there; otherwise source directly from the provider's official documentation (e.g. `developers.openai.com/api/docs/models/<id>`, Anthropic model cards). When a profile is added ahead of the models.dev entry, note the provider-doc source in a comment on the profile block and revisit once models.dev catches up. Never guess values.
 
-See `crates/core/src/model.rs` for `ModelProfile`, `ModelCost`, `ModelLimits`, and `ReasoningEffortConfig` types.
+See `crates/provider/src/model.rs` for `ModelProfile`, `ModelCost`, `ModelLimits`, and `ReasoningEffortConfig` types.
 
 Profiles matched by provider_type + model_id with version normalization (e.g., "gpt-4o-2024-11-20" → "gpt-4o").
 

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -143,7 +143,7 @@ The model's identity, promoted from a runtime-computed shadow type to a first-cl
 
 - **Stable key**: `"{vendor}/{model}"` (e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-5.5`, `openai/text-embedding-3-large`).
 - **Service kind**: which service this model belongs to (`chat`, `embeddings`, `realtime`, ...). Pickers filter on it — chat pickers never show `gpt-realtime-2`; embedding configuration only shows embedding profiles. This removes the per-model special-casing the voice spec required.
-- **Metadata**: vendor, default display name, capabilities (tools, vision, reasoning, structured output), limits, cost, modalities, reasoning-effort config, speed (service-tier) config — everything `LlmModelProfile` carries today (`crates/core/src/model.rs`), still sourced from models.dev cross-referenced with official provider docs (sourcing rules in `specs/models.md` apply unchanged).
+- **Metadata**: vendor, default display name, capabilities (tools, vision, reasoning, structured output), limits, cost, modalities, reasoning-effort config, speed (service-tier) config — everything `LlmModelProfile` carries today (`crates/provider/src/model.rs`), still sourced from models.dev cross-referenced with official provider docs (sourcing rules in `specs/models.md` apply unchanged).
 - **Sources**: built-in code registry (as today) plus discovered profiles persisted from provider metadata (the OpenRouter `supported_parameters` path). Org-custom profiles are out of scope until self-hosted models need them.
 - **Invariant**: every model row has a profile. Discovery that cannot match a known profile creates a minimal one (key derived from the wire id, service `chat`, no cost/limits data — never guessed).
 
@@ -182,7 +182,7 @@ Consumers and their paths:
 
 The credential schema is a shared primitive between drivers and connectors:
 
-- **Schema**: named fields with a type (`password`, `text`, `url`), required flag, optional placeholder / help text / default value, and optional mutually-exclusive **group** label. Drivers and connectors declare schemas the same way (`crates/core/src/credential_schema.rs`); the Settings UI renders both with one form component that lays out discrete typed inputs (multi-field credentials, grouped alternatives) — no hand-authored JSON.
+- **Schema**: named fields with a type (`password`, `text`, `url`), required flag, optional placeholder / help text / default value, and optional mutually-exclusive **group** label. Drivers and connectors declare schemas the same way (`crates/provider/src/credential_schema.rs`); the Settings UI renders both with one form component that lays out discrete typed inputs (multi-field credentials, grouped alternatives) — no hand-authored JSON.
 - **Validation**: ungrouped required fields must be present; fields sharing a group label form one alternative method, and at least one group must be complete (`CredentialFormSchema::validate`). Connectors additionally declare async `validate()` against the upstream API.
 - **Storage**: the submitted field map is assembled into one credential document (`assemble_credential_document`) and encrypted with the AES-256-GCM envelope (`specs/encryption.md`); values are never returned by any API. A lone `api_key` is stored as the raw key; multi-field credentials are stored as a JSON object keyed by field name. At driver-construction time the document is parsed back into the typed `DriverConfig::credentials` map (`parse_credential_document`), the single point where the stored string becomes typed fields for every path (server, worker, sync, dev).
 
@@ -200,7 +200,7 @@ A driver may additionally declare an **interactive OAuth connect flow** so an or
 
 The capability is declared, not special-cased, mirroring services and credential schema:
 
-- `DriverDescriptor::oauth: Option<DriverOAuthConfig>` (`crates/core/src/driver_registry.rs`). `Some` makes "Connect with {provider}" available; `None` means manual entry only. `DriverOAuthConfig` carries the authorize/token endpoints and a `DriverOAuthFlow` wire-flavor discriminator. Adding OAuth to another driver is filling in this field plus a `DriverOAuthFlow` variant — **no new endpoints**.
+- `DriverDescriptor::oauth: Option<DriverOAuthConfig>` (`crates/provider/src/driver_registry.rs`). `Some` makes "Connect with {provider}" available; `None` means manual entry only. `DriverOAuthConfig` carries the authorize/token endpoints and a `DriverOAuthFlow` wire-flavor discriminator. Adding OAuth to another driver is filling in this field plus a `DriverOAuthFlow` variant — **no new endpoints**.
 - Two org-scoped endpoints under the existing provider resource drive every OAuth driver: `GET /v1/providers/{id}/oauth/authorize` (redirects to the provider with PKCE) and `GET /v1/providers/{id}/oauth/callback` (exchanges the code, stores the credential, redirects to Settings → Providers). Both require `provider.manage`.
 
 **OpenRouter** is the first driver to declare it (`DriverOAuthFlow::OpenRouterPkce`). OpenRouter's one-click PKCE flow returns a *user-controlled API key*; the admin authorizes once and the key is stored org-wide. PKCE uses a public client (no client id/secret or app registration). Note OpenRouter's callback URL must be HTTPS on port 443 or 3000 for non-localhost deployments.
@@ -286,11 +286,11 @@ PR-sized slices, each leaving the tree green and self-consistent (code + specs +
 
 The refactor has landed; current implementations live at:
 
-- `crates/core/src/provider.rs` — `Provider` entity + `DriverId`
-- `crates/core/src/model.rs` — `Model` / `ModelWithProvider` entity types
-- `crates/core/src/model_profiles.rs` — built-in profile data
-- `crates/core/src/driver_registry.rs` — `ChatDriver` trait + `DriverRegistry` (string-keyed driver ids, credential schema + service factories); `DriverConfig` typed `credentials` map
-- `crates/core/src/credential_schema.rs` — declared credential form schema (typed fields, groups, validation) + credential-document assemble/parse
+- `crates/provider/src/provider.rs` — `Provider` entity + `DriverId`
+- `crates/provider/src/model.rs` — `Model` / `ModelWithProvider` entity types
+- `crates/provider/src/model_profiles.rs` — built-in profile data
+- `crates/provider/src/driver_registry.rs` — `ChatDriver` trait + `DriverRegistry` (string-keyed driver ids, credential schema + service factories); `DriverConfig` typed `credentials` map
+- `crates/provider/src/credential_schema.rs` — declared credential form schema (typed fields, groups, validation) + credential-document assemble/parse
 - `crates/core/src/traits.rs` — `ProviderStore` + `ResolvedModel`
 - `crates/server/src/services/provider_resolver.rs` — fail-closed resolution (`resolve_service`)
 - `crates/server/src/services/model_sync.rs` — model discovery

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -45,7 +45,7 @@ Note: OpenAI Responses API (`function_call_output`) does not support images in t
 
 ### Tool Hints
 
-`ToolHints` provides semantic metadata about a tool's behavioral properties. See `crates/core/src/tool_types.rs` for the struct definition. All fields are `Option<bool>` — `None` means unspecified.
+`ToolHints` provides semantic metadata about a tool's behavioral properties. See `crates/provider/src/tool_types.rs` for the struct definition. All fields are `Option<bool>` — `None` means unspecified.
 
 Follows the [MCP tool annotations](https://spec.modelcontextprotocol.io) convention plus everruns-specific hints:
 

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -203,7 +203,7 @@ let use_tool_search = profile.tool_search && config.tools.len() >= TOOL_SEARCH_T
 
 ## Model Profile Updates
 
-Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/core/src/model_profiles.rs` for current profile definitions. OpenAI sets the flag per model literal (the `gpt-5.4*` / `gpt-5.5*` families); Anthropic sets it centrally by family in `anthropic_family_supports_tool_search` (Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, Fable 5 — per docs.claude.com), since the support rule is a clean family cutoff.
+Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/provider/src/model_profiles.rs` for current profile definitions. OpenAI sets the flag per model literal (the `gpt-5.4*` / `gpt-5.5*` families); Anthropic sets it centrally by family in `anthropic_family_supports_tool_search` (Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, Fable 5 — per docs.claude.com), since the support rule is a clean family cutoff.
 
 A model's `tool_search: true` flag must be backed by a verified end-to-end round-trip
 (deferred-load → schema fetch → tool call) against the live provider, not just the
@@ -229,7 +229,7 @@ There are two enforcement points, and they sit at different layers:
 
 ## Driver Changes
 
-The OpenAI driver extends `ResponsesTool` with `Namespace` and `ToolSearch` variants and adds `convert_tools_with_search()` (namespace grouping + defer_loading + `{"type":"tool_search"}`). See `crates/core/src/openresponses_protocol.rs`.
+The OpenAI driver extends `ResponsesTool` with `Namespace` and `ToolSearch` variants and adds `convert_tools_with_search()` (namespace grouping + defer_loading + `{"type":"tool_search"}`). See `crates/provider/src/openresponses_protocol.rs`.
 
 The Anthropic driver adds an `AnthropicToolEntry` (untagged: a function tool or a `tool_search_tool_bm25_20251119` server tool) and `convert_tools_with_search()`, which marks deferrable tools `defer_loading: true` and prepends the search-tool entry. No namespaces — Anthropic defers each tool individually. The hosted search-tool entry is always non-deferred, which also satisfies Anthropic's "at least one tool must be non-deferred" constraint. No beta header is required. See `crates/anthropic/src/driver.rs`. The streaming parser ignores the server-side `server_tool_use` / `tool_search_tool_result` blocks (parse-or-skip) and captures the model's subsequent normal `tool_use` for the discovered tool.
 


### PR DESCRIPTION
## What changed

Follow-up to #2825 (the `everruns-provider` extraction). That PR moved 17 modules from `crates/core/src/` to `crates/provider/src/` and pointed the provider crates at `everruns-provider`, which left two kinds of stale artifacts. This PR fixes them.

**1. Release config (the important one — prevents a broken release).** The published provider crates (openai, anthropic, openrouter, bedrock, gemini) now pin `everruns-provider` by exact version, but it was absent from the publish pipeline, so the next `cargo publish` run would fail on a missing dependency.
- `publish-crates.yml`: add `everruns-provider` to the publish-order `CRATES` array (before `everruns-core`, which depends on it); swap the five providers' `dependency_versions` from `everruns-core` → `everruns-provider` (they no longer have `everruns-core` as a regular dependency — only a dev-dependency); add `everruns-provider` to core's pinned deps.
- `sync-publish-pin-versions.py`: mirror the five providers in `INNER_PINS`; add `everruns-provider` to `WORKSPACE_PIN_DEPS` so the release bumps its version pin in lockstep.
- `mai`/`fireworks` (unpublished): drop the version from their `everruns-provider` path dep to match the unpublished-crate convention.

**2. Docs.**
- ~37 stale `crates/core/src/<module>.rs` source-path references across 11 specs → `crates/provider/src/`.
- `code-organization.md`: rewrite the crate-dependency conventions (providers depend on `everruns-provider`, not `everruns-core` with `default-features = false`; core is a dev-dep for their tests).
- `architecture.md`: add `everruns-provider` to the crate map/tree; point the `ChatDriver` trait + protocol implementations at it.
- `llm-drivers.md`: the architecture diagram groups `ChatDriver`/`DriverRegistry`/`AgentLoopError` under `everruns-provider`.
- Provider crate READMEs: the `ChatDriver` contract now comes from `everruns-provider`; fixed the provider-only snippets that imported `everruns_core::DriverRegistry` (a crate those crates no longer depend on) → `everruns_provider::DriverRegistry`. openai's full-app example, which pulls `everruns-runtime` (→ core), is left as-is.

## Why

Leaving the specs pointing at moved files and the publish config missing a now-required dependency are both regressions introduced by the extraction. The release-config gap is exactly what `code-organization.md` warns about ("published crates that pin a sibling by exact version must be registered in both publish-crates.yml and sync-publish-pin-versions.py").

## Before / After

Docs/config only — no code changes, no runtime behavior change.

- `python3 scripts/sync-publish-pin-versions.py --check` → `all path-dep pins at 0.17.12` (passes).
- `cargo metadata` resolves the whole workspace after the mai/fireworks manifest edits.

## Risk

- **Low.** No Rust source changed. The publish-config change only takes effect at release time; validated locally with the repo's own `--check`. Doc edits are text-only.

## Security

- No security-relevant changes. Documentation and release-tooling configuration only; no code, endpoints, or trust boundaries touched.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — docs/config; validated with `sync-publish-pin-versions.py --check`)
- [x] Backward compatibility considered (docs/config only; no API surface change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01MS4xWKHMu3AyQeCirSaBN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MS4xWKHMu3AyQeCirSaBN1)_