### PR TITLE
refactor(core): avoid if_let_guard in spawn-mode parsing

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1427,12 +1427,14 @@ impl Tool for SpawnAgentTool {
         };
         let mode = match arguments.get("mode").and_then(Value::as_str) {
             None => SpawnMode::Foreground,
-            Some(value) if let Some(mode) = SpawnMode::parse(value) => mode,
-            Some(other) => {
-                return ToolExecutionResult::tool_error(format!(
-                    "Invalid mode: {other}. Expected background, foreground"
-                ));
-            }
+            Some(value) => match SpawnMode::parse(value) {
+                Some(mode) => mode,
+                None => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Invalid mode: {value}. Expected background, foreground"
+                    ));
+                }
+            },
         };
         let timeout_secs = arguments
             .get("wait_timeout_secs")

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -386,13 +386,17 @@ impl SpawnAgentHandoffMode {
     fn parse(value: Option<&str>, context: &ToolContext) -> std::result::Result<Self, String> {
         let explicit = match value.map(str::trim).filter(|s| !s.is_empty()) {
             None => None,
-            Some(value) if let Some(mode) = SpawnMode::parse(value) => Some(Self::Spawn(mode)),
-            Some("invite") => Some(Self::Invite),
-            Some(other) => {
-                return Err(format!(
-                    "Invalid mode: \"{other}\". Valid modes: background, foreground, invite."
-                ));
-            }
+            Some(value) => match SpawnMode::parse(value) {
+                Some(mode) => Some(Self::Spawn(mode)),
+                None => match value {
+                    "invite" => Some(Self::Invite),
+                    other => {
+                        return Err(format!(
+                            "Invalid mode: \"{other}\". Valid modes: background, foreground, invite."
+                        ));
+                    }
+                },
+            },
         };
         let has_registry = context.session_task_registry.is_some();
         match explicit {

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -834,12 +834,14 @@ fn resolve_spawn_mode(
         .filter(|s| !s.is_empty())
     {
         None => None,
-        Some(value) if let Some(mode) = SpawnMode::parse(value) => Some(mode),
-        Some(other) => {
-            return Err(ToolExecutionResult::tool_error(format!(
-                "Invalid mode: \"{other}\". Valid modes: background, foreground."
-            )));
-        }
+        Some(value) => match SpawnMode::parse(value) {
+            Some(mode) => Some(mode),
+            None => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Invalid mode: \"{value}\". Valid modes: background, foreground."
+                )));
+            }
+        },
     };
     let has_registry = context.session_task_registry.is_some();
     match explicit {


### PR DESCRIPTION
## What changed
Rewrites the three `spawn_agent` mode-parsing match arms in `a2a_delegation`, `agent_handoff`, and `subagents` from `if let` match guards (`if_let_guard`) to equivalent nested `match` expressions. No behavior change: the same mode strings parse to the same variants, and the same `Invalid mode: …` errors are returned for unknown input.

## Why
`if_let_guard` is stabilized on the toolchain CI builds with (the repo-pinned `1.96.0`), so `main` and the crates.io publish of 0.17.13 are green. But the feature is still gated as unstable on lower stable toolchains — including the crate's own declared MSRV floor (`rust-version = "1.94.0"`) and default stable installs that lag the pin. On those, `everruns-core` fails to compile with:

```
error[E0658]: `if let` guards are experimental
```

This surfaced as a consumer reporting 0.17.13 "broken on stable" — the actual cause was building with a non-pinned older stable (rustc 1.94.1) instead of the pinned 1.96.0. Dropping the feature removes that toolchain-version dependency so core compiles across all of them, not just the pin.

## Before / After
Same source, toolchain where `if_let_guard` is gated (e.g. rustc 1.94.1):

- **Before:** `cargo build -p everruns-core` → `error[E0658]: if let guards are experimental` (×3), build fails.
- **After:** compiles cleanly.

On the pinned `1.96.0`, both before and after compile — this only widens toolchain support; it does not change behavior. Evidence on pinned toolchain:

```
cargo clippy -p everruns-core --all-features --all-targets -- -D warnings   # clean
test capabilities::subagents::tests::spawn_agent_subagent_rejects_invalid_mode ... ok
```

## Risk
- Low
- Pure control-flow refactor of already-tested parse paths; behavior is identical. The one visible surface is the invalid-mode error string, which is unchanged and asserted by an existing test.

## Security
- Threat categories reviewed: TM-TOOL (spawn_agent mode parsing sits on the tool-execution path).
- Findings and resolutions: none. The change does not alter input handling, validation, or which modes are accepted/rejected — it only restructures the same conditional. No security-relevant behavior change.

## Follow-ups
- **Alternative to this PR (team's call):** if you'd rather keep `if_let_guard`, bump `rust-version` to the version where it stabilized instead of merging this — that documents the real floor rather than silently requiring it. This PR takes the other path (keep MSRV low, drop the feature).
- **Unrelated CI hardening (not needed for this incident):** the `ci-success` "Build Check" aggregator treats a *skipped* required job as success. That did not fire here (main CI genuinely ran and passed), but it's a latent branch-protection footgun worth closing separately.
- No follow-ups required for this change itself.

## Checklist
- [x] Tests added or updated — existing `spawn_agent_subagent_rejects_invalid_mode` covers the refactored path; behavior identical so no new test needed
- [x] Backward compatibility considered — no API or behavior change
- [x] Security review performed against relevant threat model categories — TM-TOOL, no findings
- [ ] Final CI ran checks affected by this PR — pending
- [ ] All review comments addressed — pending

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKXC4fGMRXt7vYBQpkHZ8J)_