### PR TITLE
feat(provider): add Kimi K3 model profile

### DIFF
--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -436,6 +436,11 @@ static REGISTRY: &[ModelDescriptor] = &[
         OPENAI_COMPAT,
     ),
     md(
+        &["kimi-k3", "moonshotai/kimi-k3"],
+        ModelVendor::Moonshot,
+        OPENAI_COMPAT,
+    ),
+    md(
         &["grok-4.3", "x-ai/grok-4.3", "xai/grok-4.3"],
         ModelVendor::XAi,
         OPENAI_COMPAT,
@@ -2409,6 +2414,49 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
             }),
             modalities: Some(ModelModalities {
                 input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            speed: None,
+            verbosity: None,
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
+        // Moonshot Kimi K3 — flagship multimodal Kimi model with a 1M-token
+        // context window. Source: models.dev (moonshotai provider). models.dev
+        // lists graded reasoning effort (low/high/max), but like the other
+        // OpenAI-compatible third-party models here we don't wire a graded
+        // effort selector; `reasoning: true` still gates reasoning support.
+        // Knowledge cutoff not published.
+        "kimi-k3" | "moonshotai/kimi-k3" => Some(ModelProfile {
+            name: "Kimi K3".into(),
+            family: "kimi-k3".into(),
+            description: None,
+            release_date: Some("2026-07-16".into()),
+            last_updated: Some("2026-07-16".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: true,
+            cost: Some(ModelCost {
+                input: 3.00,
+                output: 15.00,
+                cache_read: Some(0.30),
+                cost_tiers: vec![],
+            }),
+            limits: Some(ModelLimits {
+                context: 1_048_576,
+                input: None,
+                output: 131_072,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Video],
                 output: vec![Modality::Text],
             }),
             reasoning_effort: None,
@@ -4860,6 +4908,8 @@ mod tests {
             ("MAI-1-preview", "MAI-1-preview"),
             ("MiniMax-M3", "MiniMax-M3"),
             ("kimi-k2-thinking", "Kimi K2 Thinking"),
+            ("kimi-k3", "Kimi K3"),
+            ("moonshotai/kimi-k3", "Kimi K3"),
             ("grok-4.3", "Grok 4.3"),
             ("x-ai/grok-4.3", "Grok 4.3"),
         ];
@@ -4868,6 +4918,30 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing profile for {id}"));
             assert_eq!(profile.name, name, "wrong profile for {id}");
         }
+    }
+
+    #[test]
+    fn test_kimi_k3_profile() {
+        let profile = get_model_profile(&DriverId::OpenAICompletions, "kimi-k3").unwrap();
+        assert_eq!(profile.name, "Kimi K3");
+        assert_eq!(profile.family, "kimi-k3");
+        assert!(profile.reasoning);
+        assert!(profile.tool_call);
+        assert!(profile.open_weights);
+        assert!(!profile.temperature);
+        let cost = profile.cost.as_ref().unwrap();
+        assert_eq!(cost.input, 3.00);
+        assert_eq!(cost.output, 15.00);
+        assert_eq!(cost.cache_read, Some(0.30));
+        assert!(cost.cost_tiers.is_empty());
+        let limits = profile.limits.as_ref().unwrap();
+        assert_eq!(limits.context, 1_048_576);
+        assert_eq!(limits.output, 131_072);
+        let modalities = profile.modalities.as_ref().unwrap();
+        assert_eq!(
+            modalities.input,
+            vec![Modality::Text, Modality::Image, Modality::Video]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed
Adds the Moonshot **Kimi K3** model to the built-in profile registry. It resolves
under the OpenAI-compatible surfaces (OpenAI, OpenRouter, OpenAI Completions) via
the bare `kimi-k3` id and the `moonshotai/kimi-k3` gateway alias. With the profile
in place, callers using Kimi K3 now get correct pricing/cost estimation, context
and output limits, modality/capability flags, and vendor branding (Moonshot),
instead of falling back to no profile.

Profile values (sourced verbatim from models.dev, moonshotai provider):
- Context 1,048,576 (1M) / output 131,072
- Cost $3.00 input, $15.00 output, $0.30 cache read per million tokens (no tiers)
- Input modalities text/image/video, output text
- reasoning, tool calling, structured output, open weights; temperature not supported
- Released/updated 2026-07-16; knowledge cutoff unpublished (left unset)

models.dev lists graded reasoning effort (low/high/max) for K3, but — consistent
with every other OpenAI-compatible third-party model in this registry
(kimi-k2-thinking, minimax-m3, grok-4.3, …) — no graded effort selector is wired.
The `reasoning: true` flag still gates reasoning support. See Follow-ups.

## Why
Kimi K3 shipped on models.dev but had no profile here, so cost estimation and the
model picker/capability metadata had nothing to resolve for it.

## Before / After
Behavior is exercised by unit tests resolving the id through the registry.

- **Before:** `get_model_profile(OpenAICompletions, "kimi-k3")` → `None`; no cost
  estimate available for Kimi K3 generations.
- **After:** resolves to the `Kimi K3` profile; `estimate_cost_usd` and picker
  metadata work. New `test_kimi_k3_profile` asserts name/family, cost
  ($3/$15/$0.30, no tiers), limits (1M context / 131K output), input modalities
  (text/image/video), and capability flags. `test_third_party_profiles_via_openai_completions`
  covers both the bare id and the `moonshotai/` alias.

```
cargo test -p everruns-provider model_profiles
test result: ok. 72 passed; 0 failed; 0 ignored
```

`bash scripts/lib/pre-push.sh` → all checks pass (fmt, clippy `-D warnings`,
Cargo.lock, migration ordering/immutability, server test enumeration, specs index,
author attribution).

## Risk
- Low
- Pure additive static data plus tests. No control-flow, schema, or API changes.
  Worst case is an incorrect constant, which the assertion test guards against and
  which is sourced directly from models.dev.

## Security
- Threat categories reviewed: TM-LLM (model parameters/metadata). The change adds
  static, non-secret model metadata (pricing, limits, capability flags) to a
  compile-time registry. No user input, no injection surface, no auth/authz, no
  queries, no new dependencies, no logging of sensitive data.
- Findings and resolutions: none.

## Follow-ups
- Wire a graded reasoning-effort selector for Kimi K3 (models.dev exposes
  low/high/max via `output_config.effort`). Deferred because no third-party
  OpenAI-compatible model in this registry currently wires graded effort, and the
  enum→wire mapping for "max" over the OpenRouter/Completions passthrough is not
  verified here; doing it correctly is a separate, testable change. Safe to defer:
  `reasoning: true` already enables reasoning for the model.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cEqJgWWBgQkdTLrBN7x64)_