### PR TITLE
chore(release): prepare v0.17.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.14] - 2026-07-19
+
+### Highlights
+
+- **Kimi K3 model** — Added a model profile for Kimi K3, so it can be selected as a provider model ([#2848](https://github.com/everruns/everruns/pull/2848)).
+
+### What's Changed
+
+- feat(provider): add Kimi K3 model profile ([#2848](https://github.com/everruns/everruns/pull/2848)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): avoid if_let_guard in spawn-mode parsing ([#2847](https://github.com/everruns/everruns/pull/2847)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.13] - 2026-07-19
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.13"
+version = "0.17.14"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3159,11 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.13"
+version = "0.17.14"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4859,11 +4859,12 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -4874,11 +4875,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
+dependencies = [
+ "jiff-core",
  "proc-macro2 1.0.107",
  "quote 1.0.47",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.13"
+version = "0.17.14"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.13" }
-everruns-provider = { path = "crates/provider", version = "0.17.13" }
+everruns-core = { path = "crates/core", version = "0.17.14" }
+everruns-provider = { path = "crates/provider", version = "0.17.14" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.13" }
-everruns-ard = { path = "crates/ard", version = "0.17.13" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.14" }
+everruns-ard = { path = "crates/ard", version = "0.17.14" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.13" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.14" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.13",
+  "version": "0.17.14",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.13" }
+everruns-provider = { path = "../provider", version = "0.17.14" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.13" }
+everruns-provider = { path = "../provider", version = "0.17.14" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.13", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.14", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.13", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.14", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.13" }
+everruns-provider = { path = "../provider", version = "0.17.14" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.13" }
+everruns-provider = { path = "../provider", version = "0.17.14" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.13" }
+everruns-provider = { path = "../provider", version = "0.17.14" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed

Prepares the v0.17.14 release: bumps the workspace version (0.17.13 → 0.17.14), UI package version, path-dependency pins, and lockfile, and adds the CHANGELOG entry.

User-facing change in this release:
- **Kimi K3 model** — new provider model profile so Kimi K3 can be selected ([#2848](https://github.com/everruns/everruns/pull/2848)).

Also includes an internal refactor of spawn-mode parsing ([#2847](https://github.com/everruns/everruns/pull/2847)).

## Why

Cut a maintenance release capturing changes merged since v0.17.13.

## Before / After

Version-only release-prep change. `python3 scripts/sync-publish-pin-versions.py --check` → `all path-dep pins at 0.17.14`; migration ordering check → `migrations sequential (001..108)`.

## Risk
- Low
- Release metadata only; no runtime behavior change in this PR.

## Security
- Threat categories reviewed: No security-relevant code changes (version/changelog/lockfile bumps only).
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Post-merge
The release workflow will tag `v0.17.14`, create the GitHub Release from CHANGELOG.md, and trigger the versioned image/crates publish.

## Checklist
- [x] Tests added or updated (n/a — release prep)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)