### PR TITLE
test(ui): browser regression test for Settings org create dialog

### DIFF
--- a/apps/ui/e2e/settings-organization-create.spec.ts
+++ b/apps/ui/e2e/settings-organization-create.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// EVE-796 reproduction: the Settings > Organization page "Create Organization"
+// button must open the create-organization dialog in a real browser. The
+// existing jsdom unit test passes, so this exercises the real base-ui Dialog +
+// CSS rendering path that jsdom cannot cover.
+
+const DEFAULT_ORG_ID = "org_00000000000000000000000000000001";
+
+async function mockAppApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    let json: unknown;
+
+    if (pathname === "/api/v1/auth/config") {
+      json = {
+        mode: "none",
+        password_auth_enabled: false,
+        oauth_providers: [],
+        signup_enabled: false,
+      };
+    } else if (pathname === "/api/v1/auth/me") {
+      json = {
+        id: "user-1",
+        email: "dev@example.com",
+        name: "Dev User",
+        roles: [],
+        email_verified: true,
+        organizations: [
+          { public_id: DEFAULT_ORG_ID, name: "Default", role: "owner" },
+          { public_id: "org_second", name: "Second Org", role: "member" },
+        ],
+      };
+    } else if (pathname.endsWith("/feature-flags")) {
+      json = {
+        global_chat: false,
+        notifications: false,
+        evals: false,
+        app_budgets: false,
+        agent_versions: false,
+        voice: false,
+        agent_delegation: false,
+        observers: false,
+        public_chat: false,
+      };
+    } else if (pathname.endsWith("/switch-org")) {
+      json = { success: true, org_id: DEFAULT_ORG_ID };
+    } else if (/^\/api\/v1\/orgs\/[^/]+$/.test(pathname)) {
+      json = {
+        id: DEFAULT_ORG_ID,
+        name: "Default",
+        default_model_id: null,
+        default_harness_id: "harness-generic",
+        base_harness_id: "harness-base",
+      };
+    } else if (pathname.endsWith("/harnesses")) {
+      json = {
+        data: [
+          { id: "harness-generic", name: "Generic" },
+          { id: "harness-base", name: "Base" },
+        ],
+        has_more: false,
+        total: 2,
+      };
+    } else if (pathname.endsWith("/config")) {
+      json = { policies: {} };
+    } else {
+      json = { data: [], has_more: false, total: 0 };
+    }
+
+    await route.fulfill({ json });
+  });
+}
+
+test.describe("Settings > Organization create dialog", () => {
+  test.beforeEach(async ({ context, page, baseURL }) => {
+    const origin = new URL(baseURL ?? "http://localhost:9100");
+    await context.addCookies([
+      { name: "access_token", value: "e2e-only", domain: origin.hostname, path: "/" },
+    ]);
+    await mockAppApi(page);
+  });
+
+  // Cover both responsive branches of the button: the desktop `xl:w-auto`
+  // header button and the narrow-viewport full-width variant.
+  for (const viewport of [
+    { name: "desktop", width: 1440, height: 2000 },
+    { name: "mobile", width: 768, height: 1400 },
+  ]) {
+    test(`Create Organization button opens the dialog (${viewport.name})`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto("/settings/organization");
+
+      const createButton = page.getByRole("button", { name: "Create Organization" });
+      await expect(createButton).toBeVisible();
+      await createButton.scrollIntoViewIfNeeded();
+      await createButton.click();
+
+      // The dialog should render its heading and the name textbox.
+      await expect(page.getByRole("heading", { name: "Create Organization" })).toBeVisible();
+      const nameInput = page.getByRole("textbox", { name: "Name" });
+      await expect(nameInput).toBeVisible();
+
+      // The dialog must be interactive, not merely mounted-but-hidden.
+      await nameInput.fill("Repro Org");
+      await expect(nameInput).toHaveValue("Repro Org");
+    });
+  }
+});


### PR DESCRIPTION
## What changed
Adds a real-browser Playwright e2e test (`apps/ui/e2e/settings-organization-create.spec.ts`) asserting that the **Settings > Organization "Create Organization" button opens an interactive create-organization dialog**, across both responsive branches (desktop `xl:w-auto` and narrow-viewport full-width). No product code changes.

## Why
EVE-796 reported the Settings > Organization "Create Organization" button "does nothing" on the deployed SaaS UI, while the identical dialog worked from the sidebar org switcher.

Investigation against current `main`:
- The button wiring is correct — `onClick={() => setCreateDialogOpen(true)}` driving `<Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>`, the exact controlled pattern used by ~30 other dialogs in the app (including the dashboard "New Session" dialog).
- The existing jsdom unit test (`settings-organization.test.tsx`) already drives click → open → fill → submit and passes — so it structurally **cannot** catch a browser-only rendering regression.
- A real-browser Playwright run of the actual `/settings/organization` route opens the dialog correctly on both desktop and mobile.

So the reported failure does **not** reproduce against current `main`; it was deployment-specific/transient (stale asset or smoke-test false negative). Per the process-issues "never blind-patch a symptom you have not observed" rule, no speculative product fix is made. The deliverable is the browser-level regression test that closes the coverage gap the jsdom test leaves and guards the reported path in CI's `ui-e2e` job.

## Before / After
No product behavior change. Test evidence:

```
$ pnpm exec playwright test settings-organization-create --project=chromium
  ✓  Create Organization button opens the dialog (desktop) (5.2s)
  ✓  Create Organization button opens the dialog (mobile)  (5.1s)
  2 passed
```

Before: only jsdom coverage for this flow (blind to real-browser rendering). After: real-browser coverage runs in CI on any `apps/ui/**` change.

## Risk
- Low
- Test-only addition. Worst case is a flaky/failing e2e; the spec reuses the existing e2e harness's mocking and cookie-auth pattern and asserts an interactive (fill-able) dialog, not merely a mounted node.

## Security
- Threat categories reviewed: No security-relevant code changes — test-only addition using mocked API responses; no auth/authz/data-path/runtime code is touched.
- Findings and resolutions: none.

## Follow-ups
- The reported symptom was not reproducible in-repo. If the deployed SaaS UI still exhibits it, it is a deployment/asset-staleness or environment issue outside this repo's code, not a code defect — flagged on EVE-796 for ops verification rather than deferred code work.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8hTaL7NRzGUr47h3ntdJS)_