### PR TITLE
style(docs): refine sidebar hierarchy

### DIFF
--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -61,6 +61,35 @@
 }
 
 /* Sidebar links - left border accent for active state (Slate design) */
+.sidebar-content a,
+.sidebar-content summary {
+  border-radius: 0;
+}
+
+/* Nested groups are navigation controls, not section headings. Keep a quiet
+   three-step hierarchy: top-level group, nested group, then page link. */
+.sidebar-content ul ul > li > details > summary {
+  border-left: 2px solid transparent;
+  margin-left: -2px;
+  padding-left: 0.5rem;
+}
+
+.sidebar-content ul ul > li > details > summary .large {
+  color: inherit;
+  font-size: 0.9375rem;
+  font-weight: 400;
+}
+
+.sidebar-content ul ul > li > details > summary .caret {
+  font-size: 1rem;
+  opacity: 0.6;
+}
+
+.sidebar-content ul ul > li > details > summary:focus-visible {
+  outline: 2px solid #d4a43a;
+  outline-offset: 2px;
+}
+
 :root[data-theme="light"] .sidebar-content a {
   color: #404040;
   border-left: 2px solid transparent;
@@ -69,6 +98,15 @@
 }
 
 :root[data-theme="light"] .sidebar-content a:hover {
+  color: #0a0a0a;
+  background: #f5f5f5;
+}
+
+:root[data-theme="light"] .sidebar-content ul ul > li > details > summary {
+  color: #404040;
+}
+
+:root[data-theme="light"] .sidebar-content ul ul > li > details > summary:hover {
   color: #0a0a0a;
   background: #f5f5f5;
 }
@@ -88,6 +126,15 @@
 }
 
 :root[data-theme="dark"] .sidebar-content a:hover {
+  color: #ffffff;
+  background: #1a1a1a;
+}
+
+:root[data-theme="dark"] .sidebar-content ul ul > li > details > summary {
+  color: #a0a0a0;
+}
+
+:root[data-theme="dark"] .sidebar-content ul ul > li > details > summary:hover {
   color: #ffffff;
   background: #1a1a1a;
 }


### PR DESCRIPTION
## What changed

Nested documentation sidebar groups now read as secondary navigation instead of competing with top-level section headings. They use regular-weight 15px labels, quieter carets, full-row hover feedback, square Slate corners, and a visible keyboard focus ring in both themes.

## Why

Expandable capability categories used the same bold treatment as the top-level Capabilities section, flattening the hierarchy and making a long sidebar harder to scan.

## Before / After

- Before: nested category labels rendered at 600 weight and 16px, matching the visual emphasis of top-level groups; expandable rows had no matching hover treatment.
- After: rendered verification reports 400 weight, 15px labels, 16px carets at 0.6 opacity, and theme-aware hover/focus feedback. Desktop and mobile sidebars were smoke-tested in light and dark themes.

Validation:
- `just pre-push`
- `cd apps/docs && astro check`
- `cd apps/docs && astro build`
- Internal link validation and notebook build verification

## Risk

- Low
- The selectors intentionally affect expandable groups nested anywhere in the documentation sidebar; an upstream Starlight markup change could require selector maintenance.

## Security

- Threat categories reviewed: TM-WEB
- Findings and resolutions: No security-relevant behavior changed. The CSS only adjusts static typography and interaction presentation; it does not render content, execute scripts, change dependencies, or touch authentication, data, network, or trust boundaries. No threat-model update is needed.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated (not applicable for CSS-only styling; covered by rendered smoke tests and the docs build)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review comments were submitted)
