### PR TITLE
chore(release): prepare v0.17.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.15] - 2026-07-20
+
+### Highlights
+
+- **Claim-level citations** — Added composable citation capabilities so agents can attach sources directly to individual claims ([#2852](https://github.com/everruns/everruns/pull/2852)).
+
+### What's Changed
+
+- feat(citations): claim-level citations as composable capabilities ([#2852](https://github.com/everruns/everruns/pull/2852)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): validate tool context services ([#2854](https://github.com/everruns/everruns/pull/2854)) by [@chaliy](https://github.com/chaliy)
+- style(docs): refine sidebar hierarchy ([#2853](https://github.com/everruns/everruns/pull/2853)) by [@chaliy](https://github.com/chaliy)
+- test(ui): browser regression test for Settings org create dialog ([#2851](https://github.com/everruns/everruns/pull/2851)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.14] - 2026-07-19
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1146,9 +1146,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1294,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2 1.0.107",
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.14"
+version = "0.17.15"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3159,11 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.14"
+version = "0.17.15"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3472,9 +3472,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -4324,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4550,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4859,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -4885,9 +4885,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
 dependencies = [
  "jiff-core",
  "proc-macro2 1.0.107",
@@ -5128,9 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libgit2-sys"
@@ -7429,7 +7429,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -8136,7 +8136,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -8178,9 +8178,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -8218,7 +8218,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -8913,9 +8913,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
@@ -9158,7 +9158,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -9172,9 +9172,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -9194,9 +9194,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9238,9 +9238,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -10758,18 +10758,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.14"
+version = "0.17.15"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.14" }
-everruns-provider = { path = "crates/provider", version = "0.17.14" }
+everruns-core = { path = "crates/core", version = "0.17.15" }
+everruns-provider = { path = "crates/provider", version = "0.17.15" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.14" }
-everruns-ard = { path = "crates/ard", version = "0.17.14" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.15" }
+everruns-ard = { path = "crates/ard", version = "0.17.15" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.14" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.15" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.14",
+  "version": "0.17.15",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.14" }
+everruns-provider = { path = "../provider", version = "0.17.15" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.14" }
+everruns-provider = { path = "../provider", version = "0.17.15" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.14", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.15", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.14", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.15", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.14" }
+everruns-provider = { path = "../provider", version = "0.17.15" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.14" }
+everruns-provider = { path = "../provider", version = "0.17.15" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.14" }
+everruns-provider = { path = "../provider", version = "0.17.15" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## Release v0.17.15

This PR prepares the v0.17.15 release.

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Add highlights/screenshots if needed
- [x] Verify version numbers updated
- [x] CI passes

### Validation
- `python3 scripts/sync-publish-pin-versions.py --check`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
- Latest push-only live integration workflows and Integration Live Sweep are green

### Risk
Low. This release-only change updates package versions, exact internal publish pins, generated lockfiles, and release notes. There are no migration or operator-visible upgrade caveats.

### Security
No security-relevant runtime behavior changes. The dependency graph is unchanged apart from lockfile-compatible patch refreshes generated by the required release command; CI dependency licensing and published-crate validation remain required.

### Follow-ups
No follow-ups.

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.17.15`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Trigger CLI/server/worker binaries and crates.io publishing