### PR TITLE
fix(compaction): preserve native compact context

### DIFF
--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -30,6 +30,7 @@ fn config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/anthropic/tests/parallel_tool_calls_live.rs
+++ b/crates/anthropic/tests/parallel_tool_calls_live.rs
@@ -54,6 +54,7 @@ fn config_with(parallel: Option<bool>) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -49,9 +49,7 @@ use crate::llm_retry::{
 };
 use crate::message::{Message, MessageRole};
 use crate::message_retriever::MessageRetriever;
-use crate::openresponses_protocol::{
-    CompactInputItem, CompactRequest, compact_output_to_messages, messages_to_compact_input,
-};
+use crate::openresponses_protocol::{CompactRequest, messages_to_compact_input};
 use crate::output_guardrail::{
     ArmedGuardrail, OutputGuardrailContext, PostGenerationOutputContext, PostGenerationProvider,
     TrippedGuardrail, evaluate_guardrails, evaluate_post_generation_guardrails,
@@ -1772,7 +1770,7 @@ impl ReasonAtom {
             llm_config_builder = llm_config_builder.with_metadata("model_id", model_id.to_string());
         }
 
-        let llm_config = llm_config_builder
+        let mut llm_config = llm_config_builder
             .previous_response_id(previous_response_id.clone())
             .volatile_suffix_len(volatile_suffix_len)
             .build();
@@ -2162,11 +2160,17 @@ impl ReasonAtom {
 
                         let compact_input = messages_to_compact_input(messages_to_compact);
                         let input_count = compact_input.len();
+                        let (compact_input, compact_previous_response_id) =
+                            if stateful_response_continuation {
+                                (Vec::new(), previous_response_id.clone())
+                            } else {
+                                (compact_input, None)
+                            };
 
                         let compact_request = CompactRequest {
                             model: runtime_agent.model.clone(),
                             input: compact_input,
-                            previous_response_id: previous_response_id.clone(),
+                            previous_response_id: compact_previous_response_id,
                             instructions: if has_system_prompt {
                                 Some(runtime_agent.system_prompt.clone())
                             } else {
@@ -2176,9 +2180,6 @@ impl ReasonAtom {
 
                         match chat_driver.compact(compact_request).await {
                             Ok(Some(compact_response)) => {
-                                let (compacted_messages, compaction_items) =
-                                    compact_output_to_messages(&compact_response.output);
-
                                 let input_tokens_after = compact_response
                                     .usage
                                     .as_ref()
@@ -2190,46 +2191,26 @@ impl ReasonAtom {
                                     Some(step_start.elapsed().as_millis() as u64),
                                 ));
 
-                                let mut compacted_llm_messages = Vec::new();
-                                if has_system_prompt {
-                                    compacted_llm_messages.push(llm_messages_for_call[0].clone());
-                                }
-                                compacted_llm_messages.extend(compacted_messages);
-
-                                for item in compaction_items {
-                                    if let CompactInputItem::Compaction { encrypted_content } = item
-                                    {
-                                        compacted_llm_messages.push(LlmMessage {
-                                            role: LlmMessageRole::System,
-                                            content: LlmMessageContent::Text(format!(
-                                                "[COMPACTED_CONTEXT:{encrypted_content}]"
-                                            )),
-                                            tool_calls: None,
-                                            tool_call_id: None,
-                                            phase: None,
-                                            thinking: None,
-                                            thinking_signature: None,
-                                        });
-                                    }
-                                }
-
-                                llm_messages_for_call =
-                                    crate::tool_call_integrity::retain_complete_llm_tool_exchanges(
-                                        compacted_llm_messages,
-                                    );
+                                let messages_after = compact_response.output.len();
+                                llm_config.previous_response_id = None;
+                                llm_config.provider_opaque_context = Some(
+                                    crate::driver_registry::ProviderOpaqueContext::OpenResponsesCompact {
+                                        output: compact_response.output,
+                                    },
+                                );
 
                                 let step_duration = step_start.elapsed().as_millis() as u64;
                                 strategies_used.push("native".to_string());
                                 steps.push(CompactionStepData {
                                     strategy: "native".to_string(),
-                                    messages_after: llm_messages_for_call.len(),
+                                    messages_after,
                                     duration_ms: step_duration,
                                 });
 
                                 tracing::info!(
                                     session_id = %session_id,
                                     duration_ms = step_duration,
-                                    messages_after = llm_messages_for_call.len(),
+                                    messages_after,
                                     "ReasonAtom: native compaction applied"
                                 );
                             }
@@ -2303,6 +2284,7 @@ impl ReasonAtom {
                                 reasoning_effort: None,
                                 metadata: HashMap::new(),
                                 previous_response_id: None,
+                                provider_opaque_context: None,
                                 tool_search: None,
                                 prompt_cache: None,
                                 openrouter_routing: None,
@@ -4000,6 +3982,7 @@ mod tests {
             reasoning_effort: None,
             metadata: HashMap::new(),
             previous_response_id: Some("resp_123".to_string()),
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(PromptCacheConfig {
                 enabled: true,
@@ -4036,6 +4019,7 @@ mod tests {
             reasoning_effort: None,
             metadata: HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(PromptCacheConfig {
                 enabled: true,
@@ -4072,6 +4056,7 @@ mod tests {
             reasoning_effort: None,
             metadata: HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(PromptCacheConfig {
                 enabled: false,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -310,7 +310,7 @@ pub use driver_registry::{
     EmbedResponse, EmbeddingsDriver, EmbeddingsDriverError, EmbeddingsDriverFactory, LlmCallConfig,
     LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamError, LlmStreamEvent, ProviderConfig,
-    ServiceKind, fold_system_messages,
+    ProviderOpaqueContext, ServiceKind, fold_system_messages,
 };
 
 // LLM retry types re-exports
@@ -328,7 +328,7 @@ pub use openai_protocol::AuthHeaderProvider;
 pub use openresponses_protocol::{
     CompactContent, CompactContentPart, CompactInputItem, CompactOutputItem, CompactRequest,
     CompactResponse, CompactUsage, OpenResponsesProtocolChatDriver, OpenResponsesRequestExtension,
-    compact_output_to_messages, messages_to_compact_input,
+    messages_to_compact_input,
 };
 
 // Tool abstraction re-exports

--- a/crates/core/src/llm_conversions.rs
+++ b/crates/core/src/llm_conversions.rs
@@ -181,6 +181,7 @@ pub fn llm_call_config_from_agent(runtime_agent: &RuntimeAgent) -> LlmCallConfig
         verbosity: None,
         metadata: HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: runtime_agent.tool_search.clone(),
         prompt_cache: runtime_agent.prompt_cache.clone(),
         openrouter_routing: runtime_agent.openrouter_routing.clone(),

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -1007,6 +1007,7 @@ mod tests {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -98,6 +98,7 @@ impl UtilityLlmRequest {
                 .map(|effort| effort.as_str().to_string()),
             metadata: self.metadata,
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,

--- a/crates/core/tests/openai_protocol_wire.rs
+++ b/crates/core/tests/openai_protocol_wire.rs
@@ -29,6 +29,7 @@ fn config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/core/tests/openai_reconnect_wire.rs
+++ b/crates/core/tests/openai_reconnect_wire.rs
@@ -32,6 +32,7 @@ fn config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/core/tests/openresponses_protocol_wire.rs
+++ b/crates/core/tests/openresponses_protocol_wire.rs
@@ -14,8 +14,9 @@
 use everruns_core::OpenResponsesProtocolChatDriver;
 use everruns_core::driver_registry::{
     ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
-    LlmResponseStream, LlmStreamEvent,
+    LlmResponseStream, LlmStreamEvent, ProviderOpaqueContext,
 };
+use everruns_core::{CompactContent, CompactOutputItem};
 use futures::StreamExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -31,6 +32,7 @@ fn config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,
@@ -208,5 +210,73 @@ async fn fragmented_function_call_golden_events() {
                 finish: Some("tool_calls".into()),
             },
         ]
+    );
+}
+
+#[tokio::test]
+async fn native_compact_context_is_the_exact_ordered_responses_input() {
+    let server = MockServer::start().await;
+    let body = [
+        r#"data: {"type":"response.completed","response":{"id":"resp_compact_retry","status":"completed","output":[],"usage":{"input_tokens":4,"output_tokens":1}}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n");
+    mount_sse(&server, body).await;
+
+    let output = vec![
+        CompactOutputItem::Message {
+            role: "user".to_string(),
+            content: CompactContent::Text("first".to_string()),
+        },
+        CompactOutputItem::Compaction {
+            encrypted_content: "opaque-native-context".to_string(),
+        },
+        CompactOutputItem::Message {
+            role: "user".to_string(),
+            content: CompactContent::Text("last".to_string()),
+        },
+    ];
+    let context = ProviderOpaqueContext::OpenResponsesCompact {
+        output: output.clone(),
+    };
+    let debug = format!("{context:?}");
+    assert!(debug.contains("item_count"));
+    assert!(!debug.contains("opaque-native-context"));
+    let encoded = serde_json::to_value(&context).expect("context should serialize");
+    assert_eq!(encoded["type"], "open_responses_compact");
+    assert_eq!(
+        serde_json::from_value::<ProviderOpaqueContext>(encoded).unwrap(),
+        context
+    );
+
+    let mut call_config = config("gpt-5-mini");
+    call_config.previous_response_id = Some("resp_must_not_be_mixed".to_string());
+    call_config.provider_opaque_context = Some(context);
+    let stream = driver(&server)
+        .chat_completion_stream(
+            vec![
+                LlmMessage::text(LlmMessageRole::System, "instructions"),
+                LlmMessage::text(LlmMessageRole::User, "reconstructed transcript"),
+            ],
+            &call_config,
+        )
+        .await
+        .expect("stream should start");
+    let _ = drain_golden(stream).await;
+
+    let requests = server.received_requests().await.unwrap();
+    let request: serde_json::Value = requests[0].body_json().unwrap();
+    assert!(request.get("previous_response_id").is_none());
+    assert_eq!(request["instructions"], "instructions");
+    assert_eq!(
+        request["input"],
+        serde_json::json!([
+            { "type": "message", "role": "user", "content": "first" },
+            { "type": "compaction", "encrypted_content": "opaque-native-context" },
+            { "type": "message", "role": "user", "content": "last" }
+        ])
     );
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -197,6 +197,98 @@ struct FlakyStreamDriver {
     attempts: Arc<AtomicUsize>,
 }
 
+#[derive(Clone, Debug)]
+struct NativeCompactRetryDriver {
+    attempts: Arc<AtomicUsize>,
+    compact_request: Arc<Mutex<Option<everruns_core::CompactRequest>>>,
+}
+
+#[async_trait]
+impl everruns_core::ChatDriver for NativeCompactRetryDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<everruns_core::LlmMessage>,
+        config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Err(everruns_core::AgentLoopError::request_too_large(
+                "test context limit",
+            ));
+        }
+
+        assert_eq!(config.previous_response_id, None);
+        let context = config
+            .provider_opaque_context
+            .as_ref()
+            .expect("retry must carry the standalone compact output");
+        let everruns_core::ProviderOpaqueContext::OpenResponsesCompact { output } = context;
+        assert!(matches!(
+            &output[0],
+            everruns_core::CompactOutputItem::Message { role, content }
+                if role == "user"
+                    && matches!(content, everruns_core::CompactContent::Text(text) if text == "first")
+        ));
+        assert!(matches!(
+            &output[1],
+            everruns_core::CompactOutputItem::Compaction { encrypted_content }
+                if encrypted_content == "encrypted-compact-context"
+        ));
+        assert!(matches!(
+            &output[2],
+            everruns_core::CompactOutputItem::Message { role, content }
+                if role == "user"
+                    && matches!(content, everruns_core::CompactContent::Text(text) if text == "last")
+        ));
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(everruns_core::LlmStreamEvent::TextDelta(
+                "Recovered from native compact context.".to_string(),
+            )),
+            Ok(everruns_core::LlmStreamEvent::Done(Box::new(
+                everruns_core::LlmCompletionMetadata {
+                    total_tokens: Some(8),
+                    prompt_tokens: Some(5),
+                    completion_tokens: Some(3),
+                    model: Some(config.model.clone()),
+                    finish_reason: Some("stop".to_string()),
+                    ..Default::default()
+                },
+            ))),
+        ])))
+    }
+
+    fn supports_compact(&self) -> bool {
+        true
+    }
+
+    fn supports_stateful_responses(&self) -> bool {
+        true
+    }
+
+    async fn compact(
+        &self,
+        request: everruns_core::CompactRequest,
+    ) -> everruns_core::Result<Option<everruns_core::CompactResponse>> {
+        *self.compact_request.lock().await = Some(request);
+        Ok(Some(everruns_core::CompactResponse {
+            output: vec![
+                everruns_core::CompactOutputItem::Message {
+                    role: "user".to_string(),
+                    content: everruns_core::CompactContent::Text("first".to_string()),
+                },
+                everruns_core::CompactOutputItem::Compaction {
+                    encrypted_content: "encrypted-compact-context".to_string(),
+                },
+                everruns_core::CompactOutputItem::Message {
+                    role: "user".to_string(),
+                    content: everruns_core::CompactContent::Text("last".to_string()),
+                },
+            ],
+            usage: None,
+        }))
+    }
+}
+
 #[async_trait]
 impl everruns_core::ChatDriver for FlakyStreamDriver {
     async fn chat_completion_stream(
@@ -388,6 +480,124 @@ async fn test_reason_atom_with_fixed_response() {
             panic!("Expected OutputMessageCompleted data");
         }
     }
+}
+
+#[tokio::test]
+async fn native_compact_retry_reuses_ordered_opaque_output_without_previous_response_id() {
+    use everruns_core::AgentCapabilityConfig;
+    use everruns_core::capabilities::{COMPACTION_CAPABILITY_ID, CompactionCapability};
+    use everruns_core::in_memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    provider_store
+        .set_default_model(ResolvedModel {
+            model: "gpt-5.4".to_string(),
+            provider_type: DriverId::OpenAI,
+            api_key: Some("fake-api-key".to_string()),
+            base_url: None,
+            provider_metadata: None,
+        })
+        .await;
+
+    let now = chrono::Utc::now();
+    agent_store
+        .add_agent(Agent {
+            public_id: AgentId::from_uuid(agent_id),
+            internal_id: agent_id,
+            name: "native-compact-test-agent".to_string(),
+            display_name: Some("Native Compact Test Agent".to_string()),
+            description: None,
+            system_prompt: "You are a helpful assistant.".to_string(),
+            default_model_id: None,
+            harness_id: HarnessId::from_uuid(uuid::Uuid::nil()),
+            default_version_id: None,
+            forked_from_agent_id: None,
+            forked_from_version_id: None,
+            root_agent_id: None,
+            capabilities: vec![AgentCapabilityConfig::with_config(
+                COMPACTION_CAPABILITY_ID,
+                json!({ "strategy": "native", "proactive": false }),
+            )],
+            initial_files: vec![],
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            tools: vec![],
+            mcp_servers: Default::default(),
+            tags: vec![],
+            status: AgentStatus::Active,
+            created_at: now,
+            updated_at: now,
+            archived_at: None,
+            deleted_at: None,
+            usage: None,
+        })
+        .await;
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("latest delta")])
+        .await;
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let compact_request = Arc::new(Mutex::new(None));
+    let driver = NativeCompactRetryDriver {
+        attempts: attempts.clone(),
+        compact_request: compact_request.clone(),
+    };
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(DriverId::OpenAI, move |_config| Box::new(driver.clone()));
+
+    let mut capability_registry = CapabilityRegistry::new();
+    capability_registry.register(CompactionCapability);
+    let event_emitter = InMemoryEventEmitter::new();
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        capability_registry,
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let result = atom
+        .execute(ReasonInput {
+            context: create_context(session_id),
+            harness_id,
+            agent_id: Some(agent_id.into()),
+            org_id: 0,
+            mcp_tool_definitions: vec![],
+            previous_response_id: Some("resp_before_compaction".to_string()),
+            iteration: 1,
+        })
+        .await
+        .expect("native compact retry should succeed");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(result.text, "Recovered from native compact context.");
+    let compact_request = compact_request
+        .lock()
+        .await
+        .clone()
+        .expect("compact request should be captured");
+    assert!(compact_request.input.is_empty());
+    assert_eq!(
+        compact_request.previous_response_id.as_deref(),
+        Some("resp_before_compaction")
+    );
+
+    let public_events = serde_json::to_string(&event_emitter.events().await).unwrap();
+    assert!(!public_events.contains("encrypted-compact-context"));
 }
 
 #[tokio::test]
@@ -1310,6 +1520,7 @@ async fn test_driver_registry_integration() {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -38,6 +38,7 @@ async fn fireworks_chat_streams_response() {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -31,6 +31,7 @@ fn config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -573,6 +573,7 @@ mod tests {
             reasoning_effort: None,
             metadata: Default::default(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -31,6 +31,7 @@ fn config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/openai/tests/parallel_tool_calls_live.rs
+++ b/crates/openai/tests/parallel_tool_calls_live.rs
@@ -53,6 +53,7 @@ fn config_with(parallel: Option<bool>) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -37,6 +37,7 @@ async fn openrouter_chat_with_session_id_and_routing_succeeds() {
         reasoning_effort: None,
         metadata,
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         // Exercise the routing-decoration path alongside session_id forwarding.

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -29,6 +29,7 @@ fn base_config(model: &str) -> LlmCallConfig {
         reasoning_effort: None,
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
+        provider_opaque_context: None,
         tool_search: None,
         prompt_cache: None,
         openrouter_routing: None,

--- a/crates/provider/src/driver_registry.rs
+++ b/crates/provider/src/driver_registry.rs
@@ -16,7 +16,7 @@
 
 use crate::credential_schema::CredentialFormSchema;
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
-use crate::openresponses_protocol::{CompactRequest, CompactResponse};
+use crate::openresponses_protocol::{CompactOutputItem, CompactRequest, CompactResponse};
 use crate::tool_types::{ToolCall, ToolDefinition};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -32,6 +32,29 @@ use std::sync::Arc;
 
 /// Type alias for the LLM response stream
 pub type LlmResponseStream = Pin<Box<dyn Stream<Item = Result<LlmStreamEvent>> + Send>>;
+
+/// Ordered provider-owned context returned by a native compaction operation.
+///
+/// The runtime carries this value without interpreting or exposing its opaque
+/// payload. The matching provider driver is responsible for putting the items
+/// back on the wire exactly as returned.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProviderOpaqueContext {
+    /// Standalone `output` returned by OpenAI `/responses/compact`.
+    OpenResponsesCompact { output: Vec<CompactOutputItem> },
+}
+
+impl std::fmt::Debug for ProviderOpaqueContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OpenResponsesCompact { output } => f
+                .debug_struct("OpenResponsesCompact")
+                .field("item_count", &output.len())
+                .finish_non_exhaustive(),
+        }
+    }
+}
 
 /// Structured provider error emitted inside an accepted response stream.
 ///
@@ -1292,6 +1315,12 @@ pub struct LlmCallConfig {
     /// Previous response ID for stateful continuation (OpenAI Responses API).
     /// When set, the provider can skip re-encoding cached context.
     pub previous_response_id: Option<String>,
+    /// Standalone, ordered native compact output for this request.
+    ///
+    /// This is mutually exclusive with `previous_response_id`. Provider
+    /// drivers must serialize it as the request input without transcript-delta
+    /// trimming or structural pruning.
+    pub provider_opaque_context: Option<ProviderOpaqueContext>,
     /// Tool search configuration for deferred tool loading
     pub tool_search: Option<ToolSearchConfig>,
     /// Prompt caching configuration for provider-specific cache controls.
@@ -1426,6 +1455,12 @@ impl LlmCallConfigBuilder {
     /// Set previous response ID for stateful continuation
     pub fn previous_response_id(mut self, id: Option<String>) -> Self {
         self.config.previous_response_id = id;
+        self
+    }
+
+    /// Set standalone provider-owned compact context for the request.
+    pub fn provider_opaque_context(mut self, context: Option<ProviderOpaqueContext>) -> Self {
+        self.config.provider_opaque_context = context;
         self
     }
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -52,7 +52,7 @@ pub use driver_registry::{
     EmbedResponse, EmbeddingsDriver, EmbeddingsDriverError, EmbeddingsDriverFactory, LlmCallConfig,
     LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamError, LlmStreamEvent, ProviderConfig,
-    ServiceKind, fold_system_messages,
+    ProviderOpaqueContext, ServiceKind, fold_system_messages,
 };
 pub use error::{
     AgentLoopError, FileSystemError, FileSystemErrorClass, LlmError, LlmErrorKind, Result,
@@ -69,7 +69,7 @@ pub use openai_protocol::{AuthHeaderProvider, OpenAIProtocolChatDriver};
 pub use openresponses_protocol::{
     CompactContent, CompactContentPart, CompactInputItem, CompactOutputItem, CompactRequest,
     CompactResponse, CompactUsage, OpenResponsesProtocolChatDriver, OpenResponsesRequestExtension,
-    compact_output_to_messages, messages_to_compact_input,
+    messages_to_compact_input,
 };
 pub use provider::{Provider, ProviderStatus, ProviderTraceConfig};
 pub use tool_types::{

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -1006,25 +1006,31 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             .as_ref()
             .is_some_and(|profile| profile.tool_search);
 
-        let (instructions, input_items) = Self::build_input(&messages, supports_phases);
+        let (instructions, transcript_input_items) = Self::build_input(&messages, supports_phases);
 
         // Only chain via `previous_response_id` when the endpoint actually persists
         // responses server-side. Stateless OpenAI-compatible gateways (OpenRouter,
         // Gemini compat, …) accept the field but ignore it, so chaining there drops
         // the conversation from turn 2 onward (EVE-523). For those we send no
         // continuation handle and replay the full transcript in `input` below.
-        let previous_response_id = if endpoint_persists_responses(&self.api_url) {
+        let mut previous_response_id = if endpoint_persists_responses(&self.api_url) {
             config.previous_response_id.clone()
         } else {
             None
         };
 
-        // Stateful Responses continuations must not mix `previous_response_id` with
-        // the prior transcript input the provider already holds server-side. When a
-        // continuation handle is present, trim `input_items` to the delta window so
-        // the request only carries new tool results / user messages. With no handle
-        // (incl. stateless gateways), the full transcript is kept.
-        let input_items = finalize_input_for_request(input_items, &previous_response_id);
+        // Native compact output is a standalone context checkpoint: its ordered
+        // items replace transcript reconstruction and must not be trimmed. It is
+        // therefore mutually exclusive with server-side continuation state.
+        let input_items = match &config.provider_opaque_context {
+            Some(crate::driver_registry::ProviderOpaqueContext::OpenResponsesCompact {
+                output,
+            }) => {
+                previous_response_id = None;
+                output.iter().map(ResponsesInputItem::from).collect()
+            }
+            None => finalize_input_for_request(transcript_input_items, &previous_response_id),
+        };
 
         let tools = if config.tools.is_empty() {
             None
@@ -1825,7 +1831,7 @@ pub enum CompactInputItem {
 }
 
 /// Content for compact input items
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CompactContent {
     /// Simple text content
@@ -1835,7 +1841,7 @@ pub enum CompactContent {
 }
 
 /// Content part for compact input
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum CompactContentPart {
     /// Text content
@@ -1856,7 +1862,7 @@ pub struct CompactResponse {
 }
 
 /// Output item from compact response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum CompactOutputItem {
     /// A user message (kept verbatim)
@@ -1986,102 +1992,12 @@ impl CompactInputItem {
     }
 }
 
-impl CompactOutputItem {
-    /// Convert a CompactOutputItem to LlmMessage
-    ///
-    /// Compaction items are converted to a special system message containing
-    /// the encrypted context that will be included in subsequent requests.
-    pub fn to_llm_message(&self) -> Option<LlmMessage> {
-        match self {
-            CompactOutputItem::Message { role, content } => {
-                let llm_role = match role.as_str() {
-                    "user" => LlmMessageRole::User,
-                    "assistant" => LlmMessageRole::Assistant,
-                    "developer" | "system" => LlmMessageRole::System,
-                    "tool" => LlmMessageRole::Tool,
-                    _ => LlmMessageRole::User, // Default to user
-                };
-
-                let llm_content = match content {
-                    CompactContent::Text(text) => LlmMessageContent::Text(text.clone()),
-                    CompactContent::Parts(parts) => {
-                        let llm_parts: Vec<LlmContentPart> = parts
-                            .iter()
-                            .map(|p| match p {
-                                CompactContentPart::InputText { text } => {
-                                    LlmContentPart::Text { text: text.clone() }
-                                }
-                                CompactContentPart::InputImage { image_url } => {
-                                    // Pass the URL directly - it's already in data URL format
-                                    LlmContentPart::Image {
-                                        url: image_url.clone(),
-                                    }
-                                }
-                            })
-                            .collect();
-                        LlmMessageContent::Parts(llm_parts)
-                    }
-                };
-
-                Some(LlmMessage {
-                    role: llm_role,
-                    content: llm_content,
-                    tool_calls: None,
-                    tool_call_id: None,
-                    phase: None,
-                    thinking: None,
-                    thinking_signature: None,
-                })
-            }
-            CompactOutputItem::Compaction { .. } => {
-                // Compaction items are handled separately - they're passed as-is
-                // to the next request, not converted to messages
-                None
-            }
-        }
-    }
-}
-
 /// Convert a slice of LlmMessages to CompactInputItems
 pub fn messages_to_compact_input(messages: &[LlmMessage]) -> Vec<CompactInputItem> {
     messages
         .iter()
         .flat_map(CompactInputItem::from_llm_message)
         .collect()
-}
-
-/// Convert CompactResponse output to LlmMessages plus any compaction items
-///
-/// Returns a tuple of (regular messages, compaction items).
-/// The compaction items should be preserved and included in subsequent compact requests.
-pub fn compact_output_to_messages(
-    output: &[CompactOutputItem],
-) -> (Vec<LlmMessage>, Vec<CompactInputItem>) {
-    let mut messages = Vec::new();
-    let mut compaction_items = Vec::new();
-
-    for item in output {
-        match item {
-            CompactOutputItem::Message { role, content } => {
-                if let Some(msg) = item.to_llm_message() {
-                    messages.push(msg);
-                } else {
-                    // Re-add as compact input for next request
-                    compaction_items.push(CompactInputItem::Message {
-                        role: role.clone(),
-                        content: content.clone(),
-                    });
-                }
-            }
-            CompactOutputItem::Compaction { encrypted_content } => {
-                compaction_items.push(CompactInputItem::Compaction {
-                    encrypted_content: encrypted_content.clone(),
-                });
-            }
-        }
-    }
-
-    (messages, compaction_items)
 }
 
 // ============================================================================
@@ -2181,6 +2097,49 @@ enum ResponsesInputItem {
         /// Encrypted reasoning content (required for multi-turn conversations)
         encrypted_content: String,
     },
+    /// Opaque native context returned by `/responses/compact`.
+    Compaction {
+        r#type: String,
+        encrypted_content: String,
+    },
+}
+
+impl From<&CompactOutputItem> for ResponsesInputItem {
+    fn from(item: &CompactOutputItem) -> Self {
+        match item {
+            CompactOutputItem::Message { role, content } => Self::Message {
+                r#type: "message".to_string(),
+                role: role.clone(),
+                content: match content {
+                    CompactContent::Text(text) => ResponsesContent::Text(text.clone()),
+                    CompactContent::Parts(parts) => ResponsesContent::Parts(
+                        parts
+                            .iter()
+                            .map(|part| match part {
+                                CompactContentPart::InputText { text } => {
+                                    ResponsesContentPart::InputText {
+                                        r#type: "input_text".to_string(),
+                                        text: text.clone(),
+                                    }
+                                }
+                                CompactContentPart::InputImage { image_url } => {
+                                    ResponsesContentPart::InputImage {
+                                        r#type: "input_image".to_string(),
+                                        image_url: image_url.clone(),
+                                    }
+                                }
+                            })
+                            .collect(),
+                    ),
+                },
+                phase: None,
+            },
+            CompactOutputItem::Compaction { encrypted_content } => Self::Compaction {
+                r#type: "compaction".to_string(),
+                encrypted_content: encrypted_content.clone(),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2485,6 +2444,7 @@ mod tests {
             reasoning_effort: None,
             metadata,
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(crate::driver_registry::PromptCacheConfig {
                 enabled: true,
@@ -2527,6 +2487,7 @@ mod tests {
             reasoning_effort: None,
             metadata,
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(crate::driver_registry::PromptCacheConfig {
                 enabled: true,
@@ -2582,6 +2543,7 @@ mod tests {
             reasoning_effort: None,
             metadata,
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(crate::driver_registry::PromptCacheConfig {
                 enabled: true,
@@ -2627,6 +2589,7 @@ mod tests {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: Some(crate::driver_registry::PromptCacheConfig {
                 enabled: true,
@@ -3514,6 +3477,7 @@ mod tests {
             // Continuation handle from a prior turn — must be ignored on a
             // stateless gateway.
             previous_response_id: Some("gen-turn-1".to_string()),
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,
@@ -3599,6 +3563,7 @@ mod tests {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: Some(crate::driver_registry::ToolSearchConfig {
                 enabled: true,
                 threshold: 15,
@@ -3661,6 +3626,7 @@ mod tests {
             reasoning_effort: None,
             metadata,
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: Some(OpenRouterRoutingConfig {
@@ -3728,6 +3694,7 @@ mod tests {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,
@@ -4451,6 +4418,7 @@ mod tests {
             reasoning_effort: Some("none".to_string()),
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,
@@ -4487,6 +4455,7 @@ mod tests {
             reasoning_effort: Some("high".to_string()),
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,
@@ -5113,6 +5082,7 @@ mod tests {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -218,6 +218,7 @@ impl JudgeClient for LlmJudgeClient {
                 ("scorer".to_string(), "observer_llm_judge".to_string()),
             ]),
             previous_response_id: None,
+            provider_opaque_context: None,
             tool_search: None,
             prompt_cache: None,
             openrouter_routing: None,

--- a/docs/advanced/compaction.md
+++ b/docs/advanced/compaction.md
@@ -50,7 +50,7 @@ The most recent N tool outputs are always kept verbatim (default: 5).
 
 ### Native Provider Compaction
 
-Delegates compaction to the LLM provider's own endpoint. Currently supported by OpenAI's Responses API (`/responses/compact`). When available, this can be more intelligent than generic strategies since the provider understands its own tokenization.
+Delegates compaction to the LLM provider's own endpoint. Currently supported by OpenAI's Responses API (`/responses/compact`). When available, this can be more intelligent than generic strategies since the provider understands its own tokenization. Everruns sends either a stateful response handle or a standalone transcript to the compact endpoint, never both. The returned ordered context is then reused directly as the next Responses API input.
 
 ### Summarization
 
@@ -257,6 +257,7 @@ Compaction emits two SSE events:
 | `context.compacted` | Cascade completes | `strategy_used`, `messages_before`, `messages_after`, `duration_ms`, `steps[]` |
 
 Each step in the cascade is recorded with its strategy name, resulting message count, and duration.
+Provider-encrypted native compact content is never included in these public events.
 
 ## Best Practices
 

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -34,6 +34,24 @@ hierarchical tiers, provider-compacted output, and infinity-context composition.
 Reducers only change prompt-facing copies: stored session history remains
 lossless, and reducers never invent successful tool results.
 
+### Native compact context handoff
+
+Native compact output is a standalone, provider-owned context checkpoint. The
+runtime preserves the returned item array as an ordered typed value and does
+not translate encrypted items into messages, reorder them, or run generic
+message/tool pruning over them. The next matching provider request uses that
+array directly as `input`; `previous_response_id` is cleared because the
+standalone checkpoint replaces the earlier server-side continuation chain.
+
+The compact request itself uses exactly one source of conversation context. A
+stateful Responses continuation sends `previous_response_id` with empty
+`input`. A stateless request sends reconstructed `input` without
+`previous_response_id`. System instructions remain a separate request field in
+both cases.
+
+Opaque compact content is provider transport state, not a public event payload.
+Compaction events expose counts, strategy, duration, and usage metadata only.
+
 ## Current State
 
 ### What Exists

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -120,6 +120,8 @@ construction, streaming parse logic, retry classification, and error mapping.
    - `verbosity`: Optional verbosity selector (low, medium, high), sent as OpenAI `verbosity`
    - `metadata`: Optional request metadata for provider-side correlation
    - `previous_response_id`: Optional OpenAI Responses continuation handle
+   - `provider_opaque_context`: Optional losslessly serializable, ordered native
+     compact output; mutually exclusive with `previous_response_id`
    - `tool_search`: Optional deferred tool-loading config
    - `prompt_cache`: Optional provider-agnostic prompt-cache config
 
@@ -641,6 +643,20 @@ The `/v1/responses/compact` endpoint is a context-compression feature for the Op
    - All prior **user messages** are kept verbatim
    - Prior assistant messages, tool calls/results, and encrypted reasoning are replaced by one encrypted **compaction item**
 3. Use the returned `output` array as the `input` for the next `/v1/responses` call
+
+The two request modes are intentionally disjoint:
+
+- Compact by stateful handle: `previous_response_id` is present and `input` is
+  empty.
+- Compact by standalone transcript: `input` is present and
+  `previous_response_id` is absent.
+
+After either mode succeeds, the returned `output` is carried in
+`ProviderOpaqueContext::OpenResponsesCompact` and reused, in its original
+order, as the next Responses `input`. That retry omits `previous_response_id`
+and bypasses transcript-delta trimming and tool-structure pruning. The context
+enum supports lossless serialization for durable runtime checkpoints and uses
+a payload-redacting `Debug` implementation.
 
 ### ChatDriver Compact Methods
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -832,7 +832,7 @@ if self.current_iteration >= self.max_iterations {
 Default: 100 iterations. Each Reason→Act cycle counts as one iteration. Configurable per agent.
 
 **TM-AGENT-008 — Context Window Poisoning (MITIGATED):**
-When the message history exceeds the LLM's context window, the `ReasonAtom` catches `RequestTooLarge` errors and calls `llm_driver.compact()` to compress older messages. This prevents unbounded context growth. Adversarial early messages are still present but may be summarized during compaction.
+When the message history exceeds the LLM's context window, the `ReasonAtom` catches `RequestTooLarge` errors and calls `llm_driver.compact()` to compress older messages. This prevents unbounded context growth. Adversarial early messages are still present but may be summarized during compaction. Native encrypted compact output remains typed provider transport state: it is reused only on the matching provider request, its `Debug` representation redacts payloads, and public compaction/generation events expose metadata rather than encrypted content.
 
 **TM-AGENT-013 — Exfiltration via web_fetch (ACCEPTED):**
 An agent with `web_fetch` capability can:


### PR DESCRIPTION
## What changed
Native OpenAI compaction now stays typed and provider-opaque from `/responses/compact` through the retry. The returned output array is reused exactly in order as the next `/responses` input, with no magic system-message conversion or generic pruning.

`ProviderOpaqueContext` is losslessly serializable for durable checkpoints and redacts payloads from `Debug`. Public events continue to expose compaction metadata only.

Compact requests now choose one context source explicitly: stateful `previous_response_id` with empty `input`, or standalone reconstructed `input` without a continuation handle. The standalone retry clears `previous_response_id`.

## Why
The prior retry converted encrypted compact content into `[COMPACTED_CONTEXT:...]`, which was not valid Responses wire input, separated message and compaction items, and lost canonical provider ordering. Compact requests could also mix `input` with `previous_response_id`.

## Before / After
Before: native compact output was decomposed into messages plus a fake system message and then passed through tool-exchange pruning.

After: the real ReasonAtom request-too-large → compact → retry test preserves `[message, compaction, message]` ordering, clears the continuation handle, and verifies serialized public events omit the encrypted blob. The HTTP wire test observes the exact retry body:

```json
{"input":[{"type":"message","role":"user","content":"first"},{"type":"compaction","encrypted_content":"<opaque>"},{"type":"message","role":"user","content":"last"}]}
```

Validation:
- `cargo test -p everruns-provider` — 472 passed
- `cargo test -p everruns-core --test openresponses_protocol_wire` — 3 passed
- `cargo test -p everruns-core --test reason_atom_test` — 31 passed
- `cargo clippy -p everruns-provider -p everruns-core --all-targets --all-features -- -D warnings`
- `just pre-push`
- Mock smoke: real ReasonAtom compact→retry seam plus HTTP wiremock request capture passed
- Live OpenAI smoke was unavailable because this worktree has no Doppler project/config; no secret fallback was used
- Full dev-stack smoke was stopped after the API server could not become ready before a fresh full build completed; UI dependencies are absent. All started services were stopped.
- Docs `pnpm run check` was blocked before execution by the repository lockfile supply-chain age policy for 19 existing entries; no dependencies or policy were changed.

## Risk
- Medium
- Changes the driver call contract and native compact retry input selection. Non-Responses drivers receive `None` and retain existing behavior. Exact wire and entry-point tests cover the affected seam.

## Security
- Threat categories reviewed: TM-LLM, TM-AGENT-008, data exposure, input-boundary handling, and resource exhaustion.
- Findings and resolutions: encrypted compact content is typed transport state, the `Debug` implementation reveals only item count, public-event serialization is regression-tested payload-free, and no new dependency/auth/tenant/unbounded-allocation surface was introduced. The threat-model mitigation was updated.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)