### PR TITLE
fix(session): enforce automatic title policy

### DIFF
--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -149,7 +149,7 @@ impl Capability for SessionCapability {
                 "auto_title": {
                     "type": "boolean",
                     "title": "Automatic session titles",
-                    "description": "Set a concise title after the first substantive request and update it only when the conversation's primary theme materially changes.",
+                    "description": "Require a concise title before handling the first substantive request and update it only when the conversation's primary theme materially changes.",
                     "default": false
                 }
             },
@@ -176,7 +176,7 @@ impl Capability for SessionCapability {
         }
 
         Some(format!(
-            "<capability id=\"{}\">\nAfter the first substantive user request, call `write_session_title` with a concise 3–7 word title for the conversation's primary theme. Ignore greetings, acknowledgements, and other non-substantive messages. On later turns, update the title only when the primary theme materially changes; do not update it for minor subtopics, follow-ups, or implementation details.\n</capability>",
+            "<capability id=\"{}\">\nTitle maintenance is mandatory when automatic titles are enabled. On the first substantive user request, you MUST call `write_session_title` with a concise 3–7 word title for the conversation's primary theme before using any other tool, doing substantive work, or giving a substantive response. Ignore greetings, acknowledgements, and other non-substantive messages. On later turns, if the primary theme materially changes, you MUST call `write_session_title` before using any other tool, doing substantive work, or responding. You MUST NOT update the title for minor subtopics, follow-ups, or implementation details. Calling `write_session_title` updates session metadata only; it does not change project or workspace files and must not be treated as a project-file change.\n</capability>",
             self.id()
         ))
     }
@@ -542,7 +542,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auto_title_policy_is_opt_in() {
+    async fn auto_title_policy_is_opt_in_and_mandatory_when_enabled() {
         let capability = SessionCapability;
         let ctx = super::super::SystemPromptContext::without_file_store(SessionId::new());
 
@@ -556,9 +556,10 @@ mod tests {
             .system_prompt_contribution_with_config(&ctx, &json!({"auto_title": true}))
             .await
             .expect("auto-title prompt");
-        assert!(prompt.contains("3–7 word title"));
-        assert!(prompt.contains("primary theme materially changes"));
-        assert!(prompt.contains("minor subtopics"));
+        assert_eq!(
+            prompt,
+            "<capability id=\"session\">\nTitle maintenance is mandatory when automatic titles are enabled. On the first substantive user request, you MUST call `write_session_title` with a concise 3–7 word title for the conversation's primary theme before using any other tool, doing substantive work, or giving a substantive response. Ignore greetings, acknowledgements, and other non-substantive messages. On later turns, if the primary theme materially changes, you MUST call `write_session_title` before using any other tool, doing substantive work, or responding. You MUST NOT update the title for minor subtopics, follow-ups, or implementation details. Calling `write_session_title` updates session metadata only; it does not change project or workspace files and must not be treated as a project-file change.\n</capability>"
+        );
     }
 
     #[tokio::test]

--- a/docs/capabilities/session.md
+++ b/docs/capabilities/session.md
@@ -18,9 +18,11 @@ Tools to read and update session metadata like title and agent information.
 
 Automatic title maintenance is opt-in. Set `auto_title` to `true` in the
 capability configuration to have the agent create a concise 3–7 word title
-after the first substantive request. The agent updates it later only when the
-conversation's primary theme materially changes, not for minor follow-ups or
-subtopics.
+before handling the first substantive request. The title is a required pre-work
+update. The agent updates it later, also before other work or a response, only
+when the conversation's primary theme materially changes—not for minor
+follow-ups or subtopics. Title writes update session metadata and do not count
+as project or workspace file changes.
 
 Title changes emit `session.title.updated` with the previous and new title. A
 repeated write of the current title is a no-op and emits no event.

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -173,6 +173,12 @@ model sets a concise 3–7 word title after the first substantive request and
 changes it later only when the conversation's primary theme materially changes,
 not for follow-ups or minor subtopics.
 
+Title maintenance is a required pre-work action while automatic titles are
+enabled: the initial title and any material primary-theme update happen before
+other tools, substantive work, or a substantive response. Session-title writes
+change session metadata only and do not count as project or workspace file
+changes.
+
 All participating title mutation paths suppress no-ops and emit the typed
 `session.title.updated` semantic event after an actual change. Tool-originated
 mutations preserve the current turn correlation. Embedders can reuse the core


### PR DESCRIPTION
## What changed
Automatic session-title maintenance is now an explicit pre-work requirement when `auto_title` is enabled. The first substantive request must set a concise 3–7 word primary-theme title before other tools, work, or response; a material primary-theme switch must retitle at the same boundary; minor follow-ups must not retitle.

The policy also clarifies that title writes update session metadata only and do not count as project or workspace file changes. Public capability docs and the durable capability spec now reflect the same contract.

## Why
The earlier advisory prompt allowed a live Anthropic model to skip `write_session_title` on both the first substantive request and an explicit topic switch. Embedders need predictable title maintenance at the start of substantive work.

## Before / After
Before: Claude could answer a substantive request or a complete topic switch without calling `write_session_title`.

After: a local Claude Sonnet 5 smoke observed:

- First request: `write_session_title("Payment Retry Strategy Design")`, then the substantive answer.
- Minor follow-up: no new title call or `session.title.updated` event.
- Explicit topic switch: `write_session_title("Shaded Chicago Native Plant Garden")`, `session.title.updated` with the prior title, then the substantive answer.

Direct Rust contract coverage asserts the complete enabled prompt and the opt-in disabled path.

## Risk
- Low
- The behavior remains opt-in. Stronger wording may make enabled agents spend one extra tool iteration exactly when a title is required.

## Security
- Threat categories reviewed: TM-LLM, TM-AGENT, TM-TOOL
- Findings and resolutions: the change strengthens an existing system-prompt policy without adding tools, permissions, inputs, dependencies, or data flows. Prompt-injection boundaries and the existing session-scoped title mutation authorization remain unchanged. No new threat-model entry is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)