### PR TITLE
chore(release): prepare v0.17.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.17.16] - 2026-07-22
+
+### Highlights
+
+- **Automatic session titles** — Sessions now generate titles automatically via title events, with a policy enforcing consistent automatic titling ([#2867](https://github.com/everruns/everruns/pull/2867), [#2869](https://github.com/everruns/everruns/pull/2869)).
+- **Durable context checkpoints** — Compaction persists durable context checkpoints, improving reliability of long-running sessions across compaction ([#2868](https://github.com/everruns/everruns/pull/2868), [#2870](https://github.com/everruns/everruns/pull/2870), [#2866](https://github.com/everruns/everruns/pull/2866)).
+
+### What's Changed
+
+- feat(runtime): surface structured turn stop reasons ([#2864](https://github.com/everruns/everruns/pull/2864)) by [@chaliy](https://github.com/chaliy)
+- feat(session): add automatic title events ([#2867](https://github.com/everruns/everruns/pull/2867)) by [@chaliy](https://github.com/chaliy)
+- feat(compaction): persist durable context checkpoints ([#2868](https://github.com/everruns/everruns/pull/2868)) by [@chaliy](https://github.com/chaliy)
+- fix(compaction): preserve native compact context ([#2866](https://github.com/everruns/everruns/pull/2866)) by [@chaliy](https://github.com/chaliy)
+- fix(session): enforce automatic title policy ([#2869](https://github.com/everruns/everruns/pull/2869)) by [@chaliy](https://github.com/chaliy)
+- fix(compaction): persist effective proactive checkpoints ([#2870](https://github.com/everruns/everruns/pull/2870)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump the cargo group with 6 updates ([#2863](https://github.com/everruns/everruns/pull/2863))
+- chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates ([#2856](https://github.com/everruns/everruns/pull/2856))
+- chore(deps): bump rust to 1.97.1-slim across server, worker, and docker ([#2858](https://github.com/everruns/everruns/pull/2858), [#2860](https://github.com/everruns/everruns/pull/2860), [#2862](https://github.com/everruns/everruns/pull/2862))
+- chore(deps): bump distroless/cc-debian12 across server, worker, and docker ([#2857](https://github.com/everruns/everruns/pull/2857), [#2859](https://github.com/everruns/everruns/pull/2859), [#2861](https://github.com/everruns/everruns/pull/2861))
+
 ## [0.17.15] - 2026-07-20
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.15"
+version = "0.17.16"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3159,11 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.15"
+version = "0.17.16"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.15"
+version = "0.17.16"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.15" }
-everruns-provider = { path = "crates/provider", version = "0.17.15" }
+everruns-core = { path = "crates/core", version = "0.17.16" }
+everruns-provider = { path = "crates/provider", version = "0.17.16" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.15" }
-everruns-ard = { path = "crates/ard", version = "0.17.15" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.16" }
+everruns-ard = { path = "crates/ard", version = "0.17.16" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.15" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.16" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.15",
+  "version": "0.17.16",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.15" }
+everruns-provider = { path = "../provider", version = "0.17.16" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.15" }
+everruns-provider = { path = "../provider", version = "0.17.16" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.15", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.16", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.15", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.16", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.15" }
+everruns-provider = { path = "../provider", version = "0.17.16" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.15" }
+everruns-provider = { path = "../provider", version = "0.17.16" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.15" }
+everruns-provider = { path = "../provider", version = "0.17.16" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed

Prepares the **v0.17.16** release. Bumps the workspace version (`0.17.15` → `0.17.16`), syncs path-dependency pins, updates the UI package version, regenerates lockfiles (workspace-only), and adds the CHANGELOG entry.

User-facing changes in this release:
- **Automatic session titles** — sessions generate titles automatically via title events, with a policy enforcing consistent automatic titling ([#2867](https://github.com/everruns/everruns/pull/2867), [#2869](https://github.com/everruns/everruns/pull/2869)).
- **Durable context checkpoints** — compaction persists durable context checkpoints, improving reliability of long-running sessions across compaction ([#2868](https://github.com/everruns/everruns/pull/2868), [#2870](https://github.com/everruns/everruns/pull/2870), [#2866](https://github.com/everruns/everruns/pull/2866)).
- **Structured turn stop reasons** — runtime surfaces structured stop reasons for turns ([#2864](https://github.com/everruns/everruns/pull/2864)).

Plus dependency bumps (cargo group, npm group, Rust 1.97.1, distroless base image).

## Why

Cut the next maintenance release off `main` since v0.17.15.

## Before / After

Version-only release prep; no runtime behavior change from this PR itself. `cargo metadata --locked` resolves cleanly and `scripts/sync-publish-pin-versions.py --check` reports all path-dep pins at 0.17.16. Migration list verified sequential (001..109).

## Risk

- Low
- Mechanical version/changelog bump; auto-tag + publish workflows fire on merge.

## Security

- Threat categories reviewed: No security-relevant code changes (version/changelog/lockfile only).
- Findings and resolutions: None.

## Follow-ups

No follow-ups.

## Post-merge

The release workflow will automatically create tag `v0.17.16`, publish the GitHub Release from CHANGELOG.md, build the versioned Docker image, and publish crates.

## Checklist

- [x] Version numbers updated (Cargo workspace, path-dep pins, UI package)
- [x] CHANGELOG.md entry added
- [x] Lockfiles regenerated (workspace-only)
- [x] Migration ordering verified (001..109)
- [x] CI passes