### PR TITLE
fix(server): bind MCP OAuth grants to provider authority

### DIFF
--- a/crates/server/src/domains/mcp_servers/commands.rs
+++ b/crates/server/src/domains/mcp_servers/commands.rs
@@ -252,6 +252,22 @@ pub struct UpdateMcpServerCmd {
     pub req: UpdateMcpServerRequest,
 }
 
+/// OAuth authority is immutable. The MCP server row id doubles as the OAuth
+/// provider id, so changing an OAuth server's URL — or toggling it out of OAuth
+/// mode — would let a stored refresh token be replayed against a newly
+/// discovered token endpoint. Returns true when an update tries to retarget an
+/// OAuth server's authority and must therefore be rejected.
+fn oauth_authority_retargeted(
+    existing_auth_mode: &McpServerAuthMode,
+    existing_url: &str,
+    req_url: Option<&str>,
+    req_auth_mode: Option<&McpServerAuthMode>,
+) -> bool {
+    *existing_auth_mode == McpServerAuthMode::OAuth
+        && (req_url.is_some_and(|url| url != existing_url)
+            || req_auth_mode.is_some_and(|mode| *mode != McpServerAuthMode::OAuth))
+}
+
 impl Command for UpdateMcpServerCmd {
     type Output = McpServer;
 
@@ -310,6 +326,19 @@ impl Command for UpdateMcpServerCmd {
 
         // Build settings
         let mut settings = q::settings_from_row(&existing_row);
+        // OAuth authority is immutable: reject retargeting the server URL or
+        // toggling it out of OAuth so a stored refresh token cannot flow to a
+        // newly discovered token endpoint. (This is the live PATCH path.)
+        if oauth_authority_retargeted(
+            &settings.auth_mode,
+            &existing_row.url,
+            req.url.as_deref(),
+            req.auth_mode.as_ref(),
+        ) {
+            return Err(CommandError::bad_request(
+                "OAuth MCP server authority cannot be changed; create a new server instead",
+            ));
+        }
         if let Some(auth_mode) = req.auth_mode.clone() {
             settings.auth_mode = auth_mode;
             if settings.auth_mode != McpServerAuthMode::OAuth {
@@ -496,3 +525,49 @@ impl Command for DestroyMcpServer {
 }
 
 inventory::submit! { CommandDescriptor::of::<DestroyMcpServer>() }
+
+#[cfg(test)]
+mod oauth_authority_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_url_change_on_oauth_server() {
+        assert!(oauth_authority_retargeted(
+            &McpServerAuthMode::OAuth,
+            "https://original.example/mcp",
+            Some("https://attacker.example/mcp"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn rejects_toggling_oauth_server_out_of_oauth() {
+        assert!(oauth_authority_retargeted(
+            &McpServerAuthMode::OAuth,
+            "https://original.example/mcp",
+            None,
+            Some(&McpServerAuthMode::ApiKey),
+        ));
+    }
+
+    #[test]
+    fn allows_unrelated_update_on_oauth_server() {
+        // Same URL, no auth-mode change (e.g. name/description/header edit).
+        assert!(!oauth_authority_retargeted(
+            &McpServerAuthMode::OAuth,
+            "https://original.example/mcp",
+            Some("https://original.example/mcp"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn allows_url_change_on_non_oauth_server() {
+        assert!(!oauth_authority_retargeted(
+            &McpServerAuthMode::ApiKey,
+            "https://original.example/mcp",
+            Some("https://new.example/mcp"),
+            None,
+        ));
+    }
+}

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -303,6 +303,23 @@ impl McpServerService {
         let existing_row =
             existing_row.ok_or_else(|| crate::errors::ResourceNotFoundError::new("MCP server"))?;
         let mut settings = Self::settings_from_row(&existing_row);
+        if settings.auth_mode == McpServerAuthMode::OAuth
+            && (req
+                .url
+                .as_deref()
+                .is_some_and(|url| url != existing_row.url)
+                || req
+                    .auth_mode
+                    .as_ref()
+                    .is_some_and(|mode| *mode != McpServerAuthMode::OAuth))
+        {
+            // The row id is the OAuth provider id. Retargeting it would make
+            // existing refresh tokens flow to newly discovered metadata. Keep
+            // the identity immutable, including against a mode-toggle bypass.
+            anyhow::bail!(
+                "OAuth MCP server authority cannot be changed; create a new server instead"
+            );
+        }
         if let Some(auth_mode) = req.auth_mode.clone() {
             settings.auth_mode = auth_mode;
             if settings.auth_mode != McpServerAuthMode::OAuth {
@@ -859,6 +876,42 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_rejects_oauth_server_retargeting() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db.clone(), Some(test_encryption()));
+        let settings = McpServerSettings {
+            auth_mode: McpServerAuthMode::OAuth,
+            ..Default::default()
+        };
+        let row = db
+            .create_mcp_server(
+                1,
+                CreateMcpServerRow {
+                    name: "oauth-server".into(),
+                    description: None,
+                    url: "https://original.example/mcp".into(),
+                    transport_type: "streamable_http".into(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: Some(McpServerService::settings_to_value(&settings)),
+                },
+            )
+            .await
+            .unwrap();
+        let req: UpdateMcpServerRequest = serde_json::from_value(serde_json::json!({
+            "url": "https://attacker.example/mcp"
+        }))
+        .unwrap();
+
+        let error = svc
+            .update(&test_caller(1), row.id.uuid(), req)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("create a new server"));
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/plugins/oauth_anchor.rs
+++ b/crates/server/src/domains/plugins/oauth_anchor.rs
@@ -81,11 +81,11 @@ async fn list_plugin_anchors(
 /// its provider id; remove anchors for servers the plugin no longer declares.
 ///
 /// Mutates `definition` in place (sets `oauth_provider_id` on OAuth servers).
-/// Idempotent: re-running against existing anchors reuses them, preserving any
+/// Idempotent: re-running against unchanged anchors reuses them, preserving any
 /// registered OAuth client and existing user connections across plugin
-/// updates. If a server's URL changed, the cached OAuth discovery metadata is
-/// reset (the authorization server may differ) but the anchor row — and thus
-/// the provider id and user connections — is kept.
+/// updates. If a server's URL changed, its anchor is replaced so credentials
+/// issued by the previous OAuth authority cannot be refreshed against the new
+/// server.
 pub async fn sync_plugin_oauth_anchors(
     db: &StorageBackend,
     org_id: i64,
@@ -102,22 +102,14 @@ pub async fn sync_plugin_oauth_anchors(
             let anchor_id = match existing.remove(server_name) {
                 Some(row) => {
                     if row.url != server.url {
-                        // URL changed: keep the anchor (provider id + user
-                        // connections survive) but drop stale OAuth discovery
-                        // metadata and client registration.
-                        db.update_mcp_server(
-                            org_id,
-                            row.id.uuid(),
-                            UpdateMcpServer {
-                                url: Some(server.url.clone()),
-                                settings: Some(anchor_settings_value(plugin_name, server_name)),
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                        .context("failed to update plugin OAuth anchor")?;
+                        // The provider id is the credential's authority binding.
+                        // Never reuse it after retargeting: the refresh path must
+                        // not send old user secrets to newly discovered metadata.
+                        db.delete_mcp_server(org_id, row.id.uuid()).await?;
+                        create_anchor(db, org_id, plugin_name, server_name, &server.url).await?
+                    } else {
+                        row.id.uuid()
                     }
-                    row.id.uuid()
                 }
                 None => create_anchor(db, org_id, plugin_name, server_name, &server.url).await?,
             };
@@ -301,6 +293,32 @@ mod tests {
         assert_eq!(
             list_plugin_anchors(&db, 1, "resend").await.unwrap().len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_url_rotates_provider_id() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let mut first = oauth_definition("resend", "https://mcp.resend.com/mcp");
+        sync_plugin_oauth_anchors(&db, 1, "resend", &mut first)
+            .await
+            .unwrap();
+        let first_provider = first.mcp_servers.as_ref().unwrap()["resend"]
+            .oauth_provider_id
+            .clone();
+
+        let mut retargeted = oauth_definition("resend", "https://attacker.example/mcp");
+        sync_plugin_oauth_anchors(&db, 1, "resend", &mut retargeted)
+            .await
+            .unwrap();
+        let retargeted_provider = retargeted.mcp_servers.as_ref().unwrap()["resend"]
+            .oauth_provider_id
+            .clone();
+
+        assert_ne!(first_provider, retargeted_provider);
+        assert_eq!(
+            list_plugin_anchors(&db, 1, "resend").await.unwrap()["resend"].url,
+            "https://attacker.example/mcp"
         );
     }
 

--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -112,9 +112,11 @@ machinery unchanged:
   token is connected, the MCP executor returns a `connection_required` tool
   result, rendering the inline "connect" prompt instead of a raw 401.
 
-Anchors are reused across plugin **updates** (provider id and user connections
-survive; a changed server URL resets only the cached OAuth discovery metadata),
-removed when a server is dropped from the plugin, and deleted on **uninstall**.
+Anchors are reused across plugin **updates** while the server URL is unchanged.
+A changed URL replaces the anchor and rotates its provider id, requiring users
+to reconnect rather than risking refresh of an old grant against a new OAuth
+authority. Anchors are removed when a server is dropped from the plugin and
+deleted on **uninstall**.
 Because the provider id is always assigned server-side from a host-created row,
 plugin content can never bind to another provider (e.g. `github`) and read
 tokens connected for it (`TM-PLUGIN-004`).


### PR DESCRIPTION
### Motivation

- Prevent refresh-token exfiltration when an MCP OAuth provider is retargeted so a stored refresh token cannot be sent to a different token endpoint. 
- Ensure stored grants remain bound to the OAuth authority that issued them, or are rotated/invalidated when the authority changes. 

### Description

- Make org-managed OAuth MCP server authority immutable by rejecting URL or auth-mode changes in `McpServerService::update`, returning an error that instructs operators to create a new server instead of retargeting the existing one. 
- Change plugin anchor sync (`sync_plugin_oauth_anchors`) to replace the anchor and create a new provider id when a plugin's MCP server URL changes instead of reusing the old provider id. 
- Add unit tests: `changed_url_rotates_provider_id` in `oauth_anchor.rs` and `update_rejects_oauth_server_retargeting` in `mcp_servers::service` to cover plugin- and managed-server retargeting behavior. 
- Update spec text in `specs/plugins.md` to document that URL changes rotate provider ids and require user reconnection. 

### Testing

- Ran `cargo fmt --check` and `git diff --check`, both succeeded. 
- Added focused unit tests for anchor rotation and update rejection; targeted `cargo test -p everruns-server domains::plugins::oauth_anchor::tests --lib` began building but the full dependency compilation was interrupted before completion in this environment. 
- The new tests are included and expected to pass in CI; a full `just pre-push` / continuous integration run should be performed before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c04ee0be4832b87ec61033ca718f4)