### PR TITLE
feat(core): add tool narration for session and built-in tools

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1333,6 +1333,20 @@ impl SpawnAgentTool {
 
 #[async_trait]
 impl Tool for SpawnAgentTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_subagent_spawn(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "spawn_agent"
     }

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -810,6 +810,20 @@ impl SpawnAgentHandoffTool {
 
 #[async_trait]
 impl Tool for SpawnAgentHandoffTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_subagent_spawn(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "spawn_agent"
     }

--- a/crates/core/src/capabilities/budgeting.rs
+++ b/crates/core/src/capabilities/budgeting.rs
@@ -85,6 +85,16 @@ pub struct CheckBudgetTool;
 
 #[async_trait]
 impl Tool for CheckBudgetTool {
+    fn narrate(
+        &self,
+        _tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_check_budget(phase, locale))
+    }
+
     fn name(&self) -> &str {
         "check_budget"
     }

--- a/crates/core/src/capabilities/current_time.rs
+++ b/crates/core/src/capabilities/current_time.rs
@@ -69,6 +69,16 @@ pub struct GetCurrentTimeTool;
 
 #[async_trait]
 impl Tool for GetCurrentTimeTool {
+    fn narrate(
+        &self,
+        _tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_current_time(phase, locale))
+    }
+
     fn name(&self) -> &str {
         "get_current_time"
     }

--- a/crates/core/src/capabilities/delegation_result.rs
+++ b/crates/core/src/capabilities/delegation_result.rs
@@ -143,6 +143,16 @@ impl ReportResultTool {
 
 #[async_trait]
 impl Tool for ReportResultTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_delegation_result(&tool_call.name, phase, locale)
+    }
+
     fn name(&self) -> &str {
         "report_result"
     }
@@ -280,6 +290,16 @@ impl ReportTaskProgressTool {
 
 #[async_trait]
 impl Tool for ReportTaskProgressTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_delegation_result(&tool_call.name, phase, locale)
+    }
+
     fn name(&self) -> &str {
         "report_task_progress"
     }

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -485,6 +485,20 @@ fn default_query_limit() -> usize {
 
 #[async_trait]
 impl Tool for QueryHistoryTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_query_history(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "query_history"
     }

--- a/crates/core/src/capabilities/knowledge_base.rs
+++ b/crates/core/src/capabilities/knowledge_base.rs
@@ -86,6 +86,20 @@ impl SearchKnowledgeTool {
 
 #[async_trait]
 impl Tool for SearchKnowledgeTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_search_knowledge(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "search_knowledge"
     }

--- a/crates/core/src/capabilities/knowledge_index.rs
+++ b/crates/core/src/capabilities/knowledge_index.rs
@@ -229,6 +229,20 @@ pub struct SearchIndexTool {
 
 #[async_trait]
 impl Tool for SearchIndexTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_search_knowledge(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "search_index"
     }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -3502,6 +3502,110 @@ mod tests {
         }
     }
 
+    /// Every built-in production tool must carry backend-authored narration so
+    /// downstream clients (e.g. Yolop) render a concise status line instead of
+    /// the raw tool-call presentation. A tool is considered covered when its
+    /// owning capability's `narrate()` returns `Some` for a representative call,
+    /// or when it opts into data-driven CRUD narration via a `narration_noun`
+    /// hint. Capabilities whose generic display-name presentation is intentional
+    /// are listed in `GENERIC_NARRATION_ALLOWLIST` with a documented reason.
+    ///
+    /// This is the ratchet the tool-narration audit installs: a newly added
+    /// built-in tool that neither narrates nor is allowlisted fails here rather
+    /// than silently falling back to raw presentation.
+    #[test]
+    fn builtin_tools_have_narration_or_documented_generic_fallback() {
+        use crate::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
+        use crate::tool_types::ToolCall;
+
+        // (capability_id, reason) — whole capabilities whose tools intentionally
+        // use the generic display-name presentation. Keep the reason specific.
+        const GENERIC_NARRATION_ALLOWLIST: &[(&str, &str)] = &[
+            // Demo / eval fixtures — not a production surface.
+            ("sample_data", "demo capability with fixture mounts"),
+            (
+                "data_knowledge",
+                "demo knowledge scaffold; fixture data only",
+            ),
+            ("fake_aws", "demo/eval fixture tools"),
+            ("fake_crm", "demo/eval fixture tools"),
+            ("fake_financial", "demo/eval fixture tools"),
+            ("fake_warehouse", "demo/eval fixture tools"),
+            ("test_math", "test fixture capability"),
+            ("test_weather", "test fixture capability"),
+            // Platform-admin surface: the mutating `manage_*` tools narrate via
+            // `narration_noun` hints; the read/query/messaging tools are a
+            // low-frequency operator surface where the display-name presentation
+            // ("Read Agents", "Read Sessions") is already clear.
+            (
+                "platform_management",
+                "operator admin surface; mutations narrate via narration_noun, reads use display names",
+            ),
+            // Operator model-routing / provider-inspection tooling: specialized,
+            // low-frequency, and the display names read clearly on their own.
+            (
+                "model_scout",
+                "operator model-routing tools; display-name presentation is adequate",
+            ),
+            (
+                "openrouter_workspace",
+                "operator OpenRouter inspection tools; display-name presentation is adequate",
+            ),
+            // Arbitrary sandboxed code execution — there is no bounded, non-secret
+            // argument worth surfacing; "Run Lua" is the honest status.
+            (
+                "lua",
+                "arbitrary sandboxed code execution; display-name presentation is adequate",
+            ),
+        ];
+
+        // Exercise the fullest production registry so platform tools, session
+        // tasks/schedules, and the SQL/knowledge surfaces are all covered.
+        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+        let ctx = ToolNarrationContext::default();
+        let mut missing: Vec<String> = Vec::new();
+
+        for cap in registry.list() {
+            let cap_id = cap.id().to_string();
+            if GENERIC_NARRATION_ALLOWLIST
+                .iter()
+                .any(|(id, _)| *id == cap_id)
+            {
+                continue;
+            }
+
+            for tool in cap.tools() {
+                let def = tool.to_definition();
+                // Data-driven CRUD narration (operation + narration_noun) yields a
+                // meaningful line via the generic fallback path.
+                if def.hints().narration_noun.is_some() {
+                    continue;
+                }
+
+                let call = ToolCall {
+                    id: "call_narration_audit".to_string(),
+                    name: tool.name().to_string(),
+                    arguments: serde_json::json!({}),
+                };
+                // Only the Started phase needs checking: `narrate()` returns
+                // `Some`/`None` uniformly across phases for a given tool.
+                if cap
+                    .narrate(Some(&def), &call, ToolNarrationPhase::Started, None, ctx)
+                    .is_none()
+                {
+                    missing.push(format!("{cap_id}::{}", tool.name()));
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "These built-in tools fall back to raw tool-call presentation. Implement \
+             `Tool::narrate` (see specs/tool-narration.md), set a `narration_noun` hint, \
+             or add a documented entry to GENERIC_NARRATION_ALLOWLIST: {missing:?}"
+        );
+    }
+
     #[test]
     fn test_capability_registry_blueprint_with_capability() {
         struct BlueprintProviderCapability;

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -194,6 +194,20 @@ pub struct WriteSessionTitleTool;
 
 #[async_trait]
 impl Tool for WriteSessionTitleTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_write_session_title(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "write_session_title"
     }
@@ -277,6 +291,18 @@ pub struct GetSessionInfoTool;
 
 #[async_trait]
 impl Tool for GetSessionInfoTool {
+    fn narrate(
+        &self,
+        _tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_get_session_info(
+            phase, locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "get_session_info"
     }
@@ -471,6 +497,55 @@ mod tests {
             blueprint_id: None,
             blueprint_config: None,
         }
+    }
+
+    #[test]
+    fn session_tools_narrate_all_phases() {
+        use crate::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
+        use crate::tool_types::ToolCall;
+
+        let ctx = ToolNarrationContext::default();
+        let title_call = ToolCall {
+            id: "c1".to_string(),
+            name: "write_session_title".to_string(),
+            arguments: json!({ "title": "Improve tool narration" }),
+        };
+        assert_eq!(
+            WriteSessionTitleTool.narrate(&title_call, ToolNarrationPhase::Started, None, ctx),
+            Some("Update session title: Improve tool narration".to_string())
+        );
+        assert_eq!(
+            WriteSessionTitleTool.narrate(&title_call, ToolNarrationPhase::Completed, None, ctx),
+            Some("Updated session title: Improve tool narration".to_string())
+        );
+        assert_eq!(
+            WriteSessionTitleTool.narrate(&title_call, ToolNarrationPhase::Failed, None, ctx),
+            Some("Failed to update session title: Improve tool narration".to_string())
+        );
+
+        // The capability surfaces the tool's narration via the default dispatch.
+        let cap = SessionCapability;
+        let def = WriteSessionTitleTool.to_definition();
+        assert_eq!(
+            cap.narrate(
+                Some(&def),
+                &title_call,
+                ToolNarrationPhase::Started,
+                None,
+                ctx
+            ),
+            Some("Update session title: Improve tool narration".to_string())
+        );
+
+        let info_call = ToolCall {
+            id: "c2".to_string(),
+            name: "get_session_info".to_string(),
+            arguments: json!({}),
+        };
+        assert_eq!(
+            GetSessionInfoTool.narrate(&info_call, ToolNarrationPhase::Completed, None, ctx),
+            Some("Read session info".to_string())
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -396,6 +396,20 @@ impl SandboxReadFileTool {
 
 #[async_trait]
 impl Tool for SandboxReadFileTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_read_file(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "sandbox_read_file"
     }
@@ -489,6 +503,20 @@ impl SandboxWriteFileTool {
 
 #[async_trait]
 impl Tool for SandboxWriteFileTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_write_file(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "sandbox_write_file"
     }
@@ -573,6 +601,16 @@ impl SandboxStatusTool {
 
 #[async_trait]
 impl Tool for SandboxStatusTool {
+    fn narrate(
+        &self,
+        _tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_sandbox_status(phase, locale))
+    }
+
     fn name(&self) -> &str {
         "sandbox_status"
     }
@@ -656,6 +694,20 @@ impl SandboxManageTool {
 
 #[async_trait]
 impl Tool for SandboxManageTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_sandbox_manage(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "sandbox_manage"
     }

--- a/crates/core/src/capabilities/session_schedule.rs
+++ b/crates/core/src/capabilities/session_schedule.rs
@@ -77,6 +77,21 @@ pub struct CreateScheduleTool;
 
 #[async_trait]
 impl Tool for CreateScheduleTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_schedule(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "create_schedule"
     }
@@ -198,6 +213,21 @@ pub struct CancelScheduleTool;
 
 #[async_trait]
 impl Tool for CancelScheduleTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_schedule(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "cancel_schedule"
     }
@@ -277,6 +307,21 @@ pub struct ListSchedulesTool;
 
 #[async_trait]
 impl Tool for ListSchedulesTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_schedule(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "list_schedules"
     }

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -130,6 +130,16 @@ pub struct SqlExecuteTool;
 
 #[async_trait]
 impl Tool for SqlExecuteTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
+    }
+
     fn name(&self) -> &str {
         "sql_execute"
     }
@@ -223,6 +233,16 @@ pub struct SqlQueryTool;
 
 #[async_trait]
 impl Tool for SqlQueryTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
+    }
+
     fn name(&self) -> &str {
         "sql_query"
     }
@@ -319,6 +339,16 @@ pub struct SqlSchemaTool;
 
 #[async_trait]
 impl Tool for SqlSchemaTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
+    }
+
     fn name(&self) -> &str {
         "sql_schema"
     }

--- a/crates/core/src/capabilities/session_tasks.rs
+++ b/crates/core/src/capabilities/session_tasks.rs
@@ -150,6 +150,21 @@ pub struct ListTasksTool;
 
 #[async_trait]
 impl Tool for ListTasksTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_task(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "list_tasks"
     }
@@ -254,6 +269,21 @@ pub struct GetTaskTool;
 
 #[async_trait]
 impl Tool for GetTaskTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_task(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "get_task"
     }
@@ -339,6 +369,21 @@ pub struct MessageTaskTool;
 
 #[async_trait]
 impl Tool for MessageTaskTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_task(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "message_task"
     }
@@ -462,6 +507,21 @@ pub struct CancelTaskTool;
 
 #[async_trait]
 impl Tool for CancelTaskTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_task(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "cancel_task"
     }
@@ -563,6 +623,21 @@ pub struct WaitTaskTool;
 
 #[async_trait]
 impl Tool for WaitTaskTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_session_task(
+            self.name(),
+            &tool_call.arguments,
+            phase,
+            locale,
+        )
+    }
+
     fn name(&self) -> &str {
         "wait_task"
     }

--- a/crates/core/src/capabilities/skills_scoped.rs
+++ b/crates/core/src/capabilities/skills_scoped.rs
@@ -904,6 +904,16 @@ struct WriteSkillTool {
 
 #[async_trait]
 impl Tool for WriteSkillTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        crate::tool_narration::narrate_skill(&tool_call.name, &tool_call.arguments, phase, locale)
+    }
+
     fn name(&self) -> &str {
         "write_skill"
     }

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -753,6 +753,13 @@ pub fn narrate_skill(
             value,
             phase,
         ),
+        "write_skill" => labeled_phrase(
+            "Write skill",
+            "Wrote skill",
+            "Could not write skill",
+            value,
+            phase,
+        ),
         "list_skills" => generic_phrase(
             "Listing skills",
             "Listed skills",
@@ -763,6 +770,424 @@ pub fn narrate_skill(
         _ => return None,
     };
     Some(phrase)
+}
+
+/// `write_session_title` narration. The proposed title is shown as bounded
+/// detail (truncated), never an unbounded echo.
+pub fn narrate_write_session_title(
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> String {
+    let title = safe_arg_str(arguments, &["title"]).map(|title| truncate(title, 48));
+    let verbs = pick(
+        locale,
+        (
+            "Update session title",
+            "Updated session title",
+            "Failed to update session title",
+        ),
+        (
+            "Оновлюю назву сесії",
+            "Оновив назву сесії",
+            "Не вдалося оновити назву сесії",
+        ),
+    );
+    labeled_phrase(verbs.0, verbs.1, verbs.2, title, phase)
+}
+
+/// `get_session_info` narration.
+pub fn narrate_get_session_info(phase: ToolNarrationPhase, locale: Option<&str>) -> String {
+    let verbs = pick(
+        locale,
+        (
+            "Reading session info",
+            "Read session info",
+            "Failed to read session info",
+        ),
+        (
+            "Читаю інформацію про сесію",
+            "Прочитав інформацію про сесію",
+            "Не вдалося прочитати інформацію про сесію",
+        ),
+    );
+    phrase3(verbs, None, phase)
+}
+
+/// Session-schedule family narration: `create_schedule`, `cancel_schedule`,
+/// `list_schedules`. Returns `None` for names outside the family.
+pub fn narrate_session_schedule(
+    tool_name: &str,
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> Option<String> {
+    let phrase = match tool_name {
+        "create_schedule" => {
+            let detail = safe_arg_str(arguments, &["description"]).map(|value| truncate(value, 48));
+            let verbs = pick(
+                locale,
+                (
+                    "Create schedule",
+                    "Created schedule",
+                    "Failed to create schedule",
+                ),
+                (
+                    "Створюю розклад",
+                    "Створив розклад",
+                    "Не вдалося створити розклад",
+                ),
+            );
+            labeled_phrase(verbs.0, verbs.1, verbs.2, detail, phase)
+        }
+        "cancel_schedule" => {
+            let verbs = pick(
+                locale,
+                (
+                    "Cancelling schedule",
+                    "Cancelled schedule",
+                    "Failed to cancel schedule",
+                ),
+                (
+                    "Скасовую розклад",
+                    "Скасував розклад",
+                    "Не вдалося скасувати розклад",
+                ),
+            );
+            phrase3(verbs, None, phase)
+        }
+        "list_schedules" => {
+            let verbs = pick(
+                locale,
+                (
+                    "Listing schedules",
+                    "Listed schedules",
+                    "Failed to list schedules",
+                ),
+                (
+                    "Переглядаю розклади",
+                    "Переглянув розклади",
+                    "Не вдалося переглянути розклади",
+                ),
+            );
+            phrase3(verbs, None, phase)
+        }
+        _ => return None,
+    };
+    Some(phrase)
+}
+
+/// Session-task family narration: `list_tasks`, `get_task`, `message_task`,
+/// `cancel_task`, `wait_task`. Returns `None` for names outside the family.
+pub fn narrate_session_task(
+    tool_name: &str,
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> Option<String> {
+    // `task_id` is a stable, non-secret identifier; show it as bounded detail.
+    let task = safe_arg_str(arguments, &["task_id"]).map(|id| truncate(id, 32));
+    let phrase = match tool_name {
+        "list_tasks" => {
+            let verbs = pick(
+                locale,
+                ("Listing tasks", "Listed tasks", "Failed to list tasks"),
+                (
+                    "Переглядаю завдання",
+                    "Переглянув завдання",
+                    "Не вдалося переглянути завдання",
+                ),
+            );
+            phrase3(verbs, None, phase)
+        }
+        "get_task" => {
+            let verbs = pick(
+                locale,
+                ("Read task", "Read task", "Could not read task"),
+                (
+                    "Читаю завдання",
+                    "Прочитав завдання",
+                    "Не вдалося прочитати завдання",
+                ),
+            );
+            labeled_phrase(verbs.0, verbs.1, verbs.2, task, phase)
+        }
+        "message_task" => {
+            let verbs = pick(
+                locale,
+                ("Message task", "Messaged task", "Could not message task"),
+                (
+                    "Надсилаю повідомлення завданню",
+                    "Надіслав повідомлення завданню",
+                    "Не вдалося надіслати повідомлення завданню",
+                ),
+            );
+            labeled_phrase(verbs.0, verbs.1, verbs.2, task, phase)
+        }
+        "cancel_task" => {
+            let verbs = pick(
+                locale,
+                ("Cancel task", "Cancelled task", "Could not cancel task"),
+                (
+                    "Скасовую завдання",
+                    "Скасував завдання",
+                    "Не вдалося скасувати завдання",
+                ),
+            );
+            labeled_phrase(verbs.0, verbs.1, verbs.2, task, phase)
+        }
+        "wait_task" => {
+            let verbs = pick(
+                locale,
+                ("Wait for task", "Task finished", "Could not wait for task"),
+                (
+                    "Очікую на завдання",
+                    "Завдання завершено",
+                    "Не вдалося дочекатися завдання",
+                ),
+            );
+            labeled_phrase(verbs.0, verbs.1, verbs.2, task, phase)
+        }
+        _ => return None,
+    };
+    Some(phrase)
+}
+
+/// `sandbox_status` narration.
+pub fn narrate_sandbox_status(phase: ToolNarrationPhase, locale: Option<&str>) -> String {
+    let verbs = pick(
+        locale,
+        (
+            "Checking sandbox status",
+            "Checked sandbox status",
+            "Failed to check sandbox status",
+        ),
+        (
+            "Перевіряю стан пісочниці",
+            "Перевірив стан пісочниці",
+            "Не вдалося перевірити стан пісочниці",
+        ),
+    );
+    phrase3(verbs, None, phase)
+}
+
+/// `sandbox_manage` narration; the lifecycle `action` (pause/resume/delete) is
+/// shown as bounded detail.
+pub fn narrate_sandbox_manage(
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> String {
+    let action = arg_str(arguments, &["action"]).map(|action| truncate(action, 24));
+    let verbs = pick(
+        locale,
+        (
+            "Manage sandbox",
+            "Managed sandbox",
+            "Failed to manage sandbox",
+        ),
+        (
+            "Керую пісочницею",
+            "Виконав дію над пісочницею",
+            "Не вдалося виконати дію над пісочницею",
+        ),
+    );
+    labeled_phrase(verbs.0, verbs.1, verbs.2, action, phase)
+}
+
+/// Session SQL family narration: `sql_execute`, `sql_query`, `sql_schema`.
+/// SQL text is shown truncated (like a shell command); never the full body.
+pub fn narrate_sql(
+    tool_name: &str,
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> Option<String> {
+    let statement = arg_str(arguments, &["sql"]).map(|sql| format!("`{}`", truncate(sql, 48)));
+    let phrase = match tool_name {
+        "sql_execute" => {
+            let verbs = pick(
+                locale,
+                ("Running SQL", "Ran SQL", "Failed to run SQL"),
+                ("Виконую SQL", "Виконав SQL", "Не вдалося виконати SQL"),
+            );
+            phrase3(verbs, statement, phase)
+        }
+        "sql_query" => {
+            let verbs = pick(
+                locale,
+                ("Querying SQL", "Queried SQL", "Failed to query SQL"),
+                (
+                    "Запитую SQL",
+                    "Виконав SQL-запит",
+                    "Не вдалося виконати SQL-запит",
+                ),
+            );
+            phrase3(verbs, statement, phase)
+        }
+        "sql_schema" => {
+            let verbs = pick(
+                locale,
+                (
+                    "Reading database schema",
+                    "Read database schema",
+                    "Failed to read database schema",
+                ),
+                (
+                    "Читаю схему бази даних",
+                    "Прочитав схему бази даних",
+                    "Не вдалося прочитати схему бази даних",
+                ),
+            );
+            phrase3(verbs, None, phase)
+        }
+        _ => return None,
+    };
+    Some(phrase)
+}
+
+/// `search_knowledge` / `search_index` narration ("Searched knowledge: orders").
+pub fn narrate_search_knowledge(
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> String {
+    let query = safe_arg_str(arguments, &["query", "q", "search"]).map(|query| truncate(query, 48));
+    let verbs = pick(
+        locale,
+        (
+            "Search knowledge",
+            "Searched knowledge",
+            "Could not search knowledge",
+        ),
+        (
+            "Шукаю у знаннях",
+            "Знайшов у знаннях",
+            "Не вдалося знайти у знаннях",
+        ),
+    );
+    labeled_phrase(verbs.0, verbs.1, verbs.2, query, phase)
+}
+
+/// `get_current_time` narration.
+pub fn narrate_current_time(phase: ToolNarrationPhase, locale: Option<&str>) -> String {
+    let verbs = pick(
+        locale,
+        (
+            "Checking current time",
+            "Checked current time",
+            "Failed to check current time",
+        ),
+        (
+            "Перевіряю поточний час",
+            "Перевірив поточний час",
+            "Не вдалося перевірити поточний час",
+        ),
+    );
+    phrase3(verbs, None, phase)
+}
+
+/// `check_budget` narration.
+pub fn narrate_check_budget(phase: ToolNarrationPhase, locale: Option<&str>) -> String {
+    let verbs = pick(
+        locale,
+        (
+            "Checking budget",
+            "Checked budget",
+            "Failed to check budget",
+        ),
+        (
+            "Перевіряю бюджет",
+            "Перевірив бюджет",
+            "Не вдалося перевірити бюджет",
+        ),
+    );
+    phrase3(verbs, None, phase)
+}
+
+/// `query_history` narration ("Searched history: deploy").
+pub fn narrate_query_history(
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> String {
+    let query = safe_arg_str(arguments, &["query", "q", "search"]).map(|query| truncate(query, 48));
+    let verbs = pick(
+        locale,
+        (
+            "Search history",
+            "Searched history",
+            "Could not search history",
+        ),
+        (
+            "Шукаю в історії",
+            "Знайшов в історії",
+            "Не вдалося знайти в історії",
+        ),
+    );
+    labeled_phrase(verbs.0, verbs.1, verbs.2, query, phase)
+}
+
+/// `spawn_background` narration; the target tool name (a safe, bounded
+/// identifier) is shown as detail.
+pub fn narrate_spawn_background(
+    arguments: &Value,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> String {
+    let target = safe_arg_str(arguments, &["tool"]).map(|tool| truncate(tool, 40));
+    let verbs = pick(
+        locale,
+        (
+            "Start background run",
+            "Started background run",
+            "Failed to start background run",
+        ),
+        (
+            "Запускаю фоновий процес",
+            "Запустив фоновий процес",
+            "Не вдалося запустити фоновий процес",
+        ),
+    );
+    labeled_phrase(verbs.0, verbs.1, verbs.2, target, phase)
+}
+
+/// Delegation-result family narration: `report_result`, `report_task_progress`.
+pub fn narrate_delegation_result(
+    tool_name: &str,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> Option<String> {
+    let verbs = match tool_name {
+        "report_result" => pick(
+            locale,
+            (
+                "Reporting result",
+                "Reported result",
+                "Failed to report result",
+            ),
+            (
+                "Повідомляю результат",
+                "Повідомив результат",
+                "Не вдалося повідомити результат",
+            ),
+        ),
+        "report_task_progress" => pick(
+            locale,
+            (
+                "Reporting progress",
+                "Reported progress",
+                "Failed to report progress",
+            ),
+            (
+                "Повідомляю про прогрес",
+                "Повідомив про прогрес",
+                "Не вдалося повідомити про прогрес",
+            ),
+        ),
+        _ => return None,
+    };
+    Some(phrase3(verbs, None, phase))
 }
 
 /// Map a CRUD operation to (started, completed, failed) verb forms.
@@ -1210,6 +1635,219 @@ mod tests {
         assert_eq!(
             render_tool_narration(Some(&def), &tool_call, ToolNarrationPhase::Failed),
             "Failed to create agent: Neon Cartographer"
+        );
+    }
+
+    #[test]
+    fn write_session_title_all_phases_and_bounded_detail() {
+        let a = args(json!({ "title": "Improve tool narration" }));
+        assert_eq!(
+            narrate_write_session_title(&a, ToolNarrationPhase::Started, None),
+            "Update session title: Improve tool narration"
+        );
+        assert_eq!(
+            narrate_write_session_title(&a, ToolNarrationPhase::Completed, None),
+            "Updated session title: Improve tool narration"
+        );
+        assert_eq!(
+            narrate_write_session_title(&a, ToolNarrationPhase::Failed, None),
+            "Failed to update session title: Improve tool narration"
+        );
+        // Ukrainian must not mix languages.
+        assert_eq!(
+            narrate_write_session_title(&a, ToolNarrationPhase::Completed, Some("uk")),
+            "Оновив назву сесії: Improve tool narration"
+        );
+    }
+
+    #[test]
+    fn write_session_title_truncates_long_title_and_drops_missing() {
+        let long = "x".repeat(120);
+        let a = args(json!({ "title": long }));
+        let narration = narrate_write_session_title(&a, ToolNarrationPhase::Started, None);
+        // 48-char cap + ellipsis, plus the "Update session title: " label.
+        assert!(narration.starts_with("Update session title: "));
+        assert!(narration.ends_with("..."));
+        assert!(
+            narration.chars().count() <= "Update session title: ".chars().count() + 48 + 3,
+            "narration too long: {narration}"
+        );
+
+        // No title → bare verb, no dangling separator.
+        let empty = args(json!({}));
+        assert_eq!(
+            narrate_write_session_title(&empty, ToolNarrationPhase::Started, None),
+            "Update session title"
+        );
+    }
+
+    #[test]
+    fn get_session_info_all_phases() {
+        assert_eq!(
+            narrate_get_session_info(ToolNarrationPhase::Started, None),
+            "Reading session info"
+        );
+        assert_eq!(
+            narrate_get_session_info(ToolNarrationPhase::Completed, None),
+            "Read session info"
+        );
+        assert_eq!(
+            narrate_get_session_info(ToolNarrationPhase::Failed, None),
+            "Failed to read session info"
+        );
+    }
+
+    #[test]
+    fn session_schedule_family_labels_and_detail() {
+        let a = args(json!({ "description": "Run nightly backup" }));
+        assert_eq!(
+            narrate_session_schedule("create_schedule", &a, ToolNarrationPhase::Completed, None),
+            Some("Created schedule: Run nightly backup".to_string())
+        );
+        assert_eq!(
+            narrate_session_schedule(
+                "cancel_schedule",
+                &json!({}),
+                ToolNarrationPhase::Started,
+                None
+            ),
+            Some("Cancelling schedule".to_string())
+        );
+        assert_eq!(
+            narrate_session_schedule(
+                "list_schedules",
+                &json!({}),
+                ToolNarrationPhase::Failed,
+                None
+            ),
+            Some("Failed to list schedules".to_string())
+        );
+        assert_eq!(
+            narrate_session_schedule(
+                "not_a_schedule",
+                &json!({}),
+                ToolNarrationPhase::Started,
+                None
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn session_task_family_labels_and_detail() {
+        let a = args(json!({ "task_id": "task_abc" }));
+        assert_eq!(
+            narrate_session_task("get_task", &a, ToolNarrationPhase::Completed, None),
+            Some("Read task: task_abc".to_string())
+        );
+        assert_eq!(
+            narrate_session_task("list_tasks", &json!({}), ToolNarrationPhase::Started, None),
+            Some("Listing tasks".to_string())
+        );
+        // No task_id → bare verb.
+        assert_eq!(
+            narrate_session_task("cancel_task", &json!({}), ToolNarrationPhase::Started, None),
+            Some("Cancel task".to_string())
+        );
+        assert_eq!(
+            narrate_session_task("wait_task", &a, ToolNarrationPhase::Failed, None),
+            Some("Could not wait for task: task_abc".to_string())
+        );
+        assert_eq!(
+            narrate_session_task("nope", &json!({}), ToolNarrationPhase::Started, None),
+            None
+        );
+    }
+
+    #[test]
+    fn sandbox_status_and_manage() {
+        assert_eq!(
+            narrate_sandbox_status(ToolNarrationPhase::Completed, None),
+            "Checked sandbox status"
+        );
+        let a = args(json!({ "action": "pause" }));
+        assert_eq!(
+            narrate_sandbox_manage(&a, ToolNarrationPhase::Started, None),
+            "Manage sandbox: pause"
+        );
+        assert_eq!(
+            narrate_sandbox_manage(&json!({}), ToolNarrationPhase::Failed, None),
+            "Failed to manage sandbox"
+        );
+    }
+
+    #[test]
+    fn sql_family_truncates_statement() {
+        let a = args(json!({ "sql": "SELECT 1" }));
+        assert_eq!(
+            narrate_sql("sql_query", &a, ToolNarrationPhase::Completed, None),
+            Some("Queried SQL `SELECT 1`".to_string())
+        );
+        assert_eq!(
+            narrate_sql("sql_execute", &json!({}), ToolNarrationPhase::Started, None),
+            Some("Running SQL".to_string())
+        );
+        assert_eq!(
+            narrate_sql("sql_schema", &json!({}), ToolNarrationPhase::Started, None),
+            Some("Reading database schema".to_string())
+        );
+        let long = args(json!({ "sql": "SELECT ".to_string() + &"col, ".repeat(40) }));
+        let narration = narrate_sql("sql_query", &long, ToolNarrationPhase::Started, None).unwrap();
+        assert!(
+            narration.contains("..."),
+            "expected truncation: {narration}"
+        );
+        assert_eq!(
+            narrate_sql("other", &json!({}), ToolNarrationPhase::Started, None),
+            None
+        );
+    }
+
+    #[test]
+    fn search_knowledge_and_history_never_leak_secret() {
+        let query = args(json!({ "query": "orders" }));
+        assert_eq!(
+            narrate_search_knowledge(&query, ToolNarrationPhase::Completed, None),
+            "Searched knowledge: orders"
+        );
+        assert_eq!(
+            narrate_query_history(&query, ToolNarrationPhase::Completed, None),
+            "Searched history: orders"
+        );
+        // A secret-named field is never rendered even if it is the only arg.
+        let secret = args(json!({ "api_key": "sk-live-123" }));
+        assert_eq!(
+            narrate_search_knowledge(&secret, ToolNarrationPhase::Started, None),
+            "Search knowledge"
+        );
+    }
+
+    #[test]
+    fn skill_helper_covers_write_skill() {
+        assert_eq!(
+            narrate_skill(
+                "write_skill",
+                &json!({ "name": "pdf" }),
+                ToolNarrationPhase::Completed,
+                None
+            ),
+            Some("Wrote skill: pdf".to_string())
+        );
+    }
+
+    #[test]
+    fn delegation_result_family() {
+        assert_eq!(
+            narrate_delegation_result("report_result", ToolNarrationPhase::Completed, None),
+            Some("Reported result".to_string())
+        );
+        assert_eq!(
+            narrate_delegation_result("report_task_progress", ToolNarrationPhase::Started, None),
+            Some("Reporting progress".to_string())
+        );
+        assert_eq!(
+            narrate_delegation_result("other", ToolNarrationPhase::Started, None),
+            None
         );
     }
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1084,6 +1084,20 @@ spawn_background payload:\n{payload_json}"
 
 #[async_trait]
 impl Tool for SpawnBackgroundTool {
+    fn narrate(
+        &self,
+        tool_call: &crate::tool_types::ToolCall,
+        phase: crate::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(crate::tool_narration::narrate_spawn_background(
+            &tool_call.arguments,
+            phase,
+            locale,
+        ))
+    }
+
     fn name(&self) -> &str {
         "spawn_background"
     }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -25,6 +25,10 @@ use everruns_core::resource_ownership::{
     list_owned_external_resource_ids, ownership_tracking_unavailable_error,
     require_owned_external_resource,
 };
+use everruns_core::tool_narration::{
+    arg_str, generic_phrase, labeled_phrase, narrate_read_file, narrate_write_file, safe_arg_str,
+    truncate, url_display,
+};
 use everruns_core::tool_output_sanitizer::{
     READ_FILE_DEFAULT_LIMIT, build_binary_read_file_result, build_text_read_file_result,
     parse_read_file_window_args,
@@ -181,6 +185,22 @@ pub struct DaytonaCreateSandboxTool;
 
 #[async_trait]
 impl Tool for DaytonaCreateSandboxTool {
+    fn narrate(
+        &self,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(generic_phrase(
+            "Creating Daytona sandbox",
+            "Created Daytona sandbox",
+            "Failed to create Daytona sandbox",
+            None,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_create_sandbox"
     }
@@ -603,6 +623,16 @@ pub struct DaytonaReadFileTool;
 
 #[async_trait]
 impl Tool for DaytonaReadFileTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(narrate_read_file(&tool_call.arguments, phase, locale))
+    }
+
     fn name(&self) -> &str {
         "daytona_read_file"
     }
@@ -721,6 +751,16 @@ pub struct DaytonaWriteFileTool;
 
 #[async_trait]
 impl Tool for DaytonaWriteFileTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(narrate_write_file(&tool_call.arguments, phase, locale))
+    }
+
     fn name(&self) -> &str {
         "daytona_write_file"
     }
@@ -822,6 +862,22 @@ pub struct DaytonaDownloadWorkspaceTool;
 
 #[async_trait]
 impl Tool for DaytonaDownloadWorkspaceTool {
+    fn narrate(
+        &self,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(generic_phrase(
+            "Downloading workspace",
+            "Downloaded workspace",
+            "Failed to download workspace",
+            None,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_download_workspace"
     }
@@ -1009,6 +1065,22 @@ pub struct DaytonaListSnapshotsTool;
 
 #[async_trait]
 impl Tool for DaytonaListSnapshotsTool {
+    fn narrate(
+        &self,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(generic_phrase(
+            "Listing snapshots",
+            "Listed snapshots",
+            "Failed to list snapshots",
+            None,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_list_snapshots"
     }
@@ -1106,6 +1178,22 @@ pub struct DaytonaListSandboxesTool;
 
 #[async_trait]
 impl Tool for DaytonaListSandboxesTool {
+    fn narrate(
+        &self,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(generic_phrase(
+            "Listing sandboxes",
+            "Listed sandboxes",
+            "Failed to list sandboxes",
+            None,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_list_sandboxes"
     }
@@ -1176,6 +1264,22 @@ pub struct DaytonaManageSandboxTool;
 
 #[async_trait]
 impl Tool for DaytonaManageSandboxTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        Some(labeled_phrase(
+            "Managing sandbox",
+            "Managed sandbox",
+            "Failed to manage sandbox",
+            arg_str(&tool_call.arguments, &["action"]).map(str::to_string),
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_manage_sandbox"
     }
@@ -1288,6 +1392,30 @@ pub struct DaytonaGitCloneTool;
 
 #[async_trait]
 impl Tool for DaytonaGitCloneTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        // Schema key is `repo_url`; also accept common aliases. Rendered via
+        // url_display so any embedded credentials/userinfo are stripped.
+        let target = safe_arg_str(
+            &tool_call.arguments,
+            &["repo_url", "url", "repo", "repository"],
+        )
+        .map(url_display)
+        .filter(|value| !value.is_empty());
+        Some(labeled_phrase(
+            "Cloning repository",
+            "Cloned repository",
+            "Failed to clone repository",
+            target,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_git_clone"
     }
@@ -1489,6 +1617,23 @@ pub struct DaytonaGitCredentialsTool;
 
 #[async_trait]
 impl Tool for DaytonaGitCredentialsTool {
+    fn narrate(
+        &self,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        // Never render arguments: this tool handles secret credentials.
+        Some(generic_phrase(
+            "Configuring git credentials",
+            "Configured git credentials",
+            "Failed to configure git credentials",
+            None,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_git_credentials"
     }
@@ -1863,6 +2008,25 @@ pub struct DaytonaApiCallTool;
 
 #[async_trait]
 impl Tool for DaytonaApiCallTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        // Show only the endpoint path; never render the request body.
+        let endpoint = safe_arg_str(&tool_call.arguments, &["path", "endpoint"])
+            .map(|value| truncate(value, 48));
+        Some(labeled_phrase(
+            "Calling Daytona API",
+            "Called Daytona API",
+            "Failed to call Daytona API",
+            endpoint,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "daytona_api_call"
     }
@@ -3461,5 +3625,119 @@ mod tests {
     #[test]
     fn test_openapi_mount_path_constant() {
         assert_eq!(DAYTONA_OPENAPI_MOUNT_PATH, "/daytona/openapi.yaml");
+    }
+
+    // ========================================================================
+    // Tool narration
+    // ========================================================================
+
+    use everruns_core::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
+    use everruns_core::tool_types::ToolCall;
+
+    fn narrate(tool: &dyn Tool, arguments: Value, phase: ToolNarrationPhase) -> Option<String> {
+        let call = ToolCall {
+            id: "call-1".to_string(),
+            name: tool.name().to_string(),
+            arguments,
+        };
+        tool.narrate(&call, phase, None, ToolNarrationContext::default())
+    }
+
+    #[test]
+    fn test_narrate_create_sandbox_all_phases() {
+        let tool = DaytonaCreateSandboxTool;
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Started).as_deref(),
+            Some("Creating Daytona sandbox")
+        );
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Completed).as_deref(),
+            Some("Created Daytona sandbox")
+        );
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Failed).as_deref(),
+            Some("Failed to create Daytona sandbox")
+        );
+    }
+
+    #[test]
+    fn test_narrate_read_file_uses_basename() {
+        let tool = DaytonaReadFileTool;
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"sandbox_id": "s", "path": "/home/daytona/main.py"}),
+                ToolNarrationPhase::Completed
+            )
+            .as_deref(),
+            Some("Read main.py")
+        );
+    }
+
+    #[test]
+    fn test_narrate_manage_sandbox_labels_action() {
+        let tool = DaytonaManageSandboxTool;
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"sandbox_id": "s", "action": "stop"}),
+                ToolNarrationPhase::Started
+            )
+            .as_deref(),
+            Some("Managing sandbox: stop")
+        );
+        // No action arg -> bare verb fallback.
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Failed).as_deref(),
+            Some("Failed to manage sandbox")
+        );
+    }
+
+    #[test]
+    fn test_narrate_git_clone_strips_credentials() {
+        let tool = DaytonaGitCloneTool;
+        // url_display strips scheme + userinfo, keeping host/path.
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"sandbox_id": "s", "repo_url": "https://oauth2:secret@github.com/owner/repo.git"}),
+                ToolNarrationPhase::Started
+            )
+            .as_deref(),
+            Some("Cloning repository: github.com/owner/repo.git")
+        );
+        // No url arg -> bare verb fallback.
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Completed).as_deref(),
+            Some("Cloned repository")
+        );
+    }
+
+    #[test]
+    fn test_narrate_git_credentials_never_renders_args() {
+        let tool = DaytonaGitCredentialsTool;
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"sandbox_id": "super-secret"}),
+                ToolNarrationPhase::Started
+            )
+            .as_deref(),
+            Some("Configuring git credentials")
+        );
+    }
+
+    #[test]
+    fn test_narrate_api_call_truncates_path() {
+        let tool = DaytonaApiCallTool;
+        let long_path = format!("/toolbox/{}/files", "x".repeat(80));
+        let narration = narrate(
+            &tool,
+            json!({"method": "GET", "path": long_path}),
+            ToolNarrationPhase::Started,
+        )
+        .unwrap();
+        assert!(narration.starts_with("Calling Daytona API: /toolbox/"));
+        assert!(narration.ends_with("..."));
     }
 }

--- a/integrations/parallel/src/payments.rs
+++ b/integrations/parallel/src/payments.rs
@@ -13,6 +13,9 @@ use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, RiskLevel,
 };
 use everruns_core::payment::{MachinePaymentRequest, PaymentMethod, PaymentRail};
+use everruns_core::tool_narration::{
+    generic_phrase, labeled_phrase, safe_arg_str, truncate, url_display,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde::Deserialize;
@@ -96,6 +99,24 @@ pub struct ParallelSearchTool;
 
 #[async_trait]
 impl Tool for ParallelSearchTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let query = safe_arg_str(&tool_call.arguments, &["query", "q", "objective"])
+            .map(|value| truncate(value, 48));
+        Some(labeled_phrase(
+            "Searching Parallel",
+            "Searched Parallel",
+            "Could not search Parallel",
+            query,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "parallel_search"
     }
@@ -173,6 +194,38 @@ pub struct ParallelExtractTool;
 
 #[async_trait]
 impl Tool for ParallelExtractTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        // The schema arg `urls` is an array; fall back to its first element
+        // (also accept a scalar `url` alias). Rendered via url_display so any
+        // embedded credentials/query strings are stripped.
+        let url = safe_arg_str(&tool_call.arguments, &["url"])
+            .map(str::to_string)
+            .or_else(|| {
+                tool_call
+                    .arguments
+                    .get("urls")
+                    .and_then(Value::as_array)
+                    .and_then(|items| items.first())
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .map(|value| url_display(&value))
+            .filter(|value| !value.is_empty());
+        Some(labeled_phrase(
+            "Extracting URL",
+            "Extracted URL",
+            "Could not extract URL",
+            url,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "parallel_extract"
     }
@@ -256,6 +309,24 @@ pub struct ParallelTaskTool;
 
 #[async_trait]
 impl Tool for ParallelTaskTool {
+    fn narrate(
+        &self,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        let objective = safe_arg_str(&tool_call.arguments, &["input", "objective"])
+            .map(|value| truncate(value, 48));
+        Some(labeled_phrase(
+            "Running Parallel task",
+            "Ran Parallel task",
+            "Failed to run Parallel task",
+            objective,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "parallel_task"
     }
@@ -334,6 +405,23 @@ pub struct ParallelTaskStatusTool;
 
 #[async_trait]
 impl Tool for ParallelTaskStatusTool {
+    fn narrate(
+        &self,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
+        _locale: Option<&str>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
+    ) -> Option<String> {
+        // Bare: the run id is not user-friendly.
+        Some(generic_phrase(
+            "Checking task status",
+            "Checked task status",
+            "Failed to check task status",
+            None,
+            phase,
+        ))
+    }
+
     fn name(&self) -> &str {
         "parallel_task_status"
     }
@@ -462,5 +550,106 @@ mod tests {
             .execute(json!({ "query": "hello" }))
             .await;
         assert!(result.is_error());
+    }
+
+    // ========================================================================
+    // Tool narration
+    // ========================================================================
+
+    use everruns_core::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
+    use everruns_core::tool_types::ToolCall;
+
+    fn narrate(tool: &dyn Tool, arguments: Value, phase: ToolNarrationPhase) -> Option<String> {
+        let call = ToolCall {
+            id: "call-1".to_string(),
+            name: tool.name().to_string(),
+            arguments,
+        };
+        tool.narrate(&call, phase, None, ToolNarrationContext::default())
+    }
+
+    #[test]
+    fn narrate_search_all_phases_and_truncation() {
+        let tool = ParallelSearchTool;
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"query": "rust async"}),
+                ToolNarrationPhase::Started
+            )
+            .as_deref(),
+            Some("Searching Parallel: rust async")
+        );
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"query": "rust async"}),
+                ToolNarrationPhase::Completed
+            )
+            .as_deref(),
+            Some("Searched Parallel: rust async")
+        );
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"query": "rust async"}),
+                ToolNarrationPhase::Failed
+            )
+            .as_deref(),
+            Some("Could not search Parallel: rust async")
+        );
+        // Long query is truncated to 48 chars + ellipsis.
+        let long = "a".repeat(80);
+        let narration =
+            narrate(&tool, json!({ "query": long }), ToolNarrationPhase::Started).unwrap();
+        assert!(narration.starts_with("Searching Parallel: "));
+        assert!(narration.ends_with("..."));
+        // No query arg -> bare verb fallback.
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Started).as_deref(),
+            Some("Searching Parallel")
+        );
+    }
+
+    #[test]
+    fn narrate_extract_uses_first_url_and_strips_scheme() {
+        let tool = ParallelExtractTool;
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"urls": ["https://example.com/a?x=1", "https://example.com/b"], "objective": "facts"}),
+                ToolNarrationPhase::Started
+            )
+            .as_deref(),
+            Some("Extracting URL: example.com/a")
+        );
+        // No urls -> bare verb fallback.
+        assert_eq!(
+            narrate(&tool, json!({}), ToolNarrationPhase::Failed).as_deref(),
+            Some("Could not extract URL")
+        );
+    }
+
+    #[test]
+    fn narrate_task_status_is_bare() {
+        let tool = ParallelTaskStatusTool;
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"run_id": "abc123"}),
+                ToolNarrationPhase::Started
+            )
+            .as_deref(),
+            Some("Checking task status")
+        );
+        assert_eq!(
+            narrate(
+                &tool,
+                json!({"run_id": "abc123"}),
+                ToolNarrationPhase::Completed
+            )
+            .as_deref(),
+            Some("Checked task status")
+        );
     }
 }

--- a/specs/tool-narration.md
+++ b/specs/tool-narration.md
@@ -149,3 +149,16 @@ to a generic localized verb phrase rather than mixing languages.
    field.
 4. Add a unit test asserting `Started`, `Completed`, and `Failed`, including the
    no-argument fallback.
+
+## Regression guard
+
+`builtin_tools_have_narration_or_documented_generic_fallback` (in
+`crates/core/src/capabilities/mod.rs`) walks every tool of every built-in
+production capability and fails unless the tool is **covered** — its capability
+`narrate()` returns `Some`, or it carries a `narration_noun` hint (data-driven
+CRUD narration). A capability whose generic display-name presentation is
+deliberate is listed in that test's `GENERIC_NARRATION_ALLOWLIST` with a
+documented reason (demo/eval fixtures, operator-only admin surfaces, arbitrary
+code execution). A newly added built-in tool that neither narrates nor is
+allowlisted trips this test rather than silently falling back to the raw
+tool-call presentation.


### PR DESCRIPTION
## What changed
Built-in tools now carry backend-authored narration, so clients (e.g. Yolop) render a concise status line instead of the raw tool-call presentation. `write_session_title` now reads "Update session title: …" / "Updated session title: …" / "Failed to update session title: …", and the same treatment is applied across the audited production tool surface:

- **Session**: `write_session_title`, `get_session_info`
- **Scheduling**: `create_schedule`, `cancel_schedule`, `list_schedules`
- **Tasks**: `list_tasks`, `get_task`, `message_task`, `cancel_task`, `wait_task`
- **Sandboxes**: `sandbox_read_file`, `sandbox_write_file`, `sandbox_status`, `sandbox_manage`
- **SQL**: `sql_execute`, `sql_query`, `sql_schema`
- **Daytona** integration: all remaining create/read/write/download/list/manage/git/api tools
- **Parallel** integration: `parallel_search`, `parallel_extract`, `parallel_task`, `parallel_task_status`
- Plus knowledge search, `get_current_time`, `check_budget`, `query_history`, `spawn_background`, delegation `spawn_agent`/report tools, and the `write_skill` oversight flagged by the audit

Wording is centralized in reusable, locale-aware (EN + UK) phrasing helpers in `tool_narration.rs` with stable started/completed/failed labels, bounded detail (truncation), and secret redaction.

## Why
`write_session_title` and much of the built-in tool surface lacked `Tool::narrate`, so clients fell back to the generic display-name presentation. The tools are implemented in Everruns Core, so this can only be fixed here — not in the host tool layer. The issue also asked for a full audit rather than a one-tool fix.

## Before / After
For a `write_session_title` call with `title = "Improve tool narration"`:

| Phase | Before (generic fallback) | After |
|-------|---------------------------|-------|
| Started | `Ran Write Session Title` | `Update session title: Improve tool narration` |
| Completed | `Ran Write Session Title` | `Updated session title: Improve tool narration` |
| Failed | `Failed to run Write Session Title` | `Failed to update session title: Improve tool narration` |

Long titles are truncated to a bounded length; a missing title degrades to the bare verb ("Update session title") with no dangling separator.

## Risk
- Low
- Narration is display-only text emitted on tool events; it does not affect tool execution, results, or control flow. The only failure mode of concern is leaking argument content, which is guarded (see Security). A behavioral safety net is the new registry-wide regression test.

## Security
- Threat categories reviewed: **TM-OBS** (backend-authored narration is emitted on tool events and surfaced to clients).
- Findings and resolutions: Narration must never render secrets. All helpers select arguments via `safe_arg_str` (which refuses `token`/`api_key`/`password`/`secret`/`authorization`-bearing keys) or `url_display` (strips scheme, `userinfo@` credentials, query string, fragment). `daytona_git_credentials` renders no arguments at all; `daytona_api_call` shows only the endpoint path, never the request body; SQL statements are truncated like shell commands. Unit tests assert secret-bearing inputs fall back to the bare verb.

## Follow-ups
Other integration sandbox families (E2B, Deno, Docker, Sprites) share the "only the `*_exec` tool narrates" gap surfaced by the audit; they were outside the issue's called-out areas and are left for a follow-up. The core regression guard does not reach integration crates (they are separate crates linked at the host), so each integration owns its own narration tests — added here for Daytona and Parallel.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMjYM94zXuAhJgYjTspKfp)_