### PR TITLE
fix(cli): truncate table cells on UTF-8 boundaries

### DIFF
--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -59,16 +59,25 @@ pub fn print_table_row(values: &[(&str, usize)]) {
     let row: String = values
         .iter()
         .map(|(val, width)| {
-            let s = if val.len() > *width {
-                format!("{}...", &val[..(width - 3)])
-            } else {
-                val.to_string()
-            };
+            let s = truncate_table_cell(val, *width);
             format!("{:<width$}", s, width = width)
         })
         .collect::<Vec<_>>()
         .join("  ");
     println!("{}", row);
+}
+
+fn truncate_table_cell(val: &str, width: usize) -> String {
+    if val.len() <= width {
+        return val.to_string();
+    }
+
+    let max_prefix_len = width.saturating_sub(3);
+    let mut end = max_prefix_len;
+    while !val.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &val[..end])
 }
 
 /// Format a table row (returns string instead of printing)
@@ -77,11 +86,7 @@ fn format_table_row(values: &[(&str, usize)]) -> String {
     values
         .iter()
         .map(|(val, width)| {
-            let s = if val.len() > *width {
-                format!("{}...", &val[..(width - 3)])
-            } else {
-                val.to_string()
-            };
+            let s = truncate_table_cell(val, *width);
             format!("{:<width$}", s, width = width)
         })
         .collect::<Vec<_>>()
@@ -121,6 +126,18 @@ mod tests {
     fn test_format_table_row_truncation() {
         let row = format_table_row(&[("verylongtext", 8)]);
         assert_eq!(row, "veryl...");
+    }
+
+    #[test]
+    fn test_format_table_row_truncates_on_char_boundary() {
+        let row = format_table_row(&[("aaaaaaaaaaaaaaaaaaaaaaaaa😀", 28)]);
+        assert_eq!(row, "aaaaaaaaaaaaaaaaaaaaaaaaa...");
+    }
+
+    #[test]
+    fn test_format_table_row_truncates_when_boundary_is_inside_char() {
+        let row = format_table_row(&[("aaaaaaaaaaaaaaaaaaaaaaaaa😀z", 29)]);
+        assert_eq!(row, "aaaaaaaaaaaaaaaaaaaaaaaaa... ");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The CLI table renderer sliced `&str` by byte offset when truncating cells, which panicked if the cutoff landed inside a multibyte UTF-8 character (exposed by user-controlled trigger timezone text).

### Description
- Add a shared helper `truncate_table_cell` that backs up to a valid UTF-8 character boundary before slicing and appends `...` when truncation occurs; replace the previous byte-slice logic in `print_table_row` and the test formatter. 
- Update `crates/cli/src/output.rs` to use the helper and keep ASCII behavior unchanged while ensuring safety for multibyte input. 
- Add regression tests that assert correct truncation when the cutoff is exactly on a character boundary and when the cutoff would otherwise fall inside a multibyte character. 

### Testing
- Ran focused unit tests for the CLI output module with `cargo test -p everruns-cli output::tests --all-features` and all output module tests passed. 
- Ran the focused truncation test `cargo test -p everruns-cli output::tests::test_format_table_row_truncates --all-features` and it passed. 
- The added tests cover both boundary-on-character and inside-character truncation scenarios and passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5baec8b8c4832b892a1ec322b2a55f)