### PR TITLE
fix(auth): keep signup email out of urls

### DIFF
--- a/apps/ui/e2e/auth-door.spec.ts
+++ b/apps/ui/e2e/auth-door.spec.ts
@@ -15,9 +15,7 @@ const AUTH_CONFIG = {
 };
 
 async function mockAuthConfig(page: Page, config: Record<string, unknown> = AUTH_CONFIG) {
-  await page.route("**/v1/auth/config", (route) =>
-    route.fulfill({ json: config }),
-  );
+  await page.route("**/v1/auth/config", (route) => route.fulfill({ json: config }));
 }
 
 test.describe("Unified auth door", () => {
@@ -42,9 +40,7 @@ test.describe("Unified auth door", () => {
     );
   });
 
-  test("email continue moves to the password phase with the email locked in", async ({
-    page,
-  }) => {
+  test("email continue moves to the password phase with the email locked in", async ({ page }) => {
     await page.goto("/login");
     await page.getByLabel("Email").fill("eli@acme.com");
     await page.getByRole("button", { name: "Continue with email" }).click();
@@ -60,7 +56,9 @@ test.describe("Unified auth door", () => {
     await expect(page.getByLabel("Email")).toBeFocused();
   });
 
-  test("password phase offers signup with the typed address carried over", async ({ page }) => {
+  test("password phase offers signup with the typed address carried over outside the URL", async ({
+    page,
+  }) => {
     await page.goto("/login");
     await page.getByLabel("Email").fill("newcomer@acme.com");
     await page.getByRole("button", { name: "Continue with email" }).click();
@@ -69,8 +67,9 @@ test.describe("Unified auth door", () => {
     ).toBeVisible();
     // A new user who mistook login for signup is never stuck here.
     const signup = page.getByRole("link", { name: "Create an account" });
-    await expect(signup).toHaveAttribute("href", "/signup?email=newcomer%40acme.com");
+    await expect(signup).toHaveAttribute("href", "/signup");
     await signup.click();
+    await expect(page).toHaveURL(/\/signup$/);
     await expect(
       page.getByRole("heading", { level: 1, name: "Create your account" }),
     ).toBeVisible();
@@ -197,7 +196,9 @@ test.describe("Unified auth door", () => {
     });
     // No token, no email = the former dead end ("sign in to request…").
     await page.goto("/verify-email");
-    await expect(page.getByRole("heading", { level: 1, name: "Verification failed" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Verification failed" }),
+    ).toBeVisible();
     // Now self-serve: enter an email and get a new link without leaving.
     await page.getByLabel(/Enter your email/).fill("stuck@acme.com");
     await page.getByRole("button", { name: /Resend/ }).click();

--- a/apps/ui/src/__tests__/auth-redirect.test.ts
+++ b/apps/ui/src/__tests__/auth-redirect.test.ts
@@ -1,13 +1,16 @@
 import {
   buildLoginHref,
   buildSignupHref,
+  consumeSignupEmail,
   consumeReturnTo,
   getLoginRedirectPath,
   getPostAuthTarget,
   isFullPageLoginRedirect,
   navigateToLogin,
   persistReturnTo,
+  persistSignupEmail,
   RETURN_TO_STORAGE_KEY,
+  SIGNUP_EMAIL_STORAGE_KEY,
   sanitizeReturnTo,
 } from "@/lib/auth-redirect";
 
@@ -118,16 +121,12 @@ describe("sanitizeReturnTo", () => {
 });
 
 describe("buildSignupHref", () => {
-  it("includes sanitized return_to and email when provided", () => {
-    expect(buildSignupHref("/invite/abc123", "new@example.com")).toBe(
-      "/signup?email=new%40example.com&return_to=%2Finvite%2Fabc123",
-    );
+  it("includes sanitized return_to when provided", () => {
+    expect(buildSignupHref("/invite/abc123")).toBe("/signup?return_to=%2Finvite%2Fabc123");
   });
 
   it("omits unsafe return_to values", () => {
-    expect(buildSignupHref("https://evil.com", "new@example.com")).toBe(
-      "/signup?email=new%40example.com",
-    );
+    expect(buildSignupHref("https://evil.com")).toBe("/signup");
   });
 });
 
@@ -177,5 +176,23 @@ describe("getPostAuthTarget", () => {
 
   it("falls back to dashboard when no safe target exists", () => {
     expect(getPostAuthTarget("https://evil.com")).toBe("/dashboard");
+  });
+});
+
+describe("signup email session storage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("persists and consumes a typed signup email without a URL parameter", () => {
+    persistSignupEmail(" new@example.com ");
+    expect(sessionStorage.getItem(SIGNUP_EMAIL_STORAGE_KEY)).toBe("new@example.com");
+    expect(consumeSignupEmail()).toBe("new@example.com");
+    expect(sessionStorage.getItem(SIGNUP_EMAIL_STORAGE_KEY)).toBeNull();
+  });
+
+  it("ignores blank signup email values", () => {
+    persistSignupEmail("   ");
+    expect(sessionStorage.getItem(SIGNUP_EMAIL_STORAGE_KEY)).toBeNull();
   });
 });

--- a/apps/ui/src/__tests__/signup-password-policy.test.tsx
+++ b/apps/ui/src/__tests__/signup-password-policy.test.tsx
@@ -32,6 +32,7 @@ jest.mock("@/lib/api/auth", () => ({ getOAuthUrl: jest.fn(() => "/oauth") }));
 jest.mock("@/lib/auth-redirect", () => ({
   buildLoginHref: () => "/login",
   consumeReturnTo: () => null,
+  consumeSignupEmail: () => "",
   getPostAuthTarget: () => "/dashboard",
   isBackendNavigationPath: () => false,
   persistReturnTo: jest.fn(),

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -26,6 +26,7 @@ import {
   buildSignupHref,
   RETURN_TO_STORAGE_KEY,
   persistReturnTo,
+  persistSignupEmail,
 } from "@/lib/auth-redirect";
 import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
 
@@ -291,7 +292,8 @@ export default function LoginPage() {
           <p className="mt-5 text-[13px] text-muted-foreground">
             New to Everruns?{" "}
             <Link
-              href={buildSignupHref(returnTo, email)}
+              href={buildSignupHref(returnTo)}
+              onClick={() => persistSignupEmail(email)}
               className="font-medium text-primary hover:underline"
             >
               Create an account

--- a/apps/ui/src/app/(auth)/signup/page.tsx
+++ b/apps/ui/src/app/(auth)/signup/page.tsx
@@ -21,6 +21,7 @@ import { useAuthConfig, useRegister } from "@/hooks/use-auth";
 import { getOAuthUrl } from "@/lib/api/auth";
 import {
   buildLoginHref,
+  consumeSignupEmail,
   getPostAuthTarget,
   isBackendNavigationPath,
   persistReturnTo,
@@ -42,9 +43,9 @@ export default function SignupPage() {
   const { data: config, isLoading: configLoading } = useAuthConfig();
   const registerMutation = useRegister();
 
-  // Prefilled when arriving from the login door's password screen, where the
-  // address was already typed.
-  const [email, setEmail] = useState(() => searchParams.get("email") ?? "");
+  // Prefilled when arriving from the login door's password screen. The value is
+  // a one-time sessionStorage handoff so email PII is not written into URLs.
+  const [email, setEmail] = useState(() => consumeSignupEmail());
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);

--- a/apps/ui/src/lib/auth-redirect.ts
+++ b/apps/ui/src/lib/auth-redirect.ts
@@ -5,6 +5,8 @@
 
 /** Session storage key for preserving return_to across OAuth and signup flows. */
 export const RETURN_TO_STORAGE_KEY = "everruns_return_to";
+/** One-time client-side handoff for signup prefill; keep email PII out of URLs. */
+export const SIGNUP_EMAIL_STORAGE_KEY = "everruns_signup_email";
 
 type SearchInput = URLSearchParams | string | null | undefined;
 
@@ -111,12 +113,8 @@ export function isBackendNavigationPath(path: string): boolean {
 function buildAuthPath(
   basePath: "/login" | "/signup",
   returnTo: string | null | undefined,
-  email?: string | null,
 ): string {
   const params = new URLSearchParams();
-  if (email) {
-    params.set("email", email);
-  }
   const sanitized = sanitizeReturnTo(returnTo);
   if (sanitized) {
     params.set("return_to", sanitized);
@@ -125,17 +123,14 @@ function buildAuthPath(
   return query ? `${basePath}?${query}` : basePath;
 }
 
-/** Build a signup href that preserves a sanitized return_to and optional email. */
-export function buildSignupHref(
-  returnTo: string | null | undefined,
-  email?: string | null,
-): string {
-  return buildAuthPath("/signup", returnTo, email);
+/** Build a signup href that preserves a sanitized return_to. */
+export function buildSignupHref(returnTo: string | null | undefined): string {
+  return buildAuthPath("/signup", returnTo);
 }
 
-/** Build a login href that preserves a sanitized return_to and optional email. */
-export function buildLoginHref(returnTo: string | null | undefined, email?: string | null): string {
-  return buildAuthPath("/login", returnTo, email);
+/** Build a login href that preserves a sanitized return_to. */
+export function buildLoginHref(returnTo: string | null | undefined): string {
+  return buildAuthPath("/login", returnTo);
 }
 
 /** Persist a sanitized return_to in sessionStorage for post-auth resume. */
@@ -162,4 +157,23 @@ export function getPostAuthTarget(returnTo: string | null | undefined): string {
   const sanitized = sanitizeReturnTo(returnTo);
   const stored = consumeReturnTo();
   return sanitized || stored || "/dashboard";
+}
+
+/** Persist a typed login email for the next signup page without serializing PII into the URL. */
+export function persistSignupEmail(value: string): void {
+  const trimmed = value.trim();
+  if (!trimmed || typeof sessionStorage === "undefined") {
+    return;
+  }
+  sessionStorage.setItem(SIGNUP_EMAIL_STORAGE_KEY, trimmed);
+}
+
+/** Read and clear the one-time signup email prefill. */
+export function consumeSignupEmail(): string {
+  if (typeof sessionStorage === "undefined") {
+    return "";
+  }
+  const stored = sessionStorage.getItem(SIGNUP_EMAIL_STORAGE_KEY) ?? "";
+  sessionStorage.removeItem(SIGNUP_EMAIL_STORAGE_KEY);
+  return stored;
 }


### PR DESCRIPTION
### Motivation

- A security scan flagged that the login flow serialized the typed email into `/signup?email=...`, exposing email PII via browser history, logs, bookmarks, and referrers.  
- The goal is to avoid URL-based transfer of emails while preserving the UX of prefilled signup forms.

### Description

- Stop including an `email` query parameter in auth URL builders by changing `buildSignupHref`/`buildLoginHref` and removing the `email` argument in `apps/ui/src/lib/auth-redirect.ts`.  
- Add a one-time sessionStorage handoff: `SIGNUP_EMAIL_STORAGE_KEY`, `persistSignupEmail`, and `consumeSignupEmail` to transfer the typed email without putting it in the URL.  
- Wire the handoff in the client: call `persistSignupEmail(email)` from the login password-phase signup link and initialize signup page email state from `consumeSignupEmail()` instead of `searchParams.get('email')`.  
- Update unit and e2e tests and apply formatting tweaks so the test suite asserts the signup URL is clean and the signup form still receives the typed email via the one-time storage.

### Testing

- Ran the focused unit test: `pnpm --dir apps/ui test -- auth-redirect.test.ts --runInBand`, all tests passed (22/22).  
- Ran the Playwright e2e: `pnpm --dir apps/ui exec playwright test e2e/auth-door.spec.ts`, after installing Playwright browsers and system deps the suite passed (15/15).  
- Ran static checks: `pnpm --dir apps/ui run lint`, `pnpm --dir apps/ui run typecheck`, and `oxfmt` formatting checks, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56b224d124832bae9690341ef3baf6)