### PR TITLE
fix(runtime): preserve literal workspace display paths

### DIFF
--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -207,7 +207,11 @@ impl SessionFileSystem for RealDiskFileStore {
     }
 
     fn display_path(&self, path: &str) -> String {
-        match self.paths.parse_input(path) {
+        // `display_path` receives canonical backend keys, not fresh user input.
+        // Keep a literal top-level `workspace` directory distinct from the
+        // `/workspace` input alias; routing still accepts that alias via
+        // `parse_input` for read/write/list operations.
+        match rel_from_str(path.trim()) {
             Ok(rel) => self.paths.to_display(&rel),
             Err(_) => path.to_string(),
         }

--- a/crates/runtime/tests/workspace_paths_conformance_test.rs
+++ b/crates/runtime/tests/workspace_paths_conformance_test.rs
@@ -277,6 +277,33 @@ async fn all_surfaces_agree_on_root_across_worktree_switch() {
     assert_eq!(bash_pwd(&ctx).await, "/workspace");
 }
 
+#[test]
+fn backend_native_display_keeps_literal_workspace_segment() {
+    let root = TempDir::new().unwrap();
+    let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+    let backend = Arc::new(RealDiskFileStore::new(root.path()).unwrap());
+    let store = MountFs::new(backend).with_backend_display();
+
+    assert_eq!(
+        store.display_path("/workspace/collide.txt"),
+        canonical_root
+            .join("workspace/collide.txt")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        store.resolve_path("workspace/collide.txt"),
+        canonical_root
+            .join("workspace/collide.txt")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        store.resolve_path("/workspace/collide.txt"),
+        canonical_root.join("collide.txt").display().to_string()
+    );
+}
+
 #[tokio::test]
 async fn multi_root_display_and_containment_contract() {
     let session = SessionId::from_seed(661);


### PR DESCRIPTION
### Motivation
- `DisplayPolicy::BackendNative` delegated canonical primary backend keys to the backend's `display_path`, and `RealDiskFileStore::display_path` reparsed that input as user input, collapsing a literal top-level `workspace` segment into the `/workspace` alias and producing the wrong host path. 
- The change preserves the round-trip distinction between a literal `workspace/...` backend key and the `/workspace` routing alias so displayed host paths point at the expected file.

### Description
- Change `RealDiskFileStore::display_path` to treat its `path` argument as an already-canonical backend key by using `rel_from_str(path.trim())` instead of re-running `parse_input`, keeping a literal `workspace` segment distinct from the `/workspace` input alias. 
- Add `backend_native_display_keeps_literal_workspace_segment` regression test to `crates/runtime/tests/workspace_paths_conformance_test.rs` that verifies `MountFs::with_backend_display()` preserves a literal `/workspace/...` key when rendering host-native paths while preserving existing alias routing semantics. 
- Commit with message `fix(runtime): preserve literal workspace display paths`.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo test -p everruns-runtime backend_native_display_keeps_literal_workspace_segment --test workspace_paths_conformance_test` and the new regression test passed. 
- Ran `cargo test -p everruns-runtime real_disk_display_paths_use_host_root` and the existing RealDisk display test passed. 
- Ran the repository `just pre-push` checks; all checks succeeded except the migration immutability check which failed only because `origin/main` was not configured in this checkout (environment issue), not due to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5baec94e80832b821e55199f6c8975)