### PR TITLE
fix(session-tasks): preserve root session on updates

### DIFF
--- a/crates/server/src/storage/memory/session_tasks.rs
+++ b/crates/server/src/storage/memory/session_tasks.rs
@@ -488,6 +488,8 @@ mod tests {
         let row = db.session_tasks.read().get("task_root").unwrap().clone();
         let task = row.to_task().expect("to_task");
         assert_eq!(task.root_session_id, Some(root));
+        let round_tripped = SessionTaskRow::from_task(&task).expect("from_task");
+        assert_eq!(round_tripped.root_session_id, Some(root));
 
         // A NULL root column surfaces as None (top-level session / unavailable).
         db.session_tasks

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2348,9 +2348,7 @@ impl SessionTaskRow {
         Ok(Self {
             id: task.id.clone(),
             session_id: task.session_id,
-            // Populated at the storage insert from the owning session's root;
-            // the core task carries no root, so default to None here.
-            root_session_id: None,
+            root_session_id: task.root_session_id,
             kind: task.kind.clone(),
             display_name: task.display_name.clone(),
             spec: task.spec.clone(),


### PR DESCRIPTION
### Motivation
- Fix a functional consistency bug where the denormalized `root_session_id` could be dropped when a `SessionTaskRow` was converted `row -> task -> row` during updates, causing update snapshots and the in-memory backend to lose the delegation-tree root.

### Description
- Set `root_session_id` from `task.root_session_id` in `SessionTaskRow::from_task` and add a regression assertion to `to_task_surfaces_root_session_id` to ensure the `row -> task -> row` round-trip preserves the field (changes in `crates/server/src/storage/models.rs` and `crates/server/src/storage/memory/session_tasks.rs`).

### Testing
- Ran formatting check `cargo fmt --check` and the focused unit test `cargo test -p everruns-server to_task_surfaces_root_session_id`, and the test passed (regression assertion verifies round-trip preservation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5baec9f784832b91cca87e10682a92)