### PR TITLE
feat(models): add Claude Opus 5 and make it the platform default

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1366,6 +1366,7 @@ struct AnthropicOutputConfig {
 /// adaptive-thinking profiles in `everruns_provider::model_profiles`.
 const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
     "claude-fable-5",
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -1380,6 +1381,7 @@ const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
 /// thinking, or vice versa) cannot silently mis-gate either path.
 const MILLION_CONTEXT_FAMILIES: &[&str] = &[
     "claude-fable-5",
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -2080,6 +2082,8 @@ mod tests {
         // dated suffixes.
         assert!(uses_adaptive_thinking("claude-fable-5"));
         assert!(uses_adaptive_thinking("claude-fable-5-20260601"));
+        assert!(uses_adaptive_thinking("claude-opus-5"));
+        assert!(uses_adaptive_thinking("claude-opus-5-20260101"));
         assert!(uses_adaptive_thinking("claude-opus-4-8"));
         assert!(uses_adaptive_thinking("claude-opus-4-7-20260416"));
         assert!(uses_adaptive_thinking("claude-opus-4-6"));
@@ -2899,6 +2903,10 @@ mod tests {
         assert_eq!(
             split_million_context("claude-fable-5[1m]"),
             ("claude-fable-5", true)
+        );
+        assert_eq!(
+            split_million_context("claude-opus-5[1m]"),
+            ("claude-opus-5", true)
         );
         assert_eq!(
             split_million_context("claude-opus-4-6[1m]"),

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -366,6 +366,7 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["gpt-5.6-luna"], ModelVendor::OpenAi, OPENAI),
     // Anthropic
     md(&["claude-fable-5"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-8"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-7"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-6"], ModelVendor::Anthropic, ANTHROPIC),
@@ -374,6 +375,7 @@ static REGISTRY: &[ModelDescriptor] = &[
     // driver sends the `context-1m` beta header for them. See
     // `anthropic_1m_variant` for how their profiles are derived.
     md(&["claude-fable-5[1m]"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-5[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-8[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-7[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-6[1m]"], ModelVendor::Anthropic, ANTHROPIC),
@@ -2548,6 +2550,7 @@ fn anthropic_family_supports_tool_search(family: &str) -> bool {
     matches!(
         family,
         "claude-fable-5"
+            | "claude-opus-5"
             | "claude-opus-4-8"
             | "claude-opus-4-7"
             | "claude-opus-4-6"
@@ -2603,6 +2606,52 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
             }),
             limits: Some(ModelLimits {
                 // Bare id is the 200K profile; `claude-fable-5[1m]` is the 1M twin.
+                context: 200_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
+            verbosity: None,
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
+        // Claude Opus 5 (current Opus; below Fable 5, above Opus 4.8)
+        // Source: Anthropic model card (claude-api skill `shared/models.md`) and
+        // docs.claude.com — Opus 5 is not yet in models.dev. A drop-in upgrade at
+        // Opus 4.8's pricing ($5/$25, cache-read $0.50) with the same 200K/1M-twin
+        // context and 128K output. Adaptive thinking is on by default and sampling
+        // parameters are removed (temperature returns 400, hence `temperature:
+        // false`), matching the Opus 4.8/4.7 surface. Release/knowledge dates are
+        // not published in the model card; the Models API exposes them at runtime.
+        "claude-opus-5" => Some(ModelProfile {
+            name: "Claude Opus 5".into(),
+            family: "claude-opus-5".into(),
+            description: None,
+            release_date: None,
+            last_updated: None,
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 5.00,
+                output: 25.00,
+                cache_read: Some(0.50),
+                cost_tiers: vec![],
+            }),
+            limits: Some(ModelLimits {
+                // Bare id is the 200K profile; `claude-opus-5[1m]` is the 1M twin.
                 context: 200_000,
                 input: None,
                 output: 128_000,
@@ -2748,6 +2797,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
         // 1M-context twins of the base profiles above. Same pricing and
         // capabilities; only the context limit and display name differ.
         "claude-fable-5[1m]" => anthropic_profile_data("claude-fable-5").map(anthropic_1m_variant),
+        "claude-opus-5[1m]" => anthropic_profile_data("claude-opus-5").map(anthropic_1m_variant),
         "claude-opus-4-8[1m]" => {
             anthropic_profile_data("claude-opus-4-8").map(anthropic_1m_variant)
         }
@@ -3776,6 +3826,7 @@ mod tests {
         (DriverId::OpenAI, "gpt-5.6-luna"),
         // Anthropic
         (DriverId::Anthropic, "claude-fable-5"),
+        (DriverId::Anthropic, "claude-opus-5"),
         (DriverId::Anthropic, "claude-opus-4-8"),
         (DriverId::Anthropic, "claude-opus-4-7"),
         (DriverId::Anthropic, "claude-opus-4-6"),
@@ -4848,6 +4899,26 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_opus_5_1m_variant() {
+        let base = get_model_profile(&DriverId::Anthropic, "claude-opus-5").unwrap();
+        assert_eq!(base.limits.as_ref().unwrap().context, 200_000);
+
+        let m1 = get_model_profile(&DriverId::Anthropic, "claude-opus-5[1m]").unwrap();
+        assert_eq!(m1.name, "Claude Opus 5 (1M)");
+        assert_eq!(m1.family, "claude-opus-5");
+        assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
+        assert_eq!(m1.limits.as_ref().unwrap().output, 128_000);
+
+        // Flat standard pricing — the 1M window carries no long-context premium,
+        // so cost matches the 200K base exactly.
+        let (base_cost, m1_cost) = (base.cost.unwrap(), m1.cost.unwrap());
+        assert_eq!(m1_cost.input, base_cost.input);
+        assert_eq!(m1_cost.output, base_cost.output);
+        assert_eq!(m1_cost.cache_read, base_cost.cache_read);
+        assert!(m1_cost.cost_tiers.is_empty());
+    }
+
+    #[test]
     fn test_claude_fable_5_1m_variant() {
         let base = get_model_profile(&DriverId::Anthropic, "claude-fable-5").unwrap();
         assert_eq!(base.limits.as_ref().unwrap().context, 200_000);
@@ -5023,6 +5094,7 @@ mod tests {
         // Claude 4-family + Fable advertise Anthropic's hosted tool_search.
         for id in [
             "claude-fable-5",
+            "claude-opus-5",
             "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -124,6 +124,7 @@ mod seed_ids {
     pub const O1_PREVIEW: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021e);
 
     // Anthropic Models (0x300-0x3FF)
+    pub const CLAUDE_OPUS_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030e);
     pub const CLAUDE_SONNET_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030c);
     pub const CLAUDE_OPUS_4_8: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030d);
     pub const CLAUDE_OPUS_4_7: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000309);
@@ -138,6 +139,7 @@ mod seed_ids {
     pub const CLAUDE_3_5_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000307);
     pub const CLAUDE_3_5_HAIKU: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000308);
     // 1M-context variants (`[1m]` model ids), 0x3a0+ sub-range.
+    pub const CLAUDE_OPUS_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a8);
     pub const CLAUDE_OPUS_4_7_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a7);
     pub const CLAUDE_SONNET_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a5);
 
@@ -2031,7 +2033,28 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // Anthropic current-gen (Opus 4.8, Sonnet 5)
+    // Anthropic current-gen (Opus 5, Sonnet 5, Opus 4.8)
+    SeedModel {
+        // Platform default model (see `DEFAULT_MODEL_ID`). Opus 5 is the current
+        // Opus flagship — the recommended Anthropic model.
+        id: seed_ids::CLAUDE_OPUS_5,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-opus-5",
+        display_name: "Claude Opus 5",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        // 1M-context twin of the 200K base above (driver sends the `context-1m`
+        // beta header for `[1m]` ids). Keeps a 1M Opus in the default picker
+        // alongside the bare `claude-opus-5` 200K variant.
+        id: seed_ids::CLAUDE_OPUS_5_1M,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-opus-5[1m]",
+        display_name: "Claude Opus 5 (1M)",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
     SeedModel {
         id: seed_ids::CLAUDE_OPUS_4_8,
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
@@ -2249,8 +2272,8 @@ const SEED_MODELS: &[SeedModel] = &[
     },
 ];
 
-/// Default model ID for org settings seeding (GPT-5.6 Sol)
-const DEFAULT_MODEL_ID: Uuid = seed_ids::GPT_5_6_SOL;
+/// Default model ID for org settings seeding (Claude Opus 5)
+const DEFAULT_MODEL_ID: Uuid = seed_ids::CLAUDE_OPUS_5;
 
 /// Seed organization settings (default model, etc.)
 async fn seed_organization_settings(db: &StorageBackend) -> anyhow::Result<SeedResult> {
@@ -3403,13 +3426,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_seed_all_sets_default_and_seeds_opus_48() {
+    async fn test_seed_all_sets_default_and_seeds_opus_5() {
         let db = make_db();
         seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
             .await
             .unwrap();
 
-        // Platform default model is GPT-5.6 Sol.
+        // Platform default model is Claude Opus 5.
         let settings = db
             .get_organization_settings(DEFAULT_ORG_ID)
             .await
@@ -3417,19 +3440,28 @@ mod tests {
             .unwrap();
         assert_eq!(
             settings.default_model_id,
-            Some(everruns_core::ModelId::from_uuid(seed_ids::GPT_5_6_SOL)),
+            Some(everruns_core::ModelId::from_uuid(seed_ids::CLAUDE_OPUS_5)),
         );
 
-        // Claude Opus 4.8 is seeded for the Anthropic provider, enabled and
-        // marked favorite (the recommended Anthropic model).
+        // Claude Opus 5 is seeded for the Anthropic provider, enabled and marked
+        // favorite (the recommended Anthropic model, and the platform default).
         let opus = db
-            .get_model(DEFAULT_ORG_ID, seed_ids::CLAUDE_OPUS_4_8)
+            .get_model(DEFAULT_ORG_ID, seed_ids::CLAUDE_OPUS_5)
             .await
             .unwrap()
-            .expect("claude-opus-4-8 should be seeded");
-        assert_eq!(opus.model_id, "claude-opus-4-8");
-        assert!(opus.enabled, "claude-opus-4-8 should be enabled");
-        assert!(opus.is_favorite, "claude-opus-4-8 should be favorite");
+            .expect("claude-opus-5 should be seeded");
+        assert_eq!(opus.model_id, "claude-opus-5");
+        assert!(opus.enabled, "claude-opus-5 should be enabled");
+        assert!(opus.is_favorite, "claude-opus-5 should be favorite");
+
+        // The 1M-context twin is seeded and enabled alongside the 200K base.
+        let opus_1m = db
+            .get_model(DEFAULT_ORG_ID, seed_ids::CLAUDE_OPUS_5_1M)
+            .await
+            .unwrap()
+            .expect("claude-opus-5[1m] should be seeded");
+        assert_eq!(opus_1m.model_id, "claude-opus-5[1m]");
+        assert!(opus_1m.enabled, "claude-opus-5[1m] should be enabled");
     }
 
     #[tokio::test]
@@ -3644,6 +3676,16 @@ mod tests {
             .await
             .unwrap();
         let anthropic = by_id(&anthropic);
+        assert_eq!(
+            anthropic.get("claude-opus-5"),
+            Some(&(true, true)),
+            "Opus 5 must be the enabled favorite Opus (platform default)"
+        );
+        assert_eq!(
+            anthropic.get("claude-opus-5[1m]"),
+            Some(&(true, true)),
+            "Opus 5 (1M) twin must be seeded and enabled"
+        );
         assert_eq!(
             anthropic.get("claude-sonnet-5"),
             Some(&(true, true)),


### PR DESCRIPTION
## What changed

Adds **Claude Opus 5** to the model catalog and makes it the platform default.

- New model profiles for `claude-opus-5` and its 1M-context twin `claude-opus-5[1m]`: $5/$25 per MTok (cache-read $0.50), 200K base context with the 1M twin, 128K output, adaptive thinking, and Text/Image/PDF input. Sampling parameters are removed on this model, so the profile advertises `temperature: false`.
- Wired Opus 5 into the surfaces that key off model family: native hosted `tool_search`, adaptive-thinking request shaping, and `[1m]` `context-1m` beta-header gating in the Anthropic driver.
- Seeds `claude-opus-5` and `claude-opus-5[1m]` for the Anthropic provider (enabled + favorite), mirroring the Sonnet 5 seeding shape.
- Repoints the org-settings default model from **GPT-5.6 Sol → Claude Opus 5**, so fresh default-org sessions now start on Opus 5.

## Why

Opus 5 is the current Anthropic Opus flagship. It should be available in the picker and — per the request that prompted this — be the platform default model.

## Before / After

Smoke test: booted the server in `DEV_MODE` (in-memory) and queried the models API.

**Before** — org default was GPT-5.6 Sol; no Opus 5 in the registry or picker.

**After** — `GET /api/v1/orgs`:
```json
{ "name": "Default Organization",
  "default_model_id": "model_01933b5a00007000800000000000030e" }   // == CLAUDE_OPUS_5 (0x…030e)
```
`GET /api/v1/models` (Anthropic, filtered to Opus 5):
```json
[ { "model_id": "claude-opus-5",     "display_name": "Claude Opus 5",      "enabled": true, "is_favorite": true },
  { "model_id": "claude-opus-5[1m]", "display_name": "Claude Opus 5 (1M)",  "enabled": true, "is_favorite": true } ]
```
Unit tests exercise the same end-to-end seed path (`test_seed_all_sets_default_and_seeds_opus_5`, `test_seed_surfaces_current_gen_models`) and profile resolution (`test_claude_opus_5_1m_variant`, `test_anthropic_native_tool_search_by_family`, driver `test_split_million_context` / `test_uses_adaptive_thinking_by_family`).

## Risk

- **Low / Medium.** Static catalog + config data; no schema, endpoint, or auth changes.
- The notable behavioral change is the default provider flipping from OpenAI (GPT-5.6 Sol) to Anthropic (Opus 5): fresh default-org sessions now require an Anthropic API key (`DEFAULT_ANTHROPIC_API_KEY` / configured provider). Key resolution is unchanged. Existing orgs that already have a `default_model_id` are untouched — the org-settings seed only writes when the default is unset.

## Security

- Threat categories reviewed: **TM-LLM** (default model selection) and **TM-TENANT** (org-scoped seed). No new endpoints, input parsing, auth/authz, SQL, file paths, secrets, or dependencies; no `THREAT` comments near the changed code.
- Findings and resolutions: none. Change is hardcoded catalog/config data. The only operational note (Anthropic credentials now needed for the default) is captured under Risk; no secret is added or exposed in the diff.

## Follow-ups

No follow-ups. Opus 4.8/4.7 remain enabled favorites in the picker (not demoted), matching the existing multi-Opus precedent.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016TvMRhRrMJCCCmMKD7HP9U)_