### PR TITLE
chore(agents): apply Claude 5 context engineering to agent docs

### DIFF
--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -1,159 +1,92 @@
 # Prepare Release
 
-Prepare a new release for Everruns. This command generates changelog entries, updates version numbers, and creates a PR for review.
+Cut a release PR: changelog entry, version bumps, lockfiles.
+`$ARGUMENTS` is the new version (e.g. `0.4.0`); ask for it if missing.
 
-See `specs/release-process.md` for the full release process specification.
+[`specs/release-process.md`](../../specs/release-process.md) owns the release contract — changelog
+structure, tagging, migration handling, and what happens after merge. Read it before deviating.
 
-## Arguments
+## 1. Collect the commits
 
-- `$ARGUMENTS` - The new version number (e.g., "0.4.0")
+```bash
+# Cloud agents often have shallow clones
+git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow origin main
 
-## Instructions
+# Previous release: tag first, then the release commit, else everything
+PREV=$(git describe --tags --abbrev=0 2>/dev/null \
+  || git log --oneline --grep='chore(release): prepare v' --format='%H' | head -1)
 
-1. **Validate version argument**
-   - If no version provided, ask for one
-   - Version should follow semver (e.g., 0.4.0)
-   - Confirm the version makes sense (check current version in Cargo.toml)
+[ -n "$PREV" ] && git log "$PREV"..HEAD --oneline || git log --oneline
+```
 
-2. **Generate commit list using git log**
-   ```bash
-   # Unshallow if needed (cloud agents often have shallow clones)
-   git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow origin main
+## 2. Propose highlights, then wait
 
-   # Find previous release: tag first, then chore(release) commit, then all commits
-   PREV=$(git describe --tags --abbrev=0 2>/dev/null \
-     || git log --oneline --grep='chore(release): prepare v' --format='%H' | head -1)
+Highlights are user-facing only: new capabilities, integrations, significant UX work, and
+reliability or security improvements users feel. Internal refactors, CI, dependency bumps,
+spec/docs, and tests belong in **What's Changed**. Do not pad to a count — a maintenance release may
+have one highlight or none, in which case recommend dropping the section.
 
-   # List commits since previous release (or all if no release found)
-   if [ -n "$PREV" ]; then
-     git log "$PREV"..HEAD --oneline
-   else
-     git log --oneline
-   fi
-   ```
+Present the commit list and your proposed highlights, and let the user confirm or replace them
+before editing files.
 
-3. **Analyze commits and suggest highlights**:
-   - Review the commit list and identify only the genuinely impactful **user-facing** features and changes
-   - Prioritize: new capabilities users can interact with, new integrations, significant UX improvements, security/reliability improvements that affect users
-   - Exclude: internal refactors, CI changes, dependency bumps, spec/docs updates, test additions, minor fixes (unless they directly resolve a user-visible regression)
-   - Do not pad the list to hit a target count. Maintenance releases (mostly fixes and internal work) may have one or two highlights, or none at all — in which case omit the Highlights section entirely
-   - Present the commit list and your suggested highlights (or a recommendation to skip the section) to the user
-   - Ask the user to confirm, adjust, or replace the highlights
-   - Note: Add markdown links for PRs `([#123](url))` and usernames `[@user](url)`
+## 3. Update versions
 
-4. **After user approval**, update these files:
+- `Cargo.toml` → `workspace.package.version`
+- `apps/ui/package.json` → `version`
+- Sibling path-dependency pins (`crates/core/Cargo.toml` pins `everruns-openui`, `everruns-a2ui`, …)
+  must match the workspace version or the `publish-crates` workflow rejects the tag:
 
-   **Cargo.toml** - Update `workspace.package.version`:
-   ```toml
-   [workspace.package]
-   version = "X.Y.Z"
-   ```
+  ```bash
+  python3 scripts/sync-publish-pin-versions.py            # rewrite drift
+  python3 scripts/sync-publish-pin-versions.py --check    # CI-style verify
+  ```
 
-   **Sub-crate path-dependency pins** - Several sub-crates pin sibling crates
-   by exact version (e.g. `crates/core/Cargo.toml` pins `everruns-openui`,
-   `everruns-a2ui`). These must match the workspace version
-   or the `publish-crates` workflow rejects the tag. Run the helper after
-   bumping the workspace version:
+  Its pin map mirrors `dependency_versions` in `.github/workflows/publish-crates.yml`; keep both in
+  lockstep when adding path-pinned crates.
 
-   ```bash
-   python3 scripts/sync-publish-pin-versions.py            # rewrite drift
-   python3 scripts/sync-publish-pin-versions.py --check    # CI-style verify
-   ```
+## 4. Add the CHANGELOG entry
 
-   The helper's pin map mirrors `dependency_versions` in
-   `.github/workflows/publish-crates.yml`; keep both in lockstep when adding
-   new path-pinned crates.
+Insert after `## [Unreleased]`, preserving the file header and versioning policy:
 
-   **apps/ui/package.json** - Update `version`:
-   ```json
-   {
-     "version": "X.Y.Z"
-   }
-   ```
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
 
-   **CHANGELOG.md** - Add new version section after `## [Unreleased]`:
-   ```markdown
-   ## [X.Y.Z] - YYYY-MM-DD
+### Highlights
 
-   ### Highlights
+- **Feature Name** - Short description
 
-   - **Feature Name** - Short description
-   - **Feature Name** - Short description
+### What's Changed
 
-   ### What's Changed
+- feat: commit message ([#123](https://github.com/everruns/everruns/pull/123)) by [@username](https://github.com/username)
+```
 
-   - feat: commit message ([#123](https://github.com/everruns/everruns/pull/123)) by [@username](https://github.com/username)
-   - fix: commit message ([#124](https://github.com/everruns/everruns/pull/124)) by [@username](https://github.com/username)
+Link PRs and usernames. Add a **Migration Notes** section only when operators need upgrade guidance;
+engineering-only migration detail belongs in `crates/server/migrations/` and `specs/migrations.md`.
+Include screenshot links for UI changes.
 
-   <!-- Optional: keep only when the release needs user-facing upgrade guidance. -->
-   <!--
-   ### Migration Notes
+## 5. Verify migrations without rewriting them
 
-   - Upgrade guidance, if needed.
-   -->
-   ```
+Never squash, rename, or delete existing migrations for a release. Confirm the sorted basenames in
+`crates/server/migrations/` still start at `001_` and stay strictly sequential
+(`bash scripts/lib/check-migration-ordering.sh`).
 
-5. **Review migrations without rewriting them**:
+## 6. Refresh lockfiles
 
-   See `specs/release-process.md` ("Migration Handling") and `specs/migrations.md`.
+```bash
+cargo generate-lockfile
+(cd apps/ui && pnpm install --lockfile-only)
+(cd apps/docs && pnpm install --lockfile-only)
+```
 
-   - Do not squash, rename, rewrite, or delete existing migrations solely for release prep.
-   - Verify the sorted list of migration file basenames starts at `001_` and remains strictly sequential with no gaps or duplicates (matching `specs/migrations.md`).
-   - If a release includes an operator-visible migration caveat, note it in the release PR and release notes; otherwise skip migration-specific release notes.
+## 7. Commit and open the PR
 
-6. **Update lock files**:
-   ```bash
-   # Regenerate Cargo.lock with new workspace version
-   cargo generate-lockfile
-   # Regenerate pnpm lockfiles
-   (cd apps/ui && pnpm install --lockfile-only)
-   (cd apps/docs && pnpm install --lockfile-only)
-   ```
+Stage the files you touched by name, then:
 
-7. **Skip migration notes unless necessary**:
-   - Do not add a dedicated migration section by default
-   - Add one only when a release needs user-facing upgrade guidance
-   - If migration behavior only needs engineering discussion, capture it in the canonical migration locations, for example `crates/server/migrations/` and/or `specs/migrations.md`, instead of the changelog
+```bash
+git commit -m "chore(release): prepare vX.Y.Z"   # this message triggers auto-tagging on merge
+git push -u origin <current-branch>
+```
 
-8. **Create commit**:
-   ```bash
-   git add -A
-   git commit -m "chore(release): prepare vX.Y.Z"
-   ```
-
-9. **Create PR**:
-   ```bash
-   git push -u origin <current-branch>
-   gh pr create --title "chore(release): prepare vX.Y.Z" --body "$(cat <<'EOF'
-   ## Release vX.Y.Z
-
-   This PR prepares the vX.Y.Z release.
-
-   ### Checklist
-   - [ ] Review CHANGELOG.md entries
-   - [ ] Add highlights/screenshots if needed
-   - [ ] Verify version numbers updated
-   - [ ] CI passes
-
-   ### Post-merge
-   After merging, the release workflow will automatically:
-   - Create git tag `vX.Y.Z`
-   - Create GitHub Release with notes from CHANGELOG.md
-   - Trigger Docker image build with version tag
-   EOF
-   )"
-   ```
-
-10. **Remind user**:
-   - Review the PR, especially CHANGELOG.md
-   - Add any highlights or screenshots by editing CHANGELOG.md
-   - Merge when CI is green
-   - Tag and GitHub Release will be created automatically
-
-## Notes
-
-- Always preserve the CHANGELOG.md header and versioning policy section
-- The Highlights section is optional. Recommended for minor/major releases that ship genuinely noteworthy user-facing changes; omit entirely for maintenance releases
-- Include screenshots for UI changes (can be added as links in CHANGELOG.md)
-- Do not add a "Migration Notes" section to release entries unless it is necessary for user-facing upgrade guidance
-- The `chore(release): prepare vX.Y.Z` commit message triggers auto-tagging on merge
+Open the PR with `.github/pull_request_template.md`, and tell the user to review CHANGELOG.md, add
+any highlights or screenshots, and merge once CI is green — the tag, GitHub Release, Docker images,
+and crate publishes follow automatically.

--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -8,188 +8,48 @@ user-invocable: true
 
 # Maintenance
 
-Goal: leave the repo materially healthier and closer to release-ready state, with evidence.
+Leave the repo materially healthier and closer to release-ready, with evidence.
 
-This skill implements [`specs/maintenance.md`](../../../specs/maintenance.md). Keep operational guidance here. Keep design intent and constraints in the spec.
+Read [`specs/maintenance.md`](../../../specs/maintenance.md) first — it owns the success bar, the
+constraints, and the release-readiness standard. This skill owns execution only. Choose the smallest
+set of actions that closes the real maintenance risk in front of you; a longer checklist is not a
+better one.
 
-This skill is outcome-oriented. Do not blindly walk a fixed checklist. Choose the smallest set of actions that closes the real maintenance risk in front of you.
+## Sequence
 
-## When To Use
+1. **Fix the scope.** Use the user's scope if given. Otherwise infer one from recent diffs, release
+   posture, and obviously stale areas — and state the assumption.
+2. **Pick the highest-signal surface first.** Recent diffs, failing or flaky checks, stale specs,
+   outdated dependencies, known security or performance hotspots. Skip untouched areas deliberately
+   and say why. Surface-by-surface goals and evidence live in
+   [`references/surfaces.md`](references/surfaces.md).
+3. **Prefer fixing over reporting.** Fix what is small and local. For anything larger, produce a
+   crisp finding with evidence and the next action, and file it in Linear (OSS project, EVE team).
+   Bugs found here prefer a failing test before the fix.
+4. **Validate to the risk.** Go deeper for auth, persistence, migrations, public API, external
+   integrations, and end-to-end UI flows.
+5. **Keep it PR-sized.** If a theme explodes, finish the highest-value slice and report the boundary.
 
-Use this skill when the task is about repo maintenance rather than a single feature:
+Do not claim release readiness unless the changed and high-risk surfaces were actually checked.
 
-- release-readiness review
-- dependency refreshes
-- spec or docs drift
-- test coverage gaps
-- threat-model or security hygiene review
-- performance review of recently changed code
-- technical debt analysis and issue tracking
-- AGENTS/skills/command hygiene
+## Evidence commands
 
-## Required Outcomes
+Pick only what matches the scope:
 
-1. The maintenance scope is explicit.
-   - If the user provided a scope, use it.
-   - If not, infer a reasonable scope from recent changes, release posture, and obviously stale areas. State the assumption.
-2. The work produces concrete improvement.
-   - Fix issues when the change is small and local.
-   - If an issue is too large for the current task, capture a crisp finding with evidence and the next action.
-3. Validation matches risk.
-   - Run checks that prove the updated areas are healthy.
-   - Increase depth for auth, persistence, migrations, public API, external integrations, and end-to-end UI flows.
-4. A release claim is backed by evidence.
-   - Do not call the repo release-ready unless the changed or high-risk surfaces were actually checked.
-
-## Operating Model
-
-- Start from goals and risk surface, not checklist order.
-- Prefer the highest-signal path first: recent diffs, flaky areas, failing checks, stale specs, outdated dependencies, or known security/performance hotspots.
-- Always run `cargo outdated` (or `cargo search` per-crate) and `pnpm outdated` during release-readiness or dependency-scoped maintenance — even when no security advisory exists. Patch/minor bumps are cheap to miss and cheap to apply; skipping them silently accumulates drift.
-- Check Linear issues in the OSS project (EVE team) already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues whose `updatedAt` is older than 1 day as stale by default, then triage or report them.
-- When maintenance covers release readiness or repo workflow hygiene, review recent upstream plugin-platform changes before declaring local plugins current. Check the Codex and Claude Code Everruns Dev plugin surfaces together: compare `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, shipped plugin behavior, skills, docs, and marketplace entries; run `scripts/test-everruns-dev-plugin.sh` or equivalent metadata validation so registration, version parity, compatibility, and non-contradiction are proven.
-- When maintenance covers recently shipped features or release readiness, check for half-built cross-surface features: UI disconnected from backend behavior, backend capabilities missing intended MCP/CLI/docs exposure, MCP or CLI behavior lagging API semantics, or tests/manual cases claiming more than the product provides.
-- Skip untouched areas when there is a clear reason. Say why they were skipped.
-- Prefer fixing over reporting.
-- For bugs uncovered during maintenance, prefer a failing test before the fix when practical.
-- Keep changes PR-sized. If a maintenance theme explodes in scope, finish the highest-value slice and report the boundary.
-
-## Maintenance Surfaces
-
-Use judgment on which surfaces matter for the current task.
-
-### Dependency Health
-
-Goal: all packages — including CLI, server, worker, integrations, UI, and docs — run on current dependency versions. Outdated major versions are upgraded proactively, not deferred indefinitely.
-
-Actions:
-- audit every workspace crate and pnpm-managed package for outdated dependencies, including major-version bumps
-- upgrade major versions when the migration path is clear; document blockers when it is not
-- flag deprecated crates/packages and identify replacements
-- check for unused dependencies (`cargo udeps` or manual review)
-
-Good evidence:
-- `cargo outdated` (or `cargo search`) checked for each CLI and workspace dependency
-- `pnpm outdated` checked for `apps/ui/` and `apps/docs/`
-- major-version upgrades applied and tested, not just noted
-- deprecated dependencies flagged with replacement plan
-- lockfiles updated intentionally
-- relevant build/lint/test checks pass
-
-### Specs And Docs Alignment
-
-Goal: docs describe the current system intent and constraints, without drifting into code duplication.
-
-Good evidence:
-- changed behavior reflected in `specs/`, `apps/docs/`, OpenAPI, or examples when relevant
-- stale or duplicate spec detail removed in favor of links to source files
-
-### Feature Completeness Across Surfaces
-
-Goal: features that appear shipped in one surface are connected, reachable, and consistent across the intended UI, backend, MCP, CLI, docs, and tests.
-
-Good evidence:
-- UI affordances call real backend APIs and handle loading, errors, auth, and state refresh
-- backend features intended for agent or automation use are exposed through MCP/app surfaces where applicable
-- CLI commands and flags match current API semantics and do not duplicate stale assumptions
-- docs, specs, examples, tests, and manual test cases do not claim unavailable behavior
-- gaps are fixed locally or captured as specific findings with the missing surface, user impact, and next action
-
-### Security And Threat Posture
-
-Goal: new or changed attack surface is understood, and mitigations/docs match reality.
-
-Actions:
-- run DeepSec when maintenance includes security posture, release readiness, auth/tenant/public-ingress review, or repo-wide hygiene:
-  - if `.deepsec/` is missing, initialize it with `npx deepsec init`
-  - install from `.deepsec/` with `pnpm install`
-  - keep `data/<project>/INFO.md` short and project-specific before processing
-  - run `pnpm deepsec scan --project-id everruns` from `.deepsec/`
-  - use `pnpm deepsec process --project-id everruns --agent codex` only with an explicit budgeted focus (`--filter`, `--limit`, `--only-slugs`, or `--manifest`) unless the user asks for a full AI pass
-  - revalidate high-severity results with `pnpm deepsec revalidate --project-id everruns --agent codex --min-severity HIGH`
-- keep durable DeepSec workspace files tracked: `.deepsec/.gitignore`, `.deepsec/AGENTS.md`, `.deepsec/README.md`, `.deepsec/deepsec.config.ts`, `.deepsec/package.json`, `.deepsec/pnpm-lock.yaml`, `.deepsec/pnpm-workspace.yaml`, and `.deepsec/data/*/{INFO.md,SETUP.md}`
-- do not commit generated DeepSec state unless explicitly requested: `.deepsec/node_modules/`, `.deepsec/.env*.local`, `.deepsec/data/*/{files,runs,reports,project.json,tech.json}`
-- create Linear issues in the OSS project (EVE team) for actionable DeepSec findings that are not fixed in the current maintenance pass
-
-Good evidence:
-- threat model updated when behavior or trust boundaries changed
-- obvious gaps in auth, validation, secret handling, or data exposure were reviewed
-- DeepSec scan/process/revalidate run IDs, scope, finding count, and budget/cost noted when DeepSec was used
-- [GitHub Security Overview](https://github.com/everruns/everruns/security) checked for advisories
-- [Dependabot alerts](https://github.com/everruns/everruns/security/dependabot) reviewed and triaged
-- [Secret scanning alerts](https://github.com/everruns/everruns/security/secret-scanning?query=is%3Aopen+results%3Ageneric) reviewed — no open generic secret leaks
-
-### Test And Runtime Confidence
-
-Goal: important paths are covered by the right proof, not ceremony.
-
-Good evidence:
-- targeted tests added or updated for regressions
-- smoke tests or manual verification used where unit tests are insufficient
-- checks match the touched surface instead of running an arbitrary full matrix
-
-### Performance And Operational Safety
-
-Goal: recent changes do not introduce obvious scale or latency regressions.
-
-Good evidence:
-- query shape, pagination, indexes, batching, and background job cost reviewed where relevant
-- no unbounded list paths or easy N+1 regressions in touched code
-
-### Technical Debt Analysis
-
-Goal: structural debt is identified, quantified, and tracked before it compounds into development friction or bugs.
-
-Good evidence:
-- god objects, duplicated logic, and boilerplate patterns identified with line counts and file locations
-- severity assessed (critical/high/medium/low) based on active harm vs. friction
-- concrete Linear issues created for each finding with actionable scope
-- hacks, shortcuts, and open vulnerabilities surfaced with code references
-- large files (>2K lines non-test) catalogued with the structural reason they grew
-
-### Issue Tracking Hygiene
-
-Goal: Linear reflects reality closely enough that active work is visible, stalled work is noticed, and release planning is not distorted by stale execution state.
-
-Good evidence:
-- OSS project issues already in `In Progress` were reviewed for stale ownership or stalled execution
-- issues whose `updatedAt` was older than 1 day were triaged, commented, re-scoped, or moved out of `In Progress`
-- maintenance findings that should not be fixed immediately were captured as actionable Linear issues or comments instead of left implicit
-
-### Repo Workflow Hygiene
-
-Goal: agent instructions, commands, skills, examples, and release helpers still match reality.
-
-Good evidence:
-- `AGENTS.md`, `.claude/commands/`, and `.claude/skills/` do not contradict each other
-- release or maintenance instructions point at the canonical workflow instead of duplicating stale detail
-- `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, and shipped plugin behavior were checked against recent upstream plugin-platform changes; registration, version parity, compatibility, or discoverability gaps were fixed or captured
-
-## Common Evidence Commands
-
-Pick only what matches the task:
-
-- `just pre-push`
-- `just pre-pr`
-- `cargo fmt --check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test --all-features`
+- `just pre-push` / `just pre-pr`
+- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo test --all-features`
 - `cd apps/ui && pnpm run lint && pnpm run build`
 - `cd apps/docs && pnpm run build`
 - `./scripts/export-openapi.sh`
-- `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/dependabot/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open Dependabot alert count
-- `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/secret-scanning/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open secret scanning alert count
-- `scripts/test-everruns-dev-plugin.sh` — Everruns Dev plugin metadata, registration, and version parity
-- Linear MCP: list OSS project issues in `In Progress`, compare each issue's `updatedAt` to current time, and flag items older than 1 day for triage
+- `scripts/test-everruns-dev-plugin.sh` — plugin metadata, registration, and version parity
+- Dependabot / secret-scanning alert counts:
+  ```bash
+  doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/dependabot/alerts --jq "[.[] | select(.state==\"open\")] | length"'
+  doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/secret-scanning/alerts --jq "[.[] | select(.state==\"open\")] | length"'
+  ```
 
 ## Deliverable
 
-Report:
-
-- what scope was covered
-- what was fixed or found
-- what evidence was gathered
-- which stale `In Progress` Linear issues were triaged, if that check was in scope
-- what was intentionally skipped and why
-
-If the user asks to ship after maintenance, hand off to [`/ship`](../ship/SKILL.md).
+Report the scope covered, what was fixed or found, the evidence gathered, and what was intentionally
+skipped and why. If the user then asks to ship, hand off to [`/ship`](../ship/SKILL.md).

--- a/.agents/skills/maintenance/references/surfaces.md
+++ b/.agents/skills/maintenance/references/surfaces.md
@@ -1,0 +1,98 @@
+# Maintenance surfaces
+
+Goals and good evidence per surface. Use judgment about which ones the current task touches.
+
+## Dependency health
+
+Every workspace crate and pnpm package — CLI, server, worker, integrations, UI, docs — runs on
+current versions, with major bumps applied rather than deferred indefinitely.
+
+- Run `cargo outdated` (or `cargo search` per crate) and `pnpm outdated` during any
+  release-readiness or dependency-scoped pass, even with no advisory outstanding. `specs/maintenance.md`
+  records the current `cargo outdated` tooling caveat and the pnpm release-age floor.
+- Apply and test major upgrades when the migration path is clear; document the blocker when it is not.
+- Flag deprecated crates/packages with a replacement, and check for unused dependencies
+  (`cargo udeps` or manual review).
+- Update lockfiles intentionally.
+
+## Specs and docs alignment
+
+Docs describe current intent and constraints without drifting into code duplication: changed
+behavior reflected in `specs/`, `apps/docs/`, OpenAPI, or examples; stale or duplicated spec detail
+replaced by links to source. Follow the spec hygiene rules in `specs/README.md` and
+`specs/maintenance.md`.
+
+## Feature completeness across surfaces
+
+Features that look shipped in one surface are connected and consistent in the others:
+
+- UI affordances call real backend APIs and handle loading, errors, auth, and refresh
+- backend features intended for agents or automation are exposed through MCP/app surfaces
+- CLI commands and flags match current API semantics
+- docs, specs, examples, tests, and manual test cases do not claim behavior the product lacks
+
+Fix locally, or record the missing surface, user impact, and next action.
+
+## Security and threat posture
+
+New or changed attack surface is understood and its mitigations match reality: threat model updated
+when trust boundaries moved, and obvious gaps in auth, validation, secret handling, or data exposure
+reviewed. Check the GitHub [security overview](https://github.com/everruns/everruns/security),
+[Dependabot alerts](https://github.com/everruns/everruns/security/dependabot), and
+[secret scanning](https://github.com/everruns/everruns/security/secret-scanning?query=is%3Aopen+results%3Ageneric).
+
+DeepSec runs when the pass covers security posture, release readiness, auth/tenant/public-ingress
+review, or repo-wide hygiene. Setup and usage live in [`.deepsec/AGENTS.md`](../../../../.deepsec/AGENTS.md);
+from `.deepsec/` after `pnpm install`:
+
+```bash
+pnpm deepsec scan --project-id everruns
+pnpm deepsec process --project-id everruns --agent codex --limit <n>   # budget the AI pass
+pnpm deepsec revalidate --project-id everruns --agent codex --min-severity HIGH
+```
+
+Keep the durable workspace files tracked (`.gitignore`, `AGENTS.md`, `README.md`,
+`deepsec.config.ts`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`,
+`data/*/{INFO.md,SETUP.md}`) and leave generated state (`node_modules/`, `.env*.local`,
+`data/*/{files,runs,reports,project.json,tech.json}`) uncommitted unless asked. Note run IDs, scope,
+finding count, and cost. File Linear issues for findings not fixed in this pass.
+
+## Test and runtime confidence
+
+Important paths carry the right proof, not ceremony: targeted tests for regressions, smoke tests or
+manual verification where unit tests are insufficient, and checks matched to the touched surface
+rather than an arbitrary full matrix.
+
+## Performance and operational safety
+
+Recent changes introduce no obvious scale or latency regression: query shape, pagination, indexes,
+batching, and background job cost reviewed where relevant; no unbounded list paths or easy N+1s.
+
+## Technical debt
+
+Structural debt is named and tracked before it compounds: god objects, duplicated logic, and
+boilerplate identified with file locations and line counts; severity judged by active harm versus
+friction; large non-test files (>2K lines) catalogued with the structural reason they grew; hacks
+and open vulnerabilities surfaced with code references. Each finding becomes an actionable Linear
+issue.
+
+## Issue tracking hygiene
+
+Linear reflects reality closely enough that stalled work is visible. Review OSS project issues
+already in `In Progress`; treat `updatedAt` older than 1 day as stale and triage, comment, re-scope,
+or move them out. Capture maintenance findings you are not fixing as issues rather than leaving them
+implicit.
+
+## Repo workflow hygiene
+
+Agent instructions, commands, and skills still match reality and do not contradict each other.
+
+- Each fact belongs to exactly one layer — see the guidance-layering table in
+  [`AGENTS.md`](../../../../AGENTS.md). Prune restatements instead of syncing them; move detail a
+  skill only needs sometimes into a `references/` file.
+- Release and maintenance instructions point at the canonical workflow rather than duplicating it.
+- Check plugin surfaces against recent upstream platform changes across
+  `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`,
+  `.cursor-plugin/marketplace.json`, and the per-host manifests under `plugins/everruns-dev/`
+  (see [`plugins/AGENTS.md`](../../../../plugins/AGENTS.md)); prove parity with
+  `scripts/test-everruns-dev-plugin.sh`.

--- a/.agents/skills/manual-ui-testing/SKILL.md
+++ b/.agents/skills/manual-ui-testing/SKILL.md
@@ -9,161 +9,60 @@ allowed-tools: Bash(npx agent-browser:*), Bash(agent-browser:*), Bash(just:*), B
 
 # Manual UI Testing
 
-Goal: execute UI test cases from `test_cases/ui/` using `agent-browser`, record results, and file issues for failures.
+Execute the test cases in `test_cases/ui/` against a running stack with `agent-browser`, record
+results, and file issues for failures. [`specs/test-cases.md`](../../../specs/test-cases.md) defines
+the test case format.
 
-## When To Use
+## Scope
 
-- User asks to run UI tests, manual tests, or test the UI
-- User asks to verify a specific UI flow or feature
-- User asks to re-test after a fix
+Each subdirectory of `test_cases/ui/` is a category — list the directory rather than assuming a
+fixed set. Every case states its own preconditions (auth mode, existing data), test data, steps, and
+expected result; read them before running. With no scope given, run everything in dependency order:
+auth → org → features.
 
-## Prerequisites
+## Stack
 
-### 1. Running Stack
-
-Full auth mode requires the full stack (not DEV_MODE). Start with a unique `PORT_PREFIX`:
+Full auth mode needs the real stack, not DEV_MODE. Start it with a unique per-worktree prefix and
+wait for PostgreSQL, Valkey, API, worker, UI, and Caddy to come up:
 
 ```bash
 PORT_PREFIX=<prefix> doppler run -- just start-all
-```
-
-Wait for all services (PostgreSQL, Valkey, API, Worker, UI, Caddy) to be healthy. Verify:
-
-```bash
 curl -s http://localhost:<prefix>00/healthz
 ```
 
-If the stack is already running, confirm the PORT_PREFIX and auth mode before proceeding.
+If a stack is already running, confirm its `PORT_PREFIX` and auth mode before using it.
 
-### 2. Agent-Browser
+## Driving the browser
 
-`agent-browser` runs headless Chromium. No special install needed — it's available via npx. The browser daemon persists between commands within a session.
-
-## Execution Flow
-
-### Step 1: Identify Test Scope
-
-Ask the user or determine from context which test categories to run:
-
-| Category | Path | Requires |
-|----------|------|----------|
-| admin_login | `test_cases/ui/admin_login/` | AUTH_MODE=admin |
-| full_auth | `test_cases/ui/full_auth/` | AUTH_MODE=full |
-| org_creation | `test_cases/ui/org_creation/` | Authenticated user |
-| mcp_servers | `test_cases/ui/mcp_servers/` | Authenticated + org |
-| global_chat | `test_cases/ui/global_chat/` | Authenticated + org |
-| global_search | `test_cases/ui/global_search/` | Authenticated + org |
-| scheduled_tasks | `test_cases/ui/scheduled_tasks/` | Authenticated + org + agent |
-
-If no specific scope requested, run all categories. Prioritize by dependency order: auth → org → features.
-
-### Step 2: Read Test Cases
-
-Read each `.md` file in the target category. Each test case has:
-- **Preconditions**: Required state (auth mode, existing data)
-- **Test Data**: Specific values to use
-- **Steps**: Numbered actions
-- **Expected Result**: Pass criteria
-
-### Step 3: Execute with agent-browser
-
-Core pattern for each test:
+`agent-browser` runs headless Chromium via `npx`; the daemon persists between commands in a session.
 
 ```bash
-# Navigate
 agent-browser open http://localhost:<prefix>00/<path>
 agent-browser wait --load networkidle
-
-# Discover elements
-agent-browser snapshot -i
-# Output: @e1 [input type="email"], @e2 [button] "Submit", etc.
-
-# Interact using refs
+agent-browser snapshot -i            # → @e1 [input type="email"], @e2 [button] "Submit", …
 agent-browser fill @e1 "value"
 agent-browser click @e2
 agent-browser wait --load networkidle
-
-# Verify result
 agent-browser snapshot -i
 agent-browser screenshot /tmp/test_<category>_<tc>.png
 ```
 
-**Key patterns:**
+Hints that cost time to rediscover:
 
-- **Login flow**: Navigate to login page → snapshot → fill email/password → click submit → wait → snapshot to verify redirect
-- **Form submission**: Navigate → snapshot → fill fields → click submit → wait → snapshot to verify success/error
-- **Navigation**: Click sidebar/menu refs → wait for networkidle → snapshot to verify page content
-- **Validation**: Fill partial data → attempt submit → verify error messages appear
+- Refs are invalidated by any navigation or DOM change — re-snapshot after every one.
+- Always `wait --load networkidle` after navigation, form submission, and before screenshots.
+- Chain independent commands with `&&`; do not chain when the next ref depends on reading a snapshot.
+- Next.js dev compilation can add 2–5s to a first page load.
+- Keyboard shortcuts (Ctrl+K) often do not reach headless Chromium — drive the equivalent click.
+- Screenshot each significant step, not just the verdict.
+- Element missing from a snapshot? `agent-browser scroll down` first.
+- Login redirect loop usually means `AUTH_MODE` does not match the test category.
 
-**Hints from experience:**
+## Recording
 
-- Always `wait --load networkidle` after navigation and form submissions
-- Re-snapshot after every navigation or DOM change — refs (`@e1`, etc.) are invalidated
-- Chain independent commands with `&&` for efficiency: `agent-browser fill @e1 "x" && agent-browser fill @e2 "y"`
-- Don't chain when you need to read snapshot output to determine next refs
-- In dev mode, Next.js compilation can delay page loads 2-5s — add extra waits if needed
-- Ctrl+K and other keyboard shortcuts may not work in headless Chromium — test via click instead
-- Take a screenshot at each significant step for evidence, not just pass/fail
+Write or update `test_cases/ui/MANUAL_TEST_RESULTS_<YYYY-MM-DD>.md` using
+[`references/results-template.md`](references/results-template.md). Partial or re-test runs append to
+(or update) the existing file for that date.
 
-### Step 4: Record Results
-
-Create or update `test_cases/ui/MANUAL_TEST_RESULTS_<date>.md` with:
-
-```markdown
-# Manual UI Test Results - <YYYY-MM-DD>
-
-## Environment
-
-- **Auth Mode**: <admin|full>
-- **Stack**: <components running>
-- **PORT_PREFIX**: <value>
-- **Browser**: Chromium (headless, via agent-browser)
-
-## Test Summary
-
-| Category | Tests | Pass | Fail/Partial | Issues |
-|----------|-------|------|-------------|--------|
-| ... | ... | ... | ... | ... |
-| **Total** | **N** | **N** | **N** | **N** |
-
-## Detailed Results
-
-### <Category> (N/M PASS)
-
-- **TC001 <Name>**: PASS|FAIL|PARTIAL - <one-line description of what happened>
-
-## Issues Found
-
-### Issue #N (<Severity>): <Title>
-- **Severity**: Low|Medium|High|Info
-- **Steps**: How to reproduce
-- **Expected**: What should happen
-- **Actual**: What happened
-- **Impact**: User-facing consequence
-```
-
-### Step 5: File Issues (Optional)
-
-If the user asks to file issues for failures, use Linear MCP tools:
-- Team: EVE, Project: OSS
-- Include severity, repro steps, expected vs actual
-- Reference the test case ID (e.g., "org_creation/TC003")
-
-## Partial Runs
-
-If the user asks to test a single feature or re-test a specific case:
-1. Read just that test case file
-2. Set up preconditions (may need to run auth tests first)
-3. Execute and record
-4. Append to or update the existing results file
-
-## Troubleshooting
-
-| Problem | Solution |
-|---------|----------|
-| `agent-browser` not found | Run via `npx agent-browser` |
-| Stale refs after click | Always re-snapshot after DOM changes |
-| Page doesn't load | Check stack health: `curl localhost:<prefix>00/healthz` |
-| Login redirect loop | Verify AUTH_MODE env var matches test category |
-| Screenshots blank | Add `wait --load networkidle` before screenshot |
-| Element not visible | Try `agent-browser scroll down` before snapshot |
+If the user asks for issues to be filed, create them via Linear MCP (EVE team, OSS project) with
+severity, repro steps, expected vs actual, and the test case ID (e.g. `org_creation/TC003`).

--- a/.agents/skills/manual-ui-testing/references/results-template.md
+++ b/.agents/skills/manual-ui-testing/references/results-template.md
@@ -1,0 +1,37 @@
+# Results file template
+
+Write to `test_cases/ui/MANUAL_TEST_RESULTS_<YYYY-MM-DD>.md`.
+
+```markdown
+# Manual UI Test Results - <YYYY-MM-DD>
+
+## Environment
+
+- **Auth Mode**: <admin|full>
+- **Stack**: <components running>
+- **PORT_PREFIX**: <value>
+- **Browser**: Chromium (headless, via agent-browser)
+
+## Test Summary
+
+| Category | Tests | Pass | Fail/Partial | Issues |
+|----------|-------|------|--------------|--------|
+| ... | ... | ... | ... | ... |
+| **Total** | **N** | **N** | **N** | **N** |
+
+## Detailed Results
+
+### <Category> (N/M PASS)
+
+- **TC001 <Name>**: PASS|FAIL|PARTIAL — <what happened, one line>
+
+## Issues Found
+
+### Issue #N (<Severity>): <Title>
+
+- **Severity**: Low|Medium|High|Info
+- **Steps**: how to reproduce
+- **Expected**: what should happen
+- **Actual**: what happened
+- **Impact**: user-facing consequence
+```

--- a/.agents/skills/process-issues/SKILL.md
+++ b/.agents/skills/process-issues/SKILL.md
@@ -8,139 +8,69 @@ user-invocable: true
 
 # Process Issues
 
-Goal: resolve open Linear issues from the **OSS** project by shipping one merged PR per issue, with full `/ship` quality.
+Resolve open Linear issues from the **OSS** project (EVE team) by shipping one merged PR per issue.
+The same workflow applies whether the user names one issue or asks for the backlog.
 
-This skill is outcome-oriented. Do not blindly walk a fixed checklist. Start from the issue backlog, pick the highest-value work, and drive each issue to a merged PR.
+`$ARGUMENTS` may carry issue IDs, a priority filter, or a project override.
+[`specs/issue-tracking.md`](../../../specs/issue-tracking.md) has project scope and prerequisites.
 
-See [`specs/issue-tracking.md`](../../../specs/issue-tracking.md) for project scope and prerequisites.
+## Rules that do not bend
 
-## When To Use
+- **One issue, one branch, one PR.** No batch PRs, no partial fixes.
+- **[`/ship`](../ship/SKILL.md) does the shipping.** Invoke it via the Skill tool for every PR.
+  Never re-implement its validation, PR, CI, or merge logic here.
+- **Reproduce before fixing.** The issue text is a claim, not a spec.
+- **Never take over someone else's issue silently.**
 
-Use this skill when the user asks to:
+## Per issue
 
-- process one Linear issue or a specific issue ID
-- process issues or work on Linear issues
-- tackle the backlog or fix open issues
-- pick up and ship Linear issues
-- work through outstanding bugs or features
+1. **Check ownership.** Read state, `updatedAt`, recent comments, and linked PRs.
+   - `In Progress` and touched within 1 day → actively owned; skip, no comment.
+   - `In Progress` and older than 1 day → raise the stale-ownership conflict to the human. Do not
+     auto-claim, reassign, or reset.
+   - Anything else → eligible.
+2. **Claim it.** Move to **In Progress** and assign before any analysis or code, so humans can see
+   the issue is owned.
+3. **Doubt the issue.** Parse it, search the codebase, and decide whether the described problem is
+   real, current, and correctly diagnosed. Ambiguous → comment asking for clarification, skip.
+4. **Branch** from `origin/main` as `{issue-id}-{short-description}` (lowercase kebab-case).
+5. **Reproduce against current `main`** — a failing test, a script, or a documented manual repro for
+   bugs; a verified gap for features. Cannot reproduce → comment with what you tried and observed,
+   then skip. Never patch symptoms you have not seen.
+6. **Fix the root cause you reproduced**, not necessarily the fix the reporter prescribed. Note any
+   divergence in the PR and in Linear. Commit as `fix(scope): … — Fixes EVE-123`.
+7. **Ship** via `/ship`, passing what you implemented, which issue it resolves, and the branch.
+8. **Close** — mark **Done** in Linear with a comment linking the merged PR.
 
-Invoke this skill even when the request names exactly one issue. A single issue still follows the same ownership, implementation, `/ship`, and Linear-closing workflow.
+Comment in Linear at milestones worth human attention: PR opened, blocker hit, scope decision, or
+substantial CI/review follow-up. Keep them short.
 
-## Arguments
+## Batches
 
-- `$ARGUMENTS` — Optional: specific issue IDs, priority filter, or project override (defaults to OSS project)
+Up to 5 issues per run, processed concurrently with subagents. Sort eligible issues by priority
+(Urgent > Critical > High > Medium > Low), then oldest first.
 
-## Required Outcomes
+Merge sequentially, never in parallel: let `/ship` merge one PR, rebase the next onto updated `main`,
+then ship it. Concurrent merges touching `Cargo.toml` workspace deps produce duplicate-key
+conflicts, and a PR whose CI ran against a stale base is not evidence.
 
-1. **One PR per issue, always.**
-   - Every issue gets its own branch and PR. No batch PRs. No partial fixes.
-   - Branch naming: `{issue-id}-{short-description}` from `origin/main` (lowercase kebab-case).
+## Skips
 
-2. **Each PR ships via the `/ship` skill.**
-   - Always invoke `/ship` using the Skill tool — never duplicate its logic (validation, PR creation, CI checks, merge).
-   - `/ship` owns the full shipping lifecycle: diff review, simplification, security review, artifact sync, evidence gathering, PR creation, CI wait, and squash merge.
-   - Each PR must satisfy all `/ship` required outcomes: goal met, validation matches risk, artifacts updated, CI green, PR merged safely.
+Skip when the issue is actively owned, stale-owned pending a human decision, not reproducible,
+blocked externally, ambiguous with clarification pending, or needs access you lack. Leave a Linear
+comment explaining the skip only when this run actually investigated it — ownership-only skips go to
+the human instead.
 
-3. **Issues are fully resolved or explicitly skipped.**
-   - Resolved: PR merged via `/ship`, issue marked **Done** in Linear with a comment linking the merged PR.
-   - Skipped: leave a Linear comment only when the current run investigated the issue and the skip is due to a blocker, missing clarification, or missing access. For ownership-only skips, raise the issue to the human user without leaving an automated takeover comment. Leave the issue as **In Progress** or unchanged.
+## Report
 
-4. **Issue text is doubted and the problem is reproduced before any fix.**
-   - Treat the issue description as a claim, not ground truth. Reporters misdiagnose, describe stale behavior, or request the wrong fix.
-   - Before writing a fix, confirm the problem actually exists: reproduce a bug (failing test, script, or manual repro) or verify a feature is genuinely missing/broken against current `main`.
-   - If the issue cannot be reproduced, do not fix blindly. Comment in Linear with what you tried and the observed behavior, then skip or request clarification. Never patch symptoms you have not observed.
-   - Fix the root cause you reproduced, not the fix the reporter prescribed if it turns out to be wrong. Note any divergence from the issue text in the PR and Linear.
+Issues completed with PR links, skipped with reasons, raised for stale-ownership decisions, and
+failed with error details.
 
-5. **Ownership is checked before pickup.**
-   - Before touching an issue, inspect its Linear state, `updatedAt`, recent comments, and linked PRs to detect active ownership.
-   - If the issue is already **In Progress** and was updated within the last 1 day, treat it as actively owned by somebody else and skip it.
-   - If the issue is already **In Progress** and `updatedAt` is older than 1 day, raise it to the human user as a stale-ownership conflict. Do not auto-take over, auto-reassign, or silently reset the issue.
-   - If the issue is available to pick up, immediately move it to **In Progress** and assign it before starting analysis or implementation. Do this as the first state-changing action after the ownership check so humans can see the issue is actively owned.
-
-6. **Sequential merging prevents conflicts.**
-   - After `/ship` merges each PR, rebase remaining open PRs onto updated `main` before shipping the next.
-   - When multiple PRs touch `Cargo.toml` workspace deps, the second merge can create duplicate key errors — rebase catches this.
-   - Never ship a PR whose CI ran against a stale base.
-
-7. **A summary report is delivered.**
-   - Issues completed (with PR links)
-   - Issues skipped (with reasons)
-   - Issues raised to the human because stale **In Progress** ownership needed a decision
-   - Issues that failed (with error details)
-
-## Operating Model
-
-### Prerequisites
-
-Verify environment before starting:
+## Prerequisites
 
 ```bash
 doppler run -- env | rg 'LINEAR_API_KEY|GITHUB_TOKEN'
 doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
 ```
 
-Linear MCP server must be configured in `.mcp.json`.
-
-### Query and Prioritize
-
-1. Query open issues from the **OSS** project via Linear MCP (apply `$ARGUMENTS` filters if provided)
-2. Read each issue's title, description, labels, priority, state, `updatedAt`, recent comments, and linked PRs
-3. Check ownership before pickup:
-   - **In Progress**, updated within 1 day: somebody else is actively working on it; skip
-   - **In Progress**, updated more than 1 day ago: raise to the human user for a takeover decision; do not auto-claim it
-   - Any other state: eligible to pick up
-4. Sort eligible issues by priority (Urgent > Critical > High > Medium > Low), then oldest first within same priority
-5. Select up to **5 issues** to process
-
-### Per-Issue Execution
-
-For each issue, process up to 5 concurrently using subagents:
-
-1. **Pick up immediately** — only after the ownership check passes, mark as **In Progress** in Linear and assign it before analysis, branching, or implementation
-2. **Analyze and doubt** — parse requirements, search codebase, identify root cause or scope. Treat the issue text as a claim to be verified, not a spec to be executed. Question whether the described problem is real, current, and correctly diagnosed. If ambiguous: comment in Linear requesting clarification, skip
-3. **Branch** — `git fetch origin main && git checkout -b {issue-id}-{short-description} origin/main`
-4. **Reproduce before fixing** — confirm the problem exists against current `main` before writing any fix:
-   - Bugs: reproduce with a failing test, script, or documented manual repro. Capture the observed (wrong) behavior
-   - Features: verify the capability is genuinely missing or broken, not already present
-   - If it cannot be reproduced, do not fix blindly — comment in Linear with what you tried and what you observed, then skip or request clarification
-5. **Implement** — write the code change:
-   - Parse issue description and acceptance criteria
-   - Address the root cause you reproduced, not just the fix the reporter prescribed; note any divergence from the issue text
-   - Write failing test first for bugs; validate acceptance criteria for features
-   - Commit with conventional-commit messages referencing the issue (e.g., `fix(core): resolve X — Fixes EVE-123`)
-6. **Ship via `/ship` skill** — invoke `/ship` using the Skill tool to handle validation, PR creation, CI, and merge. **Do NOT** duplicate `/ship` logic (validation, PR creation, merge sequencing) inline — always delegate.
-   - Pass context: what was implemented, which issue it resolves, the branch name
-   - `/ship` owns: diff review, simplification, security review, artifact sync, evidence gathering, PR creation, CI wait, and merge
-7. **Keep Linear updated** — add Linear comments for major processing milestones when useful for human visibility, especially when opening a PR, discovering a blocker, making a meaningful scope decision, or when CI/review requires substantial follow-up. Keep comments concise and include PR links for PR-related updates
-8. **Close** — after `/ship` completes merge: mark issue **Done** in Linear, add comment with merged PR link
-
-### Merge Sequencing
-
-When multiple issues produce PRs, merge sequentially (not in parallel):
-
-1. Let `/ship` merge the first PR (CI must be green)
-2. Rebase next PR onto updated `main`, push, then invoke `/ship` for that PR
-3. Repeat until all PRs are merged
-
-### Skip Rules
-
-Skip an issue if:
-
-- Already **In Progress** and updated within the last 1 day (active owner)
-- Already **In Progress** and older than 1 day until a human decides whether to take it over
-- Cannot be reproduced against current `main` (comment with what you tried and observed)
-- Blocked by external dependency
-- Requirements ambiguous and clarification pending
-- Requires access/permissions not available
-
-Leave a Linear comment explaining the skip only when the current run actively investigated the issue and the skip is due to a blocker, missing clarification, or missing access. Do **not** leave an automated Linear comment for ownership-only skips: if the issue is already **In Progress** and stale, raise it to the human user for a takeover decision instead.
-
-## Constraints
-
-- Max 5 issues in parallel
-- The same workflow applies to a single requested issue and to a batch of issues
-- No batch PRs — one PR per issue
-- No partial fixes — fully resolve or skip
-- No manual deployment steps (CI/CD handles deployment)
-- No backward compatibility shims (internal code, just change it)
-- **No shipping shortcuts** — always invoke `/ship` via the Skill tool for validation, PR, CI, and merge. Never inline `/ship` logic or skip shipping steps
+The Linear MCP server must be configured in `.mcp.json`.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -8,148 +8,67 @@ user-invocable: true
 
 # Ship
 
-Goal: land the requested change safely, with evidence, and merge only after CI is green.
+Land the requested change with evidence, and merge only after CI is green.
 
-This skill implements [`specs/shipping.md`](../../../specs/shipping.md). Keep operational guidance here. Keep the shipping success bar and constraints in the spec.
+Read [`specs/shipping.md`](../../../specs/shipping.md) first — it owns the success bar, the
+constraints, the CI opt-out labels, and the reporting standard. This skill owns execution only.
+Start from the goal and the changed risk surface, then take the shortest path that proves the
+change is ready; do not walk this file as a fixed checklist.
 
-This skill is outcome-oriented. Do not blindly walk a fixed checklist. Start from the goal and changed risk surface, then choose the smallest path that proves the change is ready.
+## Sequence
 
-## When To Use
+1. **Check the branch.** Never ship from `main`. Clean tree before the final push.
+2. **Review the delta.** `git diff origin/main...HEAD` and `git log origin/main..HEAD`. Confirm the
+   requested behavior is actually implemented, then simplify avoidable complexity you introduced.
+3. **Validate to the risk.** Pick from the evidence commands below; deepen only where signal is
+   weak. Bug fixes prefer a failing test before the fix.
+4. **Security review.** Mandatory for any change touching code, config, or infrastructure. Follow
+   [`references/security-review.md`](references/security-review.md).
+5. **Sync artifacts** the change actually affects: `specs/`, `specs/threat-model.md`, `AGENTS.md`,
+   `test_cases/`, `apps/docs/`, OpenAPI exports.
+6. **Smoke test the affected flows** end to end — `just start-dev --no-watch`, or
+   `just start-all --no-watch` when database, migration, infra, or API integration risk exists.
+   Stop anything you started. Docs- or config-only changes may skip this with a stated reason.
+7. **Decide follow-ups explicitly.** Prefer implementing in-scope work now. List anything deferred
+   under **Follow-ups** in the PR body with a one-line rationale, or state "No follow-ups." — a
+   reader must be able to tell "nothing left" from "agent forgot". File Linear issues (OSS/EVE) for
+   non-trivial deferrals.
+8. **Open the PR and merge** — see [`references/pr-and-merge.md`](references/pr-and-merge.md).
 
-Use this skill when the user asks to:
+## Migrations
 
-- ship or fix and ship a change
-- take work through validation, PR creation, CI, and merge
-- prove a branch is merge-ready
+Rebase silently keeps two branches' identical migration numbers. Run
+`bash scripts/lib/check-migration-ordering.sh` after every rebase, and again immediately before
+`gh pr merge` — another PR may have merged a colliding number during review. Renumber to the next
+free number when it fails.
 
-## Required Outcomes
+Merging without a final rebase is fine when it saves a CI cycle and no migration risk exists:
 
-**ALL outcomes below are MANDATORY. These are not suggestions — do not skip or weaken any requirement.**
+```bash
+git fetch origin main
+base="$(git merge-base HEAD origin/main)"
+git diff --name-only "$base"..HEAD -- crates/server/migrations/
+git diff --name-only "$base"..origin/main -- crates/server/migrations/
+```
 
-1. The branch state is safe.
-   - Do not ship from `main` or `master`.
-   - The working tree must be clean before the final push.
-   - Prefer rebasing onto the latest `origin/main` before merge.
-   - Merging without the latest rebase is acceptable when saving another CI cycle is more valuable and migration risk is absent. Before doing this, fetch `origin/main` and check that neither `origin/main` nor the PR changed `crates/server/migrations/` since their merge base. If either side changed migrations, rebase and run `bash scripts/lib/check-migration-ordering.sh`.
-     ```bash
-     git fetch origin main
-     base="$(git merge-base HEAD origin/main)"
-     git diff --name-only "$base"..HEAD -- crates/server/migrations/
-     git diff --name-only "$base"..origin/main -- crates/server/migrations/
-     ```
-   - **After rebasing**, run `bash scripts/lib/check-migration-ordering.sh` to verify `crates/server/migrations/` numbers are strictly sequential. Migrations are the most common conflict source — multiple branches often add the same next number, and rebase silently keeps both. If the check fails, renumber your migration to the next available number.
-   - **Immediately before `gh pr merge`** (after CI is green and review threads are resolved), re-run `bash scripts/lib/check-migration-ordering.sh`. Other PRs may have merged a colliding number while yours was in review.
-2. The requested goal is achieved with evidence.
-   - Review the delta with `git diff origin/main...HEAD` and `git log origin/main..HEAD`.
-   - Confirm the requested behavior is actually implemented.
-   - Validation must match risk. For bugs, prefer a failing test first when practical.
-3. The changed code is fit to merge.
-   - Simplify obvious duplication or accidental complexity.
-   - Perform a structured security review (see **Security Review** section below).
-   - Fix issues you find and refresh the evidence.
-4. Relevant artifacts stay in sync.
-   - Update only the artifacts affected by the change: `specs/`, `specs/threat-model.md`, `AGENTS.md`, `test_cases/`, `apps/docs/`, and OpenAPI exports when applicable.
-5. Smoke test impacted functionality.
-   - **Always** smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment.
-   - Prefer `just start-dev --no-watch` for fast checks.
-   - Use `just start-all --no-watch` when database, migration, infra, or API integration risk exists.
-   - Stop any servers you started.
-   - Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
-6. Follow-ups are surfaced, not silently dropped.
-   - **Default to implementing everything in scope before merging.** Do not defer work just because the PR is "big enough".
-   - During diff review, security review, smoke testing, and review-comment handling, actively look for: TODOs you added, partial fixes, known edge cases not covered by tests, suggestions you chose not to apply, related bugs you noticed, spec/doc drift you did not fix, and threat-model items that warrant a separate change.
-   - For each candidate, decide explicitly: **implement now** (preferred) or **defer**. Prefer implementing now whenever the work is small, clearly in scope, or required for correctness.
-   - For anything deferred, list it under a **Follow-ups** section in the PR body with a one-line rationale per item (why it is safe to defer and what should happen later). File Linear issues for non-trivial follow-ups when appropriate (OSS project, EVE team).
-   - If there are no follow-ups, state "No follow-ups." in the PR body. Silence is not acceptable — readers must be able to tell the difference between "nothing left" and "agent forgot".
-7. The PR is mergeable and merged safely.
-   - Push the branch.
-   - Create or update the PR with `.github/pull_request_template.md`.
-   - Temporary CI opt-out labels (`ci:skip-docker`, `ci:skip-slow-rust`, `ci:skip-postgres-integration`, `ci:skip-sdk-compat`, `ci:skip-ui-e2e`, `ci:skip-docs-notebooks`, `ci:skip-integration-workflows`) may be used only for interim pushes after checking the skipped surface is not useful for that iteration.
-   - Before final merge readiness, remove any `ci:skip-*` label that suppresses CI affected by the PR diff and rerun CI on the latest PR commit. The `CI Opt-Out Policy` job must pass; do not merge with affected CI still skipped by opt-out.
-   - Check the PR conversation, review threads, and review state from all reviewers, including bots.
-   - After each push and again after CI turns green, wait at least 2 minutes for async reviewer bots to finish, then re-check for new comments before merge.
-   - **Address every review comment** — including low-confidence suggestions, nits, non-blocking ones (COMMENTED state), and bot suggestions. Non-blocking comments often contain valid improvements (UX, robustness, doc clarity). For each comment: analyze the concern, reason about whether a code change is warranted, and either apply the fix or reply with a clear explanation of why the current code is correct. Do not dismiss comments without reasoning.
-   - **Always reply to the comment** with what you did: what code change you made, or why the current code is correct. Then **mark the thread as resolved**. Every addressed comment must have both a reply and a resolved status before merge.
-   - Do not merge while any review comment is unresolved. Every thread must be explicitly addressed (code change or written resolution) before merge.
-   - Wait for CI to go green.
-   - Merge with squash only after CI is green, all review threads are resolved, and the final review/comment sweep above is clean.
-   - After merging, monitor main CI for the merge commit. If it fails, treat it as an active shipping regression and fix or revert promptly.
+If either side touched migrations, rebase and re-run the ordering check. After merging without a
+rebase, watch main CI for the merge commit.
 
-## Operating Model
-
-- Start from the goal and risk surface, not checklist order.
-- Choose the highest-signal path first: targeted diff review, focused tests, relevant builds, then smoke tests if gaps remain.
-- "Fix and ship" means implement first, then switch into shipping mode.
-- Docs or config-only changes can skip code tests when you explain why and run the relevant docs, lint, or build proof.
-- CI is slow enough that reducing unnecessary cycles is important. Use CI opt-out labels only to conserve interim CI time, not to weaken merge evidence. Prefer `ci:skip-docker` while iterating on non-container changes that still touch Rust/UI paths, `ci:skip-slow-rust` for early pushes where local targeted Rust evidence already covers the change, `ci:skip-postgres-integration` when only the PostgreSQL integration job is low-signal for the current push, `ci:skip-sdk-compat` when SDK contracts are unaffected, `ci:skip-ui-e2e` when UI smoke coverage is not relevant to the push, `ci:skip-docs-notebooks` when executable tutorial behavior is unchanged, and `ci:skip-integration-workflows` when the standalone integration workflow surface is unaffected. Before merge, remove opt-outs that suppress affected checks and rerun CI.
-- Do not use auto-merge or `gh pr merge --auto`; merge manually only after the final review sweep is clean because async review bots can post after the last push or after CI turns green.
-- If `just fmt` can auto-fix a failing formatting check, use it once and retry.
-- Stop only for blockers you cannot safely resolve alone: merge conflicts, missing credentials, ambiguous product intent, or CI failures you cannot reproduce or fix.
-
-## Security Review
-
-**This is a mandatory step for every change that touches code, configuration, or infrastructure. It is not optional and must not be skipped based on perceived low risk.**
-
-For every shipped change, explicitly perform these steps:
-
-1. **Identify the threat surface.** Read `git diff origin/main...HEAD` and determine which threat model categories from [`specs/threat-model.md`](../../../specs/threat-model.md) the change touches. Common categories:
-   - `TM-AUTH` — authentication changes, session handling, token generation
-   - `TM-AUTHZ` — permission checks, policy enforcement, role changes
-   - `TM-API` — new/changed endpoints, input parsing, query parameters
-   - `TM-TOOL` — tool registration, MCP servers, tool execution paths
-   - `TM-LLM` — prompt construction, API key handling, model parameters
-   - `TM-TENANT` — data queries, org scoping, cross-tenant boundaries
-   - `TM-FS` — file paths, sandbox boundaries
-   - `TM-SQL` — database queries, sandbox boundaries
-   - `TM-BASH` — sandbox configuration, command execution
-   - `TM-WEB` — frontend rendering, CORS, CSP, cookie handling
-   - `TM-DOS` — unbounded inputs, missing pagination, resource limits
-
-2. **Review each touched category.** For every relevant category, check the diff for:
-   - **Injection** — SQL, command, prompt, XSS, path traversal
-   - **Authentication/Authorization bypass** — missing auth checks, broken access control
-   - **Data exposure** — sensitive data in logs, responses, errors, or traces
-   - **Input validation** — missing or insufficient validation at trust boundaries
-   - **Dependency risk** — new dependencies, version changes, supply chain
-   - **Resource exhaustion** — unbounded loops, missing limits, large allocations
-
-3. **Check for THREAT comments.** If the change modifies code near existing `// THREAT[TM-XXX-NNN]` comments, verify the mitigation is preserved. If the change introduces new threat surface, add appropriate `THREAT` comments.
-
-4. **Update the threat model.** If the change introduces a genuinely new threat or materially changes an existing mitigation, update `specs/threat-model.md` with new entries or revised mitigations. Do not skip this for "small" changes — small changes at trust boundaries can have outsized impact.
-
-5. **Document the review.** Include a **Security** section in the PR body listing:
-   - Which threat categories were reviewed
-   - Any findings and how they were addressed
-   - Explicit statement if no security-relevant surface was touched (with reasoning)
-
-Changes that are purely docs, comments, specs, or test-only may state "No security-relevant code changes" with a one-line justification instead of the full review.
-
-## Common Evidence Commands
+## Evidence commands
 
 Pick only what matches the changed surface:
 
-- `just pre-push`
-- `just pre-pr`
-- `cargo fmt --check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test --all-features`
-- `cargo fetch --locked`
+- `just pre-push` / `just pre-pr`
+- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo test --all-features`, `cargo fetch --locked`
 - `cd apps/ui && pnpm run format:check && pnpm run lint && pnpm run build`
-- `./scripts/export-openapi.sh`
 - `cd apps/docs && pnpm run check && pnpm run build`
-- `bash scripts/lib/check-migration-ordering.sh` (migration sequentiality, ~instant)
+- `./scripts/export-openapi.sh`
+- `bash scripts/lib/check-migration-ordering.sh`
 
-## PR And Merge
+If `just fmt` can auto-fix a failing format check, use it once and retry.
 
-- Use a conventional-commit style PR title.
-- Use `.github/pull_request_template.md` as the required PR body structure. Start by copying the template headings exactly, then fill every applicable section. Do not replace the template with ad-hoc headings such as `Summary` or `Validation`, even for small docs-only changes.
-- In the PR body, explain what changed, why it changed, the Before / After proof, risk, security review, validation/checklist status, and an explicit **Follow-ups** section (or "No follow-ups." if none). Map those details into the template's existing sections instead of inventing a shorter structure. Prefer implementing follow-ups in this PR; only defer when the work is genuinely out of scope or too large, and say so per item.
-- Use `gh pr view --json url` to detect an existing PR.
-- Create a PR with `gh pr create` if needed.
-- Use `gh pr edit --add-label <label>` only for interim CI opt-outs, and `gh pr edit --remove-label <label>` before final CI. If label removal does not trigger the expected workflow, rerun the workflow or push an empty final commit only after confirming that is the repo's intended practice.
-- Use `gh pr view --comments` to inspect the PR conversation, including bot comments.
-- Use `gh pr view --json reviews,latestReviews` to inspect reviewer state.
-- If review-thread status is unclear, inspect the review threads in the GitHub UI or via `gh api graphql` before merge.
-- After the final push and after CI is green, wait at least 2 minutes for async reviewer bots, then do one last comment sweep before merge.
-- Use `gh pr checks` to watch CI.
-- Merge with `gh pr merge --squash` only after CI is green and the final review sweep is clean.
+## Stopping
+
+Stop and report only for blockers you cannot resolve safely alone: merge conflicts you cannot
+adjudicate, missing credentials, ambiguous product intent, or CI failures you cannot reproduce.

--- a/.agents/skills/ship/references/pr-and-merge.md
+++ b/.agents/skills/ship/references/pr-and-merge.md
@@ -1,0 +1,35 @@
+# PR and merge
+
+## Open or update the PR
+
+- Push the branch, then `gh pr view --json url` to detect an existing PR, `gh pr create` otherwise.
+- Title: Conventional Commits, under 70 characters.
+- Body: copy the headings from [`.github/pull_request_template.md`](../../../../.github/pull_request_template.md)
+  exactly and fill every applicable section — including Before/After proof, risk, the security
+  review, and **Follow-ups**. Do not substitute ad-hoc headings, even for small changes.
+
+## CI
+
+- `gh pr checks` watches CI. Never merge red.
+- CI opt-out labels (`ci:skip-*`) are listed in [`specs/shipping.md`](../../../../specs/shipping.md).
+  They exist to save interim CI cycles, not to weaken merge evidence: before merge, remove any label
+  suppressing CI affected by the diff and rerun CI on the final commit so the `CI Opt-Out Policy`
+  job passes. Add and remove with `gh pr edit --add-label` / `--remove-label`.
+
+## Review sweep
+
+- Inspect the full conversation and reviewer state: `gh pr view --comments`,
+  `gh pr view --json reviews,latestReviews`. Use `gh api graphql` if thread resolution is unclear.
+- Address **every** comment — nits, low-confidence suggestions, COMMENTED-state notes, and bot
+  output. Analyze the concern, then either change the code or reply explaining why the current code
+  is correct. Reply on every thread with what you did, then resolve it.
+- Async reviewer bots post late. After the final push and again after CI turns green, wait at least
+  2 minutes and re-check for new comments.
+
+## Merge
+
+- `gh pr merge --squash`, manually, only after CI is green and the final sweep is clean. Do not use
+  auto-merge — it bypasses the post-green sweep.
+- Re-run `bash scripts/lib/check-migration-ordering.sh` immediately before merging.
+- After merge, watch main CI for the merge commit. A failure there is an active regression: fix or
+  revert promptly.

--- a/.agents/skills/ship/references/security-review.md
+++ b/.agents/skills/ship/references/security-review.md
@@ -1,0 +1,35 @@
+# Security review
+
+Every change that touches code, configuration, or infrastructure gets this review. Perceived low
+risk is not a reason to skip it. Purely docs, comment, spec, or test-only changes may instead state
+"No security-relevant code changes" with a one-line justification.
+
+## 1. Identify the threat surface
+
+Read `git diff origin/main...HEAD` and map it to the categories in
+[`specs/threat-model.md`](../../../../specs/threat-model.md) — auth (`TM-AUTH`), authorization
+(`TM-AUTHZ`), API surface (`TM-API`), tools and MCP (`TM-TOOL`), prompts and provider keys
+(`TM-LLM`), tenancy (`TM-TENANT`), filesystem (`TM-FS`), SQL (`TM-SQL`), sandboxed execution
+(`TM-BASH`), frontend (`TM-WEB`), and resource exhaustion (`TM-DOS`). The spec is the current list;
+trust it over this summary.
+
+## 2. Review each touched category
+
+Check the diff for injection (SQL, command, prompt, XSS, path traversal), auth/authz bypass, data
+exposure in logs/responses/errors/traces, missing validation at trust boundaries, dependency and
+supply-chain risk, and unbounded work or allocations.
+
+## 3. Keep `THREAT` comments true
+
+Code carries `// THREAT[TM-XXX-NNN]` markers next to mitigations. If the diff touches code near one,
+verify the mitigation still holds. If it opens new surface, add a marker.
+
+## 4. Update the threat model
+
+Update `specs/threat-model.md` when the change introduces a genuinely new threat or materially
+changes a mitigation. Small changes at trust boundaries often qualify.
+
+## 5. Document it
+
+The PR body's **Security** section lists the categories reviewed, findings and how they were
+addressed, or an explicit statement that no security-relevant surface was touched, with reasoning.

--- a/.agents/skills/ui-screenshots/SKILL.md
+++ b/.agents/skills/ui-screenshots/SKILL.md
@@ -5,199 +5,41 @@ metadata:
   internal: true
 ---
 
-# UI Screenshots Skill
+# UI Screenshots
 
-Capture UI screenshots for visual verification.
+Capture UI state for review evidence with [agent-browser](https://github.com/vercel-labs/agent-browser).
+Screenshots are never committed — they are uploaded to Cloudinary and embedded in a PR comment.
 
-Uses [agent-browser](https://github.com/vercel-labs/agent-browser) for screenshots (fast Rust CLI with Node.js fallback).
+## Scripts
 
-## Prerequisites
-
-1. **agent-browser**: Install the browser automation CLI:
-   ```bash
-   npm install -g agent-browser
-   agent-browser install  # Download Chromium
-   ```
-
-   For Linux with missing dependencies:
-   ```bash
-   agent-browser install --with-deps
-   ```
-
-2. **Cloudinary Account** (free tier available):
-   - Create account at [cloudinary.com](https://cloudinary.com)
-   - Get your `CLOUDINARY_URL` from the dashboard (format: `cloudinary://API_KEY:API_SECRET@CLOUD_NAME`)
-   - Set environment variable: `CLOUDINARY_URL`
-
-3. **GitHub Token**: `GITHUB_TOKEN` environment variable for PR comments.
-
-## Usage
-
-### Taking Screenshots
-
-Use the take-screenshot script:
+Each script documents its own usage and requirements in its header; read it if the flags matter.
 
 ```bash
-.claude/skills/ui-screenshots/scripts/take-screenshot.sh [URL] [OUTPUT_PATH]
+.agents/skills/ui-screenshots/scripts/check-config.sh                       # GITHUB_TOKEN, CLOUDINARY_URL, agent-browser
+.agents/skills/ui-screenshots/scripts/take-screenshot.sh <URL> <OUTPUT>
+.agents/skills/ui-screenshots/scripts/upload-screenshot.sh <PATH> <PR> [DESCRIPTION]
 ```
 
-Example:
-```bash
-.claude/skills/ui-screenshots/scripts/take-screenshot.sh \
-  http://localhost:9300/dev/components \
-  screenshot.png
-```
+For anything the scripts do not cover, drive `agent-browser` directly (`open`, `screenshot --full`,
+`snapshot -i -c`, `scroll`, `--session <name>` to isolate instances).
 
-### Using agent-browser directly
+## Setup
 
-For more control, use agent-browser CLI commands:
-
-```bash
-# Open a page
-agent-browser open http://localhost:9300/dev/components
-
-# Take full-page screenshot
-agent-browser screenshot screenshot.png --full
-
-# Get accessibility snapshot (useful for AI agents)
-agent-browser snapshot -i -c
-```
-
-### Attaching Screenshots to PR
-
-Screenshots are NOT committed to the repo. They are uploaded to Cloudinary and embedded in PR comments:
-
-```bash
-.claude/skills/ui-screenshots/scripts/upload-screenshot.sh \
-  screenshot.png \
-  195  # PR number
-```
-
-## Integration with Smoke Tests
-
-The smoke test skill can call this skill to capture UI state:
-
-1. Run screenshot capture as part of smoke testing
-2. If a PR branch is detected, upload screenshots and add PR comment
-3. Screenshots help reviewers verify visual changes
-
-## Troubleshooting
-
-### agent-browser not found
-
-Install globally:
 ```bash
 npm install -g agent-browser
-agent-browser install
+agent-browser install            # add --with-deps on Linux when system libs are missing
 ```
 
-### Missing browser dependencies on Linux
+Uploading needs `CLOUDINARY_URL` (`cloudinary://API_KEY:API_SECRET@CLOUD_NAME`) and `GITHUB_TOKEN`.
 
-```bash
-agent-browser install --with-deps
-# Or manually:
-npx playwright install-deps chromium
-```
+## Non-obvious failures
 
-### Browser version mismatch
-
-If agent-browser reports a missing browser version (e.g., `chromium_headless_shell-1208`) but you have a similar version installed (e.g., `chromium_headless_shell-1200`), and network issues prevent downloading the correct version:
-
-```bash
-# Check available versions
-ls /root/.cache/ms-playwright/
-
-# Create symlinks to use a nearby version
-cd /root/.cache/ms-playwright
-ln -s chromium_headless_shell-1200 chromium_headless_shell-1208
-ln -s chromium-1200 chromium-1208
-```
-
-Note: This is a workaround when storage.googleapis.com is unreachable. Minor version differences (1200 vs 1208) are usually compatible.
-
-### Page hangs on localhost
-
-The dev server may not be running. Start it first:
-
-```bash
-cd apps/ui && pnpm run dev &
-sleep 10  # Wait for server
-```
-
-### Session conflicts
-
-agent-browser uses sessions to isolate browser instances:
-```bash
-# Use a named session
-agent-browser --session screenshots open http://localhost:9300
-
-# List sessions
-agent-browser session list
-```
-
-### Cloudinary upload fails
-
-Verify `CLOUDINARY_URL` is set correctly:
-- Format: `cloudinary://API_KEY:API_SECRET@CLOUD_NAME`
-- Get from Cloudinary dashboard
-
-## Script Reference
-
-### take-screenshot.sh
-
-Take a screenshot of a URL using agent-browser:
-
-```bash
-.claude/skills/ui-screenshots/scripts/take-screenshot.sh [URL] [OUTPUT_PATH]
-```
-
-Example:
-```bash
-.claude/skills/ui-screenshots/scripts/take-screenshot.sh \
-  http://localhost:9300/dev/components \
-  /tmp/screenshot.png
-```
-
-### upload-screenshot.sh
-
-Upload screenshot to Cloudinary and add PR comment:
-
-```bash
-.claude/skills/ui-screenshots/scripts/upload-screenshot.sh <SCREENSHOT_PATH> <PR_NUMBER> [DESCRIPTION]
-```
-
-Example:
-```bash
-.claude/skills/ui-screenshots/scripts/upload-screenshot.sh \
-  /tmp/screenshot.png \
-  195 \
-  "Dev components page showing message and tool call rendering"
-```
-
-### check-config.sh
-
-Check if cloud agent environment is configured:
-
-```bash
-.claude/skills/ui-screenshots/scripts/check-config.sh
-```
-
-Verifies: `GITHUB_TOKEN`, `CLOUDINARY_URL`, and agent-browser availability.
-
-## agent-browser Commands Reference
-
-Common commands for screenshot workflows:
-
-| Command | Description |
-|---------|-------------|
-| `agent-browser open <url>` | Navigate to a URL |
-| `agent-browser screenshot [path]` | Capture screenshot |
-| `agent-browser screenshot path --full` | Full page screenshot |
-| `agent-browser snapshot` | Get accessibility tree (for AI) |
-| `agent-browser snapshot -i -c` | Interactive elements only, compact |
-| `agent-browser click <selector>` | Click element |
-| `agent-browser wait <selector>` | Wait for element |
-| `agent-browser scroll down` | Scroll page |
-| `agent-browser --json ...` | JSON output for automation |
-
-See [agent-browser docs](https://github.com/vercel-labs/agent-browser) for full reference.
+- **Missing browser build** (e.g. `chromium_headless_shell-1208`) with `storage.googleapis.com`
+  unreachable: symlink a nearby version in `/root/.cache/ms-playwright/` — minor version drift
+  (1200 vs 1208) is normally compatible.
+  ```bash
+  cd /root/.cache/ms-playwright && ln -s chromium_headless_shell-1200 chromium_headless_shell-1208 && ln -s chromium-1200 chromium-1208
+  ```
+- **Page hangs on localhost**: the dev server is not up. See the local dev commands in
+  [`AGENTS.md`](../../../AGENTS.md).
+- **Blank screenshot**: wait for `networkidle` before capturing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,57 @@
-## Coding-agent guidance
+## Everruns
 
-### Required workflow
+Agentic runtime and control plane: Rust workspace in `crates/` (edition 2024), Next.js UI in
+`apps/ui/`, docs site in `apps/docs/` (content in `docs/`), embeddable examples in `examples/`.
+`just --list` shows every dev command.
+
+### Where guidance lives
+
+Keep each fact in exactly one layer, and read the layer that owns it.
+
+| Layer | Owns |
+|---|---|
+| `AGENTS.md` (this file, plus per-subtree ones) | repo gotchas that are not discoverable from the code |
+| `specs/` | why and what: design intent, contracts, success bars — start at `specs/README.md` |
+| `.agents/skills/` | how: workflows loaded on demand (`/ship`, `/maintenance`, `/process-issues`, `/manual-ui-testing`) |
+| source, `justfile`, `.github/workflows/` | exact commands, fields, shapes, and checks |
+
+Extend the owning layer instead of restating it here. When working in a subtree, check for a
+closer `AGENTS.md` (`apps/ui/`, `crates/server/migrations/`, `plugins/`, `.deepsec/`).
+
+### Norms
 
 - Telegraph. Drop filler. Keep updates short and factual.
-- Fix root cause. If unsure, read more code/specs; if still stuck, ask with short options.
-- Unrecognized working-tree changes are probably from another agent or the user. Work with them. Stop only if they make the task unsafe.
-- Start from latest main by default: `git fetch origin main`, then branch from or rebase onto `origin/main`.
-- In worktrees, verify state with `git status --branch` or `git worktree list`; do not assume `HEAD` tracks a branch.
-- When working in a subtree, check for a closer `AGENTS.md` and follow it.
-- After every rebase, check `crates/server/migrations/` for duplicate version numbers. If migrations changed, run `bash scripts/lib/check-migration-ordering.sh`.
+- Start from latest `origin/main` unless the task says otherwise.
 - Keep changes small, PR-sized, testable, and runnable locally.
 - For bug fixes, write or update a failing test before the fix when practical.
-- Important decisions belong as concise comments near the relevant code, not in scratch docs.
-- No backward compatibility required for internal code unless a spec says otherwise.
+- Record important decisions as concise comments near the relevant code, not in scratch docs.
+- Internal code needs no backward compatibility unless a spec says otherwise.
 
-### Cloud and secrets
+### Gotchas
 
-Use Doppler for all secret-backed commands in cloud agents.
+- Working-tree changes you did not make are probably another agent's or the user's. Work with
+  them, and stage files by name rather than `git add -A`.
+- Rebases silently keep colliding migration numbers. After a rebase that touches
+  `crates/server/migrations/`, run `bash scripts/lib/check-migration-ordering.sh` and renumber.
+- Run `just pre-push` before pushing.
+- Specs capture why/what; link to source instead of copying fields, enum variants, SQL DDL, or API
+  shapes. `docs/` holds public product documentation only — proposals and investigations belong in
+  `specs/` or `proposals/`.
+- Linear: OSS project, EVE team.
+
+### Local dev
+
+```bash
+PORT_PREFIX=271 just start-dev   # in-memory, no external services
+PORT_PREFIX=271 just start-all   # PostgreSQL + Valkey + NATS
+cd apps/ui && ./node_modules/.bin/next dev --port 9120   # UI only
+```
+
+Use a distinct `PORT_PREFIX` per worktree so parallel stacks do not collide.
+
+### Cloud agents and secrets
+
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, and `LINEAR_API_KEY` come from Doppler:
 
 ```bash
 ./scripts/init-cloud-env.sh
@@ -24,92 +59,17 @@ export CARGO_INCREMENTAL=0
 doppler run -- just start-dev --no-watch
 ```
 
-Secrets live in Doppler: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `LINEAR_API_KEY`.
-
-If GitHub auth fails, do not tell the user the token expired. Use:
+Failing GitHub auth means the token was not passed through, not that it expired:
 
 ```bash
 doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'
 ```
 
-### Specs and docs
+### Commits
 
-- `specs/` contains durable feature specifications and design intent. Use `rg`, `find`, and direct reads to consult relevant specs when changing behavior.
-- Start with `specs/README.md`; it is the specs index and map. For integrations, also read `specs/integrations.md`.
-- To find relevant specs, use `rg -n "<topic>" specs` and read the linked specs before changing behavior.
-- Specs capture why/what, not exhaustive how. Do not duplicate fields, enum variants, SQL DDL, or exact API shapes already readable from source.
-- Public product documentation lives in `docs/`. Internal proposals, durable design intent, and temporary investigations do not belong there.
-- UI design system (Slate): `apps/ui/src/app/design-system.css` is the runtime source of truth; `apps/ui/DESIGN.md` is its agent-readable companion in the [DESIGN.md format](https://github.com/google-labs-code/design.md). When changing design tokens, update both together and run `pnpm run design:lint` in `apps/ui`. See `specs/brand.md`.
-
-### Local dev and tests
-
-```bash
-just start-dev          # in-memory dev mode
-just start-all          # PostgreSQL + Valkey + NATS as local processes
-just --list             # all commands
-```
-
-Use a per-worktree `PORT_PREFIX` when running services:
-
-```bash
-PORT_PREFIX=271 just start-dev
-PORT_PREFIX=271 just start-all
-```
-
-UI-only iteration:
-
-```bash
-cd apps/ui
-./node_modules/.bin/next dev --port 9120
-```
-
-Rust uses stable edition 2024. For touched Rust crates, run focused tests plus formatting/linting as needed:
-
-```bash
-cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-features
-```
-
-Before pushing, always run `just pre-push`. If it fails, run `just fmt` when appropriate, fix root causes, and rerun it.
-
-### Git and commits
-
-- Conventional Commits: `type(scope): description`.
-- Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
-- Use `chore` for updates to `specs/` and `AGENTS.md`.
-- Never add Claude/session/AI attribution links in commits, PRs, docs, or code comments, except the standard yolop attribution trailer/footer for work performed by yolop.
-- Stage files explicitly by name. Avoid broad `git add .` / `git add -A`.
-
-Commit attribution must be the real human user.
-
-- If current `git config user.name` and `user.email` resolve to a real human, use them as-is.
-- If git identity is missing or agent-like, set `GIT_USER_NAME` and `GIT_USER_EMAIL`, then configure git before committing.
-- If those env vars are missing when needed, stop and ask the user. Do not commit with a bot identity.
-- Do not use AI/bot names, AI `Co-authored-by` trailers, or "generated by" metadata, except the standard yolop `Co-Authored-By` commit trailer and `Generated with yolop` PR footer for work performed by yolop.
-
-### PRs and CI
-
-- Use `.github/pull_request_template.md`.
-- PR descriptions center on functional change and impact, not a code-location
-  walkthrough (the diff shows that). Keep code-level notes short and specific, and
-  add a Before / After with proof — output, logs, metrics, or screenshots for UI —
-  whenever behavior changes.
-- PR titles must be Conventional Commits and under 70 characters.
-- Squash and Merge.
-- GitHub Actions is the CI source of truth; check with `gh`.
-- Never merge red CI.
-- Before merge, prefer rebasing onto latest `origin/main`.
-- CI opt-out labels are documented in `specs/shipping.md`; use only when skipped checks are low-signal for the diff.
-
-### Shipping and maintenance
-
-- "Ship" means implement, gather evidence, perform security review, open a mergeable PR, address all review comments, and merge only after CI is green.
-- When asked to ship, use `.agents/skills/ship/SKILL.md` and `specs/shipping.md`.
-- When asked for maintenance or release readiness, use `.agents/skills/maintenance/SKILL.md` and `specs/maintenance.md`.
-- Security review for code/config/infrastructure changes uses `specs/threat-model.md`.
-- Manual UI tests live in `test_cases/`; follow `specs/test-cases.md` and `.agents/skills/manual-ui-testing/SKILL.md`.
-
-### Linear
-
-Linear project: OSS, team: EVE. Token is `LINEAR_API_KEY` in Doppler. Use `.agents/skills/process-issues/SKILL.md` for backlog processing.
+- Conventional Commits (`type(scope): description`); use `chore` for `specs/` and `AGENTS.md`.
+- Commit as the real human user. If `git config user.name`/`user.email` are missing or agent-like,
+  set them from `GIT_USER_NAME`/`GIT_USER_EMAIL`; if those are absent, ask instead of committing
+  with a bot identity.
+- No AI attribution anywhere — commits, PRs, docs, code comments. The sole exception is yolop's
+  standard `Co-Authored-By` trailer and `Generated with yolop` PR footer for work yolop performed.

--- a/apps/ui/AGENTS.md
+++ b/apps/ui/AGENTS.md
@@ -1,0 +1,11 @@
+## UI
+
+Next.js app. Iterate without the full stack: `./node_modules/.bin/next dev --port 9120`.
+
+### Design system (Slate)
+
+`src/app/design-system.css` is the runtime source of truth; [`DESIGN.md`](./DESIGN.md) is its
+agent-readable companion in the [DESIGN.md format](https://github.com/google-labs-code/design.md).
+Change tokens in both together, then run `pnpm run design:lint`.
+
+Design intent and brand rationale live in [`specs/brand.md`](../../specs/brand.md).

--- a/specs/README.md
+++ b/specs/README.md
@@ -2,7 +2,26 @@
 
 `specs/` contains durable design intent, constraints, and feature contracts. Use this map to find the relevant spec before changing behavior. Integration specs live near their crates; see `specs/integrations.md`.
 
-Specs capture the "why" and "what", not exhaustive source detail. Link to code for full fields, enum variants, exact API shapes, or SQL DDL instead of duplicating them.
+## Spec hygiene
+
+A spec owns the **why** and the **what**: intent, rationale, constraints, contracts, success bars,
+and the options that were rejected. Everything else has a better home — see the layering table in
+[`AGENTS.md`](../AGENTS.md).
+
+Link to the source of truth instead of copying it. Copies drift silently, and a stale copy is worse
+than no copy:
+
+| Content | Belongs in |
+|---|---|
+| struct fields, enum variants, exhaustive tables (permissions, event types, flags, ID prefixes) | the Rust source, linked |
+| SQL DDL, indexes, triggers | `crates/server/migrations/`, linked |
+| request/response bodies, status codes | the handler plus the OpenAPI export, linked |
+| protobuf messages | `crates/internal-protocol/proto/`, linked |
+| commands, flags, and step-by-step procedure | the `justfile`, scripts, or the owning skill in `.agents/skills/` |
+
+Keep specs readable in one sitting. When a spec grows past what a reader can hold, split it by
+audience or subsystem and link the parts from here, rather than letting one file accumulate every
+detail. Stale "current" lists (current flags, current statuses) should become links or be deleted.
 
 ## Core
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -65,15 +65,9 @@ The expected outcome is either a small fix that reconnects the surfaces or a cri
 
 ## Spec Hygiene
 
-Specs must follow the spec hygiene guidance from `specs/README.md`: they preserve design intent, rationale, and constraints — not implementation details readable from code. During maintenance, review specs in the changed surface for:
-
-- **Struct field tables** that duplicate Rust struct definitions — replace with a link to the source file
-- **Enum variant lists** that duplicate code — replace with a link
-- **Exhaustive tables** (permissions, event types, feature flags, entity prefixes) that will drift as code evolves — replace with a link to the source of truth
-- **Code snippets** that restate already-implemented logic (SQL DDL, macro expansions, error detection patterns) — replace with a link
-- **Stale "current" lists** (e.g., "Current Flags" tables) — remove or replace with a link
-
-The pattern: keep the "why" and constraints, link to code for the "what".
+Specs in the changed surface must still meet the hygiene rules in [`specs/README.md`](./README.md),
+which owns them. Copied implementation detail is a maintenance finding: replace it with a link to the
+source of truth rather than re-syncing it.
 
 ## Release Readiness Standard
 
@@ -86,7 +80,7 @@ Before a release, maintenance should cover:
 - Linear issues already marked `In Progress` whose `updatedAt` is older than 1 day, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 - threat model and security testing in sync per `specs/security-testing.md`: every `MITIGATED` threat has coverage where feasible, durable failpoint tests pass (`cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1`), and the `cargo deny check licenses` gate (`deny.toml`) passes; advisories are tracked via Dependabot alerts in the GitHub Security tab
-- DeepSec scan run for the changed surface: `cd .deepsec && pnpm deepsec scan --project-id everruns`, `pnpm deepsec process --project-id everruns`, then review `pnpm deepsec report --project-id everruns` and file issues for any deferred true-positive findings. The `.deepsec/` scanner is local dev-only tooling, exempt from the runtime seven-day dependency-maturity floor; when bumping it, update `.deepsec` in its own commit (`pnpm update deepsec@latest`) rather than as part of a product dependency bump
+- DeepSec scan run for the changed surface, with deferred true-positive findings filed as issues (commands: [`.agents/skills/maintenance/references/surfaces.md`](../.agents/skills/maintenance/references/surfaces.md)). The `.deepsec/` scanner is local dev-only tooling, exempt from the runtime seven-day dependency-maturity floor; bump it in its own commit rather than inside a product dependency bump
 - dependency versions across all packages (Cargo workspace crates, pnpm-managed UI/docs packages, CLI) checked for outdated major versions and deprecated crates
   - `cargo outdated --root-deps-only --workspace` currently fails with a `libsqlite3-sys` `links` conflict because its temporary solve combines the workspace `sqlx 0.8` pin with the latest `rusqlite`. The real lockfile builds, so treat that failure as a tooling artifact and inspect `Cargo.toml` plus `cargo tree -i sqlx` / `cargo tree -i rusqlite` instead until `sqlx` and `rusqlite` are upgraded together
   - pnpm-managed packages enforce the seven-day release-age floor with `minimumReleaseAge: 10080`; do not bypass that gate for routine dependency maintenance

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -375,52 +375,13 @@ Acting-as-user is preserved (claims still carry the user's identity and roles); 
 
 ### Database Schema
 
-#### oauth_clients
+The OAuth tables — `oauth_clients`, `oauth_authorization_codes`, `oauth_refresh_tokens` — are defined
+in [`crates/server/migrations/009_v0.8.8.sql`](../crates/server/migrations/009_v0.8.8.sql).
 
-```sql
-CREATE TABLE oauth_clients (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    client_id TEXT NOT NULL UNIQUE,
-    client_secret_hash TEXT NOT NULL,
-    client_name TEXT NOT NULL,
-    redirect_uris JSONB NOT NULL DEFAULT '[]',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
-
-#### oauth_authorization_codes
-
-```sql
-CREATE TABLE oauth_authorization_codes (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    code_hash TEXT NOT NULL UNIQUE,
-    client_id TEXT NOT NULL,
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    org_id BIGINT NOT NULL,
-    redirect_uri TEXT NOT NULL,
-    code_challenge TEXT NOT NULL,
-    code_challenge_method TEXT NOT NULL DEFAULT 'S256',
-    scope TEXT NOT NULL DEFAULT 'mcp',
-    consumed BOOLEAN NOT NULL DEFAULT FALSE,
-    expires_at TIMESTAMPTZ NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
-
-#### oauth_refresh_tokens
-
-```sql
-CREATE TABLE oauth_refresh_tokens (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    token_hash TEXT NOT NULL UNIQUE,
-    client_id TEXT NOT NULL,
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    org_id BIGINT NOT NULL,
-    scope TEXT NOT NULL DEFAULT 'mcp',
-    expires_at TIMESTAMPTZ NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
+The shapes that carry security intent: secrets and codes are stored **hashed**, never in plaintext;
+authorization codes are single-use (`consumed`) and carry the PKCE challenge and method; and both
+codes and refresh tokens expire. Authorization codes and refresh tokens cascade on user deletion, so
+revoking a user revokes their grants.
 
 ### Route Mounting
 

--- a/specs/migrations.md
+++ b/specs/migrations.md
@@ -57,8 +57,5 @@ Migration numbers must be strictly sequential with no gaps and no duplicates. `j
 
 Migrations are the most common source of merge conflicts because multiple branches often claim the same next number. The fix is always: renumber your migration to the next available number after rebase.
 
-This is called out in:
-- `AGENTS.md` (Branch Base section)
-- `specs/shipping.md` (Required Outcomes, item 1)
-- `.agents/skills/ship/SKILL.md`
-- `crates/server/migrations/AGENTS.md`
+`scripts/lib/check-migration-ordering.sh` is the enforcement point — run after every rebase and
+again immediately before merge. It is wired into `just pre-push`, `just pre-pr`, and `/ship`.

--- a/specs/reporting.md
+++ b/specs/reporting.md
@@ -90,24 +90,10 @@ enrichment, aggregation, and backend-specific writes happen asynchronously.
 
 ## Async Projection
 
-Add a durable outbox:
-
-```sql
-CREATE TABLE reporting_outbox (
-    id UUID PRIMARY KEY,
-    org_id BIGINT NOT NULL,
-    source_type TEXT NOT NULL,
-    source_id TEXT NOT NULL,
-    source_version TEXT,
-    reason TEXT NOT NULL,
-    status TEXT NOT NULL,
-    attempts INTEGER NOT NULL DEFAULT 0,
-    next_attempt_at TIMESTAMPTZ NOT NULL,
-    last_error TEXT,
-    created_at TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL
-);
-```
+Add a durable outbox — `reporting_outbox`, defined in
+[`crates/server/migrations/040_reporting_foundation.sql`](../crates/server/migrations/040_reporting_foundation.sql).
+It records what changed (source type, id, version), why (reason), and the retry state (status,
+attempts, next attempt, last error) so projection can be retried without re-reading the world.
 
 `source_type` is one of `event`, `session`, `usage_journal`, `usage_ledger`,
 `budget`, `agent_capabilities`, `harness_capabilities`, or future durable

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -30,11 +30,11 @@ Relevant references:
 
 ## Required Outcomes
 
-**Every shipped change MUST satisfy ALL of these outcomes. These are mandatory requirements, not optional suggestions. Do not skip or weaken any requirement.**
+Every shipped change satisfies all of these outcomes. They are the success bar, not a menu.
 
 1. Safe branch state: no shipping from `main` or `master`; working tree clean before final push; prefer rebasing onto the latest `origin/main` before merge. Merging without the latest rebase is allowed when saving another CI cycle is more valuable and migration risk is absent: fetch `origin/main`, verify neither `origin/main` nor the PR changed `crates/server/migrations/` since their merge base, and monitor main CI after merge. If either side changed migrations, rebase and run `bash scripts/lib/check-migration-ordering.sh` to verify migration numbers are strictly sequential. Re-run the same check immediately before `gh pr merge`, since other PRs may have merged a colliding number while yours was in review. Renumber your migration if a conflict exists.
 2. Goal achieved with evidence: the requested behavior is implemented and validated with proof that matches the risk.
-3. Merge-ready code: touched code is reviewed for avoidable complexity and performance risk. A structured security review is performed against the relevant threat model categories from `specs/threat-model.md` (see the Security Review section in the ship skill). Issues found during review are addressed or explicitly blocked.
+3. Merge-ready code: touched code is reviewed for avoidable complexity and performance risk. A structured security review is performed against the relevant threat model categories from `specs/threat-model.md` (procedure: [`.agents/skills/ship/references/security-review.md`](../.agents/skills/ship/references/security-review.md)). Issues found during review are addressed or explicitly blocked.
 4. Synced artifacts: only the affected artifacts are updated, including specs, threat model, docs, OpenAPI, test cases, and agent instructions when relevant. Specs touched by the change must not contain implementation details that duplicate code (struct fields, enum variants, exhaustive tables, code snippets) — replace with links to source files per the spec hygiene guidance in `specs/README.md`.
 5. Smoke test impacted functionality: always smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment. Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
 6. Follow-ups surfaced: the agent actively looks for in-scope work that risks being silently dropped (TODOs, partial fixes, declined suggestions, missed edge cases, spec/doc drift) and prefers to implement them in this PR. Anything deferred is listed under a **Follow-ups** section in the PR body with a one-line rationale; if nothing is deferred, the PR body must explicitly state "No follow-ups." so readers can distinguish completeness from omission.
@@ -53,23 +53,16 @@ Relevant references:
 - Auto-merge must not bypass the final review pass; shipping should give async reviewer bots time to comment after the last push and after CI turns green, then re-check before merge.
 - If a blocker cannot be resolved safely by the agent alone, shipping must stop and report the blocker rather than guess.
 
-## Validation Menu
+## Evidence
 
-Use the smallest set that gives high confidence. The ship skill should pick from this menu based on the changed surface, not run every item mechanically.
+The command menu lives in the ship skill; it picks the smallest set that fits the changed surface
+rather than running every check mechanically. Whatever set is chosen, the evidence must show that:
 
-1. `just pre-push` before `git push`.
-2. `just pre-pr` for a full local quality pass.
-3. `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` for Rust changes.
-4. `pnpm run lint` and `pnpm run build` in `apps/ui/` for UI changes.
-5. `./scripts/export-openapi.sh` when API surface changes.
-6. `pnpm run build` in `apps/docs/` when docs change.
-7. Prefer `git fetch origin main && git rebase origin/main` before merge; if skipping the final rebase, verify no migration changes exist on either side since the merge base and monitor main CI after merge.
-8. Smoke test impacted flows in `just start-dev` or `just start-all` as risk dictates.
-9. Review performance impact: indexes, scans, N+1 patterns, pagination, and bounded result sets.
-10. Capture UI screenshots for UI changes in validation or PR comments only.
-11. Ensure test coverage proves the fix or acceptance criteria, including important negative paths.
-12. Update relevant specs, docs, test cases, threat model, OpenAPI, and `AGENTS.md`.
-13. Merge only with green CI and a final clean PR comment sweep, including async reviewer bots.
+- the changed surface built, linted, and tested cleanly, including important negative paths
+- impacted flows were smoke tested against `just start-dev` or `just start-all` as risk dictates
+- performance impact was considered where relevant: indexes, scans, N+1 patterns, pagination, and
+  bounded result sets
+- UI changes were captured as screenshots in validation or PR comments — never committed to the repo
 
 ## CI Opt-Out Labels
 

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -63,210 +63,48 @@ Two independent boolean frontmatter fields control who can invoke a skill:
 
 ## Requirements
 
-### Skill
+### Model
 
-A registered skill in the Everruns registry.
+A registered skill carries the parsed SKILL.md frontmatter plus its body, the org that owns it, a
+status, and — for archive uploads — the original ZIP alongside its extracted files. Archive files are
+stored individually rather than unpacked on demand, so activation and VFS mounting never pay for ZIP
+extraction at runtime.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Internal identifier |
-| `public_id` | SkillId | External identifier (`skill_{32-hex}`) |
-| `org_id` | i64 | Owning organization |
-| `name` | string | Unique skill name (from SKILL.md frontmatter) |
-| `description` | string | Skill description (from SKILL.md frontmatter) |
-| `license` | string? | License info (from frontmatter) |
-| `compatibility` | string? | Environment requirements (from frontmatter) |
-| `metadata` | json | Arbitrary key-value metadata (from frontmatter) |
-| `allowed_tools` | string? | Pre-approved tools list (from frontmatter, experimental) |
-| `instructions` | text | Full SKILL.md markdown body (after frontmatter) |
-| `source_type` | enum | `markdown` or `archive` |
-| `archive_data` | bytes? | Original ZIP archive (kept for reference/re-download, when source_type = archive) |
-| `status` | enum | `active` or `disabled` |
-| `version` | string | Version from metadata or "1.0" default |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last modification time |
+Fields and types: [`Skill` and `SkillFileEntry`](../crates/core/src/skill.rs). Persistence:
+`skills` and `skill_files` in [`crates/server/migrations/001_base_schema.sql`](../crates/server/migrations/001_base_schema.sql).
 
-### SkillFile
+Two source types exist: `markdown` (a pasted SKILL.md, instructions only) and `archive` (a ZIP
+holding the full skill directory with scripts, references, and assets). Statuses come from
+[`SkillStatus`](../crates/core/src/skill.rs); only `active` skills are offered to agents.
 
-Extracted files from archive-based skills. Stored individually for fast reads and VFS mounting (no ZIP extraction at runtime).
+### Limits and validation
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | UUID v7 | Internal identifier |
-| `skill_id` | UUID | FK to parent skill |
-| `path` | string | Relative path within skill directory (e.g., `scripts/extract.py`) |
-| `content` | text | File content (text files) |
-| `content_binary` | bytes? | File content (binary files, base64 in VFS) |
-| `is_binary` | boolean | Whether this is a binary file |
-| `size_bytes` | i64 | Original file size |
-| `created_at` | timestamp | Creation time |
+Names follow the agentskills.io rules exactly — 1–64 characters, `[a-z0-9-]`, no leading, trailing,
+or consecutive hyphens — and are unique per organization, which keeps capability IDs unambiguous
+across tenants.
 
-**Input Validation Limits:**
+Every other bound (field lengths, archive size, file count, decompressed size) exists to keep skills
+what they are: instructions, not binary packages. The enforced numbers live in
+[`crates/server/src/domains/skills/archive.rs`](../crates/server/src/domains/skills/archive.rs) and
+the SKILL.md parser in [`crates/core/src/skill.rs`](../crates/core/src/skill.rs).
 
-| Field | Max Size | Notes |
-|-------|----------|-------|
-| `name` | 64 chars | Must match agentskills.io spec: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens |
-| `description` | 1024 chars | Non-empty, from frontmatter |
-| `license` | 500 chars | Optional |
-| `compatibility` | 500 chars | Optional |
-| `instructions` | 100 KB | Markdown body (recommended <500 lines) |
-| `archive_data` | 10 MB | ZIP archive with skill directory |
-| `metadata` | 10 KB | JSON object |
-| `allowed_tools` | 1 KB | Space-delimited tool list |
+### API surface
 
-### Source Types
+Routes and their request/response types live in
+[`crates/server/src/api/skills.rs`](../crates/server/src/api/skills.rs) and are published in the
+OpenAPI export; that is the contract, not this list. What the endpoints must preserve:
 
-| Type | Description |
-|------|-------------|
-| `markdown` | Single SKILL.md file upload (instructions only, no scripts/assets) |
-| `archive` | ZIP archive containing full skill directory (SKILL.md + optional scripts/, references/, assets/) |
-
-### Status Values
-
-| Status | Description |
-|--------|-------------|
-| `active` | Skill is available for agent use |
-| `disabled` | Skill is disabled and hidden from capability listing |
-
-### Name Validation Rules
-
-Following the agentskills.io specification exactly:
-
-1. Must be 1-64 characters
-2. Lowercase letters, numbers, and hyphens only (`[a-z0-9-]`)
-3. Must not start or end with `-`
-4. Must not contain consecutive hyphens (`--`)
-5. Must be unique per organization
-
-### API Endpoints
-
-#### POST /v1/skills
-
-Create a new skill from a SKILL.md file (markdown body with frontmatter).
-
-**Request Body (JSON):**
-```json
-{
-  "skill_md": "---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n\n# PDF Processing\n\n## Steps\n1. Use pdfplumber..."
-}
-```
-
-**Response:** `201 Created` with Skill object
-
-**Validation:**
-- Parses YAML frontmatter from `skill_md`
-- Validates `name` field against naming rules
-- Validates `description` is non-empty and within limits
-- Checks for duplicate name within org
-- Sets `source_type = "markdown"`
-
-#### POST /v1/skills/upload
-
-Create a skill from a ZIP archive containing a skill directory.
-
-**Request:** `multipart/form-data` with `file` field containing ZIP archive
-
-**Response:** `201 Created` with Skill object
-
-**Processing:**
-- Extracts ZIP archive in memory
-- Locates SKILL.md in archive root (or single top-level directory)
-- Parses and validates SKILL.md frontmatter
-- Validates archive structure (no path traversal, size limits)
-- Validates `name` matches directory name (if present)
-- Stores parsed metadata + original ZIP archive in `skills` table
-- Extracts all files individually into `skill_files` table (for fast VFS mounting)
-- Sets `source_type = "archive"`
-
-#### GET /v1/skills
-
-List all skills.
-
-**Response:** `200 OK`
-```json
-{
-  "data": [Skill, ...]
-}
-```
-
-#### GET /v1/skills/{skill_id}
-
-Get a specific skill by ID.
-
-**Response:** `200 OK` with Skill object, or `404 Not Found`
-
-#### GET /v1/skills/{skill_id}/content
-
-Get the full SKILL.md content for a skill (used during skill activation).
-
-**Response:** `200 OK`
-```json
-{
-  "skill_md": "---\nname: ...\n---\n\n# Instructions...",
-  "files": [
-    {
-      "path": "scripts/extract.py",
-      "content": "#!/usr/bin/env python3\n..."
-    },
-    {
-      "path": "references/REFERENCE.md",
-      "content": "# Detailed Reference\n..."
-    }
-  ]
-}
-```
-
-For `source_type = "markdown"`: Returns `skill_md` only, `files` is empty.
-For `source_type = "archive"`: Returns `skill_md` and file listing from `skill_files` table.
-
-#### PATCH /v1/skills/{skill_id}
-
-Update a skill. Only provided fields are updated.
-
-**Request Body:**
-```json
-{
-  "skill_md": "---\nname: pdf-processing\ndescription: Updated description.\n---\n\nUpdated instructions...",
-  "status": "disabled"
-}
-```
-
-**Response:** `200 OK` with updated Skill object
-
-#### DELETE /v1/skills/{skill_id}
-
-Delete a skill.
-
-**Response:** `204 No Content` on success, `404 Not Found` if not exists
-
-#### POST /v1/skills/validate
-
-Validate a SKILL.md without creating a skill. Useful for client-side validation.
-
-**Request Body:**
-```json
-{
-  "skill_md": "---\nname: my-skill\ndescription: Does something.\n---\n\nInstructions..."
-}
-```
-
-**Response:** `200 OK`
-```json
-{
-  "valid": true,
-  "name": "my-skill",
-  "description": "Does something.",
-  "warnings": ["Instructions exceed 500 lines (recommended max). Consider splitting into references."]
-}
-```
-
-Or:
-```json
-{
-  "valid": false,
-  "errors": ["name: consecutive hyphens not allowed", "description: must not be empty"]
-}
-```
+- **Two creation paths.** JSON `skill_md` for a pasted SKILL.md (`source_type = markdown`), and a
+  multipart ZIP upload for a full skill directory (`source_type = archive`). Both parse and validate
+  the frontmatter before anything is stored, and reject duplicate names within the org.
+- **Archive intake is validated at the boundary**: SKILL.md located in the archive root or in a
+  single top-level directory, frontmatter name matching the directory name, and the structural
+  limits above enforced before extraction. The original ZIP is retained for re-download while the
+  extracted files land in `skill_files` for VFS mounting.
+- **Content retrieval is activation's data path.** Fetching a skill's content returns the SKILL.md
+  body plus its bundled files, so activation is a read rather than a runtime unpack.
+- **Validation without side effects.** A skill can be checked before it is created, returning
+  structured errors and warnings, so clients can validate SKILL.md as the user types.
 
 ## Skills as Virtual Capabilities
 
@@ -316,11 +154,10 @@ Skills provide a virtual tool for activation:
 |------|-----------|-------------|
 | `activate_skill` | `{ "name": "skill-name" }` | Loads the full SKILL.md instructions into the agent's context |
 
-When the agent calls `activate_skill`:
-1. Worker resolves skill by name from the registry (via gRPC)
-2. Full SKILL.md body returned as tool result
-3. Agent uses the loaded instructions to perform the task
-4. For archive-based skills, file paths in instructions can be resolved via additional tool calls
+Activation resolves the skill by name and returns its full SKILL.md body as the tool result, which
+the agent then follows. For archive-based skills, the instructions reference companion files by
+relative path and the agent reads them with ordinary filesystem tools. Because registry skills are
+already mounted into the session VFS before the tool runs, activation is a read — not a fetch.
 
 #### Idempotence
 
@@ -344,12 +181,12 @@ Example: A skill named `pdf-processing` with files `scripts/extract.py` and `ref
 
 The agent can then read these files using existing session filesystem tools (`read_file`), no special `read_skill_file` tool needed.
 
-**Mounting strategy**:
-1. On `activate_skill` call, the worker fetches skill files from the `skill_files` table via gRPC
-2. Files are mounted into the session VFS at `/.agents/skills/{skill-name}/`
-3. The `activate_skill` tool result includes instructions and metadata (`skill`, `description`, and fork-mode fields when applicable), but does not include a separate companion-file listing
-4. Text files become `MountSource::InlineFile` with `encoding: "text"`
-5. Binary files become `MountSource::InlineFile` with `encoding: "base64"`
+**Mounting strategy**: registry skills become read-only `MountPoint`s carrying each file inline —
+text or base64 for binaries — built by
+[`AttachSkillCapability`](../crates/core/src/capabilities/attach_skill.rs) during capability
+collection, before any tool runs. The `activate_skill` result carries instructions and metadata
+(`skill`, `description`, fork-mode fields where applicable) and deliberately no companion-file
+listing.
 
 This approach:
 - Reuses existing VFS infrastructure (no new tool needed)
@@ -372,50 +209,11 @@ The mount's `capability_id` is set to the contributing capability's ID so the VF
 
 ## Database Schema
 
-```sql
-CREATE TABLE skills (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    public_id TEXT NOT NULL,
-    org_id BIGINT NOT NULL REFERENCES organizations(org_id) DEFAULT 1,
-    name VARCHAR(64) NOT NULL,
-    description VARCHAR(1024) NOT NULL,
-    license TEXT,
-    compatibility VARCHAR(500),
-    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
-    allowed_tools TEXT,
-    instructions TEXT NOT NULL,
-    source_type VARCHAR(20) NOT NULL DEFAULT 'markdown'
-        CHECK (source_type IN ('markdown', 'archive')),
-    archive_data BYTEA,
-    status VARCHAR(50) NOT NULL DEFAULT 'active'
-        CHECK (status IN ('active', 'disabled')),
-    version VARCHAR(50) NOT NULL DEFAULT '1.0',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT skills_public_id_format CHECK (public_id ~ '^skill_[0-9a-f]{32}$')
-);
-
-CREATE UNIQUE INDEX idx_skills_org_public_id ON skills(org_id, public_id);
-CREATE UNIQUE INDEX idx_skills_org_name ON skills(org_id, name);
-CREATE INDEX idx_skills_status ON skills(status);
-CREATE INDEX idx_skills_org_id ON skills(org_id);
-
--- Extracted files from archive-based skills
--- Stored individually for fast reads and VFS mounting (no ZIP extraction at runtime)
-CREATE TABLE skill_files (
-    id UUID PRIMARY KEY DEFAULT uuidv7(),
-    skill_id UUID NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
-    path VARCHAR(500) NOT NULL,
-    content TEXT,
-    content_binary BYTEA,
-    is_binary BOOLEAN NOT NULL DEFAULT FALSE,
-    size_bytes BIGINT NOT NULL DEFAULT 0,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE(skill_id, path)
-);
-
-CREATE INDEX idx_skill_files_skill_id ON skill_files(skill_id);
-```
+`skills` and `skill_files` are defined in
+[`crates/server/migrations/001_base_schema.sql`](../crates/server/migrations/001_base_schema.sql).
+Two shapes carry design intent worth stating here: skills are unique per `(org_id, name)` so
+capability IDs cannot collide across tenants, and archive files are rows rather than a blob to unpack,
+because every activation mounts them into the session VFS.
 
 ## Activation Substitution Pipeline
 
@@ -450,21 +248,14 @@ Enforcement lives at a single call site in `ActivateSkillFromVfsTool::execute_wi
 
 ## Security Considerations
 
-1. **Archive Validation**: ZIP archives must be validated for:
-   - Path traversal attacks (no `../` in file paths)
-   - Zip bombs (decompressed size limits)
-   - File count limits (max 100 files)
-   - Individual file size limits (1 MB per file)
-   - Total decompressed size limit (10 MB)
-
-2. **Script Execution**: Skills may contain scripts. Execution should be:
-   - Sandboxed (via bashkit_shell capability)
-   - Logged for auditing
-   - Subject to existing session filesystem permissions
-
-3. **Content Sanitization**: SKILL.md content is rendered as markdown to agents, not to browsers. No HTML sanitization needed for the agent path, but the UI should sanitize any skill content rendered in the browser.
-
-4. **Name Uniqueness**: Per-organization uniqueness prevents capability ID conflicts.
+1. **Archive intake is hostile input.** ZIP handling must reject path traversal and bound file count,
+   individual file size, and total decompressed size so an upload cannot become a zip bomb. The
+   enforced bounds live in [`archive.rs`](../crates/server/src/domains/skills/archive.rs).
+2. **Script execution stays sandboxed.** Skills may ship scripts; they run through `bashkit_shell`
+   under existing session filesystem permissions, and are logged for auditing.
+3. **Content sanitization is a UI concern.** SKILL.md reaches agents as markdown, not a browser, so
+   the agent path needs no HTML sanitization — but anything the UI renders does.
+4. **Per-organization name uniqueness** prevents capability ID conflicts across tenants.
 
 ## Implementation Details
 
@@ -478,67 +269,16 @@ Enforcement lives at a single call site in `ActivateSkillFromVfsTool::execute_wi
 
 ### Key Components
 
-**SkillMdParser** (`crates/core/src/skill.rs`):
-- Parses YAML frontmatter from SKILL.md content
-- Validates name, description, and optional fields
-- Returns structured `ParsedSkillMd` with metadata and body
+| Concern | Source |
+|---|---|
+| SKILL.md parsing, name validation, `Skill` types | [`crates/core/src/skill.rs`](../crates/core/src/skill.rs) |
+| `skills` capability: VFS scan, `list_skills`, `activate_skill` | [`crates/core/src/capabilities/skills.rs`](../crates/core/src/capabilities/skills.rs) |
+| `skill:{uuid}` mount-only capability for registry skills | [`crates/core/src/capabilities/attach_skill.rs`](../crates/core/src/capabilities/attach_skill.rs) |
+| CRUD, archive extraction, capability listing | [`crates/server/src/domains/skills/`](../crates/server/src/domains/skills/) |
 
-**SkillsCapability** (`crates/core/src/capabilities/skills.rs`):
-- Built-in capability (ID: `"skills"`) included in the Generic harness
-- Scans `/.agents/skills/` in session VFS for SKILL.md files
-- Provides `list_skills` and `activate_skill` tools
-- System prompt explains skills system and lists discovered skills
-- Discovers both user-uploaded skills and registry-attached skills (via VFS mounts)
-
-**AttachSkillCapability** (`crates/core/src/capabilities/attach_skill.rs`):
-- Virtual capability (ID: `"skill:{uuid}"`) for database-registered skills
-- Mount-only: reconstructs SKILL.md and mounts to `/.agents/skills/{name}/`
-- Does NOT contribute to system prompt or provide tools
-- `SkillsCapability` discovers mounted skills at runtime via VFS scan
-- `from_registry(skill_id, name, description, instructions, files)` — constructs from DB fields
-- Dependencies: `["session_file_system"]` (for VFS mounting)
-- `discover_skills_from_entries()` helper parses SKILL.md files from `.agents/skills/` path
-- `is_skill` flag on `CapabilityInfo` DTO for UI badge rendering
-
-**SkillService** (`crates/server/src/domains/skills/`):
-- Business logic for CRUD operations
-- SKILL.md parsing and validation
-- ZIP archive extraction and validation
-- Integration with capability listing
-
-**ActivateSkillFromVfsTool** (`crates/core/src/capabilities/skills.rs`):
-- Backs the `activate_skill` tool, executed in-process by `everruns-core` (no worker-side executor, no gRPC fetch)
-- Reads the skill's `SKILL.md` body from the session VFS at `/.agents/skills/{name}/` and returns it as the tool result
-- Registry skills are mounted into the VFS beforehand by `AttachSkillCapability`, so activation is a pure VFS read
-
-### gRPC Protocol
-
-```protobuf
-message SkillInfo {
-    string id = 1;
-    string name = 2;
-    string description = 3;
-    string instructions = 4;
-    string source_type = 5;
-    repeated SkillFileInfo files = 6;  // Extracted files for VFS mounting
-}
-
-message SkillFileInfo {
-    string path = 1;
-    string content = 2;         // Text content (empty for binary)
-    bytes content_binary = 3;   // Binary content (empty for text)
-    bool is_binary = 4;
-}
-
-message GetSkillByNameRequest {
-    string name = 1;
-    int64 org_id = 2;
-}
-
-message GetSkillByNameResponse {
-    optional SkillInfo skill = 1;
-}
-```
+The division that matters: `AttachSkillCapability` only mounts — it contributes no prompt text and no
+tools — while `SkillsCapability` owns discovery and activation for every source. Activation is
+therefore a VFS read, with no worker-side executor and no gRPC fetch in the path.
 
 ### Error Handling
 
@@ -574,17 +314,7 @@ In the agent capability selector, skills appear with:
 
 ## Seed Data
 
-No skills are seeded by default. The registry starts empty, and users add skills as needed.
-
-Optional: A "getting started" skill could be provided:
-
-| Name | Description |
-|------|-------------|
-| `hello-world` | A simple example skill that demonstrates the Agent Skills format |
-
-## Migration Strategy
-
-New migration file: `NNN_add_skills.sql` (next available number after current migrations).
+No skills are seeded. The registry starts empty; `examples/skills/` carries the reference examples.
 
 ## Filesystem Discovery
 


### PR DESCRIPTION
## What changed

Agent-facing guidance now follows one rule: each fact lives in exactly one layer, and detail loads
when it is needed rather than up front.

- **`AGENTS.md`** is a repo map, a layering table naming which layer owns what, six norms, and only
  the gotchas that cannot be discovered from the code. Restated shipping/maintenance/PR detail and
  generic agent advice are gone.
- **`apps/ui/AGENTS.md`** (new) holds the Slate design-token rule, so it loads when working in the
  UI subtree instead of sitting in the always-loaded file.
- **Skills** keep execution only and defer their success bar to the spec that already claimed
  ownership of it. Occasionally-needed detail moved into `references/`: ship's security review and
  PR/merge mechanics, maintenance's per-surface goals, the UI test results template.
- **`specs/README.md`** now owns spec hygiene — what a spec owns, what to link instead of copy, and
  when to split. `specs/maintenance.md` pointed at a second copy of that rule; it points at README.
- Applied that rule to the specs where copies had already drifted, replacing them with links to the
  source of truth while keeping the intent in prose.

## Why

[The new rules of context engineering for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models):
keep the always-loaded layer light, prefer progressive disclosure over upfront loading, give each
instruction a single authoritative home, and let source be the specification rather than describing
it in prose. The repo's guidance had drifted the other way — the same shipping rules appeared in
`AGENTS.md`, `specs/shipping.md`, and `ship/SKILL.md`, and several specs carried copies of code.

## Before / After

No runtime behavior changes — this is documentation. The observable effect is context size,
duplication, and accuracy.

| | Before | After |
|---|---|---|
| `AGENTS.md` (always loaded) | 116 lines | 74 lines |
| Skills + commands | 1,105 lines, all loaded on invoke | 616 lines loaded, 205 in `references/` on demand |
| `specs/skills-registry.md` | 677 lines | 407 lines |
| Total | — | −1,417 / +656 lines |

Three copies that had already gone stale, each verified against source:

- `skills-registry.md` DDL predated the `archived`/`deleted` statuses and soft-delete columns; the
  status table listed 2 of the 4 values in `SkillStatus`; the endpoint list missed
  `/v1/skills/config`, `/usage`, and `/{id}/delete`; the `SkillInfo` protobuf messages do not exist
  in `worker.proto`. The spec also claimed activation fetches files over gRPC per call, contradicting
  its own statement that activation is a VFS read.
- `manual-ui-testing` hard-coded 7 test categories; `test_cases/ui/` has 23. It now reads the
  directory.
- `prepare-release` instructed `git add -A`, contradicting the stage-by-name rule in `AGENTS.md`.

Evidence:

```
$ bash scripts/lib/pre-push.sh
6/10 Migration ordering        ✅ migrations sequential (001..109)
7/10 Migration immutability    ✅ existing migrations unchanged
8/10 Server test enumeration   ✅ all 41 server test files are run by CI or allowlisted
9/10 Specs index coverage      ✅ specs/README.md covers 133 top-level specs
✅ All pre-push checks passed.
```

Every relative link in the touched files was checked to resolve, and no anchor link elsewhere in the
repo points at a removed section.

## Risk

- Low
- Guidance an agent needed could have been cut. The mitigation is that nothing was deleted without a
  home: operational detail moved into `references/` or the owning spec, and each removal was checked
  for inbound links. Worst case is an agent reading one more file than before.

## Security

- Threat categories reviewed: none touched. No security-relevant code changes — the diff is
  markdown only (19 files, zero source files).
- Findings and resolutions: `specs/mcp.md` was edited in a security-relevant area (OAuth table DDL
  replaced with a link to `009_v0.8.8.sql`). The properties that carry the intent are preserved in
  prose and were verified against the migration: secrets and codes stored hashed, authorization
  codes single-use with PKCE challenge and method, expiry on codes and refresh tokens, cascade on
  user deletion. `specs/threat-model.md` is unchanged, and no `THREAT` marker was touched.

## Follow-ups

- [EVE-800](https://linear.app/everruns/issue/EVE-800/specs-replace-copied-implementation-detail-in-the-remaining-high) —
  the remaining high-duplication specs (`events.md` at 1,641 lines with 33 JSON payload dumps,
  `toolkit-library-contract.md`, `multitenancy.md`, `agent-blueprints.md`, `domains.md`, `evals.md`,
  `client-side-tools.md`). Deferred because each needs a per-spec judgement against source —
  `events.md` in particular is an SDK-facing wire contract where the examples may be earning their
  place — and a mechanical sweep would be unreviewable. `threat-model.md` is deliberately excluded:
  it is a register, and its length is content rather than duplication.

## Checklist

- [x] Tests added or updated — n/a, documentation only; validated with `pre-push` and a link check
- [x] Backward compatibility considered — n/a, no code or interfaces
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — no `ci:skip-*` labels used; Rust/docs/Docker jobs
      self-skipped on a markdown-only diff, UI build/lint/test, Playwright smoke, migration
      immutability, server test enumeration, CI opt-out policy, and CodeQL all green
- [x] All review comments addressed (code change or written reasoning) — none received