### PR TITLE
chore(specs): remove duplicated implementation detail

### DIFF
--- a/specs/agent-blueprints.md
+++ b/specs/agent-blueprints.md
@@ -1,421 +1,158 @@
-# Agent Blueprints Specification
+# Agent Blueprints
+
+## Purpose
+
+Agent blueprints are code-defined specialist agents contributed by
+capabilities. A blueprint encapsulates a prompt, private tools, model-selection
+strategy, execution bound, and narrow configuration surface. A host delegates
+through the normal subagent task interface without gaining access to the
+blueprint's private internals.
+
+Blueprints solve work that should use different tools, instructions, or model
+economics from the parent agent. They are not persisted user-created agents and
+do not introduce a second execution engine.
+
+## Sources of truth
 
+- [`crates/core/src/capabilities/mod.rs`](../crates/core/src/capabilities/mod.rs)
+  owns the blueprint model, capability contribution hook, and registry lookup.
+- [`crates/core/src/capabilities/subagents.rs`](../crates/core/src/capabilities/subagents.rs)
+  owns discovery, invocation schema, config validation, task creation, and
+  governed-depth behavior.
+- [`crates/core/src/session.rs`](../crates/core/src/session.rs) owns persisted
+  session blueprint references.
+- [`crates/runtime/src/`](../crates/runtime/src/) owns runtime-agent assembly
+  and execution for blueprint sessions.
+- [`integrations/github/`](../integrations/github/) and
+  [`crates/core/src/capabilities/model_scout.rs`](../crates/core/src/capabilities/model_scout.rs)
+  are current concrete examples. Their source, not this spec, owns prompts,
+  tool lists, model names, and config schemas.
+- [`crates/server/migrations/`](../crates/server/migrations/) owns exact
+  persistence columns.
 
-<!-- Design Decisions:
-  - AgentBlueprint: code-defined agent template with private tools, baked-in prompt, fixed/default model
-  - Contributed by capabilities via new `agent_blueprints()` trait method
-  - Spawned via `spawn_agent` with `target.type = "subagent"` plus `blueprint` + `config`
-  - Child session stores `blueprint_id` — reason_activity and act_activity branch on it
-  - Private tools: blueprint tools never leak to host agent's tool list
-  - Fixed model: blueprint can hardcode model (e.g. Haiku for cheap scout work)
-  - Config surface is narrow and typed: JSON Schema for allowed overrides
-  - Runs on the same durable execution engine, same agentic loop, same event stream
-  - First implementation: GitHubScout (read-only GitHub search, hardcoded to fast model)
--->
+Do not copy Rust definitions, current registry entries, or JSON schemas into
+this file. They are implementation details and change as new blueprints land.
 
-## Abstract
+## Design
 
-Agent Blueprints are pre-built agent definitions contributed by capabilities. Unlike subagents (which inherit the parent's harness + agent config), blueprints encapsulate a complete agent — prompt, private tools, model selection — behind a simple invocation interface. The host agent spawns a blueprint via `spawn_agent` with a subagent target, but the blueprint controls its own internals.
+Blueprints are contributed by capabilities rather than stored as a new
+database entity. Enabling the contributing capability makes its blueprints
+available to the parent session, subject to ordinary capability and subagent
+policy.
+
+A spawned blueprint session is a real durable session. It participates in the
+same message, event, task, workspace, cancellation, recovery, and follow-up
+infrastructure as an ordinary subagent. The difference is runtime-agent
+assembly:
+
+- an ordinary subagent inherits the parent's execution configuration;
+- a blueprint session assembles its prompt, tools, model strategy, and
+  iteration bound from the registered blueprint.
 
-Inspired by Claude Code's built-in subagents (Explore, Plan, Claude Code Guide) and AmpCode's Librarian pattern.
+The session persists the blueprint identity and validated configuration so a
+worker can reconstruct the same runtime after retry or handoff. Ephemeral
+in-memory selection is insufficient.
+
+## Model selection
 
-## Motivation and Design Principles
-
-Current subagents inherit parent's tools, model, and prompt. Blueprints solve specialist delegation where the child needs different tools, a cheaper model, specialist instructions, or tool privacy.
-
-Key design principles:
-- **Blueprints are capabilities, not a new DB entity** -- contributed via `Capability` trait; session gains `blueprint_id` to signal alternate assembly
-- **Same durable execution infrastructure** -- same agentic loop and event stream; only RuntimeAgent assembly differs
-- **Private tools** -- blueprint tools never appear in the host's tool list
-- **Fixed model is first-class** -- cheap work should not burn expensive models
-- **Narrow config surface** -- host passes structured JSON Schema config; cannot override prompt or tools
-- **Discovery via system prompt** -- available blueprints listed upfront for LLM delegation
-
-## Data Model
-
-### AgentBlueprint
-
-Returned by `Capability::agent_blueprints()`. Defined in code, not persisted.
-
-See `crates/core/src/capabilities/mod.rs` for the trait definition.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | `&'static str` | Unique identifier (e.g. `"github_scout"`) |
-| `name` | `&'static str` | Human-readable display name |
-| `description` | `&'static str` | When to use this blueprint (LLM reads this for delegation decisions) |
-| `model` | `BlueprintModel` | Model selection strategy |
-| `system_prompt` | `&'static str` | Baked-in system prompt for the child agent |
-| `tools` | `Vec<Box<dyn Tool>>` | Private tools — only available inside the blueprint's session |
-| `max_turns` | `Option<usize>` | Iteration limit (default: 20) |
-| `config_schema` | `Option<Value>` | JSON Schema for allowed host-provided config. `None` = no config accepted. |
-
-### BlueprintModel
-
-```rust
-pub enum BlueprintModel {
-    /// Always use this model. Host cannot override.
-    Fixed(&'static str),
-    /// Use this model unless host provides override via config.
-    Default(&'static str),
-    /// Use whatever model the host agent uses.
-    Inherit,
-}
-```
-
-`Fixed` — scout/lookup work uses cheap models regardless of host context. `Default` — power users can upgrade via config. `Inherit` — blueprints that need the host's reasoning level.
-
-### Session Model Extension
-
-New field on `Session`:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `blueprint_id` | `Option<String>` | Blueprint ID. When set, `reason_activity` and `act_activity` build RuntimeAgent from the blueprint instead of from `harness_id`/`agent_id`. |
-| `blueprint_config` | `Option<Value>` | Validated config passed by host at spawn time. |
-
-This is the **key integration point** with the durable execution engine. The blueprint_id travels through the workflow — it's stored on the session row, not passed ephemerally.
-
-## Capability Trait Extension
-
-New method on the `Capability` trait with a default empty implementation:
-
-```rust
-/// Agent blueprints contributed by this capability.
-/// Blueprints are pre-built agents with private tools and baked-in prompts.
-fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
-    vec![]
-}
-```
-
-Additive — existing capabilities unaffected.
-
-### Blueprint Registration
-
-`CapabilityRegistry` collects blueprints from all registered capabilities:
-
-```rust
-impl CapabilityRegistry {
-    /// All blueprints from all registered capabilities.
-    pub fn blueprints(&self) -> Vec<&AgentBlueprint> { ... }
-
-    /// Find a blueprint by ID across all capabilities.
-    pub fn blueprint(&self, id: &str) -> Option<&AgentBlueprint> { ... }
-}
-```
-
-Duplicate IDs across capabilities rejected at registration time.
-
-## Execution: How It Actually Works
-
-### Spawn (in `spawn_agent` with `target.type = "subagent"`)
-
-The subagent target implementation handles blueprint parameters:
-
-```
-if blueprint param present:
-    1. Look up blueprint in CapabilityRegistry
-    2. Validate config against blueprint.config_schema
-    3. Create child session with:
-       - parent_session_id = current session
-       - harness_id = parent's harness_id (for infrastructure, not for RuntimeAgent)
-       - agent_id = None (blueprint replaces the agent)
-       - blueprint_id = blueprint.id
-       - blueprint_config = validated config
-       - lifecycle tracked via a SessionTask record (kind = subagent)
-    4. PlatformStore.send_message(child_session_id, task)
-    5. wait_for_idle(300s)
-    6. Return result
-```
-
-Key difference: child session has `blueprint_id` set and `agent_id` cleared. This signals to the worker that RuntimeAgent assembly should use the blueprint path.
-
-### RuntimeAgent Assembly (in `reason_activity`)
-
-Currently `reason_activity` builds RuntimeAgent unconditionally from harness + agent. This changes:
-
-```rust
-// In reason_activity, after loading the session:
-let runtime_agent = if let Some(ref blueprint_id) = session.blueprint_id {
-    // Blueprint path: build from blueprint definition
-    let blueprint = capability_registry.blueprint(blueprint_id)
-        .ok_or_else(|| anyhow!("unknown blueprint: {}", blueprint_id))?;
-
-    let model = match blueprint.model {
-        BlueprintModel::Fixed(m) => m.to_string(),
-        BlueprintModel::Default(m) => {
-            // Check if config overrides model
-            session.blueprint_config
-                .as_ref()
-                .and_then(|c| c.get("model"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| m.to_string())
-        }
-        BlueprintModel::Inherit => parent_model.clone(),
-    };
-
-    let mut prompt = blueprint.system_prompt.to_string();
-    if let Some(ref config) = session.blueprint_config {
-        // Inject config into prompt context
-        prompt.push_str(&format!("\n<config>\n{}\n</config>", config));
-    }
-
-    RuntimeAgentBuilder::new()
-        .system_prompt(&prompt)
-        .tools(blueprint.tool_definitions())
-        .model(&model)
-        .max_iterations(blueprint.max_turns.unwrap_or(20))
-        .build()
-} else {
-    // Standard path: build from harness + agent (unchanged)
-    RuntimeAgentBuilder::new()
-        .with_harness(harness, &registry, &ctx).await
-        .with_agent(agent, &registry, &ctx).await
-        .build()
-};
-```
-
-### Tool Execution (in `act_activity`)
-
-`act_activity` currently loads tools from harness + agent capabilities. For blueprint sessions, it loads tools from the blueprint instead:
-
-```rust
-// In act_activity, after loading the session:
-let tools: Vec<Box<dyn Tool>> = if let Some(ref blueprint_id) = session.blueprint_id {
-    let blueprint = capability_registry.blueprint(blueprint_id)?;
-    blueprint.tools()  // Private tools only
-} else {
-    // Standard: load from harness + agent capabilities (unchanged)
-    load_capability_tools(harness, agent, &registry)
-};
-```
-
-This is where tool privacy is enforced. Blueprint tools are instantiated only inside the child's `act_activity`. The host's `act_activity` never sees them.
-
-### Event Stream
-
-Blueprint sessions emit the same events as any session:
-- `task.created`, `task.updated`, `task.message.sent`, `task.message.received` (Session Task lifecycle; replaced the retired `subagent.*` events — see `specs/events.md`)
-- `turn.started`, `turn.completed` (agentic loop)
-- `output.message.*` (LLM output)
-- `tool.started`, `tool.completed` (tool execution)
-
-No new event types needed. The subagent task's snapshot (carried on the `task.created`/`task.updated` events) includes `spec.blueprint_id`, so the UI can display the blueprint name/icon.
-
-### Statefulness and Follow-ups
-
-The spawned session is **fully stateful** — real session with messages, events, durable workflow state. The host can:
-- `message_task(task_id, "also check the auth middleware tests")` — sends a follow-up
-- `get_task(task_id)` or `list_tasks(kind="subagent")` — checks status and reads messages
-
-The `AgentBlueprint` definition is stateless (code template). The session instance is stateful.
-
-## Invocation: `spawn_agent` Blueprint Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name` | string | Yes | Human-readable name (same as today) |
-| `instructions` | string | Yes | Instructions for the subagent (renamed from `task`) |
-| `target.type` | string | Yes | Must be `subagent` |
-| `blueprint` | string | No | Blueprint ID. When set, child uses blueprint's RuntimeAgent. |
-| `config` | object | No | Blueprint-specific config. Validated against `config_schema`. |
-
-## Discovery: System Prompt Contribution
-
-The `SubagentCapability` system prompt contribution expands to include available blueprints:
-
-```
-<available-blueprints>
-Specialized agents you can delegate to via spawn_agent(target.type="subagent", blueprint: "<id>"):
-
-- github_scout: Search GitHub repositories for code, issues, and discussions.
-  Fast read-only agent. Use for codebase exploration, finding patterns,
-  understanding unfamiliar repos. Config: { "repos": ["owner/repo"] }
-
-- openrouter_model_scout: Benchmark OpenRouter models/providers using small
-  probe tasks and recommend model-router updates. Use when evaluating which
-  models best suit a task profile for cost, latency, or quality.
-  Config: { "max_candidates": 10, "max_spend_usd": 0.10, "probe_timeout_ms": 10000,
-            "probe_tasks": [...], "target_route_key": "base" }
-</available-blueprints>
-```
-
-Generated dynamically from `CapabilityRegistry::blueprints()`. Each entry shows `id`, `description`, and a summary of `config_schema`.
-
-## Security Considerations
-
-| Concern | Mitigation |
-|---------|------------|
-| Capability escalation | Blueprint tools cannot exceed the contributing capability's permissions. Scoped by API keys/connections. |
-| Prompt injection via config | Config validated against typed JSON Schema. No free-form prompt override. |
-| Model cost | `Fixed` prevents host from running expensive models for cheap work. |
-| Tool leakage | Blueprint tools only instantiated in child's `act_activity`. Host's `act_activity` never loads them. |
-| Nesting | Same governed-depth constraint as subagents. |
-| Resource exhaustion | `max_turns` limit on blueprint. Same 300s timeout as subagents. |
-| Blueprint impersonation | `blueprint_id` validated against registry at spawn time. Invalid IDs rejected. |
-
-## Concrete Example: GitHub Scout
-
-First blueprint implementation. Integration crate: `integrations/github/`. The GitHub integration contributes the `github_scout` capability and `github_scout` blueprint, depends on `subagents`, and keeps host-facing GitHub tools empty unless a separate GitHub capability surface is intentionally added.
-
-### Capability
-
-```rust
-pub struct GitHubScoutCapability;
-
-impl Capability for GitHubScoutCapability {
-    fn id(&self) -> &str { "github_scout" }
-    fn name(&self) -> &str { "GitHub Scout" }
-    fn description(&self) -> &str {
-        "Blueprint-only GitHub repository scout."
-    }
-
-    // No host tools — all tools are private to the blueprint
-    fn tools(&self) -> Vec<Box<dyn Tool>> { vec![] }
-
-    fn dependencies(&self) -> Vec<&'static str> { vec!["subagents"] }
-
-    fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
-        vec![AgentBlueprint {
-            id: "github_scout",
-            name: "GitHub Scout",
-            description: "Search GitHub repositories for code, issues, and discussions. \
-                          Fast read-only agent for codebase exploration and pattern discovery.",
-            model: BlueprintModel::Fixed("claude-haiku-4-5-20251001"),
-            system_prompt: GITHUB_SCOUT_PROMPT,
-            tools: vec![
-                Box::new(SearchGitHubCodeTool),
-                Box::new(ReadGitHubFileTool),
-                Box::new(SearchGitHubIssuesTool),
-            ],
-            max_turns: Some(15),
-            config_schema: Some(json!({
-                "type": "object",
-                "properties": {
-                    "repos": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Repository list to scope searches (owner/repo format)"
-                    }
-                }
-            })),
-        }]
-    }
-}
-```
-
-### Private Tools
-
-| Tool | Description |
-|------|-------------|
-| `search_github_code` | Search code across repos using GitHub code search API |
-| `read_github_file` | Read a specific file from a GitHub repo (by path + ref) |
-| `search_github_issues` | Search issues and pull requests with filters |
-
-These use the GitHub token from User Connections. They are private to the blueprint session and never visible to the host agent.
-
-### Host Usage
-
-```json
-{
-  "name": "spawn_agent",
-  "arguments": {
-    "name": "Scout",
-    "instructions": "Find how authentication middleware is implemented in the fastify repo.",
-    "target": { "type": "subagent" },
-    "blueprint": "github_scout",
-    "config": { "repos": ["fastify/fastify"] }
-  }
-}
-```
-
-Child session runs with Haiku, 3 GitHub tools, scout prompt. Host gets back a summary.
-
-## Relationship to Subagents
-
-| Aspect | Subagent | Blueprint |
-|--------|----------|-----------|
-| RuntimeAgent source | Inherited from parent's `harness_id` + `agent_id` | Built from blueprint definition |
-| Session fields | `agent_id` = parent's, `blueprint_id` = None | `agent_id` = None, `blueprint_id` = set |
-| Prompt | Parent's prompt + task as user message | Blueprint's baked-in prompt + task as user message |
-| Tools | Parent's tools (same `act_activity` path) | Blueprint's private tools (alternate `act_activity` path) |
-| Model | Parent's model | Fixed/Default/Inherit per blueprint |
-| Config | None (host controls via task text) | Narrow, typed, validated JSON Schema |
-| Agentic loop | Same (InputAtom → ReasonAtom → ActAtom) | Same |
-| Durable execution | Same (PostgreSQL workflow) | Same |
-| Event stream | Same (SSE events on child session) | Same |
-| Lifecycle | Same (spawn/get/message tools) | Same |
-| Nesting governance | Same `max_subagent_depth` policy | Same |
-| Use case | Parallel work with same capabilities | Specialist delegation with different capabilities |
-
-## Changes Required
-
-### Session Model (`crates/core/src/session.rs`)
-
-Add two fields:
-
-```rust
-/// Blueprint ID. When set, reason_activity/act_activity use blueprint
-/// for RuntimeAgent assembly instead of harness_id/agent_id.
-pub blueprint_id: Option<String>,
-
-/// Blueprint config passed at spawn time. Validated against blueprint's config_schema.
-pub blueprint_config: Option<serde_json::Value>,
-```
-
-Migration: add nullable columns `blueprint_id TEXT` and `blueprint_config JSONB` to sessions table.
-
-### Capability Trait (`crates/core/src/capabilities/mod.rs`)
-
-Add `agent_blueprints()` default method returning `Vec<AgentBlueprint>`.
-
-Add `AgentBlueprint` and `BlueprintModel` structs.
-
-### CapabilityRegistry (`crates/core/src/capabilities/mod.rs`)
-
-Add `blueprints()` and `blueprint(id)` methods that aggregate across all registered capabilities.
-
-### SpawnSubagentAsAgentTool (`crates/core/src/capabilities/subagents.rs`)
-
-- Add `blueprint` and `config` params to schema
-- New branch: when blueprint is set, validate config, create session with `blueprint_id`/`blueprint_config`/`agent_id=None`
-- System prompt contribution includes `<available-blueprints>` section
-
-### reason_activity (`crates/worker/src/activities.rs`)
-
-Branch on `session.blueprint_id`:
-- If set: build RuntimeAgent from blueprint (prompt, model, tool definitions)
-- If not: existing path (harness + agent)
-
-### act_activity (`crates/worker/src/activities.rs`)
-
-Branch on `session.blueprint_id`:
-- If set: load tools from blueprint
-- If not: existing path (harness + agent capabilities)
-
-### Subagent Task Snapshot
-
-The subagent task snapshot (on `task.created`/`task.updated`) carries
-`spec.blueprint_id` so consumers can resolve the blueprint name/icon. (The
-legacy `subagent.*` events were retired — see `specs/events.md`.)
-
-## Implementation Path
-
-### Phase 1: Core Infrastructure
-
-1. `AgentBlueprint`, `BlueprintModel` structs
-2. `Capability::agent_blueprints()` trait method
-3. `CapabilityRegistry::blueprints()` / `blueprint(id)`
-4. Session model: `blueprint_id`, `blueprint_config` fields + migration
-5. `reason_activity` blueprint branch
-6. `act_activity` blueprint branch
-7. `spawn_agent` subagent blueprint parameter handling
-8. System prompt blueprint discovery
-
-### Phase 2: GitHub Scout
-
-1. `integrations/github/` crate with 3 private tools
-2. Wire GitHub API via User Connections
-3. Register via `inventory::submit!`
-4. Enable the `github_scout` capability wherever the `github_scout` blueprint should be available
+Blueprints choose one of three strategies:
+
+- fixed: the blueprint selects a model and the host cannot override it;
+- default: the blueprint selects a default that its validated config may
+  override;
+- inherit: the blueprint uses the parent model.
+
+The current enum representation and owned string types live in
+`crates/core/src/capabilities/mod.rs`. Concrete model identifiers belong to each
+blueprint implementation.
+
+Fixed selection is useful when specialist work has a known cost/quality target.
+Default selection supports controlled operator choice. Inheritance is for work
+that genuinely needs the parent's model characteristics.
+
+## Configuration
+
+Blueprint configuration is structured and validated against the blueprint's
+schema before a child session is created. Config without a blueprint is
+rejected. A blueprint with no schema accepts no arbitrary config.
+
+Configuration may select only behavior intentionally exposed by the blueprint.
+It cannot replace the system prompt, inject new tools, bypass model policy, or
+expand capability permissions.
+
+Invalid, unavailable, or unauthorized blueprint IDs fail before creating a
+child session or task.
+
+## Discovery and invocation
+
+The subagent capability contributes the available blueprint descriptions and
+config summaries to the parent agent's instructions. Discovery is generated
+from the active capability registry; this document does not keep a current
+blueprint list.
+
+Invocation uses the existing subagent target with optional blueprint and config
+arguments. The exact tool schema is generated by the subagent capability and is
+the authoritative caller contract.
+
+When a blueprint is requested, the spawn path:
+
+1. resolves it from the active capability registry;
+2. verifies that its contributing capability is applied to the parent;
+3. validates configuration;
+4. creates a child session carrying blueprint identity and config;
+5. records a subagent session task;
+6. sends the initial instructions and follows normal foreground/background
+   task behavior.
+
+Follow-ups address the durable task/session. The blueprint definition remains a
+stateless template; the spawned session owns conversation state.
+
+## Tool privacy
+
+Blueprint tools are instantiated only for the blueprint child's runtime. They
+do not appear in the host's tool definitions and cannot be called directly by
+the host.
+
+Private does not mean privileged. A blueprint's tools cannot exceed the
+permissions, connections, network policy, or secrets available through its
+contributing capability and child execution context.
+
+Tool definitions used for model inference and tool implementations used for
+execution must come from the same fresh blueprint registration so they cannot
+drift across retries.
+
+## Events and tasks
+
+Blueprint sessions emit the ordinary session, turn, assistant-message, and tool
+events. No blueprint-specific event family is required.
+
+The owning session task carries enough blueprint identity for clients to label
+the specialist. Current snapshot fields are defined by the session-task source
+and event payload types. Legacy `subagent.*` events are not part of this
+contract; see [`events.md`](events.md).
+
+## Security invariants
+
+- Config is schema-validated and cannot override prompt or tools.
+- Blueprint lookup is restricted to capabilities active for the parent.
+- Private tools never enter the parent runtime.
+- Model selection follows the blueprint strategy.
+- Subagent depth, concurrency, timeout, cancellation, and resource governance
+  apply unchanged.
+- Child connections and secrets are resolved through normal scoped facilities.
+- Durable retry reconstructs from persisted blueprint identity and validated
+  config.
+
+## Adding a blueprint
+
+A new blueprint should:
+
+1. live with the capability or integration that owns its tools and policy;
+2. expose a focused description and the smallest useful config schema;
+3. choose model strategy and iteration bounds intentionally;
+4. keep host-facing tools empty when the capability is blueprint-only;
+5. include registry, config-validation, runtime-assembly, and privacy tests;
+6. document product-specific usage beside the integration when users need it.
+
+The GitHub integration and model-scout capability linked above demonstrate two
+current patterns without freezing their implementation into this spec.

--- a/specs/client-side-tools.md
+++ b/specs/client-side-tools.md
@@ -1,407 +1,173 @@
-# Client-Side Tools Specification
-
-## Abstract
-
-Client-side tools let API/SDK consumers define tools that execute on the client, not the server. When the LLM requests a client-side tool call, the server pauses execution, emits a `tool.call_requested` event, and waits for the client to submit results via API. This enables integrations where tool logic lives outside Everruns (e.g., browser actions, local file access, proprietary APIs).
-
-## Requirements
-
-### Concept
-
-Standard (server-side) tools execute within the Everruns worker process. Client-side tools invert this: the server advertises the tool to the LLM, but delegates execution to the calling client. The agent loop pauses until the client submits results or the wait is cancelled.
-
-```
-┌────────┐       ┌──────────┐       ┌─────┐       ┌────────┐
-│ Client │       │  Server  │       │ LLM │       │ Client │
-└───┬────┘       └────┬─────┘       └──┬──┘       └───┬────┘
-    │  POST message    │                │              │
-    │─────────────────>│                │              │
-    │                  │  LLM call      │              │
-    │                  │───────────────>│              │
-    │                  │  tool_call     │              │
-    │                  │<───────────────│              │
-    │                  │                │              │
-    │  SSE: tool.call_requested        │              │
-    │<─────────────────│                │              │
-    │                  │ (paused, waiting_for_tool_results)
-    │                  │                │              │
-    │  POST tool-results               │              │
-    │─────────────────>│                │              │
-    │                  │  LLM call      │              │
-    │                  │───────────────>│              │
-    │                  │  final text    │              │
-    │                  │<───────────────│              │
-    │  SSE: output.message.completed   │              │
-    │<─────────────────│                │              │
-```
-
-### Tool Definition
-
-Client-side tools are defined on the **agent** using `type: "client"`. They follow the same JSON Schema format as server-side tools but are not backed by a server implementation.
-
-```json
-{
-  "type": "client",
-  "name": "lookup_crm",
-  "description": "Look up a customer record in the CRM system",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "customer_id": {
-        "type": "string",
-        "description": "The customer ID to look up"
-      }
-    },
-    "required": ["customer_id"]
-  }
-}
-```
-
-**Fields:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | Must be `"client"` |
-| `name` | string | Yes | Tool name (sent to LLM) |
-| `description` | string | Yes | Tool description (sent to LLM) |
-| `parameters` | object | Yes | JSON Schema for tool arguments |
-
-Client-side tools are registered on the agent alongside capabilities. They are included in the LLM tool definitions but have no server-side executor.
-
-### API Flow
-
-#### 1. Create Agent with Client-Side Tools
-
-```http
-POST /v1/agents
-Content-Type: application/json
-
-{
-  "name": "CRM Assistant",
-  "system_prompt": "You help users look up customer information.",
-  "capabilities": [
-    { "ref": "current_time" }
-  ],
-  "client_tools": [
-    {
-      "type": "client",
-      "name": "lookup_crm",
-      "description": "Look up a customer record in the CRM system",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "customer_id": {
-            "type": "string",
-            "description": "The customer ID to look up"
-          }
-        },
-        "required": ["customer_id"]
-      }
-    }
-  ]
-}
-```
-
-#### 2. Create Session
-
-```http
-POST /v1/sessions
-Content-Type: application/json
-
-{
-  "agent_id": "agent_01234567-..."
-}
-```
-
-#### 3. Send Message (Triggers Turn)
-
-```http
-POST /v1/sessions/{session_id}/messages
-Content-Type: application/json
-
-{
-  "message": {
-    "content": [
-      { "type": "text", "text": "Look up customer CUST-42" }
-    ]
-  }
-}
-```
-
-#### 4. Receive `tool.call_requested` Event via SSE
-
-The server calls the LLM, which returns a tool call for `lookup_crm`. Since this is a client-side tool, the server does **not** execute it. Instead, it emits a `tool.call_requested` event and pauses.
-
-```
-event: tool.call_requested
-data: {
-  "id": "01937abc-...",
-  "type": "tool.call_requested",
-  "ts": "2024-01-15T10:30:01.000Z",
-  "session_id": "session_01234567-...",
-  "context": {
-    "turn_id": "turn_01234567-...",
-    "input_message_id": "message_01234567-..."
-  },
-  "data": {
-    "tool_calls": [
-      {
-        "id": "call_abc123",
-        "name": "lookup_crm",
-        "arguments": { "customer_id": "CUST-42" }
-      }
-    ],
-    "tool_summaries": [
-      {
-        "id": "call_abc123",
-        "name": "lookup_crm",
-        "display_name": "Lookup CRM",
-        "narration": "Looking up customer CUST-42"
-      }
-    ],
-    "headline": "Looking up customer CUST-42"
-  }
-}
-```
-
-At this point, the session status transitions to `waiting_for_tool_results`.
-
-#### 5. Submit Tool Results
-
-```http
-POST /v1/sessions/{session_id}/tool-results
-Content-Type: application/json
-
-{
-  "tool_results": [
-    {
-      "tool_call_id": "call_abc123",
-      "result": {
-        "name": "Alice Johnson",
-        "email": "alice@example.com",
-        "plan": "enterprise",
-        "since": "2022-03-15"
-      }
-    }
-  ]
-}
-```
-
-**Response:** `200 OK`
-
-```json
-{
-  "status": "accepted",
-  "tool_results_count": 1
-}
-```
-
-The server resumes the agent loop: it feeds the tool results back to the LLM, which produces a final text response streamed via `output.message.completed`.
-
-#### 6. Receive Final Response via SSE
-
-```
-event: output.message.completed
-data: {
-  "type": "output.message.completed",
-  ...
-  "data": {
-    "message": {
-      "role": "agent",
-      "content": [
-        { "type": "text", "text": "Customer CUST-42 is Alice Johnson (alice@example.com), on the enterprise plan since March 2022." }
-      ]
-    }
-  }
-}
-```
-
-### Event Types
-
-#### `tool.call_requested`
-
-Emitted when the LLM requests one or more client-side tool calls. The agent loop pauses until results are submitted.
-
-```json
-{
-  "id": "...",
-  "type": "tool.call_requested",
-  "ts": "...",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "tool_calls": [
-      {
-        "id": "call_abc123",
-        "name": "lookup_crm",
-        "arguments": { "customer_id": "CUST-42" }
-      }
-    ]
-  }
-}
-```
-
-**Fields (data):**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `tool_calls` | array | Client-side tool calls requested by the LLM |
-| `tool_calls[].id` | string | Unique tool call ID (from LLM response) |
-| `tool_calls[].name` | string | Tool name |
-| `tool_calls[].arguments` | object | Tool arguments (parsed JSON) |
-| `tool_summaries` | array | Optional server-authored display summaries for timeline UIs |
-| `headline` | string | Optional server-authored readable summary for the requested batch |
-
-### Session Status: `waiting_for_tool_results`
-
-When a client-side tool call is requested, the session transitions to `waiting_for_tool_results`. This is a new status in addition to the existing `started`, `active`, `idle` states.
-
-```
-Status transitions:
-  started → active → waiting_for_tool_results → active → idle
-                            │
-                            └──→ idle  (if user sends a new message, cancelling the wait)
-```
-
-**Visibility:** The `GET /v1/sessions/{session_id}` response includes this status so clients can determine whether to show a "waiting for tool results" indicator.
-
-### Tool Results Endpoint
-
-#### `POST /v1/sessions/{session_id}/tool-results`
-
-Submit results for pending client-side tool calls. Resumes the agent loop.
-
-**Request:**
-
-```json
-{
-  "tool_results": [
-    {
-      "tool_call_id": "call_abc123",
-      "result": { "key": "value" },
-      "error": null
-    }
-  ]
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `tool_results` | array | Yes | One result per requested tool call |
-| `tool_results[].tool_call_id` | string | Yes | Must match an `id` from `tool.call_requested` |
-| `tool_results[].result` | any | No | Tool execution result (JSON value). Required if `error` is null. |
-| `tool_results[].error` | string | No | Error message if tool execution failed on client side |
-
-**Response (success):**
-
-```json
-{
-  "status": "accepted",
-  "tool_results_count": 1
-}
-```
-
-**Error responses:**
-
-| Status | Condition |
-|--------|-----------|
-| `400` | Session is not in `waiting_for_tool_results` status |
-| `400` | Missing or extra tool call IDs (must match exactly) |
-| `404` | Session not found |
-
-### Graceful Handling: User Message While Waiting
-
-If the user sends a new message via `POST /v1/sessions/{session_id}/messages` while the session is in `waiting_for_tool_results` status, the pending tool wait is **cancelled**:
-
-1. The pending client-side tool calls are discarded
-2. Tool results are synthesized as `{"error": "Cancelled: user sent a new message"}`
-3. The new user message starts a fresh turn
-4. Session status transitions: `waiting_for_tool_results` → `active`
-
-This prevents sessions from getting stuck if the client abandons the tool call flow.
-
-### Mixed Tool Calls (Server + Client)
-
-An LLM response may contain both server-side and client-side tool calls in the same response. The server handles this as follows:
-
-1. **Execute server-side tools immediately** - All server-side tools run as normal
-2. **Collect client-side tool calls** - Set aside for the `tool.call_requested` event
-3. **Emit events for both**:
-   - `tool.started` / `tool.completed` for each server-side tool (as today)
-   - `tool.call_requested` for the batch of client-side tool calls
-4. **Pause** - Wait for client to submit results for client-side tools
-5. **Resume** - Feed all results (server + client) to the LLM in the next iteration
-
-**Ordering:** Server-side tools execute first. Client-side tools pause after server-side tools complete. This ensures deterministic behavior and avoids partial result submission.
-
-### Agent Model Changes
-
-The `Agent` model gains a new optional field:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `client_tools` | ClientToolDef[] | Client-side tool definitions (default: empty) |
-
-Client tools are stored in the `agents` table as a JSONB column:
-
-```sql
-ALTER TABLE agents ADD COLUMN client_tools JSONB NOT NULL DEFAULT '[]';
-```
-
-**Input Validation:**
-
-| Field | Max Size | Notes |
-|-------|----------|-------|
-| `client_tools` | 50 items | Maximum client-side tools per agent |
-| `client_tools[].name` | 64 chars | Tool name |
-| `client_tools[].description` | 1 KB | Tool description |
-| `client_tools[].parameters` | 10 KB | JSON Schema |
-
-### Timeout Behavior
-
-Client-side tool waits have a configurable timeout (default: 5 minutes). If no results are submitted within the timeout:
-
-1. Tool results are synthesized as `{"error": "Timed out waiting for client tool results"}`
-2. The agent loop resumes with the error results
-3. The LLM can interpret the timeout and respond accordingly
-4. Session status transitions: `waiting_for_tool_results` → `active` → `idle`
-
-### Security Considerations
-
-1. **Tool call ID validation**: Submitted `tool_call_id` values must exactly match pending requests. Extra or missing IDs are rejected.
-2. **Session scoping**: Tool results can only be submitted by clients with access to the session (same auth as other session endpoints).
-3. **Result size limits**: Tool result payloads are limited to 100 KB per result to prevent abuse.
-4. **No server-side execution**: Client-side tool definitions never trigger server-side code. They are metadata only.
-
-### Tools-Field Deprecation Window
-
-`CreateSessionRequest.tools`, `CreateAgentRequest.tools`, and `UpdateAgentRequest.tools` only accept `client_side` definitions — they are documented as "executed by the client, not the server". Older SDK/CLI clients that still send `{"type": "builtin", ...}` entries in this field need a migration window before the server hard-rejects them.
-
-**Current behavior (deprecation window):** the deserializer drops any non-`client_side` entry from the request and emits a `tracing::warn!` with `target = "client_tools_deprecation"`, `dropped_count`, and `dropped_kinds` (e.g. `["builtin"]`). The request still succeeds. Operators can monitor the warning to detect clients that still need to migrate.
-
-**Operator opt-in to hard-reject:** set `EVERRUNS_REJECT_NON_CLIENT_SIDE_TOOLS=1` (also accepts `true` / `yes` / `on`). The deserializer then returns the original `tools must contain only client_side definitions` error, surfacing as `400 Bad Request`.
-
-**Update-request semantics:** `UpdateAgentRequest.tools` is documented as "replaces existing tools if provided". To prevent legacy clients from accidentally clearing an agent's tools during the deprecation window, the deserializer treats the field as **absent** (`None`) when *every* entry was non-`client_side` and got dropped. An explicit `"tools": []` from a modern client still clears the agent's tools (replacement semantics preserved). A mixed list keeps the surviving `client_side` entries and replaces the agent's tools with that subset.
-
-**Migration timeline:**
-
-1. **Today (deprecation window):** soft-drop with structured warning. Default behavior; existing SDK/CLI clients keep working.
-2. **Next release:** OpenAPI schema annotates the field with the cutoff date. CHANGELOG warns operators to flip the hard-reject env var in dev/staging to surface remaining offenders.
-3. **Cutoff release (planned):** flip the default to strict; `EVERRUNS_REJECT_NON_CLIENT_SIDE_TOOLS=0` becomes the legacy escape hatch (and is removed one release later).
-
-**Logging contract:** the warning logs only the discriminator (`builtin`, `client_side`, etc.) and counts — never the payload — so request bodies (prompts, tool arguments) cannot leak into logs from this path. This is enforced by `tool_definition_kind_name` in `crates/server/src/api/sessions.rs`.
-
-### Design Decisions
-
-| Question | Decision |
-|----------|----------|
-| Where are client tools defined? | On the Agent, in `client_tools` JSONB column |
-| How does the LLM see them? | Merged with server-side tools in the tool definitions sent to LLM |
-| What happens on tool call? | Server emits `tool.call_requested`, pauses until results submitted |
-| Mixed server+client calls? | Server tools execute first, then pause for client tools |
-| User message while waiting? | Cancels the wait, starts new turn |
-| Timeout? | 5 minute default, synthesized error result on expiry |
-| Can session capabilities add client tools? | Not in initial version; agent-level only |
+# Client-Side Tools
+
+## Purpose
+
+Client-side tools let an API or SDK consumer provide tool definitions whose
+implementation runs outside Everruns. The server exposes the definition to the
+model, pauses when the model calls it, emits a request event, and resumes only
+after the client submits results or the wait is resolved another way.
+
+This spec owns the pause/resume semantics and security invariants. It does not
+copy tool JSON, event payloads, endpoint bodies, database columns, limits, or
+status-code tables.
+
+## Sources of truth
+
+- [`crates/provider/src/tool_types.rs`](../crates/provider/src/tool_types.rs)
+  owns the tagged tool-definition model and exact client-side tool fields.
+- [`crates/server/src/domains/agents/types.rs`](../crates/server/src/domains/agents/types.rs)
+  owns agent create/update request validation and deprecation behavior.
+- [`crates/core/src/atoms/act_hooks.rs`](../crates/core/src/atoms/act_hooks.rs)
+  owns client-call detection, request-event emission, output limiting, and
+  pause signaling.
+- [`crates/core/src/events.rs`](../crates/core/src/events.rs) owns the exact
+  tool-request event payload.
+- [`crates/server/src/api/tool_results.rs`](../crates/server/src/api/tool_results.rs)
+  owns result submission, response shape, status validation, event persistence,
+  and workflow resume.
+- [`crates/server/src/tool_result_timeout.rs`](../crates/server/src/tool_result_timeout.rs)
+  owns timeout recovery.
+- [`docs/api/openapi.json`](../docs/api/openapi.json) is the exact SDK/wire
+  contract.
+- [`crates/server/tests/client_side_tools_test.rs`](../crates/server/tests/client_side_tools_test.rs)
+  and strict-mode tests cover serialization and compatibility behavior.
+
+Wire examples belong in OpenAPI and contract tests, not in this spec.
+
+## Definition and ownership
+
+Client-side definitions are stored with agent/session configuration and sent to
+the model alongside executable server tools. Their tagged discriminator and
+fields are defined by `ToolDefinition` and `ClientSideTool`; consumers must not
+infer them from an old example.
+
+The server has no implementation for a client-side tool. A matching model tool
+call cannot fall through to a same-named server implementation. Reserved naming
+rules prevent collisions with generated tool families.
+
+Definitions may include display metadata, category, schema-defer policy, and
+semantic hints as supported by the source type. Exact current fields and
+validation limits are generated into OpenAPI.
+
+## Lifecycle
+
+The normal lifecycle is:
+
+1. a client configures an agent or session with client-side definitions;
+2. the model requests one or more of those tools;
+3. Everruns emits the typed client-tool request event;
+4. the session enters the waiting-for-tool-results state;
+5. the client executes every requested call and submits correlated results;
+6. Everruns records tool completion events, restores active execution, and
+   resumes the durable turn;
+7. the model receives the results and continues normally.
+
+The request event is the authoritative list of pending calls. Clients correlate
+by tool-call ID and should use optional server-authored display summaries rather
+than inventing user-facing narration when present.
+
+The exact event envelope and payload live in `crates/core/src/events.rs`; see
+[`events.md`](events.md) for compatibility rules.
+
+## Result submission
+
+Result submission is accepted only when the caller can access the session and
+the session is currently waiting for client results.
+
+Each submitted item identifies the pending tool call and carries either a JSON
+result or a safe client error. The API source and OpenAPI own exact optionality,
+validation, response fields, and status codes.
+
+Accepted results become ordinary tool-completion events before execution
+resumes. This keeps replay and later model context consistent with server-side
+tool execution.
+
+Clients should submit the complete current batch and preserve every tool-call ID
+exactly. The current endpoint accepts a non-empty list while the session is in
+the waiting state and records the supplied IDs; it does not promise
+set-equality validation against the last request event. If stronger correlation
+validation is added, it must land in the endpoint and contract tests before
+this spec claims it.
+
+## Mixed batches
+
+A model response may contain server-side and client-side calls together.
+Server-side calls execute through the normal scheduler. Client-side calls are
+collected into the request event, and the turn pauses after server work reaches
+the established boundary.
+
+On resume, the next model step sees both result families in their original
+logical batch. Client submission does not re-execute completed server tools.
+
+Ordering and concurrency details belong to the act atom and scheduler tests.
+
+## Abandonment, cancellation, and timeout
+
+A new user message while waiting abandons the pending client-tool request under
+the session lifecycle contract. The runtime synthesizes interrupted results as
+needed to keep the transcript valid, then starts the new turn.
+
+If the client never responds, the timeout worker resolves the wait with safe
+error results and resumes execution so the session does not remain stuck.
+Exact timeout configuration and wording belong to
+`tool_result_timeout.rs`.
+
+Explicit session/turn cancellation follows the ordinary cancellation contract.
+All recovery paths must leave a well-formed assistant-tool transcript; see the
+repair rules in [`events.md`](events.md).
+
+## Result content
+
+Client results are untrusted tool output. The submission endpoint currently
+relies on shared HTTP request limits and does not define a separate per-result
+size contract. A dedicated limit must be implemented and covered by endpoint
+tests before product or SDK documentation promises one.
+
+The server must not execute, interpolate into a shell, or otherwise treat
+client result JSON as trusted code. It is model-visible content plus durable
+tool history.
+
+## Compatibility window for legacy tool definitions
+
+Agent and session `tools` fields are client-side-only public configuration.
+Older clients may still send obsolete non-client variants.
+
+During the compatibility window, request deserialization may drop unsupported
+entries and emit a structured warning. An operator-controlled strict mode turns
+that into request rejection. Update semantics distinguish an explicit empty
+list from a list whose every entry was dropped, preventing an old client from
+accidentally clearing valid tools.
+
+Warnings include only safe discriminator/count information, never the request
+payload. The exact environment switch, accepted values, cutoff policy, and
+deserializer implementation live in the agent/session request source. Remove
+the compatibility path when the release policy permits; do not extend it by
+adding more copied examples here.
+
+## Client requirements
+
+Clients integrating this feature must:
+
+- generate or consume definitions from the current OpenAPI model;
+- subscribe to typed session events and recognize the waiting state;
+- execute only calls present in the latest request event;
+- preserve tool-call IDs exactly;
+- submit JSON-safe results or concise errors;
+- tolerate additive event fields;
+- handle timeout, cancellation, reconnect, and duplicate UI delivery without
+  executing a call twice.
+
+SDK guides may show end-to-end examples, but those examples should be generated
+or tested against OpenAPI.
+
+## Security invariants
+
+- Session authorization applies to event streaming and result submission.
+- Client-side definitions never select server code.
+- Clients preserve pending tool-call IDs; the server gates submission by
+  session ownership and waiting state.
+- Result content is treated as untrusted and remains subject to transport
+  request limits.
+- New user input, cancellation, and timeout cannot leave the session stuck.
+- Warnings and errors do not log tool arguments, results, prompts, or secrets.
+- Mixed batches do not permit client callers to overwrite server-tool results.

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -1,470 +1,234 @@
 # Domain Modules
 
-Feature-oriented modules that own request types, validation, business logic,
-and shared query helpers for a single domain. Both HTTP and MCP adapters
-dispatch to commands defined here — no separate "services" layer.
-
-## Motivation
-
-Before this pattern, a single domain (e.g. agents) was scattered across four
-locations: `api/agents.rs` (HTTP handlers + request types + validation),
-`services/agent.rs` (business logic + policy), `api/mcp_endpoint/handlers.rs`
-(MCP handlers), and `api/mcp_endpoint/catalog.rs` (static catalog entries).
-Adding a field meant touching 4+ files in 3 directories. Validation ran only
-in the HTTP path — MCP callers bypassed it. The static catalog duplicated
-metadata already present in utoipa annotations.
-
-## Module Structure
-
-```
-crates/server/src/domains/
-  mod.rs              ← pub mod agents; pub mod sessions; ...
-  common.rs           ← Command trait, CommandError, CommandContext, Paginated
-
-  agents/
-    mod.rs            ← re-exports
-    commands.rs       ← CreateAgent, ListAgents, GetAgent, ...
-    queries.rs        ← resolve(), row_to_agent(), ensure_name_available()
-    types.rs          ← request/response types owned by this domain
-  sessions/
-    ...
-```
-
-User-facing domains normally expose `commands.rs`, `queries.rs`, and `types.rs`.
-Some internal-only domains exist purely to house shared orchestration, in which
-case they may only export `service.rs` (or another helper module) until they
-gain user-facing commands. In both cases, the helper code stays under the
-owning domain rather than a global business-logic layer.
-
-The standard files are:
-
-| File | Purpose | Who calls it |
-|------|---------|--------------|
-| `commands.rs` | User-facing operations (validation + policy + persistence) | HTTP adapters, MCP dispatch |
-| `queries.rs` | Shared read/write helpers (no policy, no input validation) | Commands, gRPC worker, other domains |
-| `types.rs` | Request/response types, DB row types owned by this domain | Commands, queries, HTTP adapters |
-
-## Command Trait
-
-See `crates/server/src/domains/common.rs` for the canonical definition.
-
-```rust
-pub trait Command: DeserializeOwned + Send + 'static {
-    type Output: Serialize + Send;
-
-    /// Static metadata — drives MCP catalog generation.
-    fn meta() -> CommandMeta;
-
-    /// Policy checked by `run()` before `execute()`. None = public/no auth.
-    fn policy() -> Option<&'static Policy> { None }
-
-    /// Execute the command. All validation and business logic lives here.
-    /// SECURITY: Do not call directly from HTTP/MCP/gRPC adapters — it skips
-    /// the policy check. Use `run()` instead. `execute` stays public so one
-    /// command can compose another already-authorized command.
-    async fn execute(self, ctx: &Ctx) -> Result<Self::Output, CommandError>;
-
-    /// Public entry point. Every caller (HTTP adapter, MCP dispatch, gRPC
-    /// `ExecuteCommand`, platform capability) goes through here.
-    ///
-    /// Evaluates `policy()` against `ctx.permission_resolver` (so SaaS
-    /// custom resolvers apply), then delegates to `execute`.
-    async fn run(self, ctx: &Ctx) -> Result<Self::Output, CommandError>;
-}
-```
-
-### Enforcement contract
-
-Policy enforcement is performed **once**, at `Command::run`. Every caller kind (HTTP, MCP, gRPC `ExecuteCommand`, platform capability) routes through `run`, which evaluates `Command::policy()` against the `PermissionResolver` carried in `Ctx`. See `specs/permissions.md` for the full model.
-
-- HTTP adapters: `CreateAgent(req).run(&ctx).await` (never `.execute(...)`).
-- MCP and gRPC `ExecuteCommand` use `domains::common::dispatch()`, which calls `run` internally.
-- Every non-GET command must declare `policy()`; `crates/server/tests/command_policy_enforcement_test.rs` verifies this at test time by iterating `inventory::iter::<CommandDescriptor>`.
-- `Ctx::new` requires the resolver as its fifth argument, so constructing a `Ctx` without a resolver is a compile error. Tests use `Ctx::minimal_for_test` which defaults to `DefaultPermissionResolver`.
-
-`Command::run` is also the chokepoint for protocol-agnostic cross-cutting concerns (tracing span, metrics, structured failure log) — every caller that goes through `run` is instrumented. The HTTP `Dispatcher` (`crates/server/src/api/dispatch.rs`) is the matching HTTP-only chokepoint: it bundles `(Ctx, UrlBuilder)` per request and exposes `run_*` helpers (`run`, `run_with_urls`, `run_created`, `run_created_with_urls`, `run_no_content`, `run_list`, `run_list_with_urls`, `run_paginated_with_urls`) so trivial HTTP handlers collapse to `state.dispatcher(&org).run_*(cmd).await`. Future HTTP-only cross-cutting concerns (request_id propagation, content-type negotiation, response body decoration) belong here once they are generalised — today most of those concerns are still threaded through specialised handlers. See `specs/observability.md` and `specs/prometheus-metrics.md` for the metric contract.
-
-### CommandMeta
-
-```rust
-pub struct CommandMeta {
-    pub name: &'static str,        // "create_agent"
-    pub category: &'static str,    // "agents"
-    pub description: &'static str, // Human-readable, shown in MCP catalog
-    pub method: &'static str,      // "POST" — HTTP method (metadata only)
-    pub path: &'static str,        // "/v1/agents" — HTTP path (metadata only)
-}
-```
-
-### CommandError
-
-Protocol-agnostic error type. HTTP adapters convert to `(StatusCode, Json<ErrorResponse>)`;
-MCP dispatch calls `.to_string()`.
-
-```rust
-// `struct CommandError` wraps a `CommandErrorKind` (crates/server/src/domains/common.rs):
-pub enum CommandErrorKind {
-    BadRequest(String),      // 400
-    Unprocessable(String),   // 422
-    Forbidden(String),       // 403
-    NotFound(String),        // 404
-    Conflict(String),        // 409
-    Internal(anyhow::Error), // 500
-}
-```
-
-### Ctx (CommandContext)
-
-Shared execution context. Constructed once, cloned into both adapters.
-
-```rust
-pub struct Ctx {
-    pub caller: Caller,
-    pub db: Arc<StorageBackend>,
-    // Domain-specific helpers that multiple commands need:
-    pub capability_service: Arc<CapabilityService>,
-    pub encryption: Option<Arc<EncryptionService>>,
-}
-```
-
-`Ctx` holds only cross-cutting dependencies (DB, encryption, capability registry).
-Domain-specific helpers live as free functions in `queries.rs`, not as service fields.
-
-## Inventory Registration
-
-Commands self-register via `inventory::submit!`. The MCP catalog and dispatch
-table are generated at runtime from the registry — no hand-maintained
-`CATALOG` array or `resolve_handler` match.
-
-```rust
-pub struct CommandDescriptor {
-    pub meta: fn() -> CommandMeta,
-    pub positional_arg: fn() -> Option<&'static str>,
-    pub dispatch: for<'a> fn(
-        serde_json::Value,
-        &'a Ctx,
-    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>,
-}
-
-inventory::collect!(CommandDescriptor);
-```
-
-Adding a new command: implement `Command` for a struct, add `inventory::submit!`
-at the bottom. The catalog auto-updates. No other files to touch.
-
-### MCP `query`/`execute` positional args
-
-`Command::positional_arg()` lets a command opt in to accepting one positional
-argument under MCP's scripted MCP tools (`query` and `execute`, both backed by
-bashkit). Returning `Some("id")` on
-`get_agent` means callers can write `get_agent <id>` instead of
-`get_agent --id <id>`; the mcp_endpoint rewrites the command string at
-statement boundaries before bashkit's flag parser runs. Only opt in when the
-command has exactly one required primary-key-like parameter. See EVE-323.
-
-`Command::read_only()` controls whether the command is exposed through the
-read-only MCP `query` tool. The default is GET-only; override it for safe
-POST-style commands such as previews or structured search helpers.
-
-`Command::output_schema()` and `Command::output_shape()` feed MCP `discover`.
-Every command reports a valid output schema; commands whose output shape is
-important for jq scripting should override both. Use `output_shape = "paginated"`
-for `{data,total,offset,limit}` list responses and `output_shape = "array"` for
-bare array responses.
-
-### Array and object parameters in bashkit builtins
-
-`api/mcp_endpoint/catalog.rs::bashkit_inventory_schema` rewrites every
-non-scalar property (any field whose type is `array`/`object`, or that carries
-`items`/`properties`) into `type: "string"` with a "Pass JSON text in bash
-mode" hint, then `make_inventory_callback` runs `coerce_json_text_params` to
-parse those JSON strings back into structured values before dispatch. Without
-this, bashkit's flag parser falls through to `string` for every non-scalar
-type and the dispatcher fails to deserialise generic operations like
-`update_agent --capabilities '[{"ref":"current_time"}]'` or
-`update_agent --tags '["a","b"]'`. The translation is generic so every
-inventory-registered command gets the same treatment automatically; do not
-special-case individual fields. JSON parse errors surface a `--<field>:
-invalid JSON (...)` message instead of the opaque `callback failed`.
-
-### Structured dispatch errors
-
-`make_inventory_callback` formats every `CommandError` returned from a
-generated MCP builtin as `<kind>: <message>`. Bashkit prefixes the builtin
-name on its own (`update_model: …`), so the wire output an operator sees is
-
-```
-update_model: bad_request: invalid type: string "true", expected bool
-```
-
-instead of the historical opaque `update_model: callback failed`. The leading
-`<kind>` token is one of the stable lower-snake-case labels emitted by
-`command_error_kind`:
-
-| `CommandError` variant | `kind` token   |
-| ---------------------- | -------------- |
-| `BadRequest`           | `bad_request`  |
-| `Unprocessable`        | `unprocessable`|
-| `Forbidden`            | `forbidden`    |
-| `NotFound`             | `not_found`    |
-| `Conflict`             | `conflict`     |
-| `Internal`             | `internal`     |
-
-The token set is part of the public MCP contract: do not rename or drop tokens
-without a corresponding spec update, and ensure `command_error_kind` covers
-every variant when adding a new one (the unit test in `catalog.rs::tests`
-enforces this).
-
-### Agent-actionable extensions
-
-`CommandError` is a struct: `{ kind, code, allowed_actions, retry_after_seconds }`.
-Construct with the helpers (`CommandError::bad_request`, `forbidden`, `conflict`,
-`not_found`, `not_found_msg`, `unprocessable`, `internal`) and chain the
-extension builders when the recovery semantics warrant it:
-
-```rust
-CommandError::conflict("agent already exists")
-    .with_code("agent_already_exists")
-    .with_action(
-        AllowedAction::new("get-existing")
-            .with_operation_id("get_agent")
-            .with_hint("Fetch the existing agent and reuse it."),
-    )
-```
-
-The HTTP adapter (`From<CommandError> for (StatusCode, Json<ErrorResponse>)` in
-`domains/common.rs`) copies every extension into the RFC 9457 Problem Details
-body (`code`, `allowed_actions`, `retry_after_seconds`). See
-[`specs/apis.md`](apis.md#error-responses) for the wire shape.
-
-Extensions are intentionally **not** surfaced over MCP `execute` today — the
-`<kind>: <message>` wire format is a documented contract that bashkit
-consumers parse. Adding a structured channel (e.g. a JSON-tail or an
-out-of-band metadata field) is a future additive extension; the internal data
-model is ready for it without further refactoring.
-
-## Writing a Command
-
-Canonical pattern (see `domains/agents/commands.rs` for reference):
-
-```rust
-#[derive(Debug, Deserialize)]
-pub struct CreateAgent {
-    pub name: String,
-    pub system_prompt: String,
-    // ... fields are the public API contract
-}
-
-impl Command for CreateAgent {
-    type Output = Agent;
-
-    fn meta() -> CommandMeta {
-        CommandMeta {
-            name: "create_agent",
-            category: "agents",
-            description: "Create a new agent with a name, system prompt, and optional capabilities.",
-            method: "POST",
-            path: "/v1/agents",
-        }
-    }
-
-    fn policy() -> Option<&'static Policy> { Some(&AGENT_MANAGE) }
-
-    async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
-        // 1. Validate input
-        // 2. Business rules (name uniqueness, capability refs, etc.)
-        // 3. Persist (DB calls via ctx.db or queries::*)
-        // 4. Return domain type
-    }
-}
-inventory::submit! { CommandDescriptor::of::<CreateAgent>() }
-```
-
-### Command composition
-
-Commands can call other commands directly. No need for service indirection:
-
-```rust
-impl Command for CopyAgent {
-    async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
-        let source = queries::resolve(&ctx.db, ctx.org_id(), &self.id).await?
-            .ok_or_else(|| CommandError::NotFound("Agent not found".into()))?;
-        CreateAgent { name: copy_name, ..from_source }.execute(ctx).await
-    }
-}
-```
-
-## Writing Queries
-
-Queries are free functions, not methods on a service struct. No policy checks,
-no input validation. Used by commands (user-facing) and gRPC worker (internal).
-
-```rust
-// domains/agents/queries.rs
-
-pub fn row_to_agent(row: AgentRow, caps: Vec<AgentCapabilityConfig>) -> Agent { ... }
-pub async fn get_capabilities(db: &StorageBackend, uuid: Uuid) -> Result<Vec<AgentCapabilityConfig>> { ... }
-pub async fn resolve(db: &StorageBackend, org_id: i64, id_or_name: &str) -> Result<Option<Agent>> { ... }
-pub async fn ensure_name_available(db: &StorageBackend, org_id: i64, name: &str, exclude: Option<AgentId>) -> Result<(), CommandError> { ... }
-```
-
-## HTTP Adapters
-
-Thin wrappers. Axum extractors → command struct → execute → wrap response.
-OpenAPI annotations stay here. ~5 lines per handler.
-
-```rust
-// api/agents.rs
-pub async fn create(org: ResolvedOrg, State(s): State<AppState>, Json(cmd): Json<CreateAgent>) -> ApiResult<Agent> {
-    let agent = cmd.execute(&s.ctx(&org)).await?;
-    Ok((StatusCode::CREATED, Json(s.wrap(agent))))
-}
-```
-
-`impl From<CommandError> for (StatusCode, Json<ErrorResponse>)` provides
-automatic HTTP error mapping.
-
-## MCP Dispatch
-
-Domain commands are exposed automatically as bash builtins inside the MCP
-scripted tools. The MCP `build_toolset` function in
-`crates/server/src/api/mcp_endpoint/catalog.rs` iterates inventory-registered
-descriptors:
-
-- `query` filters the command registry to commands whose `read_only()` returns
-  true; `execute` exposes the full catalog.
-- `CatalogContext::to_domain_ctx()` constructs the domain `Ctx` from the
-  MCP `AppState` (db, capability_service, encryption).
-- The top-level MCP `discover` tool reads inventory descriptors directly and
-  returns JSON with `input_schema`, `output_schema`, and `output_shape` for
-  focused searches. This avoids guessing whether a list command should be
-  consumed with jq `.data[]` or `.[]`.
-- Adding `inventory::submit! { CommandDescriptor::of::<Cmd>() }` makes the
-  command immediately discoverable in MCP — no other wiring needed.
-
-Generic runtime dispatch table for non-MCP callers:
-
-```rust
-pub async fn dispatch(name: &str, params: Value, ctx: &Ctx) -> Result<String, CommandError> {
-    DISPATCH_TABLE.get(name)
-        .ok_or_else(|| CommandError::NotFound(format!("Unknown command: {name}")))?
-        .dispatch(params, ctx).await
-}
-```
-
-## gRPC Command Transport
-
-gRPC workers execute inventory-registered management CRUD through the internal
-`ExecuteCommand` RPC instead of one bespoke RPC per command. This keeps the
-domain command registry as the single entry point across HTTP, MCP, and gRPC.
-
-`ExecuteCommand` contract:
-
-- `name` identifies the inventory command (for example `create_agent`)
-- `api_version` is required and currently fixed at `v1`
-- `params_json` is a UTF-8 JSON object payload with a 1 MiB limit
-- `org_id` scopes execution through `Ctx`
-- success returns serialized JSON bytes for the command output
-- domain failures return typed command errors (`bad_request`, `forbidden`,
-  `not_found`, `conflict`, `internal`) rather than bespoke response structs
-
-Workers can also call `ListCommands` to discover the current command catalog.
-Each entry mirrors `CommandMeta`, includes `positional_arg` when present, and
-publishes a `schema_hash` derived from command metadata plus positional-arg
-shape. That hash is a drift detector for transport consumers; a future
-non-backward-compatible command contract change should bump `api_version`.
-
-## Migration Strategy
-
-Domains are migrated incrementally. During migration, both the old service and
-the new command can coexist: the service delegates to queries, the command owns
-the logic. Once all callers are migrated, the service file is removed.
-
-### Status
-
-All user-facing domains have been migrated. The 39 directories under `crates/server/src/domains/` each own their HTTP/MCP/gRPC surface via commands. Several domains retain an internal `service.rs` alongside `commands.rs` for orchestration that spans multiple commands — that's intentional and not a migration backlog.
-
-**Fully migrated (commands only, no internal `service.rs`):** `agents`, `harnesses`, `apps`, `mcp_servers`, `agent_identities`, `skills`, `capabilities`, `audit_logs`, `schedules`, `events`, `images`, `tool_results`, `users`, `organizations`, `system`, `session_databases`, `session_storage`, `knowledge_bases`, `knowledge_indexes`, `memory`, `payments`, `plugins`, `session_tasks`, `workspaces`.
-
-**Commands + internal `service.rs`:** `sessions`, `messages`, `budgets`, `evals`, `models`, `providers`, `notifications`, `session_files`, `session_sandbox`, `session_resources`, `observers`, `reporting`, `session_commands`, `session_git`, `session_schedules`.
-
-**Internal-only (no user-facing commands):** `session_git`, `session_commands`, `session_schedules`.
-
-### Migration order for new domains
-
-1. Create `domains/{name}/` with `mod.rs`, `commands.rs`, `queries.rs`, `types.rs`.
-2. Move request types into `types.rs`.
-3. Put shared DB helpers in `queries.rs`.
-4. Implement `Command` for each user-facing operation in `commands.rs`, each with `inventory::submit! { CommandDescriptor::of::<Cmd>() }`. Declare `policy()` for every non-GET command — the inventory coverage test enforces this.
-5. Wire the HTTP adapter to call `cmd.run(&ctx).await` (not `.execute(...)`). MCP and gRPC integration are automatic via inventory.
-6. Thread `self.auth.permission_resolver.clone()` into the adapter's `ctx()` method so SaaS custom resolvers apply during enforcement.
-7. If orchestration needs to be shared across commands, keep it as a helper under `domains/{name}/` (for example `service.rs`).
-
-### Cross-Org Resource Resolution (`domains/org_resolver.rs`)
-
-`domains/org_resolver.rs` is an inventory-registry module, not a `Command`
-domain. Every top-level entity with a dedicated UI detail route MUST
-register an `inventory::submit! { ResourceOrgResolver { prefix, resolve } }`
-block there so the UI can auto-switch orgs on direct links. See
-`specs/multitenancy.md` (Cross-Org Resource Resolution) for the full
-contract. When introducing a new such entity, add:
-
-1. A storage method `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>`
-   (PG + in-memory).
-2. One `inventory::submit!` block in `domains/org_resolver.rs`.
-3. A UI detail hook that uses `hooks/create-crud-hooks.ts::useDetail`, or a
-   bespoke hook that calls `hooks/use-resource-org-fallback.ts` and folds
-   `isCheckingOtherOrgs` into its loading state.
-
-### Shared services (`crates/server/src/services/`)
-
-The `services/` layer exists only for code that has no single domain owner.
-A file belongs there when **all three** are true:
-
-1. No single domain owns it. If one domain is the natural owner, it moves
-   there — even if other domains consume it via free helpers.
-2. No user-facing command depends on it as a direct callee. Commands call
-   domain code; domain code may call shared services. If an HTTP/MCP/gRPC
-   command reaches straight into `services/`, that's a smell.
-3. It is one of three shapes: a registry/resolver threaded through `Ctx`,
-   an event listener reacting across domains, or a pure algorithm with no
-   persistence.
-
-The test: if you can name one domain whose commands would break without the
-file and no other, it's not a shared service — move it.
-
-Current shared services (and why each stays):
-
-- `capability` — capability registry held on `Ctx`; used by every domain.
-- `event` — event persistence + fanout; called by multiple emitting domains.
-- `llm_resolver` — spans `llm_providers`, `llm_models`, and request params;
-  no single owner.
-- `model_sync` — background listener reconciling provider catalogs with the
-  models table.
-- `principal` — resolves users and agent identities; shared lookup helper.
-- `usage_tracking` — event listener feeding budgets across domains.
-
-Everything else belongs under `domains/<owner>/`. For example, `eval_runner`
-lives at `domains/evals/runner.rs`, `scoped_mcp` at
-`domains/mcp_servers/scoped_mcp.rs`, `virtual_mount_registry` at
-`domains/session_files/virtual_mount_registry.rs`,
-`capability_validation` at `domains/capabilities/validation.rs`,
-`leased_resource` at `domains/session_resources/leased_resource.rs`.
-
-## Testing
-
-- Commands are tested directly: construct `Ctx` with a test DB, call `execute()`.
-- Queries are tested as unit functions: pass a `StorageBackend`, assert results.
-- HTTP adapters: integration tests via `axum::test` (unchanged).
-- MCP dispatch: test via `dispatch("create_agent", json!({...}), &ctx)`.
-
-## Checklist for adding a new domain
-
-1. Create `domains/{name}/` with `mod.rs`, `commands.rs`, `queries.rs`, `types.rs`
-2. Move request types from `api/{name}.rs` to `types.rs`
-3. Move business logic from `services/{name}.rs` into `domains/{name}/`
-4. Extract shared DB helpers to `queries.rs`
-5. Each command: `inventory::submit! { CommandDescriptor::of::<Cmd>() }`
-6. Update `api/{name}.rs` to call commands (thin adapter)
-7. Remove old top-level service file once all callers migrated
-8. Verify `just pre-push` passes
+## Purpose
+
+Domain modules own user-facing operations, validation, authorization policy,
+business rules, and shared persistence helpers for one feature. HTTP, MCP,
+gRPC, and platform callers converge on the same command path so behavior and
+policy cannot drift by protocol.
+
+Before this pattern, one operation was often split across an HTTP handler,
+service, MCP catalog entry, and bespoke dispatcher. Domain commands make the
+operation the unit of reuse and registration.
+
+## Sources of truth
+
+- [`crates/server/src/domains/common.rs`](../crates/server/src/domains/common.rs)
+  owns command traits, metadata, context, errors, policy enforcement,
+  instrumentation, schema helpers, and generic dispatch.
+- [`crates/server/src/domains/`](../crates/server/src/domains/) contains the
+  current domain inventory and concrete command patterns.
+- [`crates/server/src/api/dispatch.rs`](../crates/server/src/api/dispatch.rs)
+  owns the HTTP adapter chokepoint.
+- [`crates/server/src/api/mcp_endpoint/catalog.rs`](../crates/server/src/api/mcp_endpoint/catalog.rs)
+  owns MCP discovery, scripted-tool schema adaptation, and dispatch error
+  formatting.
+- [`crates/internal-protocol/proto/`](../crates/internal-protocol/proto/) owns
+  exact gRPC messages.
+- [`crates/server/tests/command_policy_enforcement_test.rs`](../crates/server/tests/command_policy_enforcement_test.rs)
+  verifies policy coverage from command inventory.
+
+Do not copy the command trait, context fields, error enum, registry descriptor,
+or current domain list into this spec. Their definitions and exhaustive tests
+are more reliable than a second inventory.
+
+## Module ownership
+
+A user-facing domain normally separates:
+
+- commands: public operations, validation, policy, and orchestration;
+- queries: reusable persistence helpers without caller policy;
+- types: request, response, and domain-owned storage shapes;
+- optional service or runner modules for substantial internal orchestration
+  shared by several commands.
+
+This is a responsibility boundary, not a mandatory file template. A small
+domain may use fewer files. Internal-only orchestration can live under the
+owning domain without manufacturing a public command.
+
+Code belongs in a global `services` module only when no single domain naturally
+owns it and it is genuinely cross-cutting infrastructure, registry behavior, or
+an external integration boundary. A command reaching into an unrelated global
+service for feature logic is a design smell.
+
+## Command contract
+
+A command defines:
+
+- serializable input and output;
+- stable catalog metadata;
+- input and output schema discovery;
+- whether it is read-only;
+- optional positional shorthand for scripted MCP use;
+- the permission policy;
+- execution against shared caller context.
+
+The exact methods and defaults live on `Command` and `CommandSchema` in
+`domains/common.rs`.
+
+### One enforcement point
+
+`Command::run` is the public entry point. It evaluates policy using the active
+permission resolver, adds protocol-independent tracing and metrics, and then
+executes the operation.
+
+HTTP adapters, generated MCP dispatch, gRPC command transport, and platform
+capabilities must call `run` or a helper that calls it. They must not call
+`execute` directly. Direct execution is reserved for composition inside an
+already-authorized command, where re-running policy would be redundant and the
+caller remains within the same operation boundary.
+
+Every non-read-only mutation declares policy. Inventory-based tests enforce
+coverage. A new caller that appears to require bypassing `run` should become a
+separate explicitly authorized command instead.
+
+### Context
+
+Command context carries authenticated caller/organization identity, the active
+permission resolver, storage, feature flags, and cross-cutting facilities
+needed by domain orchestration. The exact dependency set changes as domains
+evolve and is intentionally not listed here.
+
+Context construction is centralized per transport. Tests use the supported
+minimal test constructor rather than assembling partial production context.
+
+Domain-specific algorithms remain in their domain; adding every helper as a
+context field would recreate the old service layer.
+
+### Metadata and schema
+
+Static metadata drives MCP and gRPC discovery and contributes protocol
+instrumentation. The registered command name is the stable operation identity.
+HTTP method and path metadata describe the corresponding adapter but do not
+replace the OpenAPI handler annotation.
+
+Input schema is derived from the command type. Commands should declare useful
+output schema and shape when callers need to script the result. Generic
+discovery must always return a valid schema, even while a domain is being
+migrated.
+
+The source registry is authoritative for current commands. Do not maintain a
+parallel catalog.
+
+## Errors
+
+Domain errors are protocol-independent and may include a stable code, allowed
+recovery actions, and retry guidance. The exact error variants and exhaustive
+lower-snake-case kind mapping live in `domains/common.rs`.
+
+HTTP maps errors to RFC 9457 Problem Details and carries safe extensions. MCP
+currently emits a stable textual kind plus message for bashkit compatibility.
+Internal errors are logged with diagnostic detail but must be redacted before
+an untrusted transport response.
+
+Adding an error kind requires updating every exhaustive transport and metric
+mapping plus their tests. A copied variant table in this spec would hide that
+compiler-enforced work, so it is deliberately omitted.
+
+Classify caller mistakes with typed domain errors. String-pattern
+classification exists only for older paths and should not grow when a typed
+boundary is available.
+
+## Inventory and dispatch
+
+Commands self-register through inventory. Registration provides metadata,
+schemas, and a generic dispatch function. This single registry feeds:
+
+- MCP `discover`, read-only query, and mutation execution;
+- generic runtime dispatch;
+- internal gRPC command discovery and execution;
+- policy-coverage tests.
+
+Duplicate names are invalid. Registration and lookup behavior are tested in the
+common domain and transport-specific tests.
+
+### Scripted MCP arguments
+
+The MCP catalog adapts array and object parameters into JSON text for bashkit's
+flag parser, then coerces them back before command deserialization. This
+translation is generic; individual commands must not add ad hoc parsing for the
+same limitation.
+
+A command may opt into one positional argument only when it has one obvious
+required identity-like parameter. Read-only exposure defaults from operation
+semantics but can be overridden for safe search or preview commands.
+
+MCP failures retain a stable kind prefix. The exact labels and formatting
+function live in the catalog source and common error mapping.
+
+## HTTP adapters
+
+HTTP handlers own transport concerns: extractors, OpenAPI annotations, status
+and headers, URL decoration, and response serialization. They convert validated
+transport input into a domain command and run it through the HTTP dispatcher.
+
+Trivial handlers should use dispatcher helpers so response wrapping and future
+HTTP-only cross-cutting behavior stay centralized. A handler must not
+reimplement command validation or authorization.
+
+Exact request and response bodies belong to handler types and the generated
+OpenAPI export, not this spec.
+
+## gRPC command transport
+
+Internal workers execute registered management operations through the generic
+command RPC instead of bespoke messages per CRUD operation. The request carries
+an operation name, API version, serialized parameters, and organization scope.
+Responses preserve typed domain failure classification.
+
+Workers can discover the command catalog and schema hash. A
+non-backward-compatible command contract requires an explicit API-version
+decision; changing copied protobuf text in a Markdown file is never sufficient.
+
+Exact messages and size limits belong to the protocol source.
+
+## Query helpers and command composition
+
+Queries are policy-free building blocks for commands and trusted internal
+orchestration. They accept explicit organization scope where the data is
+org-owned. Exposing a query directly to an external adapter bypasses the domain
+contract and is prohibited.
+
+One command may compose another command's execution only after the outer
+command has authorized the complete operation. If the inner operation has a
+distinct permission or audit meaning, call its public command path instead.
+
+## Cross-cutting behavior
+
+`Command::run` is the protocol-independent chokepoint for:
+
+- permission evaluation;
+- command tracing;
+- low-cardinality success/failure metrics;
+- structured failure logging.
+
+The HTTP dispatcher is the HTTP-only chokepoint. Transport-specific concerns
+do not belong in `Command::run`, while policy and business validation do not
+belong only in HTTP.
+
+See [`permissions.md`](permissions.md),
+[`observability.md`](observability.md), and
+[`prometheus-metrics.md`](prometheus-metrics.md).
+
+## Adding or migrating a domain
+
+1. Identify the feature owner and keep helpers beneath it.
+2. Move canonical request/response types to the domain or adapter that owns
+   their contract.
+3. Extract reusable persistence helpers without policy.
+4. Implement each public operation as a command with metadata, schema, and
+   policy.
+5. Register the command and call `run` through the HTTP dispatcher.
+6. Add focused domain tests and rely on inventory tests for cross-transport
+   coverage.
+7. Remove old service/catalog/dispatcher copies after all callers converge.
+
+Migration status is visible from `crates/server/src/domains/` and inventory;
+this spec intentionally does not freeze directory counts or "current" lists.
+
+## Cross-org resolver exception
+
+`domains/org_resolver.rs` is an inventory-backed resolver registry, not a
+command domain. It supports membership-gated direct-link fallback while
+ordinary entity APIs remain strictly org-scoped. Its contract and registration
+requirements live in [`multitenancy.md`](multitenancy.md).

--- a/specs/evals.md
+++ b/specs/evals.md
@@ -1,401 +1,222 @@
 # Evals
 
-<!-- Design Decisions:
-  - Evals are user-facing: org-scoped, visible in UI, not internal testing infrastructure
-  - Each eval case creates a real session — same behavior as production, debuggable
-  - Scorers return 0.0–1.0 (not binary) to support nuanced grading
-  - Eval runs are durable workflows — reuse existing engine, no parallel infra
-  - Multi-turn cases supported via sequential InputMessage delivery
-  - LLM-as-judge scorer deferred to Phase 2 (requires model call inside scoring)
-  - No dataset management — evals are small, curated collections
-  - No cross-org visibility — evals are org-scoped like all other entities
-  - EvalTarget replaces harness_id + agent_id — unified session setup contract
-  - EvalTarget::Session mirrors CreateSessionRequest; EvalTarget::App references a deployed app
-  - Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness
-  - EvalCaseResult stores both target (live reference) and target_snapshot (frozen copy at execution time)
-  - Concurrency and volume limits bound fan-out without throttling legitimate use (EVE-509)
--->
+## Purpose
 
-## Abstract
+Evals are org-scoped, user-facing behavioral tests. An eval groups curated
+cases; each internal case runs against a real Everruns session and records
+scores, artifacts, efficiency data, and a link back to the debuggable
+conversation.
 
-Evals let users define, run, and track behavioral tests for their agents. An Eval is a named collection of cases — each case sends messages to a fresh session and scores the result. Users compare runs across models, track regressions after prompt changes, and gate App publishes on pass rates.
+This spec owns evaluation semantics and product intent. It does not repeat
+Rust models, scorer variants, database columns, identifier prefixes, route
+tables, or UI component inventories.
 
-Each eval case creates a real session with the target agent and harness. Failed cases are debuggable by clicking into the session and seeing the full conversation, tool calls, and events.
+## Sources of truth
 
-## Concepts
+- [`crates/core/src/eval.rs`](../crates/core/src/eval.rs) owns eval targets,
+  statuses, scorer variants, score/result models, summaries, datasets, and
+  serialized field shapes.
+- [`crates/server/src/domains/evals/`](../crates/server/src/domains/evals/)
+  owns validation, commands, limits, execution, import, scoring, datasets, and
+  persistence orchestration.
+- [`crates/server/src/api/evals.rs`](../crates/server/src/api/evals.rs) owns
+  HTTP routes and OpenAPI annotations.
+- [`docs/api/openapi.json`](../docs/api/openapi.json) is the exact external
+  request/response contract.
+- [`crates/server/migrations/`](../crates/server/migrations/) owns eval tables,
+  indexes, share tokens, and later schema evolution.
+- Eval integration tests under [`crates/server/tests/`](../crates/server/tests/)
+  are the executable contract for runs, import, sharing, datasets, and org
+  isolation.
 
-### EvalTarget
+## Core concepts
 
-Defines how to instantiate a session for eval cases. Two variants:
+### Target
 
-- **`session`**: Mirrors `CreateSessionRequest` — `harness_id` and `harness_name` are optional but mutually exclusive (if both are provided, validation fails; if neither, the org default harness is used). Other fields: `agent_id`, `model_id`, `system_prompt`, `max_iterations`. Full control over session setup.
-- **`app`**: Reference to a deployed App — `app_id`. Session created via the app's configuration.
+An eval target defines how a case creates a session. It either describes
+session setup or references a deployed app.
 
-**Resolution order**: `EvalRun.target` → `EvalCase.target` → `Eval.target` → org default harness.
+Target resolution is most-specific first: run override, case override, eval
+default, then the organization's default session setup. Validation follows the
+same rules as ordinary session creation so evals do not become a bypass around
+session policy.
 
-All three levels (Eval, EvalCase, EvalRun) have an optional `target` field. The first non-null target in the resolution chain is used. This allows running the same eval cases against different targets per run, or defining per-case overrides for heterogeneous test suites.
-
-### Eval
-
-Top-level entity. Contains cases that define expected behaviors.
-
-- Org-scoped, follows standard building-block lifecycle (`active → archived → deleted`)
-- Optional `target` (EvalTarget) — the default session setup for all cases
-- Optional `model_override` for baseline model selection
-- Tagged for organization and filtering
-
-### EvalCase
-
-A single test within an eval. Defines input messages, scoring criteria, execution bounds, and optional artifact collection.
-
-- Each case has a `description` explaining what behavior it measures (self-documenting)
-- Optional `target` (EvalTarget) — per-case override
-- `conversation`: one or more input messages sent sequentially (multi-turn support)
-- `post`: optional verification messages sent after conversation completes and session idles, before scoring (e.g. running test scripts for SWE-bench)
-- `artifacts`: optional named session-file reads captured after post messages and scoring complete
-- `scorers`: list of scoring rules applied after execution completes
-- `max_turns`: optional bound on agent turns (default: 10)
-- `timeout_seconds`: per-case timeout (default: 120)
-- Tagged independently from parent eval for subset runs
-
-### EvalRun
-
-A single execution of all (or a tagged subset of) cases in an eval.
-
-- Creates one session per case
-- Optional `target` (EvalTarget) — per-run override (e.g., test same cases against a different app)
-- Supports model override per run (compare models without editing the eval)
-- Tracks aggregate metrics: pass rate, average score, turns, latency, tokens
-- Triggered by user action, API call, or scheduled task
-- Status: `pending → running → completed | failed | cancelled`
-
-### EvalCaseResult
-
-The outcome of a single case within a run.
-
-- Links to the actual session created for this case (browsable in UI)
-- `target`: resolved EvalTarget at execution time (always concrete, never NULL)
-- `target_snapshot`: identical frozen copy for immutability (both set at run creation, both equal initially; `target_snapshot` must never be overwritten)
-- Contains per-scorer scores with pass/fail, value (0.0–1.0), and reason
-- Optional `metadata` records external scorer provenance for deferred write-back (scorer name, version, timestamps, raw output, reviewer notes)
-- Stores collected artifact contents keyed by the case's artifact names
-- Captures efficiency metrics: turn count, latency, token usage
-
-### Scorer
-
-A rule that grades agent output after execution. Embedded in EvalCase, not a standalone entity.
-
-- Returns `{ pass: bool, value: f64, reason: String }` where value is 0.0–1.0
-- Case passes when ALL scorers pass
-- Case-level score = weighted average of scorer values
-
-## Scorer Types
-
-| Type | Config | What It Checks |
-|------|--------|----------------|
-| `contains` | `{ text: String }` | Final assistant message contains substring |
-| `not_contains` | `{ text: String }` | Final assistant message does NOT contain substring |
-| `regex` | `{ pattern: String }` | Final assistant message matches regex pattern |
-| `tool_called` | `{ tool: String, min: Option<u32> }` | Agent called named tool at least `min` times (default 1) |
-| `tool_not_called` | `{ tool: String }` | Agent did NOT call named tool |
-| `tool_call_count` | `{ min: Option<u32>, max: Option<u32> }` | Total tool calls within range |
-| `turns_within` | `{ max: u32 }` | Completed within N turns |
-| `file_contains` | `{ path: String, text: String }` | Session filesystem file contains substring |
-| `json_schema` | `{ schema: Value }` | Final assistant message parses as JSON matching schema |
-| `llm_judge` | `{ rubric: String, model: Option<String> }` | LLM grades output against rubric (**planned; no Scorer variant yet**) |
-
-## Data Model
+The exact target variants and fields live in `crates/core/src/eval.rs`.
 
 ### Eval
 
-See `crates/core/src/eval.rs` for full field definitions.
+An eval is a named, tagged collection of cases with lifecycle state and optional
+default target/model behavior. It is isolated to one organization and follows
+the normal archive/delete conventions for building blocks.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` / `public_id` | UUID / EvalId | Dual-ID pattern (`eval_` prefix) |
-| `org_id` | i64 | Owning organization |
-| `name` | String | Display name |
-| `description` | Option\<String\> | Optional description |
-| `target` | Option\<EvalTarget\> | Session setup target (JSONB) |
-| `model_override` | Option\<String\> | Optional default model for runs |
-| `tags` | Vec\<String\> | Organization tags |
-| `status` | EvalStatus | `active`, `archived`, `deleted` |
-| `created_at` | DateTime | Creation timestamp |
-| `updated_at` | DateTime | Last update timestamp |
-| `archived_at` | Option\<DateTime\> | Archive timestamp |
-| `deleted_at` | Option\<DateTime\> | Deletion timestamp |
+### Case
 
-### EvalCase
+A case defines:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` / `public_id` | UUID / EvalCaseId | Dual-ID pattern (`evalcase_` prefix) |
-| `eval_id` | UUID | FK to parent eval |
-| `name` | String | Case name |
-| `description` | Option\<String\> | What behavior this measures |
-| `target` | Option\<EvalTarget\> | Per-case target override (JSONB) |
-| `tags` | Vec\<String\> | Tags for subset runs |
-| `conversation` | Vec\<InputMessage\> | Input messages (sequential) |
-| `post` | Option\<Vec\<InputMessage\>\> | Post-conversation verification messages (sent after session idles, before scoring) |
-| `artifacts` | Option\<Vec\<ArtifactSpec\>\> | Named session files to collect after the case finishes |
-| `scorers` | Vec\<Scorer\> | Scoring rules (JSONB) |
-| `max_turns` | Option\<u32\> | Turn limit (default: 10) |
-| `timeout_seconds` | Option\<u32\> | Timeout (default: 120) |
-| `position` | i32 | Display order |
-| `created_at` | DateTime | Creation timestamp |
-| `updated_at` | DateTime | Last update timestamp |
+- one or more input messages sent sequentially;
+- optional verification messages sent after the main conversation idles;
+- scoring rules;
+- execution bounds;
+- optional session files to collect as named artifacts;
+- an optional target override.
 
-### EvalRun
+Each internal case gets a fresh session. This preserves production behavior and
+makes failures inspectable rather than simulating the agent loop in a separate
+test harness.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` / `public_id` | UUID / EvalRunId | Dual-ID pattern (`evalrun_` prefix) |
-| `eval_id` | UUID | FK to parent eval |
-| `org_id` | i64 | Owning organization |
-| `target` | Option\<EvalTarget\> | Per-run target override (JSONB) |
-| `model_override` | Option\<String\> | Model override for this run |
-| `filter_tags` | Option\<Vec\<String\>\> | Only run cases matching these tags |
-| `status` | EvalRunStatus | `pending`, `running`, `completed`, `failed`, `cancelled` |
-| `triggered_by` | String | `user`, `schedule`, `publish_gate` |
-| `started_at` | Option\<DateTime\> | When execution started |
-| `completed_at` | Option\<DateTime\> | When execution finished |
-| `summary` | Option\<RunSummary\> | Aggregate metrics (JSONB, set on completion) |
-| `created_at` | DateTime | Creation timestamp |
-| `updated_at` | DateTime | Last update timestamp |
+### Run
 
-### RunSummary (embedded JSONB)
+A run executes all selected cases under one resolved configuration. It records
+source, trigger, lifecycle, aggregate metrics, and results.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `total` | u32 | Total cases in run |
-| `passed` | u32 | Cases that passed |
-| `failed` | u32 | Cases that failed |
-| `errored` | u32 | Cases that errored or timed out |
-| `pass_rate` | f64 | passed / total |
-| `avg_score` | f64 | Average case score |
-| `avg_turns` | f64 | Average turns per case |
-| `avg_latency_ms` | u64 | Average case latency |
-| `total_input_tokens` | u64 | Total input tokens |
-| `total_output_tokens` | u64 | Total output tokens |
+Internal runs create sessions and score them. External runs are imported
+observations and are never re-executed or silently rescored by Everruns.
 
-### EvalCaseResult
+A run is terminal when completed, failed, or cancelled. Cancellation prevents
+new case work and propagates through the durable runner according to current
+execution state.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` / `public_id` | UUID / EvalResultId | Dual-ID pattern (`evalresult_` prefix) |
-| `eval_run_id` | UUID | FK to parent run |
-| `eval_case_id` | UUID | FK to the case |
-| `session_id` | Option\<UUID\> | FK to session created for this case |
-| `target` | EvalTarget | Resolved target at execution time (JSONB, always concrete) |
-| `target_snapshot` | EvalTarget | Frozen copy of resolved target (JSONB, immutable) |
-| `status` | CaseResultStatus | `pending`, `running`, `passed`, `failed`, `errored`, `timeout` |
-| `scores` | Option\<JSON\> | Per-scorer results (JSONB) |
-| `metadata` | Option\<JSON\> | External scorer provenance and audit details (JSONB) |
-| `artifacts` | Option\<Map\<String, String\>\> | Collected session file contents (JSONB) |
-| `turns` | Option\<u32\> | Turn count |
-| `latency_ms` | Option\<u64\> | Execution time |
-| `tokens` | Option\<TokenUsage\> | Token usage |
-| `error_message` | Option\<String\> | Error details if errored |
-| `created_at` | DateTime | Creation timestamp |
-| `updated_at` | DateTime | Last update timestamp |
+### Result
 
-### Score (embedded JSONB)
+A result captures one case outcome, including its session when internally
+executed, resolved target state, scores, artifacts, timing, token counts,
+metadata, and safe error information.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `pass` | bool | Whether this scorer passed |
-| `value` | f64 | Score 0.0–1.0 |
-| `reason` | String | Human-readable explanation |
+Target information is frozen for audit at run creation. The exact optionality
+and storage representation are defined by the current source; consumers must
+use the generated API rather than a copied field table.
 
-## ID Schema
+## Scoring
 
-| Entity | Prefix | Example |
-|--------|--------|---------|
-| Eval | `eval` | `eval_01933b5a000070008000000000000001` |
-| EvalCase | `evalcase` | `evalcase_01933b5a000070008000000000000001` |
-| EvalRun | `evalrun` | `evalrun_01933b5a000070008000000000000001` |
-| EvalCaseResult | `evalresult` | `evalresult_01933b5a000070008000000000000001` |
+A scorer returns pass/fail, a normalized value from zero to one, and a
+human-readable reason. A case passes only when every required scorer passes.
+The case score is the weighted average of scorer values.
 
-## API
+The exhaustive scorer set and configuration are defined by the tagged `Scorer`
+enum in `crates/core/src/eval.rs`. Adding a scorer requires:
 
-All endpoints under `/v1/evals`. See `crates/server/src/api/evals.rs`.
+- a serialized variant and validation;
+- execution logic;
+- API/OpenAPI exposure;
+- focused tests;
+- UI authoring/rendering support where applicable.
 
-### Eval CRUD
+Do not keep an exhaustive scorer list here. The source currently includes
+output, tool-use, filesystem, schema, and citation-oriented scoring families;
+the enum and tests are authoritative as that set evolves.
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/v1/evals` | Create eval |
-| `GET` | `/v1/evals` | List evals (paginated, filterable by status) |
-| `GET` | `/v1/evals/{eval_id}` | Get eval with case count and last run summary |
-| `PATCH` | `/v1/evals/{eval_id}` | Update eval |
-| `DELETE` | `/v1/evals/{eval_id}` | Archive eval |
+External score write-back is allowed only through the explicit result/run
+commands. Provenance belongs in result metadata so a score can be audited
+without pretending Everruns computed it.
 
-### Case Management
+## Internal execution
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/v1/evals/{eval_id}/cases` | Add case |
-| `GET` | `/v1/evals/{eval_id}/cases` | List cases |
-| `GET` | `/v1/evals/{eval_id}/cases/{case_id}` | Get case |
-| `PATCH` | `/v1/evals/{eval_id}/cases/{case_id}` | Update case |
-| `DELETE` | `/v1/evals/{eval_id}/cases/{case_id}` | Remove case |
-| `POST` | `/v1/evals/{eval_id}/atif_import` | Upsert cases from ATIF trajectories (NDJSON or JSON body; see `specs/atif-adoption.md`) |
+Triggering an internal run:
 
-### Run Management
+1. validates org scope, limits, target overrides, and selected cases;
+2. creates the run and pending results with frozen resolved targets;
+3. schedules durable bounded-concurrency case work;
+4. creates one session per case;
+5. sends conversation and verification messages in order, waiting for idle
+   between messages;
+6. reads canonical session outcomes and configured artifacts;
+7. evaluates scorers and records result metrics;
+8. aggregates the terminal run summary.
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/v1/evals/{eval_id}/runs` | Trigger run (body: optional `model_override`, `filter_tags`) |
-| `GET` | `/v1/evals/{eval_id}/runs` | List runs with summaries |
-| `GET` | `/v1/evals/{eval_id}/runs/{run_id}` | Get run with case results |
-| `GET` | `/v1/evals/{eval_id}/runs/{run_id}/artifacts` | Export run artifacts as NDJSON (`instance_id` plus artifact fields, with `patch` exported as `model_patch`) |
-| `POST` | `/v1/evals/{eval_id}/runs/{run_id}/cancel` | Cancel running eval |
-| `PATCH` | `/v1/evals/{eval_id}/runs/{run_id}/results/{result_id}/scores` | Write external scores back to a completed result |
-| `PATCH` | `/v1/evals/{eval_id}/runs/{run_id}/scores` | Bulk write external scores back to a completed run |
+Eval sessions use ordinary session capabilities, events, authorization, and
+resource limits. Eval execution must not call storage or tools through a
+special privileged path.
 
-### Import (external eval results)
+The runner owns exact concurrency, timeout, tag-filter behavior, and error
+classification. Operator configuration and defaults live in the eval limits
+source rather than this spec.
 
-Everruns also hosts and visualizes runs it did **not** execute, so external eval
-systems (e.g. Mira) can publish results without onboarding into the session
-system. See `proposals/mira-results-publishing.md`.
+## Limits
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/v1/evals/import` | Ingest a full external run group (one run → one EvalRun per eval) |
-| `GET` | `/v1/evals/import/preflight` | Report `{ evals_enabled, can_import }` so optional-feature clients check before publishing |
+Run creation is bounded by per-organization concurrent-run and per-run case
+limits. Limits are checked before fan-out so one request cannot create
+unbounded durable work.
 
-- An imported `EvalRun` carries `source = external` plus `attribution` (system,
-  version, url, run id, labels); internal runs are unchanged (`source =
-  internal`). Evals and cases are upserted **by name** within the org (no
-  namespacing — name collisions merge; see proposal). External cases are
-  identity-only: everruns never re-executes or re-scores them.
-- Idempotent on the external `source.run_id`: re-publishing replaces the prior
-  run for each eval in the group.
-- Scores are stored opaque (named, attributed) — everruns trusts the external
-  verdict. Per-result transcript and an open-vocab metrics bag ride in the
-  result `metadata` envelope rather than dedicated columns.
-- Gated by `EVAL_IMPORT` (`OrgAgentsManage` only — no sessions are created, so
-  unlike `EVAL_RUN` it does not require `OrgSessionsManage`).
+Exact environment variable names, defaults, and injectable test configuration
+live in [`crates/server/src/domains/evals/limits.rs`](../crates/server/src/domains/evals/limits.rs).
 
-### Share links (read-only public views)
+## External import
 
-A run can be shared read-only via an unguessable token, so results (matrix,
-transcript, comparison-friendly data) can be shown to people without an org
-seat. General-purpose and OSS-native; no separate public domain is required.
+Everruns can host and visualize runs produced by external evaluation systems.
+Import is org-scoped and permission-gated.
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/v1/evals/{eval_id}/runs/{run_id}/share` | Mint a link (returns the raw token once); revokes any prior active link |
-| `GET` | `/v1/evals/{eval_id}/runs/{run_id}/share` | Whether the run has an active link |
-| `DELETE` | `/v1/evals/{eval_id}/runs/{run_id}/share` | Revoke all links for the run |
-| `GET` | `/v1/public/eval-runs/{token}` | **Unauthenticated** read of the shared run (sanitized) |
+External import semantics are:
 
-- Tokens (`evr_share_…`) are stored SHA-256-hashed like PATs — the raw token is
-  surfaced once. `revoked_at`/`expires_at` disable a link without deleting the
-  row (migration 091). At most one active link per run.
-- Mint/revoke require `EVAL_MANAGE`; the public read takes no auth extractor —
-  the token is the authorization (see `specs/public-endpoints.md`). The public
-  DTO is sanitized: no org/internal/session ids, no internal (session/app)
-  targets, no attribution env labels; unknown/revoked/expired ⇒ uniform 404.
+- source attribution identifies the external system and run;
+- evals and cases use the documented org-local identity strategy;
+- publishing the same external run identity is idempotent and replaces its
+  prior imported representation;
+- transcripts, opaque metrics, and scorer provenance remain attributed data;
+- imported cases are not eligible for internal re-execution merely because
+  they now appear in Everruns.
 
-#### Run Limits (EVE-509)
+Preflight lets optional-feature clients determine whether import is available
+before publishing. Exact payloads and routes live in the command source and
+OpenAPI.
 
-`POST /runs` enforces two limits at trigger time, returning HTTP 400 on violation:
+ATIF case import is a separate operation for turning trajectories into
+executable eval cases. See [`atif-adoption.md`](atif-adoption.md).
 
-- **Concurrent runs per org**: at most `EVAL_MAX_CONCURRENT_RUNS_PER_ORG` runs may be in `pending` or `running` state simultaneously (default: 5).
-- **Cases per run**: a run may not execute more than `EVAL_MAX_CASES_PER_RUN` cases (default: 500). Checked at trigger time against total cases in the eval (tag-filtered runs are Phase 2).
+## Artifacts and datasets
 
-Both limits are read from environment variables at service startup and are injectable via `EvalService::with_limits` for test isolation.
+Cases may collect named session files after conversation and verification work.
+Run artifact export provides the external evaluation-oriented record format
+defined by the command implementation.
 
-## Execution Flow
+Dataset export is durable and may have its own lifecycle and stored body. The
+current dataset commands and models are defined in the eval domain and core
+model. This spec intentionally does not copy their routes or fields.
 
-```
-POST /v1/evals/{eval_id}/runs
-  │
-  ├─ Create EvalRun (status: pending, target from request body)
-  ├─ For each case:
-  │    ├─ Resolve target: run.target → case.target → eval.target → org default
-  │    └─ Create EvalCaseResult (status: pending, target + target_snapshot = resolved target)
-  ├─ Spawn background execution task
-  │
-  │  For each case (bounded concurrency = 5):
-  │    1. Update CaseResult status → running
-  │    2. Create session from resolved EvalTarget (tags: ["eval"])
-  │    3. For each message in case.conversation:
-  │       a. POST message to session
-  │       b. Wait for session idle
-  │    4. For each message in case.post (if present):
-  │       a. POST message to session
-  │       b. Wait for session idle
-  │    5. Fetch session events (tool.completed, turn.completed)
-  │    6. Fetch final assistant messages
-  │    7. Run scorers → produce Score per scorer
-  │    8. Collect configured session files into CaseResult.artifacts
-  │    9. Update CaseResult (status, scores, artifacts, turns, latency, tokens)
-  │
-  ├─ Aggregate results → RunSummary
-  ├─ Update EvalRun (status: completed, summary)
-  └─ Return
-```
+See [`dataset-export.md`](dataset-export.md) for trajectory/reward dataset
+semantics.
 
-Sessions created by eval runs are tagged `eval` and reference the eval run for filtering.
+## Public share links
 
-## UI
+A completed run may be shared through an unguessable read-only token.
 
-### Navigation
+- Only a hash is stored; the raw token is returned once.
+- Minting replaces prior active access according to the share command.
+- Revoked, expired, malformed, and unknown tokens produce a uniform
+  non-enumerating response.
+- Public DTOs omit organization internals, private session/app targets,
+  environment labels, and other non-public metadata.
+- The token is authorization for the public read; management still requires
+  normal eval permission.
 
-Add "Evals" to the Building Blocks section in the sidebar, between "Skills" and "Capabilities". Icon: `FlaskConical` from lucide-react.
+Exact token format, lifecycle columns, public DTO, and routes belong to source,
+migrations, and OpenAPI. Public-boundary rules also follow
+[`public-endpoints.md`](public-endpoints.md).
 
-### Evals List Page (`/evals`)
+## UI intent
 
-Card grid layout (matching agents page pattern):
-- Each card shows: name, agent name, harness name, tags, last run status (pass/fail badge), last run pass rate, last run date
-- "New Eval" button in header
-- Filter: status (active/archived), tags
+The product supports:
 
-### Eval Detail Page (`/evals/[evalId]`)
+- browsing active and archived evals;
+- authoring cases, targets, messages, artifacts, and scorers;
+- triggering and cancelling runs;
+- inspecting aggregate and per-case outcomes;
+- navigating from an internal result to its session;
+- viewing imported and shared results without implying they were executed
+  locally;
+- comparing runs and identifying regressions.
 
-Two tabs: **Cases** and **Runs**.
+Exact page structure, component names, table columns, and navigation placement
+belong to the UI source and design system.
 
-**Cases tab:**
-- Table: name, tags, description (truncated), last result (pass/fail/score badge)
-- "Add Case" button
-- Click row → case detail dialog or inline expand
+## Security and isolation
 
-**Runs tab:**
-- Table: date, model, status, pass rate, avg score, avg turns, total tokens
-- "Run Eval" button (with optional model override dropdown)
-- Click row → run detail page
-
-### Run Detail Page (`/evals/[evalId]/runs/[runId]`)
-
-Header: run metadata (model, status, triggered by, duration).
-
-Summary cards row: pass rate (large number), avg score, avg turns, avg latency, total tokens.
-
-Results table: case name, status (pass/fail/error badge), score, turns, latency, tokens, session link (icon button → opens session in new tab).
-
-Click case row → expand to show per-scorer results with pass/value/reason.
-
-### Run Comparison (Phase 2)
-
-Select two runs from the runs tab → side-by-side view:
-- Summary metrics with delta indicators (green up / red down)
-- Per-case comparison table with score deltas
-- Highlights regressions (cases that passed before but fail now)
-
-### Create Eval Form (`/evals/new`)
-
-Fields: name, description, target type selector (session / app), target fields (varies by type), model override (optional), tags.
-
-Target type selector:
-- **Session**: harness (optional select, defaults to org default), agent (optional select), model (optional), system prompt (optional textarea)
-- **App**: app ID (text input)
-
-Cases added after creation on the detail page (simpler flow, avoids complex nested form).
-
-### Add Case Dialog
-
-Fields: name, description, tags, messages (textarea per message, add more button), max turns, timeout.
-
-Scorers section: add scorer dropdown → type-specific config form. Each scorer shows a card with type, config, weight, remove button.
+- Every eval, case, run, result, artifact, dataset, and management token is
+  scoped to its owning organization.
+- Internal execution uses ordinary session permissions and cannot smuggle
+  capabilities through a target.
+- Public shares expose only sanitized read-only data.
+- Raw share tokens and external credentials are never logged or persisted.
+- Imported attribution is untrusted display data and must be sanitized.
+- Artifact paths are resolved through the session filesystem boundary.
+- Scorer failures do not expose internal provider or storage errors to public
+  consumers.

--- a/specs/events.md
+++ b/specs/events.md
@@ -1,1640 +1,248 @@
-# Events Specification
+# Events
+
+## Purpose
+
+Events are Everruns' durable session protocol. They are the source of truth for
+conversation reconstruction, expose execution progress to clients, and feed
+observability and reporting projections.
+
+This document owns the event protocol's intent, compatibility rules, and
+cross-event semantics. It deliberately does not repeat the event envelope,
+payload structs, type registry, HTTP query fields, or SQL schema.
+
+## Sources of truth
+
+- [`crates/core/src/events.rs`](../crates/core/src/events.rs) owns the serialized
+  event envelope, event type constants, payload structs, the type-to-payload
+  mapping, and the valid filter registry.
+- [`docs/api/openapi.json`](../docs/api/openapi.json) is the generated
+  consumer-facing schema. It is the right source for SDK model generation and
+  exact wire fields.
+- [`crates/server/src/api/events.rs`](../crates/server/src/api/events.rs) owns
+  the JSON and SSE endpoints, query validation, filtering, pagination, and
+  summary response.
+- [`crates/server/src/services/event.rs`](../crates/server/src/services/event.rs)
+  owns emission and listener notification.
+- [`crates/server/migrations/001_base_schema.sql`](../crates/server/migrations/001_base_schema.sql)
+  and later migrations own storage columns, constraints, indexes, sequence
+  allocation, and immutability triggers.
+- The tests in [`crates/core/src/events.rs`](../crates/core/src/events.rs) cover
+  serialization, round trips, forward compatibility, and the type mapping.
+  [`crates/server/tests/workflow_test.rs`](../crates/server/tests/workflow_test.rs)
+  covers API filtering of unsupported events, while
+  [`crates/server/tests/client_side_tools_test.rs`](../crates/server/tests/client_side_tools_test.rs)
+  covers the client-tool event contract.
+
+Wire examples do not live here. Exact examples belong in the generated OpenAPI
+document and contract tests, where a source change makes drift visible. Product
+or SDK guides may show task-oriented excerpts generated from that contract, but
+must not become a second schema registry.
+
+## Public contract and compatibility
+
+The event protocol is a public API contract.
+
+The top-level envelope is stable. Its exact serialized fields and types are
+defined by `Event` in `crates/core/src/events.rs`. Payload shape is selected by
+the event's `type` through the single type-to-payload mapping in the same file.
+
+The following changes are backward-compatible:
+
+- adding an event type;
+- adding an optional payload or context field;
+- adding a string-enum value;
+- relaxing a required field to optional.
+
+The following require a major compatibility change:
+
+- removing or renaming a supported event type;
+- removing or renaming a field;
+- changing a field's serialized type or meaning;
+- making an optional field required.
+
+Consumers must ignore unknown fields, tolerate new event types, and use
+`sequence` rather than an identifier or timestamp for ordering within a
+session. The server filters payloads it cannot decode into a supported typed
+event before returning API or SSE results. Historical unsupported rows may
+remain in storage for audit and aggregate queries.
+
+Adding a constant is not enough to add an event. The payload type, mapping,
+filter registry, OpenAPI export, emission path, and round-trip tests must stay
+coherent. Tests in `crates/core/src/events.rs` are the executable contract for
+that coherence.
+
+## Correlation and tracing
+
+Turn-scoped events carry correlation context. A turn is the trace root;
+reasoning, acting, LLM, and tool activity form child spans. Started/completed
+pairs for one operation share a span identity so tracing backends can merge
+them.
+
+Correlation identifiers use Everruns' public prefixed identifier format. The
+exact optional context fields live on `EventContext`; emitters should populate
+the strongest context they possess without fabricating missing ancestry.
+Session-level events may have empty turn context.
+
+## Lifecycle conventions
+
+Long-running operations use paired lifecycle events where useful:
+
+- `started` establishes identity and lets clients show provisional state;
+- zero or more `delta` or `progress` events provide ephemeral updates;
+- `completed`, `failed`, `cancelled`, or `sealed` establishes the durable
+  outcome.
+
+Not every operation needs a separate failure event. A completed payload may
+carry a failure status when that is the established contract. The source
+registry is authoritative for the current type set.
+
+Delta and progress events are informational. Consumers accumulate them only for
+live rendering; the durable completion event is authoritative. The
+`is_ephemeral_event_type` function is the single source of truth for which
+events may be omitted from durable storage.
 
-## Abstract
+### Assistant messages
 
-Events are the core communication protocol in Everruns. They provide observability into session execution, enable SSE streaming, and serve as the source of truth for conversation data. All events follow a standard schema and are persisted to the events table.
+One assistant message is identified by its message ID across started, delta,
+replacement, and completed events. A turn may contain several assistant
+messages, so consumers must never group streamed text by turn alone.
 
-Events may also be projected into reporting facts for analytical queries. That
-projection is asynchronous and backend-neutral; see
-[specs/reporting.md](reporting.md).
+Completion is authoritative for message content and phase. A guardrail
+replacement discards only the accumulated text for the affected message ID;
+the subsequent completed event persists the replacement as the canonical
+assistant message. Suppressed model text must not be persisted or replayed.
+
+Streamed phase is a best-effort hint. It may refine once from unknown to
+commentary or final answer, but must not flip between phases or regress to
+unknown. Missing or unknown phase always falls back to ordinary assistant text,
+never to reasoning.
 
-## Contract & Compatibility
+### Turn terminal states
 
-Events are a **public API contract**. Consumers can rely on the guarantees defined here when building integrations. The server is responsible for ensuring only well-defined events reach consumers.
+A completed turn succeeded. A failed turn ended because of an error. A
+cancelled turn stopped at user request. A sealed turn was deliberately stopped
+to prevent waste, such as repeated recovery without progress or exhausted work
+budget.
+
+Sealing is terminal and non-retryable, but it does not create a separate
+session status. A user-visible assistant completion and an idle session
+transition accompany the sealed event. See
+[`durable-execution-engine.md`](durable-execution-engine.md) for forward-progress
+and dead-letter behavior.
 
-### Compatibility Guarantees
+User-facing failure events carry stable error classification and interpolation
+fields when available. Clients localize from those fields rather than matching
+English fallback text. Disclosure policy is defined in
+[`error-disclosure.md`](error-disclosure.md).
 
-#### Non-Breaking Changes
+### Session tasks
 
-These changes are safe and may happen in any release:
+Session-task events carry full task snapshots for reconciliation. Message
+events carry the task identifier and stored task message. The task contract
+lives in [`session-tasks.md`](session-tasks.md).
 
-- **Adding new event types** - New event types may be added. Server filters unknown types internally.
-- **Adding optional fields** - New optional fields may be added to existing event data types.
-- **Adding enum values** - New values may be added to string enums (e.g., new status values).
-- **Relaxing validation** - Required fields may become optional.
-
-#### Breaking Changes
-
-These changes require a major version bump:
-
-- **Removing event types** - Existing event types will not be removed without major version.
-- **Removing fields** - Existing fields will not be removed without major version.
-- **Renaming fields** - Field names are stable.
-- **Changing field types** - Field types are stable (e.g., string stays string).
-- **Making optional fields required** - Optional fields will not become required.
-- **Changing field semantics** - The meaning of fields is stable.
-
-### Server Responsibilities
-
-The server ensures consumers receive only well-defined events:
-
-1. **Filter unsupported events** - Events with unknown types are filtered before API responses (handled internally as `EventData::Unsupported`).
-2. **Log warnings** - Unknown event types trigger warning logs for debugging.
-3. **Emit only defined types** - API responses contain only documented event types.
-4. **Validate on emission** - Events are validated before storage and transmission.
-
-### Consumer Guidelines
-
-Consumers should follow these practices for robust integrations:
-
-1. **No unknown type handling needed** - All events in API responses have documented types.
-2. **Ignore unknown fields** - Deserialize with `#[serde(deny_unknown_fields)]` disabled.
-3. **Handle optional fields** - Check for presence before accessing optional fields.
-4. **Don't rely on field ordering** - JSON field order is not guaranteed.
-
-### Versioning
-
-Events follow semantic versioning aligned with the API version:
-
-- **Patch** (0.0.x): Bug fixes, no schema changes
-- **Minor** (0.x.0): New event types, new optional fields
-- **Major** (x.0.0): Breaking changes (removals, type changes)
-
-### Contract Testing
-
-Contract tests validate these guarantees:
-
-1. **Snapshot tests** - JSON structure for each event type
-2. **Round-trip tests** - Serialize/deserialize equality
-3. **Forward compatibility** - Unknown fields are ignored
-4. **API filtering** - Unsupported events never reach consumers
-
-## Standard Event Schema
-
-The core event structure is **frozen** — the top-level fields (`id`, `type`, `ts`, `session_id`, `sequence`, `context`, `data`) will not change. The `data` field follows per-type schemas documented below.
-
-Every event MUST conform to this schema:
-
-```json
-{
-  "id": "01937abc-def0-7000-8000-000000000001",
-  "type": "input.message",
-  "ts": "2024-01-15T10:30:00.000Z",
-  "session_id": "01937abc-def0-7000-8000-000000000002",
-  "context": {
-    "turn_id": "01937abc-def0-7000-8000-000000000003",
-    "input_message_id": "01937abc-def0-7000-8000-000000000004",
-    "exec_id": "01937abc-def0-7000-8000-000000000005",
-    "trace_id": "turn_01937abc",
-    "span_id": "exec_01937abc",
-    "parent_span_id": "turn_01937abc"
-  },
-  "data": {
-    // Event-specific payload
-  },
-  "metadata": { /* Optional arbitrary metadata */ },
-  "tags": ["tag1", "tag2"]
-}
-```
-
-### Schema Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | UUID v7 | Yes | Unique event identifier (ordering uses `sequence`, not ID) |
-| `type` | string | Yes | Event type in dot notation (e.g., `input.message`, `reason.started`) |
-| `ts` | ISO 8601 | Yes | Event timestamp with millisecond precision |
-| `session_id` | UUID | Yes | Session this event belongs to |
-| `context` | object | Yes | Correlation context for tracing |
-| `data` | object | Yes | Event-specific payload (can be empty `{}`) |
-| `metadata` | object | No | Arbitrary metadata for the event |
-| `tags` | array | No | Tags for filtering and categorization |
-
-When `FEATURE_AGENT_VERSIONS` is enabled and a session is bound to a saved agent version, emitted events include agent version metadata:
-
-- `agent_id`
-- `agent_version_id`
-- `agent_config_hash`
-
-### Context Object
-
-The context provides correlation data for tracing and filtering. All existing context fields are **stable** — they will not be removed, renamed, or have their types changed without a major version bump. New optional fields may be added.
-
-| Field | Type | Required | Stability | Description |
-|-------|------|----------|-----------|-------------|
-| `turn_id` | UUID | No | Stable | Turn identifier (for turn-scoped events) |
-| `input_message_id` | UUID | No | Stable | User message that triggered this turn |
-| `exec_id` | UUID | No | Stable | Atom execution identifier |
-| `trace_id` | string | No | Stable | OTel-style trace ID (typically the turn_id string) |
-| `span_id` | string | No | Stable | OTel-style span ID for this event |
-| `parent_span_id` | string | No | Stable | Parent span ID for hierarchical linking |
-
-### Hierarchical Tracing (OTel-Style)
-
-Events within an agent turn form a hierarchical trace structure using OpenTelemetry-style span relationships. This enables observability tools (Braintrust, Grafana Tempo, etc.) to visualize the execution as a tree.
-
-**Trace Structure:**
-
-```
-turn (root span)
-├── reason (child of turn)
-│   └── llm.generation (child of reason)
-├── act (child of turn)
-│   ├── tool (child of act)
-│   └── tool (child of act)
-├── reason (child of turn)
-│   └── llm.generation (child of reason)
-└── ...
-```
-
-**Span ID Relationships:**
-
-| Event Type | span_id | parent_span_id | trace_id |
-|------------|---------|----------------|----------|
-| `turn.started/completed` | turn_id | `null` (root) | turn_id |
-| `reason.started/completed` | reason_span_id | turn_id | turn_id |
-| `llm.generation` | llm_span_id | reason_span_id | turn_id |
-| `act.started/completed` | act_span_id | turn_id | turn_id |
-| `tool.started/completed/output.delta` | tool_span_id | act_span_id | turn_id |
-
-**Key Properties:**
-
-1. **trace_id**: Groups all events within a single turn into one trace. Always equals the turn_id string (prefixed format, e.g., `turn_abc123`).
-
-2. **span_id**: Uniquely identifies each event within the trace. Started/completed event pairs share the same span_id so observability tools merge them into a single span with timing.
-
-3. **parent_span_id**: Links this span to its parent in the hierarchy. Root spans (turn events) have `null` parent. Child spans reference their immediate parent.
-
-**ID Format Consistency:**
-
-All IDs (`trace_id`, `span_id`, `parent_span_id`) use the prefixed string format (e.g., `turn_xyz`, `exec_abc`) rather than raw UUIDs. This ensures spans are correctly linked in observability tools.
-
-## Event Naming Patterns
-
-### Started-Completed-Failed Pattern
-
-Operations that have a lifecycle follow a consistent **Started-Completed-Failed** pattern:
-
-```
-{operation}.started   → Operation began
-{operation}.completed → Operation finished successfully
-{operation}.failed    → Operation failed (optional, some use completed with success=false)
-```
-
-This pattern provides:
-- **Observability**: Clear boundaries for timing and tracing
-- **Error handling**: Explicit failure states for error tracking
-- **UI feedback**: Start/end signals for loading indicators
-
-**Examples:**
-
-| Operation | Started | Completed | Failed |
-|-----------|---------|-----------|--------|
-| Turn | `turn.started` | `turn.completed` | `turn.failed` (also `turn.sealed` — deliberate stop, see below) |
-| Reason | `reason.started` | `reason.completed` | (uses `success=false` in completed) |
-| Act | `act.started` | `act.completed` | (uses `success=false` in completed) |
-| Tool Call | `tool.call_started` | `tool.call_completed` | (uses `status` field) |
-| Thinking | `reason.thinking.started` | `reason.thinking.completed` | (implicit via `reason.completed`) |
-
-**Note:** Some operations use a `success` or `status` field in the completed event rather than a separate failed event. This is a design choice based on the operation's semantics.
-
-### Delta Pattern for Streaming
-
-Streaming content uses a **Delta** pattern with accumulated state:
-
-```
-{operation}.delta → Incremental update with delta and accumulated fields
-```
-
-Delta events include:
-- `delta`: New content since last event
-- `accumulated`: Total content so far (convenience for UI)
-
-**Examples:**
-
-| Content Type | Delta Event |
-|--------------|-------------|
-| Response text | `text.delta` |
-| Thinking content | `reason.thinking.delta` |
-
-### Namespace Hierarchy
-
-Event types use dot notation to indicate hierarchy:
-
-```
-{category}.{subcategory}.{action}
-```
-
-Examples:
-- `message.user` - User message event
-- `reason.started` - Reasoning phase started
-- `reason.thinking.started` - Thinking within reasoning started
-- `tool.call_completed` - Tool call within tool execution completed
-
-## Event Categories
-
-### Input Events
-
-Input events represent user messages submitted to the session.
-
-#### `input.message`
-
-User message submitted to the session. Emitted when the API stores a new user message.
-
-```json
-{
-  "id": "...",
-  "type": "input.message",
-  "ts": "...",
-  "session_id": "...",
-  "context": {},
-  "data": {
-    "message": {
-      "id": "01937abc-...",
-      "role": "user",
-      "content": [
-        { "type": "text", "text": "Hello, world!" }
-      ],
-      "controls": { "max_tokens": 1000 },
-      "metadata": { "source": "web" },
-      "created_at": "2024-01-15T10:30:00.000Z"
-    }
-  }
-}
-```
-
-### Output Events
-
-Output events represent agent responses. They follow a lifecycle pattern: `started` → `delta*` → `completed`.
-
-#### `output.message.started`
-
-Emitted when the LLM starts generating a response. UI can show a "thinking" indicator until `output.message.delta` or `output.message.completed` events arrive.
-
-```json
-{
-  "id": "...",
-  "type": "output.message.started",
-  "ts": "...",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "message_id": "message_550e8400e29b41d4a716446655440000",
-    "model": "gpt-4o",
-    "iteration": 1
-  }
-}
-```
-
-**`iteration`** (optional, u32): 1-based iteration number within the current turn. Lets the UI show which iteration the agent is on during multi-step tool-calling flows. Only displayed when > 1.
-
-**`message_id`** (required, MessageId): stable random-public identifier allocated before generation begins. It scopes one assistant message within the turn and is reused by every `output.message.delta` / `output.message.replaced` event and by the completed `message.id`. This is the same public identifier, not a separate streaming id space.
-
-**`phase`** (optional, string — `"commentary"` | `"final_answer"`): best-effort streamed phase hint (EVE-774). This event is emitted *before* the LLM call, so `phase` is generally absent here. When absent it means **"not yet classified — treat as ordinary assistant text"**, NEVER "thinking". See the shared hint semantics under `output.message.delta`.
-
-#### `output.message.delta`
-
-Streaming text update during LLM generation. Events are batched (~100ms) to reduce volume while providing real-time feedback. UI should accumulate deltas or use the `accumulated` field until `output.message.completed` arrives with the final text.
-
-```json
-{
-  "id": "...",
-  "type": "output.message.delta",
-  "ts": "...",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "message_id": "message_550e8400e29b41d4a716446655440000",
-    "delta": "Hello, ",
-    "accumulated": "Hello, ",
-    "phase": "commentary"
-  }
-}
-```
-
-**`phase`** (optional, string — `"commentary"` | `"final_answer"`): best-effort streamed phase hint (EVE-774) letting consumers classify streamed assistant text as commentary vs final answer *before* `output.message.completed` arrives.
-
-Consumers group streamed assistant text by **`message_id`**, not `turn_id`: a multi-step turn may contain multiple assistant messages, each with a distinct id. All deltas for one generated message carry the id from its corresponding `output.message.started`.
-
-- **Absent = "not yet classified — treat as ordinary assistant text", NEVER "thinking".** A missing/unknown phase must fall back to the assistant-text channel, never the reasoning/thinking channel (the EVE-448 class of bug).
-- **Monotonic refinement only.** Within a single message the hint advances `absent → "commentary" | "final_answer"` at most once and then never changes: it never flip-flops between the two values and never reverts to absent (`ExecutionPhase::refine_streamed_hint` enforces this).
-- **Best-effort, not authoritative.** Only providers whose stream carries a native phase populate it mid-stream — OpenAI Responses exposes it on `response.output_item.added` and the driver surfaces it as a mid-stream stream event. Other providers (Anthropic, Gemini, …) leave it absent until completion. The authoritative classification is always the completed `output.message.completed` `Message.phase`; a consumer that needs certainty waits for that event (unchanged behavior) but may now render optimistically meanwhile.
-- **Not derived from later tool calls.** The streamed hint is never inferred from the subsequent presence of tool calls (the EVE-448 anti-pattern); `ExecutionPhase::from_has_tool_calls` stays a completion-time fallback only.
-
-#### `output.message.replaced`
-
-Streaming output was withheld by an output guardrail (see `specs/capabilities.md` § Output Guardrails). Emitted between the last (suppressed) `output.message.delta` and the final `output.message.completed`. Clients should discard only the text accumulated for `message_id` and use `replacement` as that assistant message's text. The model's original tokens are never persisted or replayed on subsequent turns.
-
-```json
-{
-  "id": "...",
-  "type": "output.message.replaced",
-  "ts": "...",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "message_id": "message_550e8400e29b41d4a716446655440000",
-    "guardrail_capability_id": "prompt_canary_guardrail",
-    "guardrail_id": "prompt_canary",
-    "reason_code": "system_prompt_leak",
-    "replacement": "[Response withheld: the model attempted to reveal protected instructions.]"
-  }
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `turn_id` | TurnId (string, prefixed UUIDv7 — e.g. `"turn_01933b5a..."`) | yes | Turn the replaced output belongs to |
-| `message_id` | MessageId (string, random-public prefixed UUIDv4) | yes | Assistant message being replaced; matches the started/delta and subsequent completed `message.id` |
-| `guardrail_capability_id` | string | yes | Capability that contributed the guardrail (e.g. `"prompt_canary_guardrail"`) |
-| `guardrail_id` | string | yes | Stable id of the guardrail itself (e.g. `"prompt_canary"`) |
-| `reason_code` | string | yes | Stable machine-readable reason (e.g. `"system_prompt_leak"`). Clients localize their copy from this rather than `replacement` |
-| `replacement` | string | yes | Replacement text shown to the user and persisted as the assistant message |
-
-The subsequent `output.message.completed` event carries `replacement` as the message body — it is the canonical assistant message. There is no separate "leaked" message anywhere in the event stream.
-
-#### `output.message.completed`
-
-Agent response message. Emitted when LLM generation completes.
-
-```json
-{
-  "id": "...",
-  "type": "output.message.completed",
-  "ts": "...",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "message": {
-      "id": "01937abc-...",
-      "role": "agent",
-      "content": [
-        {
-          "type": "text",
-          "text": "Budget exhausted. 12.50 usd spent reached the 10.00 usd limit. Increase the budget to continue."
-        }
-      ],
-      "metadata": {
-        "model": "gpt-4o",
-        "error_code": "budget_exhausted",
-        "error_fields": {
-          "spent": 12.5,
-          "limit": 10.0,
-          "currency": "usd"
-        }
-      },
-      "phase": "completed",
-      "created_at": "2024-01-15T10:30:01.000Z"
-    },
-    "metadata": {
-      "model": "gpt-4o",
-      "model_id": "01937abc-...",
-      "provider_id": "01937abc-..."
-    },
-    "error_code": "budget_exhausted",
-    "error_fields": {
-      "spent": 12.5,
-      "limit": 10.0,
-      "currency": "usd"
-    },
-    "usage": {
-      "input_tokens": 50,
-      "output_tokens": 20
-    }
-  }
-}
-```
-
-The completed **`message.id`** is the same `message_id` allocated by `output.message.started`. Replay reconstructs assistant-message boundaries by grouping started/delta/replaced/completed lifecycle events by this id. Partial-stream recovery preserves the persisted id when finalizing an interrupted message; a legacy in-flight start that predates this field begins a new recovery lifecycle with a freshly allocated random-public id.
-
-**`message.phase`** (optional, string): Execution phase — `"in_progress"` for intermediate messages with tool calls (agent is still working), `"completed"` for the final answer. Set by `ReasonAtom` based on whether tool calls are present. Sent as input to the OpenAI Responses API on assistant messages; other providers store it internally for consistent UI behavior. See `crates/core/src/atoms/reason.rs`.
-
-**Streaming Timeline:**
-
-```
-User sends message
-       │
-       ▼
-┌──────────────────────────┐
-│ output.message.started   │  ← UI shows thinking indicator
-└───────────┬──────────────┘
-            │
-       ┌────┴────┐
-       ▼         ▼
-output.message.delta  output.message.delta  ← UI shows streaming text (batched ~100ms)
-       │         │
-       └────┬────┘
-            │
-            ▼
-┌──────────────────────────┐
-│ output.message.completed │  ← UI shows final message, stops streaming
-└──────────────────────────┘
-```
-
-### Voice Events
-
-Voice events track an active Realtime API connection attached to the session.
-They supplement, but do not replace, canonical `input.message` and
-`output.message.completed` transcript persistence. See [voice.md](voice.md).
-
-#### `voice.session.started`
-
-Emitted after the backend creates a Voice Connection and starts provider
-bootstrap.
-
-```json
-{
-  "id": "...",
-  "type": "voice.session.started",
-  "ts": "2026-05-07T20:15:00.000Z",
-  "session_id": "...",
-  "context": {},
-  "data": {
-    "voice_connection_id": "voice_conn_01933b5a00007000800000000000001",
-    "model": "gpt-realtime-2",
-    "voice": "marin",
-    "reasoning_effort": "low",
-    "transport": "webrtc_proxy"
-  }
-}
-```
-
-#### `voice.input_transcript.delta`
-
-Streaming transcript text for user speech before the user utterance is
-committed. Clients may render it as provisional text and discard it when the
-corresponding completed event arrives.
-
-```json
-{
-  "id": "...",
-  "type": "voice.input_transcript.delta",
-  "ts": "2026-05-07T20:15:01.000Z",
-  "session_id": "...",
-  "context": {},
-  "data": {
-    "voice_connection_id": "voice_conn_...",
-    "item_id": "provider_item_id",
-    "delta": "check order",
-    "accumulated": "check order"
-  }
-}
-```
-
-#### `voice.input_transcript.completed`
-
-Final transcript text for a user utterance. The server also emits a canonical
-`input.message` with the same text and `metadata.source = "voice"`.
-
-#### `voice.output_transcript.delta`
-
-Streaming assistant transcript text for spoken output. `phase` is optional and
-may be `commentary` or `final_answer` when the provider exposes response
-phases.
-
-```json
-{
-  "id": "...",
-  "type": "voice.output_transcript.delta",
-  "ts": "2026-05-07T20:15:02.000Z",
-  "session_id": "...",
-  "context": {},
-  "data": {
-    "voice_connection_id": "voice_conn_...",
-    "response_id": "provider_response_id",
-    "phase": "commentary",
-    "delta": "I'll check that now.",
-    "accumulated": "I'll check that now."
-  }
-}
-```
-
-#### `voice.output_transcript.completed`
-
-Final transcript text for assistant speech. In the durable voice bridge, the
-agent turn's `output.message.completed` remains canonical; provider speech
-transcripts stay as `voice.output_transcript.*` observability events to avoid
-duplicating the assistant message.
-
-#### `voice.session.ended`
-
-Emitted when the browser, provider, or server closes the Voice Connection.
-
-#### `voice.session.failed`
-
-Emitted when provider bootstrap, client-secret minting, sideband connection, or
-voice event handling fails. Failure events must not include raw provider secrets,
-raw SDP, or unsanitized provider payloads.
-
-### Turn Lifecycle Events
-
-Turn events track the lifecycle of a single turn in the conversation.
-
-#### `turn.started`
-
-Turn execution started.
-
-```json
-{
-  "type": "turn.started",
-  "session_id": "...",
-  "context": {
-    "turn_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  }
-}
-```
-
-#### `turn.completed`
-
-Turn execution completed successfully.
-
-```json
-{
-  "type": "turn.completed",
-  "session_id": "...",
-  "context": {
-    "turn_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "iterations": 3,
-    "duration_ms": 1500,
-    "usage": {
-      "input_tokens": 500,
-      "output_tokens": 200
-    },
-    "final_message_id": "message_...",
-    "final_answer_preview": "Done.",
-    "time_to_first_token_ms": 120,
-    "tool_call_count": 2,
-    "llm_call_count": 3,
-    "status": "completed"
-  }
-}
-```
-
-`turn.completed` is the durable turn-level summary event. New events should
-populate the optional summary fields when available so export/review consumers
-can render duration, final answer reference/preview, token usage, and basic
-execution counts from this event alone. Older persisted events remain valid when
-these optional fields are absent.
-
-#### `turn.failed`
-
-Turn execution failed. This event is emitted when:
-- The LLM call fails (e.g., API key not configured, rate limit exceeded)
-- Max iterations exceeded
-- Other unrecoverable errors during turn execution
-
-When a turn fails, an `output.message.completed` event with a user-friendly fallback message is also emitted so users see feedback in the chat. Consumers should localize from `error_code` + `error_fields` when present instead of matching English prose.
-
-```json
-{
-  "type": "turn.failed",
-  "session_id": "...",
-  "context": {
-    "turn_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "error": "An error occurred while processing your request.",
-    "error_code": "provider_rate_limited",
-    "error_fields": {
-      "provider": "anthropic",
-      "retry_after": 8
-    }
-  }
-}
-```
-
-**Structured runtime errors:**
-- `error` remains the plain-English fallback for older clients and debugging.
-- `error_code` carries the stable user-facing classification.
-- `error_fields` carries interpolation values such as `spent`, `limit`, `soft_limit`, `currency`, `model_id`, `provider`, `retry_after`, and (detailed disclosure mode only) `detail`.
-- `error_disclosure` records the error-disclosure mode applied to `error_code`/`error_fields` (`generic` | `standard` | `detailed`, see `specs/error-disclosure.md`). Full diagnostic detail remains available to operators via `reason.completed` failure events, logs, and tracing.
-
-#### `turn.sealed`
-
-Turn was deliberately **sealed** — stopped to prevent waste — and is observably
-distinct from both `turn.completed` (success) and `turn.failed` (error). A sealed
-turn is terminal and non-retryable: the durable task is routed to the DLQ rather
-than requeued. See `specs/durable-execution-engine.md` (Forward-progress guard
-and Sealed terminal) and EVE-534.
-
-Emitted when:
-- a durable turn crashed and was reclaimed `N` times (default 3, configurable
-  via `DURABLE_NO_PROGRESS_SEAL_THRESHOLD`) without its progress token advancing
-  (`reason = "no_progress"`); or
-- the work budget was exhausted (`HardLimitStopRule` balance ≤ 0)
-  (`reason = "budget"`), instead of leaving the turn reclaimable.
-
-A user-facing `output.message.completed` event and `session.idled` are emitted
-alongside, and the session returns to `idle` (there is no dedicated `sealed`
-session status; the distinct signal is this event and its `reason`).
-
-```json
-{
-  "type": "turn.sealed",
-  "session_id": "...",
-  "context": {
-    "turn_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "reason": "no_progress",
-    "detail": "No forward progress across 3 consecutive recoveries; sealed to prevent a crash-loop.",
-    "iterations": null,
-    "usage": null
-  }
-}
-```
-
-**Fields:**
-| Field | Type | Description |
-|-------|------|-------------|
-| `turn_id` | UUID | The sealed turn identifier |
-| `reason` | string | `"no_progress"` or `"budget"` |
-| `detail` | string? | Optional human-readable explanation for operators |
-| `iterations` | number? | Iterations completed before sealing, if known |
-| `usage` | object? | Aggregated token usage before sealing, if available |
-
-#### `turn.cancelled`
-
-Turn execution was cancelled by user request. This event is emitted immediately when the cancel endpoint is called.
-
-```json
-{
-  "type": "turn.cancelled",
-  "session_id": "...",
-  "context": {
-    "turn_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "reason": "User requested cancellation",
-    "usage": {
-      "input_tokens": 150,
-      "output_tokens": 30
-    }
-  }
-}
-```
-
-**Fields:**
-| Field | Type | Description |
-|-------|------|-------------|
-| `turn_id` | UUID | The cancelled turn identifier |
-| `reason` | string | Optional reason for cancellation |
-| `usage` | TokenUsage | Optional token usage up to cancellation point |
-
-**Cancellation Flow:**
-1. User clicks cancel in UI
-2. API emits `turn.cancelled` event immediately
-3. API emits `input.message` with "User requested to cancel the work."
-4. Worker detects cancellation and stops execution
-5. Worker emits `output.message.completed` with "Work was cancelled by user."
-6. Worker emits `session.idled` event
-
-### Atom Lifecycle Events
-
-Atom events provide observability into the execution pipeline.
-
-#### `reason.started` / `reason.completed`
-
-ReasonAtom lifecycle - LLM inference.
-
-```json
-{
-  "type": "reason.started",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "agent_id": "...",
-    "metadata": {
-      "model": "gpt-4o",
-      "model_id": "...",
-      "provider_id": "..."
-    }
-  }
-}
-```
-
-```json
-{
-  "type": "reason.completed",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "success": true,
-    "text_preview": "First 200 chars...",
-    "has_tool_calls": true,
-    "tool_call_count": 2
-  }
-}
-```
-
-For failed reasoning (LLM call error):
-
-```json
-{
-  "type": "reason.completed",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "success": false,
-    "text_preview": null,
-    "has_tool_calls": false,
-    "tool_call_count": 0,
-    "error": "LLM error: API key is required"
-  }
-}
-```
-
-#### `act.started` / `act.completed`
-
-ActAtom lifecycle - tool batch execution.
-
-```json
-{
-  "type": "act.started",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "tool_calls": [
-      {
-        "id": "call_123",
-        "name": "get_weather",
-        "display_name": "Get Weather",
-        "narration": "Checking weather for Tokyo"
-      }
-    ],
-    "headline": "Checking weather for Tokyo"
-  }
-}
-```
-
-```json
-{
-  "type": "act.completed",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "completed": true,
-    "success_count": 2,
-    "error_count": 0,
-    "headline": "Checked weather for Tokyo"
-  }
-}
-```
-
-**`headline`** (optional, string): Server-authored readable summary for the tool batch. UI should render this directly when present instead of synthesizing group copy from tool names.
-
-#### `tool.started` / `tool.completed`
-
-Individual tool execution within ActAtom.
-
-```json
-{
-  "type": "tool.started",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "tool_call": {
-      "id": "call_123",
-      "name": "get_weather",
-      "arguments": { "city": "Tokyo" }
-    },
-    "display_name": "Get Weather",
-    "narration": "Checking weather for Tokyo"
-  }
-}
-```
-
-```json
-{
-  "type": "tool.completed",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "tool_call_id": "call_123",
-    "tool_name": "get_weather",
-    "display_name": "Get Weather",
-    "success": true,
-    "status": "success",
-    "narration": "Checked weather for Tokyo",
-    "result": [
-      { "type": "text", "text": "Temperature: 22C, Sunny" }
-    ]
-  }
-}
-```
-
-**`narration`** (optional, string): Server-authored readable summary for an individual tool step. Intended for transcript/timeline rendering. Clients may fall back to local formatting when absent.
-
-For failed tool calls:
-
-```json
-{
-  "type": "tool.completed",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "tool_call_id": "call_456",
-    "tool_name": "search_db",
-    "display_name": "Search Database",
-    "success": false,
-    "status": "error",
-    "error": "Connection timeout"
-  }
-}
-```
-
-#### `tool.output.delta`
-
-Streamed incremental output from a tool during execution. Emitted between `tool.started` and `tool.completed`. Generic — usable by any tool that produces streamed output (bash stdout/stderr, remote command output, subagent speech, etc.).
-
-The consumer accumulates deltas by `tool_call_id` for live rendering. The final `tool.completed` result is authoritative — deltas are informational only.
-
-```json
-{
-  "type": "tool.output.delta",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "tool_call_id": "call_789",
-    "tool_name": "bash",
-    "delta": "Installing dependencies...\n",
-    "stream": "stdout"
-  }
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `tool_call_id` | string | yes | References the tool call producing output |
-| `tool_name` | string | yes | Tool name |
-| `delta` | string | yes | Incremental output chunk |
-| `stream` | string | yes | Stream identifier (e.g., `"stdout"`, `"stderr"`) |
-
-### LLM Events
-
-LLM events provide visibility into the actual LLM API calls.
-
-#### `llm.generation`
-
-Emitted after each LLM API call to provide full visibility into the messages sent to the model and the response received. This is useful for debugging, auditing, and understanding the exact prompts and responses.
-
-**Metadata fields** (aligned with gen-ai OTel semantic conventions):
-- `model` - Model name used for generation
-- `provider` - LLM provider (openai, anthropic, etc.)
-- `usage` - Token usage (input_tokens, output_tokens)
-- `duration_ms` - Request duration in milliseconds
-- `time_to_first_token_ms` - Time to first token (streaming latency)
-- `success` - Whether the generation succeeded
-- `error` - Error message if failed
-- `finish_reasons` - Array of finish reasons (e.g., `["stop"]`, `["tool_calls"]`)
-- `response_id` - Provider's response ID for correlation
-- `request_options` - Optional bag of request-side driver options that were enabled for the call
-
-`request_options` captures request intent rather than provider-reported usage. Current fields:
-
-- `prompt_cache` - Whether prompt caching was enabled, which generic strategy was requested, and the provider-specific mode the driver used (`prompt_cache_key`, `cache_control`, `cached_content`, or `implicit`)
-- `tool_search` - Whether deferred tool loading was enabled and the activation threshold
-- `provider_options` - Provider-specific booleans that do not warrant dedicated top-level fields (for example `openai.previous_response_id` or `gemini.cached_content`)
-
-```json
-{
-  "type": "llm.generation",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "messages": [
-      {
-        "id": "...",
-        "role": "system",
-        "content": [{ "type": "text", "text": "You are a helpful assistant." }],
-        "created_at": "..."
-      },
-      {
-        "id": "...",
-        "role": "user",
-        "content": [{ "type": "text", "text": "What's the weather in Tokyo?" }],
-        "created_at": "..."
-      }
-    ],
-    "output": {
-      "text": "I'll check the weather for you.",
-      "tool_calls": [
-        {
-          "id": "call_123",
-          "name": "get_weather",
-          "arguments": { "city": "Tokyo" }
-        }
-      ]
-    },
-    "metadata": {
-      "model": "gpt-4o",
-      "provider": "openai",
-      "usage": {
-        "input_tokens": 150,
-        "output_tokens": 45
-      },
-      "duration_ms": 1200,
-      "time_to_first_token_ms": 180,
-      "success": true,
-      "finish_reasons": ["stop"],
-      "response_id": "chatcmpl-abc123",
-      "request_options": {
-        "prompt_cache": {
-          "enabled": true,
-          "strategy": "auto",
-          "provider_mode": "prompt_cache_key"
-        },
-        "tool_search": {
-          "enabled": true,
-          "threshold": 8
-        },
-        "provider_options": {
-          "openai": {
-            "previous_response_id": true
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-For failed generations:
-
-```json
-{
-  "type": "llm.generation",
-  "session_id": "...",
-  "context": { "turn_id": "...", "exec_id": "..." },
-  "data": {
-    "messages": [...],
-    "output": {
-      "text": null,
-      "tool_calls": []
-    },
-    "metadata": {
-      "model": "gpt-4o",
-      "provider": "openai",
-      "duration_ms": 500,
-      "success": false,
-      "error": "Rate limit exceeded"
-    }
-  }
-}
-```
-
-### Context Compaction Events
-
-`context.compacting` records that a semantic compaction attempt started and
-includes its reason, requested strategy, message count, and optional token or
-byte size before the attempt.
-
-`context.compacted` is emitted only after a material reduction succeeds (at
-least 5%, with a 32-unit measurement floor). It
-contains the strategy actually used, before/after message counts, duration,
-optional before/after token or byte metrics, step metadata, and an optional
-durable checkpoint identifier. Optional metric fields are additive and may be
-absent when the provider cannot report them.
-
-Provider-opaque compact output, encrypted provider content, and checkpoint
-ciphertext are never event data. Observation masking alone is a model-view
-optimization and does not emit `context.compacted` because it installs no
-semantic replacement checkpoint.
-
-### Session Events
-
-Session lifecycle events.
-
-#### `session.started`
-
-Session execution started.
-
-```json
-{
-  "type": "session.started",
-  "session_id": "...",
-  "context": {},
-  "data": {
-    "agent_id": "...",
-    "model_id": "..."
-  }
-}
-```
-
-#### `session.activated`
-
-Session became active (turn started). Emitted when a new turn begins.
-
-```json
-{
-  "type": "session.activated",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  }
-}
-```
-
-#### `session.idled`
-
-Session became idle (turn completed). Contains cumulative session usage for real-time UI updates.
-
-```json
-{
-  "type": "session.idled",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "iterations": 3,
-    "usage": {
-      "input_tokens": 500,
-      "output_tokens": 150,
-      "cache_read_tokens": 100
-    }
-  }
-}
-```
-
-**Usage Field:** Contains cumulative session token usage at this point.
-
-#### `session.title.updated`
-
-The session's human-readable title changed. This event is emitted only for an
-actual value change. Tool-originated mutations retain the active turn and input
-message correlation; session-level mutation paths omit turn fields when no turn
-exists.
-
-```json
-{
-  "type": "session.title.updated",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "previous_title": "Untitled investigation",
-    "title": "Automatic Session Title Policy"
-  }
-}
-```
-
-`previous_title` is `null` when the session was previously untitled. Consumers
-can project the new value directly from `title`; no session re-fetch is needed.
-
-### Subagent Events (retired — superseded by Session Task Events)
-
-The `subagent.spawned`, `subagent.completed`, `subagent.failed`, and
-`subagent.cancelled` events have been **retired** (EVE-585). The subagent flow
-became Session Tasks, which model the same lifecycle with the `task.*` events
-below. As of the Session Tasks migration nothing emits `subagent.*`, and the
-event types and `SubagentEventData` were removed from `crates/core/src/events.rs`.
-
-Retirement is deliberate even though event types are otherwise a stability
-contract: the events had no in-repo consumer left after the CLI moved to `task.*`
-(#2177), and `task.*` carries the replacement information. Historical `subagent.*`
-rows in older session logs remain in storage, but — now that the typed variants
-are gone — they deserialize as `EventData::Unsupported` and are therefore
-**filtered out of the events list and SSE responses** like any unknown type (see
-Server Responsibilities above); they are not surfaced as typed or untyped event
-payloads. They are still counted by aggregate fields such as `error_count`, which
-match `subagent.failed` by type string at the query level. New integrations
-should consume `task.*`.
-
-### Session Task Events
-
-Session task lifecycle events (see `specs/session-tasks.md`) are emitted on
-the owning session whenever the task registry creates or mutates a task.
-They carry the **full task snapshot** so consumers reconcile by `task.id`
-without follow-up reads (snapshot-then-delta). See `crates/core/src/events.rs`
-for `SessionTaskEventData` and `TaskMessageEventData`.
-
-#### `task.created`
-
-Emitted when a task is created. `data.task` is the full snapshot.
-
-#### `task.updated`
-
-Emitted on every state, progress, detail, or cancel-intent change.
-`data.task` is the full snapshot.
-
-#### `task.message.sent` / `task.message.received`
-
-Emitted when a message is recorded on a task's channel (`sent` = inbound,
-session → task; `received` = outbound, task → session). `data` carries
-`task_id` and the stored `message`.
-
-### Extended Thinking Events
-
-Extended thinking events provide visibility into the model's chain-of-thought reasoning when using models with extended thinking capabilities (e.g., Anthropic Claude with `reasoning_effort` configured).
-
-#### `reason.thinking.started`
-
-Emitted when the LLM starts generating a response with extended thinking enabled (`reasoning_effort` is set). This event is only emitted when using models that support extended thinking. UI can show a "thinking" indicator until `output.message.delta` or `output.message.completed` events arrive.
-
-**Note:** This event is NOT emitted when `reasoning_effort` is not configured, even if the model supports extended thinking.
-
-```json
-{
-  "type": "reason.thinking.started",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "model": "claude-opus-4-5"
-  }
-}
-```
-
-#### `reason.thinking.delta`
-
-Streaming thinking/reasoning content from extended thinking models. These events contain the model's chain-of-thought reasoning before producing the final response. Events are batched (~100ms) similar to `output.message.delta`.
-
-```json
-{
-  "type": "reason.thinking.delta",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "delta": "Let me analyze this step by step...",
-    "accumulated": "Let me analyze this step by step..."
-  }
-}
-```
-
-#### `reason.thinking.completed`
-
-Emitted when the model finishes its chain-of-thought reasoning and transitions to producing the final response. Contains the complete thinking content.
-
-```json
-{
-  "type": "reason.thinking.completed",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "thinking": "Let me analyze this step by step...\n\n1. First consideration...\n2. Second consideration..."
-  }
-}
-```
-
-**Note:** Extended thinking events (`reason.thinking.*`) are only emitted when using models that support extended thinking mode. The thinking content is separate from the main response text and typically shown in a collapsible section in the UI. Thinking content is also persisted in the `output.message.completed` event's `thinking` field for multi-turn context.
-
-#### `reason.item`
-
-Durable record of an opaque assistant reasoning response item, distinct from `reason.thinking.*`. Emitted when a provider returns an opaque reasoning artifact (e.g., OpenAI Responses API reasoning items containing `encrypted_content`). Carries provider-supplied opaque content plus curated summary text and per-item metadata; plaintext hidden chain-of-thought is intentionally not persisted in this event.
-
-```json
-{
-  "type": "reason.item",
-  "session_id": "...",
-  "context": {
-    "turn_id": "...",
-    "input_message_id": "..."
-  },
-  "data": {
-    "turn_id": "...",
-    "provider": "openai",
-    "model": "gpt-5.5",
-    "item_id": "rs_abc",
-    "encrypted_content": "<opaque>",
-    "summary": ["safe summary segment"],
-    "token_count": 727
-  }
-}
-```
-
-**Constraints:**
-
-- Persisted reasoning artifacts must remain opaque/encrypted. Emitters strip plaintext reasoning content (e.g., OpenAI `reasoning_text` items) before constructing the event.
-- `summary` carries only provider-curated summary text (e.g., OpenAI `summary_text` parts). Other content variants are dropped.
-- `encrypted_content` and `token_count` are optional; not every provider supplies them.
-- User-visible thinking streams continue to flow through `reason.thinking.*`; `reason.item` is the durable record for opaque artifacts that cannot be safely streamed as plaintext.
-- **Projection:** the curated `summary` is a reasoning artifact and projects onto the reasoning channel (AG-UI `REASONING_*`/`THINKING_*`, ACP `agent_thought_chunk`) — visible by default, never the assistant-text channel. `encrypted_content` is never surfaced to a consumer. See the Channel Projection Matrix below.
-
-**Extended Thinking Timeline Example:**
-
-```
-User sends message
-       │
-       ▼
-┌──────────────────────────┐
-│ reason.thinking.started  │  ← UI shows thinking indicator
-└────────┬─────────────────┘
-         │
-         ▼
-  ┌────────────────────────┐
-  │ reason.thinking.delta  │  ← UI shows streaming reasoning
-  └────────┬───────────────┘
-           │
-           ▼
-  ┌──────────────────────────┐
-  │ reason.thinking.completed│  ← Thinking phase done
-  └────────┬─────────────────┘
-           │
-      ┌────┴────┐
-      ▼         ▼
-output.message.delta  output.message.delta  ← UI shows streaming text
-      │         │
-      └────┬────┘
-           │
-           ▼
-  ┌──────────────────────────┐
-  │ output.message.completed │  ← UI shows final message
-  └──────────────────────────┘
-```
-
-### Channel Projection Matrix (commentary vs. reasoning vs. tool)
-
-Downstream transports (AG-UI, ACP, the terminal example) render the runtime
-event stream onto a small set of **channels**. The load-bearing rule — the one
-that fixes the EVE-448 class of bug where deliberate progress was labeled
-"Thinking" — is that each runtime concept maps to exactly one channel, and a
-projection must never move an item across channels to fake a phase. The design
-rationale and protocol comparison (AG-UI/ACP/Codex) behind this model live in
-EVE-768 and its design-note PR (#2731); this spec is the authoritative contract.
-
-**Definitions (non-overlapping):**
-
-- **Commentary** — deliberate, user-visible assistant *text* produced as
-  progress/preamble before or between tool calls; does not end the turn
-  (`Message.phase = commentary`).
-- **Final answer** — the durable, turn-ending assistant *text*
-  (`Message.phase = final_answer`).
-- **Thinking** — model reasoning the provider *explicitly exposes* as
-  displayable reasoning, streamed via `reason.thinking.*`. Never inferred; raw
-  hidden chain-of-thought is never persisted or exposed.
-- **Reasoning summary** — the provider-curated safe summary carried on
-  `reason.item` (`summary`), alongside opaque/encrypted continuation state. The
-  summary is a *reasoning artifact* that may be surfaced on the reasoning
-  channel when a transport explicitly opts in — never relabeled as an assistant
-  answer. The opaque `encrypted_content` is never surfaced to a consumer.
-- **Tool activity** — narration/progress/output scoped to a `tool_call` id; its
-  own channel, never merged into the assistant-message channel.
-
-**Projection + fallback matrix:**
-
-| Runtime concept | Source event(s) | Assistant-text channel | Reasoning channel | Tool channel |
-|---|---|---|---|---|
-| Commentary | `output.message.delta` / `output.message.completed` (`phase = commentary`) | AG-UI `TEXT_MESSAGE_*`; ACP `agent_message_chunk` | — | — |
-| Final answer | `output.message.completed` (`phase = final_answer`) | AG-UI `TEXT_MESSAGE_*`; ACP `agent_message_chunk` | — | — |
-| Thinking | `reason.thinking.*` | — | AG-UI `REASONING_*` / `THINKING_*`; ACP `agent_thought_chunk` | — |
-| Reasoning summary | `reason.item` (`summary`) | — | AG-UI `REASONING_*` / `THINKING_*` (only when channel policy opts in); ACP `agent_thought_chunk` | — |
-| Tool narration/progress/output | `tool.started` / `tool.completed` | — | — | AG-UI `TOOL_CALL_*`; ACP `tool_call` / `tool_call_update` |
-
-**HARD fallback rule:** when a message's phase is missing or unknown (e.g. a
-stream that died before `output.message.completed`, or a transport with no phase
-concept), it falls back to the **assistant-text** channel — shown in order as
-ordinary assistant text. A missing/unknown phase must **NEVER** fall back to the
-thinking/reasoning channel. Only `reason.thinking.*` and the `reason.item`
-`summary` are ever routed to the reasoning channel; assistant messages never are,
-regardless of phase.
-
-**ACP mapping (spec-level contract).** No ACP adapter exists in-tree yet; when
-one lands it must honor this contract: commentary and final answer map to
-`session/update → agent_message_chunk` (role assistant); thinking and reasoning
-summaries map to `agent_thought_chunk`. Routing commentary to
-`agent_thought_chunk` is exactly the mis-projection that makes clients label
-progress "Thinking" and is prohibited.
-
-**Graceful degradation.** AG-UI and ACP have no native commentary/final `phase`,
-so commentary and final answer both render on the assistant-text channel and are
-simply shown in order — the transcript stays correct; only the "this was a
-preamble" affordance is lost. Replay reconstructs boundaries from the durable
-`output.message.*` lifecycle and classification from the authoritative
-`output.message.completed` `Message.phase`; a reasoning summary replayed from
-`reason.item` stays on the reasoning channel and is never reclassified as an
-assistant answer. AG-UI projection lives in `crates/server/src/api/ag_ui.rs`;
-the terminal example is `examples/coding-cli`.
-
-**Real-time Usage Tracking Pattern:**
-
-The UI uses a combination of events for real-time usage display:
-
-1. `session.idled` - Sets the baseline (cumulative from backend)
-2. `llm.generation` - Adds tokens during turn execution (real-time increments)
-3. `session.idled` - Resets to final cumulative value when turn completes
-
-```
-Timeline during a turn:
-──────────────────────────────────────────────────────────────────
-│ session.idled │ llm.generation │ llm.generation │ session.idled │
-│   (baseline)  │    (+tokens)   │    (+tokens)   │  (final set)  │
-──────────────────────────────────────────────────────────────────
-      500 in    →     650 in     →     800 in     →     800 in
-      100 out         130 out          175 out          175 out
-```
-
-This approach provides real-time feedback as tokens are consumed during LLM calls, while self-correcting to the accurate cumulative value when each turn ends.
-
-## Event Type Registry
-
-For the full list of event types and their `EventData` variants, see `crates/core/src/events.rs`. The event type constants are defined alongside their data structures.
-
-## Database Storage
-
-See `crates/server/migrations/001_base_schema.sql` for the `events` table DDL. Key columns: `data` (JSONB, event-specific payload), `event_type` (denormalized for filtering), `context` (JSONB, correlation data).
-
-## Storage Guarantees
-
-The event store provides three key guarantees:
-
-### 1. Append-Only Immutability
-
-Events are **immutable** once written. Database triggers block UPDATE and DELETE operations (see migrations for trigger DDL).
-
-**Rationale:** Event sourcing requires immutable history. Allowing mutations would break replay, audit trails, and data integrity guarantees.
-
-### 2. Atomic Per-Session Sequence Allocation
-
-Each event within a session is assigned a monotonically increasing sequence number. Sequences are allocated atomically to prevent race conditions under concurrent writes.
-
-**Implementation:** A dedicated `event_sequences` table with an atomic upsert function (`allocate_event_sequence`). See `crates/server/migrations/001_base_schema.sql` for DDL.
-
-**Guarantees:**
-- No sequence gaps within a session (barring transaction rollbacks)
-- No duplicate sequences within a session
-- Race-free under concurrent inserts (uses PostgreSQL's atomic upsert)
-- Sequences start at 1 for each session
-
-**Previous Approach (Deprecated):**
-The old `MAX(sequence)+1` approach had race conditions when multiple writers inserted events concurrently for the same session.
-
-### 3. Event Type Consistency Validation
-
-The `event_type` field must match the type indicated by the event's `data` payload. This is validated at the service layer before storage.
-
-**Validation Rule:**
-```
-request.event_type == request.data.event_type()
-```
-
-**Exemption:** Raw/legacy events (where `data.event_type() == "unknown"`) are exempt from this check to support backward compatibility.
-
-**Error on Mismatch:**
-```
-"event type mismatch: declared 'input.message' but data indicates 'output.message.completed'"
-```
-
-**Rationale:** Prevents drift between the declared event type and the actual payload, which would cause incorrect filtering, routing, and processing.
-
-## Message Reconstruction
-
-Messages are reconstructed from events for the conversation view. The following event types contribute to message reconstruction:
-
-| Event Type | Role | Content Source |
-|------------|------|----------------|
-| `input.message` | `user` | `data.message.content` |
-| `output.message.completed` | `agent` | `data.message.content` (may include tool calls) |
-| `tool.completed` | `tool` | `data.result` (tool execution results) |
-
-**Note:** Tool calls are embedded in `output.message.completed` events via `ContentPart::ToolCall`. Tool results come from `tool.completed` events, not a separate message type.
-
-## SSE Streaming
-
-Events are streamed to clients via Server-Sent Events (SSE):
-
-```
-event: input.message
-data: {"id":"...","type":"input.message","ts":"...","session_id":"...","context":{},"data":{...}}
-
-event: reason.started
-data: {"id":"...","type":"reason.started","ts":"...","session_id":"...","context":{...},"data":{...}}
-```
-
-The SSE `event` field matches the `type` field in the event payload.
-
-### SSE Connection Lifecycle
-
-SSE streams include special lifecycle events for connection management:
-
-| Event | Description |
-|-------|-------------|
-| `connected` | Sent immediately when the stream is established. Data: `{"status":"connected"}` |
-| `disconnecting` | Sent before graceful close. Data: `{"reason":"connection_cycle","retry_ms":100}` |
-
-### Heartbeat Comments
-
-All SSE streams send periodic heartbeat comments to allow clients to detect stale/half-open connections:
-
-```
-: heartbeat
-
-```
-
-Heartbeat comments are standard SSE comments (lines starting with `:`) and are **invisible to all spec-compliant event parsers** — they do not appear as events. They serve solely to reset the client's TCP read timer.
-
-| Property | Value |
-|----------|-------|
-| Format | `: heartbeat\n\n` (SSE comment) |
-| Interval | 30 seconds (configurable via `SSE_HEARTBEAT_INTERVAL_SECS`) |
-| Scope | All SSE streams (session events, durable monitoring, workflow monitoring) |
-| Activity-independent | Fires during idle, model-thinking, tool-execution, and active streaming |
-| Schema impact | None — SSE comments are not events |
-| Backward-compatible | Yes — all spec-compliant SSE parsers ignore comments |
-
-**Why 30 seconds?** The SDK default read timeout is 60s. At 30s heartbeat interval, clients have a 2x safety factor: if no heartbeat arrives within 45s (1.5x interval), the connection is almost certainly dead.
-
-**Bandwidth impact:** Each heartbeat is 14 bytes (`": heartbeat\r\n\r\n"`). At 30s intervals, this adds ~0.47 bytes/second per connection — negligible even at 10,000 concurrent connections (~4.7 KB/s total).
-
-### Connection Cycling
-
-To prevent stale connections through proxies and load balancers, SSE connections are automatically cycled:
-
-| Stream Type | Cycle Interval | Backoff Range |
-|-------------|----------------|---------------|
-| Session events (realtime) | 5 minutes ±20% jitter | 100ms → 500ms |
-| Durable monitoring | 10 minutes ±20% jitter | 1000ms → 20000ms |
-
-Each connection's cycle interval is jittered by ±20% (e.g., 5 min base → 4–6 min actual) to prevent thundering-herd reconnection storms when many clients connect simultaneously. The jittered duration is computed once at stream creation.
-
-Cycle intervals are configurable via environment variables:
-- `SSE_REALTIME_CYCLE_SECS` (default: 300) — session event streams
-- `SSE_MONITORING_CYCLE_SECS` (default: 600) — durable monitoring streams
-
-Before closing, the server sends a `disconnecting` event so clients can reconnect immediately using `since_id`. This ensures no events are missed. The SDK (v0.1.2+/main) handles `disconnecting` events transparently — they do not consume the retry budget.
-
-### Retry Hints
-
-Each SSE event includes a `retry:` field (in milliseconds) that hints reconnection timing:
-
-| Situation | Session Events | Durable Monitoring |
-|-----------|---------------|-------------------|
-| Active (new events) | 100ms | 1000ms |
-| Idle (backoff max) | 500ms | 20000ms |
-| After `disconnecting` | 100ms | 1000ms |
-
-The EventSource API automatically uses this hint.
-
-### SDK Implementation Requirements
-
-SDKs MUST:
-1. Track the last received event ID (`lastEventId`)
-2. Handle `disconnecting` event by reconnecting with `since_id` parameter
-3. Handle `onerror` with exponential backoff (EventSource default behavior)
-4. Use `retry:` hint for reconnection timing
-5. Set a read timeout of 45s (1.5x the 30s heartbeat interval) to detect stale connections
-
-**Heartbeat handling:** SDKs do NOT need to explicitly handle heartbeat comments — SSE parsers ignore them automatically. The heartbeats simply prevent the read timeout from firing on healthy connections. If no data (events or heartbeats) arrives within the read timeout, the SDK should treat the connection as stale and reconnect with `since_id`.
-
-**Read timeout rationale:** 45s = 1.5x heartbeat interval (30s). This gives a 0.5x margin for network jitter and server scheduling delays. The previous 60s timeout (2x) also works but is slower to detect stale connections.
-
-Example client implementation:
-
-```javascript
-eventSource.addEventListener('disconnecting', (event) => {
-  const data = JSON.parse(event.data);
-  eventSource.close();
-  setTimeout(() => reconnect(lastEventId), data.retry_ms);
-});
-```
-
-## Filtering
-
-Events can be filtered by:
-
-- `session_id`: Required for all queries
-- `event_type`: Filter by event type prefix (e.g., `message.*`, `reason.*`)
-- `sequence`: For pagination and replay (after sequence N)
-- `turn_id`: Filter events for a specific turn
-
-### Query Parameter Filters
-
-Both the SSE (`/v1/sessions/{id}/sse`) and JSON (`/v1/sessions/{id}/events`) endpoints accept:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `since_id` | EventId | Resume after this event ID (resolved to sequence for ordering) |
-| `types` | string[] | **Positive filter**: only return events matching these types. Empty = all types. |
-| `exclude` | string[] | **Negative filter**: remove matching types from the result. |
-
-**Semantics when both are provided:** `types` narrows first, then `exclude` removes from that set.
-
-**Examples:**
-- Only turn lifecycle: `?types=turn.started&types=turn.completed`
-- Everything except deltas: `?exclude=output.message.delta&exclude=reason.thinking.delta&exclude=tool.output.delta&exclude=voice.input_transcript.delta&exclude=voice.output_transcript.delta`
-- Turn events but not failures: `?types=turn.started&types=turn.completed&types=turn.failed&exclude=turn.failed`
-
-**Validation:**
-- Both parameters accept only known event types (see Event Type Registry). Unknown types return 400.
-- Maximum 40 values per parameter to prevent abuse.
-
-### Debug Filters (JSON endpoint only)
-
-The `/v1/sessions/{id}/events` JSON endpoint exposes additional filters used by debugging tooling and the MCP catalog. Setting any of these routes the query to the `list_events_advanced` storage path; otherwise the default path is used (which preserves turn-boundary snapping for UI pagination).
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `after_sequence` | i32 | Forward cursor — `sequence > after_sequence`. Mutually exclusive with `before_sequence` and `around`. |
-| `around` | EventId | Anchor event id. Returns up to `window` events on each side. Mutually exclusive with `since_id`, `after_sequence`, and `before_sequence` (combinations return 400). |
-| `window` | i32 | Window size for `around` (default 50, max 500). |
-| `from_ts` / `to_ts` | RFC 3339 | Filter by `created_at` range. |
-| `turn_id` | string | Filter by `context.turn_id`. |
-| `exec_id` | string | Filter by `context.exec_id`. |
-| `trace_id` | string | Filter by `context.trace_id`. |
-| `tags` | string[] | Any-match against `events.tags` (max 20). |
-| `tool_name` | string | Match `data.tool_name` (useful for `tool.*` events). |
-| `q` | string | Full-text search via Postgres `tsvector` (substring fallback in-memory). |
-| `order_desc` | bool | Return newest first; default oldest first. |
-
-The debug path enforces the same session ownership check and event-type allowlist as the default path. Limit defaults to 1000 and is capped at 10 000 rows.
-
-### Debug Summary Endpoint
-
-`GET /v1/sessions/{id}/events/summary` (and the `events_summary` MCP command) returns a one-shot debug snapshot:
-
-| Field | Description |
-|-------|-------------|
-| `total` | Total event count for the session. |
-| `by_type` | Per-type counts, sorted by event_type. |
-| `first_ts` / `last_ts` | Earliest / latest event timestamps. |
-| `turn_count` | Convenience: count of `turn.started`. |
-| `error_count` | Convenience: sum of `turn.failed`, `tool.failed`, `subagent.failed`, and `*.error`. |
-
-### Partial Indexes
-
-Partial indexes exist for efficient queries on message events, turn events, and tool events. See `crates/server/migrations/001_base_schema.sql` for index DDL.
-
-## Event Listeners
-
-Event listeners provide a pluggable mechanism for observability backends to react to events without modifying business logic.
-
-### EventListener Trait
-
-See `crates/core/src/event_listeners.rs` for the `EventListener` trait definition. Listeners are registered with `EventService` at startup (see `crates/server/src/services/event.rs`).
-
-### Built-in Listeners
-
-| Listener | Event Types | Purpose |
-|----------|-------------|---------|
-| `OtelEventListener` | `llm.generation`, `tool.*`, `turn.*` | Generate OpenTelemetry spans |
-
-### Execution Model
-
-1. Event is persisted to database
-2. All registered listeners are notified sequentially
-3. Listeners should not block; spawn background tasks for heavy processing
-4. Listener failures do not affect event persistence
-
-### Error Isolation
-
-Listeners are executed in isolation to ensure misbehaving listeners cannot disrupt event processing:
-
-- **Panic isolation**: Each listener runs in a separate tokio task. If a listener panics, the panic is caught and logged, but other listeners continue to execute.
-- **No error propagation**: Listener errors/panics never propagate to the event emitter or affect event persistence.
-- **Logging**: Panics are logged with `tracing::error!` including the listener name for debugging.
-- **Sequential execution**: Despite isolation, listeners are awaited sequentially to preserve ordering semantics.
-
-**Rationale:** Event listeners are pluggable integrations (OTel, metrics, audit logs) that should not affect core event processing. A bug in an observability integration should never break the application.
-
-### Custom Listeners
-
-Custom listeners can be implemented for:
-- Metrics collection (Prometheus, StatsD)
-- Analytics pipelines (event forwarding to data warehouses)
-- Audit logging
-- Real-time alerting
+Legacy `subagent.*` events are retired. They are no longer emitted or parsed as
+typed events; historical rows follow the unsupported-event behavior. New
+integrations consume `task.*`.
+
+### Context compaction
+
+Compaction emits a start event and emits a completion event only after a
+material semantic reduction. Provider-opaque content, encrypted continuation
+state, and checkpoint ciphertext must never appear in compaction event data.
+Observation-only masking is not semantic compaction and does not emit a
+completion event. See [`compaction.md`](compaction.md).
+
+### Voice
+
+Voice transcript events provide provisional and observational streaming around
+the canonical message protocol. Final user speech also becomes an input
+message; the durable agent turn's completed assistant message remains
+canonical. Provider secrets, raw session descriptions, and unsanitized provider
+payloads must not enter failure events. See [`voice.md`](voice.md).
+
+## Projection channels
+
+Downstream transports project the runtime stream onto three non-overlapping
+channels:
+
+| Runtime concept | Projection |
+|---|---|
+| Commentary and final answers | Assistant-text channel |
+| Provider-exposed thinking and safe reasoning summaries | Reasoning channel |
+| Tool narration, progress, and output | Tool channel |
+
+Commentary is deliberate user-visible assistant text produced before or between
+tool calls. A final answer is turn-ending assistant text. Thinking is only
+reasoning explicitly exposed by the provider. A reasoning summary is a safe
+provider-curated artifact; opaque or encrypted reasoning is never surfaced.
+
+A projection must not move content across channels to imitate a phase. In
+particular, absent phase never makes assistant text into thinking, and tool
+activity never becomes assistant text. AG-UI projection is implemented in
+[`crates/server/src/api/ag_ui.rs`](../crates/server/src/api/ag_ui.rs).
+
+## Storage guarantees
+
+Persisted events are append-only and immutable. Each session has an atomically
+allocated, monotonically increasing sequence. Concurrent writers must not
+derive a sequence with `MAX(sequence) + 1`.
+
+The declared event type must agree with the typed payload before persistence.
+Raw historical data may use the explicit unsupported path, but ordinary
+emitters must not bypass type consistency.
+
+Messages are reconstructed from canonical input, assistant completion, and
+tool completion events. Streaming deltas are not required for replay. Tool
+calls remain part of assistant content; tool results come from tool completion
+events.
+
+Reporting projections are asynchronous and backend-neutral. They must not
+change the semantic event record. See [`reporting.md`](reporting.md).
+
+## Streaming contract
+
+The SSE event name matches the payload's event type. A connection begins with a
+connection lifecycle signal and may end with a graceful cycling signal so the
+client can reconnect without consuming its retry budget.
+
+Heartbeat comments keep idle connections observable but are not events and do
+not affect schema or replay. Connection cycling is jittered to avoid synchronized
+reconnect storms. Exact intervals, retry hints, endpoint parameters, and
+environment controls are implementation configuration owned by the streaming
+handler and exported API documentation.
+
+SDKs and clients must:
+
+1. retain the last accepted event identity;
+2. reconnect from that identity after a disconnect or stale read;
+3. preserve event order by session sequence;
+4. ignore SSE comments and unknown JSON fields;
+5. treat duplicate delivery after reconnect as harmless.
+
+Positive event filters narrow the stream; exclusion filters remove from the
+narrowed set. Unknown filter types and unbounded filter arrays are rejected.
+Exact query names and limits belong to `crates/server/src/api/events.rs` and the
+OpenAPI export.
+
+## Listeners
+
+Listeners observe persisted events without becoming part of business logic.
+They run in registration order, and one listener's failure or panic must not
+prevent persistence or later listeners from running. Heavy listener work should
+move off the emission path while preserving any ordering it requires.
+
+Built-in and future listeners may project traces, metrics, analytics, or audit
+records. Their output is derivative; it cannot mutate the source event.
+
+## Security and privacy
+
+- Event payloads are an external disclosure boundary. Do not include secrets,
+  credentials, raw provider authentication material, hidden chain of thought,
+  or unsanitized internal errors.
+- Session ownership is checked before listing, streaming, filtering, or
+  summarizing events.
+- Unknown event data is retained only where storage/audit needs it and is not
+  passed through as an untyped public payload.
+- Full-text and debug filters preserve the same authorization and supported-type
+  checks as ordinary event listing.

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -1,726 +1,212 @@
-# Multitenancy Specification
-
-## Abstract
-
-This document defines the multitenancy model for Everruns, enabling organization-based resource isolation. Organizations are the administrative unit for ownership, membership, and billing. Users can belong to multiple organizations.
-
-## Decisions Log
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Membership model | Members only (no roles) | Simplicity; roles can be added later |
-| Multi-org support | Yes | Users switch between orgs in UI |
-| Personal namespace | No | Org-only model; SaaS auto-creates org on signup |
-| API org identifier | Auth-derived (cookie or personal access token) | Cleaner URLs, org derived from auth context |
-| Org ID format | BIGINT internal + TEXT public_id | Performance + security |
-| Resource sharing | No cross-org sharing | Isolation by default |
-| Personal access tokens | User-scoped | Org resolved per-request via header/cookie |
-| Session org selection | Cookie-based | Consistent for all requests including SSE |
-| InMemory storage | Supports multitenancy | Consistency across modes |
-| Default org | Seeded on startup | No "first boot" concept |
-| Migration | Reset (no backward compat) | Clean slate |
-
-### Why Auth-Derived Org Instead of Path-Based
-
-**Previous approach:** `/v1/orgs/{org}/agents` - org was explicit in every API path.
-
-**Current approach:** `/v1/agents` - org is derived from authentication context:
-- **Personal access token auth:** Org from `X-Org-Id` header, `everruns_org` cookie, or single-org auto-resolve
-- **Session auth (UI):** Org stored in `everruns_org` cookie
-
-**Rationale:**
-1. **Cleaner URLs** - Paths like `/v1/agents` are simpler than `/v1/orgs/{org}/agents`
-2. **Better DX** - Single-org users need no extra headers; multi-org users set `X-Org-Id`
-3. **Security** - Org is always validated against user membership, preventing org enumeration
-4. **Consistency** - Cookie works uniformly for all requests including SSE (EventSource)
-
-### Cookie-Based Org Selection (Session Auth)
-
-When using session/JWT authentication (UI), the selected organization is stored in a cookie.
-
-**Cookie specification:**
-```
-Name: everruns_org
-Value: org_xxx (organization public_id)
-Path: /
-HttpOnly: true (not accessible via JavaScript)
-SameSite: Lax
-Secure: true (in production)
-```
-
-**Switching organizations:**
-```
-POST /v1/users/me/switch-org
-Content-Type: application/json
-
-{"org_id": "org_xxx"}
-
-Response:
-200 OK
-Set-Cookie: everruns_org=org_xxx; Path=/; HttpOnly; SameSite=Lax
-```
-
-**Benefits over header-based approach:**
-- Works automatically with EventSource (SSE) - no query param workaround needed
-- No client-side header management required
-- Cookie sent automatically with all requests
-- HttpOnly prevents XSS attacks from reading org context
-
-**Server resolution order:**
-1. Personal access token auth → read `X-Org-Id` header or `everruns_org` cookie; single-org users auto-resolve
-2. Session auth → read `everruns_org` cookie
-3. No org found → return 400 (for multi-org personal access token) or 401 (missing auth)
-
-## Requirements
-
-### Organization Entity
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `org_id` | BIGINT | Internal primary key (auto-increment) |
-| `public_id` | TEXT | External identifier: `org_<uuid-hex-32>` |
-| `name` | TEXT | Display name |
-| `external_id` | TEXT? | External provider org ID (NULL for OSS, populated by SaaS auth backend sync) |
-| `created_at` | TIMESTAMPTZ | Creation time |
-| `updated_at` | TIMESTAMPTZ | Last modification time |
-
-**Public ID Format:**
-- Pattern: `^org_[0-9a-f]{32}$`
-- Example: `org_2f3c1b3e6a9d4c6f8a1d4e9c9b7f21a0`
-- Generated at creation time (UUIDv4, lowercase hex, no dashes)
-- Not derived from `org_id`
-
-**Security Rules:**
-- `org_id` MUST NOT appear in APIs, URLs, logs, or error messages
-- APIs accept and return only `public_id`
-- Authorization enforced using resolved `org_id`
-
-### Organization Membership
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `org_id` | BIGINT | Organization reference |
-| `user_id` | UUID | User reference |
-| `created_at` | TIMESTAMPTZ | Join time |
-
-**Constraints:**
-- Primary key: `(org_id, user_id)`
-- User can belong to multiple organizations
-- Role (`owner` > `admin` > `member`) governs management permissions
-
-### Organization Invitations
-
-Everruns owns the full org membership lifecycle — including pending invites and
-acceptance — so a deployment never has to mirror organizations into an external
-identity provider. **Membership is local-DB authoritative and does not depend on
-any external identity-provider org claims.** Wrappers (e.g. SaaS) may keep an
-external IdP for login/identity/JWT only; org creation, membership, roles, and
-invites stay in OSS.
-
-Invitations live in an `org_invitations` table (migration `081`):
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `public_id` | TEXT | Stable public invite id (`orginv_<32-hex>`) |
-| `org_id` | BIGINT | Organization reference |
-| `email` | TEXT | Invited email, normalized (trim + lowercase) for comparison |
-| `role` | TEXT | Role granted on acceptance (`owner`/`admin`/`member`) |
-| `invited_by` | UUID | Creator user id |
-| `token_hash` | TEXT | SHA-256 of the raw token; the raw token is never stored |
-| `expires_at` / `accepted_at` / `accepted_by` / `revoked_at` | TIMESTAMPTZ/UUID | Lifecycle |
-
-Status is derived from the timestamp columns (pending / accepted / revoked /
-expired). A partial unique index enforces at most one outstanding invite per
-`(org_id, email)`.
-
-**API** (org-scoped routes require admin/owner; only owners may invite owners,
-mirroring member management):
-
-- `POST /v1/orgs/{org}/invites` — create a pending invite; returns metadata, the
-  one-time `invite_url`, and an `email_delivery` status.
-- `GET /v1/orgs/{org}/invites` — list outstanding (pending/expired) invites.
-- `DELETE /v1/orgs/{org}/invites/{invite_id}` — revoke a pending invite.
-- `POST /v1/invites/{token}/accept` — authenticated; validates token hash,
-  status, expiry, and email match, then creates local membership.
-
-**Security:**
-- Token material is generated securely and only the SHA-256 hash is persisted.
-  The raw token is returned **once** as `invite_url` and is never logged or
-  stored, so listing cannot re-expose a link (rotation, not recovery, is the
-  future path for re-sharing).
-- Acceptance requires an authenticated principal whose normalized email matches
-  the invited email under the same normalization used at creation.
-- Expired, revoked, already-accepted, malformed, and wrong-email tokens return
-  distinct, safe error codes (`invite_expired`, `invite_revoked`,
-  `invite_already_accepted`, `invite_invalid`, `invite_email_mismatch`) without
-  leaking token secrets.
-
-**Optional email delivery.** Email is never hard-required. The platform's
-`EmailSender` (specs/email.md) is consulted at creation and the outcome is
-classified, leaving the invite pending regardless:
-
-| Sender outcome | `email_delivery` | UX |
-|----------------|------------------|----|
-| `Ok` | `sent` | Email delivered; link also available |
-| `Err(Configuration)` (disabled/unconfigured) | `not_configured` | Copy-link only |
-| `Err(_)` (transport/provider) | `failed` | Copy-link; invite still pending |
-
-Concrete email providers are deployment-owned (`EMAIL_PROVIDER`), not hardcoded
-into org logic. With no provider configured, invite creation still succeeds and
-returns a copyable `invite_url`.
-
-The accept UI route (`/invite/{token}`) works for authenticated and
-unauthenticated users: unauthenticated links preserve the target through
-login/signup via `return_to` (specs/authentication.md) and resume acceptance.
-
-### Resource Scoping
-
-| Resource | Scope | Implementation |
-|----------|-------|----------------|
-| Agent | Per-org | `org_id` FK on `agents` table |
-| Session | Inherits from Agent | No direct FK; scoped via agent join |
-| Messages/Events | Inherits from Session | No direct FK; scoped via session→agent join |
-| LLM Provider | Per-org | `org_id` FK on `llm_providers` table |
-| LLM Model | Per-org | `org_id` FK on `llm_models` table |
-| Personal Access Token | Per-user | `user_id` FK on `personal_access_tokens` table (org resolved per-request) |
-| Capabilities | Global | No `org_id`; system-defined |
-| MCP Servers | Per-org | `org_id` FK (future) |
-| Usage Tracking | Per-org | Aggregated by `org_id` |
-
-**Query Rules:**
-- ALL database queries for org-scoped resources MUST include `WHERE org_id = $org_id`
-- No exceptions, even for UUID lookups
-- Returns 404 (not 403) when resource exists but belongs to different org
-
-### Database Schema
-
-The org tables and org-scoping columns live in the migrations
-(`crates/server/migrations/`): `organizations` and `organization_members` are
-created in `001_base_schema.sql`; `org_id` FK columns and their composite
-indexes are added to the org-scoped tables (`agents`, `providers`, `models`, …)
-in `003_v0.8.0.sql`; the `llm_providers`/`llm_models` → `providers`/`models`
-rename lands in `061_rename_providers_models.sql`. Shape in brief:
-
-- `organizations` — `org_id BIGSERIAL` PK, `public_id` (`org_<32-hex>`), `name`, timestamps.
-- `organization_members` — `(org_id, user_id)` PK join table.
-- Every org-scoped table carries a non-null `org_id` FK to `organizations(org_id)` with a composite `idx_<table>_org_id` index for the mandatory `WHERE org_id = $org_id` query rule.
-
-### API Design
-
-**Path Structure (org derived from auth context):**
-```
-/v1/agents
-/v1/agents/{agent_id}
-/v1/sessions
-/v1/sessions/{session_id}
-/v1/sessions/{session_id}/messages
-/v1/sessions/{session_id}/sse
-/v1/providers
-/v1/providers/{provider_id}
-/v1/models
-```
-
-**Org Resolution:**
-- **Personal access token auth:** Org from `X-Org-Id` header, `everruns_org` cookie, or single-org auto-resolve
-- **Session auth:** Org read from `everruns_org` cookie
-
-**Global Endpoints (no org scope):**
-```
-/health
-/v1/auth/*
-/v1/users/me
-/v1/users/me/switch-org  (sets org cookie)
-/v1/capabilities
-/v1/orgs  (org CRUD - uses auth context)
-```
-
-**User Info Response Enhancement:**
-```json
-// GET /v1/users/me (or /v1/auth/me)
-{
-  "id": "...",
-  "email": "user@example.com",
-  "name": "User Name",
-  "organizations": [
-    {
-      "public_id": "org_2f3c1b3e6a9d4c6f8a1d4e9c9b7f21a0",
-      "name": "Acme Corp"
-    },
-    {
-      "public_id": "org_00000000000000000000000000000001",
-      "name": "Default Organization"
-    }
-  ]
-}
-```
-
-### Authentication Context
-
-**Enhanced AuthUser:**
-```rust
-pub struct AuthUser {
-    pub id: Uuid,
-    pub email: String,
-    pub name: String,
-    pub roles: Vec<String>,
-    pub auth_method: AuthMethod,
-    pub organizations: Vec<OrgMembership>,  // NEW
-}
-
-pub struct OrgMembership {
-    pub org_id: i64,        // Internal, for DB queries
-    pub public_id: String,  // External, for API responses
-    pub name: String,
-}
-```
-
-**ResolvedOrg Extractor:**
-```rust
-/// Extracts organization from authentication context.
-/// - Personal access token auth: X-Org-Id header, everruns_org cookie, or single-org auto-resolve
-/// - Session auth: reads everruns_org cookie
-/// Returns 401/404 if org not found or user is not a member.
-pub struct ResolvedOrg {
-    pub org_id: i64,        // For DB queries
-    pub public_id: String,  // For API responses
-    pub name: String,
-}
-
-impl<S> FromRequestParts<S> for ResolvedOrg {
-    // 1. Extract AuthUser from request
-    // 2. For personal access token auth: X-Org-Id header, cookie, or single-org fallback
-    // 3. For session auth: read org from everruns_org cookie
-    // 4. Validate user is member of requested org
-    // 5. Return ResolvedOrg or error
-}
-```
-
-**Personal Access Token Context:**
-```rust
-// Personal access tokens are user-scoped; org resolved per-request via header/cookie
-pub struct PersonalAccessTokenContext {
-    pub user_id: Uuid,
-    pub scopes: Vec<String>,
-}
-```
-
-### Storage Layer Changes
-
-**Repository Method Signatures:**
-```rust
-// All org-scoped methods require org_id as first parameter
-
-// AgentRepository
-fn list_agents(&self, org_id: i64, pagination: Pagination) -> Result<(Vec<AgentRow>, u32)>;
-fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<AgentRow>>;
-fn create_agent(&self, org_id: i64, input: CreateAgentRow) -> Result<AgentRow>;
-fn update_agent(&self, org_id: i64, agent_id: Uuid, input: UpdateAgent) -> Result<AgentRow>;
-fn delete_agent(&self, org_id: i64, agent_id: Uuid) -> Result<()>;
-
-// SessionRepository (org via agent join)
-fn list_sessions(&self, org_id: i64, agent_id: Uuid, pagination: Pagination) -> Result<...>;
-fn get_session(&self, org_id: i64, session_id: Uuid) -> Result<Option<SessionRow>>;
-
-// LlmProviderRepository
-fn list_providers(&self, org_id: i64) -> Result<Vec<LlmProviderRow>>;
-fn get_provider(&self, org_id: i64, provider_id: Uuid) -> Result<Option<LlmProviderRow>>;
-
-// LlmModelRepository
-fn list_models(&self, org_id: i64) -> Result<Vec<LlmModelRow>>;
-fn get_model(&self, org_id: i64, model_id: Uuid) -> Result<Option<LlmModelRow>>;
-
-// PersonalAccessTokenRepository (user-scoped; no org_id)
-fn list_personal_access_tokens_for_user(&self, user_id: Uuid) -> Result<Vec<PersonalAccessTokenRow>>;
-fn create_personal_access_token(&self, input: CreatePersonalAccessTokenRow) -> Result<PersonalAccessTokenRow>;
-```
-
-**Query Examples:**
-```sql
--- List agents for org
-SELECT * FROM agents WHERE org_id = $1 ORDER BY created_at DESC;
-
--- Get agent (must match both org_id and agent_id)
-SELECT * FROM agents WHERE org_id = $1 AND id = $2;
-
--- Get session (join to verify org ownership)
-SELECT s.* FROM sessions s
-JOIN agents a ON s.agent_id = a.id
-WHERE a.org_id = $1 AND s.id = $2;
-
--- Get events (join through session and agent)
-SELECT e.* FROM events e
-JOIN sessions s ON e.session_id = s.id
-JOIN agents a ON s.agent_id = a.id
-WHERE a.org_id = $1 AND e.session_id = $2
-ORDER BY e.sequence;
-```
-
-### Seeds
-
-**Default Organization:**
-```rust
-// Well-known IDs for seeded data
-pub const DEFAULT_ORG_ID: i64 = 1;
-pub const DEFAULT_ORG_PUBLIC_ID: &str = "org_00000000000000000000000000000001";
-
-pub async fn seed_default_organization(db: &Database) -> Result<()> {
-    // Insert default organization (idempotent)
-    sqlx::query!(
-        r#"
-        INSERT INTO organizations (org_id, public_id, name)
-        VALUES ($1, $2, $3)
-        ON CONFLICT (org_id) DO NOTHING
-        "#,
-        DEFAULT_ORG_ID,
-        DEFAULT_ORG_PUBLIC_ID,
-        "Default Organization"
-    ).execute(db).await?;
-    Ok(())
-}
-```
-
-**Seeded Resources:**
-- Default organization is created first
-- All seeded providers, models, agents belong to default org
-- In auth mode `none`, anonymous user is auto-added to default org
-
-**Seed Order:**
-1. `seed_default_organization()`
-2. `seed_llm_providers()` (with `org_id = DEFAULT_ORG_ID`)
-3. `seed_llm_models()` (with `org_id = DEFAULT_ORG_ID`)
-4. `seed_agents()` (with `org_id = DEFAULT_ORG_ID`)
-
-### InMemory Storage
-
-InMemory storage (DEV_MODE) supports multitenancy:
-- Default organization pre-created on initialization
-- All org-scoped methods require `org_id` parameter
-- Same API contract as PostgreSQL storage
-
-```rust
-impl InMemoryStorage {
-    pub fn new() -> Self {
-        let storage = Self::default();
-        // Pre-create default organization
-        storage.organizations.insert(DEFAULT_ORG_ID, Organization {
-            org_id: DEFAULT_ORG_ID,
-            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
-            name: "Default Organization".to_string(),
-            ..
-        });
-        storage
-    }
-}
-```
-
-### External Identity Storage Methods
-
-For SaaS auth backends that map external provider IDs to internal entities:
-
-```rust
-// Look up user by external provider ID (PropelAuth, Auth0, etc.)
-fn get_user_by_external_id(&self, external_id: &str) -> Result<Option<UserRow>>;
-
-// Look up org by external provider ID
-fn get_organization_by_external_id(&self, external_id: &str) -> Result<Option<OrganizationRow>>;
-
-// Create or update org by external ID (upsert on external_id conflict)
-fn upsert_org_by_external_id(&self, external_id: &str, name: &str) -> Result<OrganizationRow>;
-
-// Idempotent membership creation (no-op if already exists)
-fn ensure_membership(&self, org_id: i64, user_id: Uuid) -> Result<()>;
-```
-
-These are unused in OSS (external_id is always NULL) but available for SaaS auth backend implementations.
-
-### Worker Integration
-
-**gRPC Context:**
-- Worker requests include `org_id` in metadata
-- Control plane validates org ownership before returning context
-- Turn context (`GetTurnContext`) scoped to org
-
-```protobuf
-message GetTurnContextRequest {
-    string session_id = 1;
-    int64 org_id = 2;  // NEW: Required for validation
-}
-```
-
-### UI Changes
-
-**Organization Selector:**
-- Dropdown in sidebar/header showing current org
-- Lists all organizations user belongs to
-- Selection persisted in localStorage
-- API calls include selected org in path
-
-**State Management:**
-```typescript
-interface OrgState {
-  currentOrg: Organization | null;
-  organizations: Organization[];
-  setCurrentOrg: (org: Organization) => void;
-}
-
-// All API calls use current org
-const agents = useAgents(currentOrg.public_id);
-```
-
-**URL Structure:**
-```
-/orgs/{org_public_id}/agents
-/orgs/{org_public_id}/agents/{agent_id}
-/orgs/{org_public_id}/settings
-```
-
-### Usage Tracking
-
-Usage is aggregated per organization:
-```sql
--- Add org_id to usage tracking
-ALTER TABLE usage_records ADD COLUMN org_id BIGINT NOT NULL;
-
--- Query usage by org
-SELECT
-    org_id,
-    SUM(input_tokens) as total_input,
-    SUM(output_tokens) as total_output
-FROM usage_records
-WHERE org_id = $1 AND created_at >= $2
-GROUP BY org_id;
-```
-
-### Error Handling
-
-**404 vs 403:**
-- Resource exists but wrong org → 404 (prevents enumeration)
-- User not member of org → 404 (prevents org discovery)
-- Invalid public_id format → 400 Bad Request
-
-**Error Messages:**
-```rust
-// Good - no information leakage
-ApiError::NotFound("Agent not found")
-ApiError::NotFound("Organization not found")
-
-// Bad - reveals existence
-ApiError::Forbidden("You don't have access to this agent")
-```
-
-## Implementation Notes
-
-### Anonymous Auth Mode (AUTH_MODE=none)
-When auth is disabled, the system uses the default organization:
-- `public_id`: `org_00000000000000000000000000000001`
-- `name`: "Default Organization"
-
-The backend `AuthUser::anonymous()` returns a user with the default org in their organizations list. The `ResolvedOrg` extractor uses this directly (no cookie needed for `AuthMethod::None`).
-
-### Org Cookie Initialization
-
-**Problem:** Race condition where UI components try to fetch org-scoped data before the org cookie is set.
-
-**Solution:** The org cookie is set automatically during authentication:
-
-1. **Login/Register/OAuth/Refresh endpoints:** `generate_token_response()` sets `everruns_org` cookie to user's first org
-2. **GET /v1/auth/me:** Sets `everruns_org` cookie if missing (fallback for edge cases)
-3. **Anonymous mode:** No cookie needed - `ResolvedOrg` uses default org from `AuthUser.organizations`
-
-**Cookie specification:**
-```
-Name: everruns_org
-Value: org_xxx (organization public_id)
-Path: /
-HttpOnly: false (allows JS to read for UI state sync)
-SameSite: Lax
-Secure: true
-```
-
-### UI Initialization Lifecycle
-
-**Problem:** Pages showing empty states instead of loading skeletons when org context isn't ready yet.
-
-**Root cause:** React Query returns `isLoading: false` when query is disabled (`enabled: false`). If org isn't ready, queries are disabled, and pages render empty states.
-
-**Solution:** Two-part fix:
-
-1. **Hooks include org loading state:**
-   ```typescript
-   export function useAgents() {
-     const { currentOrg, isLoading: orgLoading } = useOrg();
-     const query = useQuery({
-       queryKey: [...queryKeys.agents.list(), currentOrg?.public_id],
-       queryFn: () => listAgents(),
-       enabled: !!currentOrg,
-     });
-     // Return isLoading=true while org is initializing
-     return {
-       ...query,
-       isLoading: orgLoading || query.isLoading,
-     };
-   }
-   ```
-
-2. **Main layout shows global loader:**
-   ```typescript
-   // apps/ui/src/app/(main)/layout.tsx
-   const { isLoading: authLoading } = useAuth();
-   const { isLoading: orgLoading } = useOrg();
-   
-   if (authLoading || orgLoading) {
-     return <Loader />; // Spinner while initializing
-   }
-   ```
-
-**Affected hooks (all updated to include org loading):**
-- `useAgents`, `useAgent`
-- `useSessions`, `useSession`
-- `useCapabilities`, `useCapability`
-- `useLlmProviders`, `useLlmProvider`, `useLlmModels`, `useLlmProviderModels`, `useLlmModel`
-- `useMcpServers`, `useMcpServer`
-- `useOrganization`
-- `useFiles`, `useFile`, `useFileStat`
-
-**OrgProvider initialization flow:**
-1. `AuthProvider` fetches `/v1/auth/config` and `/v1/auth/me`
-2. `/v1/auth/me` returns user with organizations list (and sets org cookie if missing)
-3. `OrgProvider` waits for `authLoading` to become false
-4. `OrgProvider` initializes `currentOrg` from user's organizations
-5. Data hooks become enabled and fetch org-scoped data
-
-**Post-login flow:**
-1. Login API succeeds, sets auth + org cookies
-2. `useLogin` calls `refetchQueries` for user data
-3. `OrgProvider` sees organizations change, sets `currentOrg`
-4. Dashboard queries fire with org context ready
-
-### System-Wide Resources
-Some resources remain system-wide (not org-scoped):
-- `/v1/durable/*` - Durable execution workers and workflows (infrastructure-level)
-- `/health` - Health check endpoint
-- `/v1/auth/*` - Authentication endpoints
-
-### UI Organization Selector
-Located in sidebar (`apps/ui/src/components/layout/sidebar.tsx`). Shows current org with dropdown to switch between user's organizations. Uses Base UI's `DropdownMenu` component. Includes a "Create Organization" button at the bottom of the dropdown.
-
-### UI Organization Creation
-Two entry points for creating organizations:
-1. **Sidebar dropdown:** "Create Organization" menu item opens a dialog
-2. **Settings > Organization page:** "Create Organization" button in the "Your Organizations" section
-
-Both use the `useCreateOrganization` hook (`hooks/use-organizations.ts`) which calls `POST /v1/orgs`. On success, the new org is auto-selected as the current org via `setCurrentOrg()`.
-
-### UI Settings Navigation
-
-The settings sidebar (`/settings/*`) is organized into two labeled sections:
-
-**Organization** (org-scoped settings):
-- **General** (`/settings/organization`) — Org name, ID, "Your Organizations" list
-- **LLM Providers** (`/settings/providers`) — Provider configs and API keys
-- **Members** (`/settings/members`) — Team member list
-
-**Personal** (user-scoped settings):
-- **Connections** (`/settings/connections`) — External account links (GitHub, etc.)
-- **Personal access tokens** (`/settings/personal-access-tokens`) — User-scoped tokens for programmatic access
-
-Section labels are rendered as uppercase headers (`text-xs font-semibold uppercase tracking-wider`). Active nav item highlighted with accent left border.
-
-### UI Organization Management
-The settings page (`/settings/organization`) has two sections:
-1. **Current Organization:** Edit name, view org ID (existing)
-2. **Your Organizations:** Lists all orgs the user belongs to with switch buttons. Current org highlighted with a "Current" badge.
-
-## Cross-Org Resource Resolution
-
-Users who belong to multiple organizations routinely follow direct links
-(shared URLs, bookmarks, external notifications) that point at a resource
-owned by one of their orgs but not the one currently selected. With strict
-org scoping (see the Query Rules above) the entity API returns 404 for that
-resource and the UI shows a "not found" screen — a recurring papercut.
-
-### Contract
-
-| Layer                | Behaviour                                                                                                                |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------|
-| Entity APIs          | UNCHANGED — still return 404 for resources in other orgs. Preserves the enumeration guarantee on lines 127–128.          |
-| `GET /v1/resolve-org`| Authenticated endpoint. Given a prefixed public ID, returns the owning org ONLY when the caller is a member of that org. |
-| UI                   | On 404 from an entity detail fetch, suppresses final "not found" UI while checking the resolver; if a member-owned org is returned, switches and retries. |
-
-Because the resolver reveals only orgs the caller already belongs to, the
-set of answers it can produce is a subset of the information the caller can
-learn by manually switching between their own orgs. No new information
-leaks across org boundaries.
-
-### Endpoint
-
-```
-GET /v1/resolve-org?id=<prefixed_public_id>
-→ 200 { "org_id": "org_xxx", "org_name": "Acme Corp" }
-→ 404 — unknown id, unknown prefix, or owning org is not a caller membership
-```
-
-### Domain trait (`ResourceOrgResolver`)
-
-Every top-level entity with a dedicated UI detail route MUST register an
-`inventory::submit! { ResourceOrgResolver { ... } }` block in
-`crates/server/src/domains/org_resolver.rs`. Each entry pairs an ID prefix
-(e.g. `"session"`) with a function that looks up the owning `org_id`. The
-endpoint dispatches by prefix; adding a new top entity requires:
-
-1. A storage method `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>`
-   on the PG and in-memory backends (no caller-side org scoping).
-2. One `inventory::submit!` block in `domains/org_resolver.rs`.
-3. Nothing else on the backend — the resolver endpoint picks up the new
-   prefix on startup.
-
-Existing registrations cover: `session`, `agent`, `harness`, `app`,
-`skill`, `mcp`, `identity`, `eval`. Virtual capability IDs (`mcp:<uuid>` and
-`skill:<uuid>`) resolve through their underlying MCP server or skill rows.
-
-### UI integration
-
-- `lib/api/resolver.ts::resolveOrgForResource(id)` wraps the endpoint.
-- `hooks/use-resource-org-fallback.ts` is the single React hook that reacts
-  to a 404 on a detail query, calls the resolver, and invokes
-  `setCurrentOrg(target, { stayOnPage: true })` when the owner is a
-  membership. The `stayOnPage` option skips the default org-switch redirect
-  that would otherwise send the user back to the list page.
-- While the resolver check or resulting org switch is pending, the hook
-  exposes `isCheckingOtherOrgs`. Detail hooks MUST fold that into their
-  loading state so users see loading/checking UI instead of a brief red 404.
-  Render final "not found" only after the fallback is exhausted.
-- For ordinary CRUD-style entities, `hooks/create-crud-hooks.ts::useDetail`
-  is the generic integration point. Agents, harnesses, apps, skills, MCP
-  servers, and evals inherit the fallback through this helper.
-- Bespoke detail hooks that do not use `createCrudHooks` MUST call
-  `useResourceOrgFallback` themselves and include `isCheckingOtherOrgs` in
-  their returned loading state. Current bespoke integrations: `useSession`,
-  `useAgentIdentity`, and `useCapability`.
-
-### Invariants
-
-- The fallback fires **at most once per resource id + current org pair**
-  (tracked via a ref inside the hook) to avoid ping-pong when the new org
-  also 404s.
-- The entity API's 404 behaviour is never relaxed. The only cross-org
-  information disclosure happens through `GET /v1/resolve-org`, which is
-  membership-gated.
-- The resolver endpoint MUST NOT be reached before authentication; it
-  requires an `AuthUser` extractor.
-
-### When to add a new entity to the resolver
-
-If you add a new top-level entity with a dedicated UI detail route
-(`apps/ui/src/app/(main)/<entity>/[id]/...`), add it to the resolver
-registry. Entities without a detail route do not need to register.
-
-## Future Considerations
-
-**Not in scope for v1:**
-- Organization roles (admin, member, viewer)
-- Invitations and onboarding flow
-- Org-level settings (allowed providers, limits)
-- Cross-org resource sharing
-- Organization deletion (with cascade)
-- Audit logging per org
+# Multitenancy
+
+## Purpose
+
+Organizations are Everruns' administrative and isolation boundary. They own
+resources, memberships, roles, invitations, policy context, and usage. A user
+may belong to several organizations and selects one organization for each
+org-scoped request.
+
+This spec owns the isolation model and security invariants. It does not copy
+database columns, request structs, repository signatures, protobuf messages, or
+route payloads.
+
+## Sources of truth
+
+- [`crates/core/src/organization.rs`](../crates/core/src/organization.rs) owns
+  organization identifiers, membership DTOs, and role ordering.
+- [`crates/server/src/auth/middleware.rs`](../crates/server/src/auth/middleware.rs)
+  owns authenticated organization resolution and membership checks.
+- [`crates/server/src/api/users.rs`](../crates/server/src/api/users.rs) owns
+  organization switching and the browser selection cookie.
+- [`crates/server/src/api/organizations.rs`](../crates/server/src/api/organizations.rs)
+  and
+  [`crates/server/src/domains/organizations/`](../crates/server/src/domains/organizations/)
+  own organization, membership, and invitation behavior.
+- [`crates/server/src/domains/org_resolver.rs`](../crates/server/src/domains/org_resolver.rs)
+  owns the cross-org resource resolver registry.
+- [`crates/server/migrations/`](../crates/server/migrations/) owns table
+  definitions, foreign keys, indexes, role storage, and invitation lifecycle.
+- [`docs/api/openapi.json`](../docs/api/openapi.json) owns exact public HTTP
+  shapes.
+- [`crates/server/tests/org_isolation_test.rs`](../crates/server/tests/org_isolation_test.rs)
+  and
+  [`crates/server/tests/org_invitations_test.rs`](../crates/server/tests/org_invitations_test.rs)
+  are executable isolation and invitation contracts.
+
+## Core decisions
+
+### Organization-only ownership
+
+There is no personal resource namespace. Org-scoped resources always resolve to
+an organization, including in auth-disabled development mode.
+
+The seeded default organization and anonymous development user keep the same
+membership and query paths as authenticated deployments. Well-known IDs and
+seed behavior belong to the source and migrations linked above.
+
+### Multiple organizations
+
+Users may belong to multiple organizations. Membership carries a hierarchical
+role: owner, admin, or member. The source enum and policy definitions are
+authoritative for the exact permission mapping.
+
+Membership, roles, organizations, and invitations are local-database
+authoritative. Hosted wrappers may use an external identity provider for login
+and user identity, but provider organization claims do not replace Everruns'
+membership checks.
+
+### Auth-derived scope
+
+Ordinary resource URLs do not contain the organization. The server derives
+scope from the authenticated principal plus explicit request selection:
+
+- personal access tokens may select an organization with the supported header
+  or browser cookie; a single membership can be resolved automatically;
+- browser sessions use the selected-organization cookie;
+- auth-disabled mode uses the default organization.
+
+Every selected organization is validated against the principal's memberships.
+Multi-org token callers that omit an explicit selection receive an error rather
+than an arbitrary organization.
+
+The browser cookie is server-set and readable by the UI so client state can
+stay synchronized. Exact cookie flags, resolution precedence, and error status
+codes are security-sensitive implementation details owned by the auth
+middleware and users API; do not duplicate them here.
+
+## Isolation invariants
+
+Every org-scoped read and mutation must include organization scope, even when a
+public resource identifier is globally unique. A lookup that finds a resource
+in another organization is indistinguishable from a missing resource to the
+ordinary entity API.
+
+Internal numeric organization IDs are storage and authorization details. Public
+APIs, URLs, client logs, and user-facing errors use public prefixed IDs.
+
+These rules apply across all storage implementations. The in-memory backend is
+not allowed to weaken isolation for convenience.
+
+Sessions and their dependent records may inherit organization through their
+owning resource or may store organization directly as the schema evolves. The
+actual join path and foreign keys belong to migrations and repositories; the
+invariant is that no access path bypasses organization scope.
+
+Global infrastructure and authentication endpoints are explicitly exempt where
+their owning specs require it. A resource is not global merely because it lacks
+an organization field in an old document.
+
+## Organizations and membership
+
+Organization creation establishes an owner membership. Role changes and member
+removal enforce the hierarchy and preserve at least the required administrative
+ownership. Exact request types and allowed transitions live in the
+organizations domain and permission policy.
+
+Callers cannot use role management to grant a role above their own authority.
+Entity APIs return non-enumerating failures when the target organization is not
+a caller membership.
+
+## Invitations
+
+Invitations create pending local membership grants without requiring an email
+provider.
+
+The invitation contract is:
+
+- the invited email is normalized consistently at creation and acceptance;
+- the raw token is generated securely, returned only where the create flow
+  requires it, and never stored or logged;
+- only a cryptographic hash is persisted;
+- acceptance requires an authenticated principal whose normalized email
+  matches the invitation;
+- expiry, revocation, prior acceptance, malformed tokens, and email mismatch
+  produce stable safe error classifications without disclosing token material;
+- at most one pending invitation exists for an organization/email pair;
+- accepting is transactional and cannot create duplicate membership.
+
+Email delivery is optional and deployment-owned. Failure or absence of an email
+provider leaves the invitation pending and the create operation usable through
+copy-link UX. See [`email.md`](email.md).
+
+The invite landing page preserves the destination through authentication and
+continues acceptance afterward. Authentication return-path safety is defined in
+[`authentication.md`](authentication.md).
+
+## Query and API policy
+
+All org-scoped commands receive organization context from the authenticated
+extractor and pass it into storage. HTTP, MCP, gRPC, background work, and
+platform capabilities must converge on the same domain policy rather than
+constructing an unscoped repository call.
+
+Wrong-organization entity access remains a not-found response to prevent
+enumeration. Membership management may return authorization failures only
+after the organization itself has been established as visible to the caller.
+
+Public identifiers are validated before storage lookup. Exact formats and
+error bodies are defined by typed-ID source and OpenAPI.
+
+## Cross-org direct links
+
+A user who belongs to several organizations may open a direct link for a
+resource outside the currently selected organization. Ordinary entity APIs
+still return not found; they never search all organizations.
+
+The authenticated resource resolver may map a public resource ID to an owning
+organization only when the caller is already a member of that organization.
+Therefore it reveals no organization outside the caller's existing membership
+set.
+
+Top-level entities with dedicated UI detail routes register a resolver by
+public-ID prefix in `crates/server/src/domains/org_resolver.rs`. The registry is
+the source of truth for current supported prefixes. Do not keep a copied list
+here.
+
+The UI handles a detail-page not-found response by:
+
+1. checking the membership-gated resolver;
+2. switching to the returned membership without navigating away;
+3. retrying the original detail query;
+4. rendering the final not-found state only after fallback is exhausted.
+
+The fallback runs at most once for a resource/current-organization pair to
+avoid ping-pong. Generic CRUD hooks own the common integration; bespoke detail
+hooks must use the same fallback and fold resolver work into loading state.
+
+Adding a new top-level detail entity requires a storage lookup for its owning
+organization, a resolver registration, and UI fallback coverage.
+
+## UI selection
+
+The UI initializes organization context from the authenticated user's
+memberships, keeps it synchronized through the switch endpoint, and delays
+org-scoped queries until selection is ready. Disabled queries alone do not
+represent a loading state, so page-level hooks must include organization
+initialization in their loading result.
+
+Switching organizations invalidates or rekeys org-scoped caches. It must not
+reuse data fetched under the previous organization.
+
+## Usage and billing
+
+Usage records are attributable to an organization at capture time. Aggregation,
+limits, and billing must not infer organization later from mutable user
+membership. Exact storage fields and aggregation queries live in the usage
+domain and migrations. See [`usage-tracking.md`](usage-tracking.md) and
+[`budgeting.md`](budgeting.md).
+
+## Security review checklist
+
+- Every resource lookup is scoped before returning existence or content.
+- Internal organization IDs do not cross public boundaries.
+- Cookie/header selection is validated against current membership.
+- In-memory and PostgreSQL backends implement the same isolation behavior.
+- Background and worker paths carry authenticated organization context.
+- Invitation tokens, hashes, and email-provider errors do not leak.
+- Cross-org resolution returns only caller memberships.
+- UI caches include organization identity and clear correctly on switch.
+
+The repository threat register remains in [`threat-model.md`](threat-model.md);
+it is intentionally not duplicated here.

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -1,803 +1,224 @@
 # Toolkit Library Contract
 
-> Convention for external `*kit` libraries (bashkit, fetchkit, future kits) that expose tools for everruns integration.
-> Not a shared crate — just a contract so all toolkit libraries feel the same to integrate.
+## Purpose
 
-## Problem
+External `*kit` crates expose standalone tools that Everruns can integrate
+without hardcoding their schemas, prompts, execution details, or errors.
 
-bashkit and fetchkit diverged in how they expose tool metadata and execution:
+This is a behavioral convention, not a shared Rust trait crate. Exact public
+items and signatures belong to each toolkit's source and generated API docs:
 
-| Concern | bashkit | fetchkit |
-|---------|---------|----------|
-| Schema | Not exposed — wrapper hardcodes JSON | `tool.input_schema()` → `Value` |
-| System prompt | `tool.system_prompt()` | `tool.llmtxt()` |
-| Execution | Separate `Bash` struct, not on `Tool` | `tool.execute(req)` on `Tool` |
-| Builder config | `.username()`, `.hostname()`, `.limits()`, `.env()` | `.enable_save_to_file()`, `.block_private_ips()` |
+- [bashkit on docs.rs](https://docs.rs/bashkit) and
+  [`crates/core/src/capabilities/bashkit_shell/mod.rs`](../crates/core/src/capabilities/bashkit_shell/mod.rs)
+- [fetchkit on docs.rs](https://docs.rs/fetchkit) and
+  [`crates/core/src/capabilities/web_fetch/mod.rs`](../crates/core/src/capabilities/web_fetch/mod.rs)
+- the pinned versions and enabled features in
+  [`crates/core/Cargo.toml`](../crates/core/Cargo.toml)
 
-This means each new toolkit requires bespoke integration code in `crates/core/src/capabilities/`. The contract below standardizes the public API shape so the integration side is predictable.
+Do not copy a released toolkit's Rust definitions into this spec. Toolkit APIs
+evolve independently, and the pinned dependency plus integration tests are the
+truth for the version Everruns actually consumes.
 
-## Contract overview
+## Why the convention exists
 
-Three objects with clear responsibilities:
+Without a common shape, every toolkit integration must duplicate metadata,
+input schemas, prompts, execution adapters, and error classification. That
+duplication drifts when the toolkit adds a parameter or changes behavior.
 
-```
-ToolBuilder (config)  →  Tool (metadata)  →  ToolExecution (runtime)
-```
+The integration should instead delegate toolkit-owned concerns to the toolkit
+and own only Everruns-specific policy and adaptation.
 
-- **`ToolBuilder`** — kit-specific configuration, produces a `Tool`
-- **`Tool`** — immutable metadata (name, description, schema, system prompt), produces a `ToolExecution`
-- **`ToolExecution`** — stateful, single-use execution of one tool call
+## Responsibility model
 
-## Contract
+Toolkits separate three responsibilities:
 
-### 1. `ToolBuilder`
+1. A builder captures stable and kit-specific configuration.
+2. A tool exposes immutable metadata and creates executions.
+3. An execution represents one stateful, single-use tool call.
 
-Every `*kit` library exposes a `ToolBuilder` for configuration. The builder is a factory that can produce different artifacts depending on what the consumer needs.
+The exact type names may differ when an established toolkit has a better native
+API. What matters is that consumers can obtain metadata without executing,
+create isolated executions, and inject host adapters where needed.
 
-```rust
-let builder = mykit::ToolBuilder::new()
-    .locale("en-US")
-    .some_feature(true)
-    .some_limit(1000);
+Builders should be reusable: producing a schema, definition, service, or tool
+must not unexpectedly consume configuration that another artifact needs.
+Toolkit-specific configuration remains fluent and discoverable.
 
-// Full object — metadata + execution factory
-let tool = builder.build();
+## Metadata contract
 
-// Or produce individual artifacts without building the full Tool:
-let definition = builder.build_tool_definition();   // OpenAI function call JSON
-let input_schema = builder.build_input_schema();     // JSON Schema for args
-let output_schema = builder.build_output_schema();   // JSON Schema for result
-let executor = builder.build_executor();             // generic Value → Value executor
-```
+A toolkit is the source of truth for:
 
-Config methods are chainable. Build methods take `&self` (non-consuming) — you can call multiple on the same builder.
+- stable LLM-facing tool name;
+- localized display name and description;
+- semantic version;
+- input and output schemas;
+- semantic hints such as read-only, destructive, idempotent, open-world,
+  secret-dependent, or long-running behavior;
+- the minimal system-prompt contribution;
+- comprehensive user-facing help.
 
-`ToolBuilder` need not be `Send + Sync`.
+Everruns wrappers must delegate those values and add only platform-specific
+extensions. For example, the bash wrapper may add a session working-directory
+parameter because that concept belongs to Everruns, but it must not copy the
+rest of bashkit's schema.
 
-#### Required config methods
+Tool objects must be safe to share across concurrent runtime assembly. Mutable
+per-call state belongs to an execution, not the metadata object.
 
-```rust
-impl ToolBuilder {
-    /// Set the locale for user-facing text (description, system prompt, error messages).
-    /// BCP 47 language tag (e.g. "en-US", "uk-UA").
-    /// Default: "en-US".
-    fn locale(self, locale: &str) -> Self;
-}
-```
+### Token economy
 
-Kit-specific config methods are added alongside `locale()`.
-
-#### Build methods
-
-```rust
-impl ToolBuilder {
-    /// Build the full Tool (metadata + execution factory).
-    fn build(&self) -> Tool;
-
-    /// Build a `tower::Service` that accepts JSON args and returns JSON result.
-    /// No metadata attached — useful for embedding in generic pipelines,
-    /// test harnesses, or consumers that manage tool definitions separately.
-    /// Implements `tower::Service<Value, Response = Value, Error = ToolError>`.
-    fn build_service(&self) -> impl Service<Value, Response = Value, Error = ToolError>;
-
-    /// Build an OpenAI-compatible function tool definition.
-    /// Returns JSON matching the OpenAI `tools` array element format:
-    /// `{"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}`
-    fn build_tool_definition(&self) -> serde_json::Value;
-
-    /// Build the JSON Schema for the tool's input parameters.
-    /// Same as `Tool::input_schema()` but without building the full Tool.
-    fn build_input_schema(&self) -> serde_json::Value;
-
-    /// Build the JSON Schema for the tool's output.
-    /// Describes the shape of `ToolOutput::result` so consumers can
-    /// validate results or generate types.
-    fn build_output_schema(&self) -> serde_json::Value;
-}
-```
-
-**`build_service()`** returns a standard `tower::Service` — the Rust equivalent of Python's callable protocol (`__call__`). This is the community-standard async request→response interface. Any tower middleware (timeout, retry, rate-limit, tracing) works out of the box.
-
-```rust
-use tower::Service;
+Descriptions and prompt contributions are paid on every model call. Names and
+JSON Schema keywords should carry the obvious meaning. Use enums, formats, and
+defaults instead of repeating the same information in prose. Add a short
+description only for a non-obvious constraint or behavior.
 
-let mut svc = mykit::ToolBuilder::new()
-    .some_feature(true)
-    .build_service();
-
-// Standard Service::call — just like Python's callable
-let result: Value = svc.call(json!({"url": "https://example.com"})).await?;
-
-// Compose with tower middleware
-use tower::ServiceBuilder;
-let svc = ServiceBuilder::new()
-    .timeout(Duration::from_secs(30))
-    .service(mykit::ToolBuilder::new().build_service());
-```
-
-Toolkits that need adapter injection provide a `ServiceBuilder`-style layer or a second factory method:
-
-```rust
-impl ToolBuilder {
-    /// Build a service with an adapter injected.
-    fn build_service_with<A: SomeAdapter>(
-        &self,
-        adapter: A,
-    ) -> impl Service<Value, Response = Value, Error = ToolError>;
-}
-```
-
-**When to use which:**
-- `build()` → everruns integration (full metadata + `ToolExecution` with cancel/stream)
-- `build_service()` → generic async callable, tower middleware composition, test harnesses
-- `build_tool_definition()` → registering tools with OpenAI-compatible APIs
-- `build_input_schema()` / `build_output_schema()` → codegen, validation, documentation
-
-### 2. `Tool` — metadata
-
-`Tool` is immutable and holds all metadata baked in from the builder config:
-
-```rust
-impl Tool {
-    /// Tool name for LLM invocation (e.g. "bash", "web_fetch").
-    /// Snake_case, stable across versions.
-    fn name(&self) -> &str;
-
-    /// Human-readable display name for UI (e.g. "Bash", "Web Fetch").
-    /// Localized per builder locale.
-    fn display_name(&self) -> &str;
-
-    /// Semantic version of the toolkit library (e.g. "0.1.8").
-    /// Defaults to the crate version (`env!("CARGO_PKG_VERSION")`).
-    /// Consumer can use this for diagnostics, logging, or compatibility checks.
-    fn version(&self) -> &str;
-
-    /// Short, token-efficient description for the LLM.
-    /// One sentence. No filler. Localized per builder locale.
-    fn description(&self) -> &str;
-
-    /// JSON Schema for the tool's input parameters.
-    /// Must be a valid JSON Schema object with `"type": "object"`.
-    /// Adapts to builder config (e.g. optional params appear/disappear).
-    /// See §2a for schema authoring rules.
-    fn input_schema(&self) -> serde_json::Value;
-
-    /// Semantic hints describing the tool's behavioral properties.
-    /// Follows the MCP annotations convention (readonly, destructive,
-    /// idempotent, open_world) plus everruns-specific hints (requires_secrets,
-    /// long_running). See `everruns_core::ToolHints` for field definitions.
-    /// Returns `ToolHints::default()` (all unspecified) if not overridden.
-    fn hints(&self) -> ToolHints;
-
-    /// Terse system prompt addition for the LLM.
-    /// Must start with tool name (e.g. "web_fetch: ..."). No title/header.
-    /// Minimal tokens — only behavior the LLM can't infer from the schema.
-    /// Returned as plain text — the consumer wraps it in XML tags.
-    /// Empty string if no system prompt contribution needed.
-    /// Localized per builder locale.
-    fn system_prompt(&self) -> String;
-
-    /// The locale this tool was built with (e.g. "en-US").
-    fn locale(&self) -> &str;
-
-    /// Comprehensive help rendered as Markdown.
-    /// Includes: description, all parameters with types/defaults/constraints,
-    /// usage examples, adapter requirements, error cases, and version.
-    /// Localized per builder locale.
-    fn help(&self) -> String;
-}
-```
-
-`Tool` is `Send + Sync` and cheap to clone (typically `Arc` internals or static data).
-
-**Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on `Tool` so the consumer can delegate without duplication.
-
-#### Token budget rules
-
-Every token in `description()` and `system_prompt()` costs money on every LLM call. Be ruthless.
-
-**`description()`** — one sentence, no articles, no filler:
-- Good: `"Fetch a URL and return content as text or markdown"`
-- Bad: `"This tool allows you to fetch content from a specified URL and return it in various formats including plain text or markdown"`
-
-**`system_prompt()`** — starts with tool name, no markdown headers, only what the LLM can't infer from the schema:
-- Good: `"web_fetch: returns truncated content if response exceeds 50KB. Use as_markdown for HTML pages. Blocked: private IPs, cloud metadata endpoints."`
-- Bad: `"# Web Fetch Tool\n\nThe web_fetch tool is used to fetch content from URLs. It supports GET and HEAD methods.\n\n## Usage\n..."`
-
-If the schema is self-explanatory, `system_prompt()` can return `""`.
-
-#### 2a. Input schema authoring rules
-
-The schema is sent to the LLM on every call. Minimize token cost:
-
-1. **Argument names carry intent** — if the name is clear, omit `description`. `url`, `command`, `timeout_ms` need no description. `as_markdown` needs no description.
-
-2. **Use `enum` for fixed values** — don't describe allowed values in text:
-   ```json
-   // Good
-   {"method": {"type": "string", "enum": ["GET", "HEAD"]}}
-   // Bad
-   {"method": {"type": "string", "description": "HTTP method. Must be GET or HEAD."}}
-   ```
-
-3. **Specify `default` in schema** — don't describe defaults in text:
-   ```json
-   // Good
-   {"timeout_ms": {"type": "integer", "default": 30000}}
-   // Bad
-   {"timeout_ms": {"type": "integer", "description": "Timeout in milliseconds. Defaults to 30000."}}
-   ```
-
-4. **Short descriptions only when needed** — format, constraints, non-obvious behavior:
-   ```json
-   {"working_dir": {"type": "string", "default": "/workspace", "description": "Absolute path"}}
-   ```
-
-5. **Use `format` for known types** — `"format": "uri"`, `"format": "date-time"`, etc.
-
-**fetchkit example** (before/after):
-```json
-// Before (verbose)
-{
-  "url": {"type": "string", "description": "The URL to fetch content from. Must start with http:// or https://."},
-  "method": {"type": "string", "description": "HTTP method to use. Supported: GET, HEAD. Default: GET."},
-  "as_markdown": {"type": "boolean", "description": "If true, converts HTML content to markdown format. Default: false."}
-}
-
-// After (token-efficient)
-{
-  "url": {"type": "string", "format": "uri"},
-  "method": {"type": "string", "enum": ["GET", "HEAD"], "default": "GET"},
-  "as_markdown": {"type": "boolean", "default": false}
-}
-```
-
-#### `help()` content
-
-`help()` returns a self-contained Markdown document. Expected sections:
-
-```markdown
-# Web Fetch
-
-Fetch content from a URL and return it as text or markdown.
-
-**Version:** 0.1.3
-**Name:** `web_fetch`
-
-## Parameters
-
-| Name | Type | Required | Default | Description |
-|------|------|----------|---------|-------------|
-| `url` | string | yes | — | URL to fetch (http/https) |
-| `method` | string | no | `"GET"` | HTTP method (`GET` or `HEAD`) |
-| `as_markdown` | boolean | no | `false` | Convert HTML to markdown |
-| `save_to_file` | string | no | — | Path to save response to |
-
-## Examples
-
-\```json
-{"url": "https://example.com", "as_markdown": true}
-\```
-
-## Adapters
-
-- **FileSaver** (optional): Required when `save_to_file` is set.
-  Without it, `save_to_file` returns an error.
+The system-prompt contribution contains only behavior the model cannot infer
+from the schema. It has no decorative title and may be empty.
+
+Comprehensive usage information belongs in toolkit help or product
+documentation, not in the always-present prompt.
+
+### Localization
+
+Locale affects human-readable display names, descriptions, help, prompt text,
+and safe user-facing errors. It does not change the stable tool name, schema
+property names, or version.
+
+Unsupported locales must degrade according to the toolkit's documented locale
+policy; wrappers must not maintain a second translation table for toolkit-owned
+text.
+
+## Schema contract
+
+Input schemas are valid JSON Schema objects suitable for LLM tool definitions.
+They adapt to builder configuration: disabled functionality does not linger as
+an apparently usable parameter.
+
+Output schemas describe the model-visible result, not host-only diagnostics.
+The toolkit's tests must verify that schemas and runtime parsing agree.
+Everruns integration tests should verify that the delegated schema reaches the
+runtime unchanged except for intentional platform extensions.
+
+OpenAI-compatible tool definitions or `tower::Service` adapters are useful
+interoperability surfaces when a toolkit provides them, but their exact Rust
+signatures are toolkit-owned.
+
+## Execution contract
+
+An execution validates or parses one call's arguments and runs at most once.
+The final output is authoritative.
+
+Long-running toolkits may support:
+
+- cancellation that is idempotent and safe to signal while execution is
+  running;
+- partial output on cancellation;
+- an informational stream obtained before execution starts.
+
+Dropping an unsupported cancellation future is an acceptable fallback. A
+toolkit must not advertise cancellation or streaming if its implementation
+cannot honor the lifecycle.
+
+Incremental output is for live rendering. Consumers must not reconstruct a
+different final result by concatenating chunks.
+
+## Adapter boundary
+
+A toolkit that needs a filesystem, file saver, HTTP transport, or another
+host-owned facility defines the adapter trait in the toolkit. The host
+implements that trait and injects it at the execution boundary.
+
+Adapters are:
+
+- named for the capability they provide rather than for Everruns;
+- safe to share across asynchronous tasks;
+- expressed in toolkit-owned input, output, and error types;
+- re-exported with all supporting types needed by implementers.
+
+The integration must preserve host policy. Session filesystem access stays
+inside the session filesystem adapter, and sanctioned outbound traffic stays
+inside the host egress boundary. See [`egress.md`](egress.md).
 
 ## Errors
 
-- `MissingUrl` — `url` parameter not provided
-- `BlockedUrl` — URL blocked by SSRF policy
-- `FirstByteTimeout` — server did not respond within 1 second
-```
-
-The exact sections vary by tool — the contract is that `help()` is comprehensive enough to use the tool without reading source code.
-
-#### Runtime error hygiene
-
-Toolkit-owned interpreters must format runtime errors as concise user-facing
-messages. Errors should name the failing builtin and cause, but must not dump
-entire structured input values or prompt-sized fields. Consumers can add
-defense-in-depth truncation, but the toolkit owns avoiding verbose `Debug`
-renders from embedded engines such as jq.
-
-#### Locale affects
-
-Locale controls the language of human-readable text:
-- `description()` — tool description sent to LLM
-- `display_name()` — UI label
-- `help()` — comprehensive help document
-- `system_prompt()` — LLM instructions
-- Error messages from `ToolError` (user-facing variants)
-
-Locale does **not** affect:
-- `name()` — always English snake_case (LLM contract)
-- `input_schema()` — property names and types are locale-independent
-- `version()` — always semver
-
-#### Examples
-
-```rust
-// English (default)
-let tool = mykit::ToolBuilder::new().build();
-assert_eq!(tool.name(), "web_fetch");
-assert_eq!(tool.display_name(), "Web Fetch");
-assert_eq!(tool.version(), "0.1.3");
-assert!(tool.description().starts_with("Fetch content from a URL"));
-
-// Ukrainian
-let tool_ua = mykit::ToolBuilder::new().locale("uk-UA").build();
-assert_eq!(tool_ua.name(), "web_fetch"); // unchanged
-assert_eq!(tool_ua.display_name(), "Веб-завантаження");
-assert!(tool_ua.description().starts_with("Завантажити вміст за URL"));
-```
-
-### 3. `ToolExecution` — runtime
-
-`ToolExecution` represents a single in-flight tool call. Created from `Tool`, it is stateful and single-use.
-
-```rust
-impl Tool {
-    /// Create an execution for the given arguments.
-    /// Validates args against input_schema() before returning.
-    fn execution(&self, args: serde_json::Value) -> Result<ToolExecution, ToolError>;
-}
-```
-
-#### Required: `execute()`
-
-```rust
-impl ToolExecution {
-    /// Run to completion. Consumes the execution.
-    async fn execute(self) -> Result<ToolOutput, ToolError>;
-}
-```
-
-If the tool needs an adapter (filesystem, file saver, etc.), provide a variant:
-
-```rust
-impl ToolExecution {
-    /// Run to completion with an injected adapter.
-    async fn execute_with<A: SomeAdapter>(self, adapter: &A) -> Result<ToolOutput, ToolError>;
-}
-```
-
-The base `execute()` must work without adapters (returning an error if an adapter-dependent feature was requested in args). This lets the consumer call `execute()` in context-free paths and `execute_with()` when context is available.
-
-#### Optional: cancellation
-
-Toolkits with long-running operations (bash scripts, multi-step fetches) may support cancellation:
-
-```rust
-impl ToolExecution {
-    /// Cancel the running execution.
-    /// Returns partial results collected so far, or None if nothing was produced yet.
-    async fn cancel(&self) -> Option<ToolOutput>;
-}
-```
-
-Design rules:
-- `cancel()` is safe to call multiple times (idempotent)
-- `cancel()` is safe to call concurrently with `execute()` — it signals cancellation, `execute()` returns promptly
-- Partial output follows the same `ToolOutput` shape (e.g. bashkit returns stdout collected so far, exit code -1)
-- If the kit does not support cancellation, omit the method entirely — the consumer falls back to dropping the future
-
-**bashkit example:** bash command running for 30s, user cancels at 5s. `cancel()` returns `ToolOutput { result: json!({"stdout": "partial output...", "exit_code": -1, "cancelled": true}), images: vec![] }`.
-
-#### Optional: streaming
-
-Toolkits that produce incremental output may expose a stream:
-
-```rust
-impl ToolExecution {
-    /// Stream incremental output chunks during execution.
-    /// The stream completes when execution finishes.
-    /// Final result is still returned from execute().
-    fn output_stream(&self) -> impl Stream<Item = ToolOutputChunk>;
-}
-
-pub struct ToolOutputChunk {
-    /// Incremental content (e.g. stdout line, fetched bytes, progress update)
-    pub data: serde_json::Value,
-    /// Chunk type for consumer routing (e.g. "stdout", "stderr", "progress")
-    pub kind: String,
-}
-```
-
-Design rules:
-- Streaming is opt-in — if the kit doesn't support it, omit the method
-- `output_stream()` must be called **before** `execute()` — it returns a receiver, `execute()` drives the sender
-- The stream is informational — the consumer uses it for live UI updates (e.g. streaming bash output to the terminal panel)
-- The final `ToolOutput` from `execute()` is the authoritative result, not the concatenation of chunks
-- If `cancel()` is called, the stream ends and `execute()` returns the partial result
-
-**bashkit example:** streaming stdout/stderr line by line as the bash command runs.
-
-**fetchkit example:** streaming download progress (`{"bytes_received": 1024, "total": 50000}`).
-
-### 4. Adapter traits
-
-When a toolkit needs a consumer-provided integration point (filesystem, file saver, HTTP client, etc.), it defines an adapter trait:
-
-```rust
-/// Trait name describes the capability, not the consumer.
-/// e.g. `FileSaver`, `FileSystem` — not `SessionFileSaver`.
-#[async_trait]
-pub trait AdapterTrait: Send + Sync {
-    async fn method(&self, ...) -> Result<..., AdapterError>;
-}
-```
-
-Rules:
-- Trait is defined in the toolkit crate, implemented by the consumer
-- Trait is `Send + Sync` (adapters are shared across async tasks)
-- Trait uses the toolkit's own error type or a dedicated adapter error type
-- Toolkit may ship a default implementation for common cases (e.g. `LocalFileSaver` in fetchkit)
-
-### 5. Error types
-
-Every toolkit defines its own error enum. Errors must be **actionable** (tell the LLM/user what to do differently) and **never expose internals** (no stack traces, no internal paths, no library names).
-
-```rust
-#[derive(Debug, thiserror::Error)]
-pub enum ToolError {
-    /// Errors safe to show to the LLM — actionable, no internal details.
-    /// Localized per builder locale.
-    #[error("...")]
-    UserFacing(String),
-
-    /// Internal failures — logged by consumer, never shown to LLM.
-    /// Not localized (English-only, for operator logs).
-    #[error("...")]
-    Internal(String),
-
-    // Kit-specific variants are fine, but must be classifiable:
-}
-
-impl ToolError {
-    /// Whether this error is safe to show to the LLM.
-    fn is_user_facing(&self) -> bool;
-}
-```
-
-The consumer maps these to `ToolExecutionResult::ToolError` or `ToolExecutionResult::InternalError` using `is_user_facing()`.
-
-#### Error message rules
-
-**User-facing errors** (shown to LLM):
-- Actionable: say what went wrong and how to fix it
-- No internal details: no file paths, no library names, no stack traces
-- Localized per builder locale
-- Short — one sentence
-
-```
-// Good
-"url is required"
-"URL scheme must be http or https"
-"Server did not respond within 1s. Retry or try a different URL."
-"Cannot save file: save_to_file requires the FileSaver adapter"
-
-// Bad
-"reqwest::Error: connection refused at 10.0.0.1:443"
-"NullPointerException in FetchHandler.java:142"
-"Error: Os { code: 2, kind: NotFound, message: \"No such file\" }"
-```
-
-**Internal errors** (logged, hidden from LLM):
-- Full details for debugging (stack traces, internal paths, etc.)
-- Always English (operator logs)
-- Consumer replaces with generic message before returning to LLM
-
-### 6. Output type
-
-Execution returns a structured output with a clear split between what goes to the LLM and what stays with the consumer:
-
-```rust
-pub struct ToolOutput {
-    /// JSON result sent to the LLM.
-    pub result: serde_json::Value,
-
-    /// Optional images sent to the LLM as native image content blocks.
-    pub images: Vec<ToolImage>,
-
-    /// Metadata for the consumer/platform — never sent to the LLM.
-    /// Toolkits attach diagnostics, metrics, and operational data here.
-    pub metadata: ToolOutputMetadata,
-}
-
-pub struct ToolImage {
-    pub base64: String,
-    pub media_type: String,
-}
-
-/// Operational metadata that stays with the consumer.
-/// None of this reaches the LLM context window.
-pub struct ToolOutputMetadata {
-    /// Execution wall-clock duration.
-    pub duration: std::time::Duration,
-
-    /// Kit-specific metadata as JSON.
-    /// Examples: HTTP status code, response headers, bytes transferred,
-    /// commands executed, exit codes, filesystem operations count.
-    pub extra: serde_json::Value,
-}
-```
-
-If the tool never returns images, `images` is always empty. The consumer maps `ToolOutput` to `ToolExecutionResult::Success` or `ToolExecutionResult::SuccessWithImages`.
-
-**Metadata contract:** `metadata` is for the consumer (logging, billing, UI, analytics) — never serialized into the LLM tool result. The consumer decides what to do with it:
-
-```rust
-// Consumer side — metadata goes to tracing/events, not to LLM
-fn map_output(output: mykit::ToolOutput) -> ToolExecutionResult {
-    tracing::info!(
-        duration_ms = output.metadata.duration.as_millis(),
-        extra = %output.metadata.extra,
-        "tool execution complete"
-    );
-    // Only result + images go to the LLM
-    ToolExecutionResult::success(output.result)
-}
-```
-
-**Kit-specific metadata examples:**
-
-```rust
-// fetchkit
-json!({
-    "http_status": 200,
-    "content_type": "text/html",
-    "content_length": 48230,
-    "redirects": 1,
-    "truncated": true
-})
-
-// bashkit
-json!({
-    "exit_code": 0,
-    "commands_executed": 3,
-    "fs_reads": 5,
-    "fs_writes": 2
-})
-```
-
-### 7. Re-exports
-
-Toolkit crates re-export all types needed to implement adapter traits and handle results from `lib.rs`. Consumer code should only need `use mykit::{...}` — no reaching into submodules.
-
-```rust
-// mykit/src/lib.rs
-pub use tool::{ToolBuilder, Tool, ToolExecution, ToolOutput, ToolOutputChunk, ToolImage};
-pub use error::ToolError;
-pub use adapters::{AdapterTrait, AdapterError, DefaultAdapter};
-// Any types needed to implement AdapterTrait:
-pub use adapters::{SaveResult, Metadata, DirEntry, ...};
-```
-
-### 8. No everruns dependency
-
-Toolkit crates must not depend on `everruns-core` or any everruns crate. They are standalone libraries. The integration boundary is:
-
-```
-toolkit crate (standalone)       everruns-core             other consumers
-├── ToolBuilder                  ├── XxxCapability          ├── build_executor()
-│   ├── build() → Tool           │   └── builds Tool        │   └── Value in → Value out
-│   ├── build_executor()         ├── XxxTool                ├── build_tool_definition()
-│   ├── build_tool_definition()  │   ├── delegates metadata │   └── OpenAI function JSON
-│   ├── build_input_schema()     │   ├── creates Execution  ├── build_input_schema()
-│   └── build_output_schema()    │   ├── wires cancel/stream└── build_output_schema()
-├── Tool (metadata+version)      │   └── maps to everruns
-├── ToolExecutor (Value→Value)   └── AdapterImpl
-├── ToolExecution (stateful)         └── bridges to SessionFileSystem
-│   ├── execute()
-│   ├── cancel() [optional]
-│   └── output_stream() [opt]
-├── AdapterTrait
-├── Error types
-└── Output types
-```
-
-### 9. Request signing for HTTP-capable kits
-
-Any toolkit that makes outbound HTTP requests **must** support request signing per [RFC 9421 (HTTP Message Signatures)](https://www.rfc-editor.org/rfc/rfc9421) using the [Web Bot Authentication Architecture](https://datatracker.ietf.org/doc/html/draft-meunier-web-bot-auth-architecture) profile. This lets target servers verify bot identity cryptographically.
-
-Reference implementation: fetchkit's `bot-auth` feature. See `specs/fetchkit.md` and `docs/advanced/request-signing.md`.
-
-#### Contract
-
-1. **Feature-gated** — signing support lives behind a cargo feature (e.g. `bot-auth`). When the feature is disabled, no crypto dependencies are compiled in and no signing code runs.
-
-2. **`BotAuthConfig` on `ToolBuilder`** — the builder accepts an optional signing config:
-
-   ```rust
-   impl ToolBuilder {
-       /// Enable request signing. When set, all outbound HTTP requests
-       /// are signed with Ed25519 per RFC 9421 / web-bot-auth profile.
-       /// When None, requests are sent unsigned.
-       fn bot_auth(self, config: BotAuthConfig) -> Self;
-   }
-   ```
-
-3. **`BotAuthConfig` shape** — kit defines its own config struct matching this shape:
-
-   ```rust
-   pub struct BotAuthConfig {
-       /// Ed25519 signing key (32-byte seed, base64url-encoded).
-       pub signing_key_seed: String,
-       /// Optional FQDN for the `Signature-Agent` header.
-       /// Tells target servers where to discover the public key.
-       pub agent_fqdn: Option<String>,
-       /// Signature validity window in seconds. Default: 300.
-       pub validity_secs: Option<u64>,
-   }
-   ```
-
-4. **Signing behavior** — when `BotAuthConfig` is present:
-   - Every outbound HTTP request gets `Signature` and `Signature-Input` headers
-   - If `agent_fqdn` is set, a `Signature-Agent` header is added
-   - Covered components: `@authority` at minimum
-   - Algorithm: Ed25519 (`alg="ed25519"`)
-   - Key identity: JWK Thumbprint (RFC 7638) as `keyid`
-   - Tag: `"web-bot-auth"`
-   - Nonce: random per request
-   - Timestamps: `created` (now) and `expires` (now + validity_secs)
-
-5. **Non-blocking** — signing failures (clock errors, key issues) **must not** block the request. The kit logs a warning and sends the request unsigned. This preserves tool availability.
-
-6. **Public key derivation** — kits that accept a seed must expose a function to derive the public key identity, so the consumer can serve it at the well-known endpoint:
-
-   ```rust
-   /// Derive the Ed25519 public key and JWK Thumbprint from a base64url seed.
-   pub fn derive_bot_auth_public_key(seed: &str) -> Result<BotAuthPublicKey, Error>;
-
-   pub struct BotAuthPublicKey {
-       /// JWK Thumbprint (RFC 7638) — used as `keyid` in signatures.
-       pub key_id: String,
-       /// Full JWK object (OKP/Ed25519) for inclusion in JWKS responses.
-       pub jwk: serde_json::Value,
-   }
-   ```
-
-7. **No everruns dependency** — the signing implementation lives entirely in the kit crate. The consumer (everruns) reads env vars (`BOT_AUTH_SIGNING_KEY_SEED`, `BOT_AUTH_AGENT_FQDN`, `BOT_AUTH_VALIDITY_SECS`), constructs `BotAuthConfig`, and passes it to the builder. The consumer also serves the well-known key directory endpoint using the derived public key.
-
-#### Consumer wiring
-
-```rust
-// crates/core/src/capabilities/xxx.rs
-fn tool_from_config(config: &Value) -> mykit::Tool {
-    let mut builder = mykit::ToolBuilder::new();
-
-    // Wire bot-auth from env if available
-    if let Ok(seed) = std::env::var("BOT_AUTH_SIGNING_KEY_SEED") {
-        builder = builder.bot_auth(mykit::BotAuthConfig {
-            signing_key_seed: seed,
-            agent_fqdn: std::env::var("BOT_AUTH_AGENT_FQDN").ok(),
-            validity_secs: std::env::var("BOT_AUTH_VALIDITY_SECS")
-                .ok()
-                .and_then(|v| v.parse().ok()),
-        });
-    }
-
-    builder.build()
-}
-```
-
-#### Kits without HTTP
-
-Toolkits that never make outbound HTTP requests (e.g. bashkit) do not need to implement this section. The requirement applies only when the kit's tools issue HTTP calls as part of execution.
-
-## Consumer integration pattern
-
-With this contract, every capability wrapper follows the same structure:
-
-```rust
-// crates/core/src/capabilities/xxx.rs
-
-use mykit;
-
-pub struct XxxCapability;
-
-impl Capability for XxxCapability {
-    fn id(&self) -> &str { "xxx" }
-    fn name(&self) -> &str { "Xxx" }
-    fn description(&self) -> &str { "..." }
-
-    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(XxxTool::new(config))]
-    }
-
-    fn system_prompt_preview(&self) -> Option<String> {
-        let tool = mykit::ToolBuilder::new().some_feature(true).build();
-        Some(tool.system_prompt())
-    }
-
-    async fn system_prompt_contribution_with_config(
-        &self, _ctx: &SystemPromptContext, config: &Value,
-    ) -> Option<String> {
-        let tool = tool_from_config(config);
-        Some(format!("<capability id=\"{}\">\n{}\n</capability>", self.id(), tool.system_prompt()))
-    }
-}
-
-/// Helper: config JSON → built Tool
-fn tool_from_config(config: &Value, locale: &str) -> mykit::Tool {
-    let feature = config.get("some_feature").and_then(|v| v.as_bool()).unwrap_or(false);
-    mykit::ToolBuilder::new()
-        .locale(locale)
-        .some_feature(feature)
-        .build()
-}
-
-pub struct XxxTool {
-    kit_tool: mykit::Tool,
-}
-
-impl XxxTool {
-    fn new(config: &Value) -> Self {
-        Self { kit_tool: tool_from_config(config) }
-    }
-}
-
-#[async_trait]
-impl Tool for XxxTool {
-    fn name(&self) -> &str { self.kit_tool.name() }
-    fn display_name(&self) -> Option<&str> { Some(self.kit_tool.display_name()) }
-    fn description(&self) -> &str { self.kit_tool.description() }
-    fn parameters_schema(&self) -> Value { self.kit_tool.input_schema() }
-
-    async fn execute(&self, args: Value) -> ToolExecutionResult {
-        let execution = match self.kit_tool.execution(args) {
-            Ok(exec) => exec,
-            Err(e) => return map_error(e),
-        };
-        match execution.execute().await {
-            Ok(output) => map_output(output),
-            Err(e) => map_error(e),
-        }
-    }
-
-    async fn execute_with_context(&self, args: Value, ctx: &ToolContext) -> ToolExecutionResult {
-        let execution = match self.kit_tool.execution(args) {
-            Ok(exec) => exec,
-            Err(e) => return map_error(e),
-        };
-        let adapter = MyAdapter::from_context(ctx);
-        match execution.execute_with(&adapter).await {
-            Ok(output) => map_output(output),
-            Err(e) => map_error(e),
-        }
-    }
-}
-
-fn map_output(output: mykit::ToolOutput) -> ToolExecutionResult {
-    // Metadata stays with consumer — log, emit events, never send to LLM
-    tracing::debug!(
-        duration_ms = output.metadata.duration.as_millis(),
-        extra = %output.metadata.extra,
-    );
-    if output.images.is_empty() {
-        ToolExecutionResult::success(output.result)
-    } else {
-        ToolExecutionResult::success_with_images(output.result, /* map images */)
-    }
-}
-
-fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
-    if e.is_user_facing() {
-        ToolExecutionResult::tool_error(e.to_string())
-    } else {
-        ToolExecutionResult::internal_error_msg(e.to_string())
-    }
-}
-```
-
-## Existing implementations
-
-- **bashkit** — `github.com/everruns/bashkit` (bash sandbox tool, cancel + streaming)
-- **fetchkit** — `crates.io/crates/fetchkit` (HTTP fetch tool, file saver adapter)
-
-## Non-goals
-
-- **Shared trait crate**: No `toolkit-common` dependency. Each kit defines its own types following the same shape. This avoids coupling kit release cycles.
-- **Generic tool registration**: The consumer still writes a thin `XxxCapability` + `XxxTool` wrapper. The contract just makes that wrapper predictable and mechanical.
-- **Versioning contract**: Kits version independently. Breaking changes to the contract surface are communicated via this spec, not semver of a shared crate.
+Toolkit errors distinguish safe, actionable caller errors from internal
+failures.
+
+Safe errors are concise, localized when appropriate, and explain how the caller
+can correct the request. They do not expose dependency names, stack traces,
+internal paths, credentials, or debug dumps of prompt-sized values.
+
+Internal failures retain diagnostic detail for operator logs but are mapped to
+a generic model-visible failure by the consumer. The integration uses the
+toolkit's classification rather than matching error strings.
+
+Interpreter-backed toolkits own output hygiene at the source. Everruns may add
+defense-in-depth truncation, but that does not justify verbose debug rendering
+inside the toolkit.
+
+## Output separation
+
+Execution output has two audiences:
+
+- model-visible result content and supported native media;
+- host-only operational metadata such as duration, status, bytes transferred,
+  redirects, command counts, or filesystem activity.
+
+Host-only metadata may feed traces, events, billing, or UI diagnostics. It must
+not be serialized into the model's tool result unless the toolkit explicitly
+defines it as part of the result contract.
+
+Everruns maps native images into model content blocks and maps ordinary results
+into the runtime's success type. The exact output structs are defined by the
+pinned toolkit versions and should not be repeated here.
+
+## HTTP request signing
+
+HTTP-capable toolkits support optional RFC 9421 message signatures using the
+Web Bot Authentication profile. Non-HTTP toolkits are exempt.
+
+The durable requirements are:
+
+- signing is feature-gated so unused cryptography is not compiled;
+- the host can provide an Ed25519 seed, optional agent identity, and validity
+  window;
+- signed requests cover the authority and carry the profile's algorithm,
+  key identity, tag, nonce, and timestamps;
+- public-key/JWK derivation is available to the host for discovery endpoints;
+- signing is performed inside the toolkit before the request reaches an
+  injected transport;
+- invalid signing configuration disables signing with an operator-visible
+  warning rather than making the underlying tool unavailable;
+- secrets and private key material never enter tool output, events, or logs.
+
+The exact config and key types belong to the toolkit. Fetchkit's current
+implementation and [`fetchkit.md`](fetchkit.md) are the reference, while
+[`docs/advanced/request-signing.md`](../docs/advanced/request-signing.md)
+documents operator-facing setup.
+
+## Everruns integration rules
+
+An Everruns capability wrapper should:
+
+1. build the toolkit with capability configuration and locale;
+2. delegate name, display metadata, schema, hints, and prompt contribution;
+3. add only Everruns-owned schema or prompt behavior;
+4. inject session filesystem or egress adapters at execution time;
+5. map safe and internal errors through the toolkit's classification;
+6. keep operational metadata out of the model-visible result;
+7. test delegated schema and critical policy wiring against the pinned toolkit.
+
+Current integration patterns live in the bashkit and fetchkit capability
+modules linked above. Those modules, their tests, upstream toolkit docs, and the
+lockfile are authoritative when this convention and a released API appear to
+disagree.
+
+## Independence
+
+Toolkit crates do not depend on Everruns crates. Each kit releases
+independently and may serve other runtimes. Everruns owns a thin adapter, not a
+fork of the toolkit's schema or runtime.
+
+A shared `toolkit-common` crate is intentionally not required. Consistency is a
+design convention; forcing all kits onto one release cycle would defeat their
+standalone role.


### PR DESCRIPTION
## What changed
Reworked the seven remaining high-duplication specs into durable behavioral contracts with direct links to their canonical Rust source, migrations, generated OpenAPI, upstream toolkit docs, and contract tests.

The event wire examples now live with generated OpenAPI and executable contract tests; `events.md` retains compatibility, lifecycle, projection, storage, streaming, and privacy guarantees. The audit also removes stale copied claims across multitenancy, domains, evals, blueprints, toolkits, and client-side tools.

## Why
Copied field tables, Rust definitions, SQL, payload dumps, route inventories, and current-status lists had already drifted from the implementation. That made the specs less reliable than the source they attempted to duplicate and violated the repository's spec-hygiene rule.

## Before / After
Before: the seven specs totaled 4,868 lines and contained copied implementation shapes. Confirmed drift included a missing event `sequence` field and event types, contradictory multitenancy role/cookie claims, an incomplete command error set and policy-bypassing adapter example, missing eval scorers/routes, and obsolete client-tool wire shapes.

After: the seven specs total 1,471 lines, all relative source links resolve, and none contains Rust, JSON, SQL, protobuf, TypeScript, HTTP, or JavaScript implementation blocks. Exact SDK wire shapes point to `docs/api/openapi.json` and contract tests.

No runtime behavior changes; runtime smoke testing was skipped because this PR changes specifications only.

Validation:
- `just pre-push`
- relative Markdown source-link audit
- targeted implementation-block audit
- `git diff --check`

## Risk
- Low
- A durable design guarantee could be lost during condensation, or a source link could later move. The review preserved behavioral/security invariants and verified every current link.

## Security
- Threat categories reviewed: No security-relevant code changes. This is a specification-only rewrite; authentication, authorization, tenancy, API, tool, filesystem, and execution implementations are unchanged.
- Findings and resolutions: Removed stale security-adjacent claims rather than inventing implementation guarantees, including obsolete client-tool ID/size validation promises. No new threat surface or mitigation change.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — not applicable; specification-only change, validated with repository and spec-specific checks
- [x] Backward compatibility considered — no runtime or wire behavior changed
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — final post-green sweep found none
