### PR TITLE
chore(deps): bump fast-uri to 3.1.4 in apps/docs

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -36,6 +36,7 @@
     "overrides": {
       "@astrojs/mdx": "6.0.2",
       "esbuild": "0.28.1",
+      "fast-uri": "3.1.4",
       "form-data": "4.0.6",
       "lodash": "4.17.23",
       "yaml": "2.8.4"

--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@astrojs/mdx': 6.0.2
   esbuild: 0.28.1
+  fast-uri: 3.1.4
   form-data: 4.0.6
   lodash: 4.17.23
   yaml: 2.8.4
@@ -1469,8 +1470,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3748,7 +3749,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4189,7 +4190,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/apps/docs/pnpm-workspace.yaml
+++ b/apps/docs/pnpm-workspace.yaml
@@ -2,7 +2,10 @@ packages: []
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 # Security patches adopted before the maturity window (Dependabot GHSA fixes):
-# form-data 4.0.6 (GHSA-hmw2-7cc7-3qxx), esbuild 0.28.1 (GHSA-g7r4-m6w7-qqqr).
+# form-data 4.0.6 (GHSA-hmw2-7cc7-3qxx), esbuild 0.28.1 (GHSA-g7r4-m6w7-qqqr),
+# fast-uri 3.1.4 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6; only
+# patched release, still inside the 7-day window). Exact-pinned via overrides.
 minimumReleaseAgeExclude:
   - form-data
   - esbuild
+  - fast-uri


### PR DESCRIPTION
## What changed
Pins **fast-uri** to 3.1.4 in the `apps/docs` tree (via `pnpm.overrides`), clearing the one `pnpm audit` finding there: GHSA-v2hh-gcrm-f6hx (host confusion via literal IPv6), reached transitively through `@astrojs/check > @astrojs/language-server > volar-service-yaml > yaml-language-server > ajv > fast-uri` (3.1.3 → 3.1.4).

3.1.4 is the only patched release for this advisory and is still inside the 7-day `minimumReleaseAge` window, so it gets a single exact-pinned `minimumReleaseAgeExclude` entry (documented in `pnpm-workspace.yaml`), matching the existing pattern for `form-data`/`esbuild`.

## Why
`pnpm audit` flagged fast-uri (high) in `apps/docs`.

## Before / After
- **Before:** `pnpm audit` → `1 vulnerabilities found (1 high)`
- **After:** `pnpm audit` → `No known vulnerabilities found`
- Verified: `astro build` builds all 461 pages and postbuild notebook verification passes; `pnpm install --frozen-lockfile` is consistent. Lockfile diff is limited to fast-uri.

## Risk
- Low
- Patch bump on a transitive dev-tooling dependency (astro type-checker). No docs content or config changed.

## Security
- Threat categories reviewed: dependency/supply-chain. Exact-pinned override; the in-window exemption cannot pull any other freshly-published version.
- Findings and resolutions: 1 GHSA advisory → resolved.

## Follow-ups
Companion PR #2888 clears the `apps/ui` npm tree. Remaining Dependabot alerts on cargo/docker are triaged separately (GitHub's Dependabot/code-scanning REST APIs are not accessible to this session's token; enumeration is via local audits).

## Checklist
- [x] Tests added or updated (N/A — dependency bump; verified via audit + build)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA1pdgLkdHoBEB5KSghk4M)_