### PR TITLE
chore(release): prepare v0.17.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.17] - 2026-07-25
+
+### Highlights
+
+- **Claude Opus 5** - Adds model support and makes it the platform default ([#2885](https://github.com/everruns/everruns/pull/2885)).
+- **Tool narration** - Adds narration for session and built-in tool activity ([#2878](https://github.com/everruns/everruns/pull/2878)).
+- **Security and reliability fixes** - Hardens prompt rewriting, MCP OAuth grants, provider bindings, secret redaction, and signup URLs ([#2876](https://github.com/everruns/everruns/pull/2876), [#2877](https://github.com/everruns/everruns/pull/2877), [#2879](https://github.com/everruns/everruns/pull/2879), [#2880](https://github.com/everruns/everruns/pull/2880), [#2882](https://github.com/everruns/everruns/pull/2882)).
+- **Citations by default** - Enables citations in the generic harness ([#2865](https://github.com/everruns/everruns/pull/2865)).
+
+### What's Changed
+
+- chore(deps): bump fast-uri to 3.1.4 in apps/docs ([#2889](https://github.com/everruns/everruns/pull/2889)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump vulnerable ui transitive deps ([#2888](https://github.com/everruns/everruns/pull/2888)) by [@chaliy](https://github.com/chaliy)
+- chore(specs): remove duplicated implementation detail ([#2887](https://github.com/everruns/everruns/pull/2887)) by [@chaliy](https://github.com/chaliy)
+- chore(agents): apply Claude 5 context engineering to agent docs ([#2886](https://github.com/everruns/everruns/pull/2886)) by [@chaliy](https://github.com/chaliy)
+- feat(models): add Claude Opus 5 and make it the platform default ([#2885](https://github.com/everruns/everruns/pull/2885)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add tool narration for session and built-in tools ([#2878](https://github.com/everruns/everruns/pull/2878)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): prevent prompt rewrite history bypass ([#2876](https://github.com/everruns/everruns/pull/2876)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): redact structured dataset secrets ([#2880](https://github.com/everruns/everruns/pull/2880)) by [@chaliy](https://github.com/chaliy)
+- fix(server): bind MCP OAuth grants to provider authority ([#2877](https://github.com/everruns/everruns/pull/2877)) by [@chaliy](https://github.com/chaliy)
+- fix(session-tasks): preserve root session on updates ([#2884](https://github.com/everruns/everruns/pull/2884)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): reject disabled service bindings ([#2879](https://github.com/everruns/everruns/pull/2879)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): preserve literal workspace display paths ([#2883](https://github.com/everruns/everruns/pull/2883)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): keep signup email out of urls ([#2882](https://github.com/everruns/everruns/pull/2882)) by [@chaliy](https://github.com/chaliy)
+- fix(cli): truncate table cells on UTF-8 boundaries ([#2881](https://github.com/everruns/everruns/pull/2881)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): upgrade docs and security tooling ([`80a0085`](https://github.com/everruns/everruns/commit/80a0085e53a8a9c26090481506d5bce703f3cccd))
+- chore(deps): bump next from 16.2.10 to 16.2.11 in apps/ui ([#2874](https://github.com/everruns/everruns/pull/2874)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates ([#2871](https://github.com/everruns/everruns/pull/2871)) by [@app/dependabot](https://github.com/apps/dependabot)
+- feat(harness): enable citations by default in the generic harness ([#2865](https://github.com/everruns/everruns/pull/2865)) by [@chaliy](https://github.com/chaliy)
+
+
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
 ## [0.17.16] - 2026-07-22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.16"
+version = "0.17.17"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3159,11 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.16"
+version = "0.17.17"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.16"
+version = "0.17.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.16"
+version = "0.17.17"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.16" }
-everruns-provider = { path = "crates/provider", version = "0.17.16" }
+everruns-core = { path = "crates/core", version = "0.17.17" }
+everruns-provider = { path = "crates/provider", version = "0.17.17" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.16" }
-everruns-ard = { path = "crates/ard", version = "0.17.16" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.17" }
+everruns-ard = { path = "crates/ard", version = "0.17.17" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.16" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.17" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.16",
+  "version": "0.17.17",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.16" }
+everruns-provider = { path = "../provider", version = "0.17.17" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.16" }
+everruns-provider = { path = "../provider", version = "0.17.17" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.16", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.17", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.16", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.17", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.16" }
+everruns-provider = { path = "../provider", version = "0.17.17" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.16" }
+everruns-provider = { path = "../provider", version = "0.17.17" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.16" }
+everruns-provider = { path = "../provider", version = "0.17.17" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## Summary
- bump workspace and UI versions to `0.17.17`
- update publish-time dependency pins and lockfile
- document release highlights and the complete change list

## Testing
- `just pre-push`
- `/opt/homebrew/bin/python3.12 scripts/sync-publish-pin-versions.py --check`
- `git diff --check`

## Security
Release metadata and version-only changes. No code, configuration, infrastructure, auth, persistence, or external-input handling changes are introduced by this PR. Reviewed the release delta for accidental secret or security-sensitive changes; none found.

## Documentation
`CHANGELOG.md` contains the release highlights and full change list. No migration notes are required because there are no migrations since `v0.17.16`.

## Follow-ups
No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
