### PR TITLE
fix(compaction): preserve stateful request delta

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -616,7 +616,6 @@ async fn try_apply_native_compaction(
     model: &str,
     system_prompt: Option<&str>,
     stateful_response_continuation: bool,
-    previous_response_id: Option<String>,
     llm_messages: &mut Vec<LlmMessage>,
     llm_config: &mut crate::driver_registry::LlmCallConfig,
 ) -> Result<Option<AppliedNativeCompaction>> {
@@ -650,13 +649,10 @@ async fn try_apply_native_compaction(
                 .map(|value| value.len() as u64)
         })
         .flatten();
-    let (input, compact_previous_response_id) = if has_prior_opaque_context {
-        (standalone_input, None)
-    } else if stateful_response_continuation {
-        (Vec::new(), previous_response_id)
-    } else {
-        (standalone_input, None)
-    };
+    // Reconstruct standalone input even for a stateful continuation. Compacting
+    // only the previous response handle would omit the fresh request delta, then
+    // clearing that handle for the retry would make the omission permanent.
+    let (input, compact_previous_response_id) = (standalone_input, None);
 
     let compact_response = match chat_driver
         .compact(CompactRequest {
@@ -2289,7 +2285,6 @@ impl ReasonAtom {
                     &model_with_provider.model,
                     has_system_prompt.then_some(runtime_agent.system_prompt.as_str()),
                     false,
-                    None,
                     &mut llm_messages_for_call,
                     &mut llm_config,
                 )
@@ -2512,7 +2507,6 @@ impl ReasonAtom {
                             &model_with_provider.model,
                             has_system_prompt.then_some(runtime_agent.system_prompt.as_str()),
                             stateful_response_continuation,
-                            previous_response_id.clone(),
                             &mut llm_messages_for_call,
                             &mut llm_config,
                         )

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -916,11 +916,14 @@ async fn native_compact_retry_reuses_ordered_opaque_output_without_previous_resp
         .await
         .clone()
         .expect("compact request should be captured");
-    assert!(compact_request.input.is_empty());
-    assert_eq!(
-        compact_request.previous_response_id.as_deref(),
-        Some("resp_before_compaction")
-    );
+    assert!(compact_request.previous_response_id.is_none());
+    assert_eq!(compact_request.input.len(), 1);
+    assert!(matches!(
+        &compact_request.input[0],
+        everruns_core::CompactInputItem::Message { role, content }
+            if role == "user"
+                && matches!(content, everruns_core::CompactContent::Text(text) if text == "latest delta")
+    ));
 
     let public_events = serde_json::to_string(&event_emitter.events().await).unwrap();
     assert!(!public_events.contains("encrypted-compact-context"));

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -101,11 +101,11 @@ message/tool pruning over them. The next matching provider request uses that
 array directly as `input`; `previous_response_id` is cleared because the
 standalone checkpoint replaces the earlier server-side continuation chain.
 
-The compact request itself uses exactly one source of conversation context. A
-stateful Responses continuation sends `previous_response_id` with empty
-`input`. A stateless request sends reconstructed `input` without
-`previous_response_id`. System instructions remain a separate request field in
-both cases.
+The compact request itself uses reconstructed standalone `input` without
+`previous_response_id`, including for a stateful Responses continuation. This
+preserves the fresh request delta when the retry replaces the server-side
+continuation chain with the compact output. System instructions remain a
+separate request field.
 
 Opaque compact content is provider transport state, not a public event payload.
 Compaction events expose counts, strategy, duration, and usage metadata only.
@@ -114,7 +114,8 @@ Stateful `previous_response_id` requests are deltas over provider-held context.
 The reconstructed lossless transcript is therefore not a valid local pressure
 measurement for proactive policy. In the absence of authoritative provider
 usage for that server-side context, the runtime skips local proactive
-compaction and retains reactive `RequestTooLarge` recovery by stateful handle.
+compaction and retains reactive `RequestTooLarge` recovery using reconstructed
+standalone input.
 
 Observation masking remains a model-view cost optimization. It may reduce an
 outbound request without replacing semantic history, and by itself does not


### PR DESCRIPTION
### Motivation
- Reactive native compaction previously sent an empty `input` with only `previous_response_id` for stateful continuations, which could drop the fresh user/tool-result delta when the retry cleared the continuation handle.
- Dropping the current delta can silently ignore user cancellations or recent tool safety results, so the runtime must preserve the delta across compaction retries.

### Description
- Change `try_apply_native_compaction` to always reconstruct and send the standalone `input` (the transcript-derived delta) and to use `previous_response_id = None` for the compact request so the retry preserves the fresh delta instead of omitting it (`crates/core/src/atoms/reason.rs`).
- Remove the `previous_response_id` argument usage from the compaction call sites so compaction no longer depends on provider-held continuation state for the reactive path (`crates/core/src/atoms/reason.rs`).
- Strengthen the regression test `native_compact_retry_reuses_ordered_opaque_output_without_previous_response_id` to assert the compact request contains the latest user message and that `previous_response_id` is cleared (`crates/core/tests/reason_atom_test.rs`).
- Update `specs/compaction.md` to document that compact requests use reconstructed standalone `input` (no `previous_response_id`) for stateful recovery.

### Testing
- Ran `cargo fmt --check` — passed.
- Ran `cargo test -p everruns-core --test reason_atom_test native_compact_retry_reuses_ordered_opaque_output_without_previous_response_id` — passed (1 test).
- Ran `cargo clippy -p everruns-core --test reason_atom_test --all-features -- -D warnings` — passed.
- Ran `cargo test -p everruns-core --test openresponses_protocol_wire native_compact_context_is_the_exact_ordered_responses_input` — failed due to the local wiremock server closing before the request (reproduced locally); this is an existing environmental flake, not the compaction logic.
- Ran `just pre-push` — formatting step passed; full repository-wide checks were interrupted before completion due to long dependency builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301744d14832bbd856892f2b34207)