### PR TITLE
fix(citations): guard citation metadata output

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -54,6 +54,7 @@ use crate::openresponses_protocol::{CompactRequest, messages_to_compact_input};
 use crate::output_guardrail::{
     ArmedGuardrail, OutputGuardrailContext, PostGenerationOutputContext, PostGenerationProvider,
     TrippedGuardrail, evaluate_guardrails, evaluate_post_generation_guardrails,
+    post_generation_guardrail_text,
 };
 use crate::runtime_context::{AssembledTurnContext, assemble_turn_context};
 use crate::tool_types::{ToolCall, ToolDefinition};
@@ -3192,26 +3193,10 @@ impl ReasonAtom {
         let (mut text, mut thinking, thinking_signature, mut tool_calls) =
             (text, thinking, thinking_signature, tool_calls);
 
-        // End-of-message output guardrail seam (EVE-573). Runs once on the
-        // finalized assistant text after streaming completes, before the
-        // message is built into context. Async, time-bounded, and fail-open
-        // (each provider owns its own timeout). Skipped when the streaming seam
-        // already tripped (the message is already a replacement), when there
-        // are no post-generation providers, or when there is no assistant text.
-        // A trip here reuses the same replacement/emit path as the streaming
-        // seam below, so the original tokens are never persisted.
-        if tripped.is_none() && !post_output_providers.is_empty() && !text.is_empty() {
-            let ctx = PostGenerationOutputContext {
-                system_prompt: &runtime_agent.system_prompt,
-                message_text: &text,
-                utility_llm_service: self.utility_llm_service.as_ref(),
-            };
-            tripped = evaluate_post_generation_guardrails(&post_output_providers, &ctx).await;
-        }
-
         // End-of-message citation annotation seam (see specs/citations.md). Runs
-        // once on the finalized final-answer text after guardrails allow it, to
-        // attach claim-level citations. Skipped when a guardrail already tripped,
+        // once on the finalized final-answer text to attach claim-level citations
+        // before guardrails inspect the complete client-visible payload. Skipped
+        // when a guardrail already tripped,
         // when there are no citation providers, when there is no text, or while
         // the message still carries tool calls (citations attach to answer
         // prose, not intermediate tool-calling turns). The built-in feeds do not
@@ -3239,9 +3224,24 @@ impl ReasonAtom {
             text = collected.text;
             citation_annotations = collected.annotations;
 
+            // Post-generation guardrails must inspect citation metadata as well
+            // as prose because annotations are persisted and rendered to clients.
+            if !citation_annotations.is_empty() && !post_output_providers.is_empty() {
+                let guarded_output = post_generation_guardrail_text(&text, &citation_annotations);
+                let ctx = PostGenerationOutputContext {
+                    system_prompt: &runtime_agent.system_prompt,
+                    message_text: &guarded_output,
+                    utility_llm_service: self.utility_llm_service.as_ref(),
+                };
+                tripped = evaluate_post_generation_guardrails(&post_output_providers, &ctx).await;
+            }
+
             // Verification pass: stamp faithfulness verdicts on the collected
             // citations (no-op when no citation_verification capability is on).
-            if !citation_annotations.is_empty() && !citation_verifiers.is_empty() {
+            if tripped.is_none()
+                && !citation_annotations.is_empty()
+                && !citation_verifiers.is_empty()
+            {
                 citation_annotations = verify_annotations(
                     &citation_verifiers,
                     &text,
@@ -3250,6 +3250,25 @@ impl ReasonAtom {
                 )
                 .await;
             }
+        }
+
+        // Messages without citation annotations still cross the same
+        // post-generation output seam once.
+        if tripped.is_none()
+            && citation_annotations.is_empty()
+            && !post_output_providers.is_empty()
+            && !text.is_empty()
+        {
+            let ctx = PostGenerationOutputContext {
+                system_prompt: &runtime_agent.system_prompt,
+                message_text: &text,
+                utility_llm_service: self.utility_llm_service.as_ref(),
+            };
+            tripped = evaluate_post_generation_guardrails(&post_output_providers, &ctx).await;
+        }
+
+        if tripped.is_some() {
+            citation_annotations.clear();
         }
 
         // Release buffered text only after post-generation guardrails allow it.

--- a/crates/core/src/output_guardrail.rs
+++ b/crates/core/src/output_guardrail.rs
@@ -179,7 +179,8 @@ pub trait PostGenerationOutputGuardrail: Send + Sync {
     /// `output.message.replaced` event.
     fn id(&self) -> &str;
 
-    /// Inspect the finalized assistant message. Returns
+    /// Inspect the finalized client-visible assistant output, including
+    /// annotation metadata. Returns
     /// [`GuardrailDecision::Block`] to replace it; otherwise
     /// [`GuardrailDecision::Pass`]. Must fail open on any error.
     async fn check_message(&self, ctx: &PostGenerationOutputContext<'_>) -> GuardrailDecision;
@@ -190,7 +191,8 @@ pub trait PostGenerationOutputGuardrail: Send + Sync {
 pub struct PostGenerationOutputContext<'a> {
     /// The fully assembled system prompt for this turn.
     pub system_prompt: &'a str,
-    /// The finalized assistant message text (post-streaming, pre-context).
+    /// The finalized client-visible output (post-streaming, pre-context), with
+    /// persisted annotation metadata appended when present.
     pub message_text: &'a str,
     /// Utility LLM service for model-backed checks. `None` when the deployment
     /// has no utility model configured — model-backed checks then fail open.
@@ -202,6 +204,41 @@ pub struct PostGenerationOutputContext<'a> {
 pub struct PostGenerationProvider {
     pub capability_id: String,
     pub provider: Arc<dyn PostGenerationOutputGuardrail>,
+}
+
+/// Build the complete client-visible output inspected by post-generation
+/// guardrails. Citation metadata is persisted and rendered alongside the
+/// assistant text, so it must cross the same output policy boundary.
+pub fn post_generation_guardrail_text(
+    message_text: &str,
+    annotations: &[crate::message::TextAnnotation],
+) -> String {
+    if annotations.is_empty() {
+        return message_text.to_string();
+    }
+
+    let mut output = String::from(message_text);
+    for annotation in annotations {
+        output.push('\n');
+        output.push_str(&annotation.source.uri);
+        if let Some(title) = &annotation.source.title {
+            output.push('\n');
+            output.push_str(title);
+        }
+        if let Some(snippet) = &annotation.source.snippet {
+            output.push('\n');
+            output.push_str(snippet);
+        }
+        if let Some(location) = &annotation.source.location {
+            output.push('\n');
+            output.push_str(&location.to_string());
+        }
+        if let Some(external_id) = &annotation.external_id {
+            output.push('\n');
+            output.push_str(external_id);
+        }
+    }
+    output
 }
 
 /// Run post-generation guardrails in registration order, returning the first
@@ -229,6 +266,7 @@ pub async fn evaluate_post_generation_guardrails(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::{AnnotationSource, TextAnnotation};
 
     struct AlwaysBlock;
     impl OutputGuardrailRun for AlwaysBlock {
@@ -339,5 +377,30 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[test]
+    fn post_generation_text_includes_client_visible_citation_metadata() {
+        let annotations = vec![TextAnnotation {
+            start: 0,
+            end: 5,
+            origin: "citation_retrieval".to_string(),
+            source: AnnotationSource {
+                uri: "https://example.com/private".to_string(),
+                title: Some("Private roadmap".to_string()),
+                snippet: Some("password S3CR3T".to_string()),
+                location: Some(serde_json::json!({ "page": 4 })),
+            },
+            external_id: None,
+            verified: None,
+        }];
+
+        let output = post_generation_guardrail_text("An answer.", &annotations);
+
+        assert!(output.contains("An answer."));
+        assert!(output.contains("https://example.com/private"));
+        assert!(output.contains("Private roadmap"));
+        assert!(output.contains("password S3CR3T"));
+        assert!(output.contains(r#"{"page":4}"#));
     }
 }


### PR DESCRIPTION
### Motivation

- Close a confidentiality bypass where retrieval `snippet` text was attached to message annotations and rendered to clients after post-generation guardrails had already allowed the assistant prose. 

### Description

- Run citation collection before post-generation guardrails and include the client-visible citation payload (URI, title, snippet, location, external id) in the guardrail input by adding `post_generation_guardrail_text` and passing its output to `evaluate_post_generation_guardrails`. 
- If a post-generation guardrail blocks the combined output, clear citation annotations so sensitive retrieval snippets are not persisted or emitted. 
- Update the `PostGenerationOutputGuardrail` contract docs to explicitly cover persisted annotation metadata and add a unit test that asserts sensitive `snippet` content is included in the inspected output. 
- Changes touch `crates/core/src/atoms/reason.rs` and `crates/core/src/output_guardrail.rs` and add a regression test exercising the new guardrail input behaviour. 

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test -p everruns-core output_guardrail::tests --all-features` and `cargo test -p everruns-core --test citation_pipeline_test --all-features`, and the relevant tests passed. 
- Ran `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` which passed for the modified crate. 
- A workspace-wide `just pre-push` run was started but stopped early for environment/time reasons; focused formatting/linting and unit tests covering the change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6307f59ae8832bb6e7ec985eec636f)