### PR TITLE
fix(runtime): bound file grep resource usage

### DIFF
--- a/crates/runtime/src/grep_limits.rs
+++ b/crates/runtime/src/grep_limits.rs
@@ -1,0 +1,42 @@
+use everruns_core::error::{AgentLoopError, Result};
+use regex::{Regex, RegexBuilder};
+
+pub(crate) const MAX_PATTERN_LEN: usize = 1_000;
+pub(crate) const MAX_REGEX_SIZE: usize = 512 * 1024;
+pub(crate) const MAX_FILE_BYTES: usize = 512 * 1024;
+pub(crate) const MAX_TOTAL_SCAN_BYTES: usize = 5 * 1024 * 1024;
+
+pub(crate) fn build_regex(pattern: &str) -> Result<Regex> {
+    if pattern.len() > MAX_PATTERN_LEN {
+        return Err(AgentLoopError::tool(format!(
+            "Regex pattern too long (max {MAX_PATTERN_LEN} characters)"
+        )));
+    }
+
+    RegexBuilder::new(pattern)
+        .size_limit(MAX_REGEX_SIZE)
+        .build()
+        .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))
+}
+
+pub(crate) fn validate_path_pattern(path_pattern: Option<&str>) -> Result<()> {
+    if path_pattern.is_some_and(|pattern| pattern.len() > MAX_PATTERN_LEN) {
+        return Err(AgentLoopError::tool(format!(
+            "Path pattern too long (max {MAX_PATTERN_LEN} characters)"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn account_scan(total: &mut usize, file_bytes: usize) -> Result<bool> {
+    if file_bytes > MAX_FILE_BYTES {
+        return Ok(false);
+    }
+    *total = total.saturating_add(file_bytes);
+    if *total > MAX_TOTAL_SCAN_BYTES {
+        return Err(AgentLoopError::tool(format!(
+            "Grep scan exceeds maximum total size of {MAX_TOTAL_SCAN_BYTES} bytes"
+        )));
+    }
+    Ok(true)
+}

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -16,7 +16,6 @@ use everruns_core::traits::{
     SessionFileSystemFactoryContext, SessionMutator, SessionStorageStore, SessionStore,
 };
 use everruns_core::typed_id::SessionId;
-use regex::Regex;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -407,13 +406,14 @@ impl SessionFileSystem for InMemorySessionFileStore {
         pattern: &str,
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
-        let regex = Regex::new(pattern)
-            .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))?;
+        let regex = crate::grep_limits::build_regex(pattern)?;
+        crate::grep_limits::validate_path_pattern(path_pattern)?;
         let path_pattern = path_pattern
             .map(everruns_core::session_path::GrepPathPattern::new)
             .transpose()?;
         let files = self.files.read().await;
         let mut matches = Vec::new();
+        let mut total_scanned = 0;
 
         for ((sid, path), entry) in files.iter() {
             if *sid != session_id || entry.file.is_directory || entry.file.encoding != "text" {
@@ -428,6 +428,9 @@ impl SessionFileSystem for InMemorySessionFileStore {
             let Some(content) = &entry.file.content else {
                 continue;
             };
+            if !crate::grep_limits::account_scan(&mut total_scanned, content.len())? {
+                continue;
+            }
 
             for (idx, line) in content.lines().enumerate() {
                 if regex.is_match(line) {
@@ -449,32 +452,31 @@ impl SessionFileSystem for InMemorySessionFileStore {
         pattern: &str,
         options: &GrepOptions,
     ) -> Result<GrepSearchResult> {
-        let regex = Regex::new(pattern)
-            .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))?;
+        let regex = crate::grep_limits::build_regex(pattern)?;
+        crate::grep_limits::validate_path_pattern(options.path_pattern.as_deref())?;
         let path_pattern = options
             .path_pattern
             .as_deref()
             .map(everruns_core::session_path::GrepPathPattern::new)
             .transpose()?;
         let files = self.files.read().await;
-        let text_files = files
-            .iter()
-            .filter(|((sid, path), entry)| {
-                *sid == session_id
-                    && !entry.file.is_directory
-                    && entry.file.encoding == "text"
-                    && path_pattern
-                        .as_ref()
-                        .is_none_or(|matcher| matcher.is_match(path))
-            })
-            .filter_map(|((_, path), entry)| {
-                entry
-                    .file
-                    .content
+        let mut total_scanned = 0;
+        let mut text_files = Vec::new();
+        for ((_, path), entry) in files.iter().filter(|((sid, path), entry)| {
+            *sid == session_id
+                && !entry.file.is_directory
+                && entry.file.encoding == "text"
+                && path_pattern
                     .as_ref()
-                    .map(|content| (path.clone(), content.clone()))
-            })
-            .collect();
+                    .is_none_or(|matcher| matcher.is_match(path))
+        }) {
+            let Some(content) = entry.file.content.as_ref() else {
+                continue;
+            };
+            if crate::grep_limits::account_scan(&mut total_scanned, content.len())? {
+                text_files.push((path.clone(), content.clone()));
+            }
+        }
         Ok(build_grep_search_result(text_files, &regex, options))
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -100,6 +100,7 @@
 mod backends;
 mod builders;
 mod file_store_decorators;
+mod grep_limits;
 mod host;
 mod in_memory;
 mod mcp;

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -22,7 +22,6 @@ use everruns_core::traits::{
 use everruns_core::typed_id::SessionId;
 use everruns_core::{MountFs, WorkspaceRootSet};
 use ignore::WalkBuilder;
-use regex::Regex;
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -519,8 +518,8 @@ impl SessionFileSystem for RealDiskFileStore {
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
         let root = self.root();
-        let regex = Regex::new(pattern)
-            .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))?;
+        let regex = crate::grep_limits::build_regex(pattern)?;
+        crate::grep_limits::validate_path_pattern(path_pattern)?;
         let path_pattern = match path_pattern {
             Some(path) => Some(everruns_core::session_path::GrepPathPattern::new(
                 self.paths.parse_input(path)?.as_relative(),
@@ -533,6 +532,7 @@ impl SessionFileSystem for RealDiskFileStore {
         // block the executor on large trees.
         tokio::task::spawn_blocking(move || -> Result<Vec<GrepMatch>> {
             let mut out = Vec::new();
+            let mut total_scanned = 0;
             let walker = WalkBuilder::new(&root)
                 .hidden(false)
                 .git_ignore(true)
@@ -584,6 +584,15 @@ impl SessionFileSystem for RealDiskFileStore {
                 {
                     continue;
                 }
+                let Ok(metadata) = entry.metadata() else {
+                    continue;
+                };
+                let Ok(file_bytes) = usize::try_from(metadata.len()) else {
+                    continue;
+                };
+                if !crate::grep_limits::account_scan(&mut total_scanned, file_bytes)? {
+                    continue;
+                }
                 let bytes = match std::fs::read(path) {
                     Ok(b) => b,
                     Err(_) => continue,
@@ -619,8 +628,8 @@ impl SessionFileSystem for RealDiskFileStore {
         options: &GrepOptions,
     ) -> Result<GrepSearchResult> {
         let root = self.root();
-        let regex = Regex::new(pattern)
-            .map_err(|error| AgentLoopError::tool(format!("Invalid regex pattern: {error}")))?;
+        let regex = crate::grep_limits::build_regex(pattern)?;
+        crate::grep_limits::validate_path_pattern(options.path_pattern.as_deref())?;
         let path_pattern = match options.path_pattern.as_deref() {
             Some(path) => Some(everruns_core::session_path::GrepPathPattern::new(
                 self.paths.parse_input(path)?.as_relative(),
@@ -631,6 +640,7 @@ impl SessionFileSystem for RealDiskFileStore {
 
         tokio::task::spawn_blocking(move || -> Result<GrepSearchResult> {
             let mut text_files = Vec::new();
+            let mut total_scanned = 0;
             let walker = WalkBuilder::new(&root)
                 .hidden(false)
                 .git_ignore(true)
@@ -652,6 +662,15 @@ impl SessionFileSystem for RealDiskFileStore {
                     .as_ref()
                     .is_some_and(|matcher| !matcher.is_match(&rel_str))
                 {
+                    continue;
+                }
+                let Ok(metadata) = entry.metadata() else {
+                    continue;
+                };
+                let Ok(file_bytes) = usize::try_from(metadata.len()) else {
+                    continue;
+                };
+                if !crate::grep_limits::account_scan(&mut total_scanned, file_bytes)? {
                     continue;
                 }
                 let Ok(bytes) = std::fs::read(entry.path()) else {

--- a/crates/runtime/tests/file_store_grep_conformance_test.rs
+++ b/crates/runtime/tests/file_store_grep_conformance_test.rs
@@ -133,14 +133,44 @@ async fn assert_regex_contract(store: Arc<dyn SessionFileSystem>) {
     );
 }
 
+async fn assert_grep_limits(store: Arc<dyn SessionFileSystem>) {
+    let session = SessionId::from_seed(777);
+    let error = store
+        .grep_files(session, &"a".repeat(1_001), None)
+        .await
+        .expect_err("oversized regex must fail before scanning");
+    assert!(error.to_string().contains("Regex pattern too long"));
+
+    let error = store
+        .grep_files(session, "needle", Some(&"a".repeat(1_001)))
+        .await
+        .expect_err("oversized path pattern must fail before scanning");
+    assert!(error.to_string().contains("Path pattern too long"));
+
+    store
+        .write_file(session, "/large.txt", &"needle".repeat(100_000), "text")
+        .await
+        .unwrap();
+    assert!(
+        store
+            .grep_files(session, "needle", None)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
 #[tokio::test]
 async fn in_memory_store_honors_grep_regex_contract() {
-    assert_regex_contract(Arc::new(InMemorySessionFileStore::new())).await;
+    let store = Arc::new(InMemorySessionFileStore::new());
+    assert_regex_contract(store.clone()).await;
+    assert_grep_limits(store).await;
 }
 
 #[tokio::test]
 async fn real_disk_store_honors_grep_regex_contract() {
     let root = TempDir::new().unwrap();
     let store = Arc::new(RealDiskFileStore::new(root.path()).unwrap());
-    assert_regex_contract(store).await;
+    assert_regex_contract(store.clone()).await;
+    assert_grep_limits(store).await;
 }

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -326,7 +326,9 @@ The following behaviors hold across all implementations:
 5. **`grep_files`** searches text files only. The content `pattern` uses Rust
    [`regex`](https://docs.rs/regex) syntax and is compiled once before scanning;
    an invalid pattern returns an explicit error. Implementations are free to
-   skip binary content, oversized files, and explicitly excluded directories.
+   skip binary content and explicitly excluded directories. All implementations
+   cap content and path patterns at 1,000 bytes, compiled regex size at 512 KiB,
+   skip files above 512 KiB, and reject scans exceeding 5 MiB in total.
    `path_pattern` filters canonical workspace paths using globs:
    `*` and `?` match within one path segment, `**` crosses directories, and
    bracket classes and brace alternation are supported. A basename-only glob


### PR DESCRIPTION
### Motivation

- Runtime file-store grep previously compiled and applied caller-supplied regexes without the server-side TM-DOS-008 bounds, allowing attacker/LLM-controlled patterns to exhaust CPU/memory or force large scans in in-process embedders.

### Description

- Add `crates/runtime/src/grep_limits.rs` providing `MAX_*` constants and helpers `build_regex`, `validate_path_pattern`, and `account_scan` to enforce pattern, compiled-regex, per-file, and total-scan limits.
- Apply the new limits to both flat and contextual grep paths in the in-memory store (`InMemorySessionFileStore`) and the real-disk store (`RealDiskFileStore`), using the bounded `RegexBuilder` and tracking total scanned bytes during iteration.
- Add conformance tests in `crates/runtime/tests/file_store_grep_conformance_test.rs` that assert oversized patterns/path-patterns are rejected and oversized files are skipped while existing regex behavior remains intact.
- Update `specs/file-store.md` to document the runtime grep resource bounds and wire the new module into the runtime crate.

### Testing

- Ran `cargo test -p everruns-runtime --test file_store_grep_conformance_test` and both tests passed.
- Ran `cargo fmt --all -- --check` and `cargo clippy -p everruns-runtime --all-targets --all-features -- -D warnings` for the runtime crate and they passed.
- Executed the repository `just pre-push` checks; the Rust formatting check passed and the focused runtime checks completed, while a full workspace all-features build was long-running and was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6307f5e9b0832baa6917100bb2a626)