### PR TITLE
fix(api): bound user preference storage

### DIFF
--- a/crates/server/src/api/user_preferences.rs
+++ b/crates/server/src/api/user_preferences.rs
@@ -7,7 +7,7 @@
 // flag).
 
 use crate::auth::middleware::{AuthState, AuthUser};
-use crate::storage::StorageBackend;
+use crate::storage::{StorageBackend, backend::USER_PREFERENCE_LIMIT_EXCEEDED};
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -21,6 +21,19 @@ use utoipa::ToSchema;
 
 use super::common::impl_auth_state;
 use crate::storage::models::UserPreferenceRow;
+
+const MAX_PREFERENCES_PER_USER: usize = 100;
+const MAX_PREFERENCE_VALUE_BYTES: usize = 4 * 1024;
+
+fn validate_preference(key: &str, value: &str) -> Result<(), StatusCode> {
+    if key.is_empty() || key.len() > 255 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if value.len() > MAX_PREFERENCE_VALUE_BYTES {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    Ok(())
+}
 
 /// App state for user preference routes.
 #[derive(Clone)]
@@ -82,10 +95,14 @@ pub async fn list_preferences(
     State(state): State<AppState>,
     auth: AuthUser,
 ) -> Result<Json<Vec<PreferenceResponse>>, StatusCode> {
-    let rows = state.db.list_user_preferences(auth.id).await.map_err(|e| {
-        tracing::error!("Failed to list user preferences: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let rows = state
+        .db
+        .list_user_preferences(auth.id, MAX_PREFERENCES_PER_USER)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list user preferences: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(rows.into_iter().map(row_to_response).collect()))
 }
@@ -121,11 +138,16 @@ pub async fn set_preference(
         StatusCode::BAD_REQUEST
     })?;
 
+    validate_preference(&key, &serialized)?;
+
     let row = state
         .db
-        .set_user_preference(auth.id, &key, &serialized)
+        .set_user_preference(auth.id, &key, &serialized, MAX_PREFERENCES_PER_USER)
         .await
         .map_err(|e| {
+            if e.to_string() == USER_PREFERENCE_LIMIT_EXCEEDED {
+                return StatusCode::CONFLICT;
+            }
             tracing::error!("Failed to set user preference: {}", e);
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
@@ -152,5 +174,27 @@ pub async fn delete_preference(
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(StatusCode::NOT_FOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_preference_key_and_value_limits() {
+        assert_eq!(
+            validate_preference("", "true"),
+            Err(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            validate_preference(&"k".repeat(256), "true"),
+            Err(StatusCode::BAD_REQUEST)
+        );
+        assert!(validate_preference("key", &"x".repeat(4096)).is_ok());
+        assert_eq!(
+            validate_preference("key", &"x".repeat(4097)),
+            Err(StatusCode::PAYLOAD_TOO_LARGE)
+        );
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -15,6 +15,8 @@ use everruns_core::typed_id::{
 use sqlx::PgPool;
 use uuid::Uuid;
 
+pub const USER_PREFERENCE_LIMIT_EXCEEDED: &str = "user preference limit exceeded";
+
 use super::memory::InMemoryDatabase;
 use super::models::*;
 use super::reporting::models::ReportingOutboxRow;
@@ -3290,8 +3292,12 @@ impl StorageBackend {
         dispatch!(self, delete_user_connection, user_id, provider)
     }
 
-    pub async fn list_user_preferences(&self, user_id: Uuid) -> Result<Vec<UserPreferenceRow>> {
-        dispatch!(self, list_user_preferences, user_id)
+    pub async fn list_user_preferences(
+        &self,
+        user_id: Uuid,
+        limit: usize,
+    ) -> Result<Vec<UserPreferenceRow>> {
+        dispatch!(self, list_user_preferences, user_id, limit)
     }
 
     pub async fn get_user_preference(
@@ -3307,8 +3313,16 @@ impl StorageBackend {
         user_id: Uuid,
         key: &str,
         value: &str,
+        max_preferences: usize,
     ) -> Result<UserPreferenceRow> {
-        dispatch!(self, set_user_preference, user_id, key, value)
+        dispatch!(
+            self,
+            set_user_preference,
+            user_id,
+            key,
+            value,
+            max_preferences
+        )
     }
 
     pub async fn delete_user_preference(&self, user_id: Uuid, key: &str) -> Result<bool> {

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -3842,7 +3842,7 @@ async fn test_user_preferences_crud_and_isolation() {
 
     // Set creates the row.
     let created = db
-        .set_user_preference(user_a, "theme", "\"dark\"")
+        .set_user_preference(user_a, "theme", "\"dark\"", 100)
         .await
         .unwrap();
     assert_eq!(created.key, "theme");
@@ -3850,17 +3850,28 @@ async fn test_user_preferences_crud_and_isolation() {
 
     // Set again upserts (updates value, keeps identity, no duplicate row).
     let updated = db
-        .set_user_preference(user_a, "theme", "\"light\"")
+        .set_user_preference(user_a, "theme", "\"light\"", 100)
         .await
         .unwrap();
     assert_eq!(updated.id, created.id, "upsert must reuse the same row");
     assert_eq!(updated.value, "\"light\"");
-    assert_eq!(db.list_user_preferences(user_a).await.unwrap().len(), 1);
+    assert_eq!(
+        db.list_user_preferences(user_a, 100).await.unwrap().len(),
+        1
+    );
 
     // Preferences are isolated per user.
-    db.set_user_preference(user_b, "theme", "\"system\"")
+    db.set_user_preference(user_b, "theme", "\"system\"", 100)
         .await
         .unwrap();
+    let quota_error = db
+        .set_user_preference(user_b, "locale", "\"en\"", 1)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        quota_error.to_string(),
+        super::super::backend::USER_PREFERENCE_LIMIT_EXCEEDED
+    );
     assert_eq!(
         db.get_user_preference(user_a, "theme")
             .await
@@ -3869,7 +3880,10 @@ async fn test_user_preferences_crud_and_isolation() {
             .value,
         "\"light\""
     );
-    assert_eq!(db.list_user_preferences(user_b).await.unwrap().len(), 1);
+    assert_eq!(
+        db.list_user_preferences(user_b, 100).await.unwrap().len(),
+        1
+    );
 
     // Delete removes only the targeted key and reports whether a row was hit.
     assert!(db.delete_user_preference(user_a, "theme").await.unwrap());
@@ -3881,7 +3895,10 @@ async fn test_user_preferences_crud_and_isolation() {
             .is_none()
     );
     // user_b is unaffected by user_a's delete.
-    assert_eq!(db.list_user_preferences(user_b).await.unwrap().len(), 1);
+    assert_eq!(
+        db.list_user_preferences(user_b, 100).await.unwrap().len(),
+        1
+    );
 }
 
 // Account linking: signing in with an OAuth provider whose verified email

--- a/crates/server/src/storage/memory/user_preferences.rs
+++ b/crates/server/src/storage/memory/user_preferences.rs
@@ -10,7 +10,11 @@ impl InMemoryDatabase {
     // User Preferences
     // ============================================
 
-    pub async fn list_user_preferences(&self, user_id: Uuid) -> Result<Vec<UserPreferenceRow>> {
+    pub async fn list_user_preferences(
+        &self,
+        user_id: Uuid,
+        limit: usize,
+    ) -> Result<Vec<UserPreferenceRow>> {
         let mut prefs: Vec<_> = self
             .user_preferences
             .read()
@@ -19,6 +23,7 @@ impl InMemoryDatabase {
             .cloned()
             .collect();
         prefs.sort_by(|a, b| a.key.cmp(&b.key));
+        prefs.truncate(limit);
         Ok(prefs)
     }
 
@@ -39,10 +44,17 @@ impl InMemoryDatabase {
         user_id: Uuid,
         key: &str,
         value: &str,
+        max_preferences: usize,
     ) -> Result<UserPreferenceRow> {
         let now = Self::now();
         let mut prefs = self.user_preferences.write();
         let map_key = (user_id, key.to_string());
+
+        if !prefs.contains_key(&map_key)
+            && prefs.values().filter(|row| row.user_id == user_id).count() >= max_preferences
+        {
+            anyhow::bail!(super::super::backend::USER_PREFERENCE_LIMIT_EXCEEDED);
+        }
 
         let row = match prefs.get(&map_key) {
             Some(existing) => UserPreferenceRow {

--- a/crates/server/src/storage/repositories/user_preferences.rs
+++ b/crates/server/src/storage/repositories/user_preferences.rs
@@ -11,16 +11,22 @@ impl Database {
     // ============================================
 
     /// List all preferences for a user, ordered by key.
-    pub async fn list_user_preferences(&self, user_id: Uuid) -> Result<Vec<UserPreferenceRow>> {
+    pub async fn list_user_preferences(
+        &self,
+        user_id: Uuid,
+        limit: usize,
+    ) -> Result<Vec<UserPreferenceRow>> {
         let rows = sqlx::query_as::<_, UserPreferenceRow>(
             r#"
             SELECT id, user_id, key, value, created_at, updated_at
             FROM user_preferences
             WHERE user_id = $1
             ORDER BY key ASC
+            LIMIT $2
             "#,
         )
         .bind(user_id)
+        .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
 
@@ -54,7 +60,32 @@ impl Database {
         user_id: Uuid,
         key: &str,
         value: &str,
+        max_preferences: usize,
     ) -> Result<UserPreferenceRow> {
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))")
+            .bind(user_id.to_string())
+            .execute(&mut *transaction)
+            .await?;
+
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM user_preferences WHERE user_id = $1 AND key = $2)",
+        )
+        .bind(user_id)
+        .bind(key)
+        .fetch_one(&mut *transaction)
+        .await?;
+        if !exists {
+            let count: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM user_preferences WHERE user_id = $1")
+                    .bind(user_id)
+                    .fetch_one(&mut *transaction)
+                    .await?;
+            if count >= max_preferences as i64 {
+                anyhow::bail!(super::super::backend::USER_PREFERENCE_LIMIT_EXCEEDED);
+            }
+        }
+
         let row = sqlx::query_as::<_, UserPreferenceRow>(
             r#"
             INSERT INTO user_preferences (user_id, key, value)
@@ -67,8 +98,10 @@ impl Database {
         .bind(user_id)
         .bind(key)
         .bind(value)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *transaction)
         .await?;
+
+        transaction.commit().await?;
 
         Ok(row)
     }


### PR DESCRIPTION
### Motivation

- The user preferences API allowed authenticated clients to persist an unbounded number of large JSON values and to list them all in a single response, enabling persistent storage growth and memory/CPU amplification (storage DoS). 
- The change adds conservative, application-level limits to prevent abuse while preserving existing per-key update semantics.

### Description

- Add application limits and validation: `MAX_PREFERENCES_PER_USER = 100`, `MAX_PREFERENCE_VALUE_BYTES = 4 * 1024`, and `validate_preference` to enforce non-empty/<=255-byte keys and per-value size checks before writes in `api/user_preferences.rs` with explicit HTTP error codes. 
- Cap list reads by passing a `limit` to `list_user_preferences(...)` so `GET /v1/user/preferences` materializes at most the configured number of rows. 
- Enforce quota atomically for Postgres by acquiring a per-user advisory transaction lock, checking existence/count inside the same transaction, and returning a controlled `409 Conflict` when the per-user row limit is hit. 
- Mirror quota and list limits in the in-memory backend and update tests: propagate new `limit` and `max_preferences` parameters through `storage/backend.rs`, `storage/repositories/user_preferences.rs`, and `storage/memory/*`, and add/adjust tests (`validates_preference_key_and_value_limits`, updated `test_user_preferences_crud_and_isolation`) to cover quota rejection and CRUD behavior.

### Testing

- `cargo fmt --check` and `git diff --check` were run and completed successfully. 
- Unit tests touching user preferences were updated (`validates_preference_key_and_value_limits` added and `test_user_preferences_crud_and_isolation` adapted to new signatures). 
- Attempted `cargo test -p everruns-server user_preferences --all-features` but the run was interrupted by long dependency compilation in this environment (environment limitation), so a full test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6307f7047c832b9a5b6f54e6edf753)