### PR TITLE
fix(local): preserve task webhook secrets in snapshots

### DIFF
--- a/crates/local/src/task_registry.rs
+++ b/crates/local/src/task_registry.rs
@@ -84,8 +84,13 @@ impl LocalSessionTaskRegistry {
     }
 
     fn store_task(&self, task: &SessionTask) -> Result<()> {
-        let snapshot =
-            serde_json::to_string(task).map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        // SessionTask's public serializer redacts webhook secrets. Local snapshots
+        // are persistence, not presentation, so restore the raw spec before storage.
+        let mut snapshot =
+            serde_json::to_value(task).map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        snapshot["spec"] = task.spec.clone();
+        let snapshot = serde_json::to_string(&snapshot)
+            .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
         let id = task.id.clone();
         let session_id = task.session_id.to_string();
         let kind = task.kind.clone();

--- a/crates/local/tests/task_registry_test.rs
+++ b/crates/local/tests/task_registry_test.rs
@@ -50,6 +50,29 @@ async fn create_is_idempotent_on_supplied_id() {
 }
 
 #[tokio::test]
+async fn task_spec_webhook_secret_survives_storage_round_trip() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let mut input = create_input(session_id, TASK_KIND_SUBAGENT);
+    input.spec = serde_json::json!({
+        "push_configs": [{
+            "url": "https://hooks.example.com/everruns",
+            "secret": "spawn-time-hmac-secret",
+            "event_filter": ["terminal"]
+        }]
+    });
+
+    let created = reg.create(input).await.unwrap();
+    let loaded = reg.get(session_id, &created.id).await.unwrap().unwrap();
+
+    assert_eq!(
+        loaded.spec["push_configs"][0]["secret"],
+        "spawn-time-hmac-secret"
+    );
+    assert!(loaded.spec["push_configs"][0].get("has_secret").is_none());
+}
+
+#[tokio::test]
 async fn create_rejects_id_reuse_across_sessions() {
     let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
     let session_a = SessionId::new();


### PR DESCRIPTION
### Motivation
- A public redaction serializer was attached to the core `SessionTask.spec`, which caused the local SQLite-backed registry to persist a redacted spec and thereby drop spawn-time `push_configs[].secret`, breaking HMAC-signed webhook delivery for local/embedded hosts.

### Description
- Modify `crates/local/src/task_registry.rs` so `store_task` builds a JSON snapshot from the task but replaces the serialized `spec` with the raw `task.spec` before writing, preserving internal webhook secrets while leaving public serialization unchanged.
- Add a regression test `task_spec_webhook_secret_survives_storage_round_trip` in `crates/local/tests/task_registry_test.rs` that creates a task with a `push_configs[].secret`, persists and reloads it, and asserts the secret is preserved and `has_secret` is not injected into the stored spec.
- This change is scoped to the local persistence path and does not alter the public redaction behavior of `SessionTask` API serialization.

### Testing
- Ran `cargo fmt` which completed successfully.
- Added the focused unit test `task_spec_webhook_secret_survives_storage_round_trip` and attempted to run the focused `cargo test` invocations for the local crate and the existing core redaction test, but full compilation and test execution did not finish within the execution window so final pass/fail could not be observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6307f5939c832bb107af2ad6833cc3)