### PR TITLE
fix(messages): route turns with public agent IDs

### DIFF
--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -69,16 +69,10 @@ impl Command for CreateMessage {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("Session"))?;
-        let session_row = ctx
-            .db
-            .get_session(ctx.org_id(), session_id)
-            .await
-            .map_err(classify_anyhow)?
-            .ok_or_else(|| CommandError::not_found("Session"))?;
         let responder_agent_id = resolve_responder_agent_id(
             ctx,
             session_id,
-            session_row.agent_id,
+            session.agent_id,
             req.addressed_participant_id,
         )
         .await?;
@@ -146,7 +140,16 @@ async fn resolve_responder_agent_id(
         ));
     }
 
-    Ok(Some(agent_id))
+    let public_id = ctx
+        .db
+        .get_agent_public_id(ctx.org_id(), agent_id)
+        .await
+        .map_err(classify_anyhow)?
+        .ok_or_else(|| CommandError::internal(anyhow::anyhow!("participant agent not found")))?
+        .parse::<AgentId>()
+        .map_err(|err| CommandError::internal(anyhow::anyhow!(err)))?;
+
+    Ok(Some(public_id))
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -616,7 +619,16 @@ mod tests {
             .expect("create message");
 
         wait_for_runner_calls(&fixture.runner, 1).await;
-        assert_eq!(fixture.runner.calls(), vec![Some(fixture.host_agent.id)]);
+        assert_eq!(
+            fixture.runner.calls(),
+            vec![Some(
+                fixture
+                    .host_agent
+                    .public_id
+                    .parse()
+                    .expect("host public id")
+            )]
+        );
     }
 
     #[tokio::test]
@@ -629,7 +641,16 @@ mod tests {
             .expect("create message");
 
         wait_for_runner_calls(&fixture.runner, 1).await;
-        assert_eq!(fixture.runner.calls(), vec![Some(fixture.guest_agent.id)]);
+        assert_eq!(
+            fixture.runner.calls(),
+            vec![Some(
+                fixture
+                    .guest_agent
+                    .public_id
+                    .parse()
+                    .expect("guest public id")
+            )]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation

- The message routing path was passing internal DB agent foreign keys into the worker path, but workers expect public `agent_...` IDs, causing asynchronously-started turns to fail when agents had client-supplied public IDs. 
- The intent is to ensure both unaddressed (host) and addressed (participant) turns use the public agent identifier contract that the worker/gRPC adapters expect. 
- Fixing this prevents accepted messages from later failing in the background due to identifier mismatches.

### Description

- Use the hydrated session object (`session.agent_id`) instead of reloading the raw session row, preserving the session service's public agent ID translation for unaddressed turns in `CreateMessage::execute` (`crates/server/src/domains/messages/commands.rs`).
- Resolve an addressed participant's internal `agent_id` to the organization-scoped public agent ID via `get_agent_public_id(...)` and parse it to `AgentId` before returning from `resolve_responder_agent_id` so the runner receives a public ID. 
- Update tests in `crates/server/src/domains/messages/commands.rs` to assert that the runner receives public agent IDs (host and guest) instead of internal DB UUIDs.
- Commit message: `fix(messages): route turns with public agent IDs` (file change recorded in `crates/server/src/domains/messages/commands.rs`).

### Testing

- `cargo fmt --check` — passed.
- `git diff --check` / pre-commit checks — passed.
- `cargo check -p everruns-server --lib --all-features` — started and completed in this environment (full dependency compile occurred during validation); a focused `cargo test -p everruns-server messages::commands::tests --lib --all-features` run was attempted but the initial all-features build spent significant time downloading and compiling the dependency graph and did not complete within the validation window. Automated formatting/lint checks passed and the changes compile under `cargo check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6307f62dfc832bb1f1a056df51dee8)