### PR TITLE
chore(deps): bump bashkit to 0.14.4 and fix touch in the session filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,13 +883,13 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3189734e07ea68a23e008c486d9f3cdb1a7eea74a8a32122ec750ade99620014"
+checksum = "17175a514a671777aabb125293aca393bfdf71223fa1289e23735ae523845ddc"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bigdecimal",
  "bitflags 2.13.1",
  "chrono",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -89,7 +89,7 @@ fetchkit = { version = "=0.5.0", features = ["bot-auth", "render-rakers"], optio
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 
 # Bash interpreter backing the bashkit_shell capability
-bashkit = { version = "0.14.3", features = ["jq", "http_client", "bot-auth"] }
+bashkit = { version = "0.14.4", features = ["jq", "http_client", "bot-auth"] }
 
 # Sandboxed Lua interpreter for the experimental `lua` capability (vendored Lua
 # 5.4, never LuaJIT). Optional + behind the `lua` cargo feature so the default

--- a/crates/core/src/capabilities/bashkit_shell/mod.rs
+++ b/crates/core/src/capabilities/bashkit_shell/mod.rs
@@ -1230,6 +1230,13 @@ impl FileSystem for SessionFileSystemAdapter {
         Ok(())
     }
 
+    async fn set_modified_time(&self, _path: &Path, _time: SystemTime) -> bashkit::Result<()> {
+        // No-op: the session store does not persist mtimes, and `stat` synthesizes
+        // them. The bashkit default impl errors, which made `touch` fail after it
+        // had already created the file.
+        Ok(())
+    }
+
     fn as_search_capable(&self) -> Option<&dyn SearchCapable> {
         Some(self)
     }
@@ -1486,6 +1493,44 @@ mod tests {
                         updated_at: chrono::Utc::now(),
                     });
                 }
+            }
+
+            // Subdirectory entries. Production lists directory rows alongside file rows,
+            // so recursive walks (`find`, `grep -r`) can descend. Cover both explicitly
+            // created directories and ones implied by a nested file path.
+            let prefix = if is_root {
+                "/".to_string()
+            } else {
+                format!("{path}/")
+            };
+            let mut child_dirs: std::collections::BTreeSet<String> =
+                std::collections::BTreeSet::new();
+            let descendant_paths = files
+                .keys()
+                .chain(dirs.keys())
+                .filter(|(sid, _)| *sid == session_id)
+                .map(|(_, p)| p);
+            for candidate in descendant_paths {
+                if let Some(rest) = candidate.strip_prefix(&prefix)
+                    && let Some(name) = rest.split('/').next()
+                    && rest.contains('/')
+                    && !name.is_empty()
+                {
+                    child_dirs.insert(name.to_string());
+                }
+            }
+            for name in child_dirs {
+                entries.push(FileInfo {
+                    id: uuid::Uuid::new_v4(),
+                    session_id: session_id.into(),
+                    path: format!("{prefix}{name}"),
+                    name,
+                    is_directory: true,
+                    is_readonly: false,
+                    size_bytes: 0,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                });
             }
 
             // Return error if directory doesn't exist (not root, not explicitly created,
@@ -1847,6 +1892,63 @@ mod tests {
             assert_eq!(output["stdout"], "test content\n");
         } else {
             panic!("Expected success result");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bash_recursive_walk_descends_into_subdirectories() {
+        let (context, _guard) = create_context_with_mock_store();
+        let tool = BashTool::default();
+
+        let result = tool
+            .execute_with_context(
+                json!({"commands": "mkdir -p /workspace/a/b && echo needle > /workspace/a/b/c.txt \
+                     && ls /workspace/a && find /workspace/a -name '*.txt'"}),
+                &context,
+            )
+            .await;
+
+        match result {
+            ToolExecutionResult::Success(output) => {
+                let stdout = output["stdout"].as_str().unwrap_or("");
+                assert_eq!(output["exit_code"], 0, "stderr: {}", output["stderr"]);
+                assert!(
+                    stdout.contains("b\n"),
+                    "expected subdir in ls, got {stdout:?}"
+                );
+                assert!(
+                    stdout.contains("/workspace/a/b/c.txt"),
+                    "expected find to descend, got {stdout:?}"
+                );
+            }
+            other => panic!("Expected success result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bash_touch_creates_and_updates_files() {
+        let (context, _guard) = create_context_with_mock_store();
+        let tool = BashTool::default();
+
+        // `touch` writes the file and then sets its mtime; the session filesystem
+        // does not track mtimes, so the second step must not fail the command.
+        let result = tool
+            .execute_with_context(
+                json!({"commands": "touch /workspace/a.txt && touch /workspace/a.txt && ls /workspace"}),
+                &context,
+            )
+            .await;
+
+        match result {
+            ToolExecutionResult::Success(output) => {
+                assert_eq!(output["exit_code"], 0, "stderr: {}", output["stderr"]);
+                assert!(
+                    output["stdout"].as_str().unwrap_or("").contains("a.txt"),
+                    "expected a.txt in listing, got {:?}",
+                    output["stdout"]
+                );
+            }
+            other => panic!("Expected success result, got {other:?}"),
         }
     }
 

--- a/crates/core/src/capabilities/bashkit_shell/mod.rs
+++ b/crates/core/src/capabilities/bashkit_shell/mod.rs
@@ -980,6 +980,18 @@ impl SessionFileSystemAdapter {
     fn store_path(path: &Path) -> String {
         path.to_string_lossy().into_owned()
     }
+
+    /// Whether `session_path` is an implicit directory — one with children but no row
+    /// of its own (virtual mounts, unmaterialized parents).
+    ///
+    /// Stores answer `list_directory` for an unknown path with `Ok(vec![])`, so only a
+    /// non-empty listing distinguishes a real directory from an absent path.
+    async fn directory_has_entries(&self, session_path: &str) -> bool {
+        self.store
+            .list_directory(self.session_id, session_path)
+            .await
+            .is_ok_and(|entries| !entries.is_empty())
+    }
 }
 
 #[async_trait]
@@ -1100,26 +1112,25 @@ impl FileSystem for SessionFileSystemAdapter {
                 })
             }
             Ok(None) => {
-                // Check if it's a directory by listing it
-                match self
-                    .store
-                    .list_directory(self.session_id, &session_path)
-                    .await
-                {
-                    Ok(_entries) => {
-                        let now = SystemTime::now();
-                        Ok(Metadata {
-                            file_type: FileType::Directory,
-                            size: 0,
-                            mode: 0o755,
-                            modified: now,
-                            created: now,
-                        })
-                    }
-                    Err(_) => Err(bashkit::Error::Io(std::io::Error::new(
+                // No row: the path can still be an implicit directory (a virtual mount,
+                // or a parent never materialized as its own row). Only a *non-empty*
+                // listing proves that. Treating any `Ok` as a directory made every
+                // absent path look like an empty directory, because stores return
+                // `Ok(vec![])` rather than an error for paths they do not know.
+                if self.directory_has_entries(&session_path).await {
+                    let now = SystemTime::now();
+                    Ok(Metadata {
+                        file_type: FileType::Directory,
+                        size: 0,
+                        mode: 0o755,
+                        modified: now,
+                        created: now,
+                    })
+                } else {
+                    Err(bashkit::Error::Io(std::io::Error::new(
                         std::io::ErrorKind::NotFound,
                         format!("Path not found: {}", path.display()),
-                    ))),
+                    )))
                 }
             }
             Err(e) => Err(bashkit::Error::Io(std::io::Error::other(e.to_string()))),
@@ -1168,22 +1179,14 @@ impl FileSystem for SessionFileSystemAdapter {
 
         let session_path = Self::store_path(path);
 
-        // Check file
+        // A row exists for both files and materialized directories.
         if let Ok(Some(_)) = self.store.read_file(self.session_id, &session_path).await {
             return Ok(true);
         }
 
-        // Check directory
-        if self
-            .store
-            .list_directory(self.session_id, &session_path)
-            .await
-            .is_ok()
-        {
-            return Ok(true);
-        }
-
-        Ok(false)
+        // Otherwise only an implicit directory counts — see `stat` for why an empty
+        // listing must not be read as existence.
+        Ok(self.directory_has_entries(&session_path).await)
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> bashkit::Result<()> {
@@ -1230,10 +1233,11 @@ impl FileSystem for SessionFileSystemAdapter {
         Ok(())
     }
 
+    // THREAT[TM-BASH-017]: no-op like `chmod` (TM-BASH-014). The session store does not
+    // persist mtimes and `stat` synthesizes them, so there is nothing to spoof. The
+    // bashkit default impl errors, which made `touch` fail after it had already
+    // created the file.
     async fn set_modified_time(&self, _path: &Path, _time: SystemTime) -> bashkit::Result<()> {
-        // No-op: the session store does not persist mtimes, and `stat` synthesizes
-        // them. The bashkit default impl errors, which made `touch` fail after it
-        // had already created the file.
         Ok(())
     }
 
@@ -1408,6 +1412,28 @@ mod tests {
                     content: Some(content.clone()),
                     encoding: encoding.clone(),
                     size_bytes: content.len() as i64,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                }))
+            } else if self
+                .directories
+                .lock()
+                .unwrap()
+                .contains_key(&(session_id, path.clone()))
+            {
+                // Production stores materialize directories as rows that `read_file`
+                // returns (see `InMemorySessionFileStore::create_directory`), so the
+                // double must too — otherwise `exists`/`stat` cannot see an empty dir.
+                Ok(Some(SessionFile {
+                    id: uuid::Uuid::new_v4(),
+                    session_id: session_id.into(),
+                    path: path.clone(),
+                    name: path.split('/').next_back().unwrap_or("").to_string(),
+                    is_directory: true,
+                    is_readonly: false,
+                    content: None,
+                    encoding: "text".to_string(),
+                    size_bytes: 0,
                     created_at: chrono::Utc::now(),
                     updated_at: chrono::Utc::now(),
                 }))
@@ -1923,6 +1949,40 @@ mod tests {
             }
             other => panic!("Expected success result, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_adapter_reports_absent_paths_as_missing() {
+        let session_id = SessionId::new();
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
+        let adapter = SessionFileSystemAdapter::new(session_id, store);
+
+        // Stores answer `list_directory` for unknown paths with an empty listing, so
+        // `exists`/`stat` must not read that as "an empty directory is here". When they
+        // did, `touch` skipped creation (the file already "existed") and reported success.
+        assert!(
+            !adapter
+                .exists(Path::new("/workspace/nope.txt"))
+                .await
+                .unwrap()
+        );
+        assert!(
+            adapter
+                .stat(Path::new("/workspace/nope.txt"))
+                .await
+                .is_err()
+        );
+
+        adapter
+            .mkdir(Path::new("/workspace/realdir"), false)
+            .await
+            .unwrap();
+        assert!(
+            adapter
+                .exists(Path::new("/workspace/realdir"))
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -83,7 +83,7 @@ futures-util.workspace = true
 flate2.workspace = true
 tar.workspace = true
 
-bashkit = { version = "0.14.3", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.14.4", features = ["scripted_tool", "jq"] }
 
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }
 # Observability exporters (Braintrust, OpenTelemetry event listeners). The OTLP

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -939,6 +939,7 @@ Everruns uses [bashkit](https://github.com/everruns/bashkit) (v0.2.1) as a sandb
 | TM-BASH-014 | File permission bypass | Low | `chmod` is a no-op; session filesystem has no permission model | **BY DESIGN** |
 | TM-BASH-015 | Host information disclosure | Low | `hostname` → "everruns"; `whoami` → "everruns"; `uname` returns sandboxed values; mounted real-disk workspaces keep bash cwd/WORKSPACE in `/workspace` rather than the host checkout path | MITIGATED |
 | TM-BASH-016 | Write amplification via bash | Medium | Per-session and per-file byte quotas enforced in `DirectWorkerAdapters::write_file` (see TM-FS-008) | MITIGATED |
+| TM-BASH-017 | Timestamp spoofing via `touch -t` | Low | `SessionFileSystemAdapter.set_modified_time()` is a no-op, mirroring `chmod` (TM-BASH-014); the session store persists no mtimes and `stat` synthesizes them, so bash cannot backdate a file to influence anything that reads timestamps | **BY DESIGN** |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What changed

Bumps `bashkit` 0.14.3 → 0.14.4 in `crates/core` and `crates/server`, and fixes two `SessionFileSystemAdapter` bugs that testing the bump surfaced.

`touch` now works in the agent shell. It previously reported success and created nothing:

- **`exists()` reported every path as present.** It treated any non-erroring `list_directory` as proof of existence, but stores answer an unknown path with `Ok(vec[])`, not an error. So every absent path looked like an empty directory — `touch` skipped creation because the file already "existed", `test -e` on a missing path was true, and `stat` reported not-yet-existing files as directories. `exists()` and `stat()` now trust the file row, falling back to a listing only when it is non-empty (implicit directories: virtual mounts, unmaterialized parents).
- **`set_modified_time()` was left at the erroring bashkit default.** bashkit's `touch` writes the file and then sets its mtime, so the command exited 1 with `set_modified_time not supported` *after* the write. The session store persists no mtimes and `stat` synthesizes them, so it is now a no-op like `chmod`.

The bump itself is behavior-neutral for us. 0.14.4's substantive changes are wasm timeout hardening (we build no wasm target), removal of `max_allocations` from shared `RuntimeLimits` (python/typescript features, not enabled), `RealFs::new` → `RealFs::open` (realfs feature, not enabled), and git/sqlite/ssh builtins (not enabled). Security-relevant modules — `network/allowlist.rs`, `network/client.rs`, `credential.rs`, `fs/limits.rs` — changed only in doc-comment paths. Lockfile adds `base64 0.23.0` beside the existing 0.22.1.

## Why

`touch` is a common agent command and was silently broken against the session filesystem. The `exists()` defect is the more serious of the two: it made absent paths indistinguishable from empty directories for every caller, not just `touch`.

## Before / After

Same command through a real agent turn against `start-dev`, agent shell on `/workspace`:

Before — `touch` exits 0 but nothing is created, and absent paths claim to exist:

```
touch=0
isfile=NO
memory
nest
outputs          <- t1.txt absent
```

After:

```
touch=0
isfile=YES
memory
t1.txt
--absent--
ghost=MISSING    <- was EXISTS
--mkdir--
d1=DIR           <- empty dirs still recognized
--mtime--
toucht=0         <- touch -t reaches set_modified_time
--nested--
b
/workspace/a/b/c.txt
/workspace/a/b/c.txt:needle
```

Before the `set_modified_time` fix, the same `touch` failed loudly instead:

```
touch: cannot touch '/workspace/smoke.txt': io error: set_modified_time not supported
```

## Risk

- Low
- `exists()`/`stat()` are on every shell filesystem path, so the blast radius is wide even though the change only removes false positives. The residual risk is a directory that genuinely has no row *and* no children now reporting as missing where it previously reported as an empty directory. Production materializes directory rows on `mkdir` and on write (`create_directory`, `ensure_directory_exists`), and the live check above confirms an empty `mkdir -p` directory still stats as a directory.

## Security

- Threat categories reviewed: **TM-BASH** (sandboxed execution), **TM-FS** (filesystem), plus dependency/supply-chain review of the bump itself.
- Findings and resolutions:
  - `set_modified_time` as a no-op adds a by-design metadata gap parallel to `chmod` (TM-BASH-014). Recorded as **TM-BASH-017** in `specs/threat-model.md` with a `THREAT` marker at the mitigation. Nothing to spoof in practice: no mtimes are persisted and `stat` synthesizes them.
  - The `exists()`/`stat()` fix only narrows what is reported as existing, so it cannot widen the VFS boundary. TM-BASH-001/002/011 (workspace boundary, path traversal) are untouched — path resolution and containment still happen in `MountFs` and the backends.
  - Supply chain: diffed the 0.14.3 and 0.14.4 crate sources directly rather than relying on release notes. No changes to the network allowlist, SSRF precheck, credential handling, or fs limits beyond doc-comment paths; TM-BASH-003 (egress) is unaffected. No new capability is enabled and no feature flags changed.
  - No new logging of paths, arguments, or content.

## Follow-ups

- `touch -d DATE` is rejected by bashkit's builtin (`invalid option -- '-d'`); only `-t` is parsed. Upstream limitation in bashkit, not this adapter — left alone.
- The in-memory test double diverged from production in two ways that hid these bugs (directories were not readable rows, and `list_directory` omitted subdirectory entries). Both are fixed here so recursive walks and empty-directory stats are genuinely exercised. Worth watching for other divergences, but I found none affecting current tests.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

### Evidence

- `everruns-core` lib: 2388 tests (86 bashkit-specific), all 12 core integration suites, `everruns-runtime` 27, `everruns-server` lib 2023.
- Postgres-gated suites against a locally provisioned PG16 cluster (no Docker in this environment, so `initdb` + all 109 migrations applied by hand): `mcp_endpoint_test` 96, `guardrails_integration_test` 8, `api_integration_test` 115, `repository_integration_test`/`repository_conformance_test` 35, plus the 12 remaining suites from `just test-integration`. These predate the final two commits' code changes for the Postgres suites; core/runtime/server-lib were re-run after — and CI's own Integration Tests (PostgreSQL) job covers the gap on the final head.
- A 38-case shell battery driven through `BashTool` (pipes, jq, heredocs, arrays, awk/sed/sort/uniq, find, file ops, exit-code propagation) — this is what caught the `touch` failure. Scratch harness, not committed.
- End-to-end smoke test against `start-dev` with a real agent turn calling the Bash tool, output above.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `scripts/lib/pre-push.sh` (10/10, UI steps skipped — no `node_modules`; no UI changes in this PR).
- CI on head `f9a810a`: all 39 checks complete, zero failures (success or skipped), `mergeable_state: clean`.
- Not rebased onto latest main: verified neither side touched `crates/server/migrations/` since the merge base, and `check-migration-ordering.sh` passes (001..109). Will watch main CI after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVXhAmyFRGoVRfdMKBr94G)_