### PR TITLE
chore(deps): upgrade jsonwebtoken 10.4.0 to 11.0.0 (EVE-803)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ async-nats = "0.50"
 
 # Authentication
 argon2 = "0.5"
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "11", features = ["aws_lc_rs"] }
 sha2 = "0.11"
 hmac = "0.13"
 hex = "0.4"

--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -240,12 +240,14 @@ impl JwtService {
     /// Rejects MCP access tokens (`token_type == "mcp_access"`): they must only
     /// be accepted by the `/mcp` endpoint via [`validate_mcp_access_token`].
     pub fn validate_access_token(&self, token: &str) -> Result<AccessTokenClaims> {
-        let mut validation = Validation::default();
-        validation.validate_exp = true;
         // The `aud` claim is only set on MCP tokens. Disable the library's
         // audience check here so a stray/legacy `aud` never gates regular
         // tokens — the `token_type` gate below is the real resource boundary.
-        validation.validate_aud = false;
+        let validation = Validation {
+            validate_exp: true,
+            validate_aud: false,
+            ..Default::default()
+        };
 
         let token_data = decode::<AccessTokenClaims>(token, &self.decoding_key, &validation)
             .context("Invalid access token")?;
@@ -267,11 +269,13 @@ impl JwtService {
         token: &str,
         expected_resource: &str,
     ) -> Result<AccessTokenClaims> {
-        let mut validation = Validation::default();
-        validation.validate_exp = true;
         // We compare `aud` explicitly below so we can return a precise error and
         // avoid depending on the library's set-membership semantics.
-        validation.validate_aud = false;
+        let validation = Validation {
+            validate_exp: true,
+            validate_aud: false,
+            ..Default::default()
+        };
 
         let token_data = decode::<AccessTokenClaims>(token, &self.decoding_key, &validation)
             .context("Invalid MCP access token")?;
@@ -315,9 +319,11 @@ impl JwtService {
     /// confirm the returned `sub` matches the authenticated session user — the
     /// signature alone only proves this server issued the token, not for whom.
     pub fn validate_oauth_consent_token(&self, token: &str) -> Result<OAuthConsentClaims> {
-        let mut validation = Validation::default();
-        validation.validate_exp = true;
-        validation.validate_aud = false;
+        let validation = Validation {
+            validate_exp: true,
+            validate_aud: false,
+            ..Default::default()
+        };
 
         let token_data = decode::<OAuthConsentClaims>(token, &self.decoding_key, &validation)
             .context("Invalid OAuth consent token")?;
@@ -331,8 +337,10 @@ impl JwtService {
 
     /// Validate and decode a refresh token
     pub fn validate_refresh_token(&self, token: &str) -> Result<RefreshTokenClaims> {
-        let mut validation = Validation::default();
-        validation.validate_exp = true;
+        let validation = Validation {
+            validate_exp: true,
+            ..Default::default()
+        };
 
         let token_data = decode::<RefreshTokenClaims>(token, &self.decoding_key, &validation)
             .context("Invalid refresh token")?;


### PR DESCRIPTION
## What changed
Upgrades `jsonwebtoken` from 10.4.0 to 11.0.0. No observable behavior change — JWT validation semantics (expiry, audience, algorithm, leeway) are identical. This unblocks the dependabot cargo group, which keeps re-proposing this major bump and failing its CI until it lands.

The only source change: jsonwebtoken 11 makes `Validation`'s fields public, so the previous `let mut validation = Validation::default(); validation.field = …` pattern now trips `clippy::field_reassign_with_default` under `-D warnings`. The four constructions in `crates/server/src/auth/jwt.rs` are rewritten to struct-initializer form (`Validation { validate_exp: true, validate_aud: false, ..Default::default() }`), preserving the exact same settings.

## Why
Part of EVE-803. jsonwebtoken 11 is a major bump of the JWT library in the auth path. Left unhandled it keeps reappearing in dependabot's cargo group and breaking that group's CI.

## Before / After
- **Before:** workspace pinned to jsonwebtoken 10; `cargo clippy --all-targets --all-features -- -D warnings` would fail on v11 due to `field_reassign_with_default`.
- **After:** pinned to jsonwebtoken 11; `cargo clippy -p everruns-server --lib --all-features -- -D warnings` passes clean (exit 0), and `cargo test -p everruns-server --lib auth::` → **204 passed, 0 failed** (jwt + login/refresh + oauth suites). Full PR CI: 39 checks, 0 failed.

Validation defaults were verified against the v11 crate source and are unchanged from v10: `validate_exp: true`, `validate_aud: true`, required claim `exp`, `leeway: 60`, algorithm `HS256`. The struct has no `#[non_exhaustive]` and all fields are public, so the struct-literal form compiles for external callers.

## Risk
- **Low**
- Auth token validation is the blast radius. Mitigated: semantics verified identical against upstream source, and the full `auth::` test suite (204 tests, including the jwt validation and login/refresh tests) passes. No other crate in the workspace depends on jsonwebtoken; lockfile change is limited to jsonwebtoken 10.4.0 → 11.0.0.

## Security
- Threat categories reviewed: **TM-AUTH** (JWT validation path).
- Findings and resolutions: No semantics change — audience validation is still explicitly disabled only where the code compares `aud` itself (MCP/access/consent tokens), expiry validation stays enabled everywhere, and algorithm/leeway defaults are unchanged. No new attack surface.

## Follow-ups
- The coordinated **buffa 0.8 → 0.9** half of EVE-803 stays deferred: it's blocked upstream — the latest `connectrpc` (0.8.1) and `connectrpc-build` (0.8.0) both still require buffa `^0.8.1`, so no connectrpc release built against buffa 0.9 exists yet. Tracked in EVE-803.

## Checklist
- [x] Tests added or updated (existing `auth::` suite covers the validation paths; 204 pass)
- [x] Backward compatibility considered (internal auth only; semantics preserved)
- [x] Security review performed against relevant threat model categories (TM-AUTH)
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)