### PR TITLE
fix(deps): force @hono/node-server >=2.0.5 in .deepsec (GHSA-frvp-7c67-39w9)

### DIFF
--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -15,6 +15,7 @@
   "pnpm": {
     "overrides": {
       "@anthropic-ai/sdk": "^0.105.0",
+      "@hono/node-server": "^2.0.5",
       "tar": "7.5.22",
       "undici": "^7.28.0",
       "zod": "^3.25.76"

--- a/.deepsec/pnpm-lock.yaml
+++ b/.deepsec/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@anthropic-ai/sdk': ^0.105.0
+  '@hono/node-server': ^2.0.5
   tar: 7.5.22
   undici: ^7.28.0
   zod: ^3.25.76
@@ -205,9 +206,9 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@hono/node-server@1.19.17':
-    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.12':
+    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -1498,7 +1499,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@1.19.17(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.32)':
     dependencies:
       hono: 4.12.32
 
@@ -1564,7 +1565,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.17(hono@4.12.32)
+      '@hono/node-server': 2.0.12(hono@4.12.32)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5


### PR DESCRIPTION
## Motivation

Follow-up to #2908, which cleared 6 of 7 Dependabot advisories on `main`. The remaining one:

- **`@hono/node-server` `<2.0.5` — serveStatic path traversal** (GHSA-frvp-7c67-39w9, moderate). It resolves to `1.19.17` in `.deepsec/pnpm-lock.yaml`, pulled transitively via `deepsec@^2.2.6` → `@modelcontextprotocol/sdk@1.29.0`. There is no direct dependency or existing override for it.

Fixes EVE-805.

## Change

Add a pnpm `overrides` entry `"@hono/node-server": "^2.0.5"` in `.deepsec/package.json` and regenerate `pnpm-lock.yaml`. The override resolves to the latest patched `2.0.12`. `@hono/node-server` 2.x targets `hono ^4` (already `4.12.32` here) and `node >=20`, so it resolves cleanly with no other tree changes.

## Validation

`.deepsec` has no build/test step and is not covered by any CI workflow, so runtime validation was performed manually in this session:

- `pnpm install` and `pnpm install --frozen-lockfile` both succeed; the lockfile is internally consistent.
- No `@hono/node-server@1.x` entries remain in the lockfile.
- The `deepsec` CLI loads and runs (`deepsec --help` builds the full command tree), exercising the module graph including the MCP SDK → `@hono/node-server` 2.x path, with no load-time errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DK7doEwdWDGffmdhDGyT5c)_