### PR TITLE
chore(release): prepare v0.17.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.18] - 2026-07-31
+
+### Highlights
+
+- **MCP 2026-07-28 specification** - Adopts the final MCP 2026-07-28 specification ([#2906](https://github.com/everruns/everruns/pull/2906)).
+- **Security and reliability fixes** - Throttles chat session creation, enforces session rate limits in commands, bounds file grep and user-preference resource usage, and hardens citation, harness-dispatch, and snapshot handling ([#2902](https://github.com/everruns/everruns/pull/2902), [#2899](https://github.com/everruns/everruns/pull/2899), [#2895](https://github.com/everruns/everruns/pull/2895), [#2898](https://github.com/everruns/everruns/pull/2898), [#2893](https://github.com/everruns/everruns/pull/2893), [#2894](https://github.com/everruns/everruns/pull/2894), [#2900](https://github.com/everruns/everruns/pull/2900)).
+
+### What's Changed
+
+- fix(deps): force @hono/node-server >=2.0.5 in .deepsec (GHSA-frvp-7c67-39w9) ([#2909](https://github.com/everruns/everruns/pull/2909)) by [@chaliy](https://github.com/chaliy)
+- fix(deps): patch critical/high npm security advisories (astro, node-tar) ([#2908](https://github.com/everruns/everruns/pull/2908)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): upgrade jsonwebtoken 10.4.0 to 11.0.0 ([#2907](https://github.com/everruns/everruns/pull/2907)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): adopt the final MCP 2026-07-28 specification ([#2906](https://github.com/everruns/everruns/pull/2906)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump the cargo group with 7 updates ([#2905](https://github.com/everruns/everruns/pull/2905)) by [@app/dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump @hono/node-server from 1.19.15 to 1.19.17 in /.deepsec in the npm_and_yarn group across 1 directory ([#2904](https://github.com/everruns/everruns/pull/2904)) by [@app/dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump bashkit to 0.14.4 and fix touch in the session filesystem ([#2903](https://github.com/everruns/everruns/pull/2903)) by [@chaliy](https://github.com/chaliy)
+- fix(security): throttle chat session creation ([#2902](https://github.com/everruns/everruns/pull/2902)) by [@chaliy](https://github.com/chaliy)
+- fix(files): scope glob grep content scans ([#2896](https://github.com/everruns/everruns/pull/2896)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): preserve filtered history with prompt hooks ([#2891](https://github.com/everruns/everruns/pull/2891)) by [@chaliy](https://github.com/chaliy)
+- fix(api): bound user preference storage ([#2898](https://github.com/everruns/everruns/pull/2898)) by [@chaliy](https://github.com/chaliy)
+- fix(agent-triggers): preserve harness during dispatch ([#2894](https://github.com/everruns/everruns/pull/2894)) by [@chaliy](https://github.com/chaliy)
+- fix(security): enforce session rate limits in commands ([#2899](https://github.com/everruns/everruns/pull/2899)) by [@chaliy](https://github.com/chaliy)
+- fix(messages): route turns with public agent IDs ([#2901](https://github.com/everruns/everruns/pull/2901)) by [@chaliy](https://github.com/chaliy)
+- fix(citations): guard citation metadata output ([#2893](https://github.com/everruns/everruns/pull/2893)) by [@chaliy](https://github.com/chaliy)
+- fix(compaction): preserve stateful request delta ([#2892](https://github.com/everruns/everruns/pull/2892)) by [@chaliy](https://github.com/chaliy)
+- fix(local): preserve task webhook secrets in snapshots ([#2900](https://github.com/everruns/everruns/pull/2900)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): bound file grep resource usage ([#2895](https://github.com/everruns/everruns/pull/2895)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.17] - 2026-07-25
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,11 +2557,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.17"
+version = "0.17.18"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3165,11 +3165,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.17"
+version = "0.17.18"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.17"
+version = "0.17.18"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.17"
+version = "0.17.18"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.17" }
-everruns-provider = { path = "crates/provider", version = "0.17.17" }
+everruns-core = { path = "crates/core", version = "0.17.18" }
+everruns-provider = { path = "crates/provider", version = "0.17.18" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.17" }
-everruns-ard = { path = "crates/ard", version = "0.17.17" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.18" }
+everruns-ard = { path = "crates/ard", version = "0.17.18" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.17" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.18" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.17",
+  "version": "0.17.18",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.17" }
+everruns-provider = { path = "../provider", version = "0.17.18" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.17" }
+everruns-provider = { path = "../provider", version = "0.17.18" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.17", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.18", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.17", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.18", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.17" }
+everruns-provider = { path = "../provider", version = "0.17.18" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.17" }
+everruns-provider = { path = "../provider", version = "0.17.18" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.17" }
+everruns-provider = { path = "../provider", version = "0.17.18" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed

Cuts release **v0.17.18** (patch). Bumps the workspace version, `apps/ui` version, publish path-dep pins, and lockfile; adds the CHANGELOG entry for the 18 commits merged since v0.17.17.

Notable in this release:
- **MCP 2026-07-28 specification** — adopts the final MCP spec ([#2906](https://github.com/everruns/everruns/pull/2906)).
- **Security & reliability hardening** — throttles chat session creation, enforces session rate limits in commands, bounds file-grep and user-preference resource usage, and hardens citation, harness-dispatch, and snapshot handling.
- **Dependency security patches** — jsonwebtoken 11, @hono/node-server, and critical/high npm advisories (astro, node-tar).

See `CHANGELOG.md` for the full list.

## Why

Regular patch release to publish the fixes and dependency/security updates accumulated on `main` since v0.17.17.

## Before / After

No runtime behavior change from this PR itself — it is version/changelog/lockfile bookkeeping. On merge, the `chore(release): prepare v*` commit triggers auto-tagging (`v0.17.18`), the GitHub Release, Docker images, CLI binaries, and crate publishes.

## Risk
- Low
- Version-string and changelog changes only. Lockfile updated via `cargo update --workspace` (everruns crates only — no unrelated transitive bumps). Publish path-dep pins synced and verified (`sync-publish-pin-versions.py --check`). Migrations verified sequential (001..109).

## Security
- Threat categories reviewed: No security-relevant code changes in this PR (release bookkeeping). The underlying commits include security fixes already reviewed in their own PRs.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release bookkeeping)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7MPHeByngiRKcdrQ1X1pq)_