### PR TITLE
fix(fs): safely rebase exact stale edits

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -1470,16 +1470,23 @@ impl Tool for EditFileTool {
             Ok(hash) => hash,
             Err(e) => return ToolExecutionResult::internal_error(e),
         };
-        if expected_hash != current_hash {
-            return ToolExecutionResult::tool_error(format!(
-                "File '{}' changed since the last read. Expected {}, found {}. Read the file again before editing.",
-                display_path, expected_hash, current_hash
-            ));
-        }
+        let rebased = expected_hash != current_hash;
 
         let current_content = existing.content.unwrap_or_default();
+        // Plan every exact, unique hunk against one current snapshot, then commit
+        // the whole result with compare-and-swap. This safely rebases across an
+        // unrelated stale change while missing, ambiguous, overlapping, or racing
+        // hunks leave the file untouched. Fuzzy matching was rejected because it
+        // can silently select the wrong occurrence; the returned content hash
+        // invalidates caller-side workspace and validation caches after success.
         let (updated_content, applied_edits) = match apply_text_edits(&current_content, &edits) {
             Ok(result) => result,
+            Err(error) if rebased => {
+                return ToolExecutionResult::tool_error(format!(
+                    "File '{}' changed since the last read (expected {}, found {}) and the edits conflict with its current content: {}. Read the file again before editing.",
+                    display_path, expected_hash, current_hash, error
+                ));
+            }
             Err(error) => return ToolExecutionResult::tool_error(error),
         };
 
@@ -1555,6 +1562,7 @@ impl Tool for EditFileTool {
                     "content_hash": new_hash,
                     "previous_content_hash": current_hash,
                     "applied_edits": applied_edits,
+                    "rebased": rebased,
                     "first_changed_line": first_changed_line,
                     "diff": diff,
                     "diff_truncated": diff_truncated
@@ -3366,6 +3374,7 @@ mod tests {
 
         assert_eq!(store.content("/batch.txt").unwrap(), "ONE\ntwo\nTHREE\n");
         assert_eq!(value["applied_edits"], 2);
+        assert_eq!(value["rebased"], false);
         assert_eq!(value["first_changed_line"], 1);
     }
 
@@ -3473,24 +3482,93 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_edit_file_rejects_hash_mismatch() {
+    async fn test_edit_file_rebases_exact_edits_over_unrelated_stale_change() {
         let store = Arc::new(MockFileStore::default());
-        store.add_text_file("/stale.txt", "hello");
-        let context = make_context(store);
+        store.add_text_file("/stale.txt", "title\nold value\nfooter\n");
+        let context = make_context(store.clone());
+        let stale_hash = read_hash(&context, "/workspace/stale.txt").await;
+        store.add_text_file("/stale.txt", "new title\nold value\nfooter\n");
 
         let result = EditFileTool
             .execute_with_context(
                 json!({
                     "path": "/workspace/stale.txt",
-                    "expected_hash": "sha256:stale",
-                    "old_text": "hello",
-                    "new_text": "goodbye"
+                    "expected_hash": stale_hash,
+                    "edits": [
+                        {"old_text": "old value", "new_text": "new value"},
+                        {"old_text": "footer", "new_text": "new footer"}
+                    ]
                 }),
                 &context,
             )
             .await;
 
-        assert!(expect_tool_error(result).contains("changed since the last read"));
+        let value = expect_success(result);
+        assert_eq!(
+            store.content("/stale.txt").unwrap(),
+            "new title\nnew value\nnew footer\n"
+        );
+        assert_eq!(value["applied_edits"], 2);
+        assert_eq!(value["rebased"], true);
+        assert_ne!(value["previous_content_hash"], stale_hash);
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_stale_target_conflict_without_changes() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/stale-conflict.txt", "title\nold value\n");
+        let context = make_context(store.clone());
+        let stale_hash = read_hash(&context, "/workspace/stale-conflict.txt").await;
+        store.add_text_file("/stale-conflict.txt", "title\nother writer value\n");
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/stale-conflict.txt",
+                    "expected_hash": stale_hash,
+                    "edits": [
+                        {"old_text": "title", "new_text": "new title"},
+                        {"old_text": "old value", "new_text": "new value"}
+                    ]
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("Could not find an exact match"));
+        assert_eq!(
+            store.content("/stale-conflict.txt").unwrap(),
+            "title\nother writer value\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_stale_ambiguity_without_changes() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/stale-ambiguous.txt", "header\nunique target\n");
+        let context = make_context(store.clone());
+        let stale_hash = read_hash(&context, "/workspace/stale-ambiguous.txt").await;
+        store.add_text_file(
+            "/stale-ambiguous.txt",
+            "header\nunique target\nunique target\n",
+        );
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/stale-ambiguous.txt",
+                    "expected_hash": stale_hash,
+                    "edits": [{"old_text": "unique target", "new_text": "replacement"}]
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("matched multiple locations"));
+        assert_eq!(
+            store.content("/stale-ambiguous.txt").unwrap(),
+            "header\nunique target\nunique target\n"
+        );
     }
 
     #[tokio::test]

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -601,7 +601,7 @@ When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are au
 
 ##### Design Decision: Hash-Gated Text Edits
 
-`edit_file` is intentionally narrower than `write_file`: it only edits existing text files, requires the current `content_hash` from `read_file` or `write_file`, applies one or more exact replacements against the original file content, and commits via compare-and-set semantics so concurrent writes fail instead of clobbering newer content. This keeps the tool model-friendly while preventing stale writes, ambiguous snippet matches, and accidental binary corruption.
+`edit_file` is intentionally narrower than `write_file`: it only edits existing text files, requires a `content_hash` from `read_file` or `write_file`, and applies one or more exact replacements atomically. If the hash is stale, all replacements are preflighted as unique and non-overlapping against the current content, allowing an unrelated concurrent change to survive; a missing, ambiguous, overlapping, or racing hunk fails without modifying the file. The final write uses compare-and-set semantics so later concurrent writes are never clobbered. This keeps the tool model-friendly while preventing conflicted writes and accidental binary corruption.
 
 #### BashkitShell
 

--- a/specs/workspace.md
+++ b/specs/workspace.md
@@ -233,7 +233,7 @@ internally.
 2. **Delete cascade vs archive:** `DELETE /v1/workspaces/{id}` is a soft-delete that flips the workspace to `archived` and **keeps** its files (archived workspaces are read-only — the workspace fs HTTP layer rejects POST/PUT/DELETE on non-`active` workspaces). The `workspace_files.workspace_id` FK has `ON DELETE CASCADE`, so a hard row removal in `workspaces` (today only reachable through an out-of-band SQL deletion or a future hard-delete API) does cascade and removes all files.
 3. **Encoding detection:** Files with null bytes in first 8KB are base64 encoded.
 4. **Readonly protection:** Cannot modify or delete readonly files; recursive delete of a directory fails if it contains any readonly files.
-5. **Hash-based freshness:** `read_file` and `write_file` return a `content_hash` (`sha256:...`). `edit_file` requires that hash and rejects stale edits.
+5. **Hash-based freshness:** `read_file` and `write_file` return a `content_hash` (`sha256:...`). `edit_file` requires that hash. A stale edit safely rebases only when every exact replacement remains unique and non-overlapping in the current content; conflicts and write races fail without modifying the file.
 6. **Text-only edit tool:** `edit_file` only operates on text files. Binary/base64 files must be replaced via `write_file`.
 7. **Memory mounts:** Sessions can mount org Memories (`specs/memory.md`) into the workspace, read-only by default or read-write where trust permits.
 


### PR DESCRIPTION
## What changed\nExact edit_file hunks now safely rebase over unrelated stale workspace changes. Every hunk is still preflighted as exact, unique, and non-overlapping against one current snapshot, then the full edit is committed with compare-and-swap. Conflicts and races leave the file unchanged.\n\n## Why\nA privacy-safe sample of the latest 72 local edit_file completions reproduced 20 failures (27.8%): 17 stale hashes, 2 missing matches, and 1 ambiguity. Strict stale-hash rejection forced a read plus retry even when the requested hunks were untouched.\n\n## Before / After\n- Strict hash gate: 1/2 intended edit fixtures succeeded in one call; unrelated concurrency required one extra model/tool round.\n- Exact safe rebase: 2/2 intended edit fixtures succeeded in one call.\n- Both approaches: 3/3 missing/ambiguous/racing conflict controls rejected with zero unintended changes.\n- Existing atomic multi-hunk behavior remains covered.\n\n## Risk\n- Medium\n- A stale caller can now edit when all exact targets still uniquely match current content. Semantic conflicts outside the exact targets are intentionally treated as unrelated; CAS still rejects a later writer.\n\n## Security\n- Threat categories reviewed: TM-FS, TM-TOOL, TM-DEP\n- Findings and resolutions: path, text-only, readonly, and store boundaries are unchanged. Exact unique preflight prevents ambiguous targeting; all hunks plan before any write; CAS prevents clobbering a later concurrent writer. Fuzzy recovery was rejected because it could silently choose the wrong occurrence. No capability or dependency change.\n\n## Follow-ups\nNo follow-ups.\n\n## Checklist\n- [x] Tests added or updated\n- [x] Backward compatibility considered\n- [x] Security review performed against relevant threat model categories\n- [x] Final CI ran checks affected by this PR\n- [x] All review comments addressed (code change or written reasoning)\n\nValidation:\n- cargo fmt --check\n- cargo clippy -p everruns-core --all-targets -- -D warnings\n- cargo test -p everruns-core\n- just pre-push