### PR TITLE
fix(provider): retry provider stream stalls via shared transient path

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -2774,16 +2774,47 @@ impl ReasonAtom {
                         None => break,
                     },
                     _ = &mut stall_sleep => {
+                        // EVE-806: a stream that produced no tokens within the
+                        // liveness window is equivalent to a dropped connection.
+                        // Route it through the same bounded transient-retry path
+                        // as an in-stream provider error (everruns-provider
+                        // classifies this message as transient) instead of
+                        // failing the turn immediately. Retrying re-issues the
+                        // same request with no artificial history messages; a
+                        // stall after partial output is not retried, and repeated
+                        // stalls stay bounded by retry_config.max_retries.
+                        let stall_error =
+                            crate::driver_registry::LlmStreamError::new(format!(
+                                "provider stream stall: no tokens for {}s",
+                                stall_timeout.as_secs()
+                            ));
                         tracing::warn!(
                             session_id = %session_id,
                             turn_id = %context.turn_id,
                             stall_secs = stall_timeout.as_secs(),
                             "ReasonAtom: provider stream stall timeout"
                         );
-                        return Err(AgentLoopError::llm(format!(
-                            "provider stream stall: no tokens for {}s",
-                            stall_timeout.as_secs()
-                        )));
+                        if should_retry_stream_error(
+                            &stall_error,
+                            stream_retry_metadata.attempts,
+                            retry_config.max_retries,
+                            stream_has_output,
+                        ) {
+                            let wait_duration = retry_config
+                                .calculate_backoff(stream_retry_metadata.attempts);
+                            tracing::warn!(
+                                session_id = %session_id,
+                                turn_id = %context.turn_id,
+                                attempt = stream_retry_metadata.attempts + 1,
+                                max_retries = retry_config.max_retries,
+                                wait_secs = wait_duration.as_secs_f64(),
+                                "ReasonAtom: provider stream stall, retrying"
+                            );
+                            stream_retry_metadata.record_retry(wait_duration, None);
+                            tokio::time::sleep(wait_duration).await;
+                            continue 'stream_attempt;
+                        }
+                        return Err(AgentLoopError::llm(stall_error.message));
                     },
                     _ = keepalive_ticker.tick() => {
                         if let Some(ref hb) = self.stream_heartbeater {

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -646,6 +646,54 @@ impl everruns_core::ChatDriver for FlakyStreamDriver {
     }
 }
 
+/// EVE-806: stalls the stream (emits nothing) on the first attempt so the
+/// ReasonAtom's liveness watchdog fires, then recovers with a normal completion
+/// on the retry. `max_stalls` bounds how many leading attempts stall — set it
+/// beyond the retry budget to prove repeated stalls stay bounded and error out.
+#[derive(Clone, Debug)]
+struct StallingStreamDriver {
+    attempts: Arc<AtomicUsize>,
+    max_stalls: usize,
+    /// Number of request messages seen on each attempt, so tests can prove the
+    /// retry re-issues the same request without injecting artificial history.
+    seen_message_counts: Arc<Mutex<Vec<usize>>>,
+}
+
+#[async_trait]
+impl everruns_core::ChatDriver for StallingStreamDriver {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<everruns_core::LlmMessage>,
+        config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        self.seen_message_counts.lock().await.push(messages.len());
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
+
+        if attempt < self.max_stalls {
+            // A stream that never yields a token: the watchdog must abort it.
+            return Ok(Box::pin(stream::pending::<
+                everruns_core::Result<everruns_core::LlmStreamEvent>,
+            >()));
+        }
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(everruns_core::LlmStreamEvent::TextDelta(
+                "Recovered after stall.".to_string(),
+            )),
+            Ok(everruns_core::LlmStreamEvent::Done(Box::new(
+                everruns_core::LlmCompletionMetadata {
+                    total_tokens: Some(8),
+                    prompt_tokens: Some(5),
+                    completion_tokens: Some(3),
+                    model: Some(config.model.clone()),
+                    finish_reason: Some("stop".to_string()),
+                    ..Default::default()
+                },
+            ))),
+        ])))
+    }
+}
+
 #[derive(Clone, Debug)]
 struct ThinkingLeakDriver {
     thinking: String,
@@ -2403,6 +2451,189 @@ async fn test_reason_atom_retries_structured_processing_error_before_output() {
     } else {
         panic!("Expected llm.generation event data");
     }
+}
+
+/// EVE-806: a provider stream stall before any output must be recovered by the
+/// shared bounded retry path (one stall, one retry, then a successful response),
+/// not surfaced as a failed turn — and without injecting artificial history.
+#[tokio::test(start_paused = true)]
+async fn test_reason_atom_retries_provider_stream_stall_before_output() {
+    use everruns_core::in_memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Hello!")])
+        .await;
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_registry = Arc::clone(&attempts);
+    let seen_counts = Arc::new(Mutex::new(Vec::new()));
+    let seen_counts_for_registry = Arc::clone(&seen_counts);
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(DriverId::LlmSim, move |_config| {
+        Box::new(StallingStreamDriver {
+            attempts: Arc::clone(&attempts_for_registry),
+            max_stalls: 1,
+            seen_message_counts: Arc::clone(&seen_counts_for_registry),
+        })
+    });
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    )
+    .with_provider_stall_timeout(std::time::Duration::from_millis(50));
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("stream stall should receive a bounded retry, not fail the turn");
+
+    assert!(result.success, "stall should be recovered by the retry");
+    assert_eq!(result.text, "Recovered after stall.");
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        2,
+        "one stalled attempt plus one successful retry"
+    );
+
+    // Retry must not add an artificial user/assistant message: the request
+    // re-issued on the retry carries the same number of messages as the first.
+    let counts = seen_counts.lock().await.clone();
+    assert_eq!(counts.len(), 2, "expected one stall attempt and one retry");
+    assert_eq!(
+        counts[0], counts[1],
+        "retry must re-issue the same request without injecting history: {counts:?}"
+    );
+
+    let events = event_emitter.events().await;
+    let llm_event = events
+        .iter()
+        .find(|e| e.event_type == "llm.generation")
+        .expect("llm.generation event should be emitted");
+    if let everruns_core::EventData::LlmGeneration(data) = &llm_event.data {
+        assert!(data.metadata.success, "retry should recover the generation");
+        let retry = data
+            .metadata
+            .retry
+            .as_ref()
+            .expect("retry metadata should be recorded");
+        assert_eq!(retry.attempts, 1);
+    } else {
+        panic!("Expected llm.generation event data");
+    }
+}
+
+/// EVE-806: repeated provider stream stalls must stay bounded by the shared
+/// retry budget and eventually return an error rather than retrying forever.
+#[tokio::test(start_paused = true)]
+async fn test_reason_atom_bounds_repeated_provider_stream_stalls() {
+    use everruns_core::in_memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Hello!")])
+        .await;
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_registry = Arc::clone(&attempts);
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(DriverId::LlmSim, move |_config| {
+        Box::new(StallingStreamDriver {
+            attempts: Arc::clone(&attempts_for_registry),
+            // Never recovers — every attempt stalls.
+            max_stalls: usize::MAX,
+            seen_message_counts: Arc::new(Mutex::new(Vec::new())),
+        })
+    });
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    )
+    .with_provider_stall_timeout(std::time::Duration::from_millis(50));
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    // A terminal stall surfaces as an unsuccessful result carrying the stall
+    // error (the atom maps terminal LLM errors into a ReasonResult rather than
+    // returning Err), never an unbounded retry loop.
+    let result = atom
+        .execute(input)
+        .await
+        .expect("execute returns a failure result, not Err, on a terminal stall");
+    assert!(!result.success, "unbounded stalls must fail the turn");
+    assert!(
+        result
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("provider stream stall")),
+        "terminal error should be the stall error, got: {:?}",
+        result.error
+    );
+    // Default LlmRetryConfig::max_retries = 2, so the initial attempt plus two
+    // bounded retries = 3 total stream attempts, then a terminal error.
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        3,
+        "stalls must stay bounded by the retry budget"
+    );
 }
 
 #[tokio::test]

--- a/crates/provider/src/llm_retry.rs
+++ b/crates/provider/src/llm_retry.rs
@@ -424,6 +424,15 @@ pub fn is_transient_error_message(message: &str) -> bool {
 
     let msg = message.trim().to_ascii_lowercase();
 
+    // EVE-806: the runtime's stream-liveness watchdog aborts a stream that
+    // produced no tokens within its window with "provider stream stall: no
+    // tokens for Ns". A stall before any output is equivalent to a dropped
+    // connection, so it is transient and safe for the shared bounded retry path
+    // to recover.
+    if msg.contains("provider stream stall") {
+        return true;
+    }
+
     [
         "server_error",
         "internal server error",
@@ -853,6 +862,21 @@ mod tests {
             Some("insufficient_quota"),
             Some(429),
             "rate limit",
+        )));
+    }
+
+    #[test]
+    fn test_provider_stream_stall_is_transient() {
+        // EVE-806: the runtime stream-liveness watchdog message must be
+        // classified transient so the shared bounded retry path recovers it.
+        assert!(is_transient_error_message(
+            "provider stream stall: no tokens for 120s"
+        ));
+        // Untyped stream error carrying the stall message routes through the
+        // message fallback in is_transient_stream_error.
+        use crate::driver_registry::LlmStreamError;
+        assert!(is_transient_stream_error(&LlmStreamError::new(
+            "provider stream stall: no tokens for 120s"
         )));
     }
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -602,6 +602,13 @@ Authentication, invalid-request, and exhausted billing/quota errors fail fast.
 Once output exists, the runtime preserves it as a partial success instead of
 replaying the generation and risking duplicate visible output.
 
+A provider stream stall — the runtime's stream-liveness watchdog aborting a
+stream that produced no tokens within its window — is treated the same way as an
+in-band transient error: before any output it is classified transient and routed
+through the same bounded retry path, re-issuing the identical request with no
+artificial history; after output, or once the retry budget is exhausted, it
+fails the turn. See `crates/core/src/atoms/reason.rs`.
+
 ### Rate Limit Header Support
 
 Drivers parse provider-specific headers to determine retry timing:


### PR DESCRIPTION
## What changed
A provider stream stall — the runtime's stream-liveness watchdog aborting a stream that produced no tokens within its window (`provider stream stall: no tokens for Ns`) — is now treated as a transient failure and recovered by the existing bounded retry mechanism, instead of failing the turn on the first stall. All frontends (ACP, TUI, inline, one-shot, future clients) inherit the behavior because the recovery happens at the shared provider/runtime boundary.

- `everruns-provider` classifies the stall message as transient (`is_transient_error_message` / `is_transient_stream_error`).
- `ReasonAtom`'s stall watchdog now routes through the same `should_retry_stream_error` + `continue 'stream_attempt` path used by in-stream provider errors, instead of returning immediately. The retry re-issues the identical request (no artificial user/assistant message added to history) and is bounded by `LlmRetryConfig::max_retries` (default 2). A stall after partial output is preserved as a partial success rather than replayed.

## Why
The shared `ReasonAtom` already retries transient stream failures, but the watchdog error was minted as a plain `AgentLoopError` and returned immediately, bypassing the transient classifier and the bounded retry path. A stall before any output is equivalent to a dropped connection, yet clients received a failed turn instead of a recovery attempt. Observed in Yolop session `session_019fba52b6547af1aedc5da01716783d` (EVE-806).

## Before / After
- **Before:** first `provider stream stall: no tokens for 120s` → turn fails immediately, surfaced to the client as a processing error.
- **After:** stall before output → up to 2 bounded retries with backoff; a subsequent healthy stream recovers the turn. Repeated stalls stay bounded and eventually fail with the stall error.

Evidence (deterministic regression tests through the real `ReasonAtom::execute` path):
- `test_reason_atom_retries_provider_stream_stall_before_output` — one stall, one retry, success; asserts the retry re-issues the same request (equal request message counts) and records `retry.attempts == 1`.
- `test_reason_atom_bounds_repeated_provider_stream_stalls` — always-stalling driver → exactly 3 attempts (initial + 2 retries), then a terminal failure carrying the stall error.
- `test_provider_stream_stall_is_transient` (provider unit test).
- Full `reason_atom_test` suite: 45 passed. `cargo fmt --check` clean; `cargo clippy -p everruns-provider -p everruns-core --all-targets --all-features -D warnings` clean.

## Risk
- Low
- Blast radius is the transient-retry classification. Retries are bounded (max 2) and only fire before any output, so there is no unbounded-retry / duplicate-output risk. Non-transient provider errors (auth, invalid-request, quota) are unchanged and still fail fast.

## Security
- Threat categories reviewed: TM-DOS (resource exhaustion via retries). No auth, secrets, input-parsing, SSRF, or data-exposure surface is touched.
- Findings and resolutions: A provider could craft an error message containing the stall substring to be classified transient, but the effect is capped at 2 additional bounded, backed-off attempts — no amplification beyond the existing transient-retry policy (which already matches broad keywords like "overloaded"). No new attack surface; no changes needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Resolves EVE-806.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvSizF4w1VieRQaho8jiUn)_