### PR TITLE
chore: green main CI (OpenAI credit-exhaustion skip) + patch brace-expansion DoS (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -79,8 +79,8 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
-      "brace-expansion@1": "1.1.16",
-      "brace-expansion@2": "2.1.2",
+      "brace-expansion@1": "1.1.17",
+      "brace-expansion@2": "2.1.3",
       "dompurify": "3.4.12",
       "fast-uri": "3.1.4",
       "js-yaml": "4.3.0",

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@1: 1.1.17
+  brace-expansion@2: 2.1.3
   dompurify: 3.4.12
   fast-uri: 3.1.4
   js-yaml: 4.3.0
@@ -2307,11 +2307,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.17:
+    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.3:
+    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -6592,12 +6592,12 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8350,15 +8350,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.17
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minipass@7.1.3: {}
 

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 packages: []
 overrides:
   '@babel/core': 7.29.6
-  brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@1: 1.1.17
+  brace-expansion@2: 2.1.3
   dompurify: 3.4.12
   fast-uri: 3.1.4
   js-yaml: 4.3.0
@@ -23,10 +23,14 @@ minimumReleaseAgeStrict: true
 # (GHSA-r28c-9q8g-f849), sharp 0.35.3 — all matured past the 7-day window.
 # fast-uri 3.1.4 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6) is the
 # only patched release for that advisory and is still inside the 7-day window,
-# so it needs an exemption. Exact-pinned, so this cannot pull any other freshly
-# published version; it only lets the security fix land before maturity.
+# so it needs an exemption. brace-expansion 1.1.17 / 2.1.3 (GHSA-mh99-v99m-4gvg
+# — DoS via unbounded expansion, transitive dev-dep via jest/openapi-typescript)
+# are the patched releases and are likewise still inside the maturity window.
+# All exact-pinned via the overrides above, so an exemption cannot pull any other
+# freshly published version; it only lets the security fix land before maturity.
 minimumReleaseAgeExclude:
   - fast-uri
+  - brace-expansion
 allowBuilds:
   sharp: true
   unrs-resolver: true

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -207,6 +207,14 @@ pub fn is_quota_exhausted(err: &str) -> bool {
         return true;
     }
 
+    // OpenAI's explicit out-of-credits machine code / phrasing. Returned as a
+    // 429 with body `credit_balance_exhausted: You have no credits remaining.`
+    // — no "quota" word, and "no credits remaining" isn't an exhaustion phrase
+    // below, so match it directly here.
+    if e.contains("credit_balance_exhausted") {
+        return true;
+    }
+
     let quota_signal = e.contains("quota") || e.contains("out of quota");
     let billing_signal = e.contains("billing") || e.contains("credit");
     let exceeded_signal = e.contains("exceeded");
@@ -224,6 +232,7 @@ pub fn is_quota_exhausted(err: &str) -> bool {
         || e.contains("run out")
         || e.contains("ran out")
         || e.contains("out of credit")
+        || e.contains("no credit") // "you have no credits remaining" (OpenAI)
         || e.contains("purchase credit")
         || e.contains("depleted");
     if billing_signal && exhaustion_phrase {
@@ -398,6 +407,13 @@ mod quota_detector_tests {
             "HTTP 429 Too Many Requests: insufficient_quota"
         ));
         assert!(is_quota_exhausted("429: quota exceeded for project"));
+        // OpenAI real-world out-of-credits: 429 with `credit_balance_exhausted`
+        // machine code and "You have no credits remaining." (no "quota" word,
+        // no exhaustion phrase like "too low"). This is the exact message that
+        // red main CI until matched here.
+        assert!(is_quota_exhausted(
+            "LLM error: credit_balance_exhausted: You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/."
+        ));
         // Case-insensitive.
         assert!(is_quota_exhausted("INSUFFICIENT_QUOTA"));
     }


### PR DESCRIPTION
Two independent maintenance fixes from the scheduled repo-health sweep. Kept on one branch per the run's branch constraint; each is a separate, self-contained commit.

## 1. `test(llm)`: skip live matrix on OpenAI `credit_balance_exhausted`
The live LLM integration matrix treats provider out-of-credits responses as a skip (like an absent API key) rather than a hard failure. OpenAI's specific out-of-credits phrasing — `credit_balance_exhausted: You have no credits remaining.` — carried neither the word "quota" nor any matched exhaustion phrase, so it slipped through `is_quota_exhausted` and turned **main CI red** (run on `a952049`, job "Integration Tests (PostgreSQL)", 6 OpenAI cases).

Fix: match the `credit_balance_exhausted` machine code directly and add `"no credit"` to the exhaustion phrases, with a regression test for the exact message. A genuine API/contract break (auth, schema, model-not-available, plain rate limits) still fails loudly — the existing `does_not_match_ordinary_or_auth_errors` test guards that. Detector unit tests: 2 passed.

## 2. `chore(security)`: patch brace-expansion DoS (GHSA-mh99-v99m-4gvg)
Resolves the open high-severity Dependabot alert (#155) on the default branch. `apps/ui` pinned `brace-expansion` to exactly the vulnerable `1.1.16` / `2.1.2` via pnpm overrides; the advisory (DoS via unbounded brace expansion → OOM crash) is fixed in `>=1.1.17` / `>=2.1.3`. The dependency is a transitive **dev-only** import (jest / openapi-typescript minimatch chains), so runtime is unaffected, but the alert flags high.

Fix: bump both override pins to the minimal patched `1.1.17` / `2.1.3`, regenerate the lockfile, and add `brace-expansion` to `minimumReleaseAgeExclude` (both patched releases are still inside the maturity window) exactly as `fast-uri` already is — exact-pinned, so the exemption cannot pull any other freshly published version. `pnpm audit --audit-level=high`: no known vulnerabilities.

## Risk
- Low. (1) is test-support heuristic only. (2) is a dev-only transitive dep bump to the minimal patched versions, audit-clean.

## Security
- Threat categories reviewed: TM-AUTH is untouched. (2) removes a known high advisory from the dependency graph; (1) is test-only.
- Findings and resolutions: brace-expansion GHSA-mh99-v99m-4gvg resolved.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01LjTFum5djCmFB83f4Aw51c