### PR TITLE
fix(server): allow MCP OAuth consent redirect through CSP form-action

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -276,6 +276,15 @@ fn apply_personal_access_token_routes_wrap(
     }
 }
 
+// TM-WEB-004/005: baseline CSP stamped on every response that does not set its
+// own. `frame-src 'self' data:` lets the file-preview UI embed PDFs via a
+// `data:application/pdf` iframe (sandboxed viewers don't render in Chromium)
+// and keeps `about:srcdoc` previews (SVG/HTML/MCP cards) working under 'self'.
+// `form-action` must remain the LAST directive: the MCP OAuth consent page
+// extends it by appending the validated client redirect origin to this string
+// (see `auth::mcp_oauth::oauth_authorize`).
+pub(crate) const BASE_CONTENT_SECURITY_POLICY: &str = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; font-src 'self'; frame-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'";
+
 fn permissions_policy_header_value(voice_enabled: bool) -> axum::http::HeaderValue {
     let value = format!(
         "camera=(), {}, geolocation=()",
@@ -1701,13 +1710,7 @@ impl ServerAppBuilder {
             ))
             .layer(SetResponseHeaderLayer::if_not_present(
                 axum::http::header::HeaderName::from_static("content-security-policy"),
-                axum::http::HeaderValue::from_static(
-                    // `frame-src 'self' data:` lets the file-preview UI embed
-                    // PDFs via a `data:application/pdf` iframe (sandboxed
-                    // viewers don't render in Chromium) and keeps `about:srcdoc`
-                    // previews (SVG/HTML/MCP cards) working under 'self'.
-                    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; font-src 'self'; frame-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
-                ),
+                axum::http::HeaderValue::from_static(BASE_CONTENT_SECURITY_POLICY),
             ));
 
         let app = app.layer(TraceLayer::new_for_http().make_span_with(

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -613,7 +613,28 @@ async fn oauth_authorize(
         ip,
         serde_json::json!({"client_id": query.client_id}),
     );
-    Ok(Html(confirm_page).into_response())
+    let mut response = Html(confirm_page).into_response();
+    // Chrome checks `form-action` against every hop of a form-submission
+    // redirect chain, so the baseline `form-action 'self'` silently blocks the
+    // confirm POST's 302 to the client callback (e.g. a native client's
+    // `http://localhost:<port>/callback`). Extend it, for this page only, with
+    // the redirect origin — already validated against the registered client.
+    if let Some(csp) = url::Url::parse(&query.redirect_uri)
+        .ok()
+        .map(|u| u.origin().ascii_serialization())
+        .and_then(|origin| {
+            axum::http::HeaderValue::from_str(&format!(
+                "{} {origin}",
+                crate::app_builder::BASE_CONTENT_SECURITY_POLICY
+            ))
+            .ok()
+        })
+    {
+        response
+            .headers_mut()
+            .insert(axum::http::header::CONTENT_SECURITY_POLICY, csp);
+    }
+    Ok(response)
 }
 
 async fn oauth_authorize_confirm(

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -3385,6 +3385,31 @@ async fn test_oauth_authorize_confirm_needs_no_csrf_cookie() {
     );
 }
 
+/// The consent page must carry its own CSP whose `form-action` allows the
+/// client's redirect origin. Chrome checks `form-action` against every hop of
+/// the form-submission redirect chain, so the global `form-action 'self'`
+/// policy silently blocks the 302 to the client callback (e.g. a native
+/// client's `http://localhost:<port>/callback`) — the click appears to do
+/// nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_authorize_page_csp_allows_redirect_origin() {
+    let server = TestServer::in_memory().await;
+    let (client_id, _) = register_oauth_client(&server).await;
+
+    let page = server.get(&authorize_query_string(&client_id)).await;
+    assert_eq!(page.status(), StatusCode::OK);
+
+    let csp = page
+        .headers()
+        .get("content-security-policy")
+        .and_then(|v| v.to_str().ok())
+        .expect("consent page must set its own content-security-policy");
+    assert!(
+        csp.contains("form-action 'self' http://localhost:9999"),
+        "form-action must allow the validated redirect origin, got: {csp}"
+    );
+}
+
 /// A forged/garbage consent token must be rejected — the anti-CSRF guarantee
 /// must survive moving from a cookie to a signed session-bound token.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed
Clicking "Authorize client" on the MCP OAuth consent page now completes the flow. The consent page is served with its own Content-Security-Policy that extends `form-action` with the validated client redirect origin, so Chrome follows the post-consent 302 to the client's callback instead of silently blocking it. The baseline CSP is unchanged for every other response and is now a shared constant (`BASE_CONTENT_SECURITY_POLICY`).

## Why
The global security-header layer stamps `form-action 'self'` on all responses. Chrome enforces `form-action` against every hop of a form-submission redirect chain, so the consent form's 302 to a cross-origin redirect_uri (e.g. a native client's `http://localhost:{port}/callback` — what Claude Code, Cursor, etc. register) was blocked. The click appeared to do nothing; the only trace was a CSP violation in the browser console. Every MCP client with a loopback or external redirect URI was unable to complete OAuth in Chromium-based browsers.

## Before / After
Before: pressing "Authorize client" leaves the page unchanged; console shows `Refused to send form data ... violates ... form-action 'self'`; MCP client never receives the authorization code.
After: pressing "Authorize client" redirects to `http://localhost:{port}/callback?code=...&state=...` and the client completes the token exchange. Consent page response header now carries `form-action 'self' http://localhost:{port}`.

## Risk
- Low
- Scope is one response header on `GET /oauth/authorize` only. The added origin is already validated against the registered client's redirect URIs and the scheme allowlist (https, or http on loopback only), so no new redirect surface is introduced.

## Security
- Threat categories reviewed: TM-WEB-004/005 (security response headers), OAuth open-redirect prevention.
- Findings and resolutions: extending `form-action` is limited to the single origin of a pre-registered, scheme-validated redirect URI on the consent page only; all other responses keep the strict baseline. No secrets or tokens are exposed in the header.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
