### PR TITLE
fix(auth): keep session and org selection across token refresh

### DIFF
--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -83,6 +83,21 @@ describe("auth proxy", () => {
     expect(response.headers.get("location")).toBeNull();
   });
 
+  it("allows protected routes through when only the refresh token cookie exists", () => {
+    process.env.AUTH_MODE = "full";
+
+    const request = {
+      cookies: { has: (name: string) => name === "refresh_token" },
+      nextUrl: new URL("http://localhost/settings/providers?tab=models"),
+      url: "http://localhost/settings/providers?tab=models",
+    } as unknown as Parameters<typeof proxy>[0];
+
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("location")).toBeNull();
+  });
+
   it("adds agent discovery Link headers to the homepage", () => {
     const request = {
       cookies: { has: () => false },

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -29,7 +29,16 @@ export function proxy(request: NextRequest) {
     return response;
   }
 
-  if (authDisabled() || request.cookies.has("access_token")) {
+  // A missing access token is not a missing session: the access cookie's
+  // Max-Age is the short access-token lifetime (~15 min), while the refresh
+  // cookie lives for weeks. Let refresh-only requests through so the client's
+  // silent refresh (lib/api/client.ts) can re-mint the access token instead of
+  // bouncing every idle tab to /login.
+  if (
+    authDisabled() ||
+    request.cookies.has("access_token") ||
+    request.cookies.has("refresh_token")
+  ) {
     return NextResponse.next();
   }
 

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -20,11 +20,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use crate::auth::middleware::{AuthState, AuthUser, ResolvedOrg};
+use crate::auth::middleware::{AuthState, AuthUser, ORG_COOKIE_MAX_AGE, ResolvedOrg};
 use crate::storage::models::UpdateUser;
 
-/// Cookie name for storing selected organization
-pub const ORG_COOKIE_NAME: &str = "everruns_org";
+pub use crate::auth::middleware::ORG_COOKIE_NAME;
 
 /// App state for users routes
 #[derive(Clone)]
@@ -364,12 +363,15 @@ pub async fn switch_org(
         return Err(StatusCode::NOT_FOUND);
     }
 
-    // Build the org cookie
+    // Build the org cookie. Max-Age keeps the selection across browser
+    // restarts (a session cookie is dropped and the UI falls back to the
+    // default org).
     let org_cookie = Cookie::build((ORG_COOKIE_NAME, req.org_id.clone()))
         .path("/")
         .http_only(false) // Allow JS to read for UI state
         .secure(true)
         .same_site(SameSite::Lax)
+        .max_age(ORG_COOKIE_MAX_AGE)
         .build();
 
     let jar = jar.add(org_cookie);

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -621,9 +621,14 @@ where
 // ResolvedOrg - Organization context from auth (not URL path)
 // ============================================================================
 
-/// Cookie name for org selection in session auth
-/// Note: Also defined in api/users.rs - keep in sync
+/// Cookie name for org selection in session auth (re-exported by api/users.rs)
 pub const ORG_COOKIE_NAME: &str = "everruns_org";
+
+/// Max-Age for the org-selection cookie. Without an explicit Max-Age the
+/// browser drops it on restart and the UI falls back to the default org.
+/// Matches the default refresh-token lifetime so the selection outlives any
+/// session it can belong to.
+pub const ORG_COOKIE_MAX_AGE: time::Duration = time::Duration::days(30);
 
 /// Organization context resolved from authentication
 ///

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -1068,6 +1068,7 @@ pub async fn get_current_user(
                 .http_only(false) // Allow JS to read for UI state
                 .secure(true)
                 .same_site(SameSite::Lax)
+                .max_age(super::middleware::ORG_COOKIE_MAX_AGE)
                 .build();
             jar.add(cookie)
         } else {
@@ -1892,13 +1893,21 @@ async fn generate_token_response(
 
     let mut jar = jar.add(access_cookie).add(refresh_cookie);
 
-    // Set org cookie to user's first org (ensures org context for subsequent API calls)
-    if let Some(org) = user.organizations.first() {
+    // Ensure org context for subsequent API calls, but never clobber a
+    // selection that still maps to one of the user's organizations: this
+    // helper runs on every login AND every silent refresh (~each access-token
+    // lifetime), so unconditional re-minting silently reset the selected org
+    // to the first (alphabetical) one.
+    let keep_existing_org = jar
+        .get(ORG_COOKIE_NAME)
+        .is_some_and(|c| user.organizations.iter().any(|o| o.public_id == c.value()));
+    if !keep_existing_org && let Some(org) = user.organizations.first() {
         let org_cookie = Cookie::build((ORG_COOKIE_NAME, org.public_id.clone()))
             .path("/")
             .http_only(false) // Allow JS to read for UI state
             .secure(true)
             .same_site(SameSite::Lax)
+            .max_age(super::middleware::ORG_COOKIE_MAX_AGE)
             .build();
         jar = jar.add(org_cookie);
     }

--- a/crates/server/tests/auth_integration_test.rs
+++ b/crates/server/tests/auth_integration_test.rs
@@ -892,3 +892,104 @@ async fn test_register_safety_net_is_idempotent_when_seed_already_ran() {
         "safety net must keep the same harness row identity (idempotent upsert)"
     );
 }
+
+// ============================================
+// Org cookie persistence across login/refresh
+// ============================================
+
+// Helper: ensure default-org membership for the user (the mini auth router
+// harness does not run the full register provisioning), then hit /v1/auth/me
+// (which sets the org cookie when missing) and return the minted org id.
+async fn fetch_org_cookie(router: &Router, db: &Arc<StorageBackend>, access_token: &str) -> String {
+    let (status, body, _cookies) = send(
+        router,
+        "GET",
+        "/v1/auth/me",
+        None,
+        Some(&format!("access_token={access_token}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "/v1/auth/me failed: {body}");
+    let user_id = uuid::Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    db.add_organization_member(everruns_core::DEFAULT_ORG_ID, user_id, "member")
+        .await
+        .expect("add_organization_member failed");
+
+    let (status, body, cookies) = send(
+        router,
+        "GET",
+        "/v1/auth/me",
+        None,
+        Some(&format!("access_token={access_token}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "/v1/auth/me failed: {body}");
+    extract_cookie_value(&cookies, "everruns_org")
+        .unwrap_or_else(|| panic!("/v1/auth/me must set the org cookie, body: {body}"))
+}
+
+// The `everruns_org` cookie must not be re-minted to the user's first org on
+// every token mint: `generate_token_response` runs on login AND on each silent
+// refresh (~every access-token lifetime), so unconditional re-minting silently
+// reset the selected organization back to the first (alphabetical) org.
+#[tokio::test]
+async fn test_refresh_preserves_valid_org_cookie() {
+    let (router, db) = auth_router().await;
+    let (access_token, refresh_token, _cookies) =
+        register_user(&router, "orgkeep@example.com", "correct-horse-battery-9").await;
+    let org_id = fetch_org_cookie(&router, &db, &access_token).await;
+
+    let (status, _body, cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&format!(
+            "refresh_token={refresh_token}; everruns_org={org_id}"
+        )),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        extract_cookie_value(&cookies, "everruns_org").is_none(),
+        "refresh must not re-mint a still-valid org selection, got: {cookies:?}"
+    );
+}
+
+// An org cookie that no longer maps to one of the user's organizations must be
+// replaced with a valid one, and the replacement must be persistent (Max-Age)
+// so the selection survives a browser restart.
+#[tokio::test]
+async fn test_refresh_replaces_invalid_org_cookie_with_persistent_one() {
+    let (router, db) = auth_router().await;
+    let (access_token, refresh_token, _cookies) =
+        register_user(&router, "orgreset@example.com", "correct-horse-battery-9").await;
+    let valid_org = fetch_org_cookie(&router, &db, &access_token).await;
+
+    let (status, _body, cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/refresh",
+        None,
+        Some(&format!(
+            "refresh_token={refresh_token}; everruns_org=org_00000000000000000000000000009999"
+        )),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        extract_cookie_value(&cookies, "everruns_org").as_deref(),
+        Some(valid_org.as_str()),
+        "an org cookie outside the user's memberships must be replaced"
+    );
+    let org_header = cookies
+        .iter()
+        .find(|h| h.starts_with("everruns_org="))
+        .unwrap();
+    assert!(
+        org_header.contains("Max-Age="),
+        "org cookie must persist across browser restarts, got: {org_header}"
+    );
+}


### PR DESCRIPTION
## What changed
Two user-facing session papercuts are fixed together because they share a code path:

1. Idle browser sessions no longer bounce to `/login` after ~15 minutes. The Next.js middleware lets a request through when a `refresh_token` cookie is present (not only `access_token`), so the client-side silent refresh can re-mint the access token on the next API call. Effective idle ceiling becomes the refresh-token lifetime (30 days) instead of the access-token lifetime (15 minutes).
2. The selected organization is no longer forgotten. `generate_token_response` — which runs on every login *and every silent refresh* — previously re-minted the `everruns_org` cookie to the user's first (alphabetical) org unconditionally, resetting the selection every time the access token rotated. It now preserves an existing selection that still maps to one of the user's organizations. The org cookie also gets a 30-day Max-Age everywhere it is minted (token mint, `/v1/auth/me`, `switch_org`) so it survives browser restarts; previously it was a session cookie. `ORG_COOKIE_NAME` is deduplicated into `auth::middleware` (was defined twice).

## Why
Users were logged out after any >15-minute idle gap on hard navigation despite holding a valid 30-day refresh token, and their org selection reset to the default org roughly every 15 minutes and on every browser restart.

## Before / After
Before: reload after 15 idle minutes → 307 to `/login?return_to=...`; org switcher reverts to the default org after token refresh or browser restart.
After: reload after idle → page loads, silent refresh rotates tokens transparently; selected org sticks across refreshes, logins, and browser restarts. Covered by integration tests: refresh with a valid org cookie mints no replacement cookie; refresh with an invalid org cookie replaces it with a persistent (Max-Age) one; middleware passes refresh-token-only requests.

## Risk
- Low / Medium
- Middleware now trusts cookie *presence* for the refresh token the same way it already did for the access token — actual auth still happens server-side on every API call; a bogus refresh cookie just yields a 401 → `/login` via the client. Org-cookie preservation validates the value against the user's memberships before keeping it.

## Security
- Threat categories reviewed: TM-AUTH (session lifecycle, token rotation), TM-WEB (cookie attributes).
- Findings and resolutions: no change to token validation, rotation, or single-use refresh consumption; cookie attributes (HttpOnly/Secure/SameSite) unchanged. The org cookie is UI state, readable by JS by design, and is only ever set to a membership-validated org id.

## Follow-ups
- `AuthConfig.session_max_age` (`AUTH_SESSION_MAX_AGE`) is loaded but never applied anywhere — dead config that misleads operators; worth removing or wiring in a separate change.
- The org-provider "reset" effect (`apps/ui/src/providers/org-provider.tsx`) can still rewrite the cookie to the default org if a transient auth-user refetch returns an org list missing the current org.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
