### PR TITLE
fix(sessions): mount registry skills referenced as skill capabilities

### DIFF
--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -33,13 +33,13 @@ use everruns_core::{
     PrincipalSummary, Rule, Session, SessionFile, SessionId, SessionSeedMode, SessionStatus,
     TokenUsage, WorkspaceId,
     capabilities::{
-        MEMORY_CAPABILITY_ID, RiskLevel, SystemPromptContext, collect_capabilities_with_configs,
-        compute_features, resolve_capability_configs,
+        AttachSkillCapability, MEMORY_CAPABILITY_ID, RiskLevel, SystemPromptContext,
+        collect_capabilities_with_configs, compute_features, resolve_capability_configs,
     },
     is_declarative_capability, is_mcp_capability, is_plugin_capability, is_skill_capability,
     memory::{MemoryConfig, MemoryMountAccess},
     merge_capabilities, merge_initial_files, normalize_initial_file_path,
-    parse_declarative_capability_id,
+    parse_declarative_capability_id, parse_skill_capability_id,
     typed_id::MemoryId,
 };
 use everruns_durable::UpdateField;
@@ -1107,6 +1107,14 @@ impl SessionService {
             self.collect_workspace_memory_mounts(org_id, &resolved_configs)
                 .await?,
         );
+        // `skill:{uuid}` refs have no registry entry, so dependency resolution
+        // drops them from `resolved_configs` — resolve them from org data
+        // against the raw config list instead (same pattern as declarative and
+        // plugin refs, which carry their definition in the config payload).
+        mounts.extend(
+            self.collect_registry_skill_mounts(org_id, &capability_configs)
+                .await?,
+        );
         ensure_no_reserved_memory_mounts(&mounts)?;
         if let Some(scoped_memory) = scoped_memory {
             mounts.extend(
@@ -2160,6 +2168,73 @@ impl SessionService {
             ));
         }
 
+        Ok(mounts)
+    }
+
+    /// Mount registry skills referenced as `skill:{uuid}` capability refs.
+    ///
+    /// Each active skill is reconstructed into `/.agents/skills/{name}/`
+    /// (SKILL.md + bundled text files) so the built-in `SkillsCapability`
+    /// discovers it alongside workspace skills. Missing or non-active skills
+    /// fail session creation loudly, matching the workspace-memory behavior.
+    async fn collect_registry_skill_mounts(
+        &self,
+        org_id: i64,
+        capability_configs: &[AgentCapabilityConfig],
+    ) -> Result<Vec<MountPoint>> {
+        let mut seen = HashSet::new();
+        let mut mounts = Vec::new();
+        for config in capability_configs {
+            let cap_id = config.capability_id();
+            if !is_skill_capability(cap_id) {
+                continue;
+            }
+            let skill_uuid = parse_skill_capability_id(cap_id).ok_or_else(|| {
+                BadRequestError::new(format!("Invalid skill capability reference: {cap_id}"))
+            })?;
+            if !seen.insert(skill_uuid) {
+                continue;
+            }
+            let row = self
+                .db
+                .get_skill(org_id, skill_uuid)
+                .await?
+                .filter(|row| row.status == "active")
+                .ok_or_else(|| ResourceNotFoundError::new("Skill"))?;
+            let skill = crate::domains::skills::queries::row_to_skill(&row);
+
+            // Bundled files: text only. SKILL.md is reconstructed from the
+            // stored fields, so drop any archived copy to keep it canonical.
+            let files: Vec<(String, String)> = self
+                .db
+                .list_skill_files(skill_uuid)
+                .await?
+                .into_iter()
+                .filter(|file| file.path != "SKILL.md")
+                .filter_map(|file| {
+                    if file.is_binary {
+                        tracing::warn!(
+                            skill = %skill.name,
+                            path = %file.path,
+                            "Skipping binary skill file in session mount"
+                        );
+                        return None;
+                    }
+                    file.content.map(|content| (file.path, content))
+                })
+                .collect();
+
+            let capability = AttachSkillCapability::from_registry_with_options(
+                skill_uuid,
+                skill.name,
+                skill.description,
+                row.instructions.clone(),
+                files,
+                skill.user_invocable,
+                skill.disable_model_invocation,
+            );
+            mounts.extend(everruns_core::capabilities::Capability::mounts(&capability));
+        }
         Ok(mounts)
     }
 

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -622,3 +622,79 @@ async fn test_deleted_skill_hidden_from_usage() {
     let usage_after_body = usage_after.json_value();
     assert!(usage_after_body.get(&skill_id).is_none());
 }
+
+// Registry skills attached as `skill:{uuid}` capability refs must actually
+// mount into the session VFS under `/.agents/skills/{name}/`. The refs
+// validated and appeared in the capability catalog, but dependency resolution
+// dropped them (no registry entry), so sessions never received the skill
+// files and `list_skills` came back empty.
+#[tokio::test]
+async fn test_registry_skill_capability_mounts_into_session() {
+    let server = TestServer::in_memory().await;
+
+    let name = unique_skill_name("mount-skill");
+    server
+        .post(
+            "/v1/skills",
+            json!({ "skill_md": skill_md(&name, "Mounts into the session VFS.") }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Capability ref (`skill:{uuid}`) comes from the catalog, mirroring the UI.
+    let caps = server
+        .get("/v1/capabilities")
+        .await
+        .assert_success()
+        .json_value();
+    let cap_id = caps["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"].as_str() == Some(name.as_str()))
+        .expect("skill capability should be in the catalog")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let agent_name = unique_skill_name("mount-agent");
+    let agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": agent_name,
+                "display_name": "Mount Agent",
+                "system_prompt": "You are a helpful assistant.",
+                "capabilities": [{ "ref": cap_id, "config": {} }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+
+    let session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent["id"],
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let session_id = session["id"].as_str().unwrap();
+
+    let skill_file = server
+        .get(&format!(
+            "/v1/sessions/{session_id}/fs/.agents/skills/{name}/SKILL.md"
+        ))
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    let content = skill_file["content"].as_str().unwrap_or_default();
+    assert!(
+        content.contains(&format!("name: {name}")),
+        "mounted SKILL.md must carry the skill frontmatter, got: {content}"
+    );
+}


### PR DESCRIPTION
## What changed
Registry skills attached to harnesses/agents/sessions as `skill:{uuid}` capability refs are now actually mounted into the session VFS under `/.agents/skills/{name}/` (reconstructed `SKILL.md` + bundled text files), where the built-in `SkillsCapability` discovers them. `list_skills` and `<available_skills>` now include them. Covers both session creation and session repair (both flow through `collect_capability_mounts`).

## Why
The feature was a silent no-op: `skill:{uuid}` refs validated, appeared in the capability catalog, and were accepted on harnesses and agents — but dependency resolution passes only `declarative:` and `plugin:` refs through when a capability has no registry entry, so `skill:` refs were dropped before mount collection. `AttachSkillCapability` existed and was fully tested but was referenced only from tests. Sessions received `/memory/*` mounts from the same pass but never `/.agents/skills/*`.

## Before / After
Before: harness carries `skill:{uuid}` → session VFS has no `/.agents/skills/` entries, `list_skills` returns empty, agents report the skill missing.
After: session VFS contains `/.agents/skills/{name}/SKILL.md` (+ bundled files); integration test drives catalog → agent attach → session create → reads the mounted SKILL.md through the session fs API.

## Risk
- Low / Medium
- New behavior only for refs that previously did nothing. Failure mode choice: a missing or non-active referenced skill now fails session creation loudly (mirrors workspace-memory mounts) instead of degrading silently — an org that archived a still-referenced skill will see session creation errors until the ref is detached or the skill restored.

## Security
- Threat categories reviewed: TM-API (org scoping).
- Findings and resolutions: skills are loaded via `get_skill(org_id, uuid)` — org-scoped, consistent with `validate_capability_refs`; mounts are read-only. No cross-org access path added.

## Follow-ups
- Binary bundled skill files are skipped with a warning (`AttachSkillCapability` file API is text-only); wire base64 `MountEntry` support to mount them.
- Dependency resolution still drops `skill:` refs from `resolved_ids`; mounts are collected from the raw config list instead. Passing them through the resolver (like `declarative:`/`plugin:`) would be the deeper unification.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
