### PR TITLE
fix(skills): allow restoring archived skills via status-only update

### DIFF
--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -353,17 +353,30 @@ impl Command for UpdateSkillCmd {
             ));
         }
 
-        // Check existing status
+        // Check existing status. Archiving is documented as restorable
+        // (see DeleteSkill), so archived skills accept a status-only PATCH
+        // (the restore path) but no content edits; deleted skills stay
+        // immutable.
         if let Some(existing) = ctx
             .db
             .get_skill(ctx.org_id(), id)
             .await
             .map_err(classify_anyhow)?
-            && !matches!(existing.status.as_str(), "active" | "disabled")
         {
-            return Err(CommandError::bad_request(
-                "Archived or deleted skills cannot be edited",
-            ));
+            match existing.status.as_str() {
+                "active" | "disabled" => {}
+                "archived" => {
+                    if req.skill_md.is_some() || req.status.is_none() {
+                        return Err(CommandError::bad_request(
+                            "Archived skills only accept a status-only update (restore); \
+                             restore the skill before editing its content",
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(CommandError::bad_request("Deleted skills cannot be edited"));
+                }
+            }
         }
 
         let mut input = UpdateSkill::default();

--- a/crates/server/src/storage/memory/skills.rs
+++ b/crates/server/src/storage/memory/skills.rs
@@ -242,6 +242,9 @@ impl InMemoryDatabase {
                 skill.instructions = instructions;
             }
             if let Some(status) = input.status {
+                if status != "archived" {
+                    skill.archived_at = None;
+                }
                 skill.status = status;
             }
             if let Some(version) = input.version {

--- a/crates/server/src/storage/repositories/skills.rs
+++ b/crates/server/src/storage/repositories/skills.rs
@@ -143,7 +143,11 @@ impl Database {
                 status = COALESCE($10, status),
                 version = COALESCE($11, version),
                 archive_data = COALESCE($12, archive_data),
-                source_type = COALESCE($13, source_type)
+                source_type = COALESCE($13, source_type),
+                archived_at = CASE
+                    WHEN $10 IS NOT NULL AND $10 != 'archived' THEN NULL
+                    ELSE archived_at
+                END
             WHERE id = $1 AND org_id = $2
             RETURNING id, public_id, org_id, name, description, license, compatibility, metadata, allowed_tools, instructions, source_type, archive_data, status, version, created_at, updated_at, archived_at, deleted_at
             "#,

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -622,3 +622,67 @@ async fn test_deleted_skill_hidden_from_usage() {
     let usage_after_body = usage_after.json_value();
     assert!(usage_after_body.get(&skill_id).is_none());
 }
+
+// DELETE is documented as "Archive a skill (soft delete). Can be restored."
+// A status-only PATCH must therefore restore an archived skill; content edits
+// stay blocked until it is restored.
+#[tokio::test]
+async fn test_archived_skill_restores_via_status_only_patch() {
+    let server = TestServer::in_memory().await;
+
+    let name = unique_skill_name("restore-skill");
+    let created = server
+        .post(
+            "/v1/skills",
+            json!({ "skill_md": skill_md(&name, "Archive and restore me.") }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let skill_id = created["id"].as_str().unwrap().to_string();
+
+    server
+        .delete(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_success();
+    let archived = server
+        .get(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_success()
+        .json_value();
+    assert_eq!(archived["status"], "archived");
+
+    // Content edits on an archived skill stay rejected.
+    server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "skill_md": skill_md(&name, "Edited while archived.") }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+
+    // Status-only PATCH restores it.
+    let restored = server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "status": "active" }),
+        )
+        .await
+        .assert_success()
+        .json_value();
+    assert_eq!(restored["status"], "active");
+    assert!(
+        restored["archived_at"].is_null(),
+        "restore must clear archived_at, got: {}",
+        restored["archived_at"]
+    );
+
+    // Restored skill is editable again.
+    server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "skill_md": skill_md(&name, "Edited after restore.") }),
+        )
+        .await
+        .assert_success();
+}


### PR DESCRIPTION
## What changed
Archived skills can be restored: `PATCH /v1/skills/{id}` with a status-only body (`{"status": "active"}` or `"disabled"`) now succeeds on an archived skill and clears `archived_at` in both storage backends. Content edits (`skill_md`) on archived skills remain rejected — with a clearer error telling the caller to restore first — and deleted skills remain immutable. `PATCH` with `status: "deleted"` is still forbidden (destroy stays a separate permission).

## Why
`DELETE /v1/skills/{id}` documents "Archive a skill (soft delete). Can be restored." — but PATCH rejected *any* body on an archived skill with "Archived or deleted skills cannot be edited", including a restore. Archiving was a one-way door that also permanently reserved the skill's unique org-scoped name.

## Before / After
Before: archive a skill → `PATCH {"status":"active"}` → 400 "Archived or deleted skills cannot be edited".
After: same PATCH → 200, skill is `active` with `archived_at: null`, and content edits work again. Integration test covers the full cycle: create → archive → content-edit rejected → status-only restore → content-edit succeeds.

## Risk
- Low
- Loosens one guard along the documented direction only; delete/destroy semantics untouched.

## Security
- Threat categories reviewed: TM-API (permission boundaries).
- Findings and resolutions: restore runs under the same `SKILL_MANAGE` policy as archive; the deleted state and the dangerous-delete permission gate are unchanged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
