### PR TITLE
fix(sessions): mount registry skills referenced as skill capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,24 +1095,7 @@ dependencies = [
  "rustversion",
  "serde",
  "serde_json",
- "smoothutf8 0.1.1",
- "thiserror 2.0.19",
-]
-
-[[package]]
-name = "buffa"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
-dependencies = [
- "bytes",
- "foldhash 0.1.5",
- "hashbrown 0.15.5",
- "once_cell",
- "rustversion",
- "serde",
- "serde_json",
- "smoothutf8 0.2.3",
+ "smoothutf8",
  "thiserror 2.0.19",
 ]
 
@@ -1122,7 +1105,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6681b562b18ea719622d0d12684e88ecbdca600d517557dc7bcef7704631e28"
 dependencies = [
- "buffa 0.8.1",
+ "buffa",
  "buffa-descriptor",
  "prettyplease",
  "proc-macro2 1.0.107",
@@ -1137,7 +1120,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ed423c4ecec86d1500879ce42e7e5f6def01bc632985ac756c1fd723fa21fc"
 dependencies = [
- "buffa 0.8.1",
+ "buffa",
  "rustversion",
  "serde",
  "serde_json",
@@ -1465,7 +1448,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "base64 0.22.1",
- "buffa 0.8.1",
+ "buffa",
  "bytes",
  "flate2",
  "futures",
@@ -1498,7 +1481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cdec2dacacd00437898dad38f98105c82d51086a78baa62cee6dc66c031070"
 dependencies = [
  "anyhow",
- "buffa 0.8.1",
+ "buffa",
  "buffa-codegen",
  "connectrpc-codegen",
  "tempfile",
@@ -1511,7 +1494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c6e3bb62a4a77f41d5cd3d290a488bf529dc7e26b444cda67a3e5544c97542"
 dependencies = [
  "anyhow",
- "buffa 0.8.1",
+ "buffa",
  "buffa-codegen",
  "heck",
  "prettyplease",
@@ -2937,7 +2920,7 @@ name = "everruns-integrations-e2b"
 version = "0.17.19"
 dependencies = [
  "async-trait",
- "buffa 0.9.1",
+ "buffa",
  "chrono",
  "connectrpc",
  "connectrpc-build",
@@ -8524,15 +8507,6 @@ name = "smoothutf8"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36358427d32ecdb1624616deed99eccfef0a167fe5bf40ddb51efe6980bc1ec8"
-dependencies = [
- "simdutf8",
-]
-
-[[package]]
-name = "smoothutf8"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
 dependencies = [
  "simdutf8",
 ]

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -33,13 +33,13 @@ use everruns_core::{
     PrincipalSummary, Rule, Session, SessionFile, SessionId, SessionSeedMode, SessionStatus,
     TokenUsage, WorkspaceId,
     capabilities::{
-        MEMORY_CAPABILITY_ID, RiskLevel, SystemPromptContext, collect_capabilities_with_configs,
-        compute_features, resolve_capability_configs,
+        AttachSkillCapability, MEMORY_CAPABILITY_ID, RiskLevel, SystemPromptContext,
+        collect_capabilities_with_configs, compute_features, resolve_capability_configs,
     },
     is_declarative_capability, is_mcp_capability, is_plugin_capability, is_skill_capability,
     memory::{MemoryConfig, MemoryMountAccess},
     merge_capabilities, merge_initial_files, normalize_initial_file_path,
-    parse_declarative_capability_id,
+    parse_declarative_capability_id, parse_skill_capability_id,
     typed_id::MemoryId,
 };
 use everruns_durable::UpdateField;
@@ -1107,6 +1107,14 @@ impl SessionService {
             self.collect_workspace_memory_mounts(org_id, &resolved_configs)
                 .await?,
         );
+        // `skill:{uuid}` refs have no registry entry, so dependency resolution
+        // drops them from `resolved_configs` — resolve them from org data
+        // against the raw config list instead (same pattern as declarative and
+        // plugin refs, which carry their definition in the config payload).
+        mounts.extend(
+            self.collect_registry_skill_mounts(org_id, &capability_configs)
+                .await?,
+        );
         ensure_no_reserved_memory_mounts(&mounts)?;
         if let Some(scoped_memory) = scoped_memory {
             mounts.extend(
@@ -2160,6 +2168,73 @@ impl SessionService {
             ));
         }
 
+        Ok(mounts)
+    }
+
+    /// Mount registry skills referenced as `skill:{uuid}` capability refs.
+    ///
+    /// Each active skill is reconstructed into `/.agents/skills/{name}/`
+    /// (SKILL.md + bundled text files) so the built-in `SkillsCapability`
+    /// discovers it alongside workspace skills. Missing or non-active skills
+    /// fail session creation loudly, matching the workspace-memory behavior.
+    async fn collect_registry_skill_mounts(
+        &self,
+        org_id: i64,
+        capability_configs: &[AgentCapabilityConfig],
+    ) -> Result<Vec<MountPoint>> {
+        let mut seen = HashSet::new();
+        let mut mounts = Vec::new();
+        for config in capability_configs {
+            let cap_id = config.capability_id();
+            if !is_skill_capability(cap_id) {
+                continue;
+            }
+            let skill_uuid = parse_skill_capability_id(cap_id).ok_or_else(|| {
+                BadRequestError::new(format!("Invalid skill capability reference: {cap_id}"))
+            })?;
+            if !seen.insert(skill_uuid) {
+                continue;
+            }
+            let row = self
+                .db
+                .get_skill(org_id, skill_uuid)
+                .await?
+                .filter(|row| row.status == "active")
+                .ok_or_else(|| ResourceNotFoundError::new("Skill"))?;
+            let skill = crate::domains::skills::queries::row_to_skill(&row);
+
+            // Bundled files: text only. SKILL.md is reconstructed from the
+            // stored fields, so drop any archived copy to keep it canonical.
+            let files: Vec<(String, String)> = self
+                .db
+                .list_skill_files(skill_uuid)
+                .await?
+                .into_iter()
+                .filter(|file| file.path != "SKILL.md")
+                .filter_map(|file| {
+                    if file.is_binary {
+                        tracing::warn!(
+                            skill = %skill.name,
+                            path = %file.path,
+                            "Skipping binary skill file in session mount"
+                        );
+                        return None;
+                    }
+                    file.content.map(|content| (file.path, content))
+                })
+                .collect();
+
+            let capability = AttachSkillCapability::from_registry_with_options(
+                skill_uuid,
+                skill.name,
+                skill.description,
+                row.instructions.clone(),
+                files,
+                skill.user_invocable,
+                skill.disable_model_invocation,
+            );
+            mounts.extend(everruns_core::capabilities::Capability::mounts(&capability));
+        }
         Ok(mounts)
     }
 

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -2175,8 +2175,13 @@ impl SessionService {
     ///
     /// Each active skill is reconstructed into `/.agents/skills/{name}/`
     /// (SKILL.md + bundled text files) so the built-in `SkillsCapability`
-    /// discovers it alongside workspace skills. Missing or non-active skills
-    /// fail session creation loudly, matching the workspace-memory behavior.
+    /// discovers it alongside workspace skills.
+    ///
+    /// A skill that is missing or not active is skipped with a warning rather
+    /// than failing session creation: `validate_capability_refs` accepts a
+    /// `skill:{uuid}` ref at any status, so archiving or disabling a skill must
+    /// not take down every agent that references it. A session missing one
+    /// skill is still runnable — unlike a missing memory mount, which is fatal.
     async fn collect_registry_skill_mounts(
         &self,
         org_id: i64,
@@ -2195,12 +2200,21 @@ impl SessionService {
             if !seen.insert(skill_uuid) {
                 continue;
             }
-            let row = self
-                .db
-                .get_skill(org_id, skill_uuid)
-                .await?
-                .filter(|row| row.status == "active")
-                .ok_or_else(|| ResourceNotFoundError::new("Skill"))?;
+            let Some(row) = self.db.get_skill(org_id, skill_uuid).await? else {
+                tracing::warn!(
+                    skill_id = %skill_uuid,
+                    "Referenced skill not found; skipping session mount"
+                );
+                continue;
+            };
+            if row.status != "active" {
+                tracing::warn!(
+                    skill_id = %skill_uuid,
+                    status = %row.status,
+                    "Referenced skill is not active; skipping session mount"
+                );
+                continue;
+            }
             let skill = crate::domains::skills::queries::row_to_skill(&row);
 
             // Bundled files: text only. SKILL.md is reconstructed from the

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -761,3 +761,78 @@ async fn test_registry_skill_capability_mounts_into_session() {
         "mounted SKILL.md must carry the skill frontmatter, got: {content}"
     );
 }
+
+// Archiving a skill must not break agents that still reference it: capability
+// validation accepts a `skill:{uuid}` ref at any status, so mount collection
+// degrades (skip + warn) instead of failing session creation.
+#[tokio::test]
+async fn test_archived_skill_capability_skips_mount_without_failing_session() {
+    let server = TestServer::in_memory().await;
+
+    let name = unique_skill_name("archived-mount-skill");
+    let created = server
+        .post(
+            "/v1/skills",
+            json!({ "skill_md": skill_md(&name, "Archived before session creation.") }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let skill_id = created["id"].as_str().unwrap().to_string();
+
+    let caps = server
+        .get("/v1/capabilities")
+        .await
+        .assert_success()
+        .json_value();
+    let cap_id = caps["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"].as_str() == Some(name.as_str()))
+        .expect("skill capability should be in the catalog")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let agent_name = unique_skill_name("archived-mount-agent");
+    let agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": agent_name,
+                "display_name": "Archived Mount Agent",
+                "system_prompt": "You are a helpful assistant.",
+                "capabilities": [{ "ref": cap_id, "config": {} }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+
+    server
+        .delete(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_success();
+
+    // Session still creates; the archived skill simply is not mounted.
+    let session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent["id"],
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let session_id = session["id"].as_str().unwrap();
+
+    server
+        .get(&format!(
+            "/v1/sessions/{session_id}/fs/.agents/skills/{name}/SKILL.md"
+        ))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -622,7 +622,6 @@ async fn test_deleted_skill_hidden_from_usage() {
     let usage_after_body = usage_after.json_value();
     assert!(usage_after_body.get(&skill_id).is_none());
 }
-
 // DELETE is documented as "Archive a skill (soft delete). Can be restored."
 // A status-only PATCH must therefore restore an archived skill; content edits
 // stay blocked until it is restored.
@@ -685,4 +684,80 @@ async fn test_archived_skill_restores_via_status_only_patch() {
         )
         .await
         .assert_success();
+}
+
+// Registry skills attached as `skill:{uuid}` capability refs must actually
+// mount into the session VFS under `/.agents/skills/{name}/`. The refs
+// validated and appeared in the capability catalog, but dependency resolution
+// dropped them (no registry entry), so sessions never received the skill
+// files and `list_skills` came back empty.
+#[tokio::test]
+async fn test_registry_skill_capability_mounts_into_session() {
+    let server = TestServer::in_memory().await;
+
+    let name = unique_skill_name("mount-skill");
+    server
+        .post(
+            "/v1/skills",
+            json!({ "skill_md": skill_md(&name, "Mounts into the session VFS.") }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Capability ref (`skill:{uuid}`) comes from the catalog, mirroring the UI.
+    let caps = server
+        .get("/v1/capabilities")
+        .await
+        .assert_success()
+        .json_value();
+    let cap_id = caps["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["name"].as_str() == Some(name.as_str()))
+        .expect("skill capability should be in the catalog")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let agent_name = unique_skill_name("mount-agent");
+    let agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": agent_name,
+                "display_name": "Mount Agent",
+                "system_prompt": "You are a helpful assistant.",
+                "capabilities": [{ "ref": cap_id, "config": {} }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+
+    let session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent["id"],
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let session_id = session["id"].as_str().unwrap();
+
+    let skill_file = server
+        .get(&format!(
+            "/v1/sessions/{session_id}/fs/.agents/skills/{name}/SKILL.md"
+        ))
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    let content = skill_file["content"].as_str().unwrap_or_default();
+    assert!(
+        content.contains(&format!("name: {name}")),
+        "mounted SKILL.md must carry the skill frontmatter, got: {content}"
+    );
 }

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -27,7 +27,7 @@ http = "1"
 http-body = "1"
 futures.workspace = true
 connectrpc = { version = "0.8.1", features = ["client", "client-tls"] }
-buffa = "0.9.1"
+buffa = "0.8.1"
 rustls.workspace = true
 rustls-native-certs = "0.8"
 

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -188,6 +188,11 @@ collection, before any tool runs. The `activate_skill` result carries instructio
 (`skill`, `description`, fork-mode fields where applicable) and deliberately no companion-file
 listing.
 
+**Non-active references degrade, they do not fail**: a `skill:{uuid}` ref is accepted at any status
+by capability validation, so a referenced skill that is archived, disabled, or deleted is skipped
+with a warning at mount collection and the session still starts. Archiving a skill must not take
+down every agent that references it; the agent simply does not see that skill.
+
 This approach:
 - Reuses existing VFS infrastructure (no new tool needed)
 - Files are accessible via the same `read_file` / `list_files` tools the agent already has


### PR DESCRIPTION
Supersedes #2920 (fork branch could not be updated in place): same change, rebased onto latest `main`, with the review comment on that PR addressed. Original work by @shbodya.

## What changed
Registry skills attached to harnesses/agents/sessions as `skill:{uuid}` capability refs are now actually mounted into the session VFS under `/.agents/skills/{name}/` (reconstructed `SKILL.md` + bundled text files), where the built-in `SkillsCapability` discovers them. Covers both session creation and session repair — both flow through `collect_capability_mounts`.

A referenced skill that is missing or not `active` is **skipped with a warning**, and the session still starts. This is the change from #2920, which failed session creation in that case (see Review below).

Also included, unrelated but required to get CI green: `buffa` is pinned back to 0.8.1 (separate commit). Dependabot bumped it to 0.9.1 in #2926, but connectrpc 0.8 / connectrpc-build 0.8 generate code against the buffa 0.8 traits, so the generated E2B service code stopped compiling ("impl has stricter requirements than trait" on every `BufMut` method) and the whole Rust workspace has been red on `main` since that merge. Pin holds until connectrpc ships a 0.9-compatible release.

## Why
The feature was a silent no-op: `skill:{uuid}` refs validated, appeared in the capability catalog, and were accepted on harnesses and agents — but dependency resolution passes only `declarative:` and `plugin:` refs through when a capability has no registry entry, so `skill:` refs were dropped before mount collection. `AttachSkillCapability` existed and was fully tested but was referenced only from tests. Sessions received `/memory/*` mounts from the same pass but never `/.agents/skills/*`.

## Before / After
Before: harness carries `skill:{uuid}` → session VFS has no `/.agents/skills/` entries, `list_skills` returns empty, agents report the skill missing.

After — smoke tested against a locally running server (dev mode, in-memory), driving the real HTTP API:

```
create skill: 201
capability ref: skill:019fd488-7e8a-7031-9c3e-0fcf3b36ef9c
create agent: 201
create session: 201
read mounted SKILL.md: 200
---
name: smoke-mount-skill
description: "Smoke test skill mounted into the session VFS."
---

# Smoke Mount Skill

Do the smoke thing.
```

Archiving the skill, then creating another session with the same agent — session still starts, skill simply is not mounted:

```
archive: 204
create session after archive: 201
mounted SKILL.md after archive: 404
```

with an operator-actionable warning naming the skill and its status:

```
WARN everruns_server::domains::sessions::service: Referenced skill is not active;
     skipping session mount skill_id=019fd488-7e8a-7031-9c3e-0fcf3b36ef9c status=archived
```

## Risk
- Low / Medium
- New behavior only for refs that previously did nothing. Non-active refs degrade rather than fail, so no existing agent can be taken down by archiving a skill.
- The `buffa` pin reverts a dependency to the version the rest of the workspace already builds against; it restores the last known-good state rather than introducing a new one.

## Security
- Threat categories reviewed: TM-TENANT (tenant isolation), TM-FS (filesystem / path traversal), TM-DOS.
- Findings and resolutions:
  - TM-TENANT: skills are loaded via `get_skill(org_id, uuid)` — org-scoped, consistent with `validate_capability_refs`. No cross-org access path added.
  - TM-FS: mount directory name comes from the skill name, which `validate_skill_name` constrains to `[a-z0-9-]` (no separators, no dots), so it cannot escape `/.agents/skills/`. Bundled file paths are rejected for traversal at archive-extraction time (`domains/skills/archive.rs`, covered by `test_extract_zip_path_traversal`). Mounts are read-only.
  - TM-DOS: mounts are bounded by the capability refs already attached to the harness/agent/session, deduplicated by skill UUID; file content is bounded by the existing skill-upload limits. Binary files are skipped, not loaded.
  - No `THREAT[...]` markers sit near the touched code, and no new threat surface warranted a `specs/threat-model.md` entry.

## Review
[#2920 (comment)](https://github.com/everruns/everruns/pull/2920#discussion_r3708136543) — @chaliy: hard-failing on non-`active` skills means archiving or disabling a skill breaks every agent referencing it, with a bare 404 naming nothing. Taken as written, option 1: `collect_registry_skill_mounts` now skips missing and non-active skills with a `tracing::warn!` carrying skill id and status, and the session starts without them. `"disabled"` and `"archived"` land on the same behavior deliberately — neither is a reason to refuse to start a session, and neither is silent. Regression test: `test_archived_skill_capability_skips_mount_without_failing_session`. Documented in `specs/skills-registry.md`.

## Follow-ups
- Binary bundled skill files are skipped with a warning (`AttachSkillCapability`'s file API is text-only); wiring base64 `MountEntry` support to mount them is a separate change.
- Dependency resolution still drops `skill:` refs from `resolved_ids`; mounts are collected from the raw config list instead. Passing them through the resolver (like `declarative:`/`plugin:`) would be the deeper unification.
- The `buffa` pin should be reverted once connectrpc publishes a release built against buffa 0.9; dependabot will re-propose the bump.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HsP8d62n2vgm8cpJpeD4ZZ)_