### PR TITLE
chore(release): prepare v0.17.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.20] - 2026-08-06
+
+### Highlights
+
+- **Linked OAuth accounts** - Verified OAuth sign-ins now link to an existing account with a matching email instead of creating a duplicate ([#2914](https://github.com/everruns/everruns/pull/2914)).
+- **Operator SSRF allowlist** - Self-hosted deployments can exempt specific CIDR ranges from SSRF blocking (`EVERRUNS_SSRF_ALLOW_CIDRS`), making in-cluster MCP servers reachable without exposing them publicly ([#2923](https://github.com/everruns/everruns/pull/2923)).
+- **Auth reliability** - Sessions and org selection now persist across token refresh, and MCP OAuth consent redirects pass the CSP form-action policy ([#2919](https://github.com/everruns/everruns/pull/2919), [#2918](https://github.com/everruns/everruns/pull/2918)).
+
+### What's Changed
+
+- fix(sessions): mount registry skills referenced as skill capabilities ([#2927](https://github.com/everruns/everruns/pull/2927)) by [@chaliy](https://github.com/chaliy)
+- feat(security): operator CIDR allowlist for SSRF validation ([#2923](https://github.com/everruns/everruns/pull/2923)) by [@shbodya](https://github.com/shbodya)
+- chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates ([#2925](https://github.com/everruns/everruns/pull/2925)) by [@app/dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump the cargo group with 3 updates ([#2926](https://github.com/everruns/everruns/pull/2926)) by [@app/dependabot](https://github.com/apps/dependabot)
+- fix(deps): bump fast-uri and postcss to clear security advisories ([#2924](https://github.com/everruns/everruns/pull/2924)) by [@chaliy](https://github.com/chaliy)
+- fix(integrations): fall back to Azure OpenAI credentials for image generation ([#2922](https://github.com/everruns/everruns/pull/2922)) by [@shbodya](https://github.com/shbodya)
+- fix(skills): allow restoring archived skills via status-only update ([#2921](https://github.com/everruns/everruns/pull/2921)) by [@shbodya](https://github.com/shbodya)
+- fix(auth): keep session and org selection across token refresh ([#2919](https://github.com/everruns/everruns/pull/2919)) by [@shbodya](https://github.com/shbodya)
+- fix(server): allow MCP OAuth consent redirect through CSP form-action ([#2918](https://github.com/everruns/everruns/pull/2918)) by [@shbodya](https://github.com/shbodya)
+- feat(docker): add authentication environment variables to docker-compose ([#2917](https://github.com/everruns/everruns/pull/2917)) by [@shbodya](https://github.com/shbodya)
+- chore: green main CI (OpenAI credit-exhaustion skip) + patch brace-expansion DoS (GHSA-mh99-v99m-4gvg) ([#2916](https://github.com/everruns/everruns/pull/2916)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): retry provider stream stalls via shared transient path ([#2915](https://github.com/everruns/everruns/pull/2915)) by [@chaliy](https://github.com/chaliy)
+- feat(auth): link verified OAuth accounts ([#2914](https://github.com/everruns/everruns/pull/2914)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.19] - 2026-07-31
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -198,9 +198,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -861,9 +861,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64-simd"
@@ -889,7 +889,7 @@ checksum = "120fa07992ddc9ba216dbce72749b148614709f893a66a7bfbb2a8643ab0b0b9"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bigdecimal",
  "bitflags 2.13.1",
  "chrono",
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1928,26 +1928,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2 1.0.107",
  "quote 1.0.47",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote 1.0.47",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -2547,11 +2547,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.19"
+version = "0.17.20"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2586,12 +2586,12 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
- "base64 0.23.0",
+ "base64 0.23.1",
  "everruns-provider",
  "futures",
  "serde",
@@ -2603,10 +2603,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "clap",
  "dialoguer",
@@ -2647,7 +2647,7 @@ dependencies = [
  "ratatui-textarea",
  "serde",
  "serde_json",
- "similar 3.1.1",
+ "similar 3.1.2",
  "tempfile",
  "textwrap",
  "tokio",
@@ -2657,10 +2657,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "everruns-core",
  "hex",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2685,7 +2685,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bashkit",
  "bytes",
  "chrono",
@@ -2717,7 +2717,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
- "similar 3.1.1",
+ "similar 3.1.2",
  "sqlx",
  "tempfile",
  "thiserror 2.0.19",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2811,10 +2811,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "everruns-core",
  "futures-util",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2864,10 +2864,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "everruns-core",
  "futures-util",
@@ -2887,10 +2887,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "everruns-core",
  "inventory",
  "serde",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2944,10 +2944,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "everruns-core",
  "inventory",
@@ -2961,11 +2961,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "eventsource-stream",
  "everruns-core",
  "futures",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3155,15 +3155,15 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.19"
+version = "0.17.20"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "eventsource-stream",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3241,7 +3241,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bashkit",
  "chrono",
  "clap",
@@ -3327,10 +3327,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "everruns-core",
  "parking_lot",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3360,11 +3360,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.19"
+version = "0.17.20"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "everruns-anthropic",
  "everruns-ard",
@@ -3461,10 +3461,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
+name = "fancy-regex"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -3963,9 +3968,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -4546,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4734,15 +4739,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2 1.0.107",
  "quote 1.0.47",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4769,9 +4774,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
  "serde",
 ]
@@ -4819,9 +4824,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
+checksum = "48d801b0b57f10064c4e9f5a4f6c97d0ccf62649b179ff8ac23cd494a3120ee9"
 dependencies = [
  "bstr",
  "bytes",
@@ -4978,15 +4983,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.2"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
+checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.18.0",
+ "fancy-regex 0.19.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -5007,18 +5012,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.2"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
+checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.2"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
 dependencies = [
  "ahash",
  "bytecount",
@@ -5097,9 +5102,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -5173,9 +5178,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -5205,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -5344,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5578,9 +5583,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.21.0"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+checksum = "ef84a52be188a1d4124bd717903fdde96ca4705f2b56adfe2d91fcc57fcb6987"
 dependencies = [
  "memo-map",
  "serde",
@@ -6283,26 +6288,35 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "libm",
  "palette_derive",
+ "palette_math",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2 1.0.107",
  "quote 1.0.47",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -7458,9 +7472,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.2"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
+checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -7487,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8450,9 +8464,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
 ]
@@ -10218,9 +10232,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
  "jni",
  "log",
@@ -10891,9 +10905,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.19"
+version = "0.17.20"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.19" }
-everruns-provider = { path = "crates/provider", version = "0.17.19" }
+everruns-core = { path = "crates/core", version = "0.17.20" }
+everruns-provider = { path = "crates/provider", version = "0.17.20" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.19" }
-everruns-ard = { path = "crates/ard", version = "0.17.19" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.20" }
+everruns-ard = { path = "crates/ard", version = "0.17.20" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.19" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.20" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.19",
+  "version": "0.17.20",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.19" }
+everruns-provider = { path = "../provider", version = "0.17.20" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.19" }
+everruns-provider = { path = "../provider", version = "0.17.20" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.19", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.20", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.19", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.20", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.19" }
+everruns-provider = { path = "../provider", version = "0.17.20" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.19" }
+everruns-provider = { path = "../provider", version = "0.17.20" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.19" }
+everruns-provider = { path = "../provider", version = "0.17.20" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed
Cuts release **v0.17.20** (patch). Bumps the workspace/UI version, syncs publish path-dependency pins, adds the CHANGELOG entry for the 13 commits since v0.17.19, and refreshes lockfiles. No source behavior changes — this is the release-prep commit whose `chore(release): prepare vX.Y.Z` message triggers auto-tagging on merge.

Highlights in this release:
- **Linked OAuth accounts** — verified OAuth sign-ins link to an existing account with a matching email instead of duplicating ([#2914](https://github.com/everruns/everruns/pull/2914)).
- **Operator SSRF allowlist** — `EVERRUNS_SSRF_ALLOW_CIDRS` lets self-hosters exempt CIDR ranges so in-cluster MCP servers are reachable without public exposure ([#2923](https://github.com/everruns/everruns/pull/2923)).
- **Auth reliability** — sessions/org selection persist across token refresh; MCP OAuth consent redirects pass CSP form-action ([#2919](https://github.com/everruns/everruns/pull/2919), [#2918](https://github.com/everruns/everruns/pull/2918)).

Full list in `CHANGELOG.md` under `[0.17.20]`.

## Why
Release the changes accumulated on `main` since v0.17.19.

## Before / After
No observable runtime behavior change from this PR itself — version metadata only. Version bumped `0.17.19 → 0.17.20` across `Cargo.toml`, `apps/ui/package.json`, and path-dep pins (`sync-publish-pin-versions.py --check` passes). Migration ordering verified sequential (001..110).

## Risk
- Low
- Release-metadata-only change. On merge, auto-tagging creates `v0.17.20`, the GitHub Release, Docker images, and crate publishes.

## Security
- Threat categories reviewed: No security-relevant code changes in this PR (version/changelog/lockfile only). The security-relevant work it releases (SSRF allowlist #2923, CSP form-action #2918) was reviewed in its own PR.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release-prep only)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)