### PR TITLE
feat(guardrails): add model-backed secret-leak judge gallery preset

### DIFF
--- a/crates/core/src/guardrail_gallery.rs
+++ b/crates/core/src/guardrail_gallery.rs
@@ -13,27 +13,33 @@
 //    harness-examples pattern.
 //  - Every preset must `compile()` (enforced by a test) so an adopted preset
 //    is always valid against the engine's limits.
-//  - Presets are deterministic-only in this phase: nothing a preset does
-//    leaves the platform (see `data_egress`). Model-based and MCP-served
-//    presets will carry a different egress marker when those check types land.
+//  - Presets may be deterministic (in-process, no egress) or model-backed
+//    (`llm_judge` sends a bounded content excerpt to the utility LLM). Each
+//    preset's `data_egress` is derived from its check types so a UI can warn
+//    before adoption. MCP-served presets will add another marker when a preset
+//    uses that check type.
 
 use crate::guardrail_checks::{
     GuardrailCheck, GuardrailOnFail, GuardrailRule, GuardrailStage, GuardrailsConfig,
 };
 
-/// Where a preset's checks send data when they run. Deterministic checks run
-/// in-process and send nothing; future model-based / MCP-served presets will
-/// use other variants so a UI can warn before adoption.
+/// Where a preset's checks send data when they run. Derived from the preset's
+/// check types (see [`GuardrailGalleryItem::data_egress`]), not hand-authored,
+/// so it stays correct as presets mix deterministic and model-backed checks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataEgress {
     /// Runs entirely in-process; no data leaves the platform.
     None,
+    /// Sends a bounded content excerpt to the org's configured utility LLM
+    /// (`llm_judge` / `moderation` checks) for evaluation.
+    UtilityLlm,
 }
 
 impl DataEgress {
     pub fn as_str(&self) -> &'static str {
         match self {
             DataEgress::None => "none",
+            DataEgress::UtilityLlm => "utility_llm",
         }
     }
 }
@@ -78,11 +84,21 @@ impl GuardrailGalleryItem {
         seen
     }
 
-    /// Where this preset sends data. Deterministic presets never leave the
-    /// platform; derived from check types so it stays correct as new types
-    /// (model/MCP) are added.
+    /// Where this preset sends data, derived from its check types so it stays
+    /// correct as new types (model/MCP) are added. A check that sends content
+    /// to the utility LLM (`llm_judge` / `moderation`) marks the preset as
+    /// utility-LLM egress; otherwise everything runs in-process.
     pub fn data_egress(&self) -> DataEgress {
-        DataEgress::None
+        let uses_utility_llm = self
+            .config
+            .checks
+            .iter()
+            .any(|c| matches!(c.rule.rule_type(), "llm_judge" | "moderation"));
+        if uses_utility_llm {
+            DataEgress::UtilityLlm
+        } else {
+            DataEgress::None
+        }
     }
 }
 
@@ -122,6 +138,21 @@ fn tool_pattern(tools: &[&str]) -> GuardrailRule {
         tools: tools.iter().map(|t| t.to_string()).collect(),
     }
 }
+
+fn llm_judge(prompt: &str) -> GuardrailRule {
+    GuardrailRule::LlmJudge {
+        prompt: prompt.to_string(),
+    }
+}
+
+/// Natural-language policy for the secret-leak judge. Describes the *class* of
+/// content to block (secret material rendered in cleartext) rather than any
+/// specific value, so it catches opaque secrets not known at config time.
+const SECRET_LEAK_JUDGE_POLICY: &str = "Block any tool call whose arguments would print, echo, log, \
+    diff, display, or transmit secret or credential material in cleartext — API keys, access tokens, \
+    passwords, private keys, connection strings, or values read from a secrets manager. Allow \
+    comparisons that only reveal a hash, fingerprint, length, or redacted form. Allow reads or \
+    writes that store or move a secret without displaying its value.";
 
 fn config(checks: Vec<GuardrailCheck>) -> GuardrailsConfig {
     GuardrailsConfig {
@@ -168,6 +199,39 @@ pub fn guardrail_gallery() -> Vec<GuardrailGalleryItem> {
                     Block,
                     Some("[Tool output withheld: appears to contain a credential.]"),
                     regex(secret_patterns),
+                ),
+            ]),
+        },
+        GuardrailGalleryItem {
+            name: "secret-leak-judge",
+            display_name: "Secret Leak Prevention (LLM judge)",
+            description: "Model-backed guardrail that blocks tool calls (and tool results) revealing \
+                 secret or credential material in cleartext, without the value being known in \
+                 advance. Complements `secret-detection`: that catches known credential formats by \
+                 pattern; this catches opaque secrets by intent. Evaluated by the utility LLM (a \
+                 bounded content excerpt leaves the generating path); async and fail-open. Blocked \
+                 tool calls are recoverable — the model self-corrects to a safe form (e.g. comparing \
+                 a hash). Run advisory first to tune false positives before enforcing.",
+            tags: vec!["security", "secrets"],
+            config: config(vec![
+                check(
+                    "secret-leak-tool-use",
+                    ToolUse,
+                    Block,
+                    Some(
+                        "This tool call was blocked: it would reveal secret or credential material. \
+                         Retry without printing the secret — compare a hash or redacted form instead.",
+                    ),
+                    llm_judge(SECRET_LEAK_JUDGE_POLICY),
+                ),
+                check(
+                    "secret-leak-tool-output",
+                    ToolOutput,
+                    Block,
+                    Some(
+                        "[Tool output withheld: appears to reveal secret or credential material.]",
+                    ),
+                    llm_judge(SECRET_LEAK_JUDGE_POLICY),
                 ),
             ]),
         },
@@ -314,6 +378,13 @@ mod tests {
         assert_eq!(secret.check_types(), vec!["regex"]);
         assert_eq!(secret.stages(), vec!["output", "tool_output"]);
         assert_eq!(secret.data_egress(), DataEgress::None);
+
+        // The model-backed secret-leak judge derives utility-LLM egress from
+        // its check types, not from a hand-authored marker.
+        let judge = find_guardrail_gallery_item("secret-leak-judge").expect("present");
+        assert_eq!(judge.check_types(), vec!["llm_judge"]);
+        assert_eq!(judge.stages(), vec!["tool_use", "tool_output"]);
+        assert_eq!(judge.data_egress(), DataEgress::UtilityLlm);
 
         let shell = find_guardrail_gallery_item("block-shell-access").expect("present");
         assert_eq!(shell.check_types(), vec!["tool_pattern"]);

--- a/proposals/known-value-secret-leak-guardrail.md
+++ b/proposals/known-value-secret-leak-guardrail.md
@@ -158,9 +158,10 @@ positives before it goes active.
 
 ## Phasing
 
-1. **Ship-now, no code:** document an `llm_judge`-on-`tool_use`/`tool_output`
-   secret-leak preset (the policy prompt above) as a gallery entry. Reproduces the
-   screenshot for tool calls today; advisory-first.
+1. **Shipped:** the `secret-leak-judge` gallery preset — an `llm_judge` policy on
+   `tool_use` + `tool_output` (`guardrail_gallery.rs`). Reproduces the screenshot
+   for tool calls today; the gallery's `data_egress` is now derived from check
+   types (`utility_llm` for model-backed presets). Run advisory-first to tune.
 2. **Dedicated `secret_leak` classifier** (a `moderation` sibling), enable-able on
    all three stages — cheaper, more consistent, and covers prose echo on `output`.
 3. **Deterministic `SecretValues` redactor** + `redact` action, sourced from

--- a/proposals/known-value-secret-leak-guardrail.md
+++ b/proposals/known-value-secret-leak-guardrail.md
@@ -1,181 +1,172 @@
-# Proposal: Known-value secret-leak guardrail
+# Proposal: Secret-leak guardrail (model-backed, with a deterministic layer)
 
 Status: draft design note (pre-spec). Answers "can we build a guardrail that
 blocks an agent from echoing a secret it holds in context, and how?" On
-acceptance this becomes a new rule variant in `everruns_core::guardrail_checks`,
-a gallery preset, and additions to `specs/guardrails.md`.
+acceptance this becomes: a documented `llm_judge` secret-leak preset, an
+optional dedicated secret-leak classifier check, and — as a cheap complementary
+layer — a deterministic known-value redactor.
 
 ## The scenario
 
 An agent is rotating an AWS Secrets Manager `clientSecret`. Mid-task it wants to
 verify propagation. Two guardrail behaviors are visible:
 
-1. A tool call that would **echo part of the live secret** (a diff/compare that
-   printed secret material) is **blocked**. The refusal reason is fed back to
-   the model.
+1. A tool call that would **echo part of the live secret** (a compare that
+   printed secret material) is **blocked**, and the refusal reason is fed back.
 2. The model **self-corrects** to a hash comparison — "no secret material in the
    output at all" — and proceeds.
 
-So "such a guardrail" is really two things: a **detector** that recognizes when
-stage content contains a secret the agent is handling, and the **block →
-feed-reason-back → self-correct** loop around it. The second half already exists;
-the first half exists only for *well-known credential formats*, not for the
-*opaque, session-specific* value in this scenario.
+## What kind of guardrail this is
+
+The guardrail in the screenshot is almost certainly **model-backed** — a
+classifier or LLM judge — **not** a match against a pre-known secret value. It
+did not need the `clientSecret` enrolled ahead of time; it recognized
+*semantically* that the command was about to print credential material, then
+recognized the hash-only retry as safe. Generic secret detection with no prior
+knowledge of the value is exactly what a judge/classifier is for, and what a
+substring or regex matcher structurally cannot do.
+
+This reframes the everruns answer. There are two families of check, and the
+faithful match is the second:
+
+- **Deterministic** (`regex`, `blocklist`, `tool_pattern`) — fast, in-process,
+  but can only catch *known formats* or *known values*.
+- **Model-backed** (`llm_judge`, `moderation`, `mcp`) — dynamic, no prior
+  knowledge of the value, judges intent/shape. This is the screenshot's class.
 
 ## Verdict
 
-**Yes, and most of the machinery is already in place.** everruns already ships a
-config-driven guardrail engine (`specs/guardrails.md`) with exactly the three
-interception seams this needs, the block-and-feed-back loop, advisory mode, a
-dry-run tuning surface, and a `secret-detection` gallery preset. The one missing
-primitive is a **dynamic, session-scoped source of secret *values*** feeding a
-deterministic redaction check. Everything else is reuse.
+**Yes — and the model-backed primitive already ships.** everruns' `llm_judge`
+check on the `tool_use` stage reproduces the screenshot end-to-end today:
+dynamic, value-agnostic, block-and-feed-reason-back so the model self-corrects.
+Full parity needs one thing everruns hasn't enabled yet (judge on the `output`
+stage, EVE-572) and benefits from one new thing (a dedicated, cheaper
+secret-leak classifier). A deterministic known-value redactor is a valuable
+*complementary* layer, not the primary mechanism.
 
-## What already exists (and directly covers half the ask)
+## The faithful match: `llm_judge` on `tool_use` (already shipped)
 
-Grounded in `crates/core/src/guardrail_checks.rs`,
-`crates/core/src/guardrail_gallery.rs`, and `crates/core/src/output_guardrail.rs`:
+Grounded in `crates/core/src/capabilities/guardrails.rs` and
+`crates/core/src/guardrail_checks.rs`:
 
-- **Three stages**, which are exactly the leak surfaces: `output` (model echoes
-  the secret in prose), `tool_use` (the *command about to run* embeds the
-  secret — this is the screenshot's block), `tool_output` (a fetched file/result
-  carries one). See `GuardrailStage`.
-- **The self-correction loop is already the `tool_use` contract.** Per
-  `specs/guardrails.md` §Runtime integration, a blocking `tool_use` hit "refuses
-  the tool call and feeds the reason back to the model (which can self-correct)."
-  The screenshot's step 2 (redo as a hash compare) is this behavior, not new work.
-- **Substring matching already exists** as `GuardrailRule::Blocklist` — a
-  compiled, case-optional, linear-time `haystack.contains(word)` matcher
-  (`CompiledRule::Blocklist`). A known-secret redactor is a blocklist whose word
-  list is *sourced at runtime* instead of at config time.
-- **A `secret-detection` preset already ships** (`guardrail_gallery.rs`) with
-  high-precision regexes for AWS/GitHub/Slack/Google keys and PEM headers, on
-  `output` + `tool_output`, safe to run active.
-- **Advisory mode + dry-run** (`POST /v1/capabilities/guardrails/dry-run`) are
-  the false-positive tuning path — essential for anything heuristic.
+- `GuardrailRule::LlmJudge { prompt }` sends the stage name, tool name, and a
+  bounded content excerpt (2 000 bytes, UTF-8-safe) to the utility LLM with
+  `JUDGE_SYSTEM_PROMPT` ("You are a guardrail policy evaluator…"), and parses a
+  `{"verdict":"allow"}` / `{"verdict":"block","reason":"…"}` response
+  (`run_judge_check`).
+- On `tool_use` it runs in the **pre-tool hook**; a `block` verdict refuses the
+  call and, per `specs/guardrails.md` §Runtime integration, "feeds the reason
+  back to the model (which can self-correct)." That is exactly the screenshot:
+  block the secret-echoing compare → model retries as a hash compare.
+- It is **value-agnostic**: the policy prompt describes the *class* of thing to
+  block; no secret needs to be enrolled.
 
-## The gap
-
-The screenshot's secret is an **opaque, random, session-specific** value read
-from AWS SM at runtime. It has no well-known format, so the static `regex`
-preset cannot see it, and `Blocklist` can't help because **the value is unknown
-at agent-config time.** Two capabilities are missing:
-
-1. **A dynamic secret source.** The guardrail must know *which concrete values*
-   are "live" for this session, and that set changes per run.
-2. **Value-based deterministic matching over that set**, including partial
-   matches ("echoed *part* of the secret"), running on all three stages, with a
-   **redact** outcome (mask the matched span) in addition to today's whole-message
-   block.
-
-Neither the sync `evaluate()` path nor any compiled rule has a runtime handle to
-session state today — `evaluate()` is pure over config-time data. That is the
-core thing to add.
-
-### Where the secret values come from
-
-everruns already has the source. `session_storage` exposes `secret_store` — an
-encrypted, session-scoped namespaced-secret store (the `ns` table,
-AES-256-GCM envelope encryption per `specs/encryption.md`). It already holds
-agent-handled credentials: MCP OAuth tokens (`mcp_oauth_ns_name`), managed
-sandbox state (`specs/session-sandbox.md`), and user-provided API keys. A
-known-value guardrail draws its match set from:
-
-- **Enrolled secrets** — values the agent (or a harness) explicitly places in
-  `secret_store`. Deterministic, precise, zero false positives. This is the
-  clean path for the rotation scenario: the old/new `clientSecret` is enrolled,
-  and any stage content containing it is redacted.
-- **Auto-enrolled secrets** — high-entropy values observed in the output of
-  designated secret-reading tools (e.g. a raw `aws secretsmanager get-secret-value`
-  in bash). The value transits `tool_output` first; that seam both *learns* the
-  value into the session redaction set and redacts it downstream. Opt-in, because
-  it is heuristic.
-
-## Design
-
-### New deterministic rule variant
-
-Add to `GuardrailRule` (`guardrail_checks.rs`):
+Concretely, the config is a single check whose prompt is the policy:
 
 ```
-SecretValues {
-    source: SecretSource,   // enrolled | auto_enroll | explicit(list)
-    min_len: usize,         // default ~12: ignore short/low-entropy fragments
-    normalize: bool,        // fold whitespace/case before matching (default true)
-    partial: bool,          // also match a long contiguous run of a secret
-}
+Block any tool call whose arguments would print, echo, log, diff, or transmit
+secret or credential material in cleartext — API keys, tokens, passwords,
+private keys, connection strings, or values read from a secrets manager. Allow
+comparisons that only reveal a hash, length, or redacted form. Allow reads that
+store the secret without displaying it.
 ```
 
-Valid on all three stages. Effective action gains a third option alongside
-`block`/`log`: **`redact`** — replace only the matched span(s) with a mask
-(`«redacted»`) rather than withholding the whole message. Redaction is what
-lets the *useful* part of a tool call or answer survive while the secret does
-not, matching the screenshot's "no secret printed" outcome without nuking the
-turn. `block` and `log` remain for callers who want them.
+The same rule on `tool_output` catches a fetched file/result that carries a
+secret before it reaches context.
 
-### Runtime wiring (the one architectural change)
+### Known operational limits (from the shipped implementation)
 
-Today `CompiledGuardrails::evaluate()` takes only config-time data plus a `skip`
-closure. `SecretValues` needs the session's current secret set. Mirror how
-`llm_judge`/`mcp` checks already receive their collaborators from context: those
-are pulled out of the sync path (`judge_checks_for_stage`, `mcp_checks_for_stage`)
-and run by the capability hooks with a session-scoped invoker. Add the same
-shape for secrets:
+- **Async, hook-path only.** `llm_judge` never runs in the streaming hot path.
+  Runs in pre/post-tool hooks with a 10 s timeout (`JUDGE_TIMEOUT`).
+- **Fail-open.** Timeout, LLM error, or unparseable verdict ⇒ `allow`, so a judge
+  outage never wedges a turn. A secret-leak guardrail that fails open is a real
+  security limitation to state plainly — advisory rollout, plus the deterministic
+  layer below as a fail-closed backstop for *known* values.
+- **Cost + latency.** Each judged tool call is a utility-LLM round trip (low
+  reasoning effort), capped at `MAX_JUDGE_CALLS_PER_INVOCATION` (4) per
+  invocation, accounted through utility-LLM billing, not the session budget.
+- **`output` stage not yet enabled.** Today only `moderation` runs on `output`
+  (the end-of-message seam, EVE-573); `llm_judge`/`mcp` on `output` is tracked in
+  EVE-572. So the prose-echo case ("model writes the secret in its answer") needs
+  either EVE-572 or a `moderation`-style classifier on `output`.
 
-- A `SecretRedactor` handle (a compiled `matcher::AhoCorasick` over the current
-  secret set, rebuilt when the set changes) supplied to the output/pre-tool/
-  post-tool hooks at arm time from the session's `secret_store`.
-- Matching stays **deterministic and linear** — Aho-Corasick over N secrets is
-  O(text length), no backtracking, same DoS posture as the existing regex/
-  blocklist matchers. The `min_len` gate and an entropy floor prevent a short or
-  dictionary-word secret from redacting half the transcript.
-- The pure `evaluate()` stays pure for regex/blocklist/tool_pattern; `SecretValues`
-  is evaluated in the hooks where the session handle is available, exactly like
-  the async variants — but it is still *synchronous and deterministic*, just
-  session-stateful.
+## A better fit for the hot/common case: a dedicated secret-leak classifier
 
-### Gallery presets
+A general LLM judge on *every* tool call is heavy. The screenshot's guardrail is
+more plausibly a **narrow, cheap classifier** (as Claude Code likely uses),
+analogous to everruns' existing `moderation` check, which already runs the
+utility LLM "acting as a content classifier" with a fixed
+`MODERATION_SYSTEM_PROMPT` and a category/threshold verdict. The natural
+addition:
 
-- `known-secret-redaction` — `SecretValues{source: enrolled}` on all three
-  stages, action `redact`, active-safe (zero false positives: it only masks
-  values explicitly enrolled).
-- `entropy-secret-heuristic` — a `regex`/entropy detector for unknown
-  high-entropy tokens on `output`+`tool_output`, shipped **log-only** like the
-  existing PII and prompt-injection presets, because generic secret detection is
-  inherently noisy.
+- A `secret_leak` classifier check (a sibling of `moderation`) with a fixed
+  system prompt tuned for one job — "does this content reveal secret/credential
+  material in cleartext?" — returning a score/threshold verdict. Cheaper and more
+  consistent than an open-ended judge prompt, and enable-able on `output`,
+  `tool_use`, and `tool_output`. This mirrors the spec's own "Future phases":
+  PII (NER) and prompt-injection classifiers as dedicated model-backed checks.
 
-## Hard parts and honest limits
+## The complementary deterministic layer (fail-closed, exact, free)
 
-- **You can only redact what you can identify.** Enrolled/auto-enrolled known
-  values are exact and safe. The fully general "detect any secret the agent
-  never told us about" case is entropy heuristics — false-positive-prone, hence
-  log-only first, tuned via advisory + dry-run before `block`/`redact`.
-- **Encoding evades substring matching.** A secret that is base64'd, URL-encoded,
-  or hashed before it hits a stage won't match the raw value. `normalize` covers
-  whitespace/case; common transforms (base64, %-encoding) can be layered in, but
-  this is a cat-and-mouse tail, not a guarantee. The hash-compare self-correction
-  in the screenshot is the *right* pattern precisely because it never emits the
-  value in any encoding.
+Model-backed checks fail open and cost a round trip. For secrets the platform
+*does* know — the old/new `clientSecret` during a rotation, MCP OAuth tokens,
+user-provided API keys — a deterministic **known-value redactor** is a cheap,
+exact, in-process backstop that fails *closed*:
+
+- New `GuardrailRule::SecretValues { source, min_len, normalize }`, deterministic,
+  valid on all three stages, matching via Aho-Corasick (linear, no backtracking,
+  same DoS posture as the existing blocklist/regex matchers).
+- Value source: `session_storage`'s `secret_store` — the encrypted, session-scoped
+  namespaced-secret store (`ns` table, AES-256-GCM per `specs/encryption.md`),
+  which already holds MCP OAuth tokens (`mcp_oauth_ns_name`), sandbox state, and
+  user API keys. Optionally auto-enroll high-entropy values seen at `tool_output`.
+- New **`redact`** action (mask the matched span) alongside `block`/`log`, so the
+  useful part of a command/answer survives while the secret is masked.
+- One architectural change: `evaluate()` is currently pure over config-time data.
+  `SecretValues` needs a session-scoped secret handle, wired into the hooks the
+  same way `llm_judge`/`mcp` already receive their session collaborators.
+
+## Recommended architecture: defense in depth
+
+The two layers cover each other's weaknesses:
+
+| Layer | Catches | Fails | Cost |
+|---|---|---|---|
+| `llm_judge` / `secret_leak` classifier (model-backed) | *unknown* secrets, by shape/intent — the screenshot | open | utility-LLM round trip |
+| `SecretValues` redactor (deterministic) | *known/enrolled* values, exactly | closed | in-process, ~free |
+
+Run both: the classifier is the dynamic front line (reproduces the screenshot),
+the deterministic redactor is the exact, fail-closed net for values the platform
+already holds. Advisory mode + dry-run
+(`POST /v1/capabilities/guardrails/dry-run`) tune the classifier's false
+positives before it goes active.
+
+## Honest limits
+
+- **Model-backed checks fail open.** A judge/classifier outage degrades to no
+  protection. The deterministic layer is the fail-closed complement, but only for
+  known values.
+- **Encoding evades the deterministic layer.** base64/URL-encoding/hashing a
+  secret defeats substring matching; `normalize` covers whitespace/case only. The
+  classifier is more robust here but still probabilistic. The model's hash-compare
+  self-correction is the *right* pattern precisely because it emits no value in
+  any encoding.
 - **Self-correction is not guaranteed.** Feeding the reason back usually yields a
-  compliant retry, but a model can loop; the existing per-turn tool-call limits
-  bound this. Advisory mode is the safe rollout default.
-- **Auto-enrollment widens what the platform reads.** Learning values from
-  `tool_output` means inspecting tool results for high-entropy strings; it must
-  be opt-in and scoped to designated tools, and the learned set lives only in
-  encrypted session storage (TM-LLM / TM-TOOL in `specs/threat-model.md`).
+  compliant retry; per-turn tool-call limits bound loops.
+- **`output`-stage semantic checks are gated on EVE-572** (or a new classifier);
+  today only `moderation` runs on `output`.
 
 ## Phasing
 
-1. **Ship-nothing-new baseline:** the `secret-detection` regex preset already
-   covers well-known formats today. Document it as the answer for formatted keys.
-2. **Known-value redaction (the direct build for the screenshot):**
-   `SecretValues{enrolled}` + `redact` action + the `SecretRedactor` hook wiring,
-   sourced from `secret_store`. Deterministic, active-safe, no model calls.
-3. **Auto-enrollment** from designated secret-reading tool outputs (opt-in).
-4. **Entropy heuristic** gallery preset (log-only) for unknown secrets, plus an
-   optional `llm_judge`/`moderation`-style "never reveal credential material"
-   semantic backstop on `tool_use`/`tool_output` for cases substring matching
-   structurally cannot catch.
+1. **Ship-now, no code:** document an `llm_judge`-on-`tool_use`/`tool_output`
+   secret-leak preset (the policy prompt above) as a gallery entry. Reproduces the
+   screenshot for tool calls today; advisory-first.
+2. **Dedicated `secret_leak` classifier** (a `moderation` sibling), enable-able on
+   all three stages — cheaper, more consistent, and covers prose echo on `output`.
+3. **Deterministic `SecretValues` redactor** + `redact` action, sourced from
+   `secret_store`, as the fail-closed exact layer.
+4. **EVE-572** (`llm_judge`/`mcp` on `output`) if an open-ended judge is wanted on
+   prose output rather than the fixed classifier.
 
-Phase 2 alone reproduces the screenshot end-to-end and is a small, testable,
-in-process change with zero new egress.
+Phase 1 is configuration-only and reproduces the screenshot's tool-call behavior
+immediately; phases 2–3 add coverage and a fail-closed backstop.

--- a/proposals/known-value-secret-leak-guardrail.md
+++ b/proposals/known-value-secret-leak-guardrail.md
@@ -1,0 +1,181 @@
+# Proposal: Known-value secret-leak guardrail
+
+Status: draft design note (pre-spec). Answers "can we build a guardrail that
+blocks an agent from echoing a secret it holds in context, and how?" On
+acceptance this becomes a new rule variant in `everruns_core::guardrail_checks`,
+a gallery preset, and additions to `specs/guardrails.md`.
+
+## The scenario
+
+An agent is rotating an AWS Secrets Manager `clientSecret`. Mid-task it wants to
+verify propagation. Two guardrail behaviors are visible:
+
+1. A tool call that would **echo part of the live secret** (a diff/compare that
+   printed secret material) is **blocked**. The refusal reason is fed back to
+   the model.
+2. The model **self-corrects** to a hash comparison — "no secret material in the
+   output at all" — and proceeds.
+
+So "such a guardrail" is really two things: a **detector** that recognizes when
+stage content contains a secret the agent is handling, and the **block →
+feed-reason-back → self-correct** loop around it. The second half already exists;
+the first half exists only for *well-known credential formats*, not for the
+*opaque, session-specific* value in this scenario.
+
+## Verdict
+
+**Yes, and most of the machinery is already in place.** everruns already ships a
+config-driven guardrail engine (`specs/guardrails.md`) with exactly the three
+interception seams this needs, the block-and-feed-back loop, advisory mode, a
+dry-run tuning surface, and a `secret-detection` gallery preset. The one missing
+primitive is a **dynamic, session-scoped source of secret *values*** feeding a
+deterministic redaction check. Everything else is reuse.
+
+## What already exists (and directly covers half the ask)
+
+Grounded in `crates/core/src/guardrail_checks.rs`,
+`crates/core/src/guardrail_gallery.rs`, and `crates/core/src/output_guardrail.rs`:
+
+- **Three stages**, which are exactly the leak surfaces: `output` (model echoes
+  the secret in prose), `tool_use` (the *command about to run* embeds the
+  secret — this is the screenshot's block), `tool_output` (a fetched file/result
+  carries one). See `GuardrailStage`.
+- **The self-correction loop is already the `tool_use` contract.** Per
+  `specs/guardrails.md` §Runtime integration, a blocking `tool_use` hit "refuses
+  the tool call and feeds the reason back to the model (which can self-correct)."
+  The screenshot's step 2 (redo as a hash compare) is this behavior, not new work.
+- **Substring matching already exists** as `GuardrailRule::Blocklist` — a
+  compiled, case-optional, linear-time `haystack.contains(word)` matcher
+  (`CompiledRule::Blocklist`). A known-secret redactor is a blocklist whose word
+  list is *sourced at runtime* instead of at config time.
+- **A `secret-detection` preset already ships** (`guardrail_gallery.rs`) with
+  high-precision regexes for AWS/GitHub/Slack/Google keys and PEM headers, on
+  `output` + `tool_output`, safe to run active.
+- **Advisory mode + dry-run** (`POST /v1/capabilities/guardrails/dry-run`) are
+  the false-positive tuning path — essential for anything heuristic.
+
+## The gap
+
+The screenshot's secret is an **opaque, random, session-specific** value read
+from AWS SM at runtime. It has no well-known format, so the static `regex`
+preset cannot see it, and `Blocklist` can't help because **the value is unknown
+at agent-config time.** Two capabilities are missing:
+
+1. **A dynamic secret source.** The guardrail must know *which concrete values*
+   are "live" for this session, and that set changes per run.
+2. **Value-based deterministic matching over that set**, including partial
+   matches ("echoed *part* of the secret"), running on all three stages, with a
+   **redact** outcome (mask the matched span) in addition to today's whole-message
+   block.
+
+Neither the sync `evaluate()` path nor any compiled rule has a runtime handle to
+session state today — `evaluate()` is pure over config-time data. That is the
+core thing to add.
+
+### Where the secret values come from
+
+everruns already has the source. `session_storage` exposes `secret_store` — an
+encrypted, session-scoped namespaced-secret store (the `ns` table,
+AES-256-GCM envelope encryption per `specs/encryption.md`). It already holds
+agent-handled credentials: MCP OAuth tokens (`mcp_oauth_ns_name`), managed
+sandbox state (`specs/session-sandbox.md`), and user-provided API keys. A
+known-value guardrail draws its match set from:
+
+- **Enrolled secrets** — values the agent (or a harness) explicitly places in
+  `secret_store`. Deterministic, precise, zero false positives. This is the
+  clean path for the rotation scenario: the old/new `clientSecret` is enrolled,
+  and any stage content containing it is redacted.
+- **Auto-enrolled secrets** — high-entropy values observed in the output of
+  designated secret-reading tools (e.g. a raw `aws secretsmanager get-secret-value`
+  in bash). The value transits `tool_output` first; that seam both *learns* the
+  value into the session redaction set and redacts it downstream. Opt-in, because
+  it is heuristic.
+
+## Design
+
+### New deterministic rule variant
+
+Add to `GuardrailRule` (`guardrail_checks.rs`):
+
+```
+SecretValues {
+    source: SecretSource,   // enrolled | auto_enroll | explicit(list)
+    min_len: usize,         // default ~12: ignore short/low-entropy fragments
+    normalize: bool,        // fold whitespace/case before matching (default true)
+    partial: bool,          // also match a long contiguous run of a secret
+}
+```
+
+Valid on all three stages. Effective action gains a third option alongside
+`block`/`log`: **`redact`** — replace only the matched span(s) with a mask
+(`«redacted»`) rather than withholding the whole message. Redaction is what
+lets the *useful* part of a tool call or answer survive while the secret does
+not, matching the screenshot's "no secret printed" outcome without nuking the
+turn. `block` and `log` remain for callers who want them.
+
+### Runtime wiring (the one architectural change)
+
+Today `CompiledGuardrails::evaluate()` takes only config-time data plus a `skip`
+closure. `SecretValues` needs the session's current secret set. Mirror how
+`llm_judge`/`mcp` checks already receive their collaborators from context: those
+are pulled out of the sync path (`judge_checks_for_stage`, `mcp_checks_for_stage`)
+and run by the capability hooks with a session-scoped invoker. Add the same
+shape for secrets:
+
+- A `SecretRedactor` handle (a compiled `matcher::AhoCorasick` over the current
+  secret set, rebuilt when the set changes) supplied to the output/pre-tool/
+  post-tool hooks at arm time from the session's `secret_store`.
+- Matching stays **deterministic and linear** — Aho-Corasick over N secrets is
+  O(text length), no backtracking, same DoS posture as the existing regex/
+  blocklist matchers. The `min_len` gate and an entropy floor prevent a short or
+  dictionary-word secret from redacting half the transcript.
+- The pure `evaluate()` stays pure for regex/blocklist/tool_pattern; `SecretValues`
+  is evaluated in the hooks where the session handle is available, exactly like
+  the async variants — but it is still *synchronous and deterministic*, just
+  session-stateful.
+
+### Gallery presets
+
+- `known-secret-redaction` — `SecretValues{source: enrolled}` on all three
+  stages, action `redact`, active-safe (zero false positives: it only masks
+  values explicitly enrolled).
+- `entropy-secret-heuristic` — a `regex`/entropy detector for unknown
+  high-entropy tokens on `output`+`tool_output`, shipped **log-only** like the
+  existing PII and prompt-injection presets, because generic secret detection is
+  inherently noisy.
+
+## Hard parts and honest limits
+
+- **You can only redact what you can identify.** Enrolled/auto-enrolled known
+  values are exact and safe. The fully general "detect any secret the agent
+  never told us about" case is entropy heuristics — false-positive-prone, hence
+  log-only first, tuned via advisory + dry-run before `block`/`redact`.
+- **Encoding evades substring matching.** A secret that is base64'd, URL-encoded,
+  or hashed before it hits a stage won't match the raw value. `normalize` covers
+  whitespace/case; common transforms (base64, %-encoding) can be layered in, but
+  this is a cat-and-mouse tail, not a guarantee. The hash-compare self-correction
+  in the screenshot is the *right* pattern precisely because it never emits the
+  value in any encoding.
+- **Self-correction is not guaranteed.** Feeding the reason back usually yields a
+  compliant retry, but a model can loop; the existing per-turn tool-call limits
+  bound this. Advisory mode is the safe rollout default.
+- **Auto-enrollment widens what the platform reads.** Learning values from
+  `tool_output` means inspecting tool results for high-entropy strings; it must
+  be opt-in and scoped to designated tools, and the learned set lives only in
+  encrypted session storage (TM-LLM / TM-TOOL in `specs/threat-model.md`).
+
+## Phasing
+
+1. **Ship-nothing-new baseline:** the `secret-detection` regex preset already
+   covers well-known formats today. Document it as the answer for formatted keys.
+2. **Known-value redaction (the direct build for the screenshot):**
+   `SecretValues{enrolled}` + `redact` action + the `SecretRedactor` hook wiring,
+   sourced from `secret_store`. Deterministic, active-safe, no model calls.
+3. **Auto-enrollment** from designated secret-reading tool outputs (opt-in).
+4. **Entropy heuristic** gallery preset (log-only) for unknown secrets, plus an
+   optional `llm_judge`/`moderation`-style "never reveal credential material"
+   semantic backstop on `tool_use`/`tool_output` for cases substring matching
+   structurally cannot catch.
+
+Phase 2 alone reproduces the screenshot end-to-end and is a small, testable,
+in-process change with zero new egress.

--- a/specs/guardrails.md
+++ b/specs/guardrails.md
@@ -227,11 +227,18 @@ capability reads.
 ## Gallery
 
 The guardrail gallery is a read-only catalogue of ready-made `GuardrailsConfig`
-presets (secret detection, PII detection, a profanity starter, dangerous-shell
-blocking, shell-access blocking, prompt-injection heuristics). It mirrors the
-harness-examples pattern: presets live in code
-(`everruns_core::guardrail_gallery`), not the DB, and are served read-only via
-`GET /v1/capabilities/guardrails/examples` (gated by `capability.view`).
+presets (secret detection, a model-backed secret-leak judge, PII detection, a
+profanity starter, dangerous-shell blocking, shell-access blocking,
+prompt-injection heuristics). It mirrors the harness-examples pattern: presets
+live in code (`everruns_core::guardrail_gallery`), not the DB, and are served
+read-only via `GET /v1/capabilities/guardrails/examples` (gated by
+`capability.view`).
+
+The `secret-leak-judge` preset is the model-backed complement to the
+deterministic `secret-detection` regex preset: it evaluates an `llm_judge`
+policy on `tool_use` and `tool_output` that blocks a call or result revealing
+secret/credential material in cleartext, catching opaque secrets whose value is
+not known at config time. It reports `data_egress = utility_llm` (see below).
 
 Adoption is client-side config composition: each listing carries a full
 `config`, and a client drops it into an agent's `guardrails` capability config
@@ -240,12 +247,14 @@ import endpoint — guardrail configs already live in agent capability config.
 
 Each listing carries trust metadata so a picker can show what a preset does
 before adoption: `check_types` (the rule-type composition), `stages`, and
-`data_egress`. Deterministic presets report `data_egress = none` (everything
-runs in-process); model-based and MCP-served presets will report other egress
-markers when those check types land, derived from the check types rather than
-hand-authored. Presets that are inherently noisy (PII, prompt-injection
-heuristics) ship `log`-only so they are safe to adopt active and tuned before
-switching individual checks to `block`.
+`data_egress`. `data_egress` is derived from the check types rather than
+hand-authored: deterministic presets report `none` (everything runs
+in-process), while a preset with a model-backed check (`llm_judge` /
+`moderation`) reports `utility_llm` because it sends a bounded content excerpt
+to the org's configured utility LLM. MCP-served presets will report another
+marker when a preset uses that check type. Presets that are inherently noisy
+(PII, prompt-injection heuristics) ship `log`-only so they are safe to adopt
+active and tuned before switching individual checks to `block`.
 
 ## Composition and removal
 


### PR DESCRIPTION
## What changed
Adds a new guardrail gallery preset, **`secret-leak-judge`**, and makes the gallery's `data_egress` trust signal accurate for model-backed presets.

- The preset is an `llm_judge` policy on the `tool_use` and `tool_output` stages that blocks a tool call (or tool result) which would reveal secret/credential material in cleartext. Because it's model-backed, it catches **opaque secrets whose value is not known at config time** (e.g. a value freshly read from a secrets manager) — the case the deterministic `secret-detection` regex preset structurally cannot see. The two presets are complementary: one catches known credential *formats* by pattern, the other catches secrets by *intent*.
- On a `tool_use` block the refusal reason is fed back to the model, which self-corrects to a safe form (comparing a hash/redacted value instead of printing the secret).
- Gallery `data_egress` is now **derived from check types** instead of hardcoded to `none`: a preset containing a model-backed check (`llm_judge`/`moderation`) reports `utility_llm`, since it sends a bounded content excerpt to the org's configured utility LLM; deterministic presets still report `none`. This closes a correctness gap — the gallery previously asserted "deterministic-only / no egress" for every preset.

Also lands the design note this work came from (`proposals/known-value-secret-leak-guardrail.md`).

## Why
A model-backed secret-leak guardrail (block a command about to echo a live secret; let the agent self-correct) is exactly the behavior we want the platform to support, and it maps onto everruns' existing `llm_judge` primitive — it just wasn't offered as an adoptable preset. Shipping it as gallery config makes it a one-click default posture for security-conscious agents, with no engine changes.

## Before / After
No behavior changes for existing agents; this adds a new adoptable preset. Evidence — the served config and its derived trust metadata (via the gallery accessor):

**Before:** the gallery had no dynamic/model-backed secret guardrail, and `data_egress` was hardcoded `none` for every preset.

**After:**
```
name: secret-leak-judge
check_types: ["llm_judge"]
stages: ["tool_use", "tool_output"]
data_egress: utility_llm
```
The `secret-leak-tool-use` check carries `on_fail: block` with the policy prompt and a self-correction hint; `secret-leak-tool-output` blocks a fetched result carrying a secret. Full JSON is what the read-only `GET /v1/capabilities/guardrails/examples` endpoint serves.

Unit tests (`cargo test -p everruns-core --lib guardrail_gallery`): 7 passed — including `every_preset_compiles` (the new `llm_judge` preset validates against the engine's limits) and `trust_metadata_is_derived_from_config` (asserts the new preset reports `check_types=["llm_judge"]`, `stages=["tool_use","tool_output"]`, `data_egress=UtilityLlm`).

## Risk
- **Low**
- Blast radius is one new read-only gallery entry plus a derived trust field. No engine, endpoint, schema, migration, or credential-surface changes. Existing presets and their `data_egress=none` are unchanged. The `llm_judge` check type is pre-existing and fails open (a judge outage can only allow, never over-block beyond the no-guardrail baseline), and the preset is only active if an author adopts it.

## Security
- **Threat categories reviewed:** TM-LLM (utility-LLM data egress), TM-DOS (judge call bounds).
- **Findings and resolutions:** The preset reuses the existing, already-threat-modeled `llm_judge` plumbing (TM-LLM-027/028): a bounded content excerpt (capped, UTF-8-safe) is sent to the org's *own* configured utility LLM — no new third party, no new credential surface, no new endpoint. Per-invocation call cap and timeout (TM-DOS) are unchanged. The `data_egress` change is a net **transparency improvement**: adopters are now correctly warned this preset performs utility-LLM egress, where the gallery previously reported `none` for everything. No threat-model changes required.

## Follow-ups
Deferred phases from the design note (`proposals/known-value-secret-leak-guardrail.md`), each a separate change:
- A dedicated, cheaper `secret_leak` classifier (a `moderation` sibling) enable-able on all three stages, including `output` (prose echo).
- A deterministic `SecretValues` known-value redactor sourced from `secret_store` as a fail-*closed* backstop for values the platform already holds.
- `llm_judge`/`mcp` on the `output` stage (EVE-572).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)