### PR TITLE
perf(tool-search): compact deferred schemas

### DIFF
--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -10,9 +10,9 @@
 //   1. A `tool_definition_hook` (`DeferSchemaHook`) runs at runtime-agent build
 //      time. When the agent carries at least `threshold` tools, it replaces the
 //      parameter schema of every deferrable tool with a minimal disclosure stub.
-//      The model still sees that the tool exists, but the stub points it back
-//      to `tool_search` for the full schema instead of exposing parameters
-//      upfront. Tools marked `DeferrablePolicy::Never` (e.g. high-frequency
+//      The model still sees that the tool exists, while the single capability
+//      prompt points it to `tool_search` instead of repeating that instruction
+//      in every stub. Tools marked `DeferrablePolicy::Never` (e.g. high-frequency
 //      tools) and tools in the capability's `never_defer` allowlist keep full
 //      schemas.
 //   2. A real `tool_search` tool is added to the registry. When the model calls
@@ -91,9 +91,8 @@ const MAX_SEARCH_RESULTS: usize = 8;
 const NAME_TERM_WEIGHT: usize = 3;
 const DESC_TERM_WEIGHT: usize = 1;
 
-/// Dominant bonus when the whole query is exactly a tool name. The deferred stub
-/// tells the model to call `tool_search` with the exact tool name to load its
-/// schema, so this is the common "load this specific tool" path and that tool
+/// Dominant bonus when the whole query is exactly a tool name. This is the
+/// common "load this specific tool" path and that tool
 /// must rank first regardless of incidental matches elsewhere.
 const EXACT_NAME_BONUS: usize = 100;
 
@@ -319,17 +318,14 @@ impl Capability for ToolSearchCapability {
 // DeferSchemaHook — strips parameter schemas from deferrable, unrevealed tools
 // ============================================================================
 
-/// Stub schema sent in place of a deferred tool's real parameters.
+/// Minimal open-object schema sent in place of a deferred tool's parameters.
 ///
-/// An open object so the provider still accepts the tool definition; the
-/// description nudges the model toward `tool_search` if it somehow tries to
-/// call the tool before loading the schema.
-fn deferred_stub_schema(tool_name: &str) -> Value {
+/// The capability prompt owns the single instruction to use `tool_search`.
+/// Repeating a tool-specific copy inside every stub scales that sentence with
+/// the size of the tool catalogue and defeats much of the deferral saving.
+fn deferred_stub_schema() -> Value {
     json!({
         "type": "object",
-        "description": format!(
-            "Parameter schema hidden to save context. Call tool_search with query \"{tool_name}\" to load the full schema before using this tool."
-        ),
         "additionalProperties": true,
     })
 }
@@ -391,14 +387,14 @@ fn strip_parameters(tool: ToolDefinition) -> ToolDefinition {
             if b.full_parameters.is_none() {
                 b.full_parameters = Some(b.parameters.clone());
             }
-            b.parameters = deferred_stub_schema(&b.name);
+            b.parameters = deferred_stub_schema();
             ToolDefinition::Builtin(b)
         }
         ToolDefinition::ClientSide(mut c) => {
             if c.full_parameters.is_none() {
                 c.full_parameters = Some(c.parameters.clone());
             }
-            c.parameters = deferred_stub_schema(&c.name);
+            c.parameters = deferred_stub_schema();
             ToolDefinition::ClientSide(c)
         }
     }
@@ -708,18 +704,11 @@ mod tests {
         let hook = hook(15);
         let out = hook.transform(many_tools(20));
         for t in &out {
-            // Stub schema: no real properties, carries a progressive-disclosure hint.
+            // The shared capability prompt carries the progressive-disclosure
+            // instruction once; each stub is only the provider-valid open object.
             assert!(t.parameters().get("properties").is_none());
             assert_eq!(t.parameters()["additionalProperties"], json!(true));
-            let description = t.parameters()["description"].as_str().unwrap();
-            assert!(
-                description.contains("tool_search"),
-                "deferred stub should point the model to tool_search"
-            );
-            assert!(
-                description.contains(t.name()),
-                "deferred stub should include the search query that reveals this schema"
-            );
+            assert!(t.parameters().get("description").is_none());
             assert!(
                 t.full_parameters().get("properties").is_some(),
                 "full schema should remain available for progressive disclosure"
@@ -1295,11 +1284,11 @@ mod tests {
             "surface should meet or exceed the default threshold ({total} < {threshold})"
         );
         assert!(
-            pct > 30.0,
+            pct > 45.0,
             "deferral should cut the whole tool list by a wide margin (was {pct:.0}%)"
         );
         assert!(
-            params_pct > 45.0,
+            params_pct > 70.0,
             "parameter schemas should compress substantially (was {params_pct:.0}%)"
         );
     }

--- a/docs/capabilities/tool-search.md
+++ b/docs/capabilities/tool-search.md
@@ -27,7 +27,7 @@ The diagram below traces one deferred tool through a full round-trip — from sc
 ![Tool Search deferred-loading flow: the Agent Runtime strips parameter schemas to stubs before sending tools to the model; the model calls tool_search, which ranks visible tools in the registry and returns full schemas while recording a session-scoped reveal; on the next iteration the hook restores the revealed tool's registered schema so the model can call it with full parameters.](../images/capabilities/tool-search-flow.svg)
 
 1. **Threshold check** — deferral only activates when the total tool count meets or exceeds the threshold (default: 15). Below it, full schemas are sent unchanged.
-2. **Schema stripping** — a tool-definition hook replaces the parameter schema of every deferrable tool with a small stub (name + description survive). This runs when the runtime agent is built, so the model never receives the full schemas upfront.
+2. **Schema stripping** — a tool-definition hook replaces the parameter schema of every deferrable tool with a minimal open-object stub (name + description survive). The shared prompt carries the search instruction once instead of repeating it in every stub. This runs when the runtime agent is built, so the model never receives the full schemas upfront.
 3. **`tool_search` tool** — a real tool is added to the agent. When the model calls it with a query, the tool inspects its sibling tools and returns the full JSON parameter schemas of the matches.
 4. **Progressive disclosure** — `tool_search` also records the matched tools as *revealed*. The hook re-runs on every reasoning iteration, so on the next step the revealed tools are advertised with their full, authoritative schema on the *registered* definition. This is what lets a structured tool caller actually pass arguments to a previously deferred tool, rather than only reading its schema as text.
 5. **System-prompt guidance** — a short note instructs the model to call `tool_search` before using a tool whose parameters it has not yet loaded.
@@ -96,14 +96,14 @@ The activation threshold defaults to 15 tools (`DEFAULT_TOOL_SEARCH_THRESHOLD`).
 
 Deferral only touches how tool *parameter schemas* reach the model — names and descriptions still go out in full — so the savings scale with how many tools an agent carries and how rich their schemas are.
 
-Measured on a representative 19-tool generic-agent surface (file, shell, web-fetch, session, storage, todo, time, and subagent tools, plus `tool_search` itself), comparing the serialized tool list the driver sends to the model **with and without** deferral on the first turn:
+Measured on a representative 16-tool generic-agent surface (file, shell, web-fetch, session, storage, todo, time, and subagent tools, plus `tool_search` itself), comparing the serialized tool list the driver sends to the model **with and without** deferral on the first turn:
 
 | Metric | Full schemas | Deferred (first turn) | Saving |
 |---|---|---|---|
-| Tool list sent to model | ~11.6 KB (~2,900 tokens) | ~7.0 KB (~1,760 tokens) | **39% smaller** |
-| Parameter-schema bytes only | ~8.3 KB | ~3.7 KB | **55% smaller** |
+| Tool list sent to model | ~11.3 KB (~2,820 tokens) | ~4.0 KB (~990 tokens) | **65% smaller** |
+| Parameter-schema bytes only | ~8.2 KB | ~0.9 KB | **89% smaller** |
 
-Token figures use the ~4-chars-per-token rule of thumb for JSON. 18 of the 19 tools were deferred (`tool_search` keeps its schema). Net savings grow with tool count: an agent with dozens of MCP tools defers proportionally more.
+Token figures use the ~4-chars-per-token rule of thumb for JSON. 15 of the 16 tools were deferred (`tool_search` keeps its schema). Net savings grow with tool count: an agent with dozens of MCP tools defers proportionally more.
 
 These numbers come from the `benchmark_prompt_size_reduction` test in `crates/core/src/capabilities/tool_search.rs`, which also guards the reduction against regressions. Reproduce them with:
 

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -79,7 +79,7 @@ The executor (act) path collects without a model and so resolves to the generic 
 
 Implemented entirely in core, with no driver or agent-loop changes:
 
-1. A `ToolDefinitionHook` (`DeferSchemaHook`) runs in `RuntimeAgentBuilder::build()`. When the agent carries `>= threshold` tools, it replaces each deferrable tool's parameter schema with a small progressive-disclosure stub (name + description survive, and the stub description tells the model which `tool_search` query reveals the full schema). `DeferrablePolicy::Never` tools, tools in the capability's never-defer allowlist, and the `tool_search` tool keep full schemas.
+1. A `ToolDefinitionHook` (`DeferSchemaHook`) runs in `RuntimeAgentBuilder::build()`. When the agent carries `>= threshold` tools, it replaces each deferrable tool's parameter schema with a minimal open-object stub (name + description survive). The capability prompt carries the `tool_search` instruction once rather than repeating it in every schema. `DeferrablePolicy::Never` tools, tools in the capability's never-defer allowlist, and the `tool_search` tool keep full schemas.
 2. A real `tool_search` tool is registered. On call it reads sibling tool schemas from `ToolContext::tool_registry` (the same mechanism `spawn_background` uses) and returns the full schemas of tools matching the query.
 3. A system-prompt note tells the model to call `tool_search` before using a tool whose parameters it has not yet loaded.
 


### PR DESCRIPTION
## What changed
Client-side `tool_search` now sends the provider-valid open-object schema for each deferred tool without repeating the same search instruction inside every stub. Tool names and full descriptions remain visible, the shared capability prompt still explains discovery, and revealed tools still regain their authoritative registered schema.

The public capability documentation and durable tool-search spec now describe the single-owner prompt shape and current benchmark.

## Why
The repeated per-tool sentence scaled linearly with catalogue size and consumed much of the context that schema deferral was intended to save. The capability prompt already owns the instruction to call `tool_search`, so every schema copy was redundant.

## Before / After
The deterministic production-capability benchmark (`benchmark_prompt_size_reduction`) on a 16-tool surface changed from the documented baseline to:

- Whole serialized tool list: ~11.3 KB -> ~4.0 KB (**65% smaller**, previously 39%)
- Parameter schemas: ~8.2 KB -> ~0.9 KB (**89% smaller**, previously 55%)

All 24 focused tool-search tests pass, including session-scoped reveal, registered-schema restoration, MCP serde, visible-tool filtering, never-defer controls, and missing-registry errors. `cargo test -p everruns-core --all-features` passes (2,413 unit tests plus integrations/docs).

## Risk
- Low
- Models must rely on the capability-level instruction rather than an identical instruction repeated in each deferred parameter object. Tool names/descriptions remain intact, the stub remains permissive for structured providers, and the progressive reveal path is unchanged.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-DOS
- Findings and resolutions: tool registration, visible-tool scoping, execution policy, prompt trust boundaries, and reveal bounds are unchanged. No keys or tool data move to a new boundary. The change reduces provider payload size and allocations; existing negative-path and bounded-registry tests pass. No threat-model update is required because no mitigation or trust boundary changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)