### PR TITLE
feat(tools): host-owned metadata hatch on tool hints and capabilities

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -621,6 +621,21 @@ pub trait Capability: Send + Sync {
         None
     }
 
+    /// Host-owned annotations that core does not interpret.
+    ///
+    /// The typed accessors above (`category`, `status`, `is_guardrail`, …) are
+    /// the vocabulary core itself reasons about. This is the escape hatch for
+    /// everything a *host* wants to carry alongside a capability — a UI icon,
+    /// an embedder's grouping key, deployment provenance — without adding a
+    /// field to core for each one. Core reads nothing here.
+    ///
+    /// The schema belongs to whoever writes it. Never put credentials or other
+    /// sensitive payload here: it is surfaced to clients alongside the rest of
+    /// the capability descriptor.
+    fn metadata(&self) -> Option<serde_json::Value> {
+        None
+    }
+
     /// Whether this capability is a guardrail — a constraint on agent
     /// behavior (content checks, tool restrictions) rather than a grant of
     /// new abilities. Structural marker for UI sections and catalog
@@ -3218,6 +3233,35 @@ mod tests {
     /// Test helper: dummy context with no file store
     fn test_ctx() -> SystemPromptContext {
         SystemPromptContext::without_file_store(SessionId::new())
+    }
+
+    /// A host-defined capability carrying annotations core knows nothing about.
+    struct HostAnnotatedCapability;
+
+    #[async_trait]
+    impl Capability for HostAnnotatedCapability {
+        fn id(&self) -> &str {
+            "host_annotated"
+        }
+        fn name(&self) -> &str {
+            "Host Annotated"
+        }
+        fn description(&self) -> &str {
+            "Test capability with host-owned metadata."
+        }
+        fn metadata(&self) -> Option<serde_json::Value> {
+            Some(serde_json::json!({"icon": "sparkles", "group": "host"}))
+        }
+    }
+
+    #[test]
+    fn capability_metadata_is_an_opt_in_host_hatch() {
+        // Core capabilities carry none, so nothing changes for them.
+        assert!(NoopCapability.metadata().is_none());
+
+        let metadata = HostAnnotatedCapability.metadata().expect("metadata");
+        assert_eq!(metadata["icon"], "sparkles");
+        assert_eq!(metadata["group"], "host");
     }
 
     /// Base set of built-in capabilities present in all environments (no experimental delegation).

--- a/crates/provider/src/tool_types.rs
+++ b/crates/provider/src/tool_types.rs
@@ -384,7 +384,10 @@ pub enum SideEffectClass {
 ///
 /// These hints are informational — they do not enforce policy. Use `ToolPolicy`
 /// for execution gating (auto vs requires_approval).
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+// `Eq` is deliberately absent: `metadata` is an opaque `serde_json::Value`, which
+// is only `PartialEq`. Hints are compared for equality (`is_empty`), never hashed
+// or used as a map key, so `PartialEq` is sufficient.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ToolHints {
     /// Tool does not modify any state (read-only queries, lookups).
@@ -481,12 +484,34 @@ pub struct ToolHints {
     /// `None` is treated conservatively as `AtMostOnce`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub side_effect_class: Option<SideEffectClass>,
+
+    /// Host-owned annotations that core does not interpret.
+    ///
+    /// The typed hints above are the vocabulary core itself reasons about. This
+    /// is the escape hatch for everything a *host* wants to carry alongside a
+    /// tool — risk tiers for an approval UI, presentation hints, an embedder's
+    /// routing keys — without adding a field to core for each one. Core reads
+    /// nothing here and no driver sends it to a provider; it travels with the
+    /// definition so a consumer sees it at the point of decision (e.g. a
+    /// `PreToolUseHook` gating on what the tool declared).
+    ///
+    /// The schema belongs to whoever writes it. Never put credentials or other
+    /// sensitive payload here: like the rest of the definition, it is persisted
+    /// and surfaced to clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 impl ToolHints {
     /// Returns true when all fields are None (default/empty state).
     pub fn is_empty(&self) -> bool {
         *self == Self::default()
+    }
+
+    /// Builder: attach host-owned metadata (see [`ToolHints::metadata`]).
+    pub fn with_metadata(mut self, value: serde_json::Value) -> Self {
+        self.metadata = Some(value);
+        self
     }
 
     /// Builder: set readonly hint.
@@ -1208,6 +1233,35 @@ mod tests {
         assert_eq!(
             human_intent(&tool_call.arguments),
             Some("Listing all harnesses")
+        );
+    }
+
+    #[test]
+    fn tool_hints_metadata_is_an_opaque_host_owned_hatch() {
+        let hints = ToolHints::default()
+            .with_readonly(true)
+            .with_metadata(serde_json::json!({"risk_tier": "high"}));
+
+        // Core does not interpret it, but it survives the definition's
+        // serialization so a consumer sees it at the point of decision.
+        let json = serde_json::to_value(&hints).unwrap();
+        assert_eq!(json["metadata"]["risk_tier"], "high");
+        let restored: ToolHints = serde_json::from_value(json).unwrap();
+        assert_eq!(restored, hints);
+
+        // Absent metadata stays off the wire, so existing payloads are byte-identical.
+        let bare = serde_json::to_value(ToolHints::default().with_readonly(true)).unwrap();
+        assert!(bare.get("metadata").is_none());
+    }
+
+    #[test]
+    fn tool_hints_with_only_metadata_are_not_empty() {
+        assert!(ToolHints::default().is_empty());
+        assert!(
+            !ToolHints::default()
+                .with_metadata(serde_json::json!({"any": "thing"}))
+                .is_empty(),
+            "metadata alone must keep the hints serialized"
         );
     }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -35321,6 +35321,9 @@
             ],
             "description": "Tool may take significant time to complete (> ~5s typical).\nUseful for clients to show progress indicators and set timeouts."
           },
+          "metadata": {
+            "description": "Host-owned annotations that core does not interpret.\n\nThe typed hints above are the vocabulary core itself reasons about. This\nis the escape hatch for everything a *host* wants to carry alongside a\ntool — risk tiers for an approval UI, presentation hints, an embedder's\nrouting keys — without adding a field to core for each one. Core reads\nnothing here and no driver sends it to a provider; it travels with the\ndefinition so a consumer sees it at the point of decision (e.g. a\n`PreToolUseHook` gating on what the tool declared).\n\nThe schema belongs to whoever writes it. Never put credentials or other\nsensitive payload here: like the rest of the definition, it is persisted\nand surfaced to clients."
+          },
           "narration_noun": {
             "type": [
               "string",

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -45,7 +45,9 @@ Note: OpenAI Responses API (`function_call_output`) does not support images in t
 
 ### Tool Hints
 
-`ToolHints` provides semantic metadata about a tool's behavioral properties. See `crates/provider/src/tool_types.rs` for the struct definition. All fields are `Option<bool>` — `None` means unspecified.
+`ToolHints` provides semantic metadata about a tool's behavioral properties. See `crates/provider/src/tool_types.rs` for the struct definition. The behavioral hints are all `Option<bool>` — `None` means unspecified.
+
+Alongside them, `metadata: Option<Value>` is an opaque hatch for annotations **core does not interpret**: risk tiers for an approval UI, presentation hints, an embedder's routing keys. The typed hints are the vocabulary core reasons about; the hatch is how a host carries its own without a core patch per field. No driver sends it to a provider, and it must never carry credentials or other sensitive payload — it is persisted and surfaced to clients like the rest of the definition. `Capability::metadata()` is the same hatch one level up.
 
 Follows the [MCP tool annotations](https://spec.modelcontextprotocol.io) convention plus everruns-specific hints:
 


### PR DESCRIPTION
## What changed

Two opaque, host-owned annotation slots that core does not interpret:

- `ToolHints.metadata: Option<serde_json::Value>`, with a `with_metadata()` builder
- `Capability::metadata() -> Option<serde_json::Value>`, defaulted to `None`

Both are absent from the wire when unset (`skip_serializing_if`), so existing payloads are byte-identical. No driver sends either to a provider.

One incidental change: `ToolHints` drops its `Eq` derive, since `serde_json::Value` is only `PartialEq`. A workspace check confirms nothing hashed hints or used them as a map key; `is_empty()` needs only `PartialEq`.

## Why

Core models host-flavored richness as first-class typed fields — the `ToolHints` booleans, capability `category`/`status`/`icon`. That works until an embedder wants to annotate a tool with something core does not model, at which point the only move is a core patch that widens a shared struct for exactly one consumer. Agentyk's read of this repo flagged it as the recurring cost, and the same pattern shows up in `EventData`'s variant count.

The hatch is the cheap half of the fix: typed hints stay the vocabulary core reasons about, and anything else rides in a value core ignores. The concrete case that motivated it is approval gating — a `PreToolUseHook` can consult the risk tier a tool *declared*, at the point the decision is made, rather than pattern-matching on tool names.

## Before / After

```rust
// before — a host risk tier had nowhere to live but a core patch
ToolHints::default().with_destructive(true)

// after
ToolHints::default()
    .with_destructive(true)
    .with_metadata(json!({ "risk_tier": "high", "confirm_copy": "This force-pushes." }))
```

Serialized hints without metadata are unchanged.

## Risk

- Low
- Purely additive at the data level. The only compile-surface change is the dropped `Eq`; `cargo check --workspace` is clean, so no consumer needed it.

## Security

- Threat categories reviewed: TM-API (data exposure). The hatch is persisted and surfaced to clients exactly like the rest of the tool/capability descriptor, so it is documented — in the field docs and in `specs/tool-execution.md` — as never a place for credentials or sensitive payload. Core neither reads nor forwards it, so it cannot influence tool dispatch or reach a provider.
- Findings and resolutions: none.

## Follow-ups

The other half of the same problem — `EventData`'s ~40 variants, where an embedder's event has no home either — is not addressed here. It deserves its own change, since a `Custom { event_type, payload }` variant touches persistence and replay.

## Checklist

- [x] Tests added or updated — 3 new tests: metadata round-trips and stays off the wire when unset, metadata-only hints are not "empty", capability hatch is opt-in with core capabilities carrying none
- [x] Backward compatibility considered — additive fields with serde defaults; wire format unchanged when unset
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo check --workspace` clean, `cargo test -p everruns-provider --lib tool_hints`, `cargo test -p everruns-core --lib` (targeted), `cargo fmt`, `cargo clippy -p everruns-provider -p everruns-core --lib --all-features` clean
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_