### PR TITLE
feat(tools): cooperative cancellation token on ToolContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,6 +2722,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-opentelemetry",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,8 @@ async-trait.workspace = true
 # Async runtime
 # Note: "rt" is needed for tokio::spawn in event listener isolation
 tokio = { workspace = true, features = ["sync", "rt", "process", "time", "net"] }
+# `CancellationToken` for cooperative tool-call cancellation (ToolContext).
+tokio-util = { version = "0.7", default-features = false }
 futures.workspace = true
 
 # Serialization

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -1488,6 +1488,17 @@ where
         tool_context.event_context = Some(event_context.clone());
         tool_context.tool_call_id = Some(tool_call.id.clone());
 
+        // Cooperative cancellation for this call. The guard fires when this
+        // future is dropped — which is what a cancelled turn looks like from
+        // here — and also on normal return, so the contract a tool sees is
+        // simply "this call is over". Work the tool leaves running (a child
+        // process, a detached watcher) can hold a clone and die with the call
+        // instead of outliving it; dropping the future alone cannot tell it
+        // anything, because a dropped future is never polled again.
+        let call_cancellation = tokio_util::sync::CancellationToken::new();
+        tool_context.cancellation = Some(call_cancellation.clone());
+        let _cancel_on_call_end = call_cancellation.drop_guard();
+
         let execution_tool_call = self.transform_tool_call_for_execution(tool_call.clone());
 
         // Run pre-tool-use hooks (capability-contributed). They can mutate
@@ -2348,6 +2359,142 @@ mod tests {
             "independent tool should run concurrently with the class group (global_max={})",
             obs.global_max
         );
+    }
+
+    /// A tool that leaves work running past its own future: it hands the
+    /// call's cancellation token to a detached task and returns immediately.
+    /// That task is the thing a dropped future cannot reach.
+    struct DetachedWorkTool {
+        cancelled_tx: Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+    }
+
+    impl DetachedWorkTool {
+        fn new(cancelled_tx: tokio::sync::oneshot::Sender<()>) -> Self {
+            Self {
+                cancelled_tx: Arc::new(std::sync::Mutex::new(Some(cancelled_tx))),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl crate::tools::Tool for DetachedWorkTool {
+        fn name(&self) -> &str {
+            "detached_work"
+        }
+
+        fn description(&self) -> &str {
+            "spawns work that outlives the call unless cancelled"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({ "type": "object", "properties": {} })
+        }
+
+        fn requires_context(&self) -> bool {
+            true
+        }
+
+        async fn execute(&self, _arguments: serde_json::Value) -> crate::ToolExecutionResult {
+            crate::ToolExecutionResult::tool_error("requires context")
+        }
+
+        async fn execute_with_context(
+            &self,
+            _arguments: serde_json::Value,
+            context: &crate::traits::ToolContext,
+        ) -> crate::ToolExecutionResult {
+            let token = context
+                .cancellation
+                .clone()
+                .expect("act must supply a cancellation token");
+            assert!(!token.is_cancelled(), "token is live during the call");
+            let tx = self.cancelled_tx.clone();
+            tokio::spawn(async move {
+                token.cancelled().await;
+                if let Ok(mut guard) = tx.lock()
+                    && let Some(tx) = guard.take()
+                {
+                    let _ = tx.send(());
+                }
+            });
+            crate::ToolExecutionResult::success(json!({ "spawned": true }))
+        }
+    }
+
+    /// Work a tool leaves running must learn that its call ended. Dropping the
+    /// act future cannot tell it — a dropped future is never polled again — so
+    /// the token on `ToolContext` is the only signal that reaches it.
+    #[tokio::test]
+    async fn test_act_atom_cancels_detached_tool_work_when_the_call_ends() {
+        let (cancelled_tx, cancelled_rx) = tokio::sync::oneshot::channel();
+
+        let mut executor = ToolRegistry::new();
+        executor.register(DetachedWorkTool::new(cancelled_tx));
+
+        let atom = ActAtom::new(executor, NoopEventEmitter);
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "detached_work".to_string(),
+                arguments: json!({}),
+            }],
+            tool_definitions: vec![recording_tool_def("detached_work", None, false)],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        };
+
+        atom.execute(input).await.expect("act should succeed");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), cancelled_rx)
+            .await
+            .expect("detached work should be cancelled once the call ends")
+            .expect("cancellation signal should be sent");
+    }
+
+    #[tokio::test]
+    async fn test_act_atom_cancels_detached_tool_work_when_the_turn_is_cancelled() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+
+        let mut executor = ToolRegistry::new();
+        executor.register(CancellationProbeTool::new(started.clone(), dropped_tx));
+
+        let atom = ActAtom::new(executor, NoopEventEmitter);
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "cancellation_probe".to_string(),
+                arguments: json!({}),
+            }],
+            tool_definitions: vec![recording_tool_def("cancellation_probe", None, true)],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        };
+
+        let act_task = tokio::spawn(async move { atom.execute(input).await });
+        started.notified().await;
+        act_task.abort();
+        assert!(act_task.await.unwrap_err().is_cancelled());
+
+        // The existing abort path still holds: the tool future itself is dropped.
+        tokio::time::timeout(std::time::Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("tool future should be dropped when the turn is cancelled")
+            .expect("drop signal should be sent");
     }
 
     #[tokio::test]

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -1936,6 +1936,17 @@ pub struct ToolContext {
     /// change the reasoning effort mid-turn; subsequent LLM steps in the same
     /// `run_turn` re-read it and use the new effort.
     pub reasoning_effort_handle: Option<ReasoningEffortHandle>,
+
+    /// Cooperative cancellation for this tool call.
+    ///
+    /// The act atom cancels it when the call ends *by any means* — the turn was
+    /// cancelled, the act future was dropped, or the tool simply returned. A
+    /// tool that only awaits inside its own future needs nothing here: dropping
+    /// the future already stops it. This exists for work a tool starts and
+    /// leaves running — a child process, a detached watcher task, a prompt
+    /// waiting on an answer — which would otherwise outlive the call that
+    /// created it. Clone the token into that work and let it die with the call.
+    pub cancellation: Option<tokio_util::sync::CancellationToken>,
 }
 
 impl ToolContext {
@@ -1993,6 +2004,7 @@ impl ToolContext {
             subagent_spawn_store: None,
             subagent_nesting_policy: SubagentNestingPolicy::default(),
             reasoning_effort_handle: None,
+            cancellation: None,
         }
     }
 
@@ -2036,6 +2048,7 @@ impl ToolContext {
             subagent_spawn_store: services.subagent_spawn_store.clone(),
             subagent_nesting_policy: services.subagent_nesting_policy,
             reasoning_effort_handle: services.reasoning_effort_handle.clone(),
+            cancellation: None,
         }
     }
 
@@ -2079,6 +2092,7 @@ impl ToolContext {
             subagent_spawn_store: None,
             subagent_nesting_policy: SubagentNestingPolicy::default(),
             reasoning_effort_handle: None,
+            cancellation: None,
         }
     }
 
@@ -2125,6 +2139,7 @@ impl ToolContext {
             subagent_spawn_store: None,
             subagent_nesting_policy: SubagentNestingPolicy::default(),
             reasoning_effort_handle: None,
+            cancellation: None,
         }
     }
 
@@ -2172,6 +2187,7 @@ impl ToolContext {
             subagent_spawn_store: None,
             subagent_nesting_policy: SubagentNestingPolicy::default(),
             reasoning_effort_handle: None,
+            cancellation: None,
         }
     }
 
@@ -2205,6 +2221,21 @@ impl ToolContext {
     /// Add a live reasoning-effort handle (EVE-595). Tools can call
     /// [`ReasoningEffortHandle::set`] on it to change the effort used by
     /// subsequent LLM steps within the same turn.
+    /// Attach a cancellation token to this context (see
+    /// [`ToolContext::cancellation`]).
+    pub fn with_cancellation(mut self, token: tokio_util::sync::CancellationToken) -> Self {
+        self.cancellation = Some(token);
+        self
+    }
+
+    /// Whether this call has already been cancelled. A context with no token
+    /// never reports cancellation.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancellation
+            .as_ref()
+            .is_some_and(|token| token.is_cancelled())
+    }
+
     pub fn with_reasoning_effort_handle(mut self, handle: ReasoningEffortHandle) -> Self {
         self.reasoning_effort_handle = Some(handle);
         self
@@ -2265,6 +2296,7 @@ impl ToolContext {
             subagent_spawn_store: None,
             subagent_nesting_policy: SubagentNestingPolicy::default(),
             reasoning_effort_handle: None,
+            cancellation: None,
         }
     }
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -264,6 +264,19 @@ V1 limitation:
 - Background runs are best-effort and worker-local. They are started with `tokio::spawn` inside the worker process and are not yet durable across worker restarts.
 - This is intentional for the first iteration; durable resumption can be layered later without changing the tool contract.
 
+### Tool-Call Cancellation
+
+Dropping the act future is how a cancelled turn stops tool work, and for a tool
+that only awaits inside its own future that is enough — a dropped future is
+never polled again. It says nothing to work the tool *left running*: a child
+process, a detached watcher task, a prompt waiting on an answer.
+
+`ToolContext.cancellation` is the signal that reaches those. The act atom mints
+a token per call and cancels it when the call ends by any means — turn
+cancelled, act future dropped, or the tool simply returned — so the contract a
+tool sees is "this call is over; stop what you started for it". Cloning the
+token into detached work is what keeps it from outliving the call.
+
 ### Tool-Side Service Stores
 
 `ToolContext` may carry worker-backed service stores in addition to filesystem and session metadata handles. These stores let tools perform org-scoped operations without bypassing worker authorization boundaries.


### PR DESCRIPTION
## What changed

`ToolContext` gains `cancellation: Option<CancellationToken>` (plus `with_cancellation()` and `is_cancelled()`). The act atom mints a token per tool call and holds its drop guard, so the token fires when the call ends **by any means**: the turn was cancelled, the act future was dropped, or the tool simply returned.

Adds `tokio-util` (default-features off) to `everruns-core` — it was already in the lockfile via `everruns-durable`.

## Why

Dropping the act future is how a cancelled turn stops tool work today, and for a tool that only awaits inside its own future that is sufficient — a dropped future is never polled again. It says nothing to work the tool *left running*: a spawned child process, a detached watcher task, a middleware prompt waiting on an answer. Those outlive the call that created them, and nothing in the tool contract could tell them otherwise.

This is yolop's blocking gap in the same area, reduced to its portable core: give the tool a handle it can hand to whatever it leaves behind.

The contract is deliberately "this call is over" rather than "the turn was cancelled" — an orphaned child process after a *successful* call is the same bug as one after a cancelled turn, and a single rule is easier to hold than two.

## Before / After

```rust
// A tool that spawns something outliving its own future
async fn execute_with_context(&self, args: Value, ctx: &ToolContext) -> ToolExecutionResult {
    let token = ctx.cancellation.clone();          // new
    let mut child = Command::new("cargo").arg("test").spawn()?;
    tokio::spawn(async move {
        if let Some(token) = token { token.cancelled().await; }
        let _ = child.kill().await;                 // before: nothing reached here
    });
    ...
}
```

Existing tools are unaffected — the field is optional and every existing constructor sets it to `None` outside the act path.

## Risk

- Low
- Additive field; no tool reads it unless it opts in. The one behavioral subtlety is that the token also fires on normal completion, which is intended and documented — a tool must not treat "cancelled" as "the turn failed".

## Security

- Threat categories reviewed: no security-relevant code changes. The token carries no data and grants no capability; it only signals lifecycle.
- Findings and resolutions: none.

## Follow-ups

Racing the tool future against the token in the act host (so an in-flight call unwinds at the moment of cancellation rather than at its next await point) is the natural next step, but it changes act's control flow and belongs in its own change. This PR is the signal; that one is the enforcement.

## Checklist

- [x] Tests added or updated — two new act tests: detached work is cancelled when the call ends normally, and the existing abort path still drops the tool future when the turn is cancelled. Full `atoms::` suite passes (78 tests)
- [x] Backward compatibility considered — additive optional field; no tool or host is required to change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo test -p everruns-core --lib atoms::`, `cargo fmt`, `cargo clippy -p everruns-core --lib --all-features` clean
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_