### PR TITLE
chore(release): prepare v0.17.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.21] - 2026-08-06
+
+### Highlights
+
+- **Cumulative-cost context checkpoints** - Long tool trajectories now compact before context-window pressure when cumulative uncached input or raw tool results become costly, while preserving lossless history and query access ([#2933](https://github.com/everruns/everruns/pull/2933)).
+
+### What's Changed
+
+- feat(compaction): trigger checkpoints from cumulative cost ([#2933](https://github.com/everruns/everruns/pull/2933)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.20] - 2026-08-06
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Highlights
 
 - **Cumulative-cost context checkpoints** - Long tool trajectories now compact before context-window pressure when cumulative uncached input or raw tool results become costly, while preserving lossless history and query access ([#2933](https://github.com/everruns/everruns/pull/2933)).
+- **Lower tool context overhead** - Deferred tools now keep compact permissive schemas until revealed, reducing the production tool-list payload by 65% while preserving provider-agnostic structured tool calling ([#2935](https://github.com/everruns/everruns/pull/2935)).
 
 ### What's Changed
 
 - feat(compaction): trigger checkpoints from cumulative cost ([#2933](https://github.com/everruns/everruns/pull/2933)) by [@chaliy](https://github.com/chaliy)
+- perf(tool-search): compact deferred schemas ([#2935](https://github.com/everruns/everruns/pull/2935)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.17.20] - 2026-08-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,11 +2547,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.20"
+version = "0.17.21"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3155,11 +3155,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.20"
+version = "0.17.21"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.20"
+version = "0.17.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.20"
+version = "0.17.21"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.20" }
-everruns-provider = { path = "crates/provider", version = "0.17.20" }
+everruns-core = { path = "crates/core", version = "0.17.21" }
+everruns-provider = { path = "crates/provider", version = "0.17.21" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.20" }
-everruns-ard = { path = "crates/ard", version = "0.17.20" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.21" }
+everruns-ard = { path = "crates/ard", version = "0.17.21" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.20" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.21" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.20",
+  "version": "0.17.21",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.20" }
+everruns-provider = { path = "../provider", version = "0.17.21" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.20" }
+everruns-provider = { path = "../provider", version = "0.17.21" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -132,10 +132,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.20", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.21", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.20", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.21", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.20" }
+everruns-provider = { path = "../provider", version = "0.17.21" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.20" }
+everruns-provider = { path = "../provider", version = "0.17.21" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.20" }
+everruns-provider = { path = "../provider", version = "0.17.21" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed
Prepare Everruns v0.17.21 with lockstep workspace and public path-dependency versions plus release notes for cumulative-cost context checkpoints and compact deferred tool schemas.

## Why
Publish the changes landed since v0.17.20, including #2933 so downstream Yolop can consume cumulative context-cost control from crates.io without a git dependency.

## Before / After
Before: v0.17.20 only triggered proactive checkpoints from context-window occupancy, and repeated a search instruction in every deferred tool schema.

After: v0.17.21 also triggers checkpoints from bounded cumulative uncached input or raw tool-result bytes above a marginal prompt floor. The deterministic A/B in #2933 reduced a representative model view from 293,520 bytes to 56 bytes (at least the 75% target) while preserving task success and lossless queryable raw history. #2935 separately reduced the representative deferred tool list by 65%.

## Risk
- Low
- Release metadata and lockstep version pins can fail publishing if they drift; sync-publish-pin-versions.py --check and cargo check -p everruns-core pass.

## Security
- Threat categories reviewed: TM-DEP and release supply-chain policy.
- Findings and resolutions: No new dependencies or security behavior. Public crate pins are synchronized; lockfiles were regenerated with the repository-prescribed tool versions and policy checks.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)