### PR TITLE
chore(release): prepare v0.17.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.22] - 2026-08-06
+
+### Highlights
+
+- **Automatic interrupted-turn recovery** - Agent turns now classify provider failures, recover safely from transient transport, overload, 5xx, and stream-stall failures within bounded retry budgets, preserve completed tool effects, and surface permanent failures as precise resumable errors ([#2937](https://github.com/everruns/everruns/pull/2937)).
+- **Safer interactive tools** - Tool calls can now request host approval and receive cooperative cancellation through `ToolContext`, giving hosts explicit control without abandoning in-flight work ([#2931](https://github.com/everruns/everruns/pull/2931), [#2938](https://github.com/everruns/everruns/pull/2938)).
+- **Model-backed secret screening** - Gallery presets can now add a judge guardrail that catches likely secret leakage beyond deterministic pattern matching ([#2932](https://github.com/everruns/everruns/pull/2932)).
+
+### What's Changed
+
+- fix(runtime): recover interrupted provider turns ([#2937](https://github.com/everruns/everruns/pull/2937)) by [@chaliy](https://github.com/chaliy)
+- feat(tools): cooperative cancellation token on ToolContext ([#2938](https://github.com/everruns/everruns/pull/2938)) by [@chaliy](https://github.com/chaliy)
+- perf(anthropic): make prompt caching incremental ([#2934](https://github.com/everruns/everruns/pull/2934)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): interactive tool-approval gate ([#2931](https://github.com/everruns/everruns/pull/2931)) by [@chaliy](https://github.com/chaliy)
+- feat(tools): host-owned metadata hatch on tool hints and capabilities ([#2936](https://github.com/everruns/everruns/pull/2936)) by [@chaliy](https://github.com/chaliy)
+- feat(guardrails): add model-backed secret-leak judge gallery preset ([#2932](https://github.com/everruns/everruns/pull/2932)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.21] - 2026-08-06
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,11 +2547,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.21"
+version = "0.17.22"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3156,11 +3156,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.21"
+version = "0.17.22"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.21"
+version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.21"
+version = "0.17.22"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -153,13 +153,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.21" }
-everruns-provider = { path = "crates/provider", version = "0.17.21" }
+everruns-core = { path = "crates/core", version = "0.17.22" }
+everruns-provider = { path = "crates/provider", version = "0.17.22" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.21" }
-everruns-ard = { path = "crates/ard", version = "0.17.21" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.22" }
+everruns-ard = { path = "crates/ard", version = "0.17.22" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.21" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.22" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.21",
+  "version": "0.17.22",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -15224,6 +15224,22 @@ export interface components {
        */
       long_running?: boolean | null;
       /**
+       * @description Host-owned annotations that core does not interpret.
+       *
+       *     The typed hints above are the vocabulary core itself reasons about. This
+       *     is the escape hatch for everything a *host* wants to carry alongside a
+       *     tool — risk tiers for an approval UI, presentation hints, an embedder's
+       *     routing keys — without adding a field to core for each one. Core reads
+       *     nothing here and no driver sends it to a provider; it travels with the
+       *     definition so a consumer sees it at the point of decision (e.g. a
+       *     `PreToolUseHook` gating on what the tool declared).
+       *
+       *     The schema belongs to whoever writes it. Never put credentials or other
+       *     sensitive payload here: like the rest of the definition, it is persisted
+       *     and surfaced to clients.
+       */
+      metadata?: unknown;
+      /**
        * @description Entity noun for operation-based narration (e.g. "agent", "harness").
        *     When set, the narration system reads the `operation` argument and
        *     produces verb-based narration like "Created agent: Neon Cartographer"

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.21" }
+everruns-provider = { path = "../provider", version = "0.17.22" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.21" }
+everruns-provider = { path = "../provider", version = "0.17.22" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -134,10 +134,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.21", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.22", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.21", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.22", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.21" }
+everruns-provider = { path = "../provider", version = "0.17.22" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.21" }
+everruns-provider = { path = "../provider", version = "0.17.22" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.21" }
+everruns-provider = { path = "../provider", version = "0.17.22" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed
Prepares the lockstep Everruns v0.17.22 release: updates workspace and UI versions, synchronizes every publish-time path dependency pin, refreshes the Rust lockfile and UI API types, and adds release notes for the six changes since v0.17.21.

## Why
The interrupted-turn recovery fix and five adjacent mainline improvements landed after v0.17.21. Yolop needs the recovery APIs from published public crates; repository policy forbids a git dependency.

## Before / After
Before: the latest published release, v0.17.21, predates PRs #2931, #2932, #2934, #2936, #2937, and #2938.

After: v0.17.22 publishes those changes in lockstep. The recovery change already passed its real-loop failure matrix, deterministic retry baseline, exact-once tool test, persistence test, provider live integrations, and merge-commit main CI.

## Risk
- Low
- Mechanical version and generated-file changes can fail publication if any crate pin or API artifact drifts; `sync-publish-pin-versions.py --check`, lockfile freshness, frozen pnpm installs, API type generation/check, migration ordering, and all ten pre-push checks pass.

## Security
- Threat categories reviewed: TM-LLM and TM-DOS for #2937; this release-only diff adds no executable behavior.
- Findings and resolutions: transient retries remain bounded by attempts and elapsed time; auth, quota, unsupported-model, and invalid-request failures remain permanent; completed tool mutations are not replayed. No release-diff findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)