### PR TITLE
chore(ship): prompt for PR evidence in the ship skill

### DIFF
--- a/.agents/skills/ship/references/pr-and-merge.md
+++ b/.agents/skills/ship/references/pr-and-merge.md
@@ -7,6 +7,9 @@
 - Body: copy the headings from [`.github/pull_request_template.md`](../../../../.github/pull_request_template.md)
   exactly and fill every applicable section — including Before/After proof, risk, the security
   review, and **Follow-ups**. Do not substitute ad-hoc headings, even for small changes.
+- For the Before/After, attach evidence a skeptical reviewer can check, not just a claim — CLI/API
+  output, logs, or metrics, and screenshots for UI changes (`apps/ui`). State explicitly when a
+  change has no observable behavior.
 
 ## CI
 


### PR DESCRIPTION
## What changed

The `/ship` skill's PR-and-merge reference now spells out the evidence to attach to a PR's Before / After — CLI/API output, logs, or metrics, and **screenshots for UI changes** (`apps/ui`) — instead of just naming "Before/After proof". It reinforces the PR-description standard (functional change + impact over a code-location walkthrough) at the point where the skill writes the PR body.

## Why

The ship flow already gathers validation, but the guidance didn't say to attach that proof as something a skeptical reviewer can check. Reviewers benefit from seeing the change work, not reading that it does.

## Before / After

Docs/skill-guidance only — no runtime behavior changes.

- **Before:** `references/pr-and-merge.md` said to fill the body "including Before/After proof" with no detail on what proof.
- **After:** adds a bullet — attach evidence a skeptical reviewer can check (CLI/API output, logs, metrics; screenshots for `apps/ui`), and state explicitly when a change has no observable behavior.

## Risk

- Low
- Skill/docs only; no source, config, or CI logic touched.

## Security

- Threat categories reviewed: No security-relevant code changes (skill Markdown only).
- Findings and resolutions: None.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — N/A (skill/docs only)
- [x] Backward compatibility considered — no code paths affected
- [x] Security review performed against relevant threat model categories — no security-relevant changes
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_