### PR TITLE
feat(embedding): org-initialization hook for embedder-provisioned org resources

### DIFF
--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -98,6 +98,10 @@ pub struct AppState {
     /// Optional wrapper-supplied pre-create policy (EVE-607). Runs before any
     /// org/membership row is written; `None` keeps default OSS behavior.
     pub org_create_policy: Option<Arc<dyn OrgCreatePolicy>>,
+    /// Wrapper-supplied post-create initializers (EVE-811). Run after built-in
+    /// harnesses and the default marketplace are provisioned for a new org; empty
+    /// keeps default OSS behavior.
+    pub org_initializers: Vec<Arc<dyn crate::org_init::OrgInitializer>>,
 }
 
 impl AppState {
@@ -109,6 +113,7 @@ impl AppState {
             resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             org_rate_limiter: OrgRateLimiter::default(),
             org_create_policy: None,
+            org_initializers: Vec::new(),
         }
     }
 
@@ -124,6 +129,7 @@ impl AppState {
             resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             org_rate_limiter: OrgRateLimiter::default(),
             org_create_policy: None,
+            org_initializers: Vec::new(),
         }
     }
 }
@@ -390,6 +396,43 @@ pub async fn create_organization(
     // Seed the default plugin marketplace (everruns/everruns) for the new org.
     // Non-fatal: if it fails (e.g. name conflict), org creation still succeeds.
     crate::org_init::seed_default_plugin_marketplace(&state.db, row.org_id).await;
+
+    // Post-create org initializers (EVE-811). Runs after built-in harnesses and
+    // the default marketplace are provisioned, so embedder-provisioned per-org
+    // resources (a managed provider, a default budget, an external tenant record)
+    // are set up as part of org creation instead of by a follow-up reconciler.
+    // No-op when no initializer is registered (default OSS behavior).
+    //
+    // A required initializer that fails aborts creation: the org row is rolled
+    // back best-effort and a 500 is returned, so a caller never sees a "created"
+    // org missing host-mandated resources. Optional initializers only log.
+    if let Err(e) = crate::org_init::run_org_initializers(
+        &state.org_initializers,
+        &state.db,
+        row.org_id,
+        Some(user.id),
+    )
+    .await
+    {
+        tracing::error!(
+            org_id = row.org_id,
+            initializer = %e.initializer,
+            error = %e.source,
+            "Required org initializer failed; rolling back org creation"
+        );
+        // Best-effort rollback so a failed provisioning does not leave a dangling
+        // org the user owns. Cleanup failure is logged but the request still fails.
+        match state.db.delete_organization(row.org_id).await {
+            Ok(_) => {}
+            Err(cleanup_err) => tracing::error!(
+                org_id = row.org_id,
+                error = %cleanup_err,
+                "Failed to roll back org after initializer failure"
+            ),
+        }
+        return Err(ErrorResponse::new("Failed to initialize organization")
+            .into_response(StatusCode::INTERNAL_SERVER_ERROR));
+    }
 
     // Seed agents are available as examples (GET /v1/agent-examples) and adopted
     // on demand via POST /v1/agent-examples/{slug}/use. No automatic seeding —
@@ -1263,6 +1306,136 @@ mod tests {
 
         let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
         assert_eq!(response.status(), StatusCode::CREATED);
+        let count = db.count_user_created_organizations(user_id).await.unwrap();
+        assert_eq!(count, 1);
+    }
+
+    // ------------------------------------------------------------------------
+    // Post-create org initializers (EVE-811)
+    // ------------------------------------------------------------------------
+
+    use crate::org_init::{OrgInitContext, OrgInitializer};
+
+    /// Build a create-org router with the given post-create initializers.
+    fn create_org_app_with_initializers(
+        initializers: Vec<Arc<dyn OrgInitializer>>,
+    ) -> (Router, Arc<StorageBackend>, Uuid) {
+        let user_id = Uuid::now_v7();
+        let db = Arc::new(StorageBackend::in_memory());
+        let config = AuthConfig {
+            mode: AuthMode::Full,
+            jwt: JwtConfig {
+                secret: "test-secret-for-unit-tests-only".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let auth = AuthState::new(config, Arc::new(MockAuthBackend { user_id }));
+        let mut state = AppState::new(db.clone(), auth);
+        state.org_initializers = initializers;
+        (routes(state), db, user_id)
+    }
+
+    #[tokio::test]
+    async fn org_initializer_runs_after_org_created() {
+        use std::sync::Mutex;
+
+        /// (org_id, created_by) recorded by the initializer.
+        type SeenOrg = Arc<Mutex<Option<(i64, Option<Uuid>)>>>;
+
+        /// Records the org id and creating user it was invoked with.
+        struct RecordingInitializer {
+            seen: SeenOrg,
+        }
+        #[async_trait]
+        impl OrgInitializer for RecordingInitializer {
+            async fn on_org_created(&self, ctx: OrgInitContext<'_>) -> anyhow::Result<()> {
+                // The org exists by the time the initializer runs, and its
+                // built-in harnesses are already provisioned.
+                let harnesses = ctx.db.list_harnesses(ctx.org_id, None, false).await?;
+                assert!(
+                    !harnesses.is_empty(),
+                    "harnesses should be provisioned before initializers run"
+                );
+                *self.seen.lock().unwrap() = Some((ctx.org_id, ctx.created_by));
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(None));
+        let init: Arc<dyn OrgInitializer> = Arc::new(RecordingInitializer { seen: seen.clone() });
+        let (app, db, user_id) = create_org_app_with_initializers(vec![init]);
+
+        let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let recorded = seen.lock().unwrap().expect("initializer must have run");
+        assert_eq!(
+            recorded.1,
+            Some(user_id),
+            "created_by is the requesting user"
+        );
+        // The org persisted and the recorded id matches it.
+        let orgs = db.list_user_organizations(user_id).await.unwrap();
+        assert_eq!(orgs.len(), 1);
+        assert_eq!(recorded.0, orgs[0].org_id);
+    }
+
+    #[tokio::test]
+    async fn required_org_initializer_failure_aborts_and_rolls_back() {
+        struct FailingRequired;
+        #[async_trait]
+        impl OrgInitializer for FailingRequired {
+            async fn on_org_created(&self, _ctx: OrgInitContext<'_>) -> anyhow::Result<()> {
+                anyhow::bail!("provisioning failed")
+            }
+            fn name(&self) -> &str {
+                "failing-required"
+            }
+        }
+
+        let init: Arc<dyn OrgInitializer> = Arc::new(FailingRequired);
+        let (app, db, user_id) = create_org_app_with_initializers(vec![init]);
+
+        let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // The org was rolled back: no user-owned org survives.
+        let count = db.count_user_created_organizations(user_id).await.unwrap();
+        assert_eq!(
+            count, 0,
+            "failed required initializer must roll back the org"
+        );
+        assert!(
+            db.list_user_organizations(user_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn optional_org_initializer_failure_is_non_fatal() {
+        struct FailingOptional;
+        #[async_trait]
+        impl OrgInitializer for FailingOptional {
+            async fn on_org_created(&self, _ctx: OrgInitContext<'_>) -> anyhow::Result<()> {
+                anyhow::bail!("best-effort provisioning failed")
+            }
+            fn required(&self) -> bool {
+                false
+            }
+            fn name(&self) -> &str {
+                "failing-optional"
+            }
+        }
+
+        let init: Arc<dyn OrgInitializer> = Arc::new(FailingOptional);
+        let (app, db, user_id) = create_org_app_with_initializers(vec![init]);
+
+        let response = app.oneshot(create_org_request("Acme Corp")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        // Org still created despite the optional initializer failing.
         let count = db.count_user_created_organizations(user_id).await.unwrap();
         assert_eq!(count, 1);
     }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -18,7 +18,7 @@ use crate::pg_listener_config::resolve_pg_listener_database_url;
 use crate::server::{ServerConfig, build_router_with_prefix};
 use crate::storage::{EncryptionService, StorageBackend};
 use crate::supervised_task::{RestartPolicy, TaskSupervisor};
-use crate::{api, seed, services};
+use crate::{api, org_init, seed, services};
 
 use crate::middleware::RequestIdLayer;
 use crate::middleware::request_id::RequestId;
@@ -387,6 +387,7 @@ pub struct ServerAppBuilder {
     background_tasks: Vec<BackgroundTaskFn>,
     personal_access_token_routes_wrap: Option<PersonalAccessTokenRoutesWrapFn>,
     org_create_policy: Option<Arc<dyn api::organizations::OrgCreatePolicy>>,
+    org_initializers: Vec<Arc<dyn org_init::OrgInitializer>>,
 }
 
 impl ServerAppBuilder {
@@ -403,6 +404,7 @@ impl ServerAppBuilder {
             background_tasks: Vec::new(),
             personal_access_token_routes_wrap: None,
             org_create_policy: None,
+            org_initializers: Vec::new(),
         }
     }
 
@@ -503,6 +505,25 @@ impl ServerAppBuilder {
         policy: Arc<dyn api::organizations::OrgCreatePolicy>,
     ) -> Self {
         self.org_create_policy = Some(policy);
+        self
+    }
+
+    /// Register a post-create organization initializer (EVE-811).
+    ///
+    /// The initializer runs inside the OSS `POST /v1/orgs` handler after the new
+    /// org's built-in harnesses and default marketplace are provisioned, with
+    /// access to the storage backend, the new org id, and the creating user. It
+    /// lets a wrapper provision per-org resources — a managed provider, a default
+    /// budget, an external tenant record — as part of org creation rather than via
+    /// a follow-up reconciler, closing the window where a new org has no working
+    /// provider.
+    ///
+    /// May be called multiple times; initializers run in registration order. A
+    /// required initializer that fails aborts creation (the org is rolled back);
+    /// an optional one only logs. When none are registered, default OSS behavior
+    /// is unchanged. See `specs/embedding.md`.
+    pub fn org_initializer(mut self, initializer: Arc<dyn org_init::OrgInitializer>) -> Self {
+        self.org_initializers.push(initializer);
         self
     }
 
@@ -1322,6 +1343,7 @@ impl ServerAppBuilder {
         );
         organizations_state.org_rate_limiter = org_rate_limiter.clone();
         organizations_state.org_create_policy = self.org_create_policy;
+        organizations_state.org_initializers = self.org_initializers;
         let org_invitations_state = api::org_invitations::AppState::new(
             db.clone(),
             auth_state.clone(),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -141,6 +141,7 @@ pub use app_builder::{ServerAppBuilder, ServerContext};
 // Org creation policy extension point (EVE-607) — wrappers gate org creation
 // before any DB write without forking the OSS handler. See `specs/embedding.md`.
 pub use api::organizations::{OrgCreateContext, OrgCreatePolicy, OrgCreateRejection};
+pub use org_init::{OrgInitContext, OrgInitializer, OrgInitializerError, run_org_initializers};
 
 #[cfg(test)]
 mod tests {

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -19,12 +19,137 @@ use crate::storage::{
     models::{CreateHarnessRow, CreatePluginMarketplaceRow, UpdateOrganizationSettings},
 };
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use everruns_core::{
     BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, HarnessId,
     PluginMarketplaceId,
 };
 use everruns_durable::UpdateField;
+use std::sync::Arc;
 use uuid::Uuid;
+
+// ============================================================================
+// Org-initialization extension point (EVE-811)
+// ============================================================================
+
+/// Context handed to an [`OrgInitializer`] after a new organization and its
+/// built-in resources have been provisioned.
+///
+/// Carries what an embedder needs to provision per-org resources — a managed
+/// provider, a default budget, an external tenant record — for the freshly
+/// created org. The storage backend is exposed so initializers can write rows
+/// directly; credentials or gateway tokens the host holds are supplied by the
+/// initializer itself, not by OSS.
+pub struct OrgInitContext<'a> {
+    /// Storage backend, for writing the initializer's per-org rows.
+    pub db: &'a StorageBackend,
+    /// The organization that was just created.
+    pub org_id: i64,
+    /// The user who created the org, when creation was user-driven. `None` for
+    /// system-created orgs (e.g. the default org seeded at startup).
+    pub created_by: Option<uuid::Uuid>,
+}
+
+/// Post-create org-initialization hook for embedder-provisioned resources.
+///
+/// `PlatformDefinition` decides *what* a platform is made of; `OrgInitializer`
+/// runs *when an organization is created*. OSS invokes every registered
+/// initializer from the shared org-init routine, after built-in harnesses and
+/// the default marketplace are provisioned, so an embedder that must set up
+/// per-org resources does not have to intercept each org-creation path itself.
+///
+/// Registered via
+/// [`ServerAppBuilder::org_initializer`](crate::ServerAppBuilder::org_initializer);
+/// zero or more may be registered. When none are registered, default OSS
+/// behavior is unchanged. See `specs/embedding.md`.
+#[async_trait]
+pub trait OrgInitializer: Send + Sync {
+    /// Provision resources for the newly created org. Returning `Err` is handled
+    /// per [`required`](OrgInitializer::required): a required initializer aborts
+    /// creation, an optional one is logged and skipped.
+    async fn on_org_created(&self, ctx: OrgInitContext<'_>) -> Result<()>;
+
+    /// Whether a failure aborts org creation (default `true`).
+    ///
+    /// Required initializers make provisioning part of org setup: if the
+    /// resource cannot be created, the org is not created either. Optional
+    /// initializers (`false`) are best-effort — a failure is logged and org
+    /// creation proceeds.
+    fn required(&self) -> bool {
+        true
+    }
+
+    /// Stable name used in logs and diagnostics.
+    fn name(&self) -> &str {
+        "org-initializer"
+    }
+}
+
+/// A required [`OrgInitializer`] failed, aborting org creation.
+#[derive(Debug)]
+pub struct OrgInitializerError {
+    /// Name of the initializer that failed.
+    pub initializer: String,
+    /// The underlying error.
+    pub source: anyhow::Error,
+}
+
+impl std::fmt::Display for OrgInitializerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "required org initializer `{}` failed: {}",
+            self.initializer, self.source
+        )
+    }
+}
+
+impl std::error::Error for OrgInitializerError {}
+
+/// Run every registered [`OrgInitializer`] for a freshly created org.
+///
+/// Initializers run in registration order. A required initializer that fails
+/// short-circuits and returns [`OrgInitializerError`]; an optional one that
+/// fails is logged and skipped. Returns `Ok(())` when no initializers are
+/// registered — the default OSS case.
+pub async fn run_org_initializers(
+    initializers: &[Arc<dyn OrgInitializer>],
+    db: &StorageBackend,
+    org_id: i64,
+    created_by: Option<uuid::Uuid>,
+) -> std::result::Result<(), OrgInitializerError> {
+    for initializer in initializers {
+        let ctx = OrgInitContext {
+            db,
+            org_id,
+            created_by,
+        };
+        match initializer.on_org_created(ctx).await {
+            Ok(()) => {
+                tracing::info!(
+                    org_id,
+                    initializer = initializer.name(),
+                    "Org initializer completed"
+                );
+            }
+            Err(e) if initializer.required() => {
+                return Err(OrgInitializerError {
+                    initializer: initializer.name().to_string(),
+                    source: e,
+                });
+            }
+            Err(e) => {
+                tracing::warn!(
+                    org_id,
+                    initializer = initializer.name(),
+                    error = %e,
+                    "Optional org initializer failed (non-fatal)"
+                );
+            }
+        }
+    }
+    Ok(())
+}
 
 // ============================================================================
 // Default plugin marketplace seeding

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -378,6 +378,55 @@ ServerAppBuilder::new(config)
 
 This is the org-creation counterpart to the invitation surface moved into OSS by EVE-602; member management and invitations use the OSS surfaces directly.
 
+## Org Initialization Extension Point
+
+`OrgCreatePolicy` gates creation *before* an org exists; `OrgInitializer` provisions resources *after* one is created. Per-tenant provisioning is the normal shape of an embedded control plane — a managed provider, a default budget, a tenant row in an external system, a per-org key in a secret store. Without a hook, an embedder must reimplement every org-creation path or ship a background reconciler that repairs new orgs after the fact, leaving a window where the org is missing the resource.
+
+`everruns-server` defines (in `org_init`):
+
+- `OrgInitializer` — async trait with `on_org_created(OrgInitContext) -> anyhow::Result<()>`, plus `required(&self) -> bool` (default `true`) and `name(&self) -> &str` for diagnostics
+- `OrgInitContext` — carries the storage backend (`db`), the new `org_id`, and `created_by: Option<Uuid>` (the requesting user, `None` for system-created orgs)
+- `OrgInitializerError` — names the failed required initializer and wraps its source error
+
+`ServerAppBuilder::org_initializer(Arc<dyn OrgInitializer>)` registers an initializer; it may be called multiple times and initializers run in registration order. OSS invokes them inside the create-org handler **after built-in harnesses and the default marketplace are provisioned**, so an initializer sees a fully set-up org. Failure policy is per-initializer:
+
+- **Required** (default): a failure aborts creation — OSS rolls the org back best-effort (`delete_organization`) and returns `500`, so a caller never sees a "created" org missing host-mandated resources.
+- **Optional** (`required() == false`): a failure is logged and creation proceeds.
+
+When no initializer is registered, default OSS create-org behavior is unchanged.
+
+```rust,ignore
+use everruns_server::{OrgInitContext, OrgInitializer};
+use everruns_server::app_builder::ServerAppBuilder;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+struct ProvisionManagedProvider;
+
+#[async_trait]
+impl OrgInitializer for ProvisionManagedProvider {
+    async fn on_org_created(&self, ctx: OrgInitContext<'_>) -> anyhow::Result<()> {
+        // Wrapper-owned: create the host-managed provider row (its credential is
+        // a per-org gateway token) for ctx.org_id via ctx.db.
+        provision_gateway_provider(ctx.db, ctx.org_id).await
+    }
+
+    fn name(&self) -> &str {
+        "managed-provider"
+    }
+}
+
+ServerAppBuilder::new(config)
+    .org_initializer(Arc::new(ProvisionManagedProvider))
+    .run()
+    .await?;
+```
+
+- **OSS owns**: the `OrgInitializer` trait, `OrgInitContext` / `OrgInitializerError` types, the single post-provision call-site in the create-org handler (with best-effort rollback), and the builder hook.
+- **Wrappers own**: the concrete initializer, the resources it provisions, and its required/optional failure policy. Required initializers should stay idempotent so a retried creation converges.
+
+This is the post-create counterpart to `OrgCreatePolicy`; both hook the same OSS create-org handler, keeping OSS the owning boundary for org lifecycle.
+
 ## Zero-Org Onboarding Surface
 
 OSS owns the first screen a user sees after login when they have no organizations. Wrappers compose it instead of forking a full onboarding page plus the main-layout redirect.


### PR DESCRIPTION
## What changed
Adds an `OrgInitializer` extension point that runs **when an organization is created**. An embedder can now register one or more initializers on `ServerAppBuilder` to provision per-org resources — a managed provider, a default budget, an external tenant record — as part of org creation, instead of intercepting each org-creation path itself or running a follow-up reconciler.

OSS invokes registered initializers inside the `POST /v1/orgs` handler, after built-in harnesses and the default marketplace are provisioned, so an initializer sees a fully set-up org. This mirrors the existing `OrgCreatePolicy` (EVE-607) pattern — same handler, same "OSS owns the boundary, wrappers supply behavior" split — as its post-create counterpart.

Failure policy is per-initializer:
- **Required** (default): a failure aborts creation — the org is rolled back best-effort (`delete_organization`) and the handler returns `500`, so a caller never sees a "created" org missing host-mandated resources.
- **Optional** (`required() == false`): a failure is logged and creation proceeds.

New public surface (`everruns-server`): `OrgInitializer` trait, `OrgInitContext { db, org_id, created_by }`, `OrgInitializerError`, `run_org_initializers`, and `ServerAppBuilder::org_initializer(..)`.

## Why
`PlatformDefinition` decides *what* a platform is made of, but there was no hook that runs *when an org is created*. Orgs are created from several places; an embedder that adds its own create-org endpoint covers exactly one of them, and every other path silently produces an org missing the embedder's resources. There is no `org.created` event either, so `EventListener` cannot substitute (listeners run post-persistence and cannot fail the operation). The Everruns SaaS built-in LLM service needs one managed provider per org; its interim workaround is inline provisioning on its own create-org endpoint plus a background reconciler, which leaves a window where a new org has no working provider. This hook closes that window. Resolves **EVE-811**.

## Before / After
- **Before:** an embedder had to reimplement every org-creation path or ship a reconciler; a new org existed transiently without host-provisioned resources.
- **After:** `ServerAppBuilder::org_initializer(Arc::new(MyInitializer))` runs at the OSS create-org path; a required initializer makes provisioning part of org setup (org is not "created" unless provisioning succeeds).

Evidence — new unit tests (all green locally):
- `org_initializer_runs_after_org_created` — initializer runs with the new `org_id` + creating user, and harnesses are already provisioned when it runs.
- `required_org_initializer_failure_aborts_and_rolls_back` — required failure → `500`, org rolled back (no user-owned org survives).
- `optional_org_initializer_failure_is_non_fatal` — optional failure → `201`, org persisted.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the server test suite pass locally.

## Risk
- **Low.** OSS registers no initializers, so default behavior is byte-for-byte unchanged (guarded by the existing no-policy/no-initializer create tests). The only wired call site is the canonical `POST /v1/orgs` handler.
- What can break: an embedder registering a required initializer changes create-org failure semantics (500 + rollback). Documented; rollback is best-effort and logged.

## Security
- Threat categories reviewed: **TM-AUTH / TM-API**. No new unauthenticated surface — the hook runs inside the already-authenticated create-org handler. Initializers run embedder-authored, compiled-in code (same trust tier as the rest of `PlatformDefinition`), not client input. `created_by` is the authenticated user's id; rollback is a parameterized DELETE scoped to the freshly created `org_id`. No new secrets logged (errors via `Display`, matching the existing marketplace-seed pattern).
- Findings and resolutions: none.

## Follow-ups
- Converging the other internal org-creation paths (default-org startup seeding, invitation/test helpers) onto a single shared routine so they inherit the hook by construction was scoped out: those are host-controlled (startup) or test-only, and the SaaS gap is specifically the user-facing create-org endpoint, which this PR covers — same scope boundary as `OrgCreatePolicy`. Can be filed as a separate refactor if desired.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; default behavior unchanged)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FGequLKtTPvQZApWNLKAX)_