### PR TITLE
chore(deps): bump brace-expansion and undici to patched versions (security)

### DIFF
--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -16,8 +16,9 @@
     "overrides": {
       "@anthropic-ai/sdk": "^0.105.0",
       "@hono/node-server": "^2.0.5",
+      "brace-expansion": "5.0.9",
       "tar": "7.5.22",
-      "undici": "^7.28.0",
+      "undici": "^7.29.0",
       "zod": "^3.25.76"
     }
   }

--- a/.deepsec/pnpm-lock.yaml
+++ b/.deepsec/pnpm-lock.yaml
@@ -7,8 +7,9 @@ settings:
 overrides:
   '@anthropic-ai/sdk': ^0.105.0
   '@hono/node-server': ^2.0.5
+  brace-expansion: 5.0.9
   tar: 7.5.22
-  undici: ^7.28.0
+  undici: ^7.29.0
   zod: ^3.25.76
 
 importers:
@@ -505,8 +506,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
@@ -1087,8 +1088,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -1469,7 +1470,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.1.38
-      undici: 7.28.0
+      undici: 7.29.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -1729,7 +1730,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.28.0
+      undici: 7.29.0
       xdg-app-paths: 5.1.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -1786,7 +1787,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2161,7 +2162,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
@@ -2411,7 +2412,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unpipe@1.0.0: {}
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -79,8 +79,8 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
-      "brace-expansion@1": "1.1.17",
-      "brace-expansion@2": "2.1.3",
+      "brace-expansion@1": "1.1.18",
+      "brace-expansion@2": "2.1.4",
       "dompurify": "3.4.12",
       "fast-uri": "3.1.5",
       "js-yaml": "4.3.0",

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  brace-expansion@1: 1.1.17
-  brace-expansion@2: 2.1.3
+  brace-expansion@1: 1.1.18
+  brace-expansion@2: 2.1.4
   dompurify: 3.4.12
   fast-uri: 3.1.5
   js-yaml: 4.3.0
@@ -2307,11 +2307,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.17:
-    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -6592,12 +6592,12 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8350,15 +8350,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.17
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minipass@7.1.3: {}
 


### PR DESCRIPTION
## What changed
Bumps two npm dependencies to their patched versions to clear the repository's open Dependabot security alerts (3 high, 4 moderate — all npm):

- **apps/ui** — `brace-expansion` override `1.1.17 → 1.1.18` and `2.1.3 → 2.1.4` (GHSA-rgw5-rvv9-x895: DoS via unbounded intermediate arrays that bypasses the CVE-2026-14257 mitigation). Two override entries map to the two dependency paths (v1 and v2).
- **.deepsec** — `undici` override `^7.28.0 → ^7.29.0` (resolving 7.28.0 → 7.29.0), covering five advisories: cross-user information disclosure + parse-time crash via degenerate private cache directives (high), plus response desynchronization via the retry interceptor, CRLF injection via blob-like body `type`, cross-user disclosure via whitespace around `=` in Cache-Control, and cookie attribute injection (moderate). Also adds a `brace-expansion` override `5.0.8 → 5.0.9`.

## Why
`cargo audit` reports no Rust vulnerabilities (only two allowlisted "unmaintained" advisories) and `pnpm audit` on `apps/docs` is clean, so every open Dependabot alert maps to these two npm packages. The apps/ui overrides were already pinning `brace-expansion` — but to versions that predate the new advisory — so this bumps the pins to the first patched releases.

## Before / After
- **Before:** `pnpm audit` — apps/ui: 2 high (brace-expansion); .deepsec: 1 high + 4 moderate (undici) + 1 high (brace-expansion).
- **After:** `pnpm audit` reports **"No known vulnerabilities found"** in both workspaces. `pnpm install --frozen-lockfile` passes (lockfiles regenerated to match).

## Risk
- **Low.** All bumps are patch/minor within the same major line (transitive build/tooling deps), pinned via existing `pnpm.overrides`. No application source changes.
- What can break: nothing expected; the affected packages are indirect build/runtime tooling deps.

## Security
- Threat categories reviewed: **TM-DEPS**. This PR *is* the dependency-security remediation. Bumps are to the exact first-patched versions per each advisory. No new code paths.
- Findings and resolutions: resolves GHSA-rgw5-rvv9-x895 (brace-expansion) and the undici 7.29.0 advisory set.

## Follow-ups
No follow-ups. If Dependabot later surfaces docker/cargo alerts, they are out of scope for this npm-focused PR.

## Checklist
- [x] Tests added or updated (n/a — dependency bump; audit is the evidence)
- [x] Backward compatibility considered (same major lines)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FGequLKtTPvQZApWNLKAX)_