### PR TITLE
chore(release): prepare v0.17.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.23] - 2026-08-06
+
+### Highlights
+
+- **New model providers** - Meta Model API and Muse Spark are now available as first-class providers ([#2941](https://github.com/everruns/everruns/pull/2941)).
+- **Host-managed providers** - Org admins now see host-provisioned provider rows as read-only, making platform-managed providers visible without being editable ([#2944](https://github.com/everruns/everruns/pull/2944)).
+
+### What's Changed
+
+- feat(provider): add Meta Model API and Muse Spark ([#2941](https://github.com/everruns/everruns/pull/2941)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): host-managed provider rows (read-only to org admins) ([#2944](https://github.com/everruns/everruns/pull/2944)) by [@chaliy](https://github.com/chaliy)
+- feat(embedding): org-initialization hook for embedder-provisioned org resources ([#2943](https://github.com/everruns/everruns/pull/2943)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump brace-expansion and undici to patched versions (security) ([#2945](https://github.com/everruns/everruns/pull/2945)) by [@chaliy](https://github.com/chaliy)
+- chore(ship): prompt for PR evidence in the ship skill ([#2942](https://github.com/everruns/everruns/pull/2942)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.22] - 2026-08-06
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2547,11 +2547,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.22"
+version = "0.17.23"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3171,11 +3171,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.22"
+version = "0.17.23"
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.22"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5000,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
+checksum = "7e17384278234b10419a63c93fc85695ac9fc2da0833e3c59167f9986499590c"
 dependencies = [
  "ahash",
  "bytecount",
@@ -5029,18 +5029,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
+checksum = "ac634e339e73bf9629f6fb207f7b064d872253ae3b3f5c6e0ce8fd762b16e40f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
+checksum = "92b8e258eb4515a3fc912a9c46e3987040dc07280592280097ea2085527870b8"
 dependencies = [
  "ahash",
  "bytecount",
@@ -7489,9 +7489,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
+checksum = "42902112f88a27e9afd5683e2ba31956fed2a5d43395f166dd26775ae9c0dedb"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -10814,18 +10814,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.22"
+version = "0.17.23"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -154,13 +154,13 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.22" }
-everruns-provider = { path = "crates/provider", version = "0.17.22" }
+everruns-core = { path = "crates/core", version = "0.17.23" }
+everruns-provider = { path = "crates/provider", version = "0.17.23" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.22" }
-everruns-ard = { path = "crates/ard", version = "0.17.22" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.23" }
+everruns-ard = { path = "crates/ard", version = "0.17.23" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.22" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.23" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.22",
+  "version": "0.17.23",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.22" }
+everruns-provider = { path = "../provider", version = "0.17.23" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.22" }
+everruns-provider = { path = "../provider", version = "0.17.23" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -134,10 +134,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.22", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.23", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.22", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.23", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.22" }
+everruns-provider = { path = "../provider", version = "0.17.23" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.22" }
+everruns-provider = { path = "../provider", version = "0.17.23" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.22" }
+everruns-provider = { path = "../provider", version = "0.17.23" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.


### PR DESCRIPTION
## What changed
Patch release **v0.17.23**. Bumps the workspace version (`0.17.22` → `0.17.23`), UI package version, path-dependency publish pins, and refreshes lockfiles. Adds the `[0.17.23]` CHANGELOG entry.

Rolled-up user-facing changes since v0.17.22:
- New model providers: **Meta Model API** and **Muse Spark** (#2941)
- **Host-managed provider rows** shown read-only to org admins (#2944)
- Embedder org-initialization hook (#2943)
- Security dependency bumps: brace-expansion, undici (#2945)
- Ship-skill PR-evidence prompt (#2942)

## Why
Cut the next patch release so the changes above ship to consumers (crates, images, UI, docs) and can be adopted downstream in SaaS.

## Before / After
No runtime behavior change in this PR — version strings, changelog, and lockfiles only. Merging with the `chore(release): prepare v` commit message triggers auto-tagging (`v0.17.23`), GitHub Release, Docker images, and crate publishes.

- Before: workspace at `0.17.22`, latest tag `v0.17.22`.
- After (on merge): `0.17.23` tagged and published.

## Risk
- Low
- Only versioning/changelog/lockfile changes. Lockfile refresh pulled two in-range transitive patch bumps (`clap` 4.6.5→4.6.6, `jsonschema` 0.49.5→0.49.6); no packages added or removed.

## Security
- Threat categories reviewed: No security-relevant code changes (release metadata only). Includes previously-merged security dep bumps (#2945).
- Findings and resolutions: None.

## Follow-ups
No follow-ups. Downstream SaaS adoption tracked separately.

## Checklist
- [ ] Tests added or updated (n/a — release metadata)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016mruHHrpQXUzyduiFsbNKQ)_