### PR TITLE
feat(mcp): unified OAuth client and MCP OAuth provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "sha2 0.11.0",
  "similar 3.1.2",
@@ -3097,11 +3098,13 @@ version = "0.17.22"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "everruns-core",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "url",
  "wiremock",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -81,6 +81,8 @@ similar = "3"
 
 # URL parsing
 url = "2"
+# Form encoding for OAuth token requests (crates/core/src/oauth.rs).
+serde_urlencoded = "0.7"
 
 # Web fetching (optional; behind the `web-fetch` feature). fetchkit + the
 # ed25519 bot-auth key derivation pull a sizable HTTP/crypto subtree.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -105,6 +105,7 @@ pub use everruns_provider::model_profiles;
 pub mod model_router;
 pub mod mount_fs;
 pub mod network_access;
+pub mod oauth;
 pub mod observer;
 pub mod organization;
 pub mod payment;

--- a/crates/core/src/oauth.rs
+++ b/crates/core/src/oauth.rs
@@ -1,0 +1,990 @@
+//! OAuth 2.1 authorization-code client, shared by every everruns host.
+//!
+//! Everruns already speaks OAuth in three unrelated places — the provider
+//! connect flow, user connections, and (until now, only in downstream hosts)
+//! MCP server login. Each grew its own PKCE, its own token exchange, and its
+//! own refresh. This module is the one implementation they can share: the
+//! protocol steps, and nothing else.
+//!
+//! What lives here is deliberately the *stateless* half:
+//!
+//! - discovery — protected-resource metadata (RFC 9728) → authorization-server
+//!   metadata (RFC 8414 / OpenID discovery)
+//! - dynamic client registration (RFC 7591)
+//! - PKCE (RFC 7636) and the authorize URL
+//! - code exchange, refresh, and the resulting [`TokenSet`]
+//! - issuer validation on the callback (RFC 9207)
+//!
+//! What does *not* live here is everything hosts disagree about: opening a
+//! browser, listening on a loopback port or serving a redirect route, and
+//! where tokens are persisted. A host owns those and calls in for the rest.
+//!
+//! Every request goes through [`EgressService`], so discovery and token calls
+//! get the same egress policy and DNS-pinned SSRF protection as the traffic
+//! they authenticate. This matters more than it looks: for MCP the
+//! authorization-server URL is *discovered from the remote server*, which makes
+//! it attacker-influenced input pointed at an internal-network probe unless it
+//! goes through the boundary.
+
+use std::collections::BTreeMap;
+
+use base64::Engine as _;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use rand::RngExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::egress::{EgressRequest, EgressRequestKind, EgressService};
+
+/// Refresh this long before a token actually expires, so a request issued at
+/// the edge of validity does not race the clock.
+pub const DEFAULT_REFRESH_SKEW_SECONDS: i64 = 60;
+
+/// Errors from the OAuth client.
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthError {
+    /// The endpoint URL is not usable (not absolute, or plaintext HTTP to a
+    /// non-loopback host).
+    #[error("insecure or malformed {what} URL: {url}")]
+    InsecureUrl {
+        /// Which endpoint was rejected.
+        what: &'static str,
+        /// The offending URL.
+        url: String,
+    },
+    /// The authorization server answered, but not with success.
+    #[error("{what} failed with HTTP {status}: {body}")]
+    Http {
+        /// Which step failed.
+        what: &'static str,
+        /// HTTP status returned.
+        status: u16,
+        /// Response body, truncated for logging.
+        body: String,
+    },
+    /// The response was not the JSON document this step expects.
+    #[error("{what} returned an unusable response: {message}")]
+    Malformed {
+        /// Which step failed.
+        what: &'static str,
+        /// What was wrong.
+        message: String,
+    },
+    /// The `iss` returned on the callback did not match the issuer we started
+    /// the flow with (RFC 9207 mix-up defense).
+    #[error("authorization response issuer mismatch: expected {expected}, got {actual}")]
+    IssuerMismatch {
+        /// Issuer the flow was started against.
+        expected: String,
+        /// Issuer the callback claimed.
+        actual: String,
+    },
+    /// No refresh token is available, so the grant cannot be renewed.
+    #[error("token set has no refresh token")]
+    NotRefreshable,
+    /// The egress boundary refused or failed the request.
+    #[error("egress failure during {what}: {message}")]
+    Egress {
+        /// Which step failed.
+        what: &'static str,
+        /// Underlying error text.
+        message: String,
+    },
+}
+
+/// Result alias for this module.
+pub type Result<T> = std::result::Result<T, OAuthError>;
+
+/// A PKCE verifier/challenge pair (RFC 7636, S256).
+#[derive(Debug, Clone)]
+pub struct PkcePair {
+    /// High-entropy secret kept by the client until code exchange.
+    pub verifier: String,
+    /// S256 hash of the verifier, sent on the authorize request.
+    pub challenge: String,
+}
+
+impl PkcePair {
+    /// Generate a fresh pair.
+    pub fn generate() -> Self {
+        let verifier = random_url_safe(32);
+        let challenge = base64_url(Sha256::digest(verifier.as_bytes()).as_slice());
+        Self {
+            verifier,
+            challenge,
+        }
+    }
+}
+
+/// Generate an opaque, URL-safe random string (CSRF `state`, nonces).
+pub fn random_state() -> String {
+    random_url_safe(24)
+}
+
+fn random_url_safe(bytes: usize) -> String {
+    let mut rng = rand::rng();
+    let buf: Vec<u8> = (0..bytes).map(|_| rng.random::<u8>()).collect();
+    base64_url(&buf)
+}
+
+fn base64_url(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Protected-resource metadata (RFC 9728): what a resource server says about
+/// the authorization servers that can issue tokens for it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProtectedResourceMetadata {
+    /// Canonical resource identifier, when advertised.
+    #[serde(default)]
+    pub resource: Option<String>,
+    /// Issuers that can mint tokens for this resource.
+    #[serde(default)]
+    pub authorization_servers: Vec<String>,
+}
+
+/// Authorization-server metadata (RFC 8414 / OpenID discovery).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorizationServerMetadata {
+    /// Issuer identifier; echoed back on the callback as `iss`.
+    pub issuer: String,
+    /// Where the user-agent is sent to authorize.
+    pub authorization_endpoint: String,
+    /// Where codes and refresh tokens are exchanged.
+    pub token_endpoint: String,
+    /// Dynamic client registration endpoint, when the server offers one.
+    #[serde(default)]
+    pub registration_endpoint: Option<String>,
+    /// Scopes the server advertises.
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+    /// PKCE methods the server advertises.
+    #[serde(default)]
+    pub code_challenge_methods_supported: Vec<String>,
+}
+
+/// A client registered dynamically (RFC 7591), or configured by hand.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisteredClient {
+    /// Issued client identifier.
+    pub client_id: String,
+    /// Issued secret, for confidential clients only.
+    #[serde(default)]
+    pub client_secret: Option<String>,
+}
+
+/// Request body for dynamic client registration.
+#[derive(Debug, Clone)]
+pub struct ClientRegistration {
+    /// Human-readable client name shown on the consent screen.
+    pub client_name: String,
+    /// Redirect URIs this client will use.
+    pub redirect_uris: Vec<String>,
+    /// Scopes to request, space-delimited.
+    pub scope: Option<String>,
+}
+
+/// Tokens held for a grant, plus the bookkeeping needed to renew them without
+/// re-running discovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenSet {
+    /// The bearer (or other type) access token.
+    pub access_token: String,
+    /// Refresh token, when the server issued one.
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    /// Token type; `Bearer` unless the server says otherwise.
+    #[serde(default = "default_token_type")]
+    pub token_type: String,
+    /// Absolute expiry, derived from `expires_in` at issue time.
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Granted scope, when reported.
+    #[serde(default)]
+    pub scope: Option<String>,
+    /// Token endpoint that issued this set, so a refresh is self-contained.
+    #[serde(default)]
+    pub token_endpoint: Option<String>,
+    /// Client id used to obtain it.
+    #[serde(default)]
+    pub client_id: Option<String>,
+    /// Client secret, for confidential clients.
+    #[serde(default)]
+    pub client_secret: Option<String>,
+}
+
+fn default_token_type() -> String {
+    "Bearer".to_string()
+}
+
+impl TokenSet {
+    /// Whether the token is expired at `now`. An expiry exactly at `now`
+    /// counts as expired.
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at.is_some_and(|expiry| expiry <= now)
+    }
+
+    /// Whether the token should be renewed before use, allowing `skew_seconds`
+    /// of headroom. A token with no expiry never needs refreshing.
+    pub fn needs_refresh(&self, now: DateTime<Utc>, skew_seconds: i64) -> bool {
+        self.expires_at
+            .is_some_and(|expiry| expiry <= now + ChronoDuration::seconds(skew_seconds))
+    }
+
+    /// The `Authorization` header value this token set contributes.
+    pub fn authorization_value(&self) -> String {
+        format!("{} {}", self.token_type, self.access_token)
+    }
+}
+
+/// Parameters for building the authorize URL.
+#[derive(Debug, Clone)]
+pub struct AuthorizeParams<'a> {
+    /// Client identifier.
+    pub client_id: &'a str,
+    /// Redirect URI registered for this client.
+    pub redirect_uri: &'a str,
+    /// PKCE challenge for this attempt.
+    pub code_challenge: &'a str,
+    /// CSRF state to be echoed back.
+    pub state: &'a str,
+    /// Requested scope, space-delimited.
+    pub scope: Option<&'a str>,
+    /// Resource indicator (RFC 8707) — which API the token is for. MCP relies
+    /// on this to keep a token from being replayed against another resource.
+    pub resource: Option<&'a str>,
+}
+
+/// Build the authorization URL the user-agent should visit.
+pub fn authorize_url(
+    metadata: &AuthorizationServerMetadata,
+    params: &AuthorizeParams<'_>,
+) -> Result<String> {
+    let mut url = require_secure(&metadata.authorization_endpoint, "authorization endpoint")?;
+    {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("response_type", "code");
+        query.append_pair("client_id", params.client_id);
+        query.append_pair("redirect_uri", params.redirect_uri);
+        query.append_pair("code_challenge", params.code_challenge);
+        query.append_pair("code_challenge_method", "S256");
+        query.append_pair("state", params.state);
+        if let Some(scope) = params.scope {
+            query.append_pair("scope", scope);
+        }
+        if let Some(resource) = params.resource {
+            query.append_pair("resource", resource);
+        }
+    }
+    Ok(url.to_string())
+}
+
+/// Validate the `iss` returned on the callback against the issuer the flow
+/// started with (RFC 9207). A server that returns no `iss` is accepted, since
+/// the parameter is not universally implemented; a *mismatched* one is not.
+pub fn validate_callback_issuer(expected: &str, returned: Option<&str>) -> Result<()> {
+    match returned {
+        None => Ok(()),
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(OAuthError::IssuerMismatch {
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        }),
+    }
+}
+
+/// Reject endpoints that are not absolute HTTPS. Plaintext loopback is allowed
+/// because the redirect leg of a native-app flow (RFC 8252) is local.
+fn require_secure(raw: &str, what: &'static str) -> Result<Url> {
+    let url = Url::parse(raw).map_err(|_| OAuthError::InsecureUrl {
+        what,
+        url: raw.to_string(),
+    })?;
+    let loopback = matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"));
+    if url.scheme() == "https" || (url.scheme() == "http" && loopback) {
+        Ok(url)
+    } else {
+        Err(OAuthError::InsecureUrl {
+            what,
+            url: raw.to_string(),
+        })
+    }
+}
+
+/// The OAuth client. Holds no state: every call is a request/response.
+pub struct OAuthClient<'a> {
+    egress: &'a dyn EgressService,
+    kind: EgressRequestKind,
+    timeout_ms: u64,
+}
+
+/// Default per-request timeout for discovery and token calls.
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
+impl<'a> OAuthClient<'a> {
+    /// Build a client that sends through `egress`, labeling requests `kind`.
+    pub fn new(egress: &'a dyn EgressService, kind: EgressRequestKind) -> Self {
+        Self {
+            egress,
+            kind,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+        }
+    }
+
+    /// Override the per-request timeout.
+    pub fn timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.timeout_ms = timeout_ms;
+        self
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        url: &str,
+        what: &'static str,
+    ) -> Result<Option<T>> {
+        let request = EgressRequest::new("GET", url, self.kind.clone())
+            .header("accept", "application/json")
+            .timeout_ms(self.timeout_ms)
+            .require_dns_pinning();
+        let response = self
+            .egress
+            .send(request)
+            .await
+            .map_err(|error| OAuthError::Egress {
+                what,
+                message: error.to_string(),
+            })?;
+        if response.status == 404 {
+            return Ok(None);
+        }
+        if !(200..300).contains(&response.status) {
+            return Err(OAuthError::Http {
+                what,
+                status: response.status,
+                body: truncate(&String::from_utf8_lossy(&response.body)),
+            });
+        }
+        serde_json::from_slice(&response.body)
+            .map(Some)
+            .map_err(|error| OAuthError::Malformed {
+                what,
+                message: error.to_string(),
+            })
+    }
+
+    async fn post_form(
+        &self,
+        url: &str,
+        form: &BTreeMap<&str, String>,
+        what: &'static str,
+    ) -> Result<TokenResponse> {
+        require_secure(url, "token endpoint")?;
+        let body = serde_urlencoded::to_string(form).map_err(|error| OAuthError::Malformed {
+            what,
+            message: error.to_string(),
+        })?;
+        let request = EgressRequest::new("POST", url, self.kind.clone())
+            .header("content-type", "application/x-www-form-urlencoded")
+            .header("accept", "application/json")
+            .body(body.into_bytes())
+            .timeout_ms(self.timeout_ms)
+            .require_dns_pinning();
+        let response = self
+            .egress
+            .send(request)
+            .await
+            .map_err(|error| OAuthError::Egress {
+                what,
+                message: error.to_string(),
+            })?;
+        if !(200..300).contains(&response.status) {
+            return Err(OAuthError::Http {
+                what,
+                status: response.status,
+                body: truncate(&String::from_utf8_lossy(&response.body)),
+            });
+        }
+        serde_json::from_slice(&response.body).map_err(|error| OAuthError::Malformed {
+            what,
+            message: error.to_string(),
+        })
+    }
+
+    /// Fetch protected-resource metadata for `resource_url` (RFC 9728).
+    ///
+    /// `Ok(None)` means the resource does not publish the document — a normal
+    /// case, and the caller should fall back to treating the resource origin
+    /// as the issuer.
+    pub async fn discover_protected_resource(
+        &self,
+        resource_url: &str,
+    ) -> Result<Option<ProtectedResourceMetadata>> {
+        let url = require_secure(resource_url, "resource")?;
+        let document = well_known(&url, "oauth-protected-resource");
+        self.get_json(&document, "protected-resource discovery")
+            .await
+    }
+
+    /// Fetch authorization-server metadata for `issuer`, trying the RFC 8414
+    /// location first and the OpenID location second.
+    pub async fn discover_authorization_server(
+        &self,
+        issuer: &str,
+    ) -> Result<AuthorizationServerMetadata> {
+        let url = require_secure(issuer, "issuer")?;
+        for suffix in ["oauth-authorization-server", "openid-configuration"] {
+            let document = well_known(&url, suffix);
+            if let Some(metadata) = self
+                .get_json::<AuthorizationServerMetadata>(
+                    &document,
+                    "authorization-server discovery",
+                )
+                .await?
+            {
+                require_secure(&metadata.authorization_endpoint, "authorization endpoint")?;
+                require_secure(&metadata.token_endpoint, "token endpoint")?;
+                return Ok(metadata);
+            }
+        }
+        Err(OAuthError::Malformed {
+            what: "authorization-server discovery",
+            message: format!("no metadata document published by {issuer}"),
+        })
+    }
+
+    /// Register a public client dynamically (RFC 7591).
+    pub async fn register_client(
+        &self,
+        registration_endpoint: &str,
+        registration: &ClientRegistration,
+    ) -> Result<RegisteredClient> {
+        require_secure(registration_endpoint, "registration endpoint")?;
+        let mut body = serde_json::json!({
+            "client_name": registration.client_name,
+            "redirect_uris": registration.redirect_uris,
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        });
+        if let Some(scope) = &registration.scope {
+            body["scope"] = serde_json::Value::String(scope.clone());
+        }
+        let request = EgressRequest::new("POST", registration_endpoint, self.kind.clone())
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .body(serde_json::to_vec(&body).unwrap_or_default())
+            .timeout_ms(self.timeout_ms)
+            .require_dns_pinning();
+        let response = self
+            .egress
+            .send(request)
+            .await
+            .map_err(|error| OAuthError::Egress {
+                what: "client registration",
+                message: error.to_string(),
+            })?;
+        if !(200..300).contains(&response.status) {
+            return Err(OAuthError::Http {
+                what: "client registration",
+                status: response.status,
+                body: truncate(&String::from_utf8_lossy(&response.body)),
+            });
+        }
+        serde_json::from_slice(&response.body).map_err(|error| OAuthError::Malformed {
+            what: "client registration",
+            message: error.to_string(),
+        })
+    }
+
+    /// Exchange an authorization code for tokens.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn exchange_code(
+        &self,
+        token_endpoint: &str,
+        client: &RegisteredClient,
+        code: &str,
+        code_verifier: &str,
+        redirect_uri: &str,
+        resource: Option<&str>,
+    ) -> Result<TokenSet> {
+        let mut form = BTreeMap::new();
+        form.insert("grant_type", "authorization_code".to_string());
+        form.insert("code", code.to_string());
+        form.insert("code_verifier", code_verifier.to_string());
+        form.insert("redirect_uri", redirect_uri.to_string());
+        form.insert("client_id", client.client_id.clone());
+        if let Some(secret) = &client.client_secret {
+            form.insert("client_secret", secret.clone());
+        }
+        if let Some(resource) = resource {
+            form.insert("resource", resource.to_string());
+        }
+        let response = self
+            .post_form(token_endpoint, &form, "code exchange")
+            .await?;
+        Ok(response.into_token_set(token_endpoint, client, None))
+    }
+
+    /// Renew an access token from its refresh token.
+    ///
+    /// The renewed set carries the previous refresh token forward when the
+    /// server does not rotate it, so a non-rotating server does not silently
+    /// lose the ability to refresh again.
+    pub async fn refresh(&self, tokens: &TokenSet) -> Result<TokenSet> {
+        let refresh_token = tokens
+            .refresh_token
+            .as_deref()
+            .ok_or(OAuthError::NotRefreshable)?;
+        let token_endpoint = tokens
+            .token_endpoint
+            .as_deref()
+            .ok_or(OAuthError::Malformed {
+                what: "token refresh",
+                message: "token set has no token endpoint".to_string(),
+            })?;
+        let client = RegisteredClient {
+            client_id: tokens.client_id.clone().unwrap_or_default(),
+            client_secret: tokens.client_secret.clone(),
+        };
+
+        let mut form = BTreeMap::new();
+        form.insert("grant_type", "refresh_token".to_string());
+        form.insert("refresh_token", refresh_token.to_string());
+        if !client.client_id.is_empty() {
+            form.insert("client_id", client.client_id.clone());
+        }
+        if let Some(secret) = &client.client_secret {
+            form.insert("client_secret", secret.clone());
+        }
+        let response = self
+            .post_form(token_endpoint, &form, "token refresh")
+            .await?;
+        Ok(response.into_token_set(token_endpoint, &client, tokens.refresh_token.clone()))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    token_type: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+impl TokenResponse {
+    fn into_token_set(
+        self,
+        token_endpoint: &str,
+        client: &RegisteredClient,
+        carried_refresh_token: Option<String>,
+    ) -> TokenSet {
+        TokenSet {
+            expires_at: self
+                .expires_in
+                .map(|seconds| Utc::now() + ChronoDuration::seconds(seconds)),
+            refresh_token: self.refresh_token.or(carried_refresh_token),
+            token_type: self.token_type.unwrap_or_else(default_token_type),
+            scope: self.scope,
+            access_token: self.access_token,
+            token_endpoint: Some(token_endpoint.to_string()),
+            client_id: (!client.client_id.is_empty()).then(|| client.client_id.clone()),
+            client_secret: client.client_secret.clone(),
+        }
+    }
+}
+
+/// Well-known document URL for `url`'s origin.
+///
+/// RFC 8414 inserts the suffix *before* any issuer path
+/// (`https://host/.well-known/<suffix>/tenant`), which is what lets an issuer
+/// with a path component publish metadata at all.
+fn well_known(url: &Url, suffix: &str) -> String {
+    let origin = format!(
+        "{}://{}{}",
+        url.scheme(),
+        url.host_str().unwrap_or_default(),
+        url.port().map(|p| format!(":{p}")).unwrap_or_default()
+    );
+    let path = url.path().trim_end_matches('/');
+    if path.is_empty() {
+        format!("{origin}/.well-known/{suffix}")
+    } else {
+        format!("{origin}/.well-known/{suffix}{path}")
+    }
+}
+
+fn truncate(body: &str) -> String {
+    const LIMIT: usize = 512;
+    if body.len() <= LIMIT {
+        return body.to_string();
+    }
+    let mut end = LIMIT;
+    while !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &body[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::egress::{EgressError, EgressResponse, EgressResult};
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+
+    /// Egress double: answers by URL, records what was sent. Tests exercise
+    /// the whole client without a socket, which is the payoff of routing OAuth
+    /// through the egress seam instead of a private HTTP client.
+    #[derive(Default)]
+    struct FakeEgress {
+        responses: Mutex<Vec<(String, u16, String)>>,
+        sent: Arc<Mutex<Vec<EgressRequest>>>,
+    }
+
+    impl FakeEgress {
+        fn with(routes: Vec<(&str, u16, &str)>) -> Self {
+            Self {
+                responses: Mutex::new(
+                    routes
+                        .into_iter()
+                        .map(|(url, status, body)| (url.to_string(), status, body.to_string()))
+                        .collect(),
+                ),
+                sent: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl EgressService for FakeEgress {
+        async fn send(&self, request: EgressRequest) -> EgressResult<EgressResponse> {
+            self.sent.lock().unwrap().push(request.clone());
+            let responses = self.responses.lock().unwrap();
+            let matched = responses
+                .iter()
+                .find(|(url, _, _)| *url == request.url)
+                .map(|(_, status, body)| (*status, body.clone()));
+            match matched {
+                Some((status, body)) => Ok(EgressResponse {
+                    status,
+                    headers: BTreeMap::new(),
+                    body: body.into_bytes(),
+                }),
+                None => Ok(EgressResponse {
+                    status: 404,
+                    headers: BTreeMap::new(),
+                    body: Vec::new(),
+                }),
+            }
+        }
+
+        async fn send_stream(
+            &self,
+            _request: EgressRequest,
+        ) -> EgressResult<crate::egress::EgressStreamResponse> {
+            Err(EgressError::Transport(
+                "streaming not supported".to_string(),
+            ))
+        }
+    }
+
+    fn metadata_json() -> &'static str {
+        r#"{
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "registration_endpoint": "https://auth.example.com/register",
+            "code_challenge_methods_supported": ["S256"]
+        }"#
+    }
+
+    #[test]
+    fn pkce_challenge_is_the_s256_of_the_verifier() {
+        let pair = PkcePair::generate();
+        let expected = base64_url(Sha256::digest(pair.verifier.as_bytes()).as_slice());
+        assert_eq!(pair.challenge, expected);
+        assert_ne!(pair.verifier, pair.challenge);
+        // Two generations must not collide.
+        assert_ne!(PkcePair::generate().verifier, pair.verifier);
+    }
+
+    #[test]
+    fn plaintext_endpoints_are_rejected_except_on_loopback() {
+        assert!(require_secure("https://auth.example.com/token", "token endpoint").is_ok());
+        assert!(require_secure("http://127.0.0.1:1455/callback", "redirect").is_ok());
+        assert!(require_secure("http://auth.example.com/token", "token endpoint").is_err());
+        assert!(require_secure("not-a-url", "token endpoint").is_err());
+    }
+
+    #[test]
+    fn authorize_url_carries_pkce_state_and_resource() {
+        let metadata: AuthorizationServerMetadata = serde_json::from_str(metadata_json()).unwrap();
+        let url = authorize_url(
+            &metadata,
+            &AuthorizeParams {
+                client_id: "client-1",
+                redirect_uri: "http://127.0.0.1:1455/callback",
+                code_challenge: "challenge",
+                state: "state-1",
+                scope: Some("mcp:read"),
+                resource: Some("https://mcp.example.com/"),
+            },
+        )
+        .unwrap();
+
+        assert!(url.starts_with("https://auth.example.com/authorize?"));
+        for expected in [
+            "response_type=code",
+            "client_id=client-1",
+            "code_challenge=challenge",
+            "code_challenge_method=S256",
+            "state=state-1",
+            "scope=mcp%3Aread",
+            "resource=https%3A%2F%2Fmcp.example.com%2F",
+        ] {
+            assert!(url.contains(expected), "missing {expected} in {url}");
+        }
+    }
+
+    #[test]
+    fn callback_issuer_must_match_when_present() {
+        assert!(validate_callback_issuer("https://auth.example.com", None).is_ok());
+        assert!(
+            validate_callback_issuer("https://auth.example.com", Some("https://auth.example.com"))
+                .is_ok()
+        );
+        assert!(matches!(
+            validate_callback_issuer("https://auth.example.com", Some("https://evil.example.com")),
+            Err(OAuthError::IssuerMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn well_known_inserts_the_suffix_before_an_issuer_path() {
+        let plain = Url::parse("https://auth.example.com").unwrap();
+        assert_eq!(
+            well_known(&plain, "oauth-authorization-server"),
+            "https://auth.example.com/.well-known/oauth-authorization-server"
+        );
+        let tenanted = Url::parse("https://auth.example.com/tenant-a").unwrap();
+        assert_eq!(
+            well_known(&tenanted, "oauth-authorization-server"),
+            "https://auth.example.com/.well-known/oauth-authorization-server/tenant-a"
+        );
+    }
+
+    #[tokio::test]
+    async fn discovery_falls_back_to_the_openid_document() {
+        let egress = FakeEgress::with(vec![(
+            "https://auth.example.com/.well-known/openid-configuration",
+            200,
+            metadata_json(),
+        )]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+
+        let metadata = client
+            .discover_authorization_server("https://auth.example.com")
+            .await
+            .expect("discovery should fall back");
+
+        assert_eq!(metadata.token_endpoint, "https://auth.example.com/token");
+        // The RFC 8414 location is tried first, then OpenID.
+        let sent = egress.sent.lock().unwrap();
+        assert_eq!(sent.len(), 2);
+        assert!(sent[0].url.contains("oauth-authorization-server"));
+        assert!(sent[1].url.contains("openid-configuration"));
+    }
+
+    #[tokio::test]
+    async fn discovery_requires_secure_endpoints_in_the_metadata() {
+        // A compromised or sloppy server advertising a plaintext token endpoint
+        // must not be used, even though the metadata document itself was HTTPS.
+        let egress = FakeEgress::with(vec![(
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+            200,
+            r#"{
+                "issuer": "https://auth.example.com",
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "http://auth.example.com/token"
+            }"#,
+        )]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+
+        assert!(matches!(
+            client
+                .discover_authorization_server("https://auth.example.com")
+                .await,
+            Err(OAuthError::InsecureUrl { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_protected_resource_document_is_not_an_error() {
+        let egress = FakeEgress::with(vec![]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+
+        let found = client
+            .discover_protected_resource("https://mcp.example.com/sse")
+            .await
+            .expect("a 404 means 'not published', not a failure");
+
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn code_exchange_posts_pkce_and_returns_a_dated_token_set() {
+        let egress = FakeEgress::with(vec![(
+            "https://auth.example.com/token",
+            200,
+            r#"{"access_token":"at-1","refresh_token":"rt-1","token_type":"Bearer","expires_in":3600}"#,
+        )]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+
+        let tokens = client
+            .exchange_code(
+                "https://auth.example.com/token",
+                &RegisteredClient {
+                    client_id: "client-1".to_string(),
+                    client_secret: None,
+                },
+                "code-1",
+                "verifier-1",
+                "http://127.0.0.1:1455/callback",
+                Some("https://mcp.example.com/"),
+            )
+            .await
+            .expect("exchange should succeed");
+
+        assert_eq!(tokens.access_token, "at-1");
+        assert_eq!(tokens.authorization_value(), "Bearer at-1");
+        assert!(tokens.expires_at.is_some());
+        assert_eq!(
+            tokens.token_endpoint.as_deref(),
+            Some("https://auth.example.com/token")
+        );
+
+        let sent = egress.sent.lock().unwrap();
+        let body = String::from_utf8(sent[0].body.clone()).unwrap();
+        assert!(body.contains("grant_type=authorization_code"));
+        assert!(body.contains("code_verifier=verifier-1"));
+        assert!(body.contains("resource=https"));
+        assert!(sent[0].dns_pinning_required, "token calls must be pinned");
+    }
+
+    #[tokio::test]
+    async fn refresh_carries_the_old_refresh_token_when_the_server_does_not_rotate() {
+        let egress = FakeEgress::with(vec![(
+            "https://auth.example.com/token",
+            200,
+            r#"{"access_token":"at-2","token_type":"Bearer","expires_in":3600}"#,
+        )]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+        let existing = TokenSet {
+            access_token: "at-1".to_string(),
+            refresh_token: Some("rt-1".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(Utc::now() - ChronoDuration::seconds(1)),
+            scope: None,
+            token_endpoint: Some("https://auth.example.com/token".to_string()),
+            client_id: Some("client-1".to_string()),
+            client_secret: None,
+        };
+
+        let renewed = client.refresh(&existing).await.expect("refresh");
+
+        assert_eq!(renewed.access_token, "at-2");
+        assert_eq!(
+            renewed.refresh_token.as_deref(),
+            Some("rt-1"),
+            "a non-rotating server must not cost us the refresh token"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_without_a_refresh_token_is_a_typed_error() {
+        let egress = FakeEgress::with(vec![]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+        let tokens = TokenSet {
+            access_token: "at-1".to_string(),
+            refresh_token: None,
+            token_type: "Bearer".to_string(),
+            expires_at: None,
+            scope: None,
+            token_endpoint: Some("https://auth.example.com/token".to_string()),
+            client_id: None,
+            client_secret: None,
+        };
+
+        assert!(matches!(
+            client.refresh(&tokens).await,
+            Err(OAuthError::NotRefreshable)
+        ));
+    }
+
+    #[tokio::test]
+    async fn token_endpoint_errors_surface_status_and_body() {
+        let egress = FakeEgress::with(vec![(
+            "https://auth.example.com/token",
+            400,
+            r#"{"error":"invalid_grant"}"#,
+        )]);
+        let client = OAuthClient::new(&egress, EgressRequestKind::Mcp);
+
+        let error = client
+            .exchange_code(
+                "https://auth.example.com/token",
+                &RegisteredClient {
+                    client_id: "client-1".to_string(),
+                    client_secret: None,
+                },
+                "code-1",
+                "verifier-1",
+                "http://127.0.0.1:1455/callback",
+                None,
+            )
+            .await
+            .expect_err("a 400 must not be read as success");
+
+        match error {
+            OAuthError::Http { status, body, .. } => {
+                assert_eq!(status, 400);
+                assert!(body.contains("invalid_grant"));
+            }
+            other => panic!("expected an HTTP error, got {other}"),
+        }
+    }
+
+    #[test]
+    fn expiry_and_refresh_windows_are_distinct() {
+        let now = Utc::now();
+        let tokens = TokenSet {
+            access_token: "at".to_string(),
+            refresh_token: None,
+            token_type: "Bearer".to_string(),
+            expires_at: Some(now + ChronoDuration::seconds(30)),
+            scope: None,
+            token_endpoint: None,
+            client_id: None,
+            client_secret: None,
+        };
+
+        assert!(!tokens.is_expired(now), "still valid for another 30s");
+        assert!(
+            tokens.needs_refresh(now, DEFAULT_REFRESH_SKEW_SECONDS),
+            "but inside the refresh window, so renew before using it"
+        );
+
+        let no_expiry = TokenSet {
+            expires_at: None,
+            ..tokens
+        };
+        assert!(!no_expiry.is_expired(now));
+        assert!(!no_expiry.needs_refresh(now, DEFAULT_REFRESH_SKEW_SECONDS));
+    }
+}

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -29,6 +29,9 @@ serde_json.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+# OAuth token expiry bookkeeping and issuer/origin parsing (src/oauth.rs).
+chrono.workspace = true
+url = "2"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -34,6 +34,7 @@ pub mod auth;
 pub mod client;
 pub mod executor;
 pub mod http;
+pub mod oauth;
 pub mod protocol;
 pub mod result;
 pub mod transport;

--- a/crates/mcp/src/oauth.rs
+++ b/crates/mcp/src/oauth.rs
@@ -1,0 +1,642 @@
+//! OAuth for remote MCP servers: the login handshake and the auth provider
+//! that keeps its tokens fresh.
+//!
+//! The protocol steps are [`everruns_core::oauth`], shared with every other
+//! OAuth flow in the workspace. What is MCP-specific lives here:
+//!
+//! - **Discovery starts at the server, not at an issuer.** An MCP server
+//!   publishes protected-resource metadata (RFC 9728) naming the authorization
+//!   servers that can issue tokens for it; when it publishes nothing, the
+//!   server's own origin is treated as the issuer. Either way the URL comes
+//!   from the remote server, which is why every request goes through the
+//!   egress boundary.
+//! - **The token is bound to the server as a resource** (RFC 8707), so a token
+//!   minted for one MCP server is not replayable against another.
+//! - **Login is split in two.** [`prepare_login`] does discovery, registration
+//!   and the authorize URL; [`complete_login`] exchanges the code. How the code
+//!   comes back — a loopback listener in a CLI, a redirect route in the control
+//!   plane — is the host's business, and the only reason those two hosts needed
+//!   separate implementations before.
+//!
+//! Persistence is a [`McpTokenStore`]: the control plane writes encrypted rows,
+//! a CLI writes a file. [`OAuthAuthProvider`] reads through it on every request
+//! and refreshes inside the store's lock, so a token is renewed once rather
+//! than once per concurrent tool call.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
+use everruns_core::egress::{EgressRequestKind, EgressService};
+use everruns_core::oauth::{
+    AuthorizationServerMetadata, AuthorizeParams, ClientRegistration, DEFAULT_REFRESH_SKEW_SECONDS,
+    OAuthClient, PkcePair, RegisteredClient, TokenSet, authorize_url, random_state,
+    validate_callback_issuer,
+};
+
+use crate::auth::{McpAuthProvider, McpAuthRequest, McpCredential};
+
+/// Where a host keeps MCP OAuth tokens.
+///
+/// Keyed by logical server name, matching [`McpAuthRequest::server_name`], so a
+/// host does not have to thread MCP config through its storage layer.
+#[async_trait]
+pub trait McpTokenStore: Send + Sync {
+    /// Load the token set for `server_name`, if one was ever stored.
+    async fn load(&self, server_name: &str) -> Result<Option<TokenSet>>;
+
+    /// Persist `tokens` for `server_name`, replacing any previous set.
+    ///
+    /// Called after login and after every refresh — including refresh-token
+    /// rotation, where losing the write means losing the grant.
+    async fn save(&self, server_name: &str, tokens: &TokenSet) -> Result<()>;
+}
+
+/// In-memory token store. Useful for tests and for a host that is content to
+/// re-authorize on restart.
+#[derive(Debug, Default)]
+pub struct InMemoryTokenStore {
+    tokens: Mutex<HashMap<String, TokenSet>>,
+}
+
+impl InMemoryTokenStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed a token set, as if a login had produced it.
+    pub fn seeded(server_name: impl Into<String>, tokens: TokenSet) -> Self {
+        let store = Self::new();
+        store
+            .tokens
+            .lock()
+            .unwrap()
+            .insert(server_name.into(), tokens);
+        store
+    }
+}
+
+#[async_trait]
+impl McpTokenStore for InMemoryTokenStore {
+    async fn load(&self, server_name: &str) -> Result<Option<TokenSet>> {
+        Ok(self.tokens.lock().unwrap().get(server_name).cloned())
+    }
+
+    async fn save(&self, server_name: &str, tokens: &TokenSet) -> Result<()> {
+        self.tokens
+            .lock()
+            .unwrap()
+            .insert(server_name.to_string(), tokens.clone());
+        Ok(())
+    }
+}
+
+/// A login in progress: everything needed to finish once the authorization
+/// code arrives.
+///
+/// Hold it across the user-agent round trip. It carries the PKCE verifier and
+/// the CSRF `state`, so it must not be logged or persisted unencrypted.
+pub struct PreparedLogin {
+    /// Send the user-agent here.
+    pub authorization_url: String,
+    /// Echoed back on the callback; compare before exchanging.
+    pub state: String,
+    /// Issuer the flow was started against, for RFC 9207 validation.
+    pub issuer: String,
+    /// Resource indicator the token will be bound to.
+    pub resource: String,
+    redirect_uri: String,
+    pkce: PkcePair,
+    client: RegisteredClient,
+    metadata: AuthorizationServerMetadata,
+}
+
+impl PreparedLogin {
+    /// The client this login registered or was configured with. A host that
+    /// wants to reuse the registration across logins should persist it.
+    pub fn client(&self) -> &RegisteredClient {
+        &self.client
+    }
+}
+
+/// Begin an OAuth login for the MCP server at `server_url`.
+///
+/// Discovery order: the server's protected-resource metadata names its
+/// authorization servers; absent that document, the server origin is the
+/// issuer. When `client` is `None` and the authorization server offers dynamic
+/// registration, a public client is registered on the spot.
+pub async fn prepare_login(
+    egress: &dyn EgressService,
+    server_url: &str,
+    redirect_uri: &str,
+    client_name: &str,
+    client: Option<RegisteredClient>,
+    scope: Option<&str>,
+) -> Result<PreparedLogin> {
+    let oauth = OAuthClient::new(egress, EgressRequestKind::Mcp);
+
+    let protected = oauth
+        .discover_protected_resource(server_url)
+        .await
+        .context("discovering MCP protected-resource metadata")?;
+    let resource = protected
+        .as_ref()
+        .and_then(|metadata| metadata.resource.clone())
+        .unwrap_or_else(|| server_url.to_string());
+    let issuer = protected
+        .as_ref()
+        .and_then(|metadata| metadata.authorization_servers.first().cloned())
+        .unwrap_or_else(|| origin_of(server_url));
+
+    let metadata = oauth
+        .discover_authorization_server(&issuer)
+        .await
+        .context("discovering MCP authorization-server metadata")?;
+
+    let client = match client {
+        Some(client) => client,
+        None => {
+            let endpoint = metadata.registration_endpoint.clone().ok_or_else(|| {
+                anyhow!(
+                    "MCP server at {server_url} needs a client_id: its authorization server \
+                     offers no dynamic registration endpoint"
+                )
+            })?;
+            oauth
+                .register_client(
+                    &endpoint,
+                    &ClientRegistration {
+                        client_name: client_name.to_string(),
+                        redirect_uris: vec![redirect_uri.to_string()],
+                        scope: scope.map(str::to_string),
+                    },
+                )
+                .await
+                .context("registering an OAuth client with the MCP authorization server")?
+        }
+    };
+
+    let pkce = PkcePair::generate();
+    let state = random_state();
+    let authorization_url = authorize_url(
+        &metadata,
+        &AuthorizeParams {
+            client_id: &client.client_id,
+            redirect_uri,
+            code_challenge: &pkce.challenge,
+            state: &state,
+            scope,
+            resource: Some(&resource),
+        },
+    )?;
+
+    Ok(PreparedLogin {
+        authorization_url,
+        state,
+        issuer: metadata.issuer.clone(),
+        resource,
+        redirect_uri: redirect_uri.to_string(),
+        pkce,
+        client,
+        metadata,
+    })
+}
+
+/// Finish a login with the authorization code from the callback.
+///
+/// `returned_state` and `returned_issuer` are the callback's `state` and `iss`.
+/// A mismatched `state` is rejected here rather than by the caller, so no host
+/// can forget the CSRF check.
+pub async fn complete_login(
+    egress: &dyn EgressService,
+    prepared: &PreparedLogin,
+    code: &str,
+    returned_state: &str,
+    returned_issuer: Option<&str>,
+) -> Result<TokenSet> {
+    if returned_state != prepared.state {
+        return Err(anyhow!("authorization response state does not match"));
+    }
+    validate_callback_issuer(&prepared.issuer, returned_issuer)?;
+
+    let oauth = OAuthClient::new(egress, EgressRequestKind::Mcp);
+    oauth
+        .exchange_code(
+            &prepared.metadata.token_endpoint,
+            &prepared.client,
+            code,
+            &prepared.pkce.verifier,
+            &prepared.redirect_uri,
+            Some(&prepared.resource),
+        )
+        .await
+        .context("exchanging the MCP authorization code")
+}
+
+/// [`McpAuthProvider`] backed by stored OAuth tokens, refreshing as needed.
+pub struct OAuthAuthProvider<S: McpTokenStore> {
+    store: S,
+    egress: std::sync::Arc<dyn EgressService>,
+    refresh_skew_seconds: i64,
+    /// Serializes refreshes so concurrent tool calls against one server do not
+    /// each burn a refresh — and, with a rotating server, invalidate each
+    /// other's freshly issued refresh token.
+    refresh_lock: tokio::sync::Mutex<()>,
+}
+
+impl<S: McpTokenStore> OAuthAuthProvider<S> {
+    /// Build a provider over `store`, sending refreshes through `egress`.
+    pub fn new(store: S, egress: std::sync::Arc<dyn EgressService>) -> Self {
+        Self {
+            store,
+            egress,
+            refresh_skew_seconds: DEFAULT_REFRESH_SKEW_SECONDS,
+            refresh_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// Override how far ahead of expiry a token is renewed.
+    pub fn refresh_skew_seconds(mut self, seconds: i64) -> Self {
+        self.refresh_skew_seconds = seconds;
+        self
+    }
+}
+
+#[async_trait]
+impl<S: McpTokenStore> McpAuthProvider for OAuthAuthProvider<S> {
+    async fn authorization(&self, request: &McpAuthRequest<'_>) -> Result<Option<McpCredential>> {
+        let Some(tokens) = self.store.load(request.server_name).await? else {
+            return Ok(None);
+        };
+        if !tokens.needs_refresh(chrono::Utc::now(), self.refresh_skew_seconds) {
+            return Ok(Some(McpCredential::authorization(
+                tokens.authorization_value(),
+            )));
+        }
+
+        let _guard = self.refresh_lock.lock().await;
+        // Re-read under the lock: another caller may have refreshed while we
+        // waited, in which case rotation makes our copy's refresh token dead.
+        let current = self
+            .store
+            .load(request.server_name)
+            .await?
+            .unwrap_or(tokens);
+        if !current.needs_refresh(chrono::Utc::now(), self.refresh_skew_seconds) {
+            return Ok(Some(McpCredential::authorization(
+                current.authorization_value(),
+            )));
+        }
+
+        if current.refresh_token.is_none() {
+            // Nothing to renew with. Hand back the token we have: an expired
+            // one produces a 401 the host can turn into a re-login prompt,
+            // which beats reporting "no credential" for a configured server.
+            return Ok(Some(McpCredential::authorization(
+                current.authorization_value(),
+            )));
+        }
+
+        let oauth = OAuthClient::new(self.egress.as_ref(), EgressRequestKind::Mcp);
+        let renewed = oauth
+            .refresh(&current)
+            .await
+            .with_context(|| format!("refreshing MCP OAuth token for {}", request.server_name))?;
+        self.store.save(request.server_name, &renewed).await?;
+        Ok(Some(McpCredential::authorization(
+            renewed.authorization_value(),
+        )))
+    }
+}
+
+/// Scheme + host + port of `url`, used as the fallback issuer.
+fn origin_of(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(parsed) => format!(
+            "{}://{}{}",
+            parsed.scheme(),
+            parsed.host_str().unwrap_or_default(),
+            parsed
+                .port()
+                .map(|port| format!(":{port}"))
+                .unwrap_or_default()
+        ),
+        Err(_) => url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use everruns_core::McpServerAuthMode;
+    use everruns_core::egress::{
+        EgressError, EgressRequest, EgressResponse, EgressResult, EgressStreamResponse,
+    };
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct FakeEgress {
+        routes: Vec<(String, u16, String)>,
+        sent: Mutex<Vec<EgressRequest>>,
+    }
+
+    impl FakeEgress {
+        fn with(routes: Vec<(&str, u16, &str)>) -> Arc<Self> {
+            Arc::new(Self {
+                routes: routes
+                    .into_iter()
+                    .map(|(url, status, body)| (url.to_string(), status, body.to_string()))
+                    .collect(),
+                sent: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl EgressService for FakeEgress {
+        async fn send(&self, request: EgressRequest) -> EgressResult<EgressResponse> {
+            self.sent.lock().unwrap().push(request.clone());
+            match self.routes.iter().find(|(url, _, _)| *url == request.url) {
+                Some((_, status, body)) => Ok(EgressResponse {
+                    status: *status,
+                    headers: BTreeMap::new(),
+                    body: body.clone().into_bytes(),
+                }),
+                None => Ok(EgressResponse {
+                    status: 404,
+                    headers: BTreeMap::new(),
+                    body: Vec::new(),
+                }),
+            }
+        }
+
+        async fn send_stream(&self, _request: EgressRequest) -> EgressResult<EgressStreamResponse> {
+            Err(EgressError::Transport("unsupported".to_string()))
+        }
+    }
+
+    fn auth_request<'a>(server_name: &'a str) -> McpAuthRequest<'a> {
+        McpAuthRequest {
+            server_name,
+            auth_mode: McpServerAuthMode::OAuth,
+            oauth_provider_id: None,
+        }
+    }
+
+    fn token_set(expires_in_seconds: i64, refresh_token: Option<&str>) -> TokenSet {
+        TokenSet {
+            access_token: "at-1".to_string(),
+            refresh_token: refresh_token.map(str::to_string),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(Utc::now() + Duration::seconds(expires_in_seconds)),
+            scope: None,
+            token_endpoint: Some("https://auth.example.com/token".to_string()),
+            client_id: Some("client-1".to_string()),
+            client_secret: None,
+        }
+    }
+
+    const PROTECTED_RESOURCE: &str = r#"{
+        "resource": "https://mcp.example.com/",
+        "authorization_servers": ["https://auth.example.com"]
+    }"#;
+
+    const AS_METADATA: &str = r#"{
+        "issuer": "https://auth.example.com",
+        "authorization_endpoint": "https://auth.example.com/authorize",
+        "token_endpoint": "https://auth.example.com/token",
+        "registration_endpoint": "https://auth.example.com/register"
+    }"#;
+
+    #[tokio::test]
+    async fn login_discovers_registers_and_binds_the_token_to_the_resource() {
+        let egress = FakeEgress::with(vec![
+            (
+                "https://mcp.example.com/.well-known/oauth-protected-resource",
+                200,
+                PROTECTED_RESOURCE,
+            ),
+            (
+                "https://auth.example.com/.well-known/oauth-authorization-server",
+                200,
+                AS_METADATA,
+            ),
+            (
+                "https://auth.example.com/register",
+                200,
+                r#"{"client_id":"dyn-client-1"}"#,
+            ),
+            (
+                "https://auth.example.com/token",
+                200,
+                r#"{"access_token":"at-1","refresh_token":"rt-1","expires_in":3600}"#,
+            ),
+        ]);
+
+        let prepared = prepare_login(
+            egress.as_ref(),
+            "https://mcp.example.com/",
+            "http://127.0.0.1:1455/callback",
+            "everruns",
+            None,
+            Some("mcp:read"),
+        )
+        .await
+        .expect("login preparation");
+
+        assert_eq!(prepared.client().client_id, "dyn-client-1");
+        assert_eq!(prepared.resource, "https://mcp.example.com/");
+        assert!(
+            prepared
+                .authorization_url
+                .contains("resource=https%3A%2F%2Fmcp.example.com%2F"),
+            "the token must be bound to this server: {}",
+            prepared.authorization_url
+        );
+
+        let state = prepared.state.clone();
+        let tokens = complete_login(
+            egress.as_ref(),
+            &prepared,
+            "code-1",
+            &state,
+            Some("https://auth.example.com"),
+        )
+        .await
+        .expect("code exchange");
+
+        assert_eq!(tokens.access_token, "at-1");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("rt-1"));
+    }
+
+    #[tokio::test]
+    async fn login_falls_back_to_the_server_origin_as_issuer() {
+        // Servers that publish no protected-resource document are the common
+        // case today; treat the origin as the issuer rather than failing.
+        let egress = FakeEgress::with(vec![(
+            "https://mcp.example.com/.well-known/oauth-authorization-server",
+            200,
+            r#"{
+                "issuer": "https://mcp.example.com",
+                "authorization_endpoint": "https://mcp.example.com/authorize",
+                "token_endpoint": "https://mcp.example.com/token"
+            }"#,
+        )]);
+
+        let prepared = prepare_login(
+            egress.as_ref(),
+            "https://mcp.example.com/sse",
+            "http://127.0.0.1:1455/callback",
+            "everruns",
+            Some(RegisteredClient {
+                client_id: "configured".to_string(),
+                client_secret: None,
+            }),
+            None,
+        )
+        .await
+        .expect("login preparation");
+
+        assert_eq!(prepared.issuer, "https://mcp.example.com");
+        assert_eq!(prepared.resource, "https://mcp.example.com/sse");
+    }
+
+    #[tokio::test]
+    async fn a_mismatched_callback_state_is_refused() {
+        let egress = FakeEgress::with(vec![(
+            "https://mcp.example.com/.well-known/oauth-authorization-server",
+            200,
+            AS_METADATA,
+        )]);
+        let prepared = prepare_login(
+            egress.as_ref(),
+            "https://mcp.example.com/",
+            "http://127.0.0.1:1455/callback",
+            "everruns",
+            Some(RegisteredClient {
+                client_id: "configured".to_string(),
+                client_secret: None,
+            }),
+            None,
+        )
+        .await
+        .expect("login preparation");
+
+        let error = complete_login(egress.as_ref(), &prepared, "code-1", "not-the-state", None)
+            .await
+            .expect_err("CSRF check must fail");
+        assert!(error.to_string().contains("state"));
+    }
+
+    #[tokio::test]
+    async fn a_mismatched_callback_issuer_is_refused() {
+        let egress = FakeEgress::with(vec![(
+            "https://mcp.example.com/.well-known/oauth-authorization-server",
+            200,
+            AS_METADATA,
+        )]);
+        let prepared = prepare_login(
+            egress.as_ref(),
+            "https://mcp.example.com/",
+            "http://127.0.0.1:1455/callback",
+            "everruns",
+            Some(RegisteredClient {
+                client_id: "configured".to_string(),
+                client_secret: None,
+            }),
+            None,
+        )
+        .await
+        .expect("login preparation");
+
+        let state = prepared.state.clone();
+        let error = complete_login(
+            egress.as_ref(),
+            &prepared,
+            "code-1",
+            &state,
+            Some("https://evil.example.com"),
+        )
+        .await
+        .expect_err("mix-up defense must fail");
+        assert!(error.to_string().contains("issuer"));
+    }
+
+    #[tokio::test]
+    async fn a_live_token_is_returned_without_touching_the_network() {
+        let egress = FakeEgress::with(vec![]);
+        let provider = OAuthAuthProvider::new(
+            InMemoryTokenStore::seeded("docs", token_set(3600, Some("rt-1"))),
+            egress.clone(),
+        );
+
+        let credential = provider
+            .authorization(&auth_request("docs"))
+            .await
+            .expect("resolve")
+            .expect("credential");
+
+        assert_eq!(credential.authorization.as_deref(), Some("Bearer at-1"));
+        assert!(egress.sent.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_near_expiry_token_is_refreshed_and_persisted() {
+        let egress = FakeEgress::with(vec![(
+            "https://auth.example.com/token",
+            200,
+            r#"{"access_token":"at-2","refresh_token":"rt-2","expires_in":3600}"#,
+        )]);
+        let store = InMemoryTokenStore::seeded("docs", token_set(5, Some("rt-1")));
+        let provider = OAuthAuthProvider::new(store, egress.clone());
+
+        let credential = provider
+            .authorization(&auth_request("docs"))
+            .await
+            .expect("resolve")
+            .expect("credential");
+
+        assert_eq!(credential.authorization.as_deref(), Some("Bearer at-2"));
+        // Rotation must be persisted, or the next refresh presents a dead token.
+        let stored = provider.store.load("docs").await.unwrap().unwrap();
+        assert_eq!(stored.refresh_token.as_deref(), Some("rt-2"));
+    }
+
+    #[tokio::test]
+    async fn an_unknown_server_resolves_to_no_credential() {
+        let egress = FakeEgress::with(vec![]);
+        let provider = OAuthAuthProvider::new(InMemoryTokenStore::new(), egress);
+
+        assert!(
+            provider
+                .authorization(&auth_request("never-logged-in"))
+                .await
+                .expect("resolve")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_expired_token_with_no_refresh_token_is_still_presented() {
+        // Presenting it yields a 401 the host can turn into a re-login prompt;
+        // returning None would look like "this server needs no auth".
+        let egress = FakeEgress::with(vec![]);
+        let provider = OAuthAuthProvider::new(
+            InMemoryTokenStore::seeded("docs", token_set(-60, None)),
+            egress.clone(),
+        );
+
+        let credential = provider
+            .authorization(&auth_request("docs"))
+            .await
+            .expect("resolve")
+            .expect("credential");
+
+        assert_eq!(credential.authorization.as_deref(), Some("Bearer at-1"));
+        assert!(egress.sent.lock().unwrap().is_empty());
+    }
+}

--- a/specs/runtime-mcp.md
+++ b/specs/runtime-mcp.md
@@ -133,8 +133,22 @@ trait McpAuthProvider {
   refreshes, and atomically persists refresh-token rotation before returning
   the new access token.
 - The **runtime/coding-CLI** provides simpler implementations: a static
-  bearer/header provider, an env-var provider, and (future) a device-code
-  flow. The CLI does not require a browser redirect.
+  bearer/header provider, an env-var provider, and `OAuthAuthProvider`.
+
+The OAuth half is shared rather than per-host. `everruns_core::oauth` owns the
+protocol steps — RFC 9728 protected-resource discovery, RFC 8414/OpenID
+authorization-server metadata, RFC 7591 dynamic registration, PKCE, code
+exchange, refresh, and RFC 9207 issuer validation — with no browser, no
+listener, and no storage. `everruns_mcp::oauth` binds them to MCP: discovery
+starts at the *server* (its metadata names the issuer; absent that, its origin
+is the issuer), the token is bound to the server with a `resource` indicator
+(RFC 8707), and `prepare_login`/`complete_login` split the flow so the host
+supplies only the callback leg — a loopback listener for a CLI, a redirect
+route for the control plane. Persistence is the `McpTokenStore` trait.
+
+Every OAuth request goes through `EgressService` with DNS pinning. The
+authorization-server URL is discovered *from the remote MCP server*, so it is
+attacker-influenced input and must not bypass the egress boundary.
 - `auth_mode = OAuth` no longer implies "web". "Lifetime"/refresh is owned by
   the provider implementation (e.g. a CLI provider may cache a token and
   refresh on 401), keeping the core executor stateless.


### PR DESCRIPTION
## What changed

Two new modules, splitting OAuth into the part everyone shares and the part MCP owns.

**`everruns_core::oauth`** — the protocol steps, stateless:
- protected-resource discovery (RFC 9728) → authorization-server metadata (RFC 8414, falling back to OpenID discovery)
- dynamic client registration (RFC 7591)
- PKCE S256 (RFC 7636), authorize-URL construction, code exchange, refresh
- callback issuer validation (RFC 9207)
- `TokenSet` with `is_expired` / `needs_refresh(skew)` and the endpoint + client it was issued by, so a refresh needs no re-discovery

No browser, no listener, no storage — hosts disagree about those and keep them.

**`everruns_mcp::oauth`** — the MCP binding:
- `prepare_login` / `complete_login`, split at the callback. That split *is* the unification: a CLI's loopback listener and the control plane's redirect route are the only genuinely different pieces.
- `McpTokenStore` trait (+ `InMemoryTokenStore`) for persistence
- `OAuthAuthProvider`, implementing the existing `McpAuthProvider` seam

## Why

`crates/mcp/src/auth.rs` has been a trait with no OAuth implementation behind it, while the same flow was written three times elsewhere — the provider connect flow (`api/providers.rs`), user connections (`api/user_connections.rs`), and MCP login in downstream hosts. Each has its own PKCE and its own refresh.

Three MCP-specific decisions worth calling out:

- **Discovery starts at the server, not at a configured issuer.** The MCP server publishes the metadata naming its authorization server; when it publishes nothing, its origin is the issuer. That fallback is the common case today.
- **The token is bound to the server as a `resource`** (RFC 8707), so a token minted for one MCP server is not replayable against another.
- **Refresh happens under a lock, re-reading the store inside it.** With a rotating authorization server, two concurrent tool calls refreshing in parallel invalidate each other's tokens; the second waiter finds the first one's result and uses it.

## Before / After

```rust
// before — the seam existed, nothing implemented it
let provider = StaticAuthProvider::new().with_bearer("docs", token_pasted_by_hand);

// after
let prepared = mcp::oauth::prepare_login(egress, server_url, redirect, "everruns", None, None).await?;
open_browser(&prepared.authorization_url);              // host's job
let code = wait_for_callback().await?;                  // host's job
let tokens = mcp::oauth::complete_login(egress, &prepared, &code, &state, iss).await?;
store.save("docs", &tokens).await?;

let provider = OAuthAuthProvider::new(store, egress);   // refreshes from here on
```

Nothing in this repo changes behavior yet — both modules are additive, and no existing call site is rewired.

## Risk

- Low
- Additive. The sharp edges are all in the new code and covered: state/issuer mismatch refuse the exchange, a non-rotating server does not lose its refresh token, an expired token with no refresh token is still presented (so the host gets a 401 to turn into a re-login prompt, rather than a silent "no auth needed").

## Security

- Threat categories reviewed: TM-TOOL-018 (SSRF), TM-AUTH (credential handling).
  - **Every OAuth request goes through `EgressService` with `require_dns_pinning()`.** This is the load-bearing decision: the authorization-server URL is discovered *from the remote MCP server*, so it is attacker-influenced input, and a private HTTP client here would be an internal-network probe reachable by anyone who can get a server into a user's config.
  - Plaintext endpoints are rejected — including a token endpoint advertised over `http` inside an otherwise-HTTPS metadata document. Loopback is the one exception, for the native-app redirect leg (RFC 8252).
  - PKCE is mandatory (no non-PKCE path exists), `state` is checked inside `complete_login` so no host can forget it, and `iss` is validated when returned.
  - Refresh-token rotation is persisted before the credential is returned; losing that write loses the grant.
  - Secrets: `PreparedLogin` holds the PKCE verifier and is documented as not-for-logging; error bodies from the token endpoint are truncated to 512 bytes.
- Findings and resolutions: the concurrent-refresh race was found while writing the provider and is fixed by the re-read-under-lock; covered by test.

## Follow-ups

Migrating `api/providers.rs` and `api/user_connections.rs` onto `core::oauth` is the other half of "unified" and is deliberately not in this PR — those touch DB-backed connection flows and deserve their own change with their own tests.

## Checklist

- [x] Tests added or updated — 21 tests (13 core, 8 MCP). All run against an `EgressService` double, so the whole flow is covered without a socket
- [x] Backward compatibility considered — additive modules; no existing signature or call site touched
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo test -p everruns-core --lib oauth::`, `cargo test -p everruns-mcp --lib`, `cargo check --workspace`, `cargo fmt`, `cargo clippy -p everruns-core -p everruns-mcp --all-targets --all-features` all clean
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019nACLr5GqiemdHXVhuRdrc)_