### PR TITLE
feat(local): route background-run completions to a live host loop

### DIFF
--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1688,7 +1688,19 @@ impl SessionBackgroundSink {
     }
 
     async fn signal_session(&self, status: &str, summary: &str) -> Result<()> {
+        // Without a platform store there is nowhere to deliver the completion,
+        // and the background run finishes invisibly — the agent that spawned it
+        // never learns it ended. Say so: a host that wires `spawn_background`
+        // but no store has a hole, not a preference.
         let Some(platform_store) = &self.context.platform_store else {
+            tracing::warn!(
+                run_id = %self.run_id,
+                tool = %self.tool_name,
+                session_id = %self.context.session_id,
+                %status,
+                "background run finished but no platform store is configured; \
+                 the session will not be woken (see everruns-local's wake routing)"
+            );
             return Ok(());
         };
         let message = format!(

--- a/crates/local/src/lib.rs
+++ b/crates/local/src/lib.rs
@@ -32,6 +32,7 @@ mod runtime_builder;
 mod schedule_runner;
 mod schedule_store;
 mod task_registry;
+mod wake_routing;
 
 pub use backends::LocalBackends;
 pub use db::SqliteDb;
@@ -44,3 +45,4 @@ pub use schedule_runner::{
 };
 pub use schedule_store::LocalScheduleStore;
 pub use task_registry::LocalSessionTaskRegistry;
+pub use wake_routing::{HostRoutedRunner, WakeRoutes};

--- a/crates/local/src/wake_routing.rs
+++ b/crates/local/src/wake_routing.rs
@@ -1,0 +1,400 @@
+//! Delivering background-run completions to a host that owns the turn loop.
+//!
+//! `spawn_background` detaches a tool from the turn and, when it finishes,
+//! signals the session through `PlatformStore::send_message`. For an embedded
+//! host that is not as simple as running a turn: if the session has a *live
+//! host loop* — a terminal UI, an editor session, anything already driving
+//! turns for it — the completion must reach that loop and be run when it is
+//! idle. Running it underneath the host instead means two turns on one session
+//! at once.
+//!
+//! [`HostRoutedRunner`] is that rule, and only that rule. It decorates any
+//! [`LocalSessionRunner`]:
+//!
+//! - session has a registered route → hand the message to the host's channel
+//! - no route (a child/subagent session with nobody watching) → delegate to the
+//!   inner runner, which runs the turn synchronously
+//!
+//! Everything else passes straight through. What the host does with a delivered
+//! wake — coalescing, enriching it with session state, when to run it — stays
+//! with the host, because that part is genuinely host-specific.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::platform_store::{PlatformCreateSessionRequest, PlatformMessage};
+use everruns_core::session::Session;
+use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+use crate::platform_store::LocalSessionRunner;
+
+/// Registry of sessions with a live host loop.
+///
+/// A host registers a session when it starts driving it and drops the receiver
+/// when it stops; a send to a dropped receiver prunes the route, so a crashed
+/// or closed host does not keep swallowing wakes.
+#[derive(Debug, Clone, Default)]
+pub struct WakeRoutes {
+    routes: Arc<Mutex<HashMap<SessionId, UnboundedSender<String>>>>,
+}
+
+impl WakeRoutes {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `session_id` as host-driven and take the receiving end.
+    ///
+    /// Registering a session that already has a route replaces it — the newest
+    /// loop wins, which is what a reconnecting host wants.
+    pub fn register(&self, session_id: SessionId) -> UnboundedReceiver<String> {
+        let (sender, receiver) = unbounded_channel();
+        self.routes.lock().unwrap().insert(session_id, sender);
+        receiver
+    }
+
+    /// Stop routing to `session_id`.
+    pub fn unregister(&self, session_id: SessionId) {
+        self.routes.lock().unwrap().remove(&session_id);
+    }
+
+    /// Sessions currently claimed by a host loop.
+    pub fn live_sessions(&self) -> Vec<SessionId> {
+        self.routes.lock().unwrap().keys().copied().collect()
+    }
+
+    fn sender(&self, session_id: SessionId) -> Option<UnboundedSender<String>> {
+        self.routes.lock().unwrap().get(&session_id).cloned()
+    }
+
+    /// Drop a route only if it is still the sender that just failed. A host
+    /// that re-registered in the meantime keeps its newer route.
+    fn prune_if_same(&self, session_id: SessionId, stale: &UnboundedSender<String>) {
+        let mut routes = self.routes.lock().unwrap();
+        if routes
+            .get(&session_id)
+            .is_some_and(|current| current.same_channel(stale))
+        {
+            routes.remove(&session_id);
+        }
+    }
+}
+
+/// Wraps a [`LocalSessionRunner`] so background completions reach a live host
+/// loop instead of running a turn underneath it.
+pub struct HostRoutedRunner<R: LocalSessionRunner> {
+    inner: R,
+    routes: WakeRoutes,
+}
+
+impl<R: LocalSessionRunner> HostRoutedRunner<R> {
+    /// Decorate `inner`, routing through `routes`.
+    pub fn new(inner: R, routes: WakeRoutes) -> Self {
+        Self { inner, routes }
+    }
+
+    /// The route registry, for hosts that want to register sessions after
+    /// construction.
+    pub fn routes(&self) -> &WakeRoutes {
+        &self.routes
+    }
+
+    /// The wrapped runner.
+    pub fn inner(&self) -> &R {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
+    async fn routable_session_ids(&self) -> Result<Option<Vec<SessionId>>> {
+        // Live host sessions are always routable. If the inner runner scopes
+        // its own routes, union the two; if it routes everything (`None`), so
+        // do we.
+        let live = self.routes.live_sessions();
+        match self.inner.routable_session_ids().await? {
+            None => Ok(None),
+            Some(mut inner) => {
+                for session_id in live {
+                    if !inner.contains(&session_id) {
+                        inner.push(session_id);
+                    }
+                }
+                Ok(Some(inner))
+            }
+        }
+    }
+
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+        let Some(sender) = self.routes.sender(session_id) else {
+            // Nobody is driving this session; the inner runner runs the turn.
+            return self.inner.send_message(session_id, content).await;
+        };
+
+        sender.send(content.to_string()).map_err(|_| {
+            self.routes.prune_if_same(session_id, &sender);
+            // Retryable on purpose: the wake is not lost, it is undeliverable
+            // to a host that went away. A caller that retries will now take the
+            // inner path.
+            AgentLoopError::tool(format!(
+                "session {session_id} wake receiver is closed; wake remains retryable"
+            ))
+        })
+    }
+
+    async fn create_session(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+        locale: Option<&str>,
+        parent_session_id: Option<SessionId>,
+    ) -> Result<Session> {
+        self.inner
+            .create_session(harness_id, agent_id, title, locale, parent_session_id)
+            .await
+    }
+
+    async fn create_session_with_options(
+        &self,
+        request: PlatformCreateSessionRequest,
+    ) -> Result<Session> {
+        self.inner.create_session_with_options(request).await
+    }
+
+    async fn list_sessions(
+        &self,
+        limit: Option<usize>,
+        agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>> {
+        self.inner.list_sessions(limit, agent_id).await
+    }
+
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+        self.inner.get_session(session_id).await
+    }
+
+    async fn get_messages(
+        &self,
+        session_id: SessionId,
+        limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>> {
+        self.inner.get_messages(session_id, limit).await
+    }
+
+    async fn get_session_status(&self, session_id: SessionId) -> Result<Option<String>> {
+        self.inner.get_session_status(session_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        delivered: Mutex<Vec<(SessionId, String)>>,
+        turns_run: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LocalSessionRunner for RecordingRunner {
+        async fn create_session(
+            &self,
+            harness_id: HarnessId,
+            _agent_id: Option<AgentId>,
+            _title: Option<&str>,
+            _locale: Option<&str>,
+            _parent_session_id: Option<SessionId>,
+        ) -> Result<Session> {
+            let _ = harness_id;
+            Err(AgentLoopError::tool("create_session unused in these tests"))
+        }
+
+        async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+            // Stands in for "ran the turn synchronously".
+            self.turns_run.fetch_add(1, Ordering::SeqCst);
+            self.delivered
+                .lock()
+                .unwrap()
+                .push((session_id, content.to_string()));
+            Ok(())
+        }
+
+        async fn list_sessions(
+            &self,
+            _limit: Option<usize>,
+            _agent_id: Option<AgentId>,
+        ) -> Result<Vec<Session>> {
+            Ok(vec![])
+        }
+
+        async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+            Ok(None)
+        }
+
+        async fn get_messages(
+            &self,
+            _session_id: SessionId,
+            _limit: Option<usize>,
+        ) -> Result<Vec<PlatformMessage>> {
+            Ok(vec![])
+        }
+
+        async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+            Ok(Some("idle".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn a_live_host_session_receives_the_wake_instead_of_running_a_turn() {
+        let routes = WakeRoutes::new();
+        let session_id = SessionId::new_random();
+        let mut receiver = routes.register(session_id);
+        let runner = HostRoutedRunner::new(RecordingRunner::default(), routes);
+
+        runner
+            .send_message(session_id, "Background run completed.")
+            .await
+            .expect("wake should be routed");
+
+        assert_eq!(
+            receiver.try_recv().expect("host receives the wake"),
+            "Background run completed."
+        );
+        assert_eq!(
+            runner.inner().turns_run.load(Ordering::SeqCst),
+            0,
+            "a turn must not run underneath the host loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_session_with_no_host_loop_falls_through_to_a_synchronous_turn() {
+        // Child/subagent sessions have nobody watching; the inner runner drives
+        // them directly.
+        let runner = HostRoutedRunner::new(RecordingRunner::default(), WakeRoutes::new());
+        let session_id = SessionId::new_random();
+
+        runner
+            .send_message(session_id, "Background run completed.")
+            .await
+            .expect("wake should reach the inner runner");
+
+        assert_eq!(runner.inner().turns_run.load(Ordering::SeqCst), 1);
+        assert_eq!(runner.inner().delivered.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_closed_host_channel_prunes_the_route_and_stays_retryable() {
+        let routes = WakeRoutes::new();
+        let session_id = SessionId::new_random();
+        let receiver = routes.register(session_id);
+        drop(receiver); // the host went away
+        let runner = HostRoutedRunner::new(RecordingRunner::default(), routes.clone());
+
+        let error = runner
+            .send_message(session_id, "Background run completed.")
+            .await
+            .expect_err("a dead receiver must not look like delivery");
+        assert!(error.to_string().contains("retryable"));
+        assert!(
+            routes.live_sessions().is_empty(),
+            "the dead route must be pruned"
+        );
+
+        // The retry now takes the synchronous path rather than failing again.
+        runner
+            .send_message(session_id, "Background run completed.")
+            .await
+            .expect("retry should fall through");
+        assert_eq!(runner.inner().turns_run.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn re_registering_replaces_the_route_and_a_stale_send_does_not_prune_it() {
+        let routes = WakeRoutes::new();
+        let session_id = SessionId::new_random();
+        let stale = routes.register(session_id);
+        drop(stale);
+        let mut fresh = routes.register(session_id);
+        let runner = HostRoutedRunner::new(RecordingRunner::default(), routes.clone());
+
+        runner
+            .send_message(session_id, "second wake")
+            .await
+            .expect("the newest loop wins");
+
+        assert_eq!(
+            fresh.try_recv().expect("fresh host receives"),
+            "second wake"
+        );
+        assert_eq!(routes.live_sessions(), vec![session_id]);
+    }
+
+    #[tokio::test]
+    async fn live_sessions_are_reported_routable_alongside_the_inner_scope() {
+        struct ScopedRunner(SessionId);
+
+        #[async_trait]
+        impl LocalSessionRunner for ScopedRunner {
+            async fn routable_session_ids(&self) -> Result<Option<Vec<SessionId>>> {
+                Ok(Some(vec![self.0]))
+            }
+            async fn create_session(
+                &self,
+                harness_id: HarnessId,
+                _agent_id: Option<AgentId>,
+                _title: Option<&str>,
+                _locale: Option<&str>,
+                _parent: Option<SessionId>,
+            ) -> Result<Session> {
+                let _ = harness_id;
+                Err(AgentLoopError::tool("create_session unused in these tests"))
+            }
+            async fn send_message(&self, _session_id: SessionId, _content: &str) -> Result<()> {
+                Ok(())
+            }
+            async fn list_sessions(
+                &self,
+                _limit: Option<usize>,
+                _agent_id: Option<AgentId>,
+            ) -> Result<Vec<Session>> {
+                Ok(vec![])
+            }
+            async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+                Ok(None)
+            }
+            async fn get_messages(
+                &self,
+                _session_id: SessionId,
+                _limit: Option<usize>,
+            ) -> Result<Vec<PlatformMessage>> {
+                Ok(vec![])
+            }
+            async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+                Ok(None)
+            }
+        }
+
+        let child = SessionId::new_random();
+        let host_session = SessionId::new_random();
+        let routes = WakeRoutes::new();
+        let _receiver = routes.register(host_session);
+        let runner = HostRoutedRunner::new(ScopedRunner(child), routes);
+
+        let routable = runner
+            .routable_session_ids()
+            .await
+            .expect("routable")
+            .expect("scoped");
+
+        assert!(routable.contains(&child));
+        assert!(routable.contains(&host_session));
+    }
+}

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -250,6 +250,8 @@ Artifacts and visibility:
   - `/.background/{run_id}/output.log`
   - `/.background/{run_id}/result.json`
 - On completion or failure, the worker may send a synthetic session message summarizing the result and artifact paths.
+- That message is delivered through `PlatformStore::send_message`. **Without a platform store there is nowhere to deliver it**, and the run finishes invisibly — the agent that spawned it never learns it ended. The tool logs a warning rather than failing, since the run itself succeeded, but a host that wires `spawn_background` and no store has a hole.
+- Embedded hosts wire delivery with `everruns-local`'s `LocalPlatformStore`. A session with a live host loop (a terminal UI, an editor session) must not have a turn run underneath it, so `HostRoutedRunner` + `WakeRoutes` route the completion to the host's channel when one is registered and fall through to the inner runner's synchronous turn when nobody is watching — which is the child/subagent case. What the host does with a delivered wake (coalescing, enrichment, when to run it) stays with the host.
 
 Scheduled monitors:
 - When `schedule` is provided, `spawn_background` does not start the tool immediately.


### PR DESCRIPTION
## What changed

**Core:** `signal_session` no longer returns `Ok(())` silently when there is no platform store. It logs a warning with the run id, tool, session, and status. The run itself succeeded, so this stays a warning, not an error.

**`everruns-local`:** `HostRoutedRunner` + `WakeRoutes`. The decorator wraps any `LocalSessionRunner` and applies one rule to `send_message`:

- session registered in `WakeRoutes` (a live host loop — terminal UI, editor session) → hand the message to the host's channel
- no route (child/subagent session, nobody watching) → delegate to the inner runner, which runs the turn synchronously

Everything else on the trait passes straight through.

## Why

`spawn_background` detaches a tool and signals its session on completion via `PlatformStore::send_message`. Without a store that call did nothing, silently — so an embedded host could wire `spawn_background`, watch runs complete, and never have the agent learn about it, with nothing in the logs pointing at the cause.

The routing half exists because "deliver the completion" is not simply "run a turn". If the session already has a host driving turns for it, running one underneath means two turns on one session. But a child session spawned by a subagent has no host loop at all and *must* be driven directly. That fork is the same in every embedded host, which is why it belongs here rather than in each one.

Deliberately **not** upstreamed: coalescing pending wakes, enriching a wake with session state, and deciding when an idle host runs it. Those are real, but they are host policy.

## Before / After

```
before:  spawn_background completes → send_message → no store → Ok(()) → silence
after:   spawn_background completes → send_message → warn! naming the run and session

with everruns-local wired:
         completion → host loop registered?  yes → host channel, run when idle
                                             no  → inner runner runs the turn now
```

## Risk

- Low
- Core's change is one log line on a path that previously did nothing. The decorator is new and opt-in; a host that does not wrap its runner is unaffected.
- The one behavior worth stating: a send to a closed receiver returns a **retryable** error and prunes the route, so a host that disappeared degrades to the synchronous path on the next attempt rather than silently swallowing the wake.

## Security

- Threat categories reviewed: no security-relevant code changes. Routing is in-process (a tokio channel) and changes only where an already-authorized completion message is delivered; no new external surface, no credential handling, no change to who may send.
- The warning logs a run id, tool name, and session id — identifiers already present in the surrounding tracing spans, no message content or tool output.
- Findings and resolutions: none.

## Follow-ups

Yolop keeps the host-policy half of its `WakeRunner` (coalescing, goal/ask enrichment, TUI plumbing) and drops the routing half once this ships.

## Checklist

- [x] Tests added or updated — 5 tests: live host receives the wake and no turn runs underneath it, no-route falls through to a synchronous turn, a closed channel prunes and stays retryable then falls through on retry, re-registration wins over a stale sender, live sessions union with an inner scoped route set
- [x] Backward compatibility considered — additive decorator; the core change is a log line
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo test -p everruns-local --lib wake_routing`, `cargo fmt`, `cargo clippy -p everruns-local -p everruns-core --lib --all-features` clean
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019nACLr5GqiemdHXVhuRdrc)_