### PR TITLE
feat(core): turn completion gate and continuation budget

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -199,6 +199,7 @@ pub mod in_memory_loop;
 
 // Turn orchestration (state machine, context, outcomes)
 pub mod turn;
+pub mod turn_completion;
 
 // Note: Chat Driver implementations (AnthropicChatDriver, OpenAIChatDriver) are now in
 // separate crates (everruns-anthropic, everruns-openai) that depend on everruns-core.

--- a/crates/core/src/turn_completion.rs
+++ b/crates/core/src/turn_completion.rs
@@ -1,0 +1,339 @@
+//! Did the turn finish the user's request, or just stop?
+//!
+//! A turn ending is not the same as work being done. A turn that called tools
+//! and produced no text has stopped mid-task; a turn that ended with a question
+//! is waiting on the user; a turn whose detached background run is still going
+//! is neither finished nor stuck. A host that auto-continues needs to tell these
+//! apart, and every host that has tried has written the same classification.
+//!
+//! This is the cheap half, and deliberately only the cheap half: a pure
+//! function over what the turn already reported. It reaches a verdict on the
+//! clear-cut cases and answers [`GateDecision::Evaluate`] on the ambiguous one —
+//! tool-using work that produced a candidate final answer — where only a
+//! semantic check (an evaluator model, a goal capability) can decide. Hosts pay
+//! for that check on the small fraction of turns that need it.
+//!
+//! [`ContinuationBudget`] bounds whatever the host does next. Auto-continuation
+//! that is not bounded in turns, tokens, *and* wall-clock is a runaway; all
+//! three limits exist because each one alone has been observed to leak.
+//!
+//! Ported from yolop, where this gate sits between the turn loop and the
+//! terminal/ACP hosts.
+
+use std::time::{Duration, Instant};
+
+use crate::turn::TurnStopReason;
+
+/// Default ceiling on automatic continuations for one user request.
+pub const DEFAULT_MAX_CONTINUATION_TURNS: u32 = 6;
+
+/// Default token ceiling across those continuations.
+pub const DEFAULT_MAX_CONTINUATION_TOKENS: u64 = 64_000;
+
+/// Default wall-clock ceiling for one user request.
+pub const DEFAULT_MAX_CONTINUATION_ELAPSED: Duration = Duration::from_secs(10 * 60);
+
+/// Where the user's request stands after a turn.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompletionState {
+    /// A final answer was delivered.
+    Achieved,
+    /// Stopped for a reason only the user can clear — cancelled, or a question
+    /// was asked back.
+    Blocked,
+    /// Ended in a permanent failure.
+    Failed,
+    /// Detached background work is still running; the request is neither done
+    /// nor stuck.
+    WaitingOnBackground,
+    /// Stopped without a final answer, and continuing would make progress.
+    InProgress,
+}
+
+/// The gate's verdict.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Decided from the turn alone.
+    Conclusive(CompletionState),
+    /// Tool-using work produced a candidate final answer. Mutations and
+    /// multi-step work are ambiguous enough to justify a semantic check.
+    Evaluate,
+}
+
+/// What the gate reads from a finished turn.
+///
+/// A view rather than a concrete turn result, because the runtime and the
+/// in-memory loop have their own; both can fill this in.
+#[derive(Clone, Copy, Debug)]
+pub struct TurnSummary<'a> {
+    /// Whether the turn completed without an unrecoverable failure.
+    pub success: bool,
+    /// Why the turn stopped.
+    pub stop_reason: TurnStopReason,
+    /// Final text the turn produced.
+    pub response: &'a str,
+    /// How many tool calls ran during the turn.
+    pub tool_calls_count: usize,
+    /// Whether the session has detached background work still running.
+    pub has_active_background: bool,
+}
+
+/// Classify a finished turn.
+pub fn gate_turn(summary: &TurnSummary<'_>) -> GateDecision {
+    if !summary.success {
+        return GateDecision::Conclusive(match summary.stop_reason {
+            TurnStopReason::Cancelled => CompletionState::Blocked,
+            _ => CompletionState::Failed,
+        });
+    }
+
+    match summary.stop_reason {
+        TurnStopReason::Error | TurnStopReason::Refusal => {
+            return GateDecision::Conclusive(CompletionState::Failed);
+        }
+        TurnStopReason::Cancelled => {
+            return GateDecision::Conclusive(CompletionState::Blocked);
+        }
+        // Hitting a token or request ceiling is the definition of stopped
+        // mid-task, whatever text came with it.
+        TurnStopReason::MaxTokens | TurnStopReason::MaxTurnRequests => {
+            return GateDecision::Conclusive(CompletionState::InProgress);
+        }
+        TurnStopReason::EndTurn => {}
+    }
+
+    // Tools ran and produced no text: the model handed off to work that is
+    // still going, rather than finishing.
+    if summary.has_active_background && summary.tool_calls_count > 0 {
+        return GateDecision::Conclusive(CompletionState::WaitingOnBackground);
+    }
+
+    if summary.response.trim().is_empty() {
+        return GateDecision::Conclusive(CompletionState::InProgress);
+    }
+
+    if asks_the_user_something(summary.response) {
+        return GateDecision::Conclusive(CompletionState::Blocked);
+    }
+
+    if summary.tool_calls_count == 0 {
+        // No tools, plain text: an answer, and nothing to second-guess.
+        GateDecision::Conclusive(CompletionState::Achieved)
+    } else {
+        GateDecision::Evaluate
+    }
+}
+
+/// A trailing question that also reads like a request for input.
+///
+/// The question mark alone is not enough — "shall I continue? I'll start with
+/// the parser." is not a block — so a marker phrase must appear too. Cheap and
+/// deliberately conservative: a missed block costs one wasted continuation,
+/// while a false block strands the user waiting.
+fn asks_the_user_something(response: &str) -> bool {
+    let normalized = response.trim().to_ascii_lowercase();
+    normalized.ends_with('?')
+        && ["need", "which", "what", "could you", "please provide"]
+            .iter()
+            .any(|marker| normalized.contains(marker))
+}
+
+/// Bounds automatic continuation for one user request.
+///
+/// Turns, tokens, and elapsed time are all enforced: a cheap loop exhausts
+/// turns, an expensive one exhausts tokens, and one that stalls on slow calls
+/// exhausts neither.
+#[derive(Clone, Debug)]
+pub struct ContinuationBudget {
+    started: Instant,
+    turns: u32,
+    tokens: u64,
+    max_turns: u32,
+    max_tokens: u64,
+    max_elapsed: Duration,
+}
+
+impl Default for ContinuationBudget {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_MAX_CONTINUATION_TURNS,
+            DEFAULT_MAX_CONTINUATION_TOKENS,
+            DEFAULT_MAX_CONTINUATION_ELAPSED,
+        )
+    }
+}
+
+impl ContinuationBudget {
+    /// Build a budget with explicit limits.
+    pub fn new(max_turns: u32, max_tokens: u64, max_elapsed: Duration) -> Self {
+        Self {
+            started: Instant::now(),
+            turns: 0,
+            tokens: 0,
+            max_turns,
+            max_tokens,
+            max_elapsed,
+        }
+    }
+
+    /// Start a fresh request, keeping the configured limits.
+    pub fn reset(&mut self) {
+        *self = Self::new(self.max_turns, self.max_tokens, self.max_elapsed);
+    }
+
+    /// Record a turn and report whether continuing stays within budget.
+    ///
+    /// The turn being recorded is counted first, so the call that crosses a
+    /// limit returns `false` — the budget is a ceiling on work done, not on
+    /// work attempted.
+    pub fn observe_turn(&mut self, tokens: u64) -> bool {
+        self.turns = self.turns.saturating_add(1);
+        self.tokens = self.tokens.saturating_add(tokens);
+        self.turns <= self.max_turns
+            && self.tokens <= self.max_tokens
+            && self.started.elapsed() <= self.max_elapsed
+    }
+
+    /// Turns and tokens spent so far.
+    pub fn usage(&self) -> (u32, u64) {
+        (self.turns, self.tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary<'a>(response: &'a str, tool_calls_count: usize, success: bool) -> TurnSummary<'a> {
+        TurnSummary {
+            success,
+            stop_reason: if success {
+                TurnStopReason::EndTurn
+            } else {
+                TurnStopReason::Error
+            },
+            response,
+            tool_calls_count,
+            has_active_background: false,
+        }
+    }
+
+    #[test]
+    fn plain_text_with_no_tools_is_achieved_without_an_evaluator() {
+        assert_eq!(
+            gate_turn(&summary("Here is the summary you asked for.", 0, true)),
+            GateDecision::Conclusive(CompletionState::Achieved)
+        );
+    }
+
+    #[test]
+    fn a_tool_only_turn_is_in_progress() {
+        assert_eq!(
+            gate_turn(&summary("", 1, true)),
+            GateDecision::Conclusive(CompletionState::InProgress)
+        );
+    }
+
+    #[test]
+    fn a_tool_only_turn_with_background_work_is_waiting_not_stalled() {
+        let mut view = summary("", 1, true);
+        view.has_active_background = true;
+        assert_eq!(
+            gate_turn(&view),
+            GateDecision::Conclusive(CompletionState::WaitingOnBackground)
+        );
+    }
+
+    #[test]
+    fn tool_using_candidate_final_answers_are_sent_for_evaluation() {
+        // The expensive case, and the only one: tools ran and text came back,
+        // so whether the request is done is a semantic question.
+        assert_eq!(
+            gate_turn(&summary("Done.", 3, true)),
+            GateDecision::Evaluate
+        );
+    }
+
+    #[test]
+    fn a_permanent_failure_never_continues() {
+        assert_eq!(
+            gate_turn(&summary("", 0, false)),
+            GateDecision::Conclusive(CompletionState::Failed)
+        );
+    }
+
+    #[test]
+    fn cancellation_is_blocked_rather_than_failed() {
+        // Blocked and Failed differ in what a host does next: a cancelled turn
+        // is the user's decision, not an error to report or retry.
+        let mut view = summary("", 0, false);
+        view.stop_reason = TurnStopReason::Cancelled;
+        assert_eq!(
+            gate_turn(&view),
+            GateDecision::Conclusive(CompletionState::Blocked)
+        );
+
+        let mut succeeded_but_cancelled = summary("partial", 1, true);
+        succeeded_but_cancelled.stop_reason = TurnStopReason::Cancelled;
+        assert_eq!(
+            gate_turn(&succeeded_but_cancelled),
+            GateDecision::Conclusive(CompletionState::Blocked)
+        );
+    }
+
+    #[test]
+    fn hitting_a_ceiling_is_in_progress_even_with_text() {
+        for stop_reason in [TurnStopReason::MaxTokens, TurnStopReason::MaxTurnRequests] {
+            let mut view = summary("I was in the middle of", 2, true);
+            view.stop_reason = stop_reason;
+            assert_eq!(
+                gate_turn(&view),
+                GateDecision::Conclusive(CompletionState::InProgress),
+                "{stop_reason:?} means stopped mid-task"
+            );
+        }
+    }
+
+    #[test]
+    fn a_question_back_to_the_user_blocks() {
+        assert_eq!(
+            gate_turn(&summary("Which environment should I deploy to?", 0, true)),
+            GateDecision::Conclusive(CompletionState::Blocked)
+        );
+    }
+
+    #[test]
+    fn a_rhetorical_question_does_not_block() {
+        // No marker phrase, so this stays an ordinary answer rather than
+        // stranding the user waiting for a reply nobody asked for.
+        assert_eq!(
+            gate_turn(&summary("Ready to ship?", 0, true)),
+            GateDecision::Conclusive(CompletionState::Achieved)
+        );
+    }
+
+    #[test]
+    fn the_budget_stops_at_the_turn_that_crosses_a_limit() {
+        let mut budget = ContinuationBudget::default();
+        for _ in 0..DEFAULT_MAX_CONTINUATION_TURNS {
+            assert!(budget.observe_turn(1));
+        }
+        assert!(!budget.observe_turn(1), "the ceiling is on work done");
+
+        budget.reset();
+        assert_eq!(budget.usage(), (0, 0));
+        assert!(!budget.observe_turn(DEFAULT_MAX_CONTINUATION_TOKENS + 1));
+        assert_eq!(
+            budget.usage(),
+            (1, DEFAULT_MAX_CONTINUATION_TOKENS + 1),
+            "the crossing turn is still recorded"
+        );
+    }
+
+    #[test]
+    fn an_elapsed_budget_stops_a_cheap_but_slow_loop() {
+        // Turns and tokens both untouched; only wall-clock is exhausted.
+        let mut budget = ContinuationBudget::new(100, u64::MAX, Duration::ZERO);
+        assert!(!budget.observe_turn(1));
+    }
+}

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -266,6 +266,28 @@ V1 limitation:
 - Background runs are best-effort and worker-local. They are started with `tokio::spawn` inside the worker process and are not yet durable across worker restarts.
 - This is intentional for the first iteration; durable resumption can be layered later without changing the tool contract.
 
+### Turn Completion Gate
+
+A turn ending is not the same as the user's request being done, and a host that
+auto-continues has to tell the difference: a tool-only turn stopped mid-task, a
+turn that asked a question is waiting on the user, a turn whose detached
+background run is still going is neither.
+
+`crates/core/src/turn_completion.rs` holds the cheap half of that judgement — a
+pure function over what the turn already reported (`success`, `stop_reason`,
+response text, tool-call count, whether background work is live). It decides the
+clear-cut cases and answers `Evaluate` on the one genuinely ambiguous case:
+tool-using work that produced a candidate final answer, where only a semantic
+check can tell. Hosts pay for that check on the small fraction of turns needing
+it, not on every turn.
+
+`ContinuationBudget` bounds what the host does next in turns, tokens, *and*
+wall-clock. All three, because each alone leaks: a cheap loop exhausts turns, an
+expensive one exhausts tokens, one stalled on slow calls exhausts neither.
+
+Distinct from the `usage_limit_auto_continue` capability, which resumes after a
+*provider* limit resets. This gate asks whether the work is finished.
+
 ### Tool-Call Cancellation
 
 Dropping the act future is how a cancelled turn stops tool work, and for a tool


### PR DESCRIPTION
## What changed

New `everruns_core::turn_completion`:

- `gate_turn(&TurnSummary) -> GateDecision` — classifies a finished turn as a conclusive `CompletionState` (`Achieved` / `Blocked` / `Failed` / `WaitingOnBackground` / `InProgress`) or `Evaluate`.
- `TurnSummary` — a view (success, stop reason, response text, tool-call count, live background work) rather than a concrete result type, so both the runtime's `TurnResult` and the in-memory loop's can feed it.
- `ContinuationBudget` — turns, tokens, and wall-clock ceilings for one user request.

Ported from yolop. Nothing in this repo calls it yet.

## Why

A turn ending is not the same as the user's request being done, and any host that auto-continues has to tell those apart. Yolop's version reads only what a turn already reports, so the classification is host-neutral even though the auto-continue policy around it is not.

**`Evaluate` is the design point.** Tool-using work that produced a candidate final answer is the one case a cheap check cannot settle — mutations and multi-step work are genuinely ambiguous. Making it a distinct verdict means a host pays for a semantic check (evaluator model, goal capability) on that fraction of turns only, instead of either running one every turn or guessing.

**Three budget limits, not one.** Each leaks alone: a cheap loop exhausts turns, an expensive one exhausts tokens, one stalled on slow calls exhausts neither.

This is distinct from `usage_limit_auto_continue`, which resumes work after a *provider* usage limit resets. That one asks "can we run yet"; this one asks "are we done".

## Before / After

No behavior change — additive module, no call sites.

```rust
match gate_turn(&TurnSummary { success, stop_reason, response, tool_calls_count, has_active_background }) {
    GateDecision::Conclusive(CompletionState::InProgress) if budget.observe_turn(tokens) => continue_turn(),
    GateDecision::Conclusive(state) => report(state),
    GateDecision::Evaluate => ask_the_evaluator().await,
}
```

## Risk

- Low
- Pure functions, no I/O, no call sites yet. The judgement calls are the two heuristics, both deliberately conservative and both tested: hitting a token/request ceiling is `InProgress` regardless of accompanying text, and a trailing question only blocks when it also carries a request-for-input marker — a bare "Ready to ship?" is an answer, not a block. A missed block costs one wasted continuation; a false block strands the user waiting, so the bias is toward continuing.

## Security

- Threat categories reviewed: no security-relevant code changes. Pure classification over values the turn already produced; no I/O, no external surface, no credential or user data handling beyond reading response text in memory.
- Worth noting for anyone wiring it: the budget is what keeps auto-continuation from becoming an unbounded spend loop, so a host that calls `gate_turn` without honoring `observe_turn` has a cost-availability problem of its own making.
- Findings and resolutions: none.

## Follow-ups

A capability that wires the gate to automatic continuation is the obvious next step, but it needs the host-policy half (what prompt to re-inject, when to give up visibly) and belongs with a consumer. Yolop keeps its policy and drops the classification once this ships.

## Checklist

- [x] Tests added or updated — 11 tests covering each conclusive state, both heuristics including the rhetorical-question false positive, cancellation-vs-failure, and all three budget limits including the elapsed-only case
- [x] Backward compatibility considered — additive module; nothing existing touched
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo test -p everruns-core --lib turn_completion`, `cargo fmt`, `cargo clippy -p everruns-core --lib --all-features` clean
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019nACLr5GqiemdHXVhuRdrc)_