### PR TITLE
feat(core): serializable TurnState with pure transitions (sans-IO stage 1)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -201,6 +201,7 @@ pub mod in_memory_loop;
 // Turn orchestration (state machine, context, outcomes)
 pub mod turn;
 pub mod turn_completion;
+pub mod turn_state;
 
 // Note: Chat Driver implementations (AnthropicChatDriver, OpenAIChatDriver) are now in
 // separate crates (everruns-anthropic, everruns-openai) that depend on everruns-core.

--- a/crates/core/src/turn.rs
+++ b/crates/core/src/turn.rs
@@ -173,7 +173,11 @@ impl TurnContext {
 }
 
 /// Current phase of turn execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializable because a durable host persists it between steps
+/// (`crate::turn_state::TurnState`); the in-memory machine only reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TurnPhase {
     /// Initial state, waiting to process input
     PendingInput,

--- a/crates/core/src/turn_state.rs
+++ b/crates/core/src/turn_state.rs
@@ -1,0 +1,585 @@
+//! The turn state machine as a serializable value with pure transitions.
+//!
+//! Stage 1 of `specs/sans-io-turn-state.md`. The loop is currently implemented
+//! twice: [`TurnStateMachine`](crate::turn::TurnStateMachine) is a mutable
+//! in-memory machine for the in-process host, and `RuntimeTurnState` +
+//! `plan_next_host_turn` (in `everruns-runtime`) is a serializable state plus a
+//! parallel planner for the durable host. Same phases, same transitions, two
+//! shapes, no way to derive one from the other — so every semantics change is
+//! made twice and nothing notices when it is made once.
+//!
+//! [`TurnState`] is the representation both can share: a value that serializes,
+//! with transitions that consume it and return the next one. It holds exactly
+//! what the mutable machine holds and behaves identically — the conformance
+//! test in this module drives the same sequences through both and asserts the
+//! same actions and outcomes.
+//!
+//! Nothing is rewired yet. This module is a representation and its proof; the
+//! stages that fold in the durable bookkeeping, introduce effects, and move
+//! recording out of the atoms are described in the spec.
+//!
+//! No I/O belongs here, ever. That is the property the later stages depend on:
+//! a transition that loads or emits is a transition a durable host cannot
+//! replay.
+
+use serde::{Deserialize, Serialize};
+
+use crate::turn::{SealReason, TurnAction, TurnOutcome, TurnPhase, TurnStopReason};
+use crate::typed_id::{AgentId, MessageId, SessionId, TurnId};
+
+/// Turn-scoped identifiers, in a form that survives a round trip through
+/// storage.
+///
+/// Mirrors [`TurnContext`](crate::turn::TurnContext), which is not
+/// serializable. Stage 2 collapses the two.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnIds {
+    /// Session this turn belongs to.
+    pub session_id: SessionId,
+    /// This turn's identifier, fixed at creation and used to correlate events.
+    pub turn_id: TurnId,
+    /// The user message that started the turn.
+    pub input_message_id: MessageId,
+    /// Agent executing the turn.
+    pub agent_id: AgentId,
+    /// Owning organization.
+    pub org_id: i64,
+}
+
+impl From<&crate::turn::TurnContext> for TurnIds {
+    fn from(context: &crate::turn::TurnContext) -> Self {
+        Self {
+            session_id: context.session_id,
+            turn_id: context.turn_id,
+            input_message_id: context.input_message_id,
+            agent_id: context.agent_id,
+            org_id: context.org_id,
+        }
+    }
+}
+
+/// What the model reported when a reason step finished.
+///
+/// A struct rather than six positional arguments because every caller of the
+/// mutable machine's `on_reason_completed` has to get the order right, and two
+/// of the six are `Option<String>`.
+#[derive(Debug, Clone, Default)]
+pub struct ReasonReport {
+    /// Text the model produced; empty is normal for a tool-calling step.
+    pub response: String,
+    /// How many tool calls the model requested.
+    pub tool_call_count: usize,
+    /// Whether the call itself succeeded.
+    pub success: bool,
+    /// Failure message when `success` is false.
+    pub error: Option<String>,
+    /// Raw provider finish reason, normalized on the way in.
+    pub finish_reason: Option<String>,
+    /// Whether new user messages arrived mid-turn (in-turn steering). When the
+    /// step would otherwise end the turn, this sends it back to reason so the
+    /// next iteration picks them up.
+    pub has_pending_user_messages: bool,
+}
+
+impl ReasonReport {
+    /// A successful step that produced `response` and requested no tools.
+    pub fn text(response: impl Into<String>) -> Self {
+        Self {
+            response: response.into(),
+            success: true,
+            ..Default::default()
+        }
+    }
+
+    /// A successful step that requested `tool_call_count` tools.
+    pub fn tool_calls(response: impl Into<String>, tool_call_count: usize) -> Self {
+        Self {
+            response: response.into(),
+            tool_call_count,
+            success: true,
+            ..Default::default()
+        }
+    }
+
+    /// A failed step.
+    pub fn failed(error: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            error: Some(error.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Set the provider finish reason.
+    pub fn with_finish_reason(mut self, finish_reason: impl Into<String>) -> Self {
+        self.finish_reason = Some(finish_reason.into());
+        self
+    }
+
+    /// Mark that user messages arrived during the turn.
+    pub fn with_pending_user_messages(mut self) -> Self {
+        self.has_pending_user_messages = true;
+        self
+    }
+}
+
+/// A turn's orchestration state: phase plus the bookkeeping needed to decide
+/// what happens next and what the turn's outcome is.
+///
+/// Transitions consume `self` and return the next state, so a caller cannot
+/// half-apply one or hold a stale copy by accident.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnState {
+    /// Turn-scoped identifiers.
+    pub ids: TurnIds,
+    phase: TurnPhase,
+    max_iterations: usize,
+    current_iteration: usize,
+    total_tool_calls: usize,
+    last_response: String,
+    pending_error: Option<String>,
+    pending_stop_reason: TurnStopReason,
+    has_pending_tool_calls: bool,
+    pending_seal: Option<SealReason>,
+}
+
+impl TurnState {
+    /// Start a turn, waiting on its input step.
+    pub fn new(ids: TurnIds, max_iterations: usize) -> Self {
+        Self {
+            ids,
+            phase: TurnPhase::PendingInput,
+            max_iterations,
+            current_iteration: 0,
+            total_tool_calls: 0,
+            last_response: String::new(),
+            pending_error: None,
+            pending_stop_reason: TurnStopReason::EndTurn,
+            has_pending_tool_calls: false,
+            pending_seal: None,
+        }
+    }
+
+    /// Current phase.
+    pub fn phase(&self) -> TurnPhase {
+        self.phase
+    }
+
+    /// Reason→act cycles completed so far.
+    pub fn current_iteration(&self) -> usize {
+        self.current_iteration
+    }
+
+    /// Tool calls executed across the turn.
+    pub fn total_tool_calls(&self) -> usize {
+        self.total_tool_calls
+    }
+
+    /// Whether the last reason step left tool calls to run.
+    pub fn has_pending_tool_calls(&self) -> bool {
+        self.has_pending_tool_calls
+    }
+
+    /// Whether the turn has reached a terminal phase.
+    pub fn is_completed(&self) -> bool {
+        self.phase == TurnPhase::Completed
+    }
+
+    /// What the host should do next.
+    ///
+    /// Pure: calling it twice on the same state yields the same action, and it
+    /// never advances anything.
+    pub fn next_action(&self) -> TurnAction {
+        match self.phase {
+            TurnPhase::PendingInput => TurnAction::ExecuteInput,
+            TurnPhase::PendingReason => TurnAction::ExecuteReason,
+            TurnPhase::PendingAct => TurnAction::ExecuteAct,
+            TurnPhase::Completed => TurnAction::Complete(self.outcome()),
+        }
+    }
+
+    /// The outcome a completed turn resolves to.
+    ///
+    /// A deliberate seal wins over everything else: budget exhaustion must
+    /// resolve to `Sealed` rather than looking like a failure or leaving the
+    /// turn reclaimable.
+    fn outcome(&self) -> TurnOutcome {
+        if let Some(reason) = self.pending_seal {
+            return TurnOutcome::Sealed {
+                reason,
+                response: self.last_response.clone(),
+                iterations: self.current_iteration,
+                tool_calls_count: self.total_tool_calls,
+            };
+        }
+        if let Some(error) = &self.pending_error {
+            return TurnOutcome::Failed {
+                error: error.clone(),
+                iterations: self.current_iteration,
+                stop_reason: self.pending_stop_reason,
+            };
+        }
+        // Reaching the ceiling is the terminal, whether or not tool calls were
+        // left unrun. (Mirrors `TurnStateMachine`; the conformance test fails if
+        // this drifts, which is how the extra condition tried here was caught.)
+        if self.current_iteration >= self.max_iterations {
+            return TurnOutcome::MaxIterationsReached {
+                response: self.last_response.clone(),
+                iterations: self.current_iteration,
+                tool_calls_count: self.total_tool_calls,
+            };
+        }
+        TurnOutcome::Success {
+            response: self.last_response.clone(),
+            iterations: self.current_iteration,
+            tool_calls_count: self.total_tool_calls,
+            stop_reason: self.pending_stop_reason,
+        }
+    }
+
+    /// The input step recorded the user message.
+    pub fn on_input_completed(mut self) -> Self {
+        debug_assert_eq!(self.phase, TurnPhase::PendingInput);
+        self.phase = TurnPhase::PendingReason;
+        self
+    }
+
+    /// A reason step finished.
+    pub fn on_reason_completed(mut self, report: ReasonReport) -> Self {
+        debug_assert_eq!(self.phase, TurnPhase::PendingReason);
+
+        self.current_iteration += 1;
+
+        if !report.response.is_empty() {
+            self.last_response = report.response;
+        }
+
+        if !report.success {
+            // A refusal is a distinct terminal; anything else that failed is an
+            // error, whatever the provider called it.
+            self.pending_stop_reason = match TurnStopReason::from_provider_finish_reason(
+                report.finish_reason.as_deref(),
+            ) {
+                TurnStopReason::Refusal => TurnStopReason::Refusal,
+                _ => TurnStopReason::Error,
+            };
+            self.pending_error = report.error;
+            self.phase = TurnPhase::Completed;
+            return self;
+        }
+
+        self.pending_stop_reason =
+            TurnStopReason::from_provider_finish_reason(report.finish_reason.as_deref());
+
+        if report.tool_call_count > 0 {
+            // The ceiling is checked before anything is recorded: calls that
+            // will never run are not counted, and the turn ends with them
+            // unrun rather than running one more batch. `total_tool_calls` is
+            // therefore a count of executed calls, not requested ones.
+            if self.current_iteration >= self.max_iterations {
+                self.phase = TurnPhase::Completed;
+                return self;
+            }
+            self.has_pending_tool_calls = true;
+            self.total_tool_calls += report.tool_call_count;
+            self.phase = TurnPhase::PendingAct;
+        } else if report.has_pending_user_messages {
+            // Steering: keep reasoning so the next iteration sees the new
+            // messages — but the ceiling still applies, or a steady stream of
+            // user messages loops forever.
+            self.phase = if self.current_iteration >= self.max_iterations {
+                TurnPhase::Completed
+            } else {
+                TurnPhase::PendingReason
+            };
+        } else {
+            self.phase = TurnPhase::Completed;
+        }
+        self
+    }
+
+    /// The act step finished; loop back to reason.
+    pub fn on_act_completed(mut self) -> Self {
+        debug_assert_eq!(self.phase, TurnPhase::PendingAct);
+        self.has_pending_tool_calls = false;
+        self.phase = TurnPhase::PendingReason;
+        self
+    }
+
+    /// Deliberately stop the turn to prevent waste.
+    ///
+    /// Idempotent, and the first reason wins: a turn sealed for no-progress
+    /// that later trips the budget check is still a no-progress seal.
+    pub fn seal(mut self, reason: SealReason) -> Self {
+        if self.pending_seal.is_none() {
+            self.pending_seal = Some(reason);
+        }
+        self.phase = TurnPhase::Completed;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::turn::{TurnContext, TurnStateMachine};
+
+    fn ids() -> TurnIds {
+        TurnIds::from(&TurnContext::new(
+            SessionId::new(),
+            MessageId::new(),
+            AgentId::new(),
+            0,
+        ))
+    }
+
+    fn state(max_iterations: usize) -> TurnState {
+        TurnState::new(ids(), max_iterations)
+    }
+
+    /// One step in a turn, applied to either representation.
+    #[derive(Clone, Debug)]
+    enum Step {
+        Input,
+        Reason(ReasonReport),
+        Act,
+        Seal(SealReason),
+    }
+
+    /// Drive both representations through the same steps and assert they agree
+    /// at every point. This is the whole claim of stage 1: the value can
+    /// replace the mutable machine because it already behaves like it.
+    fn assert_equivalent(max_iterations: usize, steps: Vec<Step>) {
+        let context = TurnContext::new(SessionId::new(), MessageId::new(), AgentId::new(), 0);
+        let mut machine = TurnStateMachine::new(context.clone(), max_iterations);
+        let mut value = TurnState::new(TurnIds::from(&context), max_iterations);
+
+        assert_actions_match(&machine, &value, "before any step");
+
+        for (index, step) in steps.into_iter().enumerate() {
+            match step {
+                Step::Input => {
+                    machine.on_input_completed();
+                    value = value.on_input_completed();
+                }
+                Step::Reason(report) => {
+                    machine.on_reason_completed(
+                        report.response.clone(),
+                        report.tool_call_count,
+                        report.success,
+                        report.error.clone(),
+                        report.finish_reason.clone(),
+                        report.has_pending_user_messages,
+                    );
+                    value = value.on_reason_completed(report);
+                }
+                Step::Act => {
+                    machine.on_act_completed();
+                    value = value.on_act_completed();
+                }
+                Step::Seal(reason) => {
+                    machine.seal(reason);
+                    value = value.seal(reason);
+                }
+            }
+            assert_actions_match(&machine, &value, &format!("after step {index}"));
+        }
+    }
+
+    fn assert_actions_match(machine: &TurnStateMachine, value: &TurnState, at: &str) {
+        assert_eq!(machine.phase(), value.phase(), "phase diverged {at}");
+        assert_eq!(
+            machine.current_iteration(),
+            value.current_iteration(),
+            "iteration diverged {at}"
+        );
+        assert_eq!(
+            machine.total_tool_calls(),
+            value.total_tool_calls(),
+            "tool-call count diverged {at}"
+        );
+        assert_eq!(
+            format!("{:?}", machine.next_action()),
+            format!("{:?}", value.next_action()),
+            "next action diverged {at}"
+        );
+    }
+
+    #[test]
+    fn equivalent_on_a_plain_answer() {
+        assert_equivalent(
+            10,
+            vec![Step::Input, Step::Reason(ReasonReport::text("Hi"))],
+        );
+    }
+
+    #[test]
+    fn equivalent_on_a_tool_call_round_trip() {
+        assert_equivalent(
+            10,
+            vec![
+                Step::Input,
+                Step::Reason(ReasonReport::tool_calls("Checking…", 2)),
+                Step::Act,
+                Step::Reason(ReasonReport::text("Done.")),
+            ],
+        );
+    }
+
+    #[test]
+    fn equivalent_when_the_iteration_ceiling_is_hit() {
+        assert_equivalent(
+            2,
+            vec![
+                Step::Input,
+                Step::Reason(ReasonReport::tool_calls("one", 1)),
+                Step::Act,
+                Step::Reason(ReasonReport::tool_calls("two", 1)),
+            ],
+        );
+    }
+
+    #[test]
+    fn equivalent_on_failure_and_refusal() {
+        assert_equivalent(
+            10,
+            vec![Step::Input, Step::Reason(ReasonReport::failed("boom"))],
+        );
+        assert_equivalent(
+            10,
+            vec![
+                Step::Input,
+                Step::Reason(ReasonReport::failed("refused").with_finish_reason("content_filter")),
+            ],
+        );
+    }
+
+    #[test]
+    fn equivalent_on_in_turn_steering() {
+        assert_equivalent(
+            10,
+            vec![
+                Step::Input,
+                Step::Reason(ReasonReport::text("partial").with_pending_user_messages()),
+                Step::Reason(ReasonReport::text("final")),
+            ],
+        );
+    }
+
+    #[test]
+    fn equivalent_when_steering_hits_the_ceiling() {
+        assert_equivalent(
+            1,
+            vec![
+                Step::Input,
+                Step::Reason(ReasonReport::text("partial").with_pending_user_messages()),
+            ],
+        );
+    }
+
+    #[test]
+    fn equivalent_on_a_seal_mid_turn() {
+        assert_equivalent(
+            10,
+            vec![
+                Step::Input,
+                Step::Reason(ReasonReport::tool_calls("working", 1)),
+                Step::Seal(SealReason::Budget),
+            ],
+        );
+    }
+
+    #[test]
+    fn a_seal_keeps_its_first_reason() {
+        let sealed = state(10)
+            .on_input_completed()
+            .seal(SealReason::NoProgress)
+            .seal(SealReason::Budget);
+
+        match sealed.next_action() {
+            TurnAction::Complete(TurnOutcome::Sealed { reason, .. }) => {
+                assert_eq!(reason, SealReason::NoProgress);
+            }
+            other => panic!("expected a seal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn next_action_does_not_advance_the_state() {
+        let value = state(10).on_input_completed();
+        let before = value.clone();
+        let _ = value.next_action();
+        let _ = value.next_action();
+        assert_eq!(value, before);
+    }
+
+    #[test]
+    fn state_survives_a_round_trip_through_storage() {
+        // The property the durable host needs: persist mid-turn, resume, and
+        // continue as if nothing happened.
+        let mid_turn = state(10)
+            .on_input_completed()
+            .on_reason_completed(ReasonReport::tool_calls("checking", 3));
+
+        let json = serde_json::to_string(&mid_turn).expect("serialize");
+        let resumed: TurnState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(resumed, mid_turn);
+        assert!(matches!(resumed.next_action(), TurnAction::ExecuteAct));
+
+        let finished = resumed
+            .on_act_completed()
+            .on_reason_completed(ReasonReport::text("done"));
+        match finished.next_action() {
+            TurnAction::Complete(TurnOutcome::Success {
+                response,
+                iterations,
+                tool_calls_count,
+                ..
+            }) => {
+                assert_eq!(response, "done");
+                assert_eq!(iterations, 2);
+                assert_eq!(tool_calls_count, 3);
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replaying_from_storage_at_every_step_matches_holding_it_in_memory() {
+        // The durable path in miniature: throw the value away after each
+        // transition and rebuild it from bytes. Any hidden state that does not
+        // serialize shows up here as a divergence.
+        let steps = vec![
+            Step::Input,
+            Step::Reason(ReasonReport::tool_calls("a", 1)),
+            Step::Act,
+            Step::Reason(ReasonReport::tool_calls("b", 2)),
+            Step::Act,
+            Step::Reason(ReasonReport::text("done")),
+        ];
+
+        let mut in_memory = state(10);
+        let mut round_tripped = state(10);
+        // Same ids on both sides so the comparison is about phase/bookkeeping.
+        round_tripped.ids = in_memory.ids.clone();
+
+        for step in steps {
+            let apply = |value: TurnState, step: &Step| match step {
+                Step::Input => value.on_input_completed(),
+                Step::Reason(report) => value.on_reason_completed(report.clone()),
+                Step::Act => value.on_act_completed(),
+                Step::Seal(reason) => value.seal(*reason),
+            };
+            in_memory = apply(in_memory, &step);
+            round_tripped = apply(round_tripped, &step);
+            let bytes = serde_json::to_vec(&round_tripped).expect("serialize");
+            round_tripped = serde_json::from_slice(&bytes).expect("deserialize");
+            assert_eq!(round_tripped, in_memory);
+        }
+
+        assert!(matches!(
+            in_memory.next_action(),
+            TurnAction::Complete(TurnOutcome::Success { .. })
+        ));
+    }
+}

--- a/specs/README.md
+++ b/specs/README.md
@@ -27,6 +27,7 @@ detail. Stale "current" lists (current flags, current statuses) should become li
 
 - `specs/concepts.md` - Core entities, relationships, and concept diagram
 - `specs/architecture.md` - System architecture, crate structure, infrastructure
+- `specs/sans-io-turn-state.md` - Converging the two turn-loop implementations on one serializable state with pure transitions (staged)
 - `specs/code-organization.md` - Developer conventions: formatting, testing, error handling, UI patterns
 - `specs/models.md` - Data models (Agent, Session, Message, etc.)
 - `specs/id-schema.md` - Standardized prefixed ID format

--- a/specs/sans-io-turn-state.md
+++ b/specs/sans-io-turn-state.md
@@ -1,0 +1,153 @@
+# Sans-IO Turn State
+
+## Abstract
+
+The turn loop is implemented twice. `TurnStateMachine`
+(`crates/core/src/turn.rs`) is a mutable, in-memory machine driven by the
+in-process runtime; `RuntimeTurnState` + `plan_next_host_turn`
+(`crates/runtime/src/turn_strategy.rs`) is a serializable state plus a planner
+driven by the durable worker. They encode the same phases and the same
+transitions, in different shapes, and neither can be derived from the other.
+
+This spec proposes converging them on one **sans-IO** representation: a
+serializable `TurnState` whose transitions are pure functions, with all I/O —
+loading messages, calling the model, running tools, emitting events, persisting
+— performed by the host that drives it. The intended end state is that a durable
+host is an in-process host that persists between steps, rather than a second
+implementation of the same loop.
+
+Status: **stage 1 landed** (the value type and its equivalence proof). Later
+stages are proposals, not commitments.
+
+## Motivation
+
+**Two representations drift.** Every change to turn semantics has to be made in
+both places, and nothing detects when it is made in only one. The bug fixed in
+#2937 — a turn that died between the model call and the recording of its result
+left state the host had to reconstruct by hand — is the shape of failure this
+produces: the durable path had to re-derive knowledge that the in-process path
+simply held in memory.
+
+**Atoms own their I/O, so the machine is not the whole truth.** `ReasonAtom`
+loads messages, calls the provider, emits events, and stores results;
+`ActAtom` does the same around tools. What a turn "is" therefore lives partly in
+the state machine, partly in whatever each atom did on the way through, and
+partly in what the host persisted between steps. Reconstructing a turn means
+knowing all three.
+
+**The consequences compound at the edges.** Crash recovery, cancellation
+mid-phase, sealing, and replay each need to answer "what had already happened?"
+Today each answers it separately, which is why `RuntimeTurnState` accumulated
+fields (`llm_call_count`, `time_to_first_token_ms`, `final_answer_preview`) that
+exist to reconstruct what the in-process path never lost.
+
+## What sans-IO means here
+
+A transition is a pure function of the state and the result being reported:
+
+```text
+(TurnState, TransitionInput) -> (TurnState, Vec<TurnEffect>)
+```
+
+The state machine never loads, stores, or emits. It *returns* what should be
+recorded, and the host performs it. Three properties follow, and they are the
+point:
+
+1. **A turn is exactly its events plus a serializable state.** Resuming is
+   deserializing, not reconstructing.
+2. **One implementation, two hosts.** An in-process host applies effects
+   immediately; a durable host persists the state and schedules the next step.
+   Neither owns semantics, so they cannot disagree about them.
+3. **The loop is testable without a provider or a database.** Transition tests
+   are table tests over values.
+
+## Non-goals
+
+- Changing turn semantics. Every stage is behavior-preserving; a stage that
+  changes what a turn does is a different change.
+- Removing atoms. Atoms stay as the units of work; what moves is who performs
+  their side effects.
+- Replacing the durable engine. Task scheduling, retries, and the DLQ are
+  unaffected — the durable host keeps owning those.
+
+## Staged migration
+
+Each stage is independently shippable and independently revertible. A stage that
+cannot be verified against current behavior does not ship.
+
+### Stage 1 — the value (landed)
+
+`crates/core/src/turn_state.rs`: a serializable `TurnState` with consuming
+transitions and a pure `next_action`. It mirrors `TurnStateMachine`'s semantics
+exactly, and a conformance test drives identical sequences through both and
+asserts the same actions and outcomes.
+
+Nothing is rewired. The deliverable is a representation both hosts *could*
+share, plus the evidence that it behaves identically.
+
+### Stage 2 — fold in the durable bookkeeping
+
+Move `RuntimeTurnState`'s fields (iteration, call counts, cumulative usage,
+`previous_response_id`, first-token timing, final-answer preview) onto
+`TurnState`, so one value carries everything a resume needs. `plan_next_host_turn`
+becomes a thin projection of `next_action` rather than a parallel planner.
+
+This is where the two representations actually converge, and it is the stage
+that pays for stage 1.
+
+### Stage 3 — introduce effects
+
+Add `TurnEffect` and have transitions return the events that must be recorded.
+Both hosts apply them through one applier. Atoms still emit their own events at
+this stage; the effect list is asserted against what they emit, which is how the
+vocabulary is kept honest rather than invented.
+
+### Stage 4 — move the recording out of the atoms
+
+One effect at a time: an atom stops emitting, the transition returns the effect
+instead, the applier performs it. Each move is a small PR with an unchanged
+event stream as its success bar (event-sequence tests over a fixed scenario).
+
+### Stage 5 — the durable host becomes a persisting in-process host
+
+With no I/O left in the machine, the durable path reduces to: deserialize state,
+apply one operation, serialize, schedule. The parallel planner is deleted.
+
+## Success bars
+
+- **Behavior-preserving.** For a fixed scenario, the emitted event sequence
+  before and after each stage is identical. This is the primary bar; a stage
+  that cannot demonstrate it does not ship.
+- **No new representation.** The stage that adds a field to `TurnState` removes
+  it from `RuntimeTurnState` in the same change. Two copies of a field is the
+  failure mode this whole effort exists to remove.
+- **Durable equivalence.** A test that discards `TurnState` at every step and
+  rebuilds it from the serialized value must produce the same outcome as one
+  that keeps it in memory (agentyk's
+  `durable_host_replays_state_between_every_engine_step` is the model).
+- **Revertibility.** Until stage 5, `TurnStateMachine` stays; any stage can be
+  reverted without a migration.
+
+## Alternatives considered
+
+**Leave it.** The cost is ongoing: every turn-semantics change is made twice,
+and the failures show up in the durable path under crash and cancellation —
+the hardest place to notice them and the most expensive place to debug.
+
+**Rewrite the durable path onto the in-memory machine.** Cheaper, and wrong:
+the mutable machine cannot be persisted mid-turn, which is the durable host's
+whole requirement.
+
+**Adopt agentyk's engine wholesale.** Agentyk built this shape from scratch
+(`knowledge/foundations/plan.md`, Phase 2) and has the design worked out, but
+adopting it means adopting its `Agent`/`Session` model along with everything
+core layers on top — identity, catalog, persistence, tenancy. The staged
+migration takes the idea without the rebuild, and leaves the door open to
+converge later.
+
+## References
+
+- `crates/core/src/turn.rs` — `TurnStateMachine`, `TurnPhase`, `TurnAction`, `TurnOutcome`
+- `crates/core/src/turn_state.rs` — the stage-1 value
+- `crates/runtime/src/turn_strategy.rs` — `RuntimeTurnState`, `plan_next_host_turn`
+- `specs/durable-execution-engine.md` — the durable host this converges with


### PR DESCRIPTION
## What changed

Two things, and deliberately only two:

**`specs/sans-io-turn-state.md`** — why the turn loop should converge on one sans-IO representation, and a five-stage migration where each stage is independently shippable and revertible. Non-goals are explicit (no semantics change, atoms stay, the durable engine is untouched), and so are the success bars — the primary one being an unchanged event sequence for a fixed scenario at every stage.

**`crates/core/src/turn_state.rs`** — stage 1: `TurnState`, a serializable value with transitions that consume it and return the next one, plus a pure `next_action()`. `ReasonReport` replaces six positional arguments, two of which are `Option<String>`.

Nothing is rewired. `TurnStateMachine` and `RuntimeTurnState` both still run the show.

## Why

The loop exists twice: `TurnStateMachine` (mutable, in-memory, in-process host) and `RuntimeTurnState` + `plan_next_host_turn` (serializable + a parallel planner, durable host). Same phases, same transitions, two shapes, neither derivable from the other — so every semantics change is made twice and nothing detects when it is made once.

#2937 is the shape of failure this produces: a turn that died between the model call and the recording of its result left state the durable path had to reconstruct by hand, because the in-process path had simply held it in memory. `RuntimeTurnState` accumulated `llm_call_count`, `time_to_first_token_ms`, `final_answer_preview` for exactly that reason.

Stage 1 does not fix that. It produces the representation the fix needs, and proves it can stand in for the current machine before anything depends on it.

## Before / After

No behavior change — additive module, no call sites. The intended end state, several stages out, is that a durable host is an in-process host that persists between steps rather than a second implementation of the loop.

## Risk

- Low
- Additive. The only change to existing code is `TurnPhase` gaining `Serialize`/`Deserialize` (it is now persisted as part of the state).
- The real risk in this kind of work is a value that *looks* equivalent, which is why the conformance test is the deliverable rather than a nicety — see below.

## Security

- Threat categories reviewed: no security-relevant code changes. Pure state transitions over values already in the turn loop; no I/O, no new external surface, no credential or tenant-boundary logic. `TurnState` carries the same identifiers `TurnContext` already does.
- One thing to watch in later stages, noted in the spec: once transitions return effects, the applier becomes the single place where turn events are recorded, and it must stay tenant-scoped the way the atoms are today.
- Findings and resolutions: none.

## Follow-ups

Stage 2 (fold `RuntimeTurnState`'s durable bookkeeping into `TurnState`, reduce `plan_next_host_turn` to a projection of `next_action`) is the stage that pays for this one. Stages 3–5 (effects, moving recording out of the atoms one effect at a time, deleting the parallel planner) are in the spec as proposals, not commitments.

## Checklist

- [x] Tests added or updated — 11 tests. Eight drive identical step sequences through **both** the machine and the value, asserting matching phase, iteration, tool-call count, and next action at every point (plain answer, tool round trip, iteration ceiling, failure, refusal, in-turn steering, steering-into-ceiling, mid-turn seal). Plus: `next_action` does not advance state, a mid-turn serialize/resume, and a replay test that discards the value after *every* transition and rebuilds it from bytes — the durable path in miniature, where non-serializing hidden state shows up as a divergence.
- [x] Backward compatibility considered — additive; `TurnStateMachine` untouched and still the only thing wired up
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo test -p everruns-core --lib turn` (147 passed), `cargo check --workspace`, `cargo fmt`, `cargo clippy -p everruns-core --lib --all-features` clean
- [x] All review comments addressed (code change or written reasoning)

Worth flagging for review: the conformance test caught two divergences in code I had written from a careful reading of the machine — a `MaxIterationsReached` condition that did not match, and counting tool calls that the ceiling means will never run (the machine returns before recording them, so `total_tool_calls` counts *executed* calls, not requested ones). Both are exactly the kind of drift the whole effort is about, found in the first hour of writing the second implementation.

---
_Generated by [Claude Code](https://claude.ai/code/session_019nACLr5GqiemdHXVhuRdrc)_