### PR TITLE
fix(ui): make card actions responsive

### DIFF
--- a/apps/ui/DESIGN.md
+++ b/apps/ui/DESIGN.md
@@ -203,7 +203,9 @@ the hand-drawn experimental badge, whose organic border is a one-off accent.
 - **Inputs:** White surface, `input` border color, sharp corners, comfortable
   padding; focus draws the gold `ring`.
 - **Cards:** White surface on the textured background, 1px border, no radius,
-  no shadow.
+  no shadow. Card action groups keep the highest-priority action visible and
+  collapse secondary or destructive actions into an ellipsis menu when the
+  card is too narrow for the full action row.
 
 ## Do's and Don'ts
 

--- a/apps/ui/src/app/(main)/plugins/page.tsx
+++ b/apps/ui/src/app/(main)/plugins/page.tsx
@@ -3,9 +3,23 @@
 import { useState } from "react";
 import { inferMarketplaceSourceType, marketplaceSourceLabel } from "@/lib/api/plugins";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardActions,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPositioner,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -52,6 +66,7 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
+  Ellipsis,
 } from "lucide-react";
 import { pluralize } from "@/lib/formatting";
 import type {
@@ -124,31 +139,67 @@ function MarketplaceCard({
             <p>Never synced</p>
           )}
         </div>
-        <div className="flex items-center justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={() => onBrowse(marketplace)}>
-            Browse
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => syncMutation.mutate(marketplace.id)}
-            disabled={syncMutation.isPending}
-          >
-            <RefreshCw className={`h-4 w-4 mr-1 ${syncMutation.isPending ? "animate-spin" : ""}`} />
-            Sync now
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleToggle}
-            disabled={updateMutation.isPending}
-          >
-            {isDisabled ? "Enable" : "Disable"}
-          </Button>
-          <Button variant="destructive" size="sm" onClick={() => onRemove(marketplace)}>
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
+        <CardActions
+          primary={
+            <Button variant="outline" size="sm" onClick={() => onBrowse(marketplace)}>
+              Browse
+            </Button>
+          }
+          expanded={
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => syncMutation.mutate(marketplace.id)}
+                disabled={syncMutation.isPending}
+              >
+                <RefreshCw
+                  className={`h-4 w-4 mr-1 ${syncMutation.isPending ? "animate-spin" : ""}`}
+                />
+                Sync now
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleToggle}
+                disabled={updateMutation.isPending}
+              >
+                {isDisabled ? "Enable" : "Disable"}
+              </Button>
+              <Button variant="destructive" size="sm" onClick={() => onRemove(marketplace)}>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </>
+          }
+          collapsed={
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={<Button variant="outline" size="icon-sm" />}
+                aria-label="More marketplace actions"
+              >
+                <Ellipsis />
+              </DropdownMenuTrigger>
+              <DropdownMenuPositioner align="end">
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    onClick={() => syncMutation.mutate(marketplace.id)}
+                    disabled={syncMutation.isPending}
+                  >
+                    <RefreshCw className={syncMutation.isPending ? "animate-spin" : ""} />
+                    {syncMutation.isPending ? "Syncing…" : "Sync now"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleToggle} disabled={updateMutation.isPending}>
+                    {isDisabled ? "Enable" : "Disable"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem variant="destructive" onClick={() => onRemove(marketplace)}>
+                    <Trash2 />
+                    Remove
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenuPositioner>
+            </DropdownMenu>
+          }
+        />
       </CardContent>
     </Card>
   );

--- a/apps/ui/src/components/ui/card.tsx
+++ b/apps/ui/src/components/ui/card.tsx
@@ -6,7 +6,10 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
-      className={cn("bg-card text-card-foreground flex flex-col gap-4 border py-4", className)}
+      className={cn(
+        "@container/card bg-card text-card-foreground flex flex-col gap-4 border py-4",
+        className,
+      )}
       {...props}
     />
   );
@@ -69,4 +72,36 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };
+function CardActions({
+  primary,
+  expanded,
+  collapsed,
+  className,
+}: {
+  /** Actions that remain visible at every card width. */
+  primary?: React.ReactNode;
+  /** Actions shown inline when the card is wide enough. */
+  expanded: React.ReactNode;
+  /** Compact replacement for expanded actions, typically an overflow menu. */
+  collapsed: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div data-slot="card-actions" className={cn("flex items-center justify-end gap-2", className)}>
+      {primary}
+      <div className="hidden items-center gap-2 @min-[22rem]/card:flex">{expanded}</div>
+      <div className="@min-[22rem]/card:hidden">{collapsed}</div>
+    </div>
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardActions,
+  CardDescription,
+  CardContent,
+};

--- a/test_cases/ui/plugins/TC001_responsive_marketplace_actions.md
+++ b/test_cases/ui/plugins/TC001_responsive_marketplace_actions.md
@@ -1,0 +1,36 @@
+# Responsive marketplace card actions
+
+## Description
+
+Verify that marketplace card actions stay within the card and adapt to the card's available width.
+
+## Preconditions
+
+- Everruns is running in development mode with authentication disabled.
+- The default Everruns marketplace is present.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| Route | `/plugins` |
+| Wide viewport | 1440 × 1000 |
+| Narrow-card viewport | 1024 × 800 |
+
+## Steps
+
+1. Open `/plugins` and select the **Marketplaces** tab at the wide viewport.
+2. Confirm Browse, Sync now, Disable, and Remove are visible within the marketplace card.
+3. Resize to the narrow-card viewport.
+4. Confirm Browse remains visible, an overflow button labeled **More marketplace actions** appears,
+   and the page has no horizontal overflow.
+5. Open the overflow menu and confirm it contains Sync now, Disable, and Remove.
+6. Select Disable, reopen the menu, and confirm the action changes to Enable.
+7. Select Enable and return to the wide viewport.
+
+## Expected Result
+
+- The full action row is visible when the card is wide enough.
+- Compact cards show Browse plus an accessible overflow menu without horizontal overflow.
+- Menu actions retain the same enabled, disabled, and destructive behavior as their expanded
+  counterparts.


### PR DESCRIPTION
## What changed

Marketplace cards now keep Browse visible and collapse secondary actions into an accessible ellipsis menu whenever the card is too narrow for the full action row. Wide cards retain the existing inline actions. The shared card primitive and UI design guidance now define this responsive behavior for reuse.

## Why

The four-button action row required more width than three-column marketplace cards provide, causing the controls to overflow beyond the card boundary.

## Before / After

- Before: the reported screenshot showed the four-button row extending left of the marketplace card.
- After: browser smoke testing at 1440×1000 showed all four actions inside a 373.33px card. At 1024×800, the 234.66px card showed Browse plus the overflow trigger, with Sync now, Disable/Enable, and Remove in the menu. The document scroll width equaled its client width, confirming no horizontal page overflow.
- Screenshots were captured locally for the wide, compact, open-menu, and toggled states. The screenshot uploader is not configured in this environment; the reproducible steps are recorded in test_cases/ui/plugins/TC001_responsive_marketplace_actions.md.

## Risk

- Low
- Risk is limited to card action visibility around the 22rem container breakpoint. Both expanded and collapsed controls use the existing handlers and disabled states.

## Security

- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new trust boundary, URL handling, raw HTML, dependency, authentication, or authorization behavior. React rendering and existing mutation handlers are unchanged; the destructive action remains explicitly labeled and styled in the compact menu. No findings.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)