### PR TITLE
fix(ui): deduplicate chat turn errors

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -469,6 +469,49 @@ describe("ChatPanel placeholder", () => {
     expect(screen.queryByText("backend temporarily unavailable")).not.toBeInTheDocument();
   });
 
+  it("renders one alert when an error message and turn failure describe the same turn", () => {
+    const context = { turn_id: "turn-1", input_message_id: "message-1" };
+    mockSessionContext.chatEvents = [
+      {
+        id: "evt-error-message-1",
+        type: "output.message.completed",
+        session_id: "session-1",
+        ts: new Date().toISOString(),
+        context,
+        data: {
+          message: {
+            id: "message-2",
+            role: "agent",
+            content: [{ type: "text", text: "Provider quota exhausted" }],
+          },
+          error_code: "provider_quota_exhausted",
+        },
+      },
+      {
+        id: "evt-failed-1",
+        type: "turn.failed",
+        session_id: "session-1",
+        ts: new Date().toISOString(),
+        context,
+        data: {
+          turn_id: "turn-1",
+          error: "Provider quota exhausted",
+          error_code: "provider_quota_exhausted",
+        },
+      },
+    ];
+    mockSessionContext.getMessageText.mockReturnValue(
+      "The AI provider account is out of credits or quota. Add credits or raise the provider account limits to continue.",
+    );
+
+    render(<ChatPanel />);
+
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+    expect(
+      screen.getByText("The AI provider account is out of credits or quota.", { exact: false }),
+    ).toBeInTheDocument();
+  });
+
   it("hides raw failed turn diagnostics when no structured error code is available", () => {
     mockSessionContext.chatEvents = [
       {

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -3,6 +3,7 @@
  * - Keep event-to-component routing in one place so the transcript stays easy to extend.
  * - Tool-only assistant events share the same grouping rules as explicit tool-call-requested events.
  * - Narrated act timelines suppress duplicate tool groups to avoid repeated progress chrome.
+ * - Error message completions are canonical; matching turn failures only carry lifecycle state.
  */
 "use client";
 
@@ -249,6 +250,16 @@ export const ChatMessageList = memo(function ChatMessageList({
       for (const toolCall of data.tool_calls ?? []) {
         ids.add(toolCall.id);
       }
+    }
+    return ids;
+  }, [chatEvents]);
+  const errorMessageTurnIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const event of chatEvents) {
+      const data = getEventData(event, "output.message.completed");
+      if (!getRuntimeErrorFromOutputMessage(data)) continue;
+      const turnId = getKnownTurnId(event);
+      if (turnId) ids.add(turnId);
     }
     return ids;
   }, [chatEvents]);
@@ -554,6 +565,7 @@ export const ChatMessageList = memo(function ChatMessageList({
 
           const turnFailedData = getEventData(event, "turn.failed");
           if (turnFailedData) {
+            if (errorMessageTurnIds.has(turnFailedData.turn_id)) return null;
             return (
               <ChatErrorAlert
                 key={event.id}


### PR DESCRIPTION
## What changed
Chat now renders one error alert for a failed AI-provider turn instead of showing the same failure twice. The canonical error message remains visible, localized, and actionable; the matching lifecycle-only `turn.failed` event is omitted from the transcript.

## Why
A provider failure intentionally emits both `output.message.completed` with structured error metadata and `turn.failed` for terminal lifecycle state. The transcript rendered both events independently, producing two identical "Something went wrong" alerts for one failed turn.

## Before / After
Before: the focused regression test reproduced two `[role=alert]` elements for one quota-exhausted turn and failed with `Expected length: 1; Received length: 2`.

After: the same paired events render one alert. A fully running `just start-dev --no-watch` stack returned healthy through both the API and reverse proxy; browser DOM inspection reported `alerts: 1` with the localized quota message. Screenshot evidence is attached in a PR comment.

Validation:
- `./node_modules/.bin/jest --runInBand` — 140 suites, 1,206 tests passed
- UI format, lint, typecheck, and production build passed
- `just pre-push` — all 10 checks passed

## Risk
- Low
- Deduplication depends on the shared turn ID already carried by both runtime events. Standalone `turn.failed` events continue to render, and only output completions carrying structured runtime-error metadata suppress their matching lifecycle alert.

## Security
- Threat categories reviewed: TM-WEB, TM-LLM-024, TM-DOS
- Findings and resolutions: no new injection, disclosure, authorization, or unbounded-work surface. The canonical sanitized/localized message remains the rendered source, and the added pass is linear over the already bounded in-memory transcript. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
