### PR TITLE
feat(ui): highlight SDK code samples

### DIFF
--- a/apps/ui/src/__tests__/code-block.test.tsx
+++ b/apps/ui/src/__tests__/code-block.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const highlight = jest.fn(
+  (
+    options: { code: string; language: string },
+    callback?: (result: {
+      tokens: Array<Array<{ content: string; offset: number; htmlStyle: object }>>;
+    }) => void,
+  ) => {
+    const result = {
+      tokens: options.code.split("\n").map((line) => [
+        {
+          content: line,
+          offset: 0,
+          htmlStyle: { color: `highlight-${options.language}`, "--shiki-dark": "dark-highlight" },
+        },
+      ]),
+    };
+    callback?.(result);
+    return null;
+  },
+);
+
+jest.mock("@streamdown/code", () => ({
+  code: {
+    getThemes: () => ["github-light", "github-dark"],
+    highlight,
+    supportsLanguage: () => true,
+  },
+}));
+
+import { CodeBlock } from "@/components/ui/code-block";
+
+const samples = [
+  { label: "Python", language: "python", code: "def main():\n    return True" },
+  { label: "TypeScript", language: "ts", code: "const ready = true;" },
+  { label: "Rust", language: "rust", code: "fn main() {}" },
+];
+
+describe("CodeBlock", () => {
+  beforeEach(() => {
+    highlight.mockClear();
+  });
+
+  it("highlights Python, TypeScript, and Rust when their tabs are selected", async () => {
+    render(<CodeBlock samples={samples} />);
+
+    await waitFor(() =>
+      expect(highlight).toHaveBeenCalledWith(
+        expect.objectContaining({ language: "python" }),
+        expect.any(Function),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
+    await waitFor(() =>
+      expect(highlight).toHaveBeenCalledWith(
+        expect.objectContaining({ language: "ts" }),
+        expect.any(Function),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rust" }));
+    await waitFor(() =>
+      expect(highlight).toHaveBeenCalledWith(
+        expect.objectContaining({ language: "rust" }),
+        expect.any(Function),
+      ),
+    );
+
+    expect(screen.getByText("fn main() {}")).toHaveStyle({
+      "--code-token-light": "highlight-rust",
+    });
+  });
+
+  it("copies the raw code from the active tab", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<CodeBlock samples={samples} />);
+    await waitFor(() => expect(highlight).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith("const ready = true;");
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("keeps long code scrollable within the responsive block", async () => {
+    const { container } = render(<CodeBlock samples={[samples[0]]} />);
+    await waitFor(() => expect(highlight).toHaveBeenCalled());
+
+    expect(container.querySelector("pre")).toHaveClass("overflow-x-auto");
+    expect(screen.getByText("1")).toHaveClass("hidden", "sm:table-cell");
+  });
+});

--- a/apps/ui/src/components/ui/code-block.tsx
+++ b/apps/ui/src/components/ui/code-block.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import type { HighlightResult } from "@streamdown/code";
 import { Check, Copy } from "lucide-react";
 import { Button } from "./button";
 import { cn } from "@/lib/utils";
 
+type CodeHighlighter = (typeof import("@streamdown/code"))["code"];
+
+let highlighterPromise: Promise<CodeHighlighter> | undefined;
+
+function loadHighlighter() {
+  highlighterPromise ??= import("@streamdown/code").then(({ code }) => code);
+  return highlighterPromise;
+}
+
 export interface CodeBlockSample {
   /** Tab label shown when there is more than one sample. */
   label: string;
-  /** Optional language hint (currently informational; no highlighting theme). */
+  /** Shiki language identifier used for syntax highlighting. */
   language?: string;
   code: string;
 }
@@ -19,9 +29,9 @@ interface CodeBlockProps {
 }
 
 /**
- * Monospaced code block with optional language tabs and a copy button. The app
- * styles code as plain `<pre>`/`<code>` over `bg-muted`; this keeps that look
- * while adding multi-language switching and copy-to-clipboard in one place.
+ * Monospaced code block with optional language tabs, syntax highlighting, and
+ * a copy button. Highlighting is lazy-loaded so code samples do not add Shiki
+ * to the initial route bundle.
  */
 export function CodeBlock({ samples, className }: CodeBlockProps) {
   const [active, setActive] = useState(0);
@@ -51,12 +61,15 @@ export function CodeBlock({ samples, className }: CodeBlockProps) {
                 key={`${index}-${sample.label}`}
                 type="button"
                 aria-pressed={index === active}
-                onClick={() => setActive(index)}
+                onClick={() => {
+                  setActive(index);
+                  setCopied(false);
+                }}
                 className={cn(
-                  "px-2 py-1 text-xs font-medium transition-colors",
+                  "rounded-sm px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   index === active
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground",
+                    ? "bg-background text-foreground shadow-sm ring-1 ring-border"
+                    : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
                 )}
               >
                 {sample.label}
@@ -74,6 +87,7 @@ export function CodeBlock({ samples, className }: CodeBlockProps) {
           className="h-6 w-6 shrink-0 p-0"
           onClick={handleCopy}
           title={copied ? "Copied!" : "Copy"}
+          aria-label={copied ? "Copied" : "Copy code"}
         >
           {copied ? (
             <Check className="h-3.5 w-3.5 text-green-500" />
@@ -82,9 +96,98 @@ export function CodeBlock({ samples, className }: CodeBlockProps) {
           )}
         </Button>
       </div>
-      <pre className="overflow-x-auto p-3 text-xs leading-relaxed">
-        <code>{current.code}</code>
+      <pre className="overflow-x-auto bg-background/70 py-3 text-xs leading-5">
+        <HighlightedCode
+          key={`${current.language ?? "text"}-${current.code}`}
+          code={current.code}
+          language={current.language}
+        />
       </pre>
     </div>
+  );
+}
+
+function HighlightedCode({ code, language }: { code: string; language?: string }) {
+  const [highlighted, setHighlighted] = useState<HighlightResult | null>(null);
+
+  useEffect(() => {
+    if (!language || language === "text") return;
+
+    let active = true;
+
+    void loadHighlighter()
+      .then((highlighter) => {
+        const shikiLanguage = language as Parameters<CodeHighlighter["supportsLanguage"]>[0];
+        if (!highlighter.supportsLanguage(shikiLanguage)) return;
+
+        const update = (result: HighlightResult) => {
+          if (active) setHighlighted(result);
+        };
+        const result = highlighter.highlight(
+          { code, language: shikiLanguage, themes: highlighter.getThemes() },
+          update,
+        );
+        if (result) update(result);
+      })
+      .catch(() => {
+        // Plain code remains readable if the lazy-loaded highlighter is unavailable.
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [code, language]);
+
+  if (!highlighted) {
+    return (
+      <code className="table min-w-full w-max px-3" data-language={language ?? "text"}>
+        {code.split("\n").map((line, lineIndex) => (
+          <CodeLineNumber key={lineIndex} line={lineIndex + 1}>
+            {line || " "}
+          </CodeLineNumber>
+        ))}
+      </code>
+    );
+  }
+
+  return (
+    <code className="table min-w-full w-max px-3" data-language={language ?? "text"}>
+      {highlighted.tokens.map((line, lineIndex) => (
+        <CodeLineNumber key={lineIndex} line={lineIndex + 1}>
+          {line.length === 0 ? " " : null}
+          {line.map((token, tokenIndex) => {
+            const { color, ...htmlStyle } = token.htmlStyle ?? {};
+            const style = {
+              ...htmlStyle,
+              "--code-token-light": color ?? token.color ?? "inherit",
+            } as CSSProperties;
+
+            return (
+              <span
+                className="text-[var(--code-token-light)] dark:text-[var(--shiki-dark,var(--code-token-light))]"
+                key={`${tokenIndex}-${token.offset ?? 0}`}
+                style={style}
+              >
+                {token.content || " "}
+              </span>
+            );
+          })}
+        </CodeLineNumber>
+      ))}
+    </code>
+  );
+}
+
+function CodeLineNumber({ children, line }: { children: ReactNode; line: number }) {
+  return (
+    <span className="table-row">
+      <span
+        aria-hidden="true"
+        className="hidden select-none pr-4 text-right text-muted-foreground/60 sm:table-cell"
+      >
+        {line}
+      </span>
+      <span className="table-cell pr-3">{children}</span>
+    </span>
   );
 }


### PR DESCRIPTION
## What changed
SDK examples on agent and harness integration pages now render language-aware syntax highlighting for Python, TypeScript, and Rust, with line numbers and clearer tab states. Highlighting lazy-loads the existing Shiki-based `@streamdown/code` dependency, while the original plain code remains visible until highlighting is ready or if it cannot load. Copy behavior, language switching, and horizontal scrolling are preserved.

## Why
The SDK examples were uniform monospace text, which made multi-step samples harder to scan. Language-aware colors and line structure make imports, comments, strings, and control flow easier to distinguish without adding another highlighter dependency.

## Before / After
Before: SDK examples rendered as uniform plain text.

After: all three SDK tabs render the existing GitHub light/dark Shiki themes, with responsive line numbers and horizontal overflow contained within the code pane. A live agent-detail smoke test verified tab switching across Python, TypeScript, and Rust, the copy success state, light/dark token palettes, and a narrow viewport. Screenshot evidence is attached in a PR comment.

Validation:
- `cd apps/ui && pnpm exec jest --runInBand src/__tests__/code-block.test.tsx`
- `cd apps/ui && pnpm run typecheck && pnpm run lint && pnpm run format:check`
- `cd apps/ui && pnpm run build`
- `just pre-push`
- `PORT_PREFIX=276 just start-dev --no-watch` with agent-detail Integrate-tab smoke test

## Risk
- Low
- The highlighter loads asynchronously; a plain-code fallback keeps samples readable if its chunk fails. Tests cover all three languages, active-tab copy payloads, and responsive overflow. No dependency or API changes.

## Security
- Threat categories reviewed: TM-WEB-001, TM-DOS
- Findings and resolutions: code content remains React-escaped text and never enters a raw HTML path; token styles come from trusted bundled Shiki themes rather than sample content. Highlighting is lazy-loaded and cached by the existing plugin, avoiding initial-route bundle cost and repeated highlighter setup. No new threat-model entry is needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

