### PR TITLE
fix(chat): summarize repeated tool activity

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -49,8 +49,8 @@ use crate::tool_fingerprint::{
     tool_call_fingerprint, tool_error_fingerprint, tool_result_fingerprint,
 };
 use crate::tool_narration::{
-    ToolNarrationContext, ToolNarrationPhase, render_group_headline_with_locale,
-    render_tool_narration_with_locale,
+    GroupHeadlineAction, ToolNarrationContext, ToolNarrationPhase,
+    render_tool_narration_with_locale, summarize_group_actions, tool_call_for_group_summary,
 };
 use crate::tool_types::{SideEffectClass, ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
@@ -736,12 +736,13 @@ where
                 ));
             }
         }
-        if tool_calls.len() == 1 {
-            started_data.headline = started_data
-                .tool_calls
-                .first()
-                .and_then(|summary| summary.narration.clone());
-        }
+        started_data.headline = self.render_group_headline(
+            &context,
+            &tool_calls,
+            &tool_map,
+            ToolNarrationPhase::Started,
+            locale.as_deref(),
+        );
 
         // Emit act.started event (with display names from tool definitions)
         if let Err(e) = self
@@ -809,23 +810,13 @@ where
             act_span_id.clone(), // Same span_id as started
             Some(parent_span_id.clone()),
         );
-        let mut completed_headline = render_group_headline_with_locale(
+        let mut completed_headline = self.render_group_headline(
+            &context,
             &tool_calls,
-            &tool_definitions,
+            &tool_map,
             ToolNarrationPhase::Completed,
             locale.as_deref(),
         );
-        if tool_calls.len() == 1
-            && let Some(tool_call) = tool_calls.first()
-        {
-            completed_headline = Some(self.render_tool_narration(
-                &context,
-                tool_map.get(tool_call.name.as_str()).copied(),
-                tool_call,
-                ToolNarrationPhase::Completed,
-                locale.as_deref(),
-            ));
-        }
         if error_count > 0 {
             let suffix = crate::localization::format_error_suffix(locale.as_deref(), error_count);
             completed_headline = Some(match completed_headline {
@@ -921,6 +912,47 @@ where
             }
         }
         render_tool_narration_with_locale(tool_def, tool_call, phase, locale)
+    }
+
+    fn render_group_headline(
+        &self,
+        atom_context: &AtomContext,
+        tool_calls: &[ToolCall],
+        tool_map: &std::collections::HashMap<&str, &ToolDefinition>,
+        phase: ToolNarrationPhase,
+        locale: Option<&str>,
+    ) -> Option<String> {
+        if tool_calls.is_empty() {
+            return None;
+        }
+        if let [tool_call] = tool_calls {
+            return Some(self.render_tool_narration(
+                atom_context,
+                tool_map.get(tool_call.name.as_str()).copied(),
+                tool_call,
+                phase,
+                locale,
+            ));
+        }
+
+        let actions = tool_calls
+            .iter()
+            .map(|tool_call| {
+                let tool_def = tool_map.get(tool_call.name.as_str()).copied();
+                let narration =
+                    self.render_tool_narration(atom_context, tool_def, tool_call, phase, locale);
+                let repeated_narration = self.render_tool_narration(
+                    atom_context,
+                    tool_def,
+                    &tool_call_for_group_summary(tool_call),
+                    phase,
+                    locale,
+                );
+                GroupHeadlineAction::new(tool_call, narration, repeated_narration)
+            })
+            .collect::<Vec<_>>();
+
+        Some(summarize_group_actions(&actions, locale))
     }
 
     /// Mirror the file-store wrapping applied during tool execution so
@@ -1830,6 +1862,60 @@ mod tests {
         async fn execute(&self, arguments: serde_json::Value) -> crate::ToolExecutionResult {
             crate::ToolExecutionResult::success(arguments)
         }
+    }
+
+    #[test]
+    fn grouped_headline_uses_tool_owned_narration_for_repeated_actions() {
+        use crate::capabilities::{Capability, CapabilityNarrationHook, FileSystemCapability};
+
+        let capability: Arc<dyn Capability> = Arc::new(FileSystemCapability);
+        let tool_definitions = capability
+            .tools()
+            .into_iter()
+            .map(|tool| tool.to_definition())
+            .collect::<Vec<_>>();
+        let tool_map = tool_definitions
+            .iter()
+            .map(|tool_def| (tool_def.name(), tool_def))
+            .collect::<std::collections::HashMap<_, _>>();
+        let atom = ActAtom::new(ToolRegistry::new(), NoopEventEmitter)
+            .with_tool_call_hooks(vec![Arc::new(CapabilityNarrationHook(capability))]);
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let tool_calls = vec![
+            ToolCall {
+                id: "grep-1".to_string(),
+                name: "grep_files".to_string(),
+                arguments: json!({ "pattern": "full_name" }),
+            },
+            ToolCall {
+                id: "grep-2".to_string(),
+                name: "grep_files".to_string(),
+                arguments: json!({ "pattern": "login" }),
+            },
+        ];
+
+        assert_eq!(
+            atom.render_group_headline(
+                &context,
+                &tool_calls,
+                &tool_map,
+                ToolNarrationPhase::Started,
+                None,
+            )
+            .as_deref(),
+            Some("Searching files twice")
+        );
+        assert_eq!(
+            atom.render_group_headline(
+                &context,
+                &tool_calls,
+                &tool_map,
+                ToolNarrationPhase::Completed,
+                None,
+            )
+            .as_deref(),
+            Some("Searched files twice")
+        );
     }
 
     struct UtilityLlmContextProbeTool;

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -1278,35 +1278,142 @@ pub fn render_group_headline_with_locale(
 
     let tool_map: std::collections::HashMap<&str, &ToolDefinition> =
         tool_defs.iter().map(|def| (def.name(), def)).collect();
+    if let [tool_call] = tool_calls {
+        return Some(render_tool_narration_with_locale(
+            tool_map.get(tool_call.name.as_str()).copied(),
+            tool_call,
+            phase,
+            locale,
+        ));
+    }
 
-    let phrases = tool_calls
+    let actions = tool_calls
         .iter()
         .map(|tool_call| {
-            render_tool_narration_with_locale(
-                tool_map.get(tool_call.name.as_str()).copied(),
-                tool_call,
+            let tool_def = tool_map.get(tool_call.name.as_str()).copied();
+            let repeated_narration = render_tool_narration_with_locale(
+                tool_def,
+                &tool_call_for_group_summary(tool_call),
                 phase,
                 locale,
+            );
+            GroupHeadlineAction::new(
+                tool_call,
+                render_tool_narration_with_locale(tool_def, tool_call, phase, locale),
+                repeated_narration,
             )
         })
-        .take(3)
         .collect::<Vec<_>>();
 
-    Some(join_phrases(&phrases, tool_calls.len(), locale))
+    Some(summarize_group_actions(&actions, locale))
 }
 
-fn join_phrases(phrases: &[String], total_count: usize, locale: Option<&str>) -> String {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GroupHeadlineAction {
+    tool_name: String,
+    narration: String,
+    repeated_narration: String,
+}
+
+impl GroupHeadlineAction {
+    pub(crate) fn new(tool_call: &ToolCall, narration: String, repeated_narration: String) -> Self {
+        Self {
+            tool_name: tool_call.name.clone(),
+            narration,
+            repeated_narration,
+        }
+    }
+}
+
+/// Retain only arguments that distinguish operation types within a tool family.
+pub(crate) fn tool_call_for_group_summary(tool_call: &ToolCall) -> ToolCall {
+    let mut arguments = serde_json::Map::new();
+    for key in ["operation", "action"] {
+        if let Some(value) = tool_call.arguments.get(key) {
+            arguments.insert(key.to_string(), value.clone());
+        }
+    }
+    ToolCall {
+        id: tool_call.id.clone(),
+        name: tool_call.name.clone(),
+        arguments: Value::Object(arguments),
+    }
+}
+
+/// Collapse equivalent actions and bound a batch headline to two distinct summaries.
+pub(crate) fn summarize_group_actions(
+    actions: &[GroupHeadlineAction],
+    locale: Option<&str>,
+) -> String {
     let strings = backend_strings(locale);
-    match phrases {
+    if actions.is_empty() {
+        return strings.working.to_string();
+    }
+    if let [only] = actions {
+        return only.narration.clone();
+    }
+
+    let mut grouped: Vec<(&GroupHeadlineAction, usize)> = Vec::new();
+    let mut indexes = std::collections::HashMap::<(&str, &str), usize>::new();
+    for action in actions {
+        let key = (
+            action.tool_name.as_str(),
+            action.repeated_narration.as_str(),
+        );
+        if let Some(index) = indexes.get(&key).copied() {
+            grouped[index].1 += 1;
+        } else {
+            indexes.insert(key, grouped.len());
+            grouped.push((action, 1));
+        }
+    }
+
+    let phrases = grouped
+        .iter()
+        .take(2)
+        .map(|(action, count)| {
+            if *count == 1 {
+                action.narration.clone()
+            } else {
+                format_repeated_action(&action.repeated_narration, *count, locale)
+            }
+        })
+        .collect::<Vec<_>>();
+    let omitted_count = grouped
+        .iter()
+        .skip(2)
+        .map(|(_, count)| count)
+        .sum::<usize>();
+
+    match phrases.as_slice() {
         [] => strings.working.to_string(),
         [only] => only.clone(),
-        [first, second] => match resolve_backend_locale(locale) {
+        [first, second] if omitted_count == 0 => match resolve_backend_locale(locale) {
             BackendLocale::Uk => format!("{first} і {second}"),
             BackendLocale::En => format!("{first} and {second}"),
         },
         [first, second, ..] => {
-            let more = format_more_actions(locale, total_count.saturating_sub(2));
+            let more = format_more_actions(locale, omitted_count);
             format!("{first}, {second}, {more}")
+        }
+    }
+}
+
+fn format_repeated_action(action: &str, count: usize, locale: Option<&str>) -> String {
+    match resolve_backend_locale(locale) {
+        BackendLocale::En if count == 2 => format!("{action} twice"),
+        BackendLocale::En => format!("{action} {count} times"),
+        BackendLocale::Uk if count == 2 => format!("{action} двічі"),
+        BackendLocale::Uk => {
+            let suffix = if (11..=14).contains(&(count % 100)) {
+                "разів"
+            } else {
+                match count % 10 {
+                    2..=4 => "рази",
+                    _ => "разів",
+                }
+            };
+            format!("{action} {count} {suffix}")
         }
     }
 }
@@ -1861,6 +1968,102 @@ mod tests {
         assert_eq!(
             render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
             "Ran Mystery Tool"
+        );
+    }
+
+    fn group_action(key: &str, narration: &str, repeated_narration: &str) -> GroupHeadlineAction {
+        GroupHeadlineAction {
+            tool_name: key.to_string(),
+            narration: narration.to_string(),
+            repeated_narration: repeated_narration.to_string(),
+        }
+    }
+
+    #[test]
+    fn group_headline_preserves_one_action_narration() {
+        let actions = [group_action(
+            "grep_files",
+            "Searched files for full_name",
+            "Searched files",
+        )];
+
+        assert_eq!(
+            summarize_group_actions(&actions, None),
+            "Searched files for full_name"
+        );
+    }
+
+    #[test]
+    fn group_headline_summarizes_two_repeated_actions() {
+        let actions = [
+            group_action(
+                "grep_files",
+                "Searched files for full_name",
+                "Searched files",
+            ),
+            group_action("grep_files", "Searched files for login", "Searched files"),
+        ];
+
+        assert_eq!(
+            summarize_group_actions(&actions, None),
+            "Searched files twice"
+        );
+    }
+
+    #[test]
+    fn group_headline_summarizes_more_than_two_repeated_actions() {
+        let actions = [
+            group_action("grep_files", "Searched files for one", "Searched files"),
+            group_action("grep_files", "Searched files for two", "Searched files"),
+            group_action("grep_files", "Searched files for three", "Searched files"),
+        ];
+
+        assert_eq!(
+            summarize_group_actions(&actions, None),
+            "Searched files 3 times"
+        );
+    }
+
+    #[test]
+    fn group_headline_localizes_repeated_action_counts() {
+        let three_actions = [
+            group_action("grep_files", "Шукав у файлах: один", "Шукав у файлах"),
+            group_action("grep_files", "Шукав у файлах: два", "Шукав у файлах"),
+            group_action("grep_files", "Шукав у файлах: три", "Шукав у файлах"),
+        ];
+        let twelve_actions = (0..12)
+            .map(|index| {
+                group_action(
+                    "grep_files",
+                    &format!("Шукав у файлах: {index}"),
+                    "Шукав у файлах",
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            summarize_group_actions(&three_actions, Some("uk")),
+            "Шукав у файлах 3 рази"
+        );
+        assert_eq!(
+            summarize_group_actions(&twelve_actions, Some("uk")),
+            "Шукав у файлах 12 разів"
+        );
+    }
+
+    #[test]
+    fn group_headline_preserves_mixed_actions_and_bounds_the_fallback() {
+        let actions = [
+            group_action("grep_files", "Searched files for one", "Searched files"),
+            group_action("grep_files", "Searched files for two", "Searched files"),
+            group_action("read_file", "Read AGENTS.md", "Read file"),
+            group_action("search_web", "Searched web for docs", "Searched web"),
+            group_action("search_web", "Searched web for examples", "Searched web"),
+        ];
+
+        assert_eq!(
+            summarize_group_actions(&actions, None),
+            "Searched files twice, Read AGENTS.md, and 2 more actions"
         );
     }
 }

--- a/specs/tool-narration.md
+++ b/specs/tool-narration.md
@@ -111,6 +111,11 @@ an argument over a tool-internal name when one is available.
 
 When the relevant argument is absent, drop the value and keep the bare verb.
 
+Grouped headlines use those same bare action phrases. Repeated equivalent actions collapse to a
+localized count-aware phrase ("Searched files twice" / "Searched files 3 times") while the child
+rows retain their argument-specific narration. Mixed groups preserve the first two distinct action
+summaries, then use a localized count of remaining actions so the headline stays bounded.
+
 ## Argument display and redaction
 
 Arguments shown in narration are **display values, not faithful echoes**:


### PR DESCRIPTION
## What changed
Grouped chat activity headlines now collapse repeated equivalent tool actions into localized, count-aware narration such as “Searched files twice” or “Searched files 3 times”. Mixed groups retain the first two distinct action summaries and report the remaining action count, keeping headers bounded while child rows preserve their detailed narration.

## Why
Repeated tool batches produced noisy headers such as “Ran Grep Files and Ran Grep Files” even though the child rows already explained each search. The shared grouping rule now applies to all tool narration rather than special-casing Grep Files.

## Before / After
Before: two Grep Files calls render “Ran Grep Files and Ran Grep Files”.

After: the same collapsed and expanded group renders “Searched files twice”; expanded child rows still render “Searched files for full_name” and “Searched files for login”.

See the attached collapsed and expanded before/after screenshots in the PR conversation.

## Risk
- Low
- Risk is limited to activity-group headline wording and localization. Existing child narration and tool execution are unchanged. Focused unit/integration coverage exercises single, repeated, localized, mixed, and bounded summaries.

## Security
- Threat categories reviewed: TM-TOOL, TM-WEB, TM-DOS.
- Findings and resolutions: No execution, authorization, or trust-boundary changes. Group headlines strip detail arguments while retaining only operation/action discriminators, React text escaping is unchanged, and aggregation is linear over the existing batch with output bounded to two summaries plus a count. No new threat or threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)