### PR TITLE
feat(provider): search model catalogs across providers

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -505,9 +505,9 @@ pub use model::{
     ModelVendor, ModelWithProvider, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
 };
 pub use model_discovery::{
-    DiscoveredProviderModel, RankedDiscoveredModels, discover_provider_models,
-    enrich_with_profiles, list_openai_compatible_models, normalize_and_enrich,
-    rank_discovered_models,
+    DiscoveredProviderModel, ModelSearchMatch, ModelSearchResult, RankedDiscoveredModels,
+    discover_provider_models, enrich_with_profiles, list_openai_compatible_models, match_models,
+    normalize_and_enrich, rank_discovered_models, search_provider_models,
 };
 pub use model_profiles::{get_model_profile, get_model_vendor};
 pub use organization::{

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -66,9 +66,9 @@ pub use model::{
     ModelVendor, ModelWithProvider, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
 };
 pub use model_discovery::{
-    DiscoveredProviderModel, RankedDiscoveredModels, discover_provider_models,
-    enrich_with_profiles, list_openai_compatible_models, normalize_and_enrich,
-    rank_discovered_models,
+    DiscoveredProviderModel, ModelSearchMatch, ModelSearchResult, RankedDiscoveredModels,
+    discover_provider_models, enrich_with_profiles, list_openai_compatible_models, match_models,
+    normalize_and_enrich, rank_discovered_models, search_provider_models,
 };
 pub use model_profiles::{get_model_profile, get_model_vendor};
 pub use openai_protocol::{AuthHeaderProvider, OpenAIProtocolChatDriver};

--- a/crates/provider/src/model_discovery.rs
+++ b/crates/provider/src/model_discovery.rs
@@ -296,6 +296,103 @@ fn is_major_vendor_model(model_id: &str) -> bool {
         || model_id.starts_with("nvidia/")
 }
 
+/// One model matched by [`search_provider_models`], qualified by the provider
+/// it came from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelSearchMatch {
+    /// Caller-supplied label for the provider that offers this model.
+    pub provider: String,
+    /// Exact model id, as it must be passed back to the provider.
+    pub model_id: String,
+    /// Human-readable name, when known.
+    pub display_name: Option<String>,
+}
+
+/// Outcome of a search across several providers.
+///
+/// Partial results are the normal case, so failures are reported alongside
+/// matches rather than replacing them: one provider being down or holding a
+/// stale key should not hide the models the others offer.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ModelSearchResult {
+    /// Matches, sorted by provider then model id.
+    pub matches: Vec<ModelSearchMatch>,
+    /// Providers that were actually queried (a provider with no catalog is
+    /// skipped rather than reported as an error).
+    pub providers_searched: Vec<String>,
+    /// Per-provider failures, as `"<provider>: <error>"`.
+    pub provider_errors: Vec<String>,
+}
+
+/// Search a provider's already-discovered catalog for `query`.
+///
+/// Case-insensitive substring match over the model id and display name. Split
+/// out from the fan-out so the matching rule is testable on its own and reusable
+/// by a host that keeps its own catalog.
+pub fn match_models(
+    provider: &str,
+    models: &[DiscoveredProviderModel],
+    query: &str,
+) -> Vec<ModelSearchMatch> {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return Vec::new();
+    }
+    models
+        .iter()
+        .filter(|model| {
+            model.model_id.to_lowercase().contains(&needle)
+                || model
+                    .display_name
+                    .as_deref()
+                    .is_some_and(|name| name.to_lowercase().contains(&needle))
+        })
+        .map(|model| ModelSearchMatch {
+            provider: provider.to_string(),
+            model_id: model.model_id.clone(),
+            display_name: model.display_name.clone(),
+        })
+        .collect()
+}
+
+/// Search every supplied provider's catalog for `query`.
+///
+/// This is what turns "use the luna model" into a set of exact, provider-
+/// qualified ids a caller can act on, instead of sending an invented literal to
+/// a provider. Each entry in `providers` is a caller-chosen label paired with
+/// the config to query; the label is what comes back on each match.
+///
+/// Providers are queried in the order given. A provider with no catalog
+/// (`Ok(None)`) is silently skipped — that is "nothing to search", not a
+/// failure — while a provider that errors is recorded in `provider_errors` and
+/// the search continues.
+pub async fn search_provider_models(
+    registry: &DriverRegistry,
+    providers: &[(String, ProviderConfig)],
+    query: &str,
+) -> ModelSearchResult {
+    let mut result = ModelSearchResult::default();
+    if query.trim().is_empty() {
+        return result;
+    }
+
+    for (label, config) in providers {
+        match discover_provider_models(registry, config).await {
+            Ok(Some(models)) => {
+                result.providers_searched.push(label.clone());
+                result.matches.extend(match_models(label, &models, query));
+            }
+            Ok(None) => {}
+            Err(error) => result.provider_errors.push(format!("{label}: {error}")),
+        }
+    }
+
+    result
+        .matches
+        .sort_by(|a, b| (&a.provider, &a.model_id).cmp(&(&b.provider, &b.model_id)));
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -479,5 +576,77 @@ mod tests {
         assert!(ids.contains(&"llama3.2:latest"), "ids: {ids:?}");
         // Gemini-style `models/` prefixes are normalized to bare ids.
         assert!(ids.contains(&"qwen3"), "ids: {ids:?}");
+    }
+
+    fn presented(id: &str, display_name: Option<&str>) -> DiscoveredProviderModel {
+        DiscoveredProviderModel {
+            model_id: id.to_string(),
+            display_name: display_name.map(str::to_string),
+            description: None,
+        }
+    }
+
+    #[test]
+    fn matching_is_case_insensitive_over_id_and_display_name() {
+        let catalog = vec![
+            presented("openai/gpt-5.5", Some("GPT-5.5")),
+            presented("moon/luna-1", None),
+            presented("acme/nebula", Some("Luna Nebula")),
+        ];
+
+        let by_id = match_models("openrouter", &catalog, "LUNA");
+        let ids: Vec<&str> = by_id.iter().map(|m| m.model_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["moon/luna-1", "acme/nebula"],
+            "a display-name hit counts as much as an id hit"
+        );
+        assert!(by_id.iter().all(|m| m.provider == "openrouter"));
+    }
+
+    #[test]
+    fn an_empty_query_matches_nothing_rather_than_everything() {
+        // Returning the whole catalog for an empty query would flood the caller
+        // and, in a tool context, the model.
+        let catalog = vec![presented("openai/gpt-5.5", None)];
+        assert!(match_models("openrouter", &catalog, "   ").is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_skips_catalog_less_providers_and_records_failures() {
+        let registry = DriverRegistry::new();
+        let providers = vec![
+            // No catalog to offer: skipped, not an error.
+            ("sim".to_string(), ProviderConfig::new(DriverId::LlmSim)),
+            // No driver registered and no base URL for the HTTP fallback: an
+            // error against this provider, which must not sink the search.
+            (
+                "broken".to_string(),
+                ProviderConfig::new(DriverId::OpenAI).with_api_key("k"),
+            ),
+        ];
+
+        let result = search_provider_models(&registry, &providers, "gpt").await;
+
+        assert!(result.matches.is_empty());
+        assert!(
+            !result.providers_searched.contains(&"sim".to_string()),
+            "a provider with no catalog was not searched"
+        );
+        assert_eq!(result.provider_errors.len(), 1);
+        assert!(result.provider_errors[0].starts_with("broken: "));
+    }
+
+    #[tokio::test]
+    async fn an_empty_query_short_circuits_before_any_provider_call() {
+        let registry = DriverRegistry::new();
+        let providers = vec![(
+            "broken".to_string(),
+            ProviderConfig::new(DriverId::OpenAI).with_api_key("k"),
+        )];
+
+        let result = search_provider_models(&registry, &providers, "").await;
+
+        assert_eq!(result, ModelSearchResult::default());
     }
 }

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -313,7 +313,7 @@ The refactor has landed; current implementations live at:
 - `crates/provider/src/provider.rs` — `Provider` entity + `DriverId`
 - `crates/provider/src/model.rs` — `Model` / `ModelWithProvider` entity types
 - `crates/provider/src/model_profiles.rs` — built-in profile data
-- `crates/provider/src/model_discovery.rs` — host-side catalog presentation: driver `list_models` plus the OpenAI-compatible `GET <base>/models` fallback for endpoints the drivers decline, profile enrichment, and picker ranking (ported from yolop, which had reimplemented all of it)
+- `crates/provider/src/model_discovery.rs` — host-side catalog presentation: driver `list_models` plus the OpenAI-compatible `GET <base>/models` fallback for endpoints the drivers decline, profile enrichment, and picker ranking (ported from yolop, which had reimplemented all of it), plus `search_provider_models` — a substring search across several providers' catalogs at once, returning provider-qualified exact ids. Partial results are the contract: a provider with no catalog is skipped, one that errors is reported in `provider_errors`, and the rest still return matches
 - `crates/provider/src/driver_registry.rs` — `ChatDriver` trait + `DriverRegistry` (string-keyed driver ids, credential schema + service factories); `DriverConfig` typed `credentials` map
 - `crates/provider/src/credential_schema.rs` — declared credential form schema (typed fields, groups, validation) + credential-document assemble/parse
 - `crates/core/src/traits.rs` — `ProviderStore` + `ResolvedModel`


### PR DESCRIPTION
## What changed

`everruns-provider::model_discovery` gains cross-provider search, in two pieces:

- `match_models(provider, catalog, query)` — the matching rule alone: case-insensitive substring over model id **and** display name. Split out so a host holding its own catalog can reuse it, and so the rule is testable without touching a provider.
- `search_provider_models(registry, providers, query)` — the fan-out over `(label, ProviderConfig)` pairs, returning matches sorted by provider then id.

Re-exported from `everruns-core`.

## Why

This is the searchable half of yolop's new `models` capability, which turns "use the luna model" into a set of exact, provider-qualified ids instead of sending an invented literal to a provider and getting a 404. The search itself stops being yolop-specific once the provider set is a parameter rather than its settings file.

Two contract decisions worth stating:

- **Partial results are the contract, not a degraded mode.** A provider with no catalog is skipped (nothing to search is not a failure); a provider that errors is recorded in `provider_errors`; the rest still return matches. One stale key must not hide every other provider's models.
- **An empty query matches nothing and short-circuits before any provider call.** Returning the whole catalog would flood a caller — and in a tool context, the model's context window.

## Before / After

No behavior change — additive surface, no call sites in this repo yet.

```rust
let result = search_provider_models(&registry, &providers, "luna").await;
// result.matches:          [{provider: "openrouter", model_id: "moon/luna-1", ..}, ..]
// result.providers_searched: ["openrouter", "openai"]
// result.provider_errors:   ["azure: models API at … returned 401"]
```

## Risk

- Low
- Additive; nothing existing is touched. Bounded work: one `list_models` per supplied provider, and no call at all for an empty query.

## Security

- Threat categories reviewed: TM-API. No new outbound surface — the fan-out reuses `discover_provider_models`, which only queries provider configs the caller already holds. Per-provider errors are surfaced as `"<label>: <error>"`; the labels are caller-chosen and the errors come from the existing discovery path, which does not include credentials in its messages.
- Findings and resolutions: none.

## Follow-ups

The rest of yolop's `models` capability — `set_model` and `set_reasoning_effort` against a live session — needs two host seams this repo does not have yet: a model catalog reachable from a tool (`ToolContext` has no listing service; the catalog lives in the server's `list_models_for_provider`) and a session-model mutation on `SessionMutator`. Those, plus the server implementations, are what a generic-harness default would depend on. Deliberately not bundled here.

## Checklist

- [x] Tests added or updated — 4 new tests: case-insensitive matching across id and display name, empty query matching nothing, the fan-out skipping a catalog-less provider while recording a failing one, and an empty query short-circuiting before any provider call
- [x] Backward compatibility considered — additive; no existing signature touched
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — `cargo test -p everruns-provider --lib model_discovery` (14 passed), `cargo check --workspace`, `cargo fmt`, `cargo clippy -p everruns-provider -p everruns-core --lib --all-features` clean
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019nACLr5GqiemdHXVhuRdrc)_