### PR TITLE
fix(ui): move agent checks into edit tab

### DIFF
--- a/apps/ui/src/__tests__/agent-checks.test.tsx
+++ b/apps/ui/src/__tests__/agent-checks.test.tsx
@@ -1,0 +1,204 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AgentChecks, applyByteSpanReplacement } from "@/components/agents/agent-checks";
+import type { AgentAnalysisResponse, AgentPreviewResponse } from "@/lib/api/types";
+
+const mockUsePreviewAgent = jest.fn();
+const mockUseAnalyzeAgent = jest.fn();
+
+jest.mock("@/hooks/use-agents", () => ({
+  usePreviewAgent: () => mockUsePreviewAgent(),
+  useAnalyzeAgent: () => mockUseAnalyzeAgent(),
+}));
+
+function previewResponse(message?: string): AgentPreviewResponse {
+  return {
+    system_prompt: "resolved prompt",
+    tools: [],
+    findings: message
+      ? [
+          {
+            rule_id: "prompt.template_variables",
+            severity: "warning",
+            category: "structure",
+            message,
+            source: "builtin",
+          },
+        ]
+      : [],
+  };
+}
+
+function mutationStub({
+  isPending = false,
+  error = null,
+}: {
+  isPending?: boolean;
+  error?: Error | null;
+} = {}) {
+  return {
+    mutate: jest.fn(),
+    reset: jest.fn(),
+    isPending,
+    error,
+  };
+}
+
+describe("AgentChecks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAnalyzeAgent.mockReturnValue(mutationStub());
+  });
+
+  it("shows a loading state while built-in checks refresh", () => {
+    mockUsePreviewAgent.mockReturnValue(mutationStub({ isPending: true }));
+
+    render(<AgentChecks systemPrompt="hi" capabilities={[]} />);
+
+    expect(screen.getByLabelText("Refreshing checks")).toBeInTheDocument();
+  });
+
+  it("renders built-in findings and keeps the request in sync with edited config", async () => {
+    const preview = mutationStub();
+    preview.mutate.mockImplementation(
+      (
+        request: { system_prompt: string },
+        callbacks: { onSuccess: (data: AgentPreviewResponse) => void },
+      ) => callbacks.onSuccess(previewResponse(`Finding for ${request.system_prompt}`)),
+    );
+    mockUsePreviewAgent.mockReturnValue(preview);
+
+    const { rerender } = render(<AgentChecks systemPrompt="first" capabilities={[]} />);
+    await waitFor(() => expect(screen.getByText("Finding for first")).toBeInTheDocument());
+
+    rerender(<AgentChecks systemPrompt="second" capabilities={[]} />);
+    rerender(<AgentChecks systemPrompt="third" capabilities={[]} />);
+    await waitFor(() => expect(screen.getByText("Finding for third")).toBeInTheDocument());
+
+    expect(preview.mutate).toHaveBeenCalledTimes(2);
+    expect(preview.mutate).toHaveBeenLastCalledWith(
+      { system_prompt: "third", capabilities: [], tools: [] },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("ignores a late built-in response for an older edit", async () => {
+    const callbacks: Array<{ onSuccess: (data: AgentPreviewResponse) => void }> = [];
+    const preview = mutationStub();
+    preview.mutate.mockImplementation((_request: unknown, nextCallbacks: (typeof callbacks)[0]) => {
+      callbacks.push(nextCallbacks);
+    });
+    mockUsePreviewAgent.mockReturnValue(preview);
+
+    const { rerender } = render(<AgentChecks systemPrompt="first" capabilities={[]} />);
+    await waitFor(() => expect(callbacks).toHaveLength(1));
+    rerender(<AgentChecks systemPrompt="second" capabilities={[]} />);
+    await waitFor(() => expect(callbacks).toHaveLength(2));
+
+    act(() => callbacks[1].onSuccess(previewResponse("Current finding")));
+    act(() => callbacks[0].onSuccess(previewResponse("Stale finding")));
+
+    expect(screen.getByText("Current finding")).toBeInTheDocument();
+    expect(screen.queryByText("Stale finding")).not.toBeInTheDocument();
+  });
+
+  it("runs deeper analysis and replaces the built-in findings", async () => {
+    const preview = mutationStub();
+    preview.mutate.mockImplementation(
+      (_request: unknown, callbacks: { onSuccess: (data: AgentPreviewResponse) => void }) =>
+        callbacks.onSuccess(previewResponse("Built-in finding")),
+    );
+    const analyze = mutationStub();
+    analyze.mutate.mockImplementation(
+      (_request: unknown, callbacks: { onSuccess: (data: AgentAnalysisResponse) => void }) =>
+        callbacks.onSuccess({
+          findings: [
+            {
+              rule_id: "prompt.structure",
+              severity: "suggestion",
+              category: "structure",
+              message: "AI finding",
+              source: "llm",
+            },
+          ],
+        }),
+    );
+    mockUsePreviewAgent.mockReturnValue(preview);
+    mockUseAnalyzeAgent.mockReturnValue(analyze);
+
+    render(<AgentChecks systemPrompt="hi" capabilities={[]} />);
+    await waitFor(() => expect(screen.getByText("Built-in finding")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze" }));
+
+    expect(await screen.findByText("AI finding")).toBeInTheDocument();
+    expect(screen.queryByText("Built-in finding")).not.toBeInTheDocument();
+    expect(analyze.mutate).toHaveBeenCalledWith(
+      { system_prompt: "hi", capabilities: [], tools: [] },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("preserves built-in findings when deeper analysis fails", async () => {
+    const preview = mutationStub();
+    preview.mutate.mockImplementation(
+      (_request: unknown, callbacks: { onSuccess: (data: AgentPreviewResponse) => void }) =>
+        callbacks.onSuccess(previewResponse("Built-in finding")),
+    );
+    mockUsePreviewAgent.mockReturnValue(preview);
+    mockUseAnalyzeAgent.mockReturnValue(mutationStub({ error: new Error("utility unavailable") }));
+
+    render(<AgentChecks systemPrompt="hi" capabilities={[]} />);
+
+    expect(await screen.findByText("Built-in finding")).toBeInTheDocument();
+    expect(screen.getByText(/Analysis failed: utility unavailable/)).toBeInTheDocument();
+  });
+
+  it("applies a proposed system-prompt fix", async () => {
+    const onApplyFix = jest.fn();
+    const preview = mutationStub();
+    preview.mutate.mockImplementation(
+      (_request: unknown, callbacks: { onSuccess: (data: AgentPreviewResponse) => void }) =>
+        callbacks.onSuccess({
+          ...previewResponse(),
+          findings: [
+            {
+              rule_id: "prompt.duplicate",
+              severity: "suggestion",
+              category: "structure",
+              message: "Replace duplicate guidance.",
+              source: "builtin",
+              location: { field: "system_prompt", start: 7, end: 10 },
+              fix: "good",
+            },
+          ],
+        }),
+    );
+    mockUsePreviewAgent.mockReturnValue(preview);
+
+    render(<AgentChecks systemPrompt="héllo bad end" capabilities={[]} onApplyFix={onApplyFix} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Apply fix" }));
+
+    expect(onApplyFix).toHaveBeenCalledWith(7, 10, "good");
+  });
+
+  it("shows the built-in check error state", () => {
+    mockUsePreviewAgent.mockReturnValue(mutationStub({ error: new Error("preview unavailable") }));
+
+    render(<AgentChecks systemPrompt="hi" capabilities={[]} />);
+
+    expect(screen.getByText("Checks Error")).toBeInTheDocument();
+    expect(screen.getByText(/preview unavailable/)).toBeInTheDocument();
+  });
+});
+
+describe("applyByteSpanReplacement", () => {
+  it("replaces an ascii byte span", () => {
+    expect(applyByteSpanReplacement("Use `search_web` now.", 4, 16, "`web_fetch`")).toBe(
+      "Use `web_fetch` now.",
+    );
+  });
+
+  it("handles multibyte text before the span", () => {
+    expect(applyByteSpanReplacement("héllo bad end", 7, 10, "good")).toBe("héllo good end");
+  });
+});

--- a/apps/ui/src/__tests__/agent-edit-page.test.tsx
+++ b/apps/ui/src/__tests__/agent-edit-page.test.tsx
@@ -46,6 +46,15 @@ jest.mock("@/components/agents/agent-preview", () => ({
   AgentPreview: () => <div data-testid="agent-preview" />,
 }));
 
+jest.mock("@/components/agents/agent-checks", () => ({
+  AgentChecks: () => <div data-testid="agent-checks">Checks</div>,
+  applyByteSpanReplacement: (text: string) => text,
+}));
+
+jest.mock("@/components/agents/agent-health-check", () => ({
+  AgentHealthCheck: () => <div data-testid="agent-health-check" />,
+}));
+
 jest.mock("@/components/initial-files-editor", () => ({
   InitialFilesEditor: () => <div data-testid="initial-files-editor" />,
 }));
@@ -148,6 +157,19 @@ describe("EditAgentPage", () => {
     expect(screen.getByText("Editing")).toBeInTheDocument();
     expect(screen.getByLabelText("Tags")).toHaveValue("");
     expect(screen.getByDisplayValue("test-agent")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-checks")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-health-check")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-preview")).not.toBeInTheDocument();
+  });
+
+  it("keeps checks in Edit instead of Preview", async () => {
+    await renderWithSuspense({ agentId: "agent_123" });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Preview" }));
+
+    expect(screen.getByTestId("agent-preview")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-checks")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("agent-health-check")).not.toBeInTheDocument();
   });
 
   it("omits network_access from the update when not edited", async () => {

--- a/apps/ui/src/__tests__/agent-preview.test.tsx
+++ b/apps/ui/src/__tests__/agent-preview.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { AgentPreview, applyByteSpanReplacement } from "@/components/agents/agent-preview";
+import { AgentPreview } from "@/components/agents/agent-preview";
 import type { AgentPreviewResponse } from "@/lib/api/types";
 
 jest.mock("streamdown", () => ({
@@ -13,15 +13,8 @@ jest.mock("@streamdown/code", () => ({
 }));
 
 const mockUsePreviewAgent = jest.fn();
-const mockUseAnalyzeAgent = jest.fn(() => ({
-  mutate: jest.fn(),
-  isPending: false,
-  error: null,
-}));
-
 jest.mock("@/hooks/use-agents", () => ({
   usePreviewAgent: () => mockUsePreviewAgent(),
-  useAnalyzeAgent: () => mockUseAnalyzeAgent(),
 }));
 
 function makeMutationStub(opts: {
@@ -112,55 +105,5 @@ describe("AgentPreview", () => {
 
     expect(screen.getByText("Initial Files")).toBeInTheDocument();
     expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
-  });
-});
-
-describe("applyByteSpanReplacement", () => {
-  it("replaces an ascii byte span", () => {
-    expect(applyByteSpanReplacement("Use `search_web` now.", 4, 16, "`web_fetch`")).toBe(
-      "Use `web_fetch` now.",
-    );
-  });
-
-  it("handles multibyte text before the span", () => {
-    // "héllo " is 7 bytes (é = 2 bytes); span covers "bad".
-    expect(applyByteSpanReplacement("héllo bad end", 7, 10, "good")).toBe("héllo good end");
-  });
-});
-
-describe("AgentPreview findings", () => {
-  it("renders findings from the preview response", async () => {
-    mockUsePreviewAgent.mockReturnValue(
-      makeMutationStub({
-        data: {
-          ...sampleResponse,
-          findings: [
-            {
-              rule_id: "prompt.template_variables",
-              severity: "warning",
-              category: "structure",
-              message: "Template placeholder found.",
-              source: "builtin",
-            },
-          ],
-        },
-      }),
-    );
-    render(<AgentPreview systemPrompt="hi {{x}}" capabilities={[]} initialFiles={[]} />);
-    await waitFor(() => {
-      expect(screen.getByText("Template placeholder found.")).toBeInTheDocument();
-      expect(screen.getByText("prompt.template_variables")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /analyze/i })).toBeInTheDocument();
-    });
-  });
-
-  it("shows a clean state with the analyze button when no findings", async () => {
-    mockUsePreviewAgent.mockReturnValue(
-      makeMutationStub({ data: { ...sampleResponse, findings: [] } }),
-    );
-    render(<AgentPreview systemPrompt="hi" capabilities={[]} initialFiles={[]} />);
-    await waitFor(() => {
-      expect(screen.getByText(/no issues found by built-in rules/i)).toBeInTheDocument();
-    });
   });
 });

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -43,7 +43,8 @@ import {
 } from "@/components/ui/dialog";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { normalizeCapabilityConfigs } from "@/components/agents/capability-config";
-import { AgentPreview, applyByteSpanReplacement } from "@/components/agents/agent-preview";
+import { AgentPreview } from "@/components/agents/agent-preview";
+import { AgentChecks, applyByteSpanReplacement } from "@/components/agents/agent-checks";
 import { AgentHealthCheck } from "@/components/agents/agent-health-check";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
@@ -319,6 +320,20 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
           <PageColumns>
             {/* Main form */}
             <PageMain>
+              <AgentChecks
+                systemPrompt={formData.system_prompt}
+                capabilities={selectedCapabilities}
+                tools={agent.tools ?? []}
+                onApplyFix={(start, end, replacement) =>
+                  handleFormChange(
+                    "system_prompt",
+                    applyByteSpanReplacement(formData.system_prompt, start, end, replacement),
+                  )
+                }
+              />
+
+              <AgentHealthCheck agentId={agent.id} />
+
               <Card>
                 <CardHeader>
                   <CardTitle>Agent Details</CardTitle>
@@ -557,16 +572,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
               capabilities={selectedCapabilities}
               initialFiles={selectedInitialFiles}
               tools={agent.tools ?? []}
-              onApplyFix={(start, end, replacement) =>
-                handleFormChange(
-                  "system_prompt",
-                  applyByteSpanReplacement(formData.system_prompt, start, end, replacement),
-                )
-              }
             />
-            <div className="mt-6">
-              <AgentHealthCheck agentId={agent.id} />
-            </div>
           </div>
 
           {/* Summary sidebar */}

--- a/apps/ui/src/components/agents/agent-checks.tsx
+++ b/apps/ui/src/components/agents/agent-checks.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAnalyzeAgent, usePreviewAgent } from "@/hooks/use-agents";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import type {
+  AgentCapabilityConfig,
+  AgentFinding,
+  FindingSeverity,
+  PreviewAgentRequest,
+  ToolDefinition,
+} from "@/lib/api/types";
+import { AlertCircle, ShieldCheck, Sparkles } from "lucide-react";
+
+const CHECK_REFRESH_DELAY_MS = 300;
+
+interface AgentChecksProps {
+  systemPrompt: string;
+  capabilities: AgentCapabilityConfig[];
+  tools?: ToolDefinition[];
+  /** Applies a server-proposed byte span replacement to the authored system prompt. */
+  onApplyFix?: (start: number, end: number, replacement: string) => void;
+}
+
+export function AgentChecks({
+  systemPrompt,
+  capabilities,
+  tools = [],
+  onApplyFix,
+}: AgentChecksProps) {
+  const previewMutation = usePreviewAgent();
+  const request: PreviewAgentRequest = {
+    system_prompt: systemPrompt,
+    capabilities,
+    tools,
+  };
+  const requestKey = JSON.stringify(request);
+  const latestRequestKey = useRef(requestKey);
+  const hasRequestedChecks = useRef(false);
+  latestRequestKey.current = requestKey;
+  const [result, setResult] = useState<{ requestKey: string; findings: AgentFinding[] } | null>(
+    null,
+  );
+  const findings = result?.requestKey === requestKey ? result.findings : null;
+
+  useEffect(() => {
+    setResult(null);
+    previewMutation.reset();
+    const timeout = window.setTimeout(
+      () => {
+        hasRequestedChecks.current = true;
+        previewMutation.mutate(request, {
+          onSuccess: (data) => {
+            if (latestRequestKey.current === requestKey) {
+              setResult({ requestKey, findings: data.findings ?? [] });
+            }
+          },
+        });
+      },
+      hasRequestedChecks.current ? CHECK_REFRESH_DELAY_MS : 0,
+    );
+
+    return () => window.clearTimeout(timeout);
+    // requestKey captures every field sent to the preview endpoint. Depending on
+    // the object itself would refresh on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestKey]);
+
+  if (previewMutation.error) {
+    return (
+      <Card className="border-destructive">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <AlertCircle className="w-5 h-5" />
+            Checks Error
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Failed to run checks: {previewMutation.error.message}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (findings === null) {
+    return <ChecksSkeleton />;
+  }
+
+  return (
+    <FindingsCard
+      findings={findings}
+      request={request}
+      requestKey={requestKey}
+      onApplyFix={onApplyFix}
+    />
+  );
+}
+
+function ChecksSkeleton() {
+  return (
+    <Card aria-label="Refreshing checks">
+      <CardHeader>
+        <Skeleton className="h-6 w-32" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-24 w-full" />
+      </CardContent>
+    </Card>
+  );
+}
+
+const SEVERITY_STYLES: Record<FindingSeverity, string> = {
+  warning: "border-amber-500/50 text-amber-600 dark:text-amber-400",
+  info: "border-sky-500/50 text-sky-600 dark:text-sky-400",
+  suggestion: "border-muted-foreground/50 text-muted-foreground",
+};
+
+interface FindingsCardProps {
+  findings: AgentFinding[];
+  request: PreviewAgentRequest;
+  requestKey: string;
+  onApplyFix?: (start: number, end: number, replacement: string) => void;
+}
+
+function FindingsCard({ findings, request, requestKey, onApplyFix }: FindingsCardProps) {
+  const analyzeMutation = useAnalyzeAgent();
+  const latestRequestKey = useRef(requestKey);
+  latestRequestKey.current = requestKey;
+  const [analysis, setAnalysis] = useState<AgentFinding[] | null>(null);
+
+  useEffect(() => {
+    setAnalysis(null);
+    analyzeMutation.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestKey]);
+
+  const shown = analysis ?? findings;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2">
+          <ShieldCheck className="w-5 h-5" />
+          Checks
+          {shown.length > 0 && <Badge variant="secondary">{shown.length}</Badge>}
+          <span className="flex-1" />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={analyzeMutation.isPending}
+            onClick={() => {
+              const analyzedRequestKey = requestKey;
+              analyzeMutation.mutate(request, {
+                onSuccess: (data) => {
+                  if (latestRequestKey.current === analyzedRequestKey) {
+                    setAnalysis(data.findings);
+                  }
+                },
+              });
+            }}
+          >
+            <Sparkles className="w-4 h-4 mr-1" />
+            {analyzeMutation.isPending ? "Analyzing…" : "Analyze"}
+          </Button>
+        </CardTitle>
+        <CardDescription>
+          Advisory findings about this configuration. They never block saving. Analyze runs a deeper
+          AI review (takes ~30s).
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {analyzeMutation.error && (
+          <p className="text-sm text-destructive mb-3">
+            Analysis failed: {analyzeMutation.error.message}
+          </p>
+        )}
+        {shown.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">
+            {analysis
+              ? "No issues found by built-in rules or AI analysis."
+              : "No issues found by built-in rules."}
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {shown.map((finding, index) => (
+              <FindingRow
+                key={`${finding.rule_id}-${index}`}
+                finding={finding}
+                onApplyFix={onApplyFix}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function FindingRow({
+  finding,
+  onApplyFix,
+}: {
+  finding: AgentFinding;
+  onApplyFix?: (start: number, end: number, replacement: string) => void;
+}) {
+  const fixSpan =
+    finding.fix !== undefined &&
+    finding.location?.field === "system_prompt" &&
+    finding.location.start !== undefined &&
+    finding.location.end !== undefined
+      ? { start: finding.location.start, end: finding.location.end }
+      : null;
+
+  return (
+    <li className="flex items-start gap-3">
+      <Badge variant="outline" className={`text-xs ${SEVERITY_STYLES[finding.severity]}`}>
+        {finding.severity}
+      </Badge>
+      <div className="space-y-1 min-w-0">
+        <p className="text-sm">{finding.message}</p>
+        <p className="text-xs text-muted-foreground font-mono">{finding.rule_id}</p>
+        {finding.fix !== undefined && (
+          <div className="text-xs border p-2 bg-muted/50 space-y-1">
+            <p className="text-muted-foreground">Suggested replacement:</p>
+            <pre className="whitespace-pre-wrap font-mono">{finding.fix}</pre>
+            {fixSpan && onApplyFix && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => onApplyFix(fixSpan.start, fixSpan.end, finding.fix ?? "")}
+              >
+                Apply fix
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+/** Replace a byte-offset span (as reported by the server) in a JS string. */
+export function applyByteSpanReplacement(
+  text: string,
+  start: number,
+  end: number,
+  replacement: string,
+): string {
+  const bytes = new TextEncoder().encode(text);
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes.slice(0, start)) + replacement + decoder.decode(bytes.slice(end));
+}

--- a/apps/ui/src/components/agents/agent-preview.tsx
+++ b/apps/ui/src/components/agents/agent-preview.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAnalyzeAgent, usePreviewAgent } from "@/hooks/use-agents";
-import { Button } from "@/components/ui/button";
+import { usePreviewAgent } from "@/hooks/use-agents";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
@@ -10,14 +9,11 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { InitialFilesPreview } from "@/components/files/initial-files-preview";
 import type {
   AgentCapabilityConfig,
-  AgentFinding,
   AgentPreviewResponse,
-  FindingSeverity,
   InitialFile,
-  PreviewAgentRequest,
   ToolDefinition,
 } from "@/lib/api/types";
-import { Wrench, FileText, AlertCircle, ShieldCheck, Sparkles } from "lucide-react";
+import { Wrench, FileText, AlertCircle } from "lucide-react";
 
 interface AgentPreviewProps {
   systemPrompt: string;
@@ -25,9 +21,6 @@ interface AgentPreviewProps {
   // Accept missing `initial_files` from agents persisted before that field existed.
   initialFiles: InitialFile[] | null | undefined;
   tools?: ToolDefinition[];
-  /** When set, findings with a proposed fix show an Apply button that
-   * replaces the located span in the authored system prompt. */
-  onApplyFix?: (start: number, end: number, replacement: string) => void;
 }
 
 export function AgentPreview({
@@ -35,7 +28,6 @@ export function AgentPreview({
   capabilities,
   initialFiles,
   tools = [],
-  onApplyFix,
 }: AgentPreviewProps) {
   const previewMutation = usePreviewAgent();
   const [preview, setPreview] = useState<AgentPreviewResponse | null>(null);
@@ -104,12 +96,6 @@ export function AgentPreview({
 
   return (
     <div className="space-y-6">
-      <FindingsCard
-        findings={preview.findings ?? []}
-        request={{ system_prompt: systemPrompt, capabilities, tools }}
-        onApplyFix={onApplyFix}
-      />
-
       {/* System Prompt Preview */}
       <Card>
         <CardHeader>
@@ -159,150 +145,6 @@ export function AgentPreview({
     </div>
   );
 }
-
-const SEVERITY_STYLES: Record<FindingSeverity, string> = {
-  warning: "border-amber-500/50 text-amber-600 dark:text-amber-400",
-  info: "border-sky-500/50 text-sky-600 dark:text-sky-400",
-  suggestion: "border-muted-foreground/50 text-muted-foreground",
-};
-
-/** Replace a byte-offset span (as reported by the server) in a JS string. */
-function applyByteSpanReplacement(
-  text: string,
-  start: number,
-  end: number,
-  replacement: string,
-): string {
-  const bytes = new TextEncoder().encode(text);
-  const decoder = new TextDecoder();
-  return decoder.decode(bytes.slice(0, start)) + replacement + decoder.decode(bytes.slice(end));
-}
-
-interface FindingsCardProps {
-  findings: AgentFinding[];
-  request: PreviewAgentRequest;
-  onApplyFix?: (start: number, end: number, replacement: string) => void;
-}
-
-function FindingsCard({ findings, request, onApplyFix }: FindingsCardProps) {
-  const analyzeMutation = useAnalyzeAgent();
-  const [analysis, setAnalysis] = useState<AgentFinding[] | null>(null);
-
-  // Analysis results are tied to the config they were computed against;
-  // invalidate them when the prompt, capabilities, or tools change (tools
-  // feed the server-side llm.tool_guidance checker).
-  useEffect(() => {
-    setAnalysis(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [request.system_prompt, JSON.stringify(request.capabilities), JSON.stringify(request.tools)]);
-
-  const shown = analysis ?? findings;
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <ShieldCheck className="w-5 h-5" />
-          Checks
-          {shown.length > 0 && (
-            <Badge variant="secondary" className="ml-2">
-              {shown.length}
-            </Badge>
-          )}
-          <span className="flex-1" />
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={analyzeMutation.isPending}
-            onClick={() =>
-              analyzeMutation.mutate(request, {
-                onSuccess: (data) => setAnalysis(data.findings),
-              })
-            }
-          >
-            <Sparkles className="w-4 h-4 mr-1" />
-            {analyzeMutation.isPending ? "Analyzing…" : "Analyze"}
-          </Button>
-        </CardTitle>
-        <CardDescription>
-          Advisory findings about this configuration. They never block saving. Analyze runs a deeper
-          AI review (takes ~30s).
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {analyzeMutation.error && (
-          <p className="text-sm text-destructive mb-3">
-            Analysis failed: {analyzeMutation.error.message}
-          </p>
-        )}
-        {shown.length === 0 ? (
-          <p className="text-sm text-muted-foreground italic">
-            {analysis
-              ? "No issues found by built-in rules or AI analysis."
-              : "No issues found by built-in rules."}
-          </p>
-        ) : (
-          <ul className="space-y-3">
-            {shown.map((finding, index) => (
-              <FindingRow
-                key={`${finding.rule_id}-${index}`}
-                finding={finding}
-                onApplyFix={onApplyFix}
-              />
-            ))}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function FindingRow({
-  finding,
-  onApplyFix,
-}: {
-  finding: AgentFinding;
-  onApplyFix?: (start: number, end: number, replacement: string) => void;
-}) {
-  const fixSpan =
-    finding.fix !== undefined &&
-    finding.location?.field === "system_prompt" &&
-    finding.location.start !== undefined &&
-    finding.location.end !== undefined
-      ? { start: finding.location.start, end: finding.location.end }
-      : null;
-
-  return (
-    <li className="flex items-start gap-3">
-      <Badge variant="outline" className={`text-xs ${SEVERITY_STYLES[finding.severity]}`}>
-        {finding.severity}
-      </Badge>
-      <div className="space-y-1 min-w-0">
-        <p className="text-sm">{finding.message}</p>
-        <p className="text-xs text-muted-foreground font-mono">{finding.rule_id}</p>
-        {finding.fix !== undefined && (
-          <div className="text-xs border p-2 bg-muted/50 space-y-1">
-            <p className="text-muted-foreground">Suggested replacement:</p>
-            <pre className="whitespace-pre-wrap font-mono">{finding.fix}</pre>
-            {fixSpan && onApplyFix && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => onApplyFix(fixSpan.start, fixSpan.end, finding.fix ?? "")}
-              >
-                Apply fix
-              </Button>
-            )}
-          </div>
-        )}
-      </div>
-    </li>
-  );
-}
-
-export { applyByteSpanReplacement };
 
 function ToolCard({ tool }: { tool: ToolDefinition }) {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/specs/agent-checks.md
+++ b/specs/agent-checks.md
@@ -7,10 +7,10 @@
   - Hybrid three-tier pipeline (deterministic rules → LLM checkers → health
     checks) mirrors the converged industry architecture (OpenAI prompt
     optimizer's parallel checker agents, Arbiter arXiv:2603.08993).
-  - No while-you-type linting: tier 1 runs with preview (cheap, sync); tiers
-    2-3 are explicit user actions with visible cost/time expectations. No
-    shipping product does continuous background analysis; on-demand is the
-    proven interaction model.
+  - No request-per-keystroke linting: tier 1 refreshes automatically after
+    edits settle (cheap, sync); tiers 2-3 are explicit user actions with visible
+    cost/time expectations. No shipping product does continuous background
+    analysis; on-demand is the proven interaction model.
   - Tier 2 uses the utility LLM service, not user-configured model providers
     or session secrets (see specs/utility-llm.md, "system analysis tasks").
   - Health checks are NOT part of the evals domain UI/entities. They reuse the
@@ -133,10 +133,12 @@ Decided ordering (Option A → C → B from the design review):
 
 ## UX
 
-- **Checks panel** in the agent editor (alongside Preview), not editor
-  squiggles. Findings grouped by category with severity badges; each finding
-  links to its field or highlights its prompt span. Finding counts surface as
-  a small badge on the editor tab and on agent cards.
+- **Checks panel** at the top of the default Edit tab, not hidden in Preview or
+  rendered as editor squiggles. Preview stays focused on the resolved system
+  prompt, tools, and files. Findings grouped by category with severity badges;
+  each finding links to its field or highlights its prompt span. Finding counts
+  surface as a small badge on the editor tab and on agent cards. Behavioral
+  health checks live with the advisory checks in Edit as well.
 - **Tier triggers**: tier 1 is implicit (updates with preview); tiers 2 and 3
   are buttons with cost/time expectations ("~30s", "runs N real sessions").
 - **Fix flow**: findings with a `fix` show a diff and an Apply button.

--- a/test_cases/ui/agent_checks/TC001_edit_tab_checks.md
+++ b/test_cases/ui/agent_checks/TC001_edit_tab_checks.md
@@ -1,0 +1,39 @@
+# TC001 Edit-Tab Agent Checks
+
+## Description
+
+Verifies that advisory agent checks are discoverable and actionable while editing, while Preview
+contains only the rendered system prompt, tools, and initial files.
+
+## Preconditions
+
+- Development stack is running.
+- At least one editable agent exists.
+- Utility LLM is configured to verify deeper analysis and proposed fixes.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| System prompt with built-in finding | `Help the user named {{customer_name}}.` |
+
+## Steps
+
+1. Open an editable agent and select Edit.
+2. Confirm the Checks and Health check cards appear above Agent Details.
+3. Change the system prompt to the test value and wait for built-in checks to refresh.
+4. Confirm the template-variable finding appears without saving the agent.
+5. Select Analyze and wait for the deeper AI review to finish.
+6. If a finding proposes a system-prompt replacement, select Apply fix and confirm the editor text changes while the agent remains unsaved.
+7. Select Preview.
+8. Confirm Preview shows Full System Prompt, Available Tools, and Initial Files without Checks or Health check cards.
+9. Resize to a narrow viewport and repeat the Edit/Preview switch.
+
+## Expected Result
+
+- Checks and Health check are visible by default in Edit and remain advisory.
+- Built-in findings refresh from the current unsaved configuration.
+- Analyze exposes a loading state and then findings or a clear error without losing built-in findings.
+- Apply fix updates only the authored form state; saving remains explicit.
+- Preview is limited to the resolved system prompt, tools, and initial files.
+- Cards and actions remain usable without horizontal clipping at narrow widths.


### PR DESCRIPTION
## What changed

- Moved advisory agent checks and health status into the default Edit tab.
- Kept Preview focused on the resolved system prompt, available tools, and initial files.
- Preserved automatic built-in check refresh, deeper AI analysis, loading/error states, and proposed-fix application.
- Debounced edit-triggered refreshes and discarded stale responses so rapid edits cannot surface outdated findings.
- Added focused component/page coverage and a manual UI test case.

## Why

Checks are actionable editing guidance. Showing them where users author the agent makes the feature discoverable and lets users investigate or apply fixes without switching to a rendering-focused tab.

## Before / After

Before, Checks appeared under Preview. After, Checks and Health check appear at the top of Edit, while Preview contains only rendered prompt/tools/files.

Manual screenshots were captured, but the repository's Cloudinary credential is absent from the available Everruns Doppler configurations, so the required uploader could not publish them. Manual verification covered built-in refresh after an unsaved edit, analysis failure while retaining built-in findings, Preview contents, and the responsive tablet layout. Proposed-fix application is covered by component tests because the local utility LLM was unavailable.

## Risk

Low. Opening Edit now performs the existing preview request and settled edits refresh checks after 300 ms. Tests cover debouncing, stale-response protection, errors, loading states, findings, and fix application.

## Security

- Reviewed TM-WEB: findings and proposed fixes remain React text content; this change adds no raw HTML or navigation surface.
- Reviewed TM-DOS: edit-triggered requests are debounced and tested so rapid changes collapse to the latest refresh.
- No authentication, authorization, API contract, dependency, or trust-boundary changes.

## Follow-ups

No follow-ups.

## Checklist

- [x] Added or updated tests
- [x] Ran relevant automated checks
- [x] Performed manual UI verification
- [x] Reviewed security implications
- [x] Updated the owning specification
