### PR TITLE
fix(ui): show tool execution in session trajectory

### DIFF
--- a/apps/ui/src/__tests__/fixtures/trajectory-tool-events.json
+++ b/apps/ui/src/__tests__/fixtures/trajectory-tool-events.json
@@ -1,0 +1,304 @@
+[
+  {
+    "id": "event_input",
+    "type": "input.message",
+    "ts": "2026-08-06T12:00:00.000Z",
+    "session_id": "session_fixture",
+    "sequence": 1,
+    "context": {},
+    "data": {
+      "message": {
+        "id": "message_input",
+        "role": "user",
+        "content": [{ "type": "text", "text": "Inspect the workspace and run the tests." }]
+      }
+    }
+  },
+  {
+    "id": "event_turn_started",
+    "type": "turn.started",
+    "ts": "2026-08-06T12:00:00.010Z",
+    "session_id": "session_fixture",
+    "sequence": 2,
+    "context": { "turn_id": "turn_fixture", "input_message_id": "message_input" },
+    "data": { "turn_id": "turn_fixture", "input_message_id": "message_input" }
+  },
+  {
+    "id": "event_reason_1",
+    "type": "reason.completed",
+    "ts": "2026-08-06T12:00:01.000Z",
+    "session_id": "session_fixture",
+    "sequence": 3,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": { "success": true, "has_tool_calls": true, "tool_call_count": 2, "duration_ms": 990 }
+  },
+  {
+    "id": "event_act_1",
+    "type": "act.started",
+    "ts": "2026-08-06T12:00:01.010Z",
+    "session_id": "session_fixture",
+    "sequence": 4,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": {
+      "headline": "Reading package metadata and source",
+      "tool_calls": [
+        {
+          "id": "call_package",
+          "name": "read_file",
+          "display_name": "Read file",
+          "narration": "Read package.json"
+        },
+        {
+          "id": "call_source",
+          "name": "read_file",
+          "display_name": "Read file",
+          "narration": "Read trajectory-utils.ts"
+        }
+      ]
+    }
+  },
+  {
+    "id": "event_tool_started_package",
+    "type": "tool.started",
+    "ts": "2026-08-06T12:00:01.020Z",
+    "session_id": "session_fixture",
+    "sequence": 5,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": {
+      "tool_call": {
+        "id": "call_package",
+        "name": "read_file",
+        "arguments": { "path": "apps/ui/package.json" }
+      },
+      "display_name": "Read file",
+      "narration": "Read package.json"
+    }
+  },
+  {
+    "id": "event_tool_started_source",
+    "type": "tool.started",
+    "ts": "2026-08-06T12:00:01.021Z",
+    "session_id": "session_fixture",
+    "sequence": 6,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": {
+      "tool_call": {
+        "id": "call_source",
+        "name": "read_file",
+        "arguments": {
+          "path": "apps/ui/src/components/trajectory/trajectory-utils.ts",
+          "api_key": "fixture-secret"
+        }
+      },
+      "display_name": "Read file",
+      "narration": "Read trajectory-utils.ts"
+    }
+  },
+  {
+    "id": "event_tool_completed_source",
+    "type": "tool.completed",
+    "ts": "2026-08-06T12:00:01.060Z",
+    "session_id": "session_fixture",
+    "sequence": 7,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": {
+      "tool_call_id": "call_source",
+      "tool_name": "read_file",
+      "display_name": "Read file",
+      "success": false,
+      "status": "error",
+      "error": "File not found",
+      "duration_ms": 39,
+      "narration": "Could not read trajectory-utils.ts"
+    }
+  },
+  {
+    "id": "event_tool_completed_package",
+    "type": "tool.completed",
+    "ts": "2026-08-06T12:00:01.080Z",
+    "session_id": "session_fixture",
+    "sequence": 8,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": {
+      "tool_call_id": "call_package",
+      "tool_name": "read_file",
+      "display_name": "Read file",
+      "success": true,
+      "status": "success",
+      "result": [{ "type": "text", "text": "{\"name\":\"everruns-ui\",\"private\":true}" }],
+      "duration_ms": 58,
+      "narration": "Read package.json"
+    }
+  },
+  {
+    "id": "event_act_1_completed",
+    "type": "act.completed",
+    "ts": "2026-08-06T12:00:01.090Z",
+    "session_id": "session_fixture",
+    "sequence": 9,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_1"
+    },
+    "data": { "completed": true, "success_count": 1, "error_count": 1, "duration_ms": 80 }
+  },
+  {
+    "id": "event_reason_2",
+    "type": "reason.completed",
+    "ts": "2026-08-06T12:00:02.000Z",
+    "session_id": "session_fixture",
+    "sequence": 10,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_2"
+    },
+    "data": { "success": true, "has_tool_calls": true, "tool_call_count": 1, "duration_ms": 910 }
+  },
+  {
+    "id": "event_act_2",
+    "type": "act.started",
+    "ts": "2026-08-06T12:00:02.010Z",
+    "session_id": "session_fixture",
+    "sequence": 11,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_2"
+    },
+    "data": {
+      "headline": "Running UI tests",
+      "tool_calls": [
+        { "id": "call_test", "name": "bash", "display_name": "Shell", "narration": "Run UI tests" }
+      ]
+    }
+  },
+  {
+    "id": "event_tool_started_test",
+    "type": "tool.started",
+    "ts": "2026-08-06T12:00:02.020Z",
+    "session_id": "session_fixture",
+    "sequence": 12,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_2"
+    },
+    "data": {
+      "tool_call": {
+        "id": "call_test",
+        "name": "bash",
+        "arguments": { "command": "pnpm test trajectory" }
+      },
+      "display_name": "Shell",
+      "narration": "Run UI tests"
+    }
+  },
+  {
+    "id": "event_tool_completed_test",
+    "type": "tool.completed",
+    "ts": "2026-08-06T12:00:03.270Z",
+    "session_id": "session_fixture",
+    "sequence": 13,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_2"
+    },
+    "data": {
+      "tool_call_id": "call_test",
+      "tool_name": "bash",
+      "display_name": "Shell",
+      "success": true,
+      "status": "success",
+      "result": [
+        {
+          "type": "text",
+          "text": "{\"stdout\":\"3 tests passed\",\"stderr\":\"\",\"exit_code\":0,\"success\":true}"
+        }
+      ],
+      "duration_ms": 1250,
+      "narration": "Ran UI tests"
+    }
+  },
+  {
+    "id": "event_act_2_completed",
+    "type": "act.completed",
+    "ts": "2026-08-06T12:00:03.280Z",
+    "session_id": "session_fixture",
+    "sequence": 14,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_2"
+    },
+    "data": { "completed": true, "success_count": 1, "error_count": 0, "duration_ms": 1270 }
+  },
+  {
+    "id": "event_reason_3",
+    "type": "reason.completed",
+    "ts": "2026-08-06T12:00:04.000Z",
+    "session_id": "session_fixture",
+    "sequence": 15,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_3"
+    },
+    "data": { "success": true, "has_tool_calls": false, "tool_call_count": 0, "duration_ms": 720 }
+  },
+  {
+    "id": "event_output",
+    "type": "output.message.completed",
+    "ts": "2026-08-06T12:00:04.010Z",
+    "session_id": "session_fixture",
+    "sequence": 16,
+    "context": {
+      "turn_id": "turn_fixture",
+      "input_message_id": "message_input",
+      "exec_id": "exec_3"
+    },
+    "data": {
+      "message": {
+        "id": "message_output",
+        "role": "agent",
+        "phase": "completed",
+        "content": [{ "type": "text", "text": "The tests pass." }]
+      }
+    }
+  },
+  {
+    "id": "event_turn_completed",
+    "type": "turn.completed",
+    "ts": "2026-08-06T12:00:04.020Z",
+    "session_id": "session_fixture",
+    "sequence": 17,
+    "context": { "turn_id": "turn_fixture", "input_message_id": "message_input" },
+    "data": { "turn_id": "turn_fixture", "duration_ms": 4020, "iterations": 3 }
+  }
+]

--- a/apps/ui/src/__tests__/trajectory-nodes.test.tsx
+++ b/apps/ui/src/__tests__/trajectory-nodes.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ToolGroupNode } from "@/components/trajectory/trajectory-nodes";
+
+jest.mock("@xyflow/react", () => ({
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom" },
+}));
+
+describe("ToolGroupNode", () => {
+  it("shows action, status, duration, and expandable redacted details", () => {
+    render(
+      <ToolGroupNode
+        id="tools"
+        type="toolGroup"
+        selected={false}
+        dragging={false}
+        draggable={false}
+        selectable={false}
+        deletable={false}
+        zIndex={0}
+        isConnectable={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+        data={{
+          label: "Tools (1)",
+          tools: [
+            {
+              id: "call-1",
+              name: "search_web",
+              displayName: "Web search",
+              label: "Searched the release notes",
+              success: true,
+              status: "success",
+              durationMs: 1250,
+              arguments: { query: "release notes", api_key: "do-not-render" },
+              resultText: JSON.stringify({ matches: 3, token: "also-hidden" }),
+            },
+          ],
+          successCount: 1,
+          errorCount: 0,
+          durationMs: 1250,
+          eventId: "event-1",
+          timestamp: "2026-08-06T12:00:00Z",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Searched the release notes")).toBeInTheDocument();
+    expect(screen.getByText("search_web")).toBeInTheDocument();
+    expect(screen.getByText("success")).toBeInTheDocument();
+    expect(screen.getAllByText("1.3s").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText("Searched the release notes"));
+    expect(screen.getByText("Input")).toBeInTheDocument();
+    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getAllByText(/\[redacted\]/)).toHaveLength(2);
+    expect(screen.queryByText(/do-not-render|also-hidden/)).not.toBeInTheDocument();
+  });
+
+  it("renders pending calls as running rather than successful", () => {
+    render(
+      <ToolGroupNode
+        id="tools"
+        type="toolGroup"
+        selected={false}
+        dragging={false}
+        draggable={false}
+        selectable={false}
+        deletable={false}
+        zIndex={0}
+        isConnectable={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+        data={{
+          label: "Tools (1)",
+          tools: [
+            {
+              id: "call-1",
+              name: "bash",
+              label: "Run tests",
+              status: "pending",
+              arguments: { command: "pnpm test" },
+            },
+          ],
+          successCount: 0,
+          errorCount: 0,
+          eventId: "event-1",
+          timestamp: "2026-08-06T12:00:00Z",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.queryByText("success")).not.toBeInTheDocument();
+  });
+
+  it("redacts secret assignments in plain-text results", () => {
+    render(
+      <ToolGroupNode
+        id="tools"
+        type="toolGroup"
+        selected={false}
+        dragging={false}
+        draggable={false}
+        selectable={false}
+        deletable={false}
+        zIndex={0}
+        isConnectable={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+        data={{
+          label: "Tools (1)",
+          tools: [
+            {
+              id: "call-1",
+              name: "bash",
+              label: "Ran command",
+              status: "success",
+              success: true,
+              resultText: "OPENAI_API_KEY=sk-live-secret\nok",
+            },
+          ],
+          successCount: 1,
+          errorCount: 0,
+          eventId: "event-1",
+          timestamp: "2026-08-06T12:00:00Z",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Ran command"));
+    expect(screen.getByText(/OPENAI_API_KEY=\[redacted\]/)).toBeInTheDocument();
+    expect(screen.queryByText(/sk-live-secret/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/trajectory-utils.test.ts
+++ b/apps/ui/src/__tests__/trajectory-utils.test.ts
@@ -4,6 +4,7 @@ import {
   countStructuralEvents,
 } from "@/components/trajectory/trajectory-utils";
 import type { Event, EventContext } from "@/lib/api/types";
+import trajectoryToolEvents from "./fixtures/trajectory-tool-events.json";
 
 // --- Helpers ---
 
@@ -349,6 +350,76 @@ describe("trajectory-utils", () => {
   });
 
   describe("buildTrajectory", () => {
+    it("hydrates real tool lifecycle events in iteration order", () => {
+      const { nodes, edges, stats } = buildTrajectory(trajectoryToolEvents as Event[]);
+      const orderedChildren = nodes.filter((node) => node.parentId).map((node) => node.type);
+      const toolNodes = nodes.filter((node) => node.type === "toolGroup");
+
+      expect(orderedChildren).toEqual([
+        "userMessage",
+        "reasoning",
+        "toolGroup",
+        "reasoning",
+        "toolGroup",
+        "reasoning",
+        "agentMessage",
+      ]);
+      expect(toolNodes).toHaveLength(2);
+      expect(Number(toolNodes[0].zIndex)).toBeGreaterThan(Number(toolNodes[1].zIndex));
+      expect(nodes[0].type).toBe("turnGroup");
+      expect(stats.totalToolCalls).toBe(3);
+      expect(stats.totalToolErrors).toBe(1);
+
+      const firstTools = (
+        toolNodes[0].data as {
+          tools: Array<{
+            id: string;
+            label: string;
+            arguments?: Record<string, unknown>;
+            resultText?: string;
+            error?: string;
+          }>;
+        }
+      ).tools;
+      expect(firstTools.map((tool) => tool.id)).toEqual(["call_package", "call_source"]);
+      expect(firstTools[0]).toMatchObject({
+        label: "Read package.json",
+        arguments: { path: "apps/ui/package.json" },
+        resultText: '{"name":"everruns-ui","private":true}',
+      });
+      expect(firstTools[1]).toMatchObject({
+        label: "Could not read trajectory-utils.ts",
+        error: "File not found",
+      });
+
+      expect(edges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ source: "turn-0-reason-0", target: "turn-0-tools-0" }),
+          expect.objectContaining({ source: "turn-0-tools-0", target: "turn-0-reason-1" }),
+          expect.objectContaining({ source: "turn-0-tools-1", target: "turn-0-reason-2" }),
+        ]),
+      );
+    });
+
+    it("does not fabricate a tool node when an iteration has no calls", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Hello"),
+        turnStartedEvent("turn-1", "msg-1"),
+        makeEvent(
+          "reason.completed",
+          { has_tool_calls: false, tool_call_count: 0, duration_ms: 100 },
+          turnContext("turn-1", "msg-1"),
+        ),
+        outputMessageCompletedEvent("turn-1", "msg-1", "Hi there"),
+        turnCompletedEvent("turn-1", "msg-1"),
+      ];
+
+      const { nodes, stats } = buildTrajectory(events);
+
+      expect(nodes.filter((node) => node.type === "toolGroup")).toHaveLength(0);
+      expect(stats.totalToolCalls).toBe(0);
+    });
+
     it("creates correct nodes for a single turn with orphan adoption", () => {
       const events = [
         inputMessageEvent("msg-1", "Hello"),

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -3,7 +3,17 @@
 
 import { memo } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import { User, Bot, Brain, Wrench, CheckCircle2, XCircle, Clock } from "lucide-react";
+import {
+  User,
+  Bot,
+  Brain,
+  Wrench,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  ChevronRight,
+} from "lucide-react";
 import type {
   UserMessageNodeData,
   AgentMessageNodeData,
@@ -11,6 +21,7 @@ import type {
   ToolGroupNodeData,
   TurnGroupNodeData,
 } from "./trajectory-utils";
+import { formatToolDetail } from "./trajectory-utils";
 import { formatDurationCompact } from "@/lib/formatting";
 
 function formatDuration(ms?: number): string {
@@ -153,7 +164,8 @@ export const ToolGroupNode = memo(function ToolGroupNode({
   data,
 }: NodeProps & { data: ToolGroupNodeData }) {
   const d = data as ToolGroupNodeData;
-  const hasErrors = d.errorCount > 0;
+  const hasErrors =
+    d.errorCount > 0 || d.tools.some((tool) => tool.status !== "pending" && !tool.success);
   return (
     <div
       className={`w-[308px] border px-2.5 py-2 ${
@@ -175,24 +187,77 @@ export const ToolGroupNode = memo(function ToolGroupNode({
           <span className="ml-auto text-muted-foreground/50">{formatDuration(d.durationMs)}</span>
         )}
       </div>
-      <div className="flex flex-wrap gap-1">
-        {d.tools.map((tool) => (
-          <span
-            key={tool.id}
-            className={`inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 ${
-              tool.status === "error" || !tool.success
-                ? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
-                : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
-            }`}
-          >
-            {tool.success ? (
-              <CheckCircle2 className="w-2.5 h-2.5" />
-            ) : (
-              <XCircle className="w-2.5 h-2.5" />
-            )}
-            {tool.displayName ?? tool.name}
-          </span>
-        ))}
+      <div className="space-y-1">
+        {d.tools.map((tool) => {
+          const failed = tool.status === "error" || tool.status === "timeout" || !tool.success;
+          const pending = tool.status === "pending";
+          const input = formatToolDetail(tool.arguments);
+          const output = formatToolDetail(tool.error ?? tool.resultText);
+          const hasDetails = input.length > 0 || output.length > 0;
+
+          return (
+            <details key={tool.id} className="group/tool relative text-[10px] open:z-20">
+              <summary
+                className={`nodrag flex min-w-0 list-none items-center gap-1 px-1.5 py-1 marker:hidden ${
+                  pending
+                    ? "bg-muted text-muted-foreground"
+                    : failed
+                      ? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
+                      : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
+                } ${hasDetails ? "cursor-pointer" : "cursor-default"}`}
+              >
+                {pending ? (
+                  <Loader2 className="h-2.5 w-2.5 shrink-0 animate-spin" />
+                ) : failed ? (
+                  <XCircle className="h-2.5 w-2.5 shrink-0" />
+                ) : (
+                  <CheckCircle2 className="h-2.5 w-2.5 shrink-0" />
+                )}
+                <span className="min-w-0 flex-1 truncate font-medium" title={tool.label}>
+                  {tool.label}
+                </span>
+                {tool.label !== tool.name && (
+                  <span className="max-w-20 truncate font-mono opacity-55">{tool.name}</span>
+                )}
+                <span className="capitalize opacity-65">{pending ? "running" : tool.status}</span>
+                {tool.durationMs != null && (
+                  <span className="tabular-nums opacity-65">{formatDuration(tool.durationMs)}</span>
+                )}
+                {hasDetails && (
+                  <ChevronRight className="h-2.5 w-2.5 shrink-0 transition-transform group-open/tool:rotate-90" />
+                )}
+              </summary>
+              {hasDetails && (
+                <div className="nodrag nowheel absolute left-0 top-full z-20 mt-1 w-full max-h-40 overflow-auto border border-border bg-popover p-2 text-popover-foreground shadow-lg">
+                  {input && (
+                    <div>
+                      <div className="mb-0.5 font-medium uppercase tracking-wide text-muted-foreground">
+                        Input
+                      </div>
+                      <pre className="whitespace-pre-wrap break-words font-mono text-[9px] leading-relaxed">
+                        {input}
+                      </pre>
+                    </div>
+                  )}
+                  {output && (
+                    <div className={input ? "mt-2" : undefined}>
+                      <div
+                        className={`mb-0.5 font-medium uppercase tracking-wide ${
+                          failed ? "text-red-600 dark:text-red-400" : "text-muted-foreground"
+                        }`}
+                      >
+                        {failed ? "Error" : "Result"}
+                      </div>
+                      <pre className="whitespace-pre-wrap break-words font-mono text-[9px] leading-relaxed">
+                        {output}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              )}
+            </details>
+          );
+        })}
       </div>
       <Handle
         type="target"

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -10,7 +10,7 @@
 //   NOT on every SSE delta event (which fires 10-30x per second during streaming).
 
 import type { Node, Edge } from "@xyflow/react";
-import type { Event, ToolCompletedData } from "@/lib/api/types";
+import type { Event, ToolCompletedData, ToolStartedData } from "@/lib/api/types";
 import { getTextFromContent, getEventData } from "@/lib/api/types";
 import type { SupportedLocale } from "@/lib/i18n";
 import {
@@ -56,9 +56,14 @@ export interface ToolGroupNodeData {
     name: string;
     /** Human-readable display name for UI rendering */
     displayName?: string;
-    success: boolean;
+    /** Argument-aware narration, falling back to displayName/name. */
+    label: string;
+    success?: boolean;
     status: string;
     durationMs?: number;
+    arguments?: Record<string, unknown>;
+    resultText?: string;
+    error?: string;
   }>;
   successCount: number;
   errorCount: number;
@@ -117,6 +122,7 @@ export const STRUCTURAL_EVENT_TYPES = new Set([
   "reason.completed",
   "act.started",
   "act.completed",
+  "tool.started",
   "tool.completed",
 ]);
 
@@ -133,6 +139,51 @@ const GROUP_GAP = 40; // vertical gap between turn groups
 function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return text.slice(0, maxLen) + "…";
+}
+
+const SENSITIVE_DETAIL_KEY =
+  /(?:^|_)(?:api_?key|authorization|cookie|credential|password|private_?key|secret|token)(?:$|_)/i;
+const TOOL_DETAIL_LIMIT = 1_200;
+
+function redactSensitiveDetails(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSensitiveDetails);
+  if (value === null || typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+      key,
+      SENSITIVE_DETAIL_KEY.test(key) ? "[redacted]" : redactSensitiveDetails(nested),
+    ]),
+  );
+}
+
+function limitToolDetail(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length <= TOOL_DETAIL_LIMIT
+    ? trimmed
+    : `${trimmed.slice(0, TOOL_DETAIL_LIMIT)}\n…`;
+}
+
+function redactSensitiveText(text: string): string {
+  return text.replace(
+    /(\b[\w-]*(?:api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token)[\w-]*\b)(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+    "$1$2[redacted]",
+  );
+}
+
+/** Format bounded, secret-aware content for an expandable trajectory detail. */
+export function formatToolDetail(value: unknown): string {
+  if (value == null || value === "") return "";
+  let structured = value;
+  if (typeof value === "string") {
+    try {
+      structured = JSON.parse(value);
+    } catch {
+      return limitToolDetail(redactSensitiveText(value));
+    }
+  }
+
+  return limitToolDetail(JSON.stringify(redactSensitiveDetails(structured), null, 2));
 }
 
 // --- Build trajectory from events ---
@@ -173,9 +224,14 @@ export interface IterationAccumulator {
     tools: Array<{
       id: string;
       name: string;
-      success: boolean;
+      displayName?: string;
+      label: string;
+      success?: boolean;
       status: string;
       durationMs?: number;
+      arguments?: Record<string, unknown>;
+      resultText?: string;
+      error?: string;
     }>;
     successCount: number;
     errorCount: number;
@@ -189,7 +245,12 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
   let currentIteration: IterationAccumulator | null = null;
 
   const toolResults = new Map<string, ToolCompletedData>();
+  const toolStarts = new Map<string, ToolStartedData>();
   for (const event of events) {
+    const tsData = getEventData(event, "tool.started");
+    if (tsData) {
+      toolStarts.set(tsData.tool_call.id, tsData);
+    }
     const tcData = getEventData(event, "tool.completed");
     if (tcData) {
       toolResults.set(tcData.tool_call_id, tcData);
@@ -279,18 +340,33 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
           eventId: event.id,
           ts: event.ts,
           tools: data.tool_calls.map((tc) => {
+            const started = toolStarts.get(tc.id);
             const result = toolResults.get(tc.id);
             return {
               id: tc.id,
-              name: tc.name,
-              displayName: tc.display_name ?? result?.display_name,
-              success: result?.success ?? true,
+              name: started?.tool_call.name ?? result?.tool_name ?? tc.name,
+              displayName: started?.display_name ?? tc.display_name ?? result?.display_name,
+              label:
+                result?.narration ??
+                started?.narration ??
+                tc.narration ??
+                started?.display_name ??
+                tc.display_name ??
+                result?.display_name ??
+                started?.tool_call.name ??
+                result?.tool_name ??
+                tc.name,
+              success: result?.success,
               status: result?.status ?? "pending",
               durationMs: result?.duration_ms,
+              arguments: started?.tool_call.arguments,
+              resultText: result?.result ? getTextFromContent(result.result) : undefined,
+              error: result?.error,
             };
           }),
-          successCount: 0,
-          errorCount: 0,
+          successCount: data.tool_calls.filter((tc) => toolResults.get(tc.id)?.success).length,
+          errorCount: data.tool_calls.filter((tc) => toolResults.get(tc.id)?.success === false)
+            .length,
         };
         break;
       }
@@ -304,6 +380,13 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
         currentIteration.toolGroup.durationMs = data.duration_ms;
         break;
       }
+
+      // tool lifecycle events are pre-indexed above and hydrated into the
+      // act.started batch. They remain structural so live completion updates
+      // replace pending status/details without changing batch ordering.
+      case "tool.started":
+      case "tool.completed":
+        break;
 
       case "output.message.completed": {
         if (!currentTurn) break;
@@ -418,6 +501,7 @@ export function buildTrajectory(
   for (let turnIdx = 0; turnIdx < turns.length; turnIdx++) {
     const turn = turns[turnIdx];
     const groupId = `turn-${turnIdx}-group`;
+    const groupInsertIndex = nodes.length;
     let childY = GROUP_PAD_TOP; // relative Y within group
     let firstChildId: string | null = null;
     let lastChildId: string | null = null;
@@ -432,6 +516,10 @@ export function buildTrajectory(
         position: { x: CHILD_X, y: childY },
         parentId: groupId,
         extent: "parent" as const,
+        // Earlier tool popovers must paint over every later node in the flow.
+        // A descending positive value keeps expanded details readable without
+        // changing the chronological layout.
+        zIndex: type === "toolGroup" ? events.length - nodes.length : undefined,
         data: data as TrajectoryNodeData & Record<string, unknown>,
       });
       if (!firstChildId) firstChildId = id;
@@ -507,7 +595,8 @@ export function buildTrajectory(
     const groupHeight = childY - CHILD_SPACING_CONTENT + CHILD_SPACING_COMPACT + GROUP_PAD_BOTTOM;
 
     // Create turn group node
-    nodes.push({
+    // React Flow requires a parent to precede all of its children.
+    nodes.splice(groupInsertIndex, 0, {
       id: groupId,
       type: "turnGroup",
       position: { x: 0, y: groupY },


### PR DESCRIPTION
## What changed

Session Trajectory now hydrates tool batches from the full `tool.started` / `tool.completed` lifecycle. Each call stays in its original iteration and batch order and shows argument-aware narration, technical tool name, live/final status, duration, and bounded expandable input/result/error details. Turns with no calls retain only their existing user, reasoning, and agent nodes.

The flow also emits parent nodes before children (the ordering React Flow requires) and gives earlier tool popovers a descending stack order so expanded details stay readable over later graph nodes.

## Why

Trajectory previously reduced `act.started` to compact success/error chips. It discarded real call arguments, result/error content, completed narration, and per-call duration, making tool execution difficult to understand and leaving pending calls visually indistinguishable from success in some partial event states.

## Before / After

Before: trajectory tool batches showed only a display/tool name and aggregate styling; the parser ignored `tool.started` details and most `tool.completed` fields.

After: a production-shaped fixture proves `User → Reasoning 1 → parallel tool batch → Reasoning 2 → tool batch → Reasoning 3 → Agent`, including one failed parallel call, per-call durations, and no tool node for the final no-call iteration. Manual screenshots were captured at 1280×720 (compact and expanded) and 390×844; labels stayed legible, the graph fit the narrow viewport, and expanded details painted above later nodes. Screenshot upload was unavailable because this environment has no Cloudinary configuration; screenshots were not committed per repository policy.

Validation:

- `just pre-push`
- UI: format, lint, typecheck
- UI: 141 suites / 1,211 tests
- UI production build
- Manual local trajectory smoke at desktop and 390px widths
- Post-rebase typecheck and focused trajectory tests (22 tests)

The supplied hosted session `session_019fd9c1be847c01a973d47f30ebd2ee` was used as the target scenario, but direct export was blocked by production authentication unavailable to this worktree/browser. The parser behavior was instead verified against the runtime's canonical event order and a representative production-shaped lifecycle fixture with real read/shell call payloads, parallel completion order, failure, and multiple iterations.

## Risk

- Low
- UI-only event parsing/rendering. Main risks are graph ordering/stacking and exposing oversized or sensitive event details; tests cover ordering/status and rendering, details are capped at 1,200 characters, and secret-shaped structured/plaintext fields are redacted.

## Security

- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: event content remains React text (no raw HTML), expandable payload work/output is bounded, and common credential-shaped fields are recursively redacted in structured data and masked in plaintext assignments. No auth, authorization, API, persistence, or dependency surface changed. No threat-model update required.

## Follow-ups

- Recheck the supplied hosted session after deployment; this environment had no authenticated production session/API access, so exact production-session export and screenshot comparison could not be completed locally.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no comments were posted after both review sweeps)
