### PR TITLE
fix(sessions): show user names for participants

### DIFF
--- a/apps/ui/src/__tests__/session-participant-label.test.ts
+++ b/apps/ui/src/__tests__/session-participant-label.test.ts
@@ -1,0 +1,37 @@
+import { getSessionParticipantLabel } from "@/lib/session-participant-label";
+import type { SessionParticipant } from "@/lib/api/types";
+
+function participant(overrides: Partial<SessionParticipant> = {}): SessionParticipant {
+  return {
+    id: "part_01933b5a00007000800000000000001",
+    session_id: "session_01933b5a00007000800000000000001",
+    kind: "user",
+    principal_id: "principal_01933b5a000070008000000000000001",
+    role: "member",
+    joined_at: "2026-08-06T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("getSessionParticipantLabel", () => {
+  it("uses the participant's persisted display name", () => {
+    expect(getSessionParticipantLabel(participant({ display_name: "Mykhailo Chalyi" }))).toBe(
+      "Mykhailo Chalyi",
+    );
+  });
+
+  it("preserves an explicit name ahead of an agent lookup", () => {
+    const agentNames = new Map([["agent_1", "Current agent name"]]);
+    expect(
+      getSessionParticipantLabel(
+        participant({ kind: "agent", agent_id: "agent_1", display_name: "Invited expert" }),
+        agentNames,
+      ),
+    ).toBe("Invited expert");
+  });
+
+  it("uses non-misleading kind fallbacks for missing or blank names", () => {
+    expect(getSessionParticipantLabel(participant({ display_name: "  " }))).toBe("User");
+    expect(getSessionParticipantLabel(participant({ kind: "agent" }))).toBe("Agent");
+  });
+});

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -22,6 +22,7 @@ import type {
   ToolProgressData,
 } from "@/lib/api/types";
 import { getDisplayName } from "@/lib/entity-lifecycle";
+import { getSessionParticipantLabel } from "@/lib/session-participant-label";
 import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { getEventData, isImageFilePart, isTextPart } from "@/lib/api/types";
 import type { TextAnnotation } from "@/lib/api/types";
@@ -386,12 +387,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   }, [participantMarkers, chatEvents]);
 
   const participantLabel = useCallback(
-    (p: SessionParticipant): string => {
-      if (p.kind === "agent") {
-        return (p.agent_id && agentNameById.get(p.agent_id)) || "Agent";
-      }
-      return "Participant";
-    },
+    (p: SessionParticipant): string => getSessionParticipantLabel(p, agentNameById),
     [agentNameById],
   );
 

--- a/apps/ui/src/components/session/session-participants-rail.tsx
+++ b/apps/ui/src/components/session/session-participants-rail.tsx
@@ -19,6 +19,7 @@ import {
   useSessionParticipants,
 } from "@/hooks";
 import { getDisplayName } from "@/lib/entity-lifecycle";
+import { getSessionParticipantLabel } from "@/lib/session-participant-label";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -71,12 +72,8 @@ export function SessionParticipantsRail({ sessionId, className }: SessionPartici
   // Guard: keep ordinary 1:1 sessions (host only) untouched.
   if (active.length < 2 && left.length === 0) return null;
 
-  const participantLabel = (p: SessionParticipant): string => {
-    if (p.kind === "agent") {
-      return (p.agent_id && agentNameById.get(p.agent_id)) || "Agent";
-    }
-    return "Participant";
-  };
+  const participantLabel = (p: SessionParticipant): string =>
+    getSessionParticipantLabel(p, agentNameById);
 
   const handleInvite = async (agentId: string) => {
     try {

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -14343,6 +14343,8 @@ export interface components {
        * @example agentver_01933b5a00007000800000000000001
        */
       agent_version_id?: string | null;
+      /** @description Human-readable name captured for this participant. */
+      display_name?: string | null;
       /**
        * @description Unique identifier for the participant row (format: part_{32-hex}).
        * @example part_01933b5a00007000800000000000001

--- a/apps/ui/src/lib/session-participant-label.ts
+++ b/apps/ui/src/lib/session-participant-label.ts
@@ -1,0 +1,13 @@
+import type { SessionParticipant } from "@/lib/api/types";
+
+export function getSessionParticipantLabel(
+  participant: SessionParticipant,
+  agentNameById?: ReadonlyMap<string, string>,
+): string {
+  const explicitName = participant.display_name?.trim();
+  if (explicitName) return explicitName;
+  if (participant.kind === "agent") {
+    return (participant.agent_id && agentNameById?.get(participant.agent_id)) || "Agent";
+  }
+  return "User";
+}

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -847,6 +847,7 @@ pub mod tests {
                 agent_id: Some(agent_id),
                 agent_version_id: self.agent.default_version_id,
                 principal_id: self.session.owner_principal_id,
+                display_name: None,
                 role: crate::session::SessionParticipantRole::Member,
                 joined_at: chrono::Utc::now(),
                 left_at: None,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -224,6 +224,9 @@ pub struct SessionParticipant {
         )
     )]
     pub principal_id: PrincipalId,
+    /// Human-readable name captured for this participant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     pub role: SessionParticipantRole,
     pub joined_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/server/migrations/112_session_participant_display_name.sql
+++ b/crates/server/migrations/112_session_participant_display_name.sql
@@ -1,0 +1,21 @@
+ALTER TABLE session_participants
+    ADD COLUMN display_name TEXT;
+
+UPDATE session_participants AS participant
+SET display_name = COALESCE(
+    NULLIF(BTRIM(users.name), ''),
+    NULLIF(BTRIM(principals.metadata ->> 'external_actor_name'), ''),
+    NULLIF(BTRIM(principals.metadata ->> 'name'), ''),
+    'User'
+)
+FROM principals
+LEFT JOIN users ON users.id = principals.resolved_user_id
+WHERE participant.kind = 'user'
+  AND participant.principal_id = principals.id;
+
+UPDATE session_participants
+SET display_name = 'User'
+WHERE kind = 'user' AND display_name IS NULL;
+
+COMMENT ON COLUMN session_participants.display_name IS
+    'Human-readable participant name captured from the authoritative identity profile or external actor.';

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -903,6 +903,7 @@ async fn ensure_slack_user_participant(
             agent_id: None,
             agent_version_id: None,
             principal_id: principal.id,
+            display_name: Some(actor.display_label().to_string()),
             role: SessionParticipantRole::Member,
             joined_at: None,
         })

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -513,6 +513,7 @@ mod tests {
                 agent_id: Some(guest_agent.id),
                 agent_version_id: None,
                 principal_id: session.owner_principal_id,
+                display_name: None,
                 role: SessionParticipantRole::Member,
                 joined_at: None,
             })

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -4,6 +4,7 @@ use super::types::{
     ForkSessionRequest, GetOrCreateChatSessionRequest, SessionStatsResponse, UpdateSessionRequest,
 };
 use crate::domains::common::*;
+use crate::services::PrincipalService;
 use crate::storage::backend::MAX_SESSION_PARTICIPANT_HISTORY;
 use everruns_core::events::{
     EventContext, EventData, EventRequest, InputMessageData, LLM_GENERATION, SessionIdledData,
@@ -372,13 +373,37 @@ impl Command for AddSessionParticipant {
             }
         }
 
+        let (principal_id, display_name) = if is_user_participant {
+            match ctx.caller.user_id {
+                Some(user_id) => {
+                    let principal = PrincipalService::new(ctx.db.clone())
+                        .ensure_user_principal(ctx.org_id(), user_id)
+                        .await
+                        .map_err(classify_anyhow)?;
+                    let display_name = ctx
+                        .db
+                        .get_user(user_id)
+                        .await
+                        .map_err(classify_anyhow)?
+                        .map(|user| user.name.trim().to_string())
+                        .filter(|name| !name.is_empty())
+                        .unwrap_or_else(|| "User".to_string());
+                    (principal.id, Some(display_name))
+                }
+                None => (session.owner_principal_id, Some("User".to_string())),
+            }
+        } else {
+            (session.owner_principal_id, None)
+        };
+
         let input = crate::storage::models::CreateSessionParticipantRow {
             org_id: ctx.org_id(),
             session_id,
             kind: self.req.kind,
             agent_id,
             agent_version_id,
-            principal_id: session.owner_principal_id,
+            principal_id,
+            display_name,
             role,
             joined_at: None,
         };

--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -657,6 +657,7 @@ mod tests {
                 agent_id: Some(guest_agent_id),
                 agent_version_id: None,
                 principal_id: PrincipalId::from_seed(2),
+                display_name: None,
                 role: SessionParticipantRole::Member,
                 joined_at: None,
             })

--- a/crates/server/src/storage/memory/session_participants.rs
+++ b/crates/server/src/storage/memory/session_participants.rs
@@ -20,6 +20,7 @@ impl InMemoryDatabase {
                 agent_id: Some(agent_id),
                 agent_version_id: session.agent_version_id,
                 principal_id: session.owner_principal_id,
+                display_name: None,
                 role: SessionParticipantRole::Host.to_string(),
                 joined_at: session.created_at,
                 left_at: None,
@@ -28,6 +29,16 @@ impl InMemoryDatabase {
             })?;
         }
 
+        let display_name = session
+            .resolved_owner_user_id
+            .and_then(|user_id| {
+                self.users
+                    .read()
+                    .get(&user_id)
+                    .map(|user| user.name.trim().to_string())
+            })
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| "User".to_string());
         self.insert_session_participant_unchecked(SessionParticipantRow {
             id: SessionParticipantId::new(),
             org_id: session.org_id,
@@ -36,6 +47,7 @@ impl InMemoryDatabase {
             agent_id: None,
             agent_version_id: None,
             principal_id: session.owner_principal_id,
+            display_name: Some(display_name),
             role: SessionParticipantRole::Member.to_string(),
             joined_at: session.created_at,
             left_at: None,
@@ -62,6 +74,7 @@ impl InMemoryDatabase {
             agent_id: input.agent_id,
             agent_version_id: input.agent_version_id,
             principal_id: input.principal_id,
+            display_name: input.display_name,
             role: input.role.to_string(),
             joined_at,
             left_at: None,
@@ -85,20 +98,33 @@ impl InMemoryDatabase {
             bail!("active user participant upsert requires a user member shape");
         }
 
-        if let Some(existing) = self
-            .session_participants
-            .read()
-            .values()
-            .find(|row| {
-                row.org_id == input.org_id
-                    && row.session_id == input.session_id
-                    && row.kind == SessionParticipantKind::User.to_string()
-                    && row.principal_id == input.principal_id
-                    && row.left_at.is_none()
-            })
-            .cloned()
-        {
-            return Ok(existing);
+        let existing_id = {
+            self.session_participants
+                .read()
+                .values()
+                .find(|row| {
+                    row.org_id == input.org_id
+                        && row.session_id == input.session_id
+                        && row.kind == SessionParticipantKind::User.to_string()
+                        && row.principal_id == input.principal_id
+                        && row.left_at.is_none()
+                })
+                .map(|row| row.id)
+        };
+        if let Some(existing_id) = existing_id {
+            let mut participants = self.session_participants.write();
+            let existing = participants
+                .get_mut(&existing_id)
+                .expect("participant exists");
+            if input
+                .display_name
+                .as_ref()
+                .is_some_and(|name| !name.is_empty())
+            {
+                existing.display_name = input.display_name;
+                existing.updated_at = Self::now();
+            }
+            return Ok(existing.clone());
         }
 
         self.validate_session_participant(&input)?;
@@ -113,6 +139,7 @@ impl InMemoryDatabase {
             agent_id: None,
             agent_version_id: None,
             principal_id: input.principal_id,
+            display_name: input.display_name,
             role: SessionParticipantRole::Member.to_string(),
             joined_at,
             left_at: None,

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -353,6 +353,63 @@ async fn test_create_session_seeds_agent_and_user_participants() {
     assert_eq!(user.role, SessionParticipantRole::Member);
     assert_eq!(user.agent_id, None);
     assert_eq!(user.principal_id, PrincipalId::from_seed(1));
+    assert_eq!(user.display_name.as_deref(), Some("User"));
+}
+
+#[tokio::test]
+async fn test_user_participant_uses_and_tracks_profile_name() {
+    let db = InMemoryDatabase::new();
+    let user = db
+        .create_user(CreateUserRow {
+            email: "mykhailo@example.com".to_string(),
+            name: "Mykhailo Chalyi".to_string(),
+            avatar_url: None,
+            roles: vec!["user".to_string()],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .unwrap();
+    let principal = db
+        .create_principal(CreatePrincipalRow {
+            id: PrincipalId::new(),
+            org_id: DEFAULT_ORG_ID,
+            kind: "user".to_string(),
+            subject_id: Some(user.id),
+            parent_principal_id: None,
+            resolved_user_id: Some(user.id),
+            metadata: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+    let mut input = test_session_input(None);
+    input.owner_principal_id = principal.id;
+    input.resolved_owner_user_id = Some(user.id);
+
+    let session = db.create_session(input).await.unwrap();
+    let initial = db
+        .list_session_participants(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap();
+    assert_eq!(initial[0].display_name.as_deref(), Some("Mykhailo Chalyi"));
+
+    db.update_user(
+        user.id,
+        UpdateUser {
+            name: Some("Mike Chalyi".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let updated = db
+        .list_session_participants(DEFAULT_ORG_ID, session.id)
+        .await
+        .unwrap();
+    assert_eq!(updated[0].display_name.as_deref(), Some("Mike Chalyi"));
 }
 
 #[tokio::test]
@@ -415,6 +472,7 @@ async fn test_create_session_participant_rejects_second_active_host() {
             agent_id: Some(AgentId::new()),
             agent_version_id: None,
             principal_id: PrincipalId::from_seed(1),
+            display_name: None,
             role: SessionParticipantRole::Host,
             joined_at: None,
         })
@@ -440,6 +498,7 @@ async fn test_ensure_active_user_session_participant_is_idempotent() {
         agent_id: None,
         agent_version_id: None,
         principal_id,
+        display_name: Some("Alice".to_string()),
         role: SessionParticipantRole::Member,
         joined_at: None,
     };
@@ -453,6 +512,7 @@ async fn test_ensure_active_user_session_participant_is_idempotent() {
         .unwrap();
 
     assert_eq!(first.id, second.id);
+    assert_eq!(second.display_name.as_deref(), Some("Alice"));
     let active_for_principal = db
         .list_session_participants(DEFAULT_ORG_ID, session.id)
         .await
@@ -477,6 +537,7 @@ async fn test_leave_session_participant_preserves_history() {
             agent_id: Some(AgentId::new()),
             agent_version_id: None,
             principal_id: PrincipalId::from_seed(1),
+            display_name: None,
             role: SessionParticipantRole::Member,
             joined_at: None,
         })

--- a/crates/server/src/storage/memory/users.rs
+++ b/crates/server/src/storage/memory/users.rs
@@ -155,6 +155,7 @@ impl InMemoryDatabase {
     }
 
     pub async fn update_user(&self, id: Uuid, input: UpdateUser) -> Result<Option<UserRow>> {
+        let changed_name = input.name.clone();
         let mut users = self.users.write();
         if let Some(user) = users.get_mut(&id) {
             if let Some(name) = input.name {
@@ -173,7 +174,30 @@ impl InMemoryDatabase {
                 user.email_verified = email_verified;
             }
             user.updated_at = Self::now();
-            return Ok(Some(user.clone()));
+            let updated = user.clone();
+            drop(users);
+            if let Some(name) = changed_name {
+                let display_name = match name.trim() {
+                    "" => "User".to_string(),
+                    name => name.to_string(),
+                };
+                let principal_ids = self
+                    .principals
+                    .read()
+                    .values()
+                    .filter(|principal| principal.resolved_user_id == Some(id))
+                    .map(|principal| principal.id)
+                    .collect::<std::collections::HashSet<_>>();
+                for participant in self.session_participants.write().values_mut() {
+                    if participant.kind == "user"
+                        && principal_ids.contains(&participant.principal_id)
+                    {
+                        participant.display_name = Some(display_name.clone());
+                        participant.updated_at = Self::now();
+                    }
+                }
+            }
+            return Ok(Some(updated));
         }
         Ok(None)
     }

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -901,6 +901,7 @@ pub struct SessionParticipantRow {
     pub agent_id: Option<AgentId>,
     pub agent_version_id: Option<everruns_core::AgentVersionId>,
     pub principal_id: PrincipalId,
+    pub display_name: Option<String>,
     pub role: String,
     pub joined_at: DateTime<Utc>,
     pub left_at: Option<DateTime<Utc>>,
@@ -917,6 +918,7 @@ impl SessionParticipantRow {
             agent_id: self.agent_id,
             agent_version_id: self.agent_version_id,
             principal_id: self.principal_id,
+            display_name: self.display_name.clone(),
             role: SessionParticipantRole::from(self.role.as_str()),
             joined_at: self.joined_at,
             left_at: self.left_at,
@@ -932,6 +934,7 @@ pub struct CreateSessionParticipantRow {
     pub agent_id: Option<AgentId>,
     pub agent_version_id: Option<everruns_core::AgentVersionId>,
     pub principal_id: PrincipalId,
+    pub display_name: Option<String>,
     pub role: SessionParticipantRole,
     pub joined_at: Option<DateTime<Utc>>,
 }

--- a/crates/server/src/storage/repositories/session_participants.rs
+++ b/crates/server/src/storage/repositories/session_participants.rs
@@ -17,11 +17,11 @@ impl Database {
             r#"
             INSERT INTO session_participants (
                 id, org_id, session_id, kind, agent_id, agent_version_id,
-                principal_id, role, joined_at
+                principal_id, display_name, role, joined_at
             )
-            VALUES (uuidv7(), $1, $2, $3, $4, $5, $6, $7, $8)
+            VALUES (uuidv7(), $1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING id, org_id, session_id, kind, agent_id, agent_version_id,
-                      principal_id, role, joined_at, left_at, created_at, updated_at
+                      principal_id, display_name, role, joined_at, left_at, created_at, updated_at
             "#,
         )
         .bind(input.org_id)
@@ -30,6 +30,7 @@ impl Database {
         .bind(input.agent_id.map(|id| id.uuid()))
         .bind(input.agent_version_id.map(|id| id.uuid()))
         .bind(input.principal_id)
+        .bind(input.display_name)
         .bind(input.role.to_string())
         .bind(joined_at)
         .fetch_one(&self.pool)
@@ -55,19 +56,24 @@ impl Database {
             r#"
             INSERT INTO session_participants (
                 id, org_id, session_id, kind, agent_id, agent_version_id,
-                principal_id, role, joined_at
+                principal_id, display_name, role, joined_at
             )
-            VALUES (uuidv7(), $1, $2, 'user', NULL, NULL, $3, 'member', $4)
+            VALUES (uuidv7(), $1, $2, 'user', NULL, NULL, $3, $4, 'member', $5)
             ON CONFLICT (session_id, principal_id)
                 WHERE kind = 'user' AND left_at IS NULL
-            DO UPDATE SET updated_at = NOW()
+            DO UPDATE SET display_name = COALESCE(
+                              NULLIF(EXCLUDED.display_name, ''),
+                              session_participants.display_name
+                          ),
+                          updated_at = NOW()
             RETURNING id, org_id, session_id, kind, agent_id, agent_version_id,
-                      principal_id, role, joined_at, left_at, created_at, updated_at
+                      principal_id, display_name, role, joined_at, left_at, created_at, updated_at
             "#,
         )
         .bind(input.org_id)
         .bind(input.session_id.uuid())
         .bind(input.principal_id)
+        .bind(input.display_name)
         .bind(joined_at)
         .fetch_one(&self.pool)
         .await
@@ -82,7 +88,7 @@ impl Database {
         sqlx::query_as::<_, SessionParticipantRow>(
             r#"
             SELECT id, org_id, session_id, kind, agent_id, agent_version_id,
-                   principal_id, role, joined_at, left_at, created_at, updated_at
+                   principal_id, display_name, role, joined_at, left_at, created_at, updated_at
             FROM session_participants
             WHERE org_id = $1 AND session_id = $2
             ORDER BY joined_at ASC, created_at ASC, id ASC
@@ -110,7 +116,7 @@ impl Database {
                 updated_at = NOW()
             WHERE org_id = $1 AND session_id = $2 AND id = $3
             RETURNING id, org_id, session_id, kind, agent_id, agent_version_id,
-                      principal_id, role, joined_at, left_at, created_at, updated_at
+                      principal_id, display_name, role, joined_at, left_at, created_at, updated_at
             "#,
         )
         .bind(org_id)

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -128,9 +128,9 @@ impl Database {
                 r#"
                 INSERT INTO session_participants (
                     id, org_id, session_id, kind, agent_id, agent_version_id,
-                    principal_id, role, joined_at
+                    principal_id, display_name, role, joined_at
                 )
-                VALUES (uuidv7(), $1, $2, 'agent', $3, $4, $5, 'host', $6)
+                VALUES (uuidv7(), $1, $2, 'agent', $3, $4, $5, NULL, 'host', $6)
                 "#,
             )
             .bind(row.org_id)
@@ -147,14 +147,22 @@ impl Database {
             r#"
             INSERT INTO session_participants (
                 id, org_id, session_id, kind, agent_id, agent_version_id,
-                principal_id, role, joined_at
+                principal_id, display_name, role, joined_at
             )
-            VALUES (uuidv7(), $1, $2, 'user', NULL, NULL, $3, 'member', $4)
+            VALUES (
+                uuidv7(), $1, $2, 'user', NULL, NULL, $3,
+                COALESCE(
+                    NULLIF(BTRIM((SELECT name FROM users WHERE id = $4)), ''),
+                    'User'
+                ),
+                'member', $5
+            )
             "#,
         )
         .bind(row.org_id)
         .bind(row.id.uuid())
         .bind(row.owner_principal_id)
+        .bind(row.resolved_owner_user_id)
         .bind(row.created_at)
         .execute(&mut *tx)
         .await?;

--- a/crates/server/src/storage/repositories/users.rs
+++ b/crates/server/src/storage/repositories/users.rs
@@ -174,7 +174,16 @@ impl Database {
     }
 
     pub async fn update_user(&self, id: Uuid, input: UpdateUser) -> Result<Option<UserRow>> {
+        let display_name = input
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .unwrap_or("User")
+            .to_string();
+        let name_changed = input.name.is_some();
         let roles_json = input.roles.map(|r| serde_json::to_value(&r)).transpose()?;
+        let mut tx = self.pool.begin().await?;
 
         let row = sqlx::query_as::<_, UserRow>(
             r#"
@@ -196,8 +205,28 @@ impl Database {
         .bind(&roles_json)
         .bind(&input.password_hash)
         .bind(input.email_verified)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *tx)
         .await?;
+
+        if row.is_some() && name_changed {
+            sqlx::query(
+                r#"
+                UPDATE session_participants AS participant
+                SET display_name = $2,
+                    updated_at = NOW()
+                FROM principals
+                WHERE participant.kind = 'user'
+                  AND participant.principal_id = principals.id
+                  AND principals.resolved_user_id = $1
+                "#,
+            )
+            .bind(id)
+            .bind(display_name)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
 
         Ok(row)
     }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -33546,6 +33546,13 @@
             "description": "Immutable agent version captured for an agent participant when known.",
             "example": "agentver_01933b5a00007000800000000000001"
           },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable name captured for this participant."
+          },
           "id": {
             "type": "string",
             "description": "Unique identifier for the participant row (format: part_{32-hex}).",

--- a/specs/session-participants.md
+++ b/specs/session-participants.md
@@ -13,7 +13,8 @@ This spec captures the durable model and its invariants. Field-level shapes,
 enum variants, and SQL live in code — see `crates/core/src/session.rs`
 (`SessionParticipant`, `SessionParticipantKind`, `SessionParticipantRole`), the
 command layer in `crates/server/src/domains/sessions/commands.rs`, and migrations
-`095_session_participants.sql` / `098_session_participant_user_identity.sql`.
+`095_session_participants.sql` / `098_session_participant_user_identity.sql` /
+`112_session_participant_display_name.sql`.
 
 ## Model
 
@@ -26,6 +27,11 @@ Each participant row binds a principal to a session:
 - **principal_id** — the principal that joined. This is the provenance anchor:
   turns, resources, and audit attribute back to the participant's principal
   rather than to `system`.
+- **display name** — the human-readable identity captured with the participant.
+  Signed-in users use the authoritative user profile and existing participant
+  rows track profile renames. External-channel participants retain their
+  explicit actor name. Missing names fall back to the actor kind rather than
+  implying that all unnamed people share the same identity.
 - **joined_at / left_at** — the participation interval. `left_at = null` means
   the participant is still active; a set `left_at` marks a past membership that
   is retained for history.

--- a/test_cases/ui/session_participants/TC001_manage_session_participants.md
+++ b/test_cases/ui/session_participants/TC001_manage_session_participants.md
@@ -17,12 +17,14 @@ Verify that the session participant rail identifies the host and members, suppor
 | --- | --- |
 | Host agent | `Participant Host` |
 | Guest agent | `Participant Specialist` |
+| Current user display name | The name shown in the signed-in profile; `Anonymous` in `AUTH_MODE=none` |
 | Addressed message | `Reply with exactly: specialist reply` |
 
 ## Steps
 
 1. Open the host agent's session and locate the **In this session** participant rail.
-2. Verify the host agent appears with the host role and the current user appears among the members.
+2. Verify the host agent appears with the host role and the current user appears among the members
+   under the current profile display name, both in the participant rail and its transcript join marker.
 3. Use the invite control to add `Participant Specialist`.
 4. Verify the guest appears as an active agent member without replacing the host.
 5. Address `Participant Specialist` and send `Reply with exactly: specialist reply`.
@@ -33,6 +35,8 @@ Verify that the session participant rail identifies the host and members, suppor
 ## Expected Result
 
 - The participant rail distinguishes the host, user members, and invited agent members.
+- The current user's persisted participant and transcript marker use the same profile display name;
+  neither renders the generic label `Participant`.
 - Inviting an agent adds it as a member while preserving the original host.
 - An addressed turn routes to the selected active agent and attributes its reply to that participant.
 - Removing the guest retains membership history and renders a leave system line in the transcript.


### PR DESCRIPTION
## What changed
Human session participants now persist and publish the signed-in user profile display name. The transcript join marker and participant rail render that same participant value, while explicit external participant names remain unchanged. Profiles without a usable name, including `AUTH_MODE=none`, use the non-misleading fallback `User`. Profile renames propagate to existing participant records.

## Why
The default human participant was stored without a name, causing both session surfaces to show the generic label `Participant` instead of identifying the signed-in user.

## Before / After
Before: the default human appeared as `Participant joined the session` and `Participant` in the **In this session** rail.

After (manual isolated-stack verification): the API returned the persisted user participant with `display_name: "Anonymous"`; the transcript showed `Anonymous joined the session`; and the rail showed `Anonymous` / `Member` / `User`. Explicit agent names (`Participant Host`, `Participant Specialist`) remained intact. A local headless-browser screenshot was captured during validation.

## Risk
- Medium
- Adds and backfills a nullable participant column and synchronizes participant names when user profiles change. Incorrect principal resolution or migration ordering could affect participant labels; focused storage/API tests, generated contract checks, migration ordering validation, and the full pre-push suite cover these paths.

## Security
- Threat categories reviewed: TM-AUTH, TM-TENANT, TM-WEB; SQL injection and denial-of-service boundaries.
- Findings and resolutions: Names come from the existing authoritative profile/principal resolution, participant queries remain organization-scoped, SQL stays parameterized, and React renders names as escaped text. No new authorization boundary or secret exposure was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)