### PR TITLE
fix(ui): redact secret store trajectory values

### DIFF
--- a/apps/ui/src/__tests__/trajectory-nodes.test.tsx
+++ b/apps/ui/src/__tests__/trajectory-nodes.test.tsx
@@ -132,4 +132,49 @@ describe("ToolGroupNode", () => {
     expect(screen.getByText(/OPENAI_API_KEY=\[redacted\]/)).toBeInTheDocument();
     expect(screen.queryByText(/sk-live-secret/)).not.toBeInTheDocument();
   });
+
+  it("redacts secret_store values from inputs and results", () => {
+    render(
+      <ToolGroupNode
+        id="tools"
+        type="toolGroup"
+        selected={false}
+        dragging={false}
+        draggable={false}
+        selectable={false}
+        deletable={false}
+        zIndex={0}
+        isConnectable={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+        data={{
+          label: "Tools (1)",
+          tools: [
+            {
+              id: "call-1",
+              name: "secret_store",
+              label: "Stored a secret",
+              status: "success",
+              success: true,
+              arguments: { operation: "set", name: "API_TOKEN", value: "input-secret" },
+              resultText: JSON.stringify({
+                operation: "get",
+                name: "API_TOKEN",
+                value: "output-secret",
+                found: true,
+              }),
+            },
+          ],
+          successCount: 1,
+          errorCount: 0,
+          eventId: "event-1",
+          timestamp: "2026-08-06T12:00:00Z",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Stored a secret"));
+    expect(screen.getAllByText(/\[redacted\]/)).toHaveLength(2);
+    expect(screen.queryByText(/input-secret|output-secret/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -191,8 +191,8 @@ export const ToolGroupNode = memo(function ToolGroupNode({
         {d.tools.map((tool) => {
           const failed = tool.status === "error" || tool.status === "timeout" || !tool.success;
           const pending = tool.status === "pending";
-          const input = formatToolDetail(tool.arguments);
-          const output = formatToolDetail(tool.error ?? tool.resultText);
+          const input = formatToolDetail(tool.arguments, tool.name);
+          const output = formatToolDetail(tool.error ?? tool.resultText, tool.name);
           const hasDetails = input.length > 0 || output.length > 0;
 
           return (

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -145,14 +145,17 @@ const SENSITIVE_DETAIL_KEY =
   /(?:^|_)(?:api_?key|authorization|cookie|credential|password|private_?key|secret|token)(?:$|_)/i;
 const TOOL_DETAIL_LIMIT = 1_200;
 
-function redactSensitiveDetails(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(redactSensitiveDetails);
+function redactSensitiveDetails(value: unknown, redactValue = false): unknown {
+  if (Array.isArray(value))
+    return value.map((nested) => redactSensitiveDetails(nested, redactValue));
   if (value === null || typeof value !== "object") return value;
 
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
       key,
-      SENSITIVE_DETAIL_KEY.test(key) ? "[redacted]" : redactSensitiveDetails(nested),
+      SENSITIVE_DETAIL_KEY.test(key) || (redactValue && key === "value")
+        ? "[redacted]"
+        : redactSensitiveDetails(nested, redactValue),
     ]),
   );
 }
@@ -172,7 +175,7 @@ function redactSensitiveText(text: string): string {
 }
 
 /** Format bounded, secret-aware content for an expandable trajectory detail. */
-export function formatToolDetail(value: unknown): string {
+export function formatToolDetail(value: unknown, toolName?: string): string {
   if (value == null || value === "") return "";
   let structured = value;
   if (typeof value === "string") {
@@ -183,7 +186,9 @@ export function formatToolDetail(value: unknown): string {
     }
   }
 
-  return limitToolDetail(JSON.stringify(redactSensitiveDetails(structured), null, 2));
+  return limitToolDetail(
+    JSON.stringify(redactSensitiveDetails(structured, toolName === "secret_store"), null, 2),
+  );
 }
 
 // --- Build trajectory from events ---


### PR DESCRIPTION
## What changed
Trajectory tool details now receive the tool name when formatting inputs and outputs. For `secret_store`, every structured `value` field is redacted recursively while operation, name, and status metadata remain visible.

A component regression test covers both a `set` input and a `get` result and verifies neither secret reaches the rendered DOM.

## Why
The trajectory path applied only generic key-name redaction. Because `secret_store` carries secret material under the contextual key `value`, session viewers could expand a tool node and read stored secret values.

## Before / After
Before: a rendered `secret_store` tool node contained `input-secret` in Input and `output-secret` in Result.

After: `pnpm exec jest --runInBand src/__tests__/trajectory-nodes.test.tsx` proves both fields render as `[redacted]` and neither sentinel secret is present in the DOM. A screenshot was not captured because the layout is unchanged and reproducing the vulnerable content visually would create an unnecessary secret-like artifact; the rendered-component assertion is the direct evidence.

## Risk
- Low
- The change is limited to expandable trajectory detail formatting. Non-`secret_store` tool details retain existing redaction, while `secret_store` metadata remains visible except for fields named `value`.

## Security
- Threat categories reviewed: TM-WEB, TM-TOOL, TM-TENANT
- Findings and resolutions: confirmed contextual secret values could reach trajectory DOM text; resolved by passing tool identity into formatting and recursively masking `secret_store.value` fields for both arguments and results. No new input, HTML, authorization, dependency, persistence, or unbounded-work surface was introduced. The existing threat model already covers frontend secret disclosure, so no threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
