### PR TITLE
fix(ui): correct knowledge index form validation

### DIFF
--- a/apps/ui/src/__tests__/embedding-model-picker.test.tsx
+++ b/apps/ui/src/__tests__/embedding-model-picker.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { EmbeddingModelPicker } from "@/components/knowledge-indexes/embedding-model-picker";
+
+const mockUseModels = jest.fn();
+
+jest.mock("@/hooks/use-providers", () => ({
+  useModels: () => mockUseModels(),
+}));
+
+describe("EmbeddingModelPicker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    mockUseModels.mockReturnValue({
+      data: [
+        {
+          id: "model_001",
+          display_name: "text-embedding-3-small",
+          provider_name: "OpenAI",
+          enabled: true,
+          capabilities: ["embeddings"],
+        },
+      ],
+      isLoading: false,
+    });
+  });
+
+  it("remains controlled when an initially empty value is selected", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const onChange = jest.fn();
+    const { rerender } = render(<EmbeddingModelPicker value="" onChange={onChange} />);
+
+    rerender(<EmbeddingModelPicker value="model_001" onChange={onChange} />);
+
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining("changing the uncontrolled value state of Select to be controlled"),
+    );
+  });
+});

--- a/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
@@ -50,13 +50,33 @@ jest.mock("@/components/ui/select", () => {
   // Find the SelectTrigger child so its id/aria-label can be lifted onto the
   // native <select> the mock renders (mirrors how the real trigger is the
   // labelable control).
-  function findTrigger(node: mockReact.ReactNode): { id?: string; ariaLabel?: string } {
-    let found: { id?: string; ariaLabel?: string } = {};
+  function findTrigger(node: mockReact.ReactNode): {
+    id?: string;
+    ariaLabel?: string;
+    ariaInvalid?: boolean;
+    ariaDescribedBy?: string;
+  } {
+    let found: {
+      id?: string;
+      ariaLabel?: string;
+      ariaInvalid?: boolean;
+      ariaDescribedBy?: string;
+    } = {};
     mockReact.Children.forEach(node, (child: mockReact.ReactNode) => {
       if (!mockReact.isValidElement(child) || found.id || found.ariaLabel) return;
       if ((child.type as { isSelectTrigger?: boolean }).isSelectTrigger) {
-        const props = child.props as { id?: string; "aria-label"?: string };
-        found = { id: props.id, ariaLabel: props["aria-label"] };
+        const props = child.props as {
+          id?: string;
+          "aria-label"?: string;
+          "aria-invalid"?: boolean;
+          "aria-describedby"?: string;
+        };
+        found = {
+          id: props.id,
+          ariaLabel: props["aria-label"],
+          ariaInvalid: props["aria-invalid"],
+          ariaDescribedBy: props["aria-describedby"],
+        };
         return;
       }
       const nested = findTrigger((child.props as { children?: mockReact.ReactNode }).children);
@@ -81,6 +101,8 @@ jest.mock("@/components/ui/select", () => {
       <select
         id={trigger.id}
         aria-label={trigger.ariaLabel ?? ariaLabel ?? "Source"}
+        aria-invalid={trigger.ariaInvalid}
+        aria-describedby={trigger.ariaDescribedBy}
         value={value}
         onChange={(event) => onValueChange(event.target.value)}
       >
@@ -94,7 +116,13 @@ jest.mock("@/components/ui/select", () => {
   }
   SelectItem.isSelectItem = true;
 
-  function SelectTrigger(_: { children: mockReact.ReactNode; id?: string; "aria-label"?: string }) {
+  function SelectTrigger(_: {
+    children: mockReact.ReactNode;
+    id?: string;
+    "aria-label"?: string;
+    "aria-invalid"?: boolean;
+    "aria-describedby"?: string;
+  }) {
     return null;
   }
   SelectTrigger.isSelectTrigger = true;
@@ -230,8 +258,37 @@ describe("KnowledgeIndexesPage", () => {
     fireEvent.change(within(dialog).getByLabelText("Name"), { target: { value: "No Model" } });
     fireEvent.click(within(dialog).getByRole("button", { name: "Create Index" }));
 
-    expect(within(dialog).getByText(/embedding model is required/i)).toBeInTheDocument();
+    const nameInput = within(dialog).getByLabelText("Name");
+    const embeddingModelPicker = within(dialog).getByRole("combobox", {
+      name: "Embedding model",
+    });
+    const error = within(dialog).getByText(/embedding model is required/i);
+
+    expect(nameInput).not.toHaveAttribute("aria-invalid", "true");
+    expect(embeddingModelPicker).toHaveAttribute("aria-invalid", "true");
+    expect(embeddingModelPicker).toHaveAttribute("aria-describedby", error.id);
     expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("associates multiple validation errors with their fields", () => {
+    render(<KnowledgeIndexesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New index" }));
+    const dialog = screen.getByRole("dialog");
+    const submitButton = within(dialog).getByRole("button", { name: "Create Index" });
+    fireEvent.submit(submitButton.closest("form")!);
+
+    const nameInput = within(dialog).getByLabelText("Name");
+    const embeddingModelPicker = within(dialog).getByRole("combobox", {
+      name: "Embedding model",
+    });
+    const nameError = within(dialog).getByText(/^name is required$/i);
+    const modelError = within(dialog).getByText(/^embedding model is required$/i);
+
+    expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    expect(nameInput).toHaveAttribute("aria-describedby", nameError.id);
+    expect(embeddingModelPicker).toHaveAttribute("aria-invalid", "true");
+    expect(embeddingModelPicker).toHaveAttribute("aria-describedby", modelError.id);
   });
 
   it("archives an index after confirmation", async () => {

--- a/apps/ui/src/components/knowledge-indexes/embedding-model-picker.tsx
+++ b/apps/ui/src/components/knowledge-indexes/embedding-model-picker.tsx
@@ -18,6 +18,8 @@ interface EmbeddingModelPickerProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  "aria-invalid"?: boolean;
+  "aria-describedby"?: string;
 }
 
 // A model is treated as an embeddings model when its capabilities advertise
@@ -37,6 +39,8 @@ export function EmbeddingModelPicker({
   placeholder = "Select an embedding model",
   disabled = false,
   className,
+  "aria-invalid": ariaInvalid = false,
+  "aria-describedby": ariaDescribedBy,
 }: EmbeddingModelPickerProps) {
   const { data: models = [], isLoading } = useModels();
 
@@ -56,8 +60,14 @@ export function EmbeddingModelPicker({
   const selectedModel = models.find((m) => m.id === value);
 
   return (
-    <Select value={value || undefined} onValueChange={onChange} disabled={disabled || isLoading}>
-      <SelectTrigger id={id} className={cn("w-full", className)} aria-label="Embedding model">
+    <Select value={value} onValueChange={onChange} disabled={disabled || isLoading}>
+      <SelectTrigger
+        id={id}
+        className={cn("w-full", className)}
+        aria-label="Embedding model"
+        aria-invalid={ariaInvalid}
+        aria-describedby={ariaDescribedBy}
+      >
         <SelectValue placeholder={isLoading ? "Loading models..." : placeholder}>
           {selectedModel
             ? `${selectedModel.display_name} (${selectedModel.provider_name})`

--- a/apps/ui/src/components/knowledge-indexes/knowledge-index-form-dialog.tsx
+++ b/apps/ui/src/components/knowledge-indexes/knowledge-index-form-dialog.tsx
@@ -28,6 +28,7 @@ import type {
   KnowledgeIndexSourceType,
   UpdateKnowledgeIndexRequest,
 } from "@/lib/api/types";
+import { getFieldErrors, knowledgeIndexFormSchema, type FieldErrors } from "@/lib/form-validation";
 import { EmbeddingModelPicker } from "./embedding-model-picker";
 
 type FormMode = "create" | "edit";
@@ -65,7 +66,7 @@ export function KnowledgeIndexFormDialog({
   const [branch, setBranch] = useState("");
   const [rootFolder, setRootFolder] = useState("");
   const [embeddingModelId, setEmbeddingModelId] = useState("");
-  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [formError, setFormError] = useState<string | null>(null);
   const { data: connections = [] } = useUserConnections();
   const githubConnection = connections.find((connection) => connection.provider === "github");
@@ -83,7 +84,7 @@ export function KnowledgeIndexFormDialog({
     setBranch(readStringField(config, "branch"));
     setRootFolder(readStringField(config, "root_folder"));
     setEmbeddingModelId(mode === "edit" ? (index?.embedding_model_id ?? "") : "");
-    setFieldError(null);
+    setFieldErrors({});
     setFormError(null);
   }, [mode, open, index]);
 
@@ -103,21 +104,25 @@ export function KnowledgeIndexFormDialog({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setFieldError(null);
+    setFieldErrors({});
     setFormError(null);
 
-    const trimmedName = name.trim();
-    if (!trimmedName) {
-      setFieldError("Name is required");
-      return;
-    }
-    if (!embeddingModelId) {
-      setFieldError("An embedding model is required");
+    const parsed = knowledgeIndexFormSchema.safeParse({
+      name,
+      description,
+      embedding_model_id: embeddingModelId,
+    });
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
       return;
     }
 
     try {
-      const trimmedDescription = description.trim();
+      const {
+        name: trimmedName,
+        description: trimmedDescription,
+        embedding_model_id: parsedEmbeddingModelId,
+      } = parsed.data;
       const sourceConfig = buildSourceConfig();
       if (mode === "create") {
         await onSubmit({
@@ -125,14 +130,14 @@ export function KnowledgeIndexFormDialog({
           ...(trimmedDescription ? { description: trimmedDescription } : {}),
           source_type: sourceType,
           source_config: sourceConfig,
-          embedding_model_id: embeddingModelId,
+          embedding_model_id: parsedEmbeddingModelId,
         });
       } else {
         await onSubmit({
           name: trimmedName,
           description: trimmedDescription || null,
           source_config: sourceConfig,
-          embedding_model_id: embeddingModelId,
+          embedding_model_id: parsedEmbeddingModelId,
         });
       }
       onOpenChange(false);
@@ -161,11 +166,17 @@ export function KnowledgeIndexFormDialog({
               value={name}
               onChange={(event) => {
                 setName(event.target.value);
-                setFieldError(null);
+                setFieldErrors((previous) => ({ ...previous, name: undefined }));
               }}
-              aria-invalid={!!fieldError}
+              aria-invalid={!!fieldErrors.name}
+              aria-describedby={fieldErrors.name ? "kidx-name-error" : undefined}
               required
             />
+            {fieldErrors.name && (
+              <p id="kidx-name-error" className="text-xs text-destructive">
+                {fieldErrors.name}
+              </p>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="kidx-description">Description</Label>
@@ -183,12 +194,24 @@ export function KnowledgeIndexFormDialog({
               value={embeddingModelId}
               onChange={(modelId) => {
                 setEmbeddingModelId(modelId);
-                setFieldError(null);
+                setFieldErrors((previous) => ({
+                  ...previous,
+                  embedding_model_id: undefined,
+                }));
               }}
+              aria-invalid={!!fieldErrors.embedding_model_id}
+              aria-describedby={
+                fieldErrors.embedding_model_id ? "kidx-embedding-model-error" : undefined
+              }
             />
             <p className="text-xs text-muted-foreground">
               Required. Chunks are embedded with this model; it cannot be cleared.
             </p>
+            {fieldErrors.embedding_model_id && (
+              <p id="kidx-embedding-model-error" className="text-xs text-destructive">
+                {fieldErrors.embedding_model_id}
+              </p>
+            )}
           </div>
           <div className="space-y-4">
             <div className="space-y-2">
@@ -278,7 +301,6 @@ export function KnowledgeIndexFormDialog({
               </div>
             </div>
           </div>
-          {fieldError && <p className="text-xs text-destructive">{fieldError}</p>}
           {formError && <p className="text-sm text-destructive">{formError}</p>}
           <DialogFooter>
             <Button

--- a/apps/ui/src/lib/form-validation.ts
+++ b/apps/ui/src/lib/form-validation.ts
@@ -122,6 +122,12 @@ export const apiKeySecretSchema = z.object({
   api_key: requiredString("API key"),
 });
 
+export const knowledgeIndexFormSchema = z.object({
+  name: requiredString("Name"),
+  description: optionalString(),
+  embedding_model_id: requiredString("Embedding model"),
+});
+
 export function createConnectionFormSchema(fields: ConnectionFormField[]) {
   const shape = Object.fromEntries(
     fields.map((field) => [


### PR DESCRIPTION
## What changed
Knowledge Index create/edit validation now tracks errors by field, places each message beside its control, and connects errors with `aria-invalid`/`aria-describedby`. The embedding-model Select remains controlled from its initial empty state through selection, eliminating the Base UI console warning.

## Why
A missing embedding model incorrectly marked the valid Name input invalid and rendered its message away from the affected control. Selecting a model also switched the Select from uncontrolled to controlled and triggered a runtime warning.

## Before / After
Before: submitting a valid name without an embedding model outlined Name in red while the model error appeared at the bottom of the form; selecting a model emitted `A component is changing the uncontrolled value state of Select to be controlled`.

After: a headless Chromium smoke test against `PORT_PREFIX=388 just start-dev --no-watch` confirmed only the embedding-model picker is outlined, its error is directly beneath and ARIA-linked, Name remains valid, and the browser console is clean. Screenshot captured locally at `/tmp/knowledge-index-validation-fixed.png`; upload credentials were unavailable in the local environment.

## Risk
- Low
- Limited to Knowledge Index form validation and the reusable embedding-model picker. Server-side validation remains unchanged and authoritative.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new trust boundary, HTML injection path, credential flow, or server authorization behavior. React continues to escape messages; the change only scopes client-side validation state and keeps a Select controlled. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)