### PR TITLE
feat(ui): add chip-based tag editor

### DIFF
--- a/apps/ui/src/__tests__/agent-edit-page.test.tsx
+++ b/apps/ui/src/__tests__/agent-edit-page.test.tsx
@@ -162,6 +162,22 @@ describe("EditAgentPage", () => {
     expect(screen.queryByTestId("agent-preview")).not.toBeInTheDocument();
   });
 
+  it("adds tags through the tag editor and submits them", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({});
+    mockUseUpdateAgent.mockReturnValue({ mutateAsync, isPending: false });
+
+    await renderWithSuspense({ agentId: "agent_123" });
+    const tagsInput = screen.getByLabelText("Tags");
+    fireEvent.change(tagsInput, { target: { value: "support" } });
+    fireEvent.keyDown(tagsInput, { key: "Enter" });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Save changes/ }));
+    });
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutateAsync.mock.calls[0][0].request.tags).toEqual(["support"]);
+  });
+
   it("keeps checks in Edit instead of Preview", async () => {
     await renderWithSuspense({ agentId: "agent_123" });
 

--- a/apps/ui/src/__tests__/tag-input.test.tsx
+++ b/apps/ui/src/__tests__/tag-input.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+
+import { TagInput } from "@/components/ui/tag-input";
+
+function ControlledTagInput({ initialValue = "" }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <>
+      <label htmlFor="tags">Tags</label>
+      <TagInput id="tags" value={value} onChange={setValue} />
+      <output data-testid="value">{value}</output>
+    </>
+  );
+}
+
+describe("TagInput", () => {
+  it("renders existing tags as removable chips", () => {
+    render(<ControlledTagInput initialValue="ops, alerts" />);
+
+    expect(screen.getByText("ops")).toBeInTheDocument();
+    expect(screen.getByText("alerts")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Remove ops" }));
+
+    expect(screen.getByTestId("value")).toHaveTextContent("alerts");
+    expect(screen.queryByText("ops")).not.toBeInTheDocument();
+  });
+
+  it("adds trimmed tags with Enter and ignores duplicates", () => {
+    render(<ControlledTagInput initialValue="ops" />);
+    const input = screen.getByLabelText("Tags");
+
+    fireEvent.change(input, { target: { value: " alerts " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.change(input, { target: { value: "ops" } });
+    fireEvent.keyDown(input, { key: "," });
+
+    expect(screen.getByTestId("value")).toHaveTextContent("ops, alerts");
+    expect(screen.getAllByText("ops")).toHaveLength(1);
+    expect(input).toHaveValue("");
+  });
+
+  it("splits pasted comma-separated tags", () => {
+    render(<ControlledTagInput />);
+    const input = screen.getByLabelText("Tags");
+
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => "demo, support, demo" },
+    });
+
+    expect(screen.getByTestId("value")).toHaveTextContent("demo, support");
+  });
+
+  it("removes the last tag with Backspace from an empty input", () => {
+    render(<ControlledTagInput initialValue="ops, alerts" />);
+
+    fireEvent.keyDown(screen.getByLabelText("Tags"), { key: "Backspace" });
+
+    expect(screen.getByTestId("value")).toHaveTextContent("ops");
+    expect(screen.queryByText("alerts")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { TagInput } from "@/components/ui/tag-input";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -409,14 +410,17 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
 
                   <div className="space-y-2">
                     <Label htmlFor="tags">Tags</Label>
-                    <Input
+                    <TagInput
                       id="tags"
-                      placeholder="tag1, tag2, tag3"
+                      placeholder="Add a tag…"
                       value={formData.tags}
-                      onChange={(e) => handleFormChange("tags", e.target.value)}
+                      onChange={(value) => handleFormChange("tags", value)}
                       disabled={isSaving || isReadOnly}
+                      aria-describedby="tags-help"
                     />
-                    <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                    <p id="tags-help" className="text-xs text-muted-foreground">
+                      Press Enter or comma to add a tag. Backspace removes the last tag.
+                    </p>
                   </div>
 
                   <div className="space-y-2">

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -20,6 +20,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { TagInput } from "@/components/ui/tag-input";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -412,14 +413,17 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
 
                   <div className="space-y-2">
                     <Label htmlFor="tags">Tags</Label>
-                    <Input
+                    <TagInput
                       id="tags"
-                      placeholder="tag1, tag2, tag3"
+                      placeholder="Add a tag…"
                       value={formData.tags}
-                      onChange={(e) => handleFormChange("tags", e.target.value)}
+                      onChange={(value) => handleFormChange("tags", value)}
                       disabled={isSaving || isReadOnly}
+                      aria-describedby="tags-help"
                     />
-                    <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                    <p id="tags-help" className="text-xs text-muted-foreground">
+                      Press Enter or comma to add a tag. Backspace removes the last tag.
+                    </p>
                   </div>
 
                   <div className="space-y-2">

--- a/apps/ui/src/components/ui/tag-input.tsx
+++ b/apps/ui/src/components/ui/tag-input.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, type ClipboardEvent, type KeyboardEvent } from "react";
+import { X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+function parseTags(value: string): string[] {
+  return value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter((tag, index, tags) => tag.length > 0 && tags.indexOf(tag) === index);
+}
+
+interface TagInputProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  "aria-describedby"?: string;
+}
+
+export function TagInput({
+  id,
+  value,
+  onChange,
+  placeholder = "Add a tag…",
+  disabled = false,
+  className,
+  "aria-describedby": ariaDescribedBy,
+}: TagInputProps) {
+  const [draft, setDraft] = useState("");
+  const tags = parseTags(value);
+
+  const updateTags = (nextTags: string[]) => onChange(nextTags.join(", "));
+
+  const addTags = (input: string) => {
+    const additions = parseTags(input);
+    if (additions.length === 0) return;
+
+    updateTags([...tags, ...additions.filter((tag) => !tags.includes(tag))]);
+    setDraft("");
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    updateTags(tags.filter((tag) => tag !== tagToRemove));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      addTags(draft);
+      return;
+    }
+
+    if (event.key === "Backspace" && draft.length === 0 && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    const pastedValue = event.clipboardData.getData("text");
+    if (!pastedValue.includes(",")) return;
+
+    event.preventDefault();
+    addTags(pastedValue);
+  };
+
+  return (
+    <div
+      className={cn(
+        "border-input focus-within:border-ring focus-within:ring-ring/50 flex min-h-8 w-full flex-wrap items-center gap-1.5 border bg-transparent px-2 py-1 shadow-xs transition-[color,box-shadow] focus-within:ring-[3px]",
+        disabled && "pointer-events-none cursor-not-allowed opacity-50",
+        className,
+      )}
+    >
+      {tags.map((tag) => (
+        <Badge key={tag} variant="secondary" className="gap-1 pl-2 text-xs">
+          {tag}
+          <button
+            type="button"
+            className="-mr-1 inline-flex size-4 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={(event) => {
+              event.stopPropagation();
+              removeTag(tag);
+            }}
+            disabled={disabled}
+            aria-label={`Remove ${tag}`}
+          >
+            <X className="size-3" />
+          </button>
+        </Badge>
+      ))}
+      <input
+        id={id}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onBlur={() => addTags(draft)}
+        placeholder={tags.length === 0 ? placeholder : undefined}
+        disabled={disabled}
+        aria-describedby={ariaDescribedBy}
+        className="h-6 min-w-28 flex-1 bg-transparent px-0.5 text-[13px] outline-none placeholder:text-muted-foreground"
+      />
+    </div>
+  );
+}

--- a/test_cases/ui/tag_editor/TC001_edit_agent_and_harness_tags.md
+++ b/test_cases/ui/tag_editor/TC001_edit_agent_and_harness_tags.md
@@ -1,0 +1,38 @@
+# TC001 Edit Agent and Harness Tags
+
+## Description
+
+Verifies that agent and harness tags are edited as individual chips instead of a raw
+comma-separated field.
+
+## Preconditions
+
+- Development stack is running.
+- At least one editable agent and one editable harness exist.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| First tag | `support` |
+| Pasted tags | `demo, customer-facing` |
+
+## Steps
+
+1. Open an editable agent and select Edit.
+2. Enter the first tag and press Enter.
+3. Confirm the tag appears as a removable chip and the text input clears.
+4. Paste the comma-separated tags and confirm each value appears as its own chip.
+5. Remove one chip and confirm the remaining chips are unchanged.
+6. Save, reopen the agent editor, and confirm the remaining tags persist as chips.
+7. Repeat steps 2–6 for an editable harness.
+8. Open an archived agent or harness and confirm its tags cannot be changed.
+
+## Expected Result
+
+- Tags are displayed as individual chips with accessible remove controls.
+- Enter and comma commit a typed tag; comma-separated paste creates multiple tags.
+- Duplicate and empty tags are not added.
+- Backspace from an empty input removes the final chip.
+- Saved agent and harness tags persist and render as chips when reopened.
+- Archived entities keep the tag editor read-only.


### PR DESCRIPTION
## What changed
Agent Edit and Harness Edit now use a chip-based tag editor. Existing tags render as removable chips; Enter, comma, blur, and comma-separated paste commit values; duplicate and empty values are ignored; Backspace removes the final chip. Archived entities keep every tag interaction disabled.

## Why
A raw comma-separated text field hides tag boundaries and makes editing individual values unnecessarily error-prone.

## Before / After
Before: both editors exposed one plain text field with comma-separated instructions.

After: both editors expose individual removable chips with keyboard guidance. Focused tests cover add, remove, duplicate, paste, and Backspace behavior. A real-stack browser smoke test confirmed agent and harness save/reopen persistence plus archived read-only behavior. Browser evidence is recorded in a PR comment; full-page screenshots were captured locally because the configured uploader was unavailable.

Validation:
- `just pre-push`
- UI production build
- UI format, lint, and typecheck
- 10 focused Jest tests
- Manual UI test `tag_editor/TC001` on `PORT_PREFIX=286`

## Risk
- Low
- Tag serialization could regress when chips are added or removed; component and page-integration tests cover the submitted string-array payload, and the real-stack smoke test verified persistence.

## Security
- Threat categories reviewed: TM-WEB-001, TM-DOS-001
- Findings and resolutions: Tag text remains ordinary React text and is escaped; no raw HTML, dependency, or new trust boundary was introduced. Existing API request-size bounds limit input volume. No threat-model update is needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)