### PR TITLE
fix(ui): contain agent identity card content

### DIFF
--- a/apps/ui/src/__tests__/entity-card.test.tsx
+++ b/apps/ui/src/__tests__/entity-card.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { EntityCard, EntityCardIdentifier } from "@/components/ui/entity-card";
+
+describe("EntityCard", () => {
+  it("keeps long titles shrinkable beside header actions", () => {
+    const { container } = render(
+      <EntityCard title="A very long entity name" headerActions={<span>active</span>}>
+        Body
+      </EntityCard>,
+    );
+
+    expect(screen.getByText("A very long entity name")).toHaveClass("truncate");
+    expect(container.querySelector('[data-slot="entity-card-heading"]')).toHaveClass(
+      "min-w-0",
+      "flex-1",
+    );
+  });
+});
+
+describe("EntityCardIdentifier", () => {
+  it("truncates a long identifier while keeping its copy action visible", () => {
+    const value = "identity_019fda100f037c008024046d6b3d74c0";
+
+    render(<EntityCardIdentifier value={value} />);
+
+    expect(screen.getByText(value)).toHaveClass("min-w-0", "truncate");
+    expect(screen.getByTitle("Copy ID")).toHaveClass("shrink-0");
+  });
+});

--- a/apps/ui/src/app/(main)/agent-identities/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/page.tsx
@@ -6,7 +6,7 @@ import { Plus, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Badge } from "@/components/ui/badge";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityCardIdentifier } from "@/components/ui/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAgentIdentities } from "@/hooks/use-agent-identities";
 import { usePageTitle } from "@/hooks";
@@ -192,12 +192,7 @@ export default function AgentIdentitiesPage() {
                         >
                           {identity.name}
                         </h3>
-                        <div className="mt-0.5 flex items-center gap-1.5">
-                          <span className="font-mono text-xs text-muted-foreground">
-                            {identity.id}
-                          </span>
-                          <CopyButton value={identity.id} />
-                        </div>
+                        <EntityCardIdentifier value={identity.id} className="mt-0.5" />
                       </div>
                     </div>
                     <Badge variant={getEntityStatusBadgeVariant(identity.status)}>

--- a/apps/ui/src/components/ui/entity-card.tsx
+++ b/apps/ui/src/components/ui/entity-card.tsx
@@ -45,6 +45,20 @@ export interface EntityCardProps {
   className?: string;
 }
 
+export function EntityCardIdentifier({ value, className }: { value: string; className?: string }) {
+  return (
+    <div
+      data-slot="entity-card-identifier"
+      className={cn("flex min-w-0 max-w-full items-center gap-1.5", className)}
+    >
+      <span className="min-w-0 truncate font-mono text-xs text-muted-foreground" title={value}>
+        {value}
+      </span>
+      <CopyButton value={value} className="shrink-0" />
+    </div>
+  );
+}
+
 function EntityCardTitleLink({
   href,
   className,
@@ -99,7 +113,7 @@ export function EntityCard({
               >
                 {title}
               </EntityCardTitleLink>
-              {copyValue && <CopyButton value={copyValue} />}
+              {copyValue && <CopyButton value={copyValue} className="shrink-0" />}
               {inlineBadges}
             </div>
             {children}
@@ -115,14 +129,14 @@ export function EntityCard({
   return (
     <Card className={cn("bg-background transition-colors hover:bg-card", className)}>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex min-w-0 items-start gap-3">
+        <div data-slot="entity-card-heading" className="flex min-w-0 flex-1 items-start gap-3">
           {icon && <div className="flex-shrink-0">{icon}</div>}
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <CardTitle className={cn("text-lg", titleClassName)}>
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <CardTitle className={cn("min-w-0 flex-1 truncate text-lg", titleClassName)}>
                 <EntityCardTitleLink href={href}>{title}</EntityCardTitleLink>
               </CardTitle>
-              {copyValue && <CopyButton value={copyValue} />}
+              {copyValue && <CopyButton value={copyValue} className="shrink-0" />}
             </div>
             {subtitle && <div className="min-w-0">{subtitle}</div>}
           </div>


### PR DESCRIPTION
## What changed
Agent identity cards now truncate long IDs and names within their available width while keeping status badges and copy controls visible. The shared entity-card primitives provide the same containment behavior to other entity cards.

## Why
Long agent identity IDs could overflow narrow cards and render the copy control outside the card boundary.

## Before / After
Before: the supplied reproduction shows the full 41-character ID crossing the card edge and pushing the copy icon roughly 60px beyond the border.

After: manual verification at 1024×768 produced a 188px card with a 260px intrinsic ID truncated to 27px; the 20px copy control ended at x=377.7 within the card's x=452 boundary. Clicking it changed the state to `Copied!`. The captured screenshot is available locally at `/tmp/agent-identities-after.png`; Cloudinary upload was unavailable because this worktree has no `CLOUDINARY_URL`.

The `agent_identities/TC001` flow also passed: an identity with `en-US` and `America/New_York` was created and both values appeared on its list card.

## Risk
- Low
- Shared entity-card flex sizing changes could alter truncation for long titles; focused tests cover title shrinkage and copy-control retention, and the production UI build passed.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new security-relevant surface. Values remain React-escaped text, clipboard behavior is unchanged, and the change introduces no raw HTML, URL, auth, or API handling.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no comments received after the post-green sweep)
