### PR TITLE
fix(knowledge-indexes): surface actionable issue states

### DIFF
--- a/apps/ui/src/__tests__/knowledge-index-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-index-detail-page.test.tsx
@@ -41,6 +41,7 @@ const index: KnowledgeIndex = {
   },
   embedding_model_id: "model_001",
   vector_dim: 1536,
+  document_count: 1,
   status: "active",
   sync_status: "synced",
   last_synced_at: "2026-05-06T03:37:51.552849Z",
@@ -97,8 +98,27 @@ describe("KnowledgeIndexDetailPage", () => {
       mutateAsync: jest.fn().mockResolvedValue({}),
       isPending: false,
     });
-    mockUseUserConnections.mockReturnValue({ data: [], isLoading: false });
-    mockUseModels.mockReturnValue({ data: [], isLoading: false });
+    mockUseUserConnections.mockReturnValue({
+      data: [{ provider: "github", connected_at: "2026-05-01T00:00:00Z" }],
+      isLoading: false,
+      error: null,
+    });
+    mockUseModels.mockReturnValue({
+      data: [
+        {
+          id: "model_001",
+          display_name: "text-embedding-3-small",
+          provider_name: "OpenAI",
+          provider_id: "provider_001",
+          provider_type: "openai_completions",
+          enabled: true,
+          healthy: true,
+          capabilities: ["embeddings"],
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
   });
 
   it("renders index metadata, source, and documents", async () => {
@@ -134,7 +154,7 @@ describe("KnowledgeIndexDetailPage", () => {
       error: null,
     });
     await renderWithSuspense();
-    expect(screen.getByText("auth failed")).toBeInTheDocument();
+    expect(screen.getByText(/auth failed/)).toBeInTheDocument();
   });
 
   it("renders an empty documents state", async () => {
@@ -164,5 +184,63 @@ describe("KnowledgeIndexDetailPage", () => {
     await renderWithSuspense("kidx_missing");
     expect(screen.getByText("Knowledge index not found")).toBeInTheDocument();
     expect(screen.getByText("kidx_missing")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "not synced yet",
+      { sync_status: "idle", last_synced_at: null, document_count: 0 },
+      "Not synced yet",
+      "Start initial sync",
+    ],
+    ["queued", { sync_status: "pending" }, "Sync queued", null],
+    ["syncing", { sync_status: "syncing" }, "Syncing", null],
+    ["synced empty", { document_count: 0 }, "Synced — no documents", "Sync again"],
+    ["stale", { updated_at: "2026-05-06T04:37:51.552849Z" }, "Sync out of date", "Sync changes"],
+    [
+      "failed",
+      { sync_status: "failed", last_sync_error: "Repository access was denied" },
+      "Sync failed",
+      "Retry sync",
+    ],
+  ])("shows the %s diagnostic and action", async (_name, overrides, label, action) => {
+    mockUseKnowledgeIndex.mockReturnValue({
+      data: { ...index, ...overrides },
+      isLoading: false,
+      error: null,
+    });
+    await renderWithSuspense();
+
+    expect(
+      screen.getAllByRole("status", { name: `Index status: ${label}` }).length,
+    ).toBeGreaterThan(0);
+    if (action) expect(screen.getAllByRole("button", { name: action }).length).toBeGreaterThan(0);
+  });
+
+  it("blocks sync for a generation-only embedding model", async () => {
+    mockUseModels.mockReturnValue({
+      data: [
+        {
+          id: "model_001",
+          display_name: "Claude Opus 4.7 (1M)",
+          provider_name: "Anthropic",
+          provider_id: "provider_anthropic",
+          provider_type: "anthropic",
+          enabled: true,
+          healthy: true,
+          capabilities: ["text"],
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    await renderWithSuspense();
+
+    expect(
+      screen.getAllByRole("status", { name: "Index status: Embedding model invalid" }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText(/does not support embeddings/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Configure embedding model" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sync now/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
@@ -145,6 +145,7 @@ const indexes: KnowledgeIndex[] = [
     source_config: { provider: "github", repository: "everruns/everruns", branch: "main" },
     embedding_model_id: "model_001",
     vector_dim: 1536,
+    document_count: 1,
     status: "active",
     sync_status: "synced",
     last_synced_at: "2026-05-06T03:37:51.552849Z",
@@ -173,13 +174,20 @@ describe("KnowledgeIndexesPage", () => {
       mutateAsync: jest.fn().mockResolvedValue({}),
       isPending: false,
     });
-    mockUseUserConnections.mockReturnValue({ data: [], isLoading: false });
+    mockUseUserConnections.mockReturnValue({
+      data: [{ provider: "github", connected_at: "2026-05-01T00:00:00Z" }],
+      isLoading: false,
+      error: null,
+    });
     mockUseModels.mockReturnValue({
       data: [
         {
           id: "model_001",
           display_name: "text-embedding-3-small",
           provider_name: "OpenAI",
+          provider_id: "provider_001",
+          provider_type: "openai_completions",
+          healthy: true,
           enabled: true,
           capabilities: ["embeddings"],
         },
@@ -310,5 +318,103 @@ describe("KnowledgeIndexesPage", () => {
     mockUseKnowledgeIndexes.mockReturnValue({ data: [], isLoading: false, error: null });
     render(<KnowledgeIndexesPage />);
     expect(screen.getByText(/No knowledge indexes/)).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "not synced yet",
+      { sync_status: "idle", last_synced_at: null, document_count: 0 },
+      "Not synced yet",
+      "Start initial sync",
+    ],
+    ["queued", { sync_status: "pending" }, "Sync queued", null],
+    ["syncing", { sync_status: "syncing" }, "Syncing", null],
+    ["synced empty", { document_count: 0 }, "Synced — no documents", "Sync again"],
+    ["stale", { updated_at: "2026-05-06T04:37:51.552849Z" }, "Sync out of date", "Sync changes"],
+    [
+      "failed",
+      { sync_status: "failed", last_sync_error: "Repository access was denied" },
+      "Sync failed",
+      "Retry sync",
+    ],
+  ])("shows the %s diagnostic and action", (_name, overrides, label, action) => {
+    mockUseKnowledgeIndexes.mockReturnValue({
+      data: [{ ...indexes[0], ...overrides }],
+      isLoading: false,
+      error: null,
+    });
+    render(<KnowledgeIndexesPage />);
+
+    expect(screen.getByRole("status", { name: `Index status: ${label}` })).toBeInTheDocument();
+    if (action) expect(screen.getByRole("button", { name: action })).toBeInTheDocument();
+  });
+
+  it("flags a generation-only model and directs the user to configure embeddings", () => {
+    mockUseModels.mockReturnValue({
+      data: [
+        {
+          id: "model_001",
+          display_name: "Claude Opus 4.7 (1M)",
+          provider_name: "Anthropic",
+          provider_id: "provider_anthropic",
+          provider_type: "anthropic",
+          enabled: true,
+          healthy: true,
+          capabilities: ["text"],
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<KnowledgeIndexesPage />);
+
+    expect(
+      screen.getByRole("status", { name: "Index status: Embedding model invalid" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/does not support embeddings/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Configure embedding model" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sync" })).not.toBeInTheDocument();
+  });
+
+  it("links to provider setup when the embedding provider is unavailable", () => {
+    mockUseModels.mockReturnValue({
+      data: [
+        {
+          id: "model_001",
+          display_name: "text-embedding-3-small",
+          provider_name: "OpenAI",
+          provider_id: "provider_001",
+          provider_type: "openai_completions",
+          enabled: true,
+          healthy: false,
+          capabilities: ["embeddings"],
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<KnowledgeIndexesPage />);
+
+    expect(
+      screen.getByRole("status", { name: "Index status: Provider setup needed" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Configure provider" })).toHaveAttribute(
+      "href",
+      "/settings/providers/provider_001",
+    );
+  });
+
+  it("updates the diagnostic when polled index data changes", () => {
+    mockUseKnowledgeIndexes.mockReturnValue({
+      data: [{ ...indexes[0], sync_status: "pending" }],
+      isLoading: false,
+      error: null,
+    });
+    const view = render(<KnowledgeIndexesPage />);
+    expect(screen.getByRole("status", { name: "Index status: Sync queued" })).toBeInTheDocument();
+
+    mockUseKnowledgeIndexes.mockReturnValue({ data: indexes, isLoading: false, error: null });
+    view.rerender(<KnowledgeIndexesPage />);
+    expect(screen.getByRole("status", { name: "Index status: Up to date" })).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/(main)/knowledge-indexes/[indexId]/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/[indexId]/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import Link from "next/link";
 import { use, useMemo, useState } from "react";
-import { AlertCircle, Archive, GitBranch, Library, Pencil, RefreshCw } from "lucide-react";
+import { Archive, GitBranch, Library, Pencil, RefreshCw } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { ArchiveKnowledgeIndexDialog } from "@/components/knowledge-indexes/archive-knowledge-index-dialog";
+import {
+  KnowledgeIndexDiagnosticBadge,
+  KnowledgeIndexDiagnosticNotice,
+} from "@/components/knowledge-indexes/knowledge-index-diagnostic";
 import { KnowledgeIndexFormDialog } from "@/components/knowledge-indexes/knowledge-index-form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -41,6 +46,7 @@ import {
   useSyncKnowledgeIndex,
   useUpdateKnowledgeIndex,
 } from "@/hooks";
+import { useModels } from "@/hooks/use-providers";
 import type {
   KnowledgeIndex,
   KnowledgeIndexDocument,
@@ -52,7 +58,12 @@ import {
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
 import { formatDate, formatRelativeTime } from "@/lib/formatting";
-import { syncStatusBadgeVariant } from "@/lib/knowledge-index-sync";
+import {
+  getKnowledgeIndexDiagnostic,
+  knowledgeIndexDiagnosticBlocksSync,
+  knowledgeIndexSyncActionLabel,
+  type KnowledgeIndexDiagnostic,
+} from "@/lib/knowledge-index-diagnostics";
 
 function sourceField(index: KnowledgeIndex, key: string): string | null {
   const value = (index.source_config as Record<string, unknown>)?.[key];
@@ -76,6 +87,7 @@ export default function KnowledgeIndexDetailPage({
   const updateIndex = useUpdateKnowledgeIndex();
   const syncIndex = useSyncKnowledgeIndex();
   const archiveIndex = useArchiveKnowledgeIndex();
+  const { data: models, isLoading: modelsLoading, error: modelsError } = useModels();
   usePageTitle(index ? index.name : null, "Knowledge Indexes");
 
   const totalChunks = useMemo(
@@ -100,7 +112,11 @@ export default function KnowledgeIndexDetailPage({
   }
 
   const isReadOnly = isReadOnlyStatus(index.status);
-  const canSync = index.status === "active";
+  const diagnostic = getKnowledgeIndexDiagnostic(index, {
+    models,
+    modelsReady: !modelsLoading && !modelsError,
+  });
+  const canSync = index.status === "active" && !knowledgeIndexDiagnosticBlocksSync(diagnostic);
   const repository = sourceField(index, "repository");
   const gitUrl = sourceField(index, "url");
   const branch = sourceField(index, "branch");
@@ -124,7 +140,7 @@ export default function KnowledgeIndexDetailPage({
           <>
             <CopyButton value={index.id} />
             <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
-            <Badge variant={syncStatusBadgeVariant(index.sync_status)}>{index.sync_status}</Badge>
+            <KnowledgeIndexDiagnosticBadge diagnostic={diagnostic} />
           </>
         }
         description={index.description || undefined}
@@ -175,10 +191,24 @@ export default function KnowledgeIndexDetailPage({
                 }
               >
                 <RefreshCw className="size-4" />
-                Sync now
+                {knowledgeIndexSyncActionLabel(diagnostic)}
               </Button>
             )}
           </>
+        }
+      />
+
+      <KnowledgeIndexDiagnosticNotice
+        diagnostic={diagnostic}
+        action={
+          <DiagnosticAction
+            diagnostic={diagnostic}
+            index={index}
+            canSync={canSync}
+            isSyncing={syncIndex.isPending}
+            onEdit={() => setEditOpen(true)}
+            onSync={() => syncIndex.mutate(index.id)}
+          />
         }
       />
 
@@ -271,9 +301,7 @@ export default function KnowledgeIndexDetailPage({
               <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
                 <div>
                   <div className="font-medium">Status</div>
-                  <Badge variant={syncStatusBadgeVariant(index.sync_status)}>
-                    {index.sync_status}
-                  </Badge>
+                  <KnowledgeIndexDiagnosticBadge diagnostic={diagnostic} />
                 </div>
                 <div>
                   <div className="font-medium">Last synced</div>
@@ -292,12 +320,6 @@ export default function KnowledgeIndexDetailPage({
                   </div>
                 </div>
               </div>
-              {index.last_sync_error && (
-                <div className="flex gap-2 text-destructive">
-                  <AlertCircle className="mt-0.5 size-4 shrink-0" />
-                  <span>{index.last_sync_error}</span>
-                </div>
-              )}
               {canSync && (
                 <Button
                   variant="outline"
@@ -310,7 +332,7 @@ export default function KnowledgeIndexDetailPage({
                   }
                 >
                   <RefreshCw className="size-4" />
-                  Sync now
+                  {knowledgeIndexSyncActionLabel(diagnostic)}
                 </Button>
               )}
             </div>
@@ -344,6 +366,55 @@ export default function KnowledgeIndexDetailPage({
       />
     </PageContainer>
   );
+}
+
+function DiagnosticAction({
+  diagnostic,
+  index,
+  canSync,
+  isSyncing,
+  onEdit,
+  onSync,
+}: {
+  diagnostic: KnowledgeIndexDiagnostic;
+  index: KnowledgeIndex;
+  canSync: boolean;
+  isSyncing: boolean;
+  onEdit: () => void;
+  onSync: () => void;
+}) {
+  if (diagnostic.action === "configure_model") {
+    return (
+      <Button size="sm" variant="outline" onClick={onEdit} disabled={index.status !== "active"}>
+        Configure embedding model
+      </Button>
+    );
+  }
+  if (diagnostic.action === "configure_provider" && diagnostic.providerId) {
+    return (
+      <Button
+        size="sm"
+        variant="outline"
+        render={<Link href={`/settings/providers/${diagnostic.providerId}`} />}
+      >
+        Configure provider
+      </Button>
+    );
+  }
+  if (
+    diagnostic.action === "retry_sync" ||
+    diagnostic.action === "start_sync" ||
+    diagnostic.action === "sync_changes" ||
+    diagnostic.action === "sync_again"
+  ) {
+    return (
+      <Button size="sm" variant="outline" onClick={onSync} disabled={!canSync || isSyncing}>
+        <RefreshCw className="size-4" />
+        {knowledgeIndexSyncActionLabel(diagnostic)}
+      </Button>
+    );
+  }
+  return null;
 }
 
 function DocumentsCard({

--- a/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
@@ -2,19 +2,11 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import {
-  AlertCircle,
-  Archive,
-  FolderOpen,
-  GitBranch,
-  Library,
-  Pencil,
-  Plus,
-  RefreshCw,
-} from "lucide-react";
+import { Archive, FolderOpen, GitBranch, Library, Pencil, Plus, RefreshCw } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ArchiveKnowledgeIndexDialog } from "@/components/knowledge-indexes/archive-knowledge-index-dialog";
+import { KnowledgeIndexDiagnosticBadge } from "@/components/knowledge-indexes/knowledge-index-diagnostic";
 import { KnowledgeIndexFormDialog } from "@/components/knowledge-indexes/knowledge-index-form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -49,6 +41,7 @@ import {
   useSyncKnowledgeIndex,
   useUpdateKnowledgeIndex,
 } from "@/hooks";
+import { useModels } from "@/hooks/use-providers";
 import type {
   CreateKnowledgeIndexRequest,
   KnowledgeIndex,
@@ -61,7 +54,12 @@ import {
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
 import { formatRelativeTime, pluralize } from "@/lib/formatting";
-import { syncStatusBadgeVariant } from "@/lib/knowledge-index-sync";
+import {
+  getKnowledgeIndexDiagnostic,
+  knowledgeIndexDiagnosticBlocksSync,
+  knowledgeIndexSyncActionLabel,
+  type KnowledgeIndexDiagnostic,
+} from "@/lib/knowledge-index-diagnostics";
 import { cn } from "@/lib/utils";
 
 type StatusTab = "all" | "active" | "archived";
@@ -90,6 +88,7 @@ export default function KnowledgeIndexesPage() {
   const updateIndex = useUpdateKnowledgeIndex();
   const syncIndex = useSyncKnowledgeIndex();
   const archiveIndex = useArchiveKnowledgeIndex();
+  const { data: models, isLoading: modelsLoading, error: modelsError } = useModels();
 
   const counts = useMemo(() => {
     const list = indexes ?? [];
@@ -194,12 +193,12 @@ export default function KnowledgeIndexesPage() {
           >
             {(items) => (
               <div className="border">
-                <Table>
+                <Table className="min-w-[960px]">
                   <TableHeader>
                     <TableRow>
                       <TableHead>Name</TableHead>
                       <TableHead>Source</TableHead>
-                      <TableHead>Sync</TableHead>
+                      <TableHead>Index state</TableHead>
                       <TableHead>Last synced</TableHead>
                       <TableHead>Updated</TableHead>
                       <TableHead className="text-right">Actions</TableHead>
@@ -214,6 +213,10 @@ export default function KnowledgeIndexesPage() {
                         onArchive={setArchivingIndex}
                         onSync={(candidate) => syncIndex.mutate(candidate.id)}
                         isSyncing={syncIndex.isPending}
+                        diagnostic={getKnowledgeIndexDiagnostic(index, {
+                          models,
+                          modelsReady: !modelsLoading && !modelsError,
+                        })}
                       />
                     ))}
                   </TableBody>
@@ -333,15 +336,17 @@ function KnowledgeIndexRow({
   onArchive,
   onSync,
   isSyncing,
+  diagnostic,
 }: {
   index: KnowledgeIndex;
   onEdit: (index: KnowledgeIndex) => void;
   onArchive: (index: KnowledgeIndex) => void;
   onSync: (index: KnowledgeIndex) => void;
   isSyncing: boolean;
+  diagnostic: KnowledgeIndexDiagnostic;
 }) {
   const isReadOnly = isReadOnlyStatus(index.status);
-  const canSync = index.status === "active";
+  const canSync = index.status === "active" && !knowledgeIndexDiagnosticBlocksSync(diagnostic);
 
   return (
     <TableRow>
@@ -364,12 +369,6 @@ function KnowledgeIndexRow({
           <span className="truncate font-mono">{index.id}</span>
           <CopyButton value={index.id} />
         </div>
-        {index.last_sync_error && (
-          <div className="mt-1 flex gap-1.5 text-xs text-destructive">
-            <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
-            <span className="line-clamp-2">{index.last_sync_error}</span>
-          </div>
-        )}
       </TableCell>
       <TableCell>
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">
@@ -382,7 +381,32 @@ function KnowledgeIndexRow({
         </span>
       </TableCell>
       <TableCell>
-        <Badge variant={syncStatusBadgeVariant(index.sync_status)}>{index.sync_status}</Badge>
+        <div className="w-64 space-y-1.5 whitespace-normal">
+          <KnowledgeIndexDiagnosticBadge diagnostic={diagnostic} />
+          <p className="text-xs text-muted-foreground">{diagnostic.description}</p>
+          {diagnostic.failureReason && (
+            <p className="line-clamp-2 text-xs text-destructive">
+              <span className="font-medium">Latest failure:</span> {diagnostic.failureReason}
+            </p>
+          )}
+          {diagnostic.action === "configure_model" && !isReadOnly && (
+            <button
+              type="button"
+              className="text-xs font-medium text-primary hover:underline"
+              onClick={() => onEdit(index)}
+            >
+              Configure embedding model
+            </button>
+          )}
+          {diagnostic.action === "configure_provider" && diagnostic.providerId && (
+            <Link
+              href={`/settings/providers/${diagnostic.providerId}`}
+              className="block text-xs font-medium text-primary hover:underline"
+            >
+              Configure provider
+            </Link>
+          )}
+        </div>
       </TableCell>
       <TableCell className="text-muted-foreground">
         {index.last_synced_at ? formatRelativeTime(index.last_synced_at) : "Never"}
@@ -402,7 +426,7 @@ function KnowledgeIndexRow({
               }
             >
               <RefreshCw className="size-4" />
-              Sync
+              {knowledgeIndexSyncActionLabel(diagnostic)}
             </Button>
           )}
           <Link href={`/knowledge-indexes/${index.id}`}>

--- a/apps/ui/src/components/knowledge-indexes/embedding-model-picker.tsx
+++ b/apps/ui/src/components/knowledge-indexes/embedding-model-picker.tsx
@@ -22,12 +22,9 @@ interface EmbeddingModelPickerProps {
   "aria-describedby"?: string;
 }
 
-// A model is treated as an embeddings model when its capabilities advertise
-// "embeddings". The backend model registry does not reliably tag embedding
-// models through the list API today (model sync leaves capabilities empty for
-// many providers), so we fall back to listing all enabled models when no model
-// advertises the capability. The server still enforces that the chosen model
-// resolves to an Embeddings driver, so an invalid pick is rejected on save.
+// Only advertise models whose registry capabilities explicitly include
+// embeddings. Listing a generation-only fallback creates an index that cannot
+// sync and hides the configuration problem until runtime.
 export function isEmbeddingModel(model: ModelWithProvider): boolean {
   return model.capabilities.some((cap) => cap.toLowerCase() === "embeddings");
 }
@@ -45,10 +42,7 @@ export function EmbeddingModelPicker({
   const { data: models = [], isLoading } = useModels();
 
   const enabled = models.filter((m) => m.enabled);
-  const embeddingModels = enabled.filter(isEmbeddingModel);
-  // Fall back to all enabled models when the registry exposes no embeddings
-  // capability so the picker is never empty; the server validates the choice.
-  const candidates = embeddingModels.length > 0 ? embeddingModels : enabled;
+  const candidates = enabled.filter(isEmbeddingModel);
 
   const sorted = [...candidates].sort((a, b) => {
     if (a.provider_name !== b.provider_name) {
@@ -77,7 +71,7 @@ export function EmbeddingModelPicker({
       <SelectContent>
         {sorted.length === 0 && (
           <SelectItem value="__none__" disabled>
-            No models available
+            No embedding models available
           </SelectItem>
         )}
         {sorted.map((model) => (

--- a/apps/ui/src/components/knowledge-indexes/knowledge-index-diagnostic.tsx
+++ b/apps/ui/src/components/knowledge-indexes/knowledge-index-diagnostic.tsx
@@ -1,0 +1,61 @@
+import { AlertCircle, CheckCircle2, Clock3, LoaderCircle } from "lucide-react";
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+import type { KnowledgeIndexDiagnostic } from "@/lib/knowledge-index-diagnostics";
+
+function DiagnosticIcon({ diagnostic }: { diagnostic: KnowledgeIndexDiagnostic }) {
+  if (diagnostic.code === "ready") return <CheckCircle2 aria-hidden="true" />;
+  if (diagnostic.code === "queued" || diagnostic.code === "not_synced") {
+    return <Clock3 aria-hidden="true" />;
+  }
+  if (diagnostic.code === "syncing") {
+    return <LoaderCircle aria-hidden="true" className="animate-spin" />;
+  }
+  return <AlertCircle aria-hidden="true" />;
+}
+
+export function KnowledgeIndexDiagnosticBadge({
+  diagnostic,
+}: {
+  diagnostic: KnowledgeIndexDiagnostic;
+}) {
+  return (
+    <Badge
+      variant={diagnostic.variant}
+      role="status"
+      aria-label={`Index status: ${diagnostic.label}`}
+    >
+      <DiagnosticIcon diagnostic={diagnostic} />
+      {diagnostic.label}
+    </Badge>
+  );
+}
+
+export function KnowledgeIndexDiagnosticNotice({
+  diagnostic,
+  action,
+}: {
+  diagnostic: KnowledgeIndexDiagnostic;
+  action?: ReactNode;
+}) {
+  return (
+    <Notice
+      variant={diagnostic.noticeVariant}
+      icon={<DiagnosticIcon diagnostic={diagnostic} />}
+      role={diagnostic.noticeVariant === "destructive" ? "alert" : "status"}
+      aria-live="polite"
+    >
+      <NoticeTitle>{diagnostic.label}</NoticeTitle>
+      <NoticeDescription>
+        <p>{diagnostic.description}</p>
+        {diagnostic.failureReason && (
+          <p className="break-words text-foreground">
+            <span className="font-medium">Latest failure:</span> {diagnostic.failureReason}
+          </p>
+        )}
+        {action && <div className="pt-1">{action}</div>}
+      </NoticeDescription>
+    </Notice>
+  );
+}

--- a/apps/ui/src/hooks/create-crud-hooks.ts
+++ b/apps/ui/src/hooks/create-crud-hooks.ts
@@ -5,6 +5,7 @@ import {
   useQuery,
   useQueryClient,
   type QueryClient,
+  type UseQueryOptions,
   type UseMutationResult,
   type UseQueryResult,
 } from "@tanstack/react-query";
@@ -31,6 +32,7 @@ interface UseOrgScopedQueryOptions<TData> {
   queryFn: () => Promise<TData>;
   enabled?: boolean;
   staleTime?: number;
+  refetchInterval?: UseQueryOptions<TData>["refetchInterval"];
 }
 
 export function useOrgScopedQuery<TData>({
@@ -38,6 +40,7 @@ export function useOrgScopedQuery<TData>({
   queryFn,
   enabled = true,
   staleTime,
+  refetchInterval,
 }: UseOrgScopedQueryOptions<TData>): UseQueryResult<TData> & { isLoading: boolean } {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
@@ -56,6 +59,7 @@ export function useOrgScopedQuery<TData>({
     queryFn,
     enabled: enabled && !!org,
     ...(staleTime !== undefined ? { staleTime } : {}),
+    ...(refetchInterval !== undefined ? { refetchInterval } : {}),
   });
 
   return {

--- a/apps/ui/src/hooks/use-knowledge-indexes.ts
+++ b/apps/ui/src/hooks/use-knowledge-indexes.ts
@@ -50,6 +50,12 @@ export function useKnowledgeIndexes(
     queryKey: queryKeys.knowledgeIndexes.list(includeArchived, search),
     queryFn: () => listKnowledgeIndexes({ includeArchived, search }),
     enabled: options.enabled ?? true,
+    refetchInterval: (query) =>
+      query.state.data?.some(
+        (index) => index.sync_status === "pending" || index.sync_status === "syncing",
+      )
+        ? 2000
+        : false,
   });
 }
 
@@ -58,6 +64,10 @@ export function useKnowledgeIndex(indexId: string | undefined) {
     queryKey: queryKeys.knowledgeIndexes.detail(indexId ?? ""),
     queryFn: () => getKnowledgeIndex(indexId!),
     enabled: !!indexId,
+    refetchInterval: (candidate) => {
+      const status = candidate.state.data?.sync_status;
+      return status === "pending" || status === "syncing" ? 2000 : false;
+    },
   });
   const fallback = useResourceOrgFallback({
     resourceId: indexId,

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -8433,6 +8433,8 @@ export interface components {
       deleted_at?: string | null;
       /** @description Human-readable description. Safe to render in user-facing messages. */
       description?: string | null;
+      /** @description Number of documents currently retained by this index. */
+      document_count: number;
       /** @description Embedding model used to embed chunks. Required. */
       embedding_model_id: string;
       /**
@@ -9389,6 +9391,8 @@ export interface components {
         deleted_at?: string | null;
         /** @description Human-readable description. Safe to render in user-facing messages. */
         description?: string | null;
+        /** @description Number of documents currently retained by this index. */
+        document_count: number;
         /** @description Embedding model used to embed chunks. Required. */
         embedding_model_id: string;
         /**

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -2755,6 +2755,7 @@ export interface KnowledgeIndex {
   source_config: Record<string, unknown>;
   embedding_model_id: string;
   vector_dim?: number | null;
+  document_count: number;
   status: KnowledgeIndexStatus;
   sync_status: KnowledgeIndexSyncStatus;
   last_synced_at?: string | null;

--- a/apps/ui/src/lib/knowledge-index-diagnostics.ts
+++ b/apps/ui/src/lib/knowledge-index-diagnostics.ts
@@ -1,0 +1,213 @@
+import type { KnowledgeIndex, ModelWithProvider } from "@/lib/api/types";
+
+export type KnowledgeIndexDiagnosticCode =
+  | "configuration_invalid"
+  | "provider_unavailable"
+  | "sync_failed"
+  | "queued"
+  | "syncing"
+  | "not_synced"
+  | "empty"
+  | "stale"
+  | "ready";
+
+export type KnowledgeIndexDiagnosticAction =
+  | "configure_model"
+  | "configure_provider"
+  | "retry_sync"
+  | "start_sync"
+  | "sync_changes"
+  | "sync_again";
+
+export interface KnowledgeIndexDiagnostic {
+  code: KnowledgeIndexDiagnosticCode;
+  label: string;
+  description: string;
+  variant: "secondary" | "destructive" | "accent" | "success";
+  noticeVariant: "info" | "warning" | "destructive" | "success";
+  action?: KnowledgeIndexDiagnosticAction;
+  providerId?: string;
+  failureReason?: string;
+}
+
+interface DiagnosticContext {
+  models?: ModelWithProvider[];
+  modelsReady?: boolean;
+}
+
+export function knowledgeIndexDiagnosticBlocksSync(diagnostic: KnowledgeIndexDiagnostic): boolean {
+  return diagnostic.code === "configuration_invalid" || diagnostic.code === "provider_unavailable";
+}
+
+export function knowledgeIndexSyncActionLabel(diagnostic: KnowledgeIndexDiagnostic): string {
+  switch (diagnostic.action) {
+    case "start_sync":
+      return "Start initial sync";
+    case "retry_sync":
+      return "Retry sync";
+    case "sync_changes":
+      return "Sync changes";
+    case "sync_again":
+      return "Sync again";
+    default:
+      return "Sync now";
+  }
+}
+
+function didConfigurationChangeAfterSync(index: KnowledgeIndex): boolean {
+  if (!index.last_synced_at) return false;
+  const syncedAt = Date.parse(index.last_synced_at);
+  const updatedAt = Date.parse(index.updated_at);
+  return Number.isFinite(syncedAt) && Number.isFinite(updatedAt) && updatedAt > syncedAt + 1000;
+}
+
+function withFailureReason(
+  diagnostic: KnowledgeIndexDiagnostic,
+  index: KnowledgeIndex,
+): KnowledgeIndexDiagnostic {
+  return index.last_sync_error
+    ? { ...diagnostic, failureReason: index.last_sync_error }
+    : diagnostic;
+}
+
+export function getKnowledgeIndexDiagnostic(
+  index: KnowledgeIndex,
+  context: DiagnosticContext = {},
+): KnowledgeIndexDiagnostic {
+  const model = context.models?.find((candidate) => candidate.id === index.embedding_model_id);
+
+  if (context.modelsReady && !model) {
+    return withFailureReason(
+      {
+        code: "configuration_invalid",
+        label: "Embedding model unavailable",
+        description: "Choose an available embedding model before syncing.",
+        variant: "destructive",
+        noticeVariant: "destructive",
+        action: "configure_model",
+      },
+      index,
+    );
+  }
+
+  if (
+    model &&
+    !model.capabilities.some((capability) => capability.toLowerCase() === "embeddings")
+  ) {
+    return withFailureReason(
+      {
+        code: "configuration_invalid",
+        label: "Embedding model invalid",
+        description: `${model.display_name} does not support embeddings.`,
+        variant: "destructive",
+        noticeVariant: "destructive",
+        action: "configure_model",
+      },
+      index,
+    );
+  }
+
+  if (model && !model.enabled) {
+    return withFailureReason(
+      {
+        code: "configuration_invalid",
+        label: "Embedding model disabled",
+        description: `${model.display_name} is disabled. Choose an enabled embedding model.`,
+        variant: "destructive",
+        noticeVariant: "destructive",
+        action: "configure_model",
+      },
+      index,
+    );
+  }
+
+  if (model && !model.healthy) {
+    return withFailureReason(
+      {
+        code: "provider_unavailable",
+        label: "Provider setup needed",
+        description: `${model.provider_name} is not configured or available for embeddings.`,
+        variant: "destructive",
+        noticeVariant: "destructive",
+        action: "configure_provider",
+        providerId: model.provider_id,
+      },
+      index,
+    );
+  }
+
+  if (index.sync_status === "failed") {
+    return withFailureReason(
+      {
+        code: "sync_failed",
+        label: "Sync failed",
+        description: "The latest sync did not complete.",
+        variant: "destructive",
+        noticeVariant: "destructive",
+        action: "retry_sync",
+      },
+      index,
+    );
+  }
+
+  if (index.sync_status === "pending") {
+    return {
+      code: "queued",
+      label: "Sync queued",
+      description: "Waiting for a sync worker.",
+      variant: "accent",
+      noticeVariant: "info",
+    };
+  }
+
+  if (index.sync_status === "syncing") {
+    return {
+      code: "syncing",
+      label: "Syncing",
+      description: "Documents are being indexed now.",
+      variant: "accent",
+      noticeVariant: "info",
+    };
+  }
+
+  if (!index.last_synced_at) {
+    return {
+      code: "not_synced",
+      label: "Not synced yet",
+      description: "Start the initial sync to index documents.",
+      variant: "secondary",
+      noticeVariant: "warning",
+      action: "start_sync",
+    };
+  }
+
+  if (didConfigurationChangeAfterSync(index)) {
+    return {
+      code: "stale",
+      label: "Sync out of date",
+      description: "Index configuration changed after the last successful sync.",
+      variant: "accent",
+      noticeVariant: "warning",
+      action: "sync_changes",
+    };
+  }
+
+  if (index.sync_status === "synced" && index.document_count === 0) {
+    return {
+      code: "empty",
+      label: "Synced — no documents",
+      description: "The last sync succeeded but found no indexable documents.",
+      variant: "accent",
+      noticeVariant: "warning",
+      action: "sync_again",
+    };
+  }
+
+  return {
+    code: "ready",
+    label: "Up to date",
+    description: `${index.document_count} ${index.document_count === 1 ? "document" : "documents"} indexed.`,
+    variant: "success",
+    noticeVariant: "success",
+  };
+}

--- a/crates/server/src/domains/knowledge_indexes/commands.rs
+++ b/crates/server/src/domains/knowledge_indexes/commands.rs
@@ -58,6 +58,21 @@ async fn require_embedding_model(
     Ok(model_id)
 }
 
+async fn response_with_document_count(
+    ctx: &Ctx,
+    row: crate::storage::models::KnowledgeIndexRow,
+) -> Result<KnowledgeIndexResponse, CommandError> {
+    let document_count = ctx
+        .db
+        .count_knowledge_index_documents(&[row.id])
+        .await
+        .map_err(classify_anyhow)?
+        .get(&row.id)
+        .copied()
+        .unwrap_or(0);
+    knowledge_index_response(row, document_count).map_err(classify_anyhow)
+}
+
 // ============================================
 // Knowledge Index CRUD
 // ============================================
@@ -110,8 +125,16 @@ impl Command for ListKnowledgeIndexes {
             )
             .await
             .map_err(classify_anyhow)?;
+        let counts = ctx
+            .db
+            .count_knowledge_index_documents(&rows.iter().map(|row| row.id).collect::<Vec<_>>())
+            .await
+            .map_err(classify_anyhow)?;
         rows.into_iter()
-            .map(|row| knowledge_index_response(row).map_err(classify_anyhow))
+            .map(|row| {
+                let document_count = counts.get(&row.id).copied().unwrap_or(0);
+                knowledge_index_response(row, document_count).map_err(classify_anyhow)
+            })
             .collect()
     }
 }
@@ -193,7 +216,7 @@ impl Command for CreateKnowledgeIndex {
             .create_knowledge_index(ctx.org_id(), input)
             .await
             .map_err(classify_anyhow)?;
-        knowledge_index_response(row).map_err(classify_anyhow)
+        knowledge_index_response(row, 0).map_err(classify_anyhow)
     }
 }
 
@@ -238,7 +261,7 @@ impl Command for GetKnowledgeIndex {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("KnowledgeIndex"))?;
-        knowledge_index_response(row).map_err(classify_anyhow)
+        response_with_document_count(ctx, row).await
     }
 }
 
@@ -327,7 +350,7 @@ impl Command for UpdateKnowledgeIndexCmd {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("KnowledgeIndex"))?;
-        knowledge_index_response(row).map_err(classify_anyhow)
+        response_with_document_count(ctx, row).await
     }
 }
 
@@ -430,7 +453,7 @@ impl Command for SyncKnowledgeIndex {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("KnowledgeIndex"))?;
-        knowledge_index_response(row).map_err(classify_anyhow)
+        response_with_document_count(ctx, row).await
     }
 }
 

--- a/crates/server/src/domains/knowledge_indexes/source_sync/tests.rs
+++ b/crates/server/src/domains/knowledge_indexes/source_sync/tests.rs
@@ -402,6 +402,11 @@ async fn embed_persists_documents_chunks_and_vectors() {
         .await
         .expect("docs");
     assert_eq!(documents.len(), 2);
+    let document_counts = db
+        .count_knowledge_index_documents(&[index_id])
+        .await
+        .expect("document counts");
+    assert_eq!(document_counts.get(&index_id), Some(&2));
     let chunks = db
         .list_knowledge_index_chunks(index_id)
         .await

--- a/crates/server/src/domains/knowledge_indexes/types.rs
+++ b/crates/server/src/domains/knowledge_indexes/types.rs
@@ -34,6 +34,8 @@ pub struct KnowledgeIndexResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Embedding dimension, recorded on first successful sync.
     pub vector_dim: Option<i32>,
+    /// Number of documents currently retained by this index.
+    pub document_count: usize,
     /// Current lifecycle status.
     pub status: String,
     /// Syncout pipeline state. One of `idle`, `pending`, `syncing`, `synced`, `failed`.
@@ -113,7 +115,10 @@ pub struct ListKnowledgeIndexesQuery {
     pub include_archived: Option<bool>,
 }
 
-pub fn knowledge_index_response(row: KnowledgeIndexRow) -> anyhow::Result<KnowledgeIndexResponse> {
+pub fn knowledge_index_response(
+    row: KnowledgeIndexRow,
+    document_count: usize,
+) -> anyhow::Result<KnowledgeIndexResponse> {
     Ok(KnowledgeIndexResponse {
         id: row.public_id.parse()?,
         name: row.name,
@@ -123,6 +128,7 @@ pub fn knowledge_index_response(row: KnowledgeIndexRow) -> anyhow::Result<Knowle
         source_config: row.source_config,
         embedding_model_id: row.embedding_model_id,
         vector_dim: row.vector_dim,
+        document_count,
         status: row.status,
         sync_status: row.sync_status,
         last_synced_at: row.last_synced_at,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1575,6 +1575,13 @@ impl StorageBackend {
         dispatch!(self, list_knowledge_index_documents, index_id)
     }
 
+    pub async fn count_knowledge_index_documents(
+        &self,
+        index_ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, usize>> {
+        dispatch!(self, count_knowledge_index_documents, index_ids)
+    }
+
     pub async fn list_knowledge_index_chunks(
         &self,
         index_id: Uuid,

--- a/crates/server/src/storage/memory/knowledge_indexes.rs
+++ b/crates/server/src/storage/memory/knowledge_indexes.rs
@@ -5,6 +5,7 @@ use super::super::models::*;
 use super::{InMemoryDatabase, matches_search_tokens};
 use anyhow::{Result, bail};
 use chrono::{DateTime, Duration, Utc};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl InMemoryDatabase {
@@ -202,6 +203,20 @@ impl InMemoryDatabase {
             .collect();
         result.sort_by_key(|doc| std::cmp::Reverse(doc.created_at));
         Ok(result)
+    }
+
+    pub async fn count_knowledge_index_documents(
+        &self,
+        index_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, usize>> {
+        let wanted: std::collections::HashSet<_> = index_ids.iter().copied().collect();
+        let mut counts = HashMap::new();
+        for document in self.knowledge_index_documents.read().values() {
+            if wanted.contains(&document.index_id) {
+                *counts.entry(document.index_id).or_insert(0) += 1;
+            }
+        }
+        Ok(counts)
     }
 
     pub async fn list_knowledge_index_chunks(

--- a/crates/server/src/storage/repositories/knowledge_indexes.rs
+++ b/crates/server/src/storage/repositories/knowledge_indexes.rs
@@ -4,6 +4,7 @@
 use super::super::models::*;
 use super::{Database, build_search_sql};
 use anyhow::Result;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 const INDEX_COLUMNS: &str = "id, org_id, public_id, name, description, source_type, source_config, \
@@ -177,6 +178,26 @@ impl Database {
                 .fetch_all(&self.pool)
                 .await?;
         Ok(rows)
+    }
+
+    pub async fn count_knowledge_index_documents(
+        &self,
+        index_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, usize>> {
+        if index_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let rows = sqlx::query_as::<_, (Uuid, i64)>(
+            "SELECT index_id, COUNT(*) FROM knowledge_index_documents \
+             WHERE index_id = ANY($1) GROUP BY index_id",
+        )
+        .bind(index_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(index_id, count)| (index_id, count as usize))
+            .collect())
     }
 
     pub async fn list_knowledge_index_chunks(

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -23394,6 +23394,7 @@
           "source_type",
           "source_config",
           "embedding_model_id",
+          "document_count",
           "status",
           "sync_status",
           "created_at",
@@ -23427,6 +23428,11 @@
               "null"
             ],
             "description": "Human-readable description. Safe to render in user-facing messages."
+          },
+          "document_count": {
+            "type": "integer",
+            "description": "Number of documents currently retained by this index.",
+            "minimum": 0
           },
           "embedding_model_id": {
             "type": "string",
@@ -24953,6 +24959,7 @@
                 "source_type",
                 "source_config",
                 "embedding_model_id",
+                "document_count",
                 "status",
                 "sync_status",
                 "created_at",
@@ -24986,6 +24993,11 @@
                     "null"
                   ],
                   "description": "Human-readable description. Safe to render in user-facing messages."
+                },
+                "document_count": {
+                  "type": "integer",
+                  "description": "Number of documents currently retained by this index.",
+                  "minimum": 0
                 },
                 "embedding_model_id": {
                   "type": "string",

--- a/test_cases/ui/knowledge_indexes/TC001_diagnostic_status.md
+++ b/test_cases/ui/knowledge_indexes/TC001_diagnostic_status.md
@@ -1,0 +1,42 @@
+# TC001: Knowledge Index Diagnostic Status
+
+## Description
+
+Verify that an active knowledge index with an invalid embedding model is not presented as healthy,
+and that list and detail views show the same diagnostic with the correct remediation.
+
+## Preconditions
+
+- Server running with an organization selected
+- An active knowledge index that has never synced and references a generation-only model
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Index ID | `kidx_019fda06ccf67d618776620713254657` when available |
+| Embedding model | `Claude Opus 4.7 (1M)` or another model without `embeddings` capability |
+| Sync status | `idle` |
+| Last synced | unset |
+| Documents | `0` |
+
+## Steps
+
+1. Navigate to `/knowledge-indexes`.
+2. Locate the test index and inspect its lifecycle and diagnostic badges.
+3. Verify the row does not offer a sync action while the embedding configuration is invalid.
+4. Open the index detail page.
+5. Inspect the prominent diagnostic notice and available action.
+6. Open **Configure embedding model** and verify the picker does not offer generation-only models.
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Lifecycle | The index may show `active`, but also shows `Embedding model invalid` |
+| Explanation | Copy names the selected model and states that it does not support embeddings |
+| List action | **Configure embedding model** is visible; sync is not offered |
+| Detail notice | A destructive, icon-labelled notice repeats the same diagnosis and explanation |
+| Detail action | **Configure embedding model** opens the edit dialog |
+| Picker | Only enabled models advertising `embeddings` are selectable |
+| Empty state | The index is not labelled healthy or merely empty because it has never synced |


### PR DESCRIPTION
## What changed
Knowledge Index list and detail views now derive an actionable diagnostic state instead of treating lifecycle `active` as healthy. They distinguish initial sync, queued/syncing, synced-empty, stale, failed, invalid embedding configuration, unavailable provider, and ready states; show the latest safe sync error; and route users to the appropriate configuration, provider, retry, or sync action.

The API now returns `document_count` so the UI can distinguish a successful empty sync from an index that has never synced. Counts are loaded with one grouped query for lists. In-flight indexes poll every two seconds and stop polling in terminal states, so status changes appear without a reload.

## Why
An active index can still be unusable. In particular, a never-synced empty index configured with Claude Opus 4.7 (1M) looked healthy even though that model cannot create embeddings. Users need the issue and corrective action before attempting a sync.

## Before / After
Before: an active, idle, never-synced, zero-document index appeared as a healthy empty index and exposed a sync action.

After: the recreated Bashkit case is labeled `Embedding model invalid` on both list and detail views, explains that Claude Opus 4.7 (1M) does not support embeddings, and offers `Configure embedding model` instead of sync. Equivalent list/detail screenshots were captured during local smoke testing; the production record is not available in the isolated development stack, and screenshot upload is unavailable because the Cloudinary credential is not configured.

Automated coverage includes every diagnostic state on list/detail surfaces, provider action routing, failure-reason rendering, polling transitions, and server-side document count propagation.

## Risk
- Medium
- The shared state resolver could classify unusual legacy timestamps or model metadata incorrectly. Focused state-matrix tests cover precedence and actions; polling is bounded to queued/syncing indexes.
- Adding `document_count` changes the response additively. List counts use one grouped query to avoid N+1 database load.

## Security
- Threat categories reviewed: TM-WEB, TM-TENANT, TM-DOS
- Findings and resolutions: sync failure text remains server-sanitized and is rendered as escaped React text; no raw HTML or new mutation surface was added. Count queries receive only organization-scoped index IDs and do not widen tenant access. List counts are batched, and two-second polling runs only while sync is in flight and stops at terminal states. No new threat-model entry is needed.

## Follow-ups
Underlying initial-sync execution and embedding model/provider capability pipeline remain in the separate ingestion workstream; intentionally not changed here.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
