### PR TITLE
fix(models): configure embedding models separately

### DIFF
--- a/apps/ui/src/__tests__/add-model-dialog.test.tsx
+++ b/apps/ui/src/__tests__/add-model-dialog.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as mockReact from "react";
+import { AddModelDialog } from "@/components/models/add-model-dialog";
+import type { Provider } from "@/lib/api/types";
+
+const mutateAsync = jest.fn().mockResolvedValue({});
+
+jest.mock("@/hooks/use-providers", () => ({
+  useCreateModel: () => ({ mutateAsync, isPending: false }),
+}));
+
+jest.mock("@/components/ui/select", () => {
+  function collectOptions(node: mockReact.ReactNode): mockReact.ReactNode[] {
+    const options: mockReact.ReactNode[] = [];
+    mockReact.Children.forEach(node, (child: mockReact.ReactNode) => {
+      if (!mockReact.isValidElement(child)) return;
+      if ((child.type as { isSelectItem?: boolean }).isSelectItem) {
+        const props = child.props as { value: string; children: mockReact.ReactNode };
+        options.push(
+          <option key={props.value} value={props.value}>
+            {props.children}
+          </option>,
+        );
+        return;
+      }
+      options.push(...collectOptions((child.props as { children?: mockReact.ReactNode }).children));
+    });
+    return options;
+  }
+
+  function findTrigger(node: mockReact.ReactNode): { id?: string } {
+    let found: { id?: string } = {};
+    mockReact.Children.forEach(node, (child: mockReact.ReactNode) => {
+      if (!mockReact.isValidElement(child) || found.id) return;
+      if ((child.type as { isSelectTrigger?: boolean }).isSelectTrigger) {
+        found = { id: (child.props as { id?: string }).id };
+        return;
+      }
+      const nested = findTrigger((child.props as { children?: mockReact.ReactNode }).children);
+      if (nested.id) found = nested;
+    });
+    return found;
+  }
+
+  function Select({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: mockReact.ReactNode;
+  }) {
+    return (
+      <select
+        id={findTrigger(children).id}
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+      >
+        {collectOptions(children)}
+      </select>
+    );
+  }
+
+  function SelectItem(_: { value: string; children: mockReact.ReactNode }) {
+    return null;
+  }
+  SelectItem.isSelectItem = true;
+
+  function SelectTrigger(_: { children: mockReact.ReactNode; id?: string }) {
+    return null;
+  }
+  SelectTrigger.isSelectTrigger = true;
+
+  return {
+    Select,
+    SelectContent: ({ children }: { children: mockReact.ReactNode }) => <>{children}</>,
+    SelectItem,
+    SelectTrigger,
+    SelectValue: () => null,
+  };
+});
+
+const providers: Provider[] = [
+  {
+    id: "provider_openai",
+    name: "OpenAI",
+    provider_type: "openai",
+    api_key_set: true,
+    status: "active",
+    managed: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+describe("AddModelDialog", () => {
+  beforeEach(() => mutateAsync.mockClear());
+
+  it("creates a selectable embedding model", async () => {
+    render(<AddModelDialog providers={providers} open onOpenChange={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText("Provider"), {
+      target: { value: "provider_openai" },
+    });
+    fireEvent.change(screen.getByLabelText("Model type"), {
+      target: { value: "embeddings" },
+    });
+    fireEvent.change(screen.getByLabelText("Model ID"), {
+      target: { value: "text-embedding-3-small" },
+    });
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "Text Embedding 3 Small" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Model" }));
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        model_id: "text-embedding-3-small",
+        display_name: "Text Embedding 3 Small",
+        capabilities: ["embeddings"],
+        enabled: true,
+      }),
+    );
+  });
+});

--- a/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
@@ -34,9 +34,13 @@ jest.mock("@/components/ui/select", () => {
     mockReact.Children.forEach(node, (child: mockReact.ReactNode) => {
       if (!mockReact.isValidElement(child)) return;
       if ((child.type as { isSelectItem?: boolean }).isSelectItem) {
-        const props = child.props as { value: string; children: mockReact.ReactNode };
+        const props = child.props as {
+          value: string;
+          children: mockReact.ReactNode;
+          disabled?: boolean;
+        };
         options.push(
-          <option key={props.value} value={props.value}>
+          <option key={props.value} value={props.value} disabled={props.disabled}>
             {props.children}
           </option>,
         );
@@ -297,6 +301,35 @@ describe("KnowledgeIndexesPage", () => {
     expect(nameInput).toHaveAttribute("aria-describedby", nameError.id);
     expect(embeddingModelPicker).toHaveAttribute("aria-invalid", "true");
     expect(embeddingModelPicker).toHaveAttribute("aria-describedby", modelError.id);
+  });
+
+  it("does not offer chat models when no embedding models are configured", () => {
+    mockUseModels.mockReturnValue({
+      data: [
+        {
+          id: "model_chat",
+          display_name: "GPT-5.6",
+          provider_name: "OpenAI",
+          enabled: true,
+          capabilities: ["chat", "tools"],
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<KnowledgeIndexesPage />);
+    fireEvent.click(screen.getByRole("button", { name: "New index" }));
+
+    const picker = within(screen.getByRole("dialog")).getByLabelText("Embedding model");
+    expect(within(picker).queryByRole("option", { name: "GPT-5.6 (OpenAI)" })).toBeNull();
+    expect(
+      within(picker).getByRole("option", { name: "No embedding models available" }),
+    ).toBeDisabled();
+    expect(
+      within(screen.getByRole("dialog")).getByRole("link", {
+        name: "Configure an embedding model",
+      }),
+    ).toHaveAttribute("href", "/models");
   });
 
   it("archives an index after confirmation", async () => {

--- a/apps/ui/src/__tests__/model-capabilities.test.ts
+++ b/apps/ui/src/__tests__/model-capabilities.test.ts
@@ -1,0 +1,14 @@
+import { isChatModel, isEmbeddingModel } from "@/lib/model-capabilities";
+
+describe("model capabilities", () => {
+  it("keeps embedding models out of chat model selectors", () => {
+    const embeddingModel = { capabilities: ["Embeddings"] };
+
+    expect(isEmbeddingModel(embeddingModel)).toBe(true);
+    expect(isChatModel(embeddingModel)).toBe(false);
+  });
+
+  it("treats existing untagged models as chat models", () => {
+    expect(isChatModel({ capabilities: [] })).toBe(true);
+  });
+});

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -40,6 +40,7 @@ import { queryKeys } from "@/lib/query-keys";
 import { pluralize } from "@/lib/formatting";
 import { cn } from "@/lib/utils";
 import type { ModelWithProvider } from "@/lib/api/types";
+import { isChatModel } from "@/lib/model-capabilities";
 
 // Order models by release date desc (newest first), then by created_at desc.
 // Models without a release_date in their profile fall to the bottom; this works
@@ -97,7 +98,7 @@ export default function ModelsPage() {
     return { enabledModels: enabled, availableModels: available };
   }, [filteredModels]);
   const allEnabledModels = useMemo(
-    () => models.filter((model) => model.enabled).sort(compareByRecency),
+    () => models.filter((model) => model.enabled && isChatModel(model)).sort(compareByRecency),
     [models],
   );
   const selectedDefaultModelName = org?.default_model_id

--- a/apps/ui/src/components/chat/model-effort-menu.tsx
+++ b/apps/ui/src/components/chat/model-effort-menu.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { chatSurfaceStyles } from "@/components/chat/chat-surface";
 import { cn } from "@/lib/utils";
+import { isChatModel } from "@/lib/model-capabilities";
 import type { Model, ReasoningEffortConfig, VerbosityConfig } from "@/lib/api/types";
 import { useLocale } from "@/providers/locale-provider";
 
@@ -89,7 +90,7 @@ export function ModelEffortMenu({
 }: ModelEffortMenuProps) {
   const { t } = useLocale();
 
-  const enabledModels = models.filter((model) => model.enabled);
+  const enabledModels = models.filter((model) => model.enabled && isChatModel(model));
   const recentIds = new Set(recentModels.map((model) => model.id));
 
   // Effective effort name for the trigger: the explicit override, or the model's default.

--- a/apps/ui/src/components/knowledge-indexes/embedding-model-picker.tsx
+++ b/apps/ui/src/components/knowledge-indexes/embedding-model-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   Select,
   SelectContent,
@@ -8,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useModels } from "@/hooks/use-providers";
-import type { ModelWithProvider } from "@/lib/api/types";
+import { isEmbeddingModel } from "@/lib/model-capabilities";
 import { cn } from "@/lib/utils";
 
 interface EmbeddingModelPickerProps {
@@ -20,13 +21,6 @@ interface EmbeddingModelPickerProps {
   className?: string;
   "aria-invalid"?: boolean;
   "aria-describedby"?: string;
-}
-
-// Only advertise models whose registry capabilities explicitly include
-// embeddings. Listing a generation-only fallback creates an index that cannot
-// sync and hides the configuration problem until runtime.
-export function isEmbeddingModel(model: ModelWithProvider): boolean {
-  return model.capabilities.some((cap) => cap.toLowerCase() === "embeddings");
 }
 
 export function EmbeddingModelPicker({
@@ -41,45 +35,55 @@ export function EmbeddingModelPicker({
 }: EmbeddingModelPickerProps) {
   const { data: models = [], isLoading } = useModels();
 
-  const enabled = models.filter((m) => m.enabled);
-  const candidates = enabled.filter(isEmbeddingModel);
-
-  const sorted = [...candidates].sort((a, b) => {
-    if (a.provider_name !== b.provider_name) {
-      return a.provider_name.localeCompare(b.provider_name);
-    }
-    return a.display_name.localeCompare(b.display_name);
-  });
+  const sorted = models
+    .filter((m) => m.enabled && isEmbeddingModel(m))
+    .sort((a, b) => {
+      if (a.provider_name !== b.provider_name) {
+        return a.provider_name.localeCompare(b.provider_name);
+      }
+      return a.display_name.localeCompare(b.display_name);
+    });
 
   const selectedModel = models.find((m) => m.id === value);
 
   return (
-    <Select value={value} onValueChange={onChange} disabled={disabled || isLoading}>
-      <SelectTrigger
-        id={id}
-        className={cn("w-full", className)}
-        aria-label="Embedding model"
-        aria-invalid={ariaInvalid}
-        aria-describedby={ariaDescribedBy}
-      >
-        <SelectValue placeholder={isLoading ? "Loading models..." : placeholder}>
-          {selectedModel
-            ? `${selectedModel.display_name} (${selectedModel.provider_name})`
-            : undefined}
-        </SelectValue>
-      </SelectTrigger>
-      <SelectContent>
-        {sorted.length === 0 && (
-          <SelectItem value="__none__" disabled>
-            No embedding models available
-          </SelectItem>
-        )}
-        {sorted.map((model) => (
-          <SelectItem key={model.id} value={model.id}>
-            {model.display_name} ({model.provider_name})
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <div className="space-y-2">
+      <Select value={value} onValueChange={onChange} disabled={disabled || isLoading}>
+        <SelectTrigger
+          id={id}
+          className={cn("w-full", className)}
+          aria-label="Embedding model"
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+        >
+          <SelectValue placeholder={isLoading ? "Loading models..." : placeholder}>
+            {selectedModel
+              ? `${selectedModel.display_name} (${selectedModel.provider_name})`
+              : undefined}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {sorted.length === 0 && (
+            <SelectItem value="__none__" disabled>
+              No embedding models available
+            </SelectItem>
+          )}
+          {sorted.map((model) => (
+            <SelectItem key={model.id} value={model.id}>
+              {model.display_name} ({model.provider_name})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {!isLoading && sorted.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No embedding models are configured.{" "}
+          <Link href="/models" className="text-primary underline underline-offset-4">
+            Configure an embedding model
+          </Link>
+          .
+        </p>
+      )}
+    </div>
   );
 }

--- a/apps/ui/src/components/models/add-model-dialog.tsx
+++ b/apps/ui/src/components/models/add-model-dialog.tsx
@@ -23,6 +23,8 @@ import {
 import { useCreateModel } from "@/hooks/use-providers";
 import type { CreateModelRequest, Provider } from "@/lib/api/types";
 
+type ModelType = "chat" | "embeddings";
+
 export function AddModelDialog({
   providers,
   open,
@@ -35,16 +37,24 @@ export function AddModelDialog({
   const [providerId, setProviderId] = useState("");
   const [modelId, setModelId] = useState("");
   const [displayName, setDisplayName] = useState("");
+  const [modelType, setModelType] = useState<ModelType>("chat");
   const [enabled, setEnabled] = useState(true);
 
   const createModel = useCreateModel(providerId);
-  const selectedProviderName = providers.find((provider) => provider.id === providerId)?.name;
+  const selectedProvider = providers.find((provider) => provider.id === providerId);
+
+  const handleProviderChange = (nextProviderId: string) => {
+    setProviderId(nextProviderId);
+    const nextProvider = providers.find((provider) => provider.id === nextProviderId);
+    if (nextProvider?.provider_type !== "openai") setModelType("chat");
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const data: CreateModelRequest = {
       model_id: modelId,
       display_name: displayName,
+      capabilities: modelType === "embeddings" ? ["embeddings"] : [],
       enabled,
     };
     await createModel.mutateAsync(data);
@@ -52,6 +62,7 @@ export function AddModelDialog({
     setProviderId("");
     setModelId("");
     setDisplayName("");
+    setModelType("chat");
     setEnabled(true);
   };
 
@@ -65,9 +76,9 @@ export function AddModelDialog({
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="provider">Provider</Label>
-            <Select value={providerId} onValueChange={setProviderId}>
+            <Select value={providerId} onValueChange={handleProviderChange}>
               <SelectTrigger id="provider" className="w-full">
-                <SelectValue placeholder="Select provider">{selectedProviderName}</SelectValue>
+                <SelectValue placeholder="Select provider">{selectedProvider?.name}</SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {providers.map((provider) => (
@@ -79,12 +90,31 @@ export function AddModelDialog({
             </Select>
           </div>
           <div className="space-y-2">
+            <Label htmlFor="model-type">Model type</Label>
+            <Select value={modelType} onValueChange={(value) => setModelType(value as ModelType)}>
+              <SelectTrigger id="model-type" className="w-full">
+                <SelectValue>{modelType === "embeddings" ? "Embeddings" : "Chat"}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="chat">Chat</SelectItem>
+                {selectedProvider?.provider_type === "openai" && (
+                  <SelectItem value="embeddings">Embeddings</SelectItem>
+                )}
+              </SelectContent>
+            </Select>
+            {providerId && selectedProvider?.provider_type !== "openai" && (
+              <p className="text-xs text-muted-foreground">
+                This provider does not currently support embedding models.
+              </p>
+            )}
+          </div>
+          <div className="space-y-2">
             <Label htmlFor="model-id">Model ID</Label>
             <Input
               id="model-id"
               value={modelId}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModelId(e.target.value)}
-              placeholder="gpt-5.2"
+              placeholder={modelType === "embeddings" ? "text-embedding-3-small" : "gpt-5.2"}
               required
             />
           </div>

--- a/apps/ui/src/components/models/model-picker.tsx
+++ b/apps/ui/src/components/models/model-picker.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { ModelWithProvider } from "@/lib/api/types";
+import { isChatModel } from "@/lib/model-capabilities";
 import { useModels, useUpdateModel } from "@/hooks/use-providers";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -51,7 +52,7 @@ export function ModelPicker({
 
   // Only show enabled models, sorted: favorites first, then by provider and name
   const sortedModels = [...models]
-    .filter((m) => m.enabled)
+    .filter((m) => m.enabled && isChatModel(m))
     .sort((a, b) => {
       // Favorites first
       if (a.is_favorite !== b.is_favorite) {
@@ -65,7 +66,7 @@ export function ModelPicker({
       return a.display_name.localeCompare(b.display_name);
     });
 
-  const selectedModel = models.find((m) => m.id === value);
+  const selectedModel = models.find((m) => m.id === value && isChatModel(m));
 
   return (
     <Select

--- a/apps/ui/src/hooks/use-chat-model-selection.ts
+++ b/apps/ui/src/hooks/use-chat-model-selection.ts
@@ -10,6 +10,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ModelWithProvider, ReasoningEffort, Verbosity } from "@/lib/api/types";
+import { isChatModel } from "@/lib/model-capabilities";
 
 // How many recently-used models to remember and surface in the picker.
 const RECENT_MODELS_LIMIT = 2;
@@ -75,7 +76,7 @@ export function useChatModelSelection({
   }, []);
 
   const selectedModel = useMemo(
-    () => models.find((model) => model.id === selectedModelId),
+    () => models.find((model) => model.id === selectedModelId && isChatModel(model)),
     [models, selectedModelId],
   );
 
@@ -83,7 +84,9 @@ export function useChatModelSelection({
   // disabled, or otherwise missing simply drops out of the picker.
   const recentModels = useMemo(() => {
     const usable = new Map(
-      models.filter((model) => model.enabled).map((model) => [model.id, model]),
+      models
+        .filter((model) => model.enabled && isChatModel(model))
+        .map((model) => [model.id, model]),
     );
     return recentModelIds
       .map((id) => usable.get(id))

--- a/apps/ui/src/lib/model-capabilities.ts
+++ b/apps/ui/src/lib/model-capabilities.ts
@@ -1,0 +1,11 @@
+import type { Model } from "@/lib/api/types";
+
+type ModelCapabilities = Pick<Model, "capabilities">;
+
+export function isEmbeddingModel(model: ModelCapabilities): boolean {
+  return model.capabilities.some((capability) => capability.toLowerCase() === "embeddings");
+}
+
+export function isChatModel(model: ModelCapabilities): boolean {
+  return !isEmbeddingModel(model);
+}

--- a/crates/server/src/domains/knowledge_indexes/commands.rs
+++ b/crates/server/src/domains/knowledge_indexes/commands.rs
@@ -5,9 +5,9 @@ use super::types::{
 };
 use super::{DEFAULT_SOURCE_TYPE, KNOWLEDGE_INDEX_MANAGE, KNOWLEDGE_INDEX_VIEW, SOURCE_TYPES};
 use crate::domains::common::*;
-use everruns_core::Policy;
 use everruns_core::typed_id::KnowledgeIndexId;
 use everruns_core::vector_store::index_namespace;
+use everruns_core::{DriverId, Policy, ServiceKind};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -44,17 +44,49 @@ fn validate_source_type(source_type: Option<&str>) -> Result<String, CommandErro
     Ok(source_type.to_string())
 }
 
-/// Ensure the embedding model exists in this org. Cross-org / missing refs are
-/// rejected with the same bad-request message so existence is not leaked.
+/// Ensure the model is tagged for embeddings and its provider exposes an
+/// embeddings driver. Cross-org / missing refs use the same error so existence
+/// is not leaked.
 async fn require_embedding_model(
     ctx: &Ctx,
     model_id: everruns_core::ModelId,
 ) -> Result<everruns_core::ModelId, CommandError> {
-    ctx.db
+    let model = ctx
+        .db
         .get_model(ctx.org_id(), model_id.uuid())
         .await
         .map_err(classify_anyhow)?
         .ok_or_else(|| CommandError::bad_request("Embedding model not found"))?;
+    if !model.capabilities.as_array().is_some_and(|capabilities| {
+        capabilities.iter().any(|capability| {
+            capability
+                .as_str()
+                .is_some_and(|capability| capability.eq_ignore_ascii_case("embeddings"))
+        })
+    }) {
+        return Err(CommandError::bad_request(
+            "Selected model is not an embedding model",
+        ));
+    }
+
+    let provider = ctx
+        .db
+        .get_provider(ctx.org_id(), model.provider_id.uuid())
+        .await
+        .map_err(classify_anyhow)?
+        .ok_or_else(|| CommandError::bad_request("Embedding provider not found"))?;
+    let provider_type: DriverId = provider
+        .provider_type
+        .parse()
+        .expect("DriverId::from_str is infallible");
+    if !everruns_worker::create_driver_registry().supports(&provider_type, ServiceKind::Embeddings)
+    {
+        return Err(CommandError::bad_request(format!(
+            "Embedding model provider '{}' does not support embeddings",
+            provider.provider_type
+        )));
+    }
+
     Ok(model_id)
 }
 
@@ -763,6 +795,60 @@ mod tests {
         .run(&ctx)
         .await
         .expect_err("missing model should fail");
+        assert!(matches!(
+            err,
+            CommandError {
+                kind: CommandErrorKind::BadRequest(_),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_chat_model() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let provider = db
+            .create_provider(
+                DEFAULT_ORG_ID,
+                crate::storage::models::CreateProviderRow {
+                    name: "openai provider".into(),
+                    provider_type: "openai".into(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .expect("create provider");
+        let chat_model = db
+            .create_model(
+                DEFAULT_ORG_ID,
+                crate::storage::models::CreateModelRow {
+                    provider_id: provider.id,
+                    model_id: "gpt-5.6".into(),
+                    display_name: "GPT-5.6".into(),
+                    capabilities: vec!["chat".into()],
+                    enabled: true,
+                    is_favorite: false,
+                    source: "manual".into(),
+                    provider_metadata: None,
+                },
+            )
+            .await
+            .expect("create model");
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let err = CreateKnowledgeIndex {
+            name: "Wrong Model".into(),
+            description: None,
+            source_type: None,
+            source_config: None,
+            embedding_model_id: chat_model.id,
+        }
+        .run(&ctx)
+        .await
+        .expect_err("chat model should fail");
+
         assert!(matches!(
             err,
             CommandError {

--- a/test_cases/ui/models/TC001_configure_embedding_model.md
+++ b/test_cases/ui/models/TC001_configure_embedding_model.md
@@ -1,0 +1,40 @@
+# TC001 Configure an embedding model
+
+## Description
+
+Verify that an embedding model can be configured and is offered to knowledge indexes without
+appearing in chat-model selectors.
+
+## Preconditions
+
+- A local (`AUTH_MODE=none`) or authenticated Everruns UI is available
+- An OpenAI provider is configured
+- No enabled model has the `embeddings` capability
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Provider | Any configured OpenAI provider |
+| Model type | Embeddings |
+| Model ID | `text-embedding-3-small` |
+| Display name | Text Embedding 3 Small |
+
+## Steps
+
+1. Navigate to `/knowledge-indexes` and open the New Knowledge Index dialog.
+2. Verify the embedding-model field reports that no embedding models are configured and offers a
+   Configure an embedding model link.
+3. Follow the link to `/models`, click Add Model, and select the OpenAI provider.
+4. Select Embeddings as the model type, enter the model ID and display name, leave the model
+   enabled, and create it.
+5. Return to `/knowledge-indexes`, reopen the New Knowledge Index dialog, and inspect the
+   embedding-model options.
+6. Inspect an agent, harness, or organization default-model selector.
+
+## Expected Result
+
+- The empty embedding picker links to model configuration.
+- The model is created with the embeddings capability and appears in the knowledge-index picker.
+- Chat models do not appear in the embedding picker.
+- The embedding model does not appear in chat or default-model selectors.


### PR DESCRIPTION
## What changed
Embedding model selectors now show only enabled models explicitly configured for embeddings. The Add Model flow can create OpenAI embedding models, and an empty knowledge-index picker links directly to model configuration. Knowledge-index creation also rejects chat-only models and providers without embedding support.

## Why
The embedding picker previously fell back to ordinary chat models, which made the field misleading and allowed users to reach runtime failures without a valid embedding model configuration path.

## Before / After
Before: the knowledge-index embedding picker listed chat models such as Claude and GPT generation models, with no way to configure an embedding model from the empty state.

After: the picker lists only embedding-capable models; when none exist, it offers a Configure an embedding model link. The Models dialog now supports an Embeddings model type for OpenAI, while chat/default-model selectors exclude embedding-only models.

Manual UI validation covered the empty state, embedding-model creation, filtered knowledge-index picker, and exclusion from the organization default-model picker. Screenshots will be attached in a PR comment.

## Risk
- Low
- Existing models without an explicit embeddings capability no longer appear in embedding selectors. This is intentional; model configuration must identify embedding models explicitly.

## Security
- Threat categories reviewed: TM-API, TM-TENANT-001, TM-TENANT-002, TM-WEB-001, TM-WEB-008
- Findings and resolutions: backend validation now enforces embedding capability and provider support at the command boundary; organization-scoped lookups and generic cross-organization errors remain intact. The UI uses a fixed relative configuration link and React-escaped content. No new injection, XSS, path, command, dependency, or unbounded-work surface was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
