### PR TITLE
fix(ui): move agent diagnostics into edit rail

### DIFF
--- a/apps/ui/src/__tests__/agent-checks.test.tsx
+++ b/apps/ui/src/__tests__/agent-checks.test.tsx
@@ -179,6 +179,7 @@ describe("AgentChecks", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Apply fix" }));
 
     expect(onApplyFix).toHaveBeenCalledWith(7, 10, "good");
+    expect(screen.getByText("Suggested fix").closest("details")).toHaveClass("min-w-0");
   });
 
   it("shows the built-in check error state", () => {

--- a/apps/ui/src/__tests__/agent-edit-page.test.tsx
+++ b/apps/ui/src/__tests__/agent-edit-page.test.tsx
@@ -39,7 +39,20 @@ jest.mock("@/components/ui/prompt-editor", () => ({
 }));
 
 jest.mock("@/components/agents/capability-selector", () => ({
-  CapabilitySelector: () => <div data-testid="capability-selector" />,
+  CapabilitySelector: ({
+    selected,
+    onChange,
+  }: {
+    selected: Array<{ ref: string; config: Record<string, unknown> }>;
+    onChange: (selected: Array<{ ref: string; config: Record<string, unknown> }>) => void;
+  }) => (
+    <div data-testid="capability-selector">
+      <span data-testid="selected-capabilities">{JSON.stringify(selected)}</span>
+      <button type="button" onClick={() => onChange([{ ref: "memory", config: {} }])}>
+        Select memory
+      </button>
+    </div>
+  ),
 }));
 
 jest.mock("@/components/agents/agent-preview", () => ({
@@ -47,8 +60,28 @@ jest.mock("@/components/agents/agent-preview", () => ({
 }));
 
 jest.mock("@/components/agents/agent-checks", () => ({
-  AgentChecks: () => <div data-testid="agent-checks">Checks</div>,
-  applyByteSpanReplacement: (text: string) => text,
+  AgentChecks: ({
+    systemPrompt,
+    capabilities,
+    tools,
+    onApplyFix,
+  }: {
+    systemPrompt: string;
+    capabilities: Array<{ ref: string; config: Record<string, unknown> }>;
+    tools: Array<{ name: string }>;
+    onApplyFix: (start: number, end: number, replacement: string) => void;
+  }) => (
+    <div data-testid="agent-checks">
+      <span data-testid="checks-inputs">
+        {JSON.stringify({ systemPrompt, capabilities, tools: tools.map((tool) => tool.name) })}
+      </span>
+      <button type="button" onClick={() => onApplyFix(0, 5, "Fixed")}>
+        Apply check fix
+      </button>
+    </div>
+  ),
+  applyByteSpanReplacement: (text: string, start: number, end: number, replacement: string) =>
+    replacement + text.slice(end),
 }));
 
 jest.mock("@/components/agents/agent-health-check", () => ({
@@ -111,6 +144,14 @@ const malformedAgent: Agent = {
   tags: null as unknown as string[],
   capabilities: [],
   initial_files: [],
+  tools: [
+    {
+      type: "builtin",
+      name: "lookup",
+      description: "Look something up",
+      parameters: { type: "object", properties: {} },
+    },
+  ],
   status: "active",
   created_at: "2026-04-19T10:00:00Z",
   updated_at: "2026-04-19T10:00:00Z",
@@ -186,6 +227,54 @@ describe("EditAgentPage", () => {
     expect(screen.getByTestId("agent-preview")).toBeInTheDocument();
     expect(screen.queryByTestId("agent-checks")).not.toBeInTheDocument();
     expect(screen.queryByTestId("agent-health-check")).not.toBeInTheDocument();
+  });
+
+  it("orders diagnostics in the rail after capabilities and stacks the rail after the form", async () => {
+    await renderWithSuspense({ agentId: "agent_123" });
+
+    const capabilitiesCard = screen.getByText("Capabilities").closest('[data-slot="card"]');
+    const checks = screen.getByTestId("agent-checks");
+    const healthCheck = screen.getByTestId("agent-health-check");
+    const rail = capabilitiesCard?.parentElement;
+    const columns = rail?.parentElement;
+
+    expect(capabilitiesCard).not.toBeNull();
+    expect(rail).toBe(checks.parentElement);
+    expect(rail).toBe(healthCheck.parentElement);
+    expect(Array.from(rail?.children ?? [])).toEqual([capabilitiesCard, checks, healthCheck]);
+    expect(columns).toHaveClass("grid-cols-1", "xl:grid-cols-[minmax(0,1fr)_320px]");
+    expect(columns?.lastElementChild).toBe(rail);
+  });
+
+  it("keeps checks synced to unsaved prompt, capability, and tool inputs and applies fixes", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({});
+    mockUseUpdateAgent.mockReturnValue({ mutateAsync, isPending: false });
+    await renderWithSuspense({ agentId: "agent_123" });
+
+    expect(screen.getByTestId("checks-inputs")).toHaveTextContent(
+      JSON.stringify({
+        systemPrompt: "You are helpful.",
+        capabilities: [],
+        tools: ["lookup"],
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("System prompt"), {
+      target: { value: "Draft prompt" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Select memory" }));
+
+    expect(screen.getByTestId("checks-inputs")).toHaveTextContent(
+      JSON.stringify({
+        systemPrompt: "Draft prompt",
+        capabilities: [{ ref: "memory", config: {} }],
+        tools: ["lookup"],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply check fix" }));
+    expect(screen.getByLabelText("System prompt")).toHaveValue("Fixed prompt");
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
   it("omits network_access from the update when not edited", async () => {

--- a/apps/ui/src/__tests__/agent-health-check.test.tsx
+++ b/apps/ui/src/__tests__/agent-health-check.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { AgentHealthCheck } from "@/components/agents/agent-health-check";
 import type { HealthCheckRun, LatestHealthCheckRun } from "@/lib/api/types";
 
@@ -67,16 +67,40 @@ describe("AgentHealthCheck", () => {
     expect(screen.getByText(/no health check has been run/i)).toBeInTheDocument();
   });
 
+  it("starts a run from the compact rail action", () => {
+    const mutate = jest.fn();
+    mockTrigger.mockReturnValue({ mutate, isPending: false, error: null });
+    render(<AgentHealthCheck agentId="agent_1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /run health check/i }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      "agent_1",
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
   it("renders the score card and per-case results when completed", () => {
     mockRun = completedRun;
     render(<AgentHealthCheck agentId="agent_1" />);
     expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("Case results (2)")).toBeInTheDocument();
     expect(screen.getByText("greeting")).toBeInTheDocument();
     expect(screen.getByText("Responded politely.")).toBeInTheDocument();
     expect(screen.getByText("Did not clarify.")).toBeInTheDocument();
     // Token usage from the summary is surfaced.
     expect(screen.getByText(/1,500 input/)).toBeInTheDocument();
     expect(screen.getByText(/300 output tokens/)).toBeInTheDocument();
+  });
+
+  it("uses a rail-safe two-column summary and wrapped expandable details", () => {
+    mockRun = completedRun;
+    render(<AgentHealthCheck agentId="agent_1" />);
+
+    expect(screen.getByText("Pass rate").parentElement?.parentElement).toHaveClass("grid-cols-2");
+    const details = screen.getByText("Case results (2)").closest("details");
+    expect(details).toHaveClass("min-w-0");
+    expect(screen.getByText("Responded politely.")).toHaveClass("break-words");
   });
 
   it("shows the failure reason when the run failed", () => {

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -321,20 +321,6 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
           <PageColumns>
             {/* Main form */}
             <PageMain>
-              <AgentChecks
-                systemPrompt={formData.system_prompt}
-                capabilities={selectedCapabilities}
-                tools={agent.tools ?? []}
-                onApplyFix={(start, end, replacement) =>
-                  handleFormChange(
-                    "system_prompt",
-                    applyByteSpanReplacement(formData.system_prompt, start, end, replacement),
-                  )
-                }
-              />
-
-              <AgentHealthCheck agentId={agent.id} />
-
               <Card>
                 <CardHeader>
                   <CardTitle>Agent Details</CardTitle>
@@ -543,8 +529,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
               </Card>
             </PageMain>
 
-            {/* Capabilities sidebar */}
-            <PageRail>
+            <PageRail className="min-w-0">
               <Card>
                 <CardHeader>
                   <CardTitle>Capabilities</CardTitle>
@@ -558,6 +543,20 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                   />
                 </CardContent>
               </Card>
+
+              <AgentChecks
+                systemPrompt={formData.system_prompt}
+                capabilities={selectedCapabilities}
+                tools={agent.tools ?? []}
+                onApplyFix={(start, end, replacement) =>
+                  handleFormChange(
+                    "system_prompt",
+                    applyByteSpanReplacement(formData.system_prompt, start, end, replacement),
+                  )
+                }
+              />
+
+              <AgentHealthCheck agentId={agent.id} />
 
               {updateAgent.error && (
                 <p className="text-sm text-destructive">Error: {updateAgent.error.message}</p>

--- a/apps/ui/src/components/agents/agent-checks.tsx
+++ b/apps/ui/src/components/agents/agent-checks.tsx
@@ -103,12 +103,12 @@ export function AgentChecks({
 
 function ChecksSkeleton() {
   return (
-    <Card aria-label="Refreshing checks">
-      <CardHeader>
-        <Skeleton className="h-6 w-32" />
+    <Card aria-label="Refreshing checks" className="min-w-0 overflow-hidden">
+      <CardHeader className="p-4">
+        <Skeleton className="h-5 w-28" />
       </CardHeader>
-      <CardContent>
-        <Skeleton className="h-24 w-full" />
+      <CardContent className="px-4 pb-4">
+        <Skeleton className="h-16 w-full" />
       </CardContent>
     </Card>
   );
@@ -142,17 +142,19 @@ function FindingsCard({ findings, request, requestKey, onApplyFix }: FindingsCar
   const shown = analysis ?? findings;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex flex-wrap items-center gap-2">
-          <ShieldCheck className="w-5 h-5" />
-          Checks
-          {shown.length > 0 && <Badge variant="secondary">{shown.length}</Badge>}
-          <span className="flex-1" />
+    <Card className="min-w-0 overflow-hidden">
+      <CardHeader className="gap-2 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle className="flex min-w-0 items-center gap-2 text-base">
+            <ShieldCheck className="size-4 shrink-0" />
+            Checks
+            {shown.length > 0 && <Badge variant="secondary">{shown.length}</Badge>}
+          </CardTitle>
           <Button
             type="button"
             variant="outline"
             size="sm"
+            className="ml-auto max-w-full"
             disabled={analyzeMutation.isPending}
             onClick={() => {
               const analyzedRequestKey = requestKey;
@@ -165,16 +167,15 @@ function FindingsCard({ findings, request, requestKey, onApplyFix }: FindingsCar
               });
             }}
           >
-            <Sparkles className="w-4 h-4 mr-1" />
+            <Sparkles className="size-4" />
             {analyzeMutation.isPending ? "Analyzing…" : "Analyze"}
           </Button>
-        </CardTitle>
-        <CardDescription>
-          Advisory findings about this configuration. They never block saving. Analyze runs a deeper
-          AI review (takes ~30s).
+        </div>
+        <CardDescription className="text-xs leading-relaxed">
+          Advisory only. Analyze runs a deeper AI review and may take about 30 seconds.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="min-w-0 px-4 pb-4">
         {analyzeMutation.error && (
           <p className="text-sm text-destructive mb-3">
             Analysis failed: {analyzeMutation.error.message}
@@ -187,7 +188,7 @@ function FindingsCard({ findings, request, requestKey, onApplyFix }: FindingsCar
               : "No issues found by built-in rules."}
           </p>
         ) : (
-          <ul className="space-y-3">
+          <ul className="min-w-0 space-y-3">
             {shown.map((finding, index) => (
               <FindingRow
                 key={`${finding.rule_id}-${index}`}
@@ -218,28 +219,35 @@ function FindingRow({
       : null;
 
   return (
-    <li className="flex items-start gap-3">
-      <Badge variant="outline" className={`text-xs ${SEVERITY_STYLES[finding.severity]}`}>
-        {finding.severity}
-      </Badge>
-      <div className="space-y-1 min-w-0">
-        <p className="text-sm">{finding.message}</p>
-        <p className="text-xs text-muted-foreground font-mono">{finding.rule_id}</p>
+    <li className="min-w-0 space-y-1.5 border-t pt-3 first:border-t-0 first:pt-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <Badge variant="outline" className={`text-xs ${SEVERITY_STYLES[finding.severity]}`}>
+          {finding.severity}
+        </Badge>
+        <span className="min-w-0 break-all font-mono text-xs text-muted-foreground">
+          {finding.rule_id}
+        </span>
+      </div>
+      <div className="min-w-0 space-y-1.5">
+        <p className="break-words text-sm">{finding.message}</p>
         {finding.fix !== undefined && (
-          <div className="text-xs border p-2 bg-muted/50 space-y-1">
-            <p className="text-muted-foreground">Suggested replacement:</p>
-            <pre className="whitespace-pre-wrap font-mono">{finding.fix}</pre>
+          <details className="min-w-0 border bg-muted/50 p-2 text-xs">
+            <summary className="cursor-pointer text-muted-foreground">Suggested fix</summary>
+            <pre className="mt-2 whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">
+              {finding.fix}
+            </pre>
             {fixSpan && onApplyFix && (
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
+                className="mt-2 max-w-full"
                 onClick={() => onApplyFix(fixSpan.start, fixSpan.end, finding.fix ?? "")}
               >
                 Apply fix
               </Button>
             )}
-          </div>
+          </details>
         )}
       </div>
     </li>

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -46,16 +46,18 @@ export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
   const isRunning = trigger.isPending || run?.status === "pending" || run?.status === "running";
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Activity className="w-5 h-5" />
-          Health check
-          <span className="flex-1" />
+    <Card className="min-w-0 overflow-hidden">
+      <CardHeader className="gap-2 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle className="flex min-w-0 items-center gap-2 text-base">
+            <Activity className="size-4 shrink-0" />
+            Health check
+          </CardTitle>
           <Button
             type="button"
             variant="outline"
             size="sm"
+            className="ml-auto max-w-full"
             disabled={isRunning}
             onClick={() =>
               trigger.mutate(agentId, {
@@ -65,21 +67,20 @@ export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
           >
             {isRunning ? (
               <>
-                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
                 Running…
               </>
             ) : (
               "Run health check"
             )}
           </Button>
-        </CardTitle>
-        <CardDescription>
-          Generates a few smoke tests from this agent&apos;s configuration and runs them as real
-          sessions, then scores each with an AI judge. Runs several real sessions and takes a minute
-          or two.
+        </div>
+        <CardDescription className="text-xs leading-relaxed">
+          Runs generated smoke tests as real sessions, then scores them with an AI judge. Takes a
+          minute or two.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="min-w-0 px-4 pb-4">
         {trigger.error && (
           <p className="text-sm text-destructive">
             Could not start health check: {trigger.error.message}
@@ -121,9 +122,9 @@ function HealthCheckResults({ run }: { run: HealthCheckRun }) {
 
   const summary = run.summary;
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-3">
       {summary && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-2">
           <Metric label="Pass rate" value={`${Math.round(summary.pass_rate * 100)}%`} />
           <Metric label="Passed" value={`${summary.passed}/${summary.total}`} />
           <Metric label="Avg score" value={summary.avg_score.toFixed(2)} />
@@ -136,20 +137,27 @@ function HealthCheckResults({ run }: { run: HealthCheckRun }) {
           {summary.total_output_tokens.toLocaleString()} output tokens
         </p>
       )}
-      <ul className="space-y-2">
-        {(run.results ?? []).map((result, index) => (
-          <CaseRow key={result.session_id ?? `${result.name}-${index}`} result={result} />
-        ))}
-      </ul>
+      {(run.results?.length ?? 0) > 0 && (
+        <details className="min-w-0 border p-3">
+          <summary className="cursor-pointer text-sm font-medium">
+            Case results ({run.results?.length ?? 0})
+          </summary>
+          <ul className="mt-3 min-w-0 space-y-2">
+            {(run.results ?? []).map((result, index) => (
+              <CaseRow key={result.session_id ?? `${result.name}-${index}`} result={result} />
+            ))}
+          </ul>
+        </details>
+      )}
     </div>
   );
 }
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="border p-3 bg-muted/30">
+    <div className="min-w-0 border bg-muted/30 p-2.5">
       <div className="text-xs text-muted-foreground">{label}</div>
-      <div className="text-lg font-semibold">{value}</div>
+      <div className="break-words text-base font-semibold">{value}</div>
     </div>
   );
 }
@@ -164,11 +172,11 @@ function CaseRow({ result }: { result: HealthCheckCaseResult }) {
   );
 
   return (
-    <li className="flex items-start gap-3 border p-3">
+    <li className="flex min-w-0 items-start gap-2 border p-2.5">
       {icon}
       <div className="space-y-1 min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{result.name}</span>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="min-w-0 break-words text-sm font-medium">{result.name}</span>
           {!result.error && (
             <Badge variant="secondary" className="text-xs">
               {result.score.toFixed(2)}
@@ -185,11 +193,11 @@ function CaseRow({ result }: { result: HealthCheckCaseResult }) {
             </Link>
           )}
         </div>
-        <p className="text-xs text-muted-foreground">{result.user_message}</p>
+        <p className="break-words text-xs text-muted-foreground">{result.user_message}</p>
         {result.error ? (
-          <p className="text-xs text-amber-600 dark:text-amber-400">{result.error}</p>
+          <p className="break-words text-xs text-amber-600 dark:text-amber-400">{result.error}</p>
         ) : (
-          <p className="text-xs">{result.judge_reason}</p>
+          <p className="break-words text-xs">{result.judge_reason}</p>
         )}
       </div>
     </li>

--- a/test_cases/ui/agent_checks/TC001_edit_tab_checks.md
+++ b/test_cases/ui/agent_checks/TC001_edit_tab_checks.md
@@ -20,18 +20,19 @@ contains only the rendered system prompt, tools, and initial files.
 ## Steps
 
 1. Open an editable agent and select Edit.
-2. Confirm the Checks and Health check cards appear above Agent Details.
+2. At desktop width, confirm the right rail orders cards as Capabilities, Checks, then Health check.
 3. Change the system prompt to the test value and wait for built-in checks to refresh.
 4. Confirm the template-variable finding appears without saving the agent.
 5. Select Analyze and wait for the deeper AI review to finish.
 6. If a finding proposes a system-prompt replacement, select Apply fix and confirm the editor text changes while the agent remains unsaved.
 7. Select Preview.
 8. Confirm Preview shows Full System Prompt, Available Tools, and Initial Files without Checks or Health check cards.
-9. Resize to a narrow viewport and repeat the Edit/Preview switch.
+9. Resize to a narrow viewport and confirm the shared columns stack Agent Details before
+   Capabilities, Checks, and Health check; repeat the Edit/Preview switch.
 
 ## Expected Result
 
-- Checks and Health check are visible by default in Edit and remain advisory.
+- Checks and Health check are visible in the Edit rail below Capabilities and remain advisory.
 - Built-in findings refresh from the current unsaved configuration.
 - Analyze exposes a loading state and then findings or a clear error without losing built-in findings.
 - Apply fix updates only the authored form state; saving remains explicit.


### PR DESCRIPTION
## What changed
Agent Edit now groups Capabilities, Checks, and Health check in that order in the right rail. Checks still follow unsaved prompt, capability, and tool edits, while both diagnostic cards use compact, wrapping layouts with expandable details that remain usable in the 320px rail. The shared PageColumns layout stacks the rail after the form below the xl breakpoint.

## Why
Checks and Health check are configuration diagnostics. Their previous full-width placement above Agent Details competed with the primary editing workflow instead of providing supporting context beside it.

## Before / After
Before: Checks and Health check occupied full-width cards above Agent Details.

After, manually verified on the Dad Jokes Agent:
- 1440px viewport: Agent Details is 808px wide and the 320px rail orders Capabilities, Checks, Health check; document width equals viewport width (1440px).
- 1024px viewport: Agent Details is followed by 736px-wide Capabilities, Checks, and Health check cards; document width equals viewport width (1024px).
- An unsaved `{{customer_name}}` prompt edit produced the built-in warning without saving.
- Preview retained the unsaved prompt and contained neither diagnostics card.

Desktop and tablet screenshots were captured during local validation. Cloudinary credentials were unavailable in this environment, so they could not be attached to the PR.

## Risk
- Low
- Presentation and information architecture only; the existing check and health-check hooks and requests are unchanged. Native collapsed details could make result text less immediately visible, but summaries and result counts remain visible.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new trust boundary, HTML rendering, navigation, dependency, or network surface. Dynamic finding and health-check text remains React-escaped. Existing state-changing actions and authorization paths are unchanged. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

