### PR TITLE
fix(ui): reconcile marketplace plugin installs

### DIFF
--- a/apps/ui/src/__tests__/plugins-page.test.tsx
+++ b/apps/ui/src/__tests__/plugins-page.test.tsx
@@ -1,48 +1,179 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { CatalogEntryRow } from "@/app/(main)/plugins/page";
+import { ApiError } from "@/lib/api/client";
+import type { InstalledPlugin, MarketplaceCatalogEntry } from "@/lib/api/types";
+import { queryKeys } from "@/lib/query-keys";
 
 const mockInstallPlugin = jest.fn();
+const mockGetInstalledPlugins = jest.fn();
 
 jest.mock("@/lib/api/plugins", () => ({
   ...jest.requireActual("@/lib/api/plugins"),
   installPlugin: (...args: unknown[]) => mockInstallPlugin(...args),
+  getInstalledPlugins: (...args: unknown[]) => mockGetInstalledPlugins(...args),
 }));
 
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({ currentOrg: { public_id: "org-1" }, isLoading: false }),
+}));
+
+const entry: MarketplaceCatalogEntry = {
+  name: "resend",
+  display_name: "Resend",
+  description: "Send transactional email",
+  version: "1.0.0",
+  author: "Everruns",
+  category: "Productivity",
+  installed: false,
+};
+
+function installedPlugin(overrides: Partial<InstalledPlugin> = {}): InstalledPlugin {
+  return {
+    id: "plugin-1",
+    name: "resend",
+    display_name: "Resend",
+    description: "Send transactional email",
+    version: "1.0.0",
+    pinned_sha: "abc123",
+    marketplace: "official",
+    capability_ref: "plugin:resend",
+    status: "active",
+    warnings: [],
+    update_available: false,
+    created_at: "2026-08-06T00:00:00Z",
+    updated_at: "2026-08-06T00:00:00Z",
+    ...overrides,
+  };
+}
+
 describe("Plugins page catalog install", () => {
-  it("renders a rejected installation inline without an unhandled mutation promise", async () => {
-    mockInstallPlugin.mockRejectedValueOnce(new Error("archive rejected"));
-    const queryClient = new QueryClient({
+  let queryClient: QueryClient;
+  let wrapper: ({ children }: { children: ReactNode }) => ReactElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
         mutations: { retry: false },
       },
     });
-    const wrapper = ({ children }: { children: ReactNode }) => (
+    wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
+  });
 
-    render(
+  function renderRow(installedPlugins: InstalledPlugin[] = [], catalogEntry = entry) {
+    return render(
       <CatalogEntryRow
         marketplaceId="marketplace-1"
-        entry={{
-          name: "resend",
-          display_name: "Resend",
-          description: "Send transactional email",
-          version: "0.1.0",
-          author: "Everruns",
-          category: "Productivity",
-          installed: false,
-        }}
+        marketplaceName="official"
+        installedPlugins={installedPlugins}
+        entry={catalogEntry}
       />,
       { wrapper },
     );
+  }
+
+  it("reconciles the installed list and open catalog immediately after success", async () => {
+    const installed = installedPlugin();
+    const installedKey = [...queryKeys.installedPlugins.list(), "org-1"];
+    const catalogKey = [...queryKeys.pluginMarketplaces.catalog("marketplace-1"), "org-1"];
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+    queryClient.setQueryData(installedKey, []);
+    queryClient.setQueryData(catalogKey, [entry]);
+    mockInstallPlugin.mockResolvedValueOnce(installed);
+
+    renderRow();
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Installed" })).toBeDisabled());
+    expect(queryClient.getQueryData(installedKey)).toEqual([installed]);
+    expect(queryClient.getQueryData(catalogKey)).toEqual([{ ...entry, installed: true }]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: installedKey, exact: true });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: catalogKey, exact: true });
+  });
+
+  it("blocks a second click synchronously while installation is pending", async () => {
+    mockInstallPlugin.mockReturnValue(new Promise(() => undefined));
+    renderRow();
+
+    const button = screen.getByRole("button", { name: "Install" });
+    act(() => {
+      button.click();
+      button.click();
+    });
+
+    await waitFor(() => expect(mockInstallPlugin).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "Installing..." })).toBeDisabled();
+  });
+
+  it("treats an already-installed race as success after inventory reconciliation", async () => {
+    const installed = installedPlugin();
+    mockInstallPlugin.mockRejectedValueOnce(
+      new ApiError(409, "Conflict", "Plugin 'resend' is already installed"),
+    );
+    mockGetInstalledPlugins.mockResolvedValueOnce([installed]);
+
+    renderRow();
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Installed" })).toBeDisabled());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("preserves a real installation failure as inline feedback", async () => {
+    mockInstallPlugin.mockRejectedValueOnce(new Error("archive rejected"));
+    renderRow();
 
     fireEvent.click(screen.getByRole("button", { name: "Install" }));
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent("archive rejected");
+    });
+    expect(screen.getByRole("button", { name: "Install" })).toBeEnabled();
+  });
+
+  it("retains the installed state when the catalog row is reopened", async () => {
+    const installed = installedPlugin();
+    const installedKey = [...queryKeys.installedPlugins.list(), "org-1"];
+    queryClient.setQueryData(installedKey, []);
+    mockInstallPlugin.mockResolvedValueOnce(installed);
+
+    const first = renderRow();
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Installed" })).toBeDisabled());
+    first.unmount();
+
+    renderRow(queryClient.getQueryData<InstalledPlugin[]>(installedKey) ?? []);
+    expect(screen.getByRole("button", { name: "Installed" })).toBeDisabled();
+  });
+
+  it("distinguishes an available upgrade from the installed catalog version", () => {
+    renderRow([installedPlugin({ version: "0.9.0", update_available: true })]);
+
+    expect(screen.getByRole("button", { name: "Upgrade available" })).toBeDisabled();
+    expect(
+      screen.getByText("Version 0.9.0 is installed. Update it from Installed Plugins."),
+    ).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Install" })).not.toBeInTheDocument();
+  });
+
+  it("preserves a conflict when the same plugin name is installed from another marketplace", async () => {
+    mockInstallPlugin.mockRejectedValueOnce(
+      new ApiError(409, "Conflict", "Plugin 'resend' is already installed"),
+    );
+    mockGetInstalledPlugins.mockResolvedValueOnce([
+      installedPlugin({ marketplace: "private-marketplace" }),
+    ]);
+    renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("already installed");
     });
   });
 });

--- a/apps/ui/src/app/(main)/plugins/page.tsx
+++ b/apps/ui/src/app/(main)/plugins/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { inferMarketplaceSourceType, marketplaceSourceLabel } from "@/lib/api/plugins";
 import { Button } from "@/components/ui/button";
 import {
@@ -368,16 +368,49 @@ function RemoveMarketplaceDialog({
 export function CatalogEntryRow({
   entry,
   marketplaceId,
+  marketplaceName,
+  installedPlugins,
 }: {
   entry: MarketplaceCatalogEntry;
   marketplaceId: string;
+  marketplaceName: string;
+  installedPlugins: InstalledPlugin[];
 }) {
-  const installMutation = useInstallPlugin();
-  const isInstalled = entry.installed;
+  const installMutation = useInstallPlugin(marketplaceId, marketplaceName);
+  const installStarted = useRef(false);
+  const installedPlugin =
+    installedPlugins.find((plugin) => plugin.name === entry.name) ??
+    (installMutation.data?.plugin.name === entry.name ? installMutation.data.plugin : undefined);
+  const isSameSource = installedPlugin?.marketplace === marketplaceName;
+  const isUpgrade =
+    isSameSource &&
+    (installedPlugin.update_available ||
+      (!!entry.version && !!installedPlugin.version && entry.version !== installedPlugin.version));
+  const isSourceConflict = !!installedPlugin?.marketplace && !isSameSource;
+  const isInstalled = entry.installed || (!!installedPlugin && !isUpgrade && !isSourceConflict);
 
   const handleInstall = () => {
-    installMutation.mutate({ marketplace_id: marketplaceId, plugin_name: entry.name });
+    if (installStarted.current || isInstalled || isUpgrade || isSourceConflict) return;
+    installStarted.current = true;
+    installMutation.mutate(
+      { marketplace_id: marketplaceId, plugin_name: entry.name },
+      {
+        onSettled: () => {
+          installStarted.current = false;
+        },
+      },
+    );
   };
+
+  const installLabel = isUpgrade
+    ? "Upgrade available"
+    : isSourceConflict
+      ? "Installed elsewhere"
+      : isInstalled
+        ? "Installed"
+        : installMutation.isPending
+          ? "Installing..."
+          : "Install";
 
   return (
     <div className="py-3 border-b last:border-0">
@@ -396,9 +429,9 @@ export function CatalogEntryRow({
                 {entry.category}
               </Badge>
             )}
-            {isInstalled && (
+            {(isInstalled || isUpgrade || isSourceConflict) && (
               <Badge variant="default" className="text-xs">
-                Installed
+                {installLabel}
               </Badge>
             )}
           </div>
@@ -409,14 +442,24 @@ export function CatalogEntryRow({
         </div>
         <Button
           size="sm"
-          variant={isInstalled ? "outline" : "default"}
-          disabled={isInstalled || installMutation.isPending}
+          variant={isInstalled || isUpgrade || isSourceConflict ? "outline" : "default"}
+          disabled={isInstalled || isUpgrade || isSourceConflict || installMutation.isPending}
           onClick={handleInstall}
         >
           <Download className="h-4 w-4 mr-1" />
-          {isInstalled ? "Installed" : installMutation.isPending ? "Installing..." : "Install"}
+          {installLabel}
         </Button>
       </div>
+      {isUpgrade && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Version {installedPlugin.version} is installed. Update it from Installed Plugins.
+        </p>
+      )}
+      {isSourceConflict && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          This plugin name is already installed from {installedPlugin.marketplace}.
+        </p>
+      )}
       {installMutation.isError && (
         <p role="alert" className="mt-2 text-sm text-destructive">
           Failed to install {entry.display_name ?? entry.name}: {installMutation.error.message}
@@ -428,10 +471,12 @@ export function CatalogEntryRow({
 
 function MarketplaceCatalogDialog({
   marketplace,
+  installedPlugins,
   open,
   onOpenChange,
 }: {
   marketplace: Marketplace | null;
+  installedPlugins: InstalledPlugin[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -483,6 +528,8 @@ function MarketplaceCatalogDialog({
                     key={entry.name}
                     entry={entry}
                     marketplaceId={marketplace?.id ?? ""}
+                    marketplaceName={marketplace?.name ?? ""}
+                    installedPlugins={installedPlugins}
                   />
                 ))}
               </div>
@@ -871,6 +918,7 @@ export default function PluginsPage() {
       />
       <MarketplaceCatalogDialog
         marketplace={browseMarketplace}
+        installedPlugins={plugins ?? []}
         open={browseMarketplace !== null}
         onOpenChange={(open) => !open && setBrowseMarketplace(null)}
       />

--- a/apps/ui/src/hooks/use-plugins.ts
+++ b/apps/ui/src/hooks/use-plugins.ts
@@ -6,6 +6,7 @@ import {
   installedPluginsCrudApi,
   syncMarketplace,
   getMarketplaceCatalog,
+  getInstalledPlugins,
   installPlugin,
   patchInstalledPlugin,
   updateInstalledPlugin,
@@ -14,9 +15,13 @@ import type {
   CreateMarketplaceRequest,
   UpdateMarketplaceRequest,
   InstallPluginRequest,
+  InstalledPlugin,
+  MarketplaceCatalogEntry,
   UpdateInstalledPluginRequest,
 } from "@/lib/api/types";
+import { ApiError } from "@/lib/api/client";
 import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
 import { createCrudHooks, useOrgScopedQuery } from "./create-crud-hooks";
 
 // ============================================
@@ -94,15 +99,53 @@ export const useInstalledPlugins = installedPluginCrudHooks.useList;
 export const useInstalledPlugin = installedPluginCrudHooks.useDetail;
 export const useDeleteInstalledPlugin = installedPluginCrudHooks.useDelete;
 
-export function useInstallPlugin() {
+export function useInstallPlugin(marketplaceId: string, marketplaceName: string) {
   const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const orgId = currentOrg?.public_id;
+  const installedListKey = [...queryKeys.installedPlugins.list(), orgId] as const;
+  const catalogKey = [...queryKeys.pluginMarketplaces.catalog(marketplaceId), orgId] as const;
 
   return useMutation({
-    mutationFn: (request: InstallPluginRequest) => installPlugin(request),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.installedPlugins.all });
-      // Catalog entries have an `installed` flag; invalidate them too
-      queryClient.invalidateQueries({ queryKey: queryKeys.pluginMarketplaces.all });
+    mutationFn: async (request: InstallPluginRequest) => {
+      try {
+        return { plugin: await installPlugin(request), inventory: undefined };
+      } catch (error) {
+        if (!(error instanceof ApiError) || error.status !== 409) {
+          throw error;
+        }
+
+        // Another tab or request may have won the install race. Reconcile from
+        // the server and accept only the same plugin from the same marketplace.
+        const inventory = await getInstalledPlugins();
+        const plugin = inventory.find(
+          (candidate) =>
+            candidate.name === request.plugin_name && candidate.marketplace === marketplaceName,
+        );
+        if (!plugin) {
+          throw error;
+        }
+        return { plugin, inventory };
+      }
+    },
+    onSuccess: async ({ plugin, inventory }) => {
+      if (inventory) {
+        queryClient.setQueryData(installedListKey, inventory);
+      } else {
+        queryClient.setQueryData<InstalledPlugin[]>(installedListKey, (current) =>
+          current ? [...current.filter((item) => item.id !== plugin.id), plugin] : current,
+        );
+      }
+      queryClient.setQueryData<MarketplaceCatalogEntry[]>(catalogKey, (current) =>
+        current?.map((entry) =>
+          entry.name === plugin.name ? { ...entry, installed: true } : entry,
+        ),
+      );
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: installedListKey, exact: true }),
+        queryClient.invalidateQueries({ queryKey: catalogKey, exact: true }),
+      ]);
     },
   });
 }

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -289,15 +289,15 @@ export const queryKeys = {
   // Plugin marketplace queries
   pluginMarketplaces: {
     all: ["plugin-marketplaces"] as const,
-    list: () => ["plugin-marketplaces"] as const,
-    detail: (id: string) => ["plugin-marketplace", id] as const,
-    catalog: (id: string) => ["plugin-marketplace", id, "catalog"] as const,
+    list: () => ["plugin-marketplaces", "list"] as const,
+    detail: (id: string) => ["plugin-marketplaces", id] as const,
+    catalog: (id: string) => ["plugin-marketplaces", id, "catalog"] as const,
   },
 
   // Installed plugin queries
   installedPlugins: {
     all: ["installed-plugins"] as const,
-    list: () => ["installed-plugins"] as const,
-    detail: (id: string) => ["installed-plugin", id] as const,
+    list: () => ["installed-plugins", "list"] as const,
+    detail: (id: string) => ["installed-plugins", id] as const,
   },
 };

--- a/test_cases/ui/plugins/TC002_marketplace_install_state.md
+++ b/test_cases/ui/plugins/TC002_marketplace_install_state.md
@@ -1,0 +1,38 @@
+# Marketplace plugin install state
+
+## Description
+
+Verify that installing a marketplace plugin reconciles the catalog and installed-plugin views
+without a reload or duplicate install request.
+
+## Preconditions
+
+- Everruns is running in development mode with authentication disabled.
+- The default Everruns marketplace is present and synced.
+- Resend is not installed.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| Route | `/plugins` |
+| Marketplace | `everruns` |
+| Plugin | `resend` |
+
+## Steps
+
+1. Open `/plugins`, select **Marketplaces**, and browse the `everruns` catalog.
+2. Select **Install** for Resend and confirm the action immediately becomes disabled and reads
+   **Installing...**.
+3. Wait for installation to finish without closing the catalog.
+4. Confirm the Resend row reads **Installed**, its action is disabled, and no error is shown.
+5. Close the catalog and select **Installed Plugins**.
+6. Confirm Resend is present without reloading the page.
+7. Return to the marketplace catalog and confirm Resend still reads **Installed**.
+
+## Expected Result
+
+- Only one install request can be initiated while installation is pending.
+- The open catalog and installed-plugin inventory reconcile after success.
+- Installed state survives closing and reopening the catalog.
+- No rejected-promise runtime overlay or console error appears.


### PR DESCRIPTION
## What changed
Marketplace installs now reconcile the org-scoped installed inventory and the exact marketplace catalog cache immediately. Installed rows stay disabled and display Installed; available upgrades and same-name plugins from another marketplace receive distinct states. A synchronous request guard blocks duplicate clicks, while 409 races refresh inventory and succeed only when the matching plugin is installed from the same marketplace.

## Why
The catalog cache used a key prefix that marketplace invalidation could not match. The open dialog therefore retained a stale Install action after success, encouraging a duplicate request that surfaced a 409 as a failure.

## Before / After
Before: a successful install left the open catalog row actionable; a second click produced Plugin already installed.

After: manual Resend verification on the in-memory stack showed disabled Installing... and Installed states in the open dialog, an immediate Resend card in Installed Plugins, preserved Installed state after reopening the catalog, and no browser runtime errors. Screenshots were captured and visually inspected locally; PR upload was unavailable because CLOUDINARY_URL is not configured in the project environment.

Automated evidence: 7 focused component/hook tests cover success reconciliation, synchronous double click, stale inventory plus 409, real failure, modal reopen, upgrade state, and source conflict.

## Risk
- Low
- Risk is limited to plugin query-key changes and marketplace catalog install-state rendering. Existing callers use the shared key factory, and the production UI build passes.

## Security
- Threat categories reviewed: TM-TENANT, TM-WEB-002, TM-WEB-017
- Findings and resolutions: org IDs remain part of every reconciled cache key; only a 409 confirmed by refreshed same-plugin/same-marketplace inventory is treated idempotently; other conflicts and errors remain visible. No new trust boundary, user-rendered HTML, credential handling, or API authorization behavior was introduced.

## Follow-ups
Resend archive-size installation failures remain intentionally out of scope for the separate task identified by the requester.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
