### PR TITLE
fix(ui): make page mastheads responsive

### DIFF
--- a/apps/ui/e2e/page-masthead-responsive.spec.ts
+++ b/apps/ui/e2e/page-masthead-responsive.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const DEFAULT_ORG_ID = "org_00000000000000000000000000000001";
+const AGENT_ID = "agent_019fd9b43fa37512b8f25226b21c2c8b";
+
+async function mockAgentDetailApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    let json: unknown;
+
+    if (pathname === "/api/v1/auth/config") {
+      json = {
+        mode: "none",
+        password_auth_enabled: false,
+        oauth_providers: [],
+        signup_enabled: false,
+      };
+    } else if (pathname === "/api/v1/auth/me") {
+      json = {
+        id: "user-1",
+        email: "dev@example.com",
+        name: "Dev User",
+        roles: [],
+        email_verified: true,
+        organizations: [{ public_id: DEFAULT_ORG_ID, name: "Default", role: "owner" }],
+      };
+    } else if (pathname.endsWith("/feature-flags")) {
+      json = {
+        global_chat: false,
+        notifications: false,
+        evals: true,
+        app_budgets: false,
+        agent_versions: true,
+        voice: false,
+        agent_delegation: false,
+        observers: true,
+        public_chat: false,
+      };
+    } else if (pathname.endsWith("/switch-org")) {
+      json = { success: true, org_id: DEFAULT_ORG_ID };
+    } else if (pathname === `/api/v1/agents/${AGENT_ID}`) {
+      json = {
+        id: AGENT_ID,
+        name: "jokes-agent",
+        harness_id: "harness_test",
+        display_name: "Jokes Agent",
+        description:
+          "A cheerful agent with a deliberately longer localized description for responsive layout testing.",
+        system_prompt: "Tell a joke.",
+        default_model_id: null,
+        tags: [],
+        capabilities: [],
+        status: "active",
+        session_count: 12,
+        app_count: 3,
+        created_at: "2026-08-01T00:00:00Z",
+        updated_at: "2026-08-01T00:00:00Z",
+        archived_at: null,
+        deleted_at: null,
+      };
+    } else if (pathname === `/api/v1/agents/${AGENT_ID}/stats`) {
+      json = {
+        sessions: 12,
+        messages: 24,
+        input_tokens: 1200,
+        output_tokens: 600,
+      };
+    } else if (pathname === "/api/v1/sessions") {
+      json = { data: [], has_more: false, total: 0, offset: 0, limit: 10 };
+    } else if (
+      pathname === "/api/v1/capabilities" ||
+      pathname === "/api/v1/models" ||
+      pathname === "/api/v1/harnesses"
+    ) {
+      json = { data: [], has_more: false, total: 0 };
+    } else if (/^\/api\/v1\/orgs\/[^/]+$/.test(pathname)) {
+      json = {
+        id: DEFAULT_ORG_ID,
+        name: "Default",
+        default_model_id: null,
+        default_harness_id: null,
+        base_harness_id: null,
+      };
+    } else {
+      json = { data: [], has_more: false, total: 0 };
+    }
+
+    await route.fulfill({ json });
+  });
+}
+
+test.describe("Page masthead responsive layout", () => {
+  test.beforeEach(async ({ context, page, baseURL }) => {
+    const origin = new URL(baseURL ?? "http://localhost:9100");
+    await context.addCookies([
+      { name: "access_token", value: "e2e-only", domain: origin.hostname, path: "/" },
+    ]);
+    await mockAgentDetailApi(page);
+  });
+
+  for (const viewport of [
+    { name: "compact desktop", width: 1024, height: 900 },
+    { name: "tablet", width: 768, height: 900 },
+    { name: "mobile", width: 390, height: 844 },
+  ]) {
+    test(`protects identity content and contains actions at ${viewport.name} width`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(`/agents/${AGENT_ID}`);
+
+      const title = page.getByRole("heading", { name: "Jokes Agent" });
+      const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
+      const identity = masthead.locator('[data-slot="page-masthead-identity"]');
+      const actions = page
+        .getByRole("button", { name: "New session" })
+        .locator("xpath=ancestor::div[@data-slot='page-masthead-actions'][1]");
+      await expect(title).toBeVisible();
+      await expect(page.getByRole("button", { name: "Observe this agent" })).toBeVisible();
+
+      const mastheadBox = await masthead.boundingBox();
+      const identityBox = await identity.boundingBox();
+      const actionsBox = await actions.boundingBox();
+
+      expect(mastheadBox).not.toBeNull();
+      expect(identityBox).not.toBeNull();
+      expect(actionsBox).not.toBeNull();
+      expect(identityBox!.width).toBeGreaterThanOrEqual(Math.min(320, mastheadBox!.width));
+      expect(actionsBox!.x + actionsBox!.width).toBeLessThanOrEqual(
+        mastheadBox!.x + mastheadBox!.width,
+      );
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        await page.evaluate(() => document.documentElement.clientWidth),
+      );
+    });
+  }
+
+  test("keeps actions aligned beside identity content at wide desktop width", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto(`/agents/${AGENT_ID}`);
+
+    const title = page.getByRole("heading", { name: "Jokes Agent" });
+    const actions = page
+      .getByRole("button", { name: "New session" })
+      .locator("xpath=ancestor::div[@data-slot='page-masthead-actions'][1]");
+    const titleBox = await title.boundingBox();
+    const actionsBox = await actions.boundingBox();
+
+    expect(titleBox).not.toBeNull();
+    expect(actionsBox).not.toBeNull();
+    expect(actionsBox!.y).toBeLessThan(titleBox!.y + titleBox!.height);
+  });
+});

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -154,23 +154,40 @@ export function PageMasthead({
   className,
 }: PageMastheadProps) {
   return (
-    <div className={cn("flex items-start justify-between gap-4 border-b pb-4", className)}>
-      <div className="flex min-w-0 items-start gap-4">
+    <div
+      data-slot="page-masthead"
+      className={cn("flex flex-wrap items-start gap-4 border-b pb-4", className)}
+    >
+      <div
+        data-slot="page-masthead-identity"
+        className="flex min-w-0 flex-[1_1_20rem] items-start gap-4 max-sm:flex-col"
+      >
         {icon && <IconTile icon={icon} />}
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2.5">
-            <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2.5">
+            <h1 className="min-w-0 break-words text-2xl font-semibold tracking-tight text-foreground">
+              {title}
+            </h1>
             {badges}
           </div>
-          {description && <p className="mt-1.5 text-sm text-muted-foreground">{description}</p>}
+          {description && (
+            <p className="mt-1.5 break-words text-sm text-muted-foreground">{description}</p>
+          )}
           {meta && (
-            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-[13px] text-muted-foreground">
+            <div className="mt-2 flex min-w-0 flex-wrap gap-x-4 gap-y-1 text-[13px] text-muted-foreground [&>*]:min-w-0 [&>*]:break-words">
               {meta}
             </div>
           )}
         </div>
       </div>
-      {actions && <div className="flex flex-none items-center gap-2">{actions}</div>}
+      {actions && (
+        <div
+          data-slot="page-masthead-actions"
+          className="ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+        >
+          {actions}
+        </div>
+      )}
     </div>
   );
 }

--- a/test_cases/ui/page_layout/TC001_responsive_masthead.md
+++ b/test_cases/ui/page_layout/TC001_responsive_masthead.md
@@ -1,0 +1,41 @@
+# Responsive page masthead
+
+## Description
+
+Verify that shared page mastheads preserve readable identity content and contain large action sets
+when the app content area narrows.
+
+## Preconditions
+
+- Everruns is running in development mode with authentication disabled.
+- An active agent exists with a title, description, metadata, and all optional detail-page actions.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| Route | Active agent detail page |
+| Wide desktop viewport | 1440 × 1000 |
+| Compact desktop viewport | 1024 × 900 |
+| Tablet viewport | 768 × 900 |
+| Mobile viewport | 390 × 844 |
+
+## Steps
+
+1. Open the agent detail page at the wide desktop viewport.
+2. Confirm the action cluster is right-aligned beside the title, description, badges, and metadata.
+3. Resize to the compact desktop viewport and confirm the action cluster moves below the identity
+   content instead of squeezing it.
+4. Resize to the tablet and mobile viewports and confirm actions wrap within the masthead.
+5. Repeat with a long title, a long description, expanded button labels, badges, and metadata.
+6. Inspect representative detail pages for agents, harnesses, apps, capabilities, skills, memory,
+   knowledge indexes, agent identities, and sessions.
+
+## Expected Result
+
+- Identity content keeps a readable width instead of collapsing into a single-word column.
+- Actions remain visible, usable, and contained by the masthead at every viewport.
+- Long text wraps without horizontal page overflow.
+- Wide desktop mastheads retain right-aligned actions and the established visual hierarchy.
+- All consumers of the shared masthead follow the same responsive behavior without page-local
+  width overrides.


### PR DESCRIPTION
## What changed
Shared page mastheads now protect a readable identity region while allowing action clusters to wrap
or move to their own row as the available content width narrows. Long titles, descriptions,
metadata, translated action labels, and multi-action toolbars stay contained without page-level
width overrides.

A focused browser regression covers the reported agent detail route at wide desktop, compact
desktop, tablet, and mobile widths. A matching manual test case records the cross-consumer
acceptance criteria.

## Why
`PageMasthead` gave the identity side `min-w-0` while making the entire action cluster `flex-none`
and non-wrapping. At 1024px the six-action agent toolbar therefore won flex sizing and collapsed
the title/description/meta column to 62.56px, producing the reported word-per-line layout.

## Before / After
Before: the 1024×900 browser reproduction measured the title at 62.56px wide and showed the
toolbar consuming nearly the whole masthead. The same regression reproduced at 768×900 and
390×844.

After: at 1024×900 the real-stack identity region uses the full 736px content width and the 689px
action cluster moves below it. At 1440×1000 both remain on one row; at 768×900 and 390×844 actions
wrap within the available width. All tested viewports report
`documentElement.scrollWidth === clientWidth`. Before/after screenshots were captured as local
validation artifacts; automated publication was unavailable because the screenshot upload secret
is not configured in the project environment.

## Risk
- Low
- Presentational behavior changes for all 30 source files that reference `PageMasthead`; pages
  with small action sets remain side-by-side while constrained or action-heavy mastheads wrap.
- No design token, API, data, or interaction semantics changed.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: Presentational layout and test changes only. React continues to escape
  title, description, badge, metadata, and action content; no raw HTML, URL handling, request
  handling, state mutation, trust boundary, or dependency changed. No findings and no threat-model
  update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
