### PR TITLE
chore(deps): bump bashkit to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,23 +883,26 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.14.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120fa07992ddc9ba216dbce72749b148614709f893a66a7bfbb2a8643ab0b0b9"
+checksum = "ace171a860c49083fbb7dd7fe6ebda7c6535aa24cdcf396b9edd9c71c4dd1d37"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.23.1",
  "bigdecimal",
  "bitflags 2.13.1",
+ "bzip2",
  "chrono",
+ "chrono-tz",
  "clap",
  "ed25519-dalek 3.0.0",
- "fancy-regex 0.18.0",
+ "fancy-regex 0.19.0",
  "flate2",
  "futures-core",
  "futures-util",
  "getrandom 0.4.3",
+ "gloo-timers",
  "hmac 0.13.0",
  "jaq-core",
  "jaq-json",
@@ -911,8 +914,10 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "rustls",
+ "send_wrapper",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha1",
  "sha2 0.11.0",
  "thiserror 2.0.19",
@@ -1185,6 +1190,15 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -3471,17 +3485,6 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
-dependencies = [
- "bit-set 0.8.0",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
@@ -3997,6 +4000,18 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5162,6 +5177,12 @@ dependencies = [
  "loom",
  "slab",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -8158,6 +8179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8305,6 +8335,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -93,7 +93,7 @@ fetchkit = { version = "=0.5.0", features = ["bot-auth", "render-rakers"], optio
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 
 # Bash interpreter backing the bashkit_shell capability
-bashkit = { version = "0.14.4", features = ["jq", "http_client", "bot-auth"] }
+bashkit = { version = "0.16.0", features = ["jq", "http_client", "bot-auth"] }
 
 # Sandboxed Lua interpreter for the experimental `lua` capability (vendored Lua
 # 5.4, never LuaJIT). Optional + behind the `lua` cargo feature so the default

--- a/crates/core/src/capabilities/bashkit_shell/mod.rs
+++ b/crates/core/src/capabilities/bashkit_shell/mod.rs
@@ -422,13 +422,14 @@ impl Tool for BashTool {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
         let (partial_tx, partial_rx) = tokio::sync::mpsc::channel::<(String, String)>(128);
 
-        let output_callback: OutputCallback =
-            Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
-                // Best-effort: if receiver dropped, we just ignore
-                let _ = tx.send((stdout_chunk.to_string(), stderr_chunk.to_string()));
-                // Bounded: drop if full rather than growing without bound.
-                let _ = partial_tx.try_send((stdout_chunk.to_string(), stderr_chunk.to_string()));
-            });
+        let output_callback: OutputCallback = Box::new(move |stdout_chunk, stderr_chunk| {
+            // Tool output events are text, so decode Bashkit's byte-native
+            // chunks explicitly at the event boundary.
+            // Best-effort: if receiver dropped, we just ignore
+            let _ = tx.send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+            // Bounded: drop if full rather than growing without bound.
+            let _ = partial_tx.try_send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+        });
 
         // Spawn a task that reads chunks from the channel and emits events
         let emit_context = context.clone();
@@ -641,16 +642,17 @@ impl BackgroundExecutableTool for BashTool {
         let sink_for_output = sink.clone();
         let dropped_chunks = Arc::new(AtomicUsize::new(0));
         let dropped_chunks_for_callback = dropped_chunks.clone();
-        let output_callback: OutputCallback =
-            Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
-                if tx
-                    .try_send((stdout_chunk.to_string(), stderr_chunk.to_string()))
-                    .is_err()
-                {
-                    dropped_chunks_for_callback.fetch_add(1, Ordering::Relaxed);
-                }
-                let _ = partial_tx.try_send((stdout_chunk.to_string(), stderr_chunk.to_string()));
-            });
+        let output_callback: OutputCallback = Box::new(move |stdout_chunk, stderr_chunk| {
+            // Background output uses the same text boundary as foreground
+            // tool events.
+            if tx
+                .try_send((stdout_chunk.to_string(), stderr_chunk.to_string()))
+                .is_err()
+            {
+                dropped_chunks_for_callback.fetch_add(1, Ordering::Relaxed);
+            }
+            let _ = partial_tx.try_send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+        });
 
         let emit_task = tokio::spawn(async move {
             while let Some((stdout_chunk, stderr_chunk)) = rx.recv().await {

--- a/crates/core/src/hook_dispatch.rs
+++ b/crates/core/src/hook_dispatch.rs
@@ -164,8 +164,10 @@ impl BashHookDispatcher for BashkitShellHookDispatcher {
 
         match exec {
             Ok(Ok(output)) => {
-                let mut stdout = output.stdout;
-                let mut stderr = output.stderr;
+                // Hook results are a text contract; decode Bashkit's byte-native
+                // streams explicitly at this host boundary.
+                let mut stdout = output.stdout.to_string();
+                let mut stderr = output.stderr.to_string();
                 // Apply the executor-level output cap. Bashkit's own
                 // `max_input_bytes` bounds the *script* size; for output we
                 // truncate here so the parse step sees a bounded buffer.

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -83,7 +83,7 @@ futures-util.workspace = true
 flate2.workspace = true
 tar.workspace = true
 
-bashkit = { version = "0.14.4", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.16.0", features = ["scripted_tool", "jq"] }
 
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }
 # Observability exporters (Braintrust, OpenTelemetry event listeners). The OTLP

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "bzip2-1.0.6",
     "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb24275cca126dc3301d272eef07bd4cefd87f9a7dd5d6f27200fe87e8a83d0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde_json",
@@ -316,6 +316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,23 +329,26 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5250bc36a0b27983b9eaebfe743bacb7dcb090546bd0106a375803545bafe5d5"
+checksum = "ace171a860c49083fbb7dd7fe6ebda7c6535aa24cdcf396b9edd9c71c4dd1d37"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "bigdecimal",
  "bitflags",
+ "bzip2",
  "chrono",
+ "chrono-tz",
  "clap",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek 3.0.0",
  "fancy-regex",
  "flate2",
  "futures-core",
  "futures-util",
  "getrandom 0.4.2",
+ "gloo-timers",
  "hmac",
  "jaq-core",
  "jaq-json",
@@ -351,8 +360,10 @@ dependencies = [
  "regex",
  "reqwest 0.13.2",
  "rustls",
+ "send_wrapper",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha1",
  "sha2 0.11.0",
  "thiserror 2.0.18",
@@ -479,6 +490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +551,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1057,19 +1087,20 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.9"
+version = "0.17.23"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "bashkit",
  "bytes",
  "chrono",
  "cron",
  "ed25519-dalek 3.0.0",
  "eventsource-stream",
+ "everruns-provider",
  "fetchkit",
  "futures",
  "globset",
@@ -1086,11 +1117,13 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "sha2 0.11.0",
  "similar 3.1.1",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-opentelemetry",
@@ -1101,20 +1134,48 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.9"
+version = "0.17.23"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "everruns-core",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "url",
+]
+
+[[package]]
+name = "everruns-provider"
+version = "0.17.23"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "chrono",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "http",
+ "rand 0.10.1",
+ "regex",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.9"
+version = "0.17.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1133,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1155,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11487a5d22ca0dbb5b6aa7926a036e654789f98302791f7630040e54cfe8ca3"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "ed25519-dalek 2.2.0",
  "futures",
@@ -1437,6 +1498,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,7 +1710,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1906,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
 dependencies = [
  "aho-corasick",
- "base64",
+ "base64 0.22.1",
  "bstr",
  "jaq-core",
  "jiff",
@@ -2025,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.47.0"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+checksum = "7e17384278234b10419a63c93fc85695ac9fc2da0833e3c59167f9986499590c"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2039,6 +2112,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -2046,17 +2120,32 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.47.0"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+checksum = "ac634e339e73bf9629f6fb207f7b064d872253ae3b3f5c6e0ce8fd762b16e40f"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b8e258eb4515a3fc912a9c46e3987040dc07280592280097ea2085527870b8"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -2070,6 +2159,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -2490,7 +2585,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -2546,6 +2641,15 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -2630,6 +2734,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -3091,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.47.0"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+checksum = "42902112f88a27e9afd5683e2ba31956fed2a5d43395f166dd26775ae9c0dedb"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3120,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3153,7 +3266,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3196,7 +3309,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3540,6 +3653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3741,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3848,6 +3983,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4151,7 +4307,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4426,7 +4582,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",


### PR DESCRIPTION
## What changed
Upgrades the BashKit-backed shell and hook runtime from 0.14.x to 0.16.0. Everruns now explicitly decodes BashKit byte-native streams at its existing text event and hook-result boundaries. Workspace and standalone example lockfiles resolve the same BashKit release.

## Why
BashKit 0.16.0 contains execution-boundary revocation, shared request budgeting, filesystem hardening, binary-safe streams, and compatibility improvements. Its Rust stream API is intentionally breaking and requires the host boundary adaptation included here.

## Before / After
Before:
- Manifests requested BashKit 0.14.4; the root lockfile resolved 0.14.5 and the weekend-concierge lockfile resolved 0.13.0.
- Everruns callbacks assumed BashKit stdout/stderr were `String` values.

After:
- `cargo tree --invert bashkit@0.16.0 --locked` resolves BashKit 0.16.0 across the workspace.
- 80 BashKit capability tests and 17 hook-dispatch tests pass.
- `cargo check --manifest-path examples/weekend-concierge-host/Cargo.toml --locked` passes.
- `cargo deny check licenses` passes after reviewing and allowing the new `bzip2-1.0.6` dependency license.
- `just pre-push` passes all available checks; UI checks were skipped because this worktree has no `node_modules` and the diff does not touch UI.
- In-memory `just start-dev --no-watch` smoke started successfully; the live API reported `bashkit_shell` as available/high-risk with the `bash` tool.

## Risk
- Medium
- BashKit 0.16.0 includes intentional Rust API changes and new transitive dependencies. The affected shell streaming, filesystem, HTTP-egress, cancellation, hook, and example-host surfaces are covered by focused tests and the repository-wide lint/build gate.

## Security
- Threat categories reviewed: TM-BASH, TM-DOS, TM-HOOK, dependency/supply-chain risk.
- Findings and resolutions: no new Everruns trust boundary. Existing sandbox limits, offline-by-default hooks, egress-only HTTP routing, cancellation, and output caps remain intact. The new byte-native stream API is decoded only at existing text contracts. BashKit 0.16.0 strengthens execution capability revocation, shared resource accounting, and filesystem containment. The new bzip2 license was reviewed and added to the dependency allowlist. No threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — existing focused coverage validates the compatibility change
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)