### PR TITLE
feat(platform): add catalog-backed platform capability

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -241,6 +241,7 @@ export default defineConfig({
                       label: "Platform",
                       collapsed: true,
                       items: [
+                        { label: "Platform", slug: "capabilities/platform" },
                         { label: "Platform Management", slug: "capabilities/platform-management" },
                       ],
                     },

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -129,6 +129,7 @@ mod openrouter_workspace;
 #[cfg(feature = "ui-capabilities")]
 mod openui;
 mod parallel_tool_calls;
+mod platform;
 mod platform_management;
 mod progress_guard;
 mod prompt_caching;
@@ -301,6 +302,12 @@ pub use openui::{OPENUI_CAPABILITY_ID, OpenUiCapability};
 pub use parallel_tool_calls::{
     PARALLEL_TOOL_CALLS_CAPABILITY_ID, ParallelToolCallsCapability, ParallelToolCallsMode,
     parallel_tool_calls_from_config,
+};
+pub use platform::{
+    DISCOVER_DESCRIPTION as PLATFORM_DISCOVER_DESCRIPTION,
+    EXECUTE_DESCRIPTION as PLATFORM_EXECUTE_DESCRIPTION, PLATFORM_CAPABILITY_ID,
+    PlatformCapability, QUERY_DESCRIPTION as PLATFORM_QUERY_DESCRIPTION, discover_input_schema,
+    execute_input_schema, query_input_schema,
 };
 pub use platform_management::{
     ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool, PLATFORM_MANAGEMENT_CAPABILITY_ID,
@@ -1437,6 +1444,7 @@ impl CapabilityRegistry {
         registry.register(ModelScoutCapability);
         registry.register(OpenRouterWorkspaceCapability);
         registry.register(OpenRouterServerToolsCapability);
+        registry.register(PlatformCapability);
         registry.register(PlatformManagementCapability);
         registry.register(FileSystemCapability);
         registry.register(MemoryCapability);
@@ -3274,6 +3282,7 @@ mod tests {
             "noop",
             "current_time",
             "research",
+            "platform",
             "platform_management",
             "session_file_system",
             "session_storage",
@@ -3435,6 +3444,7 @@ mod tests {
         assert!(registry.has("bashkit_shell"));
 
         for platform_only in [
+            "platform",
             "platform_management",
             "model_scout",
             "openrouter_workspace",
@@ -3598,6 +3608,10 @@ mod tests {
             // `narration_noun` hints; the read/query/messaging tools are a
             // low-frequency operator surface where the display-name presentation
             // ("Read Agents", "Read Sessions") is already clear.
+            (
+                "platform",
+                "operator command surface; tool display names are the intended presentation",
+            ),
             (
                 "platform_management",
                 "operator admin surface; mutations narrate via narration_noun, reads use display names",

--- a/crates/core/src/capabilities/platform.rs
+++ b/crates/core/src/capabilities/platform.rs
@@ -1,0 +1,330 @@
+//! Catalog-backed platform management capability.
+
+use super::{Capability, CapabilityLocalization, CapabilityStatus, MountPoint, RiskLevel};
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
+use crate::capability_types::{MountAccess, MountSource};
+use crate::tool_types::{DeferrablePolicy, ToolHints};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::{ToolContext, ToolContextService};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+pub const PLATFORM_CAPABILITY_ID: &str = "platform";
+
+pub const DISCOVER_DESCRIPTION: &str = "Search the Everruns API catalog to find available operations. Returns matching operations with input/output schemas and jq-oriented output shape hints. Use all: true to list every operation grouped by category. Read-only operations are available as bash builtins in query; the full catalog is available in execute.";
+pub const QUERY_DESCRIPTION: &str = "Execute a bash script in an environment where only read-only Everruns API operations are available as built-in commands. Supports pipes, variables, loops, conditionals, jq, and direct access to safe builtins. Mutating commands are intentionally unavailable.";
+pub const EXECUTE_DESCRIPTION: &str = "Execute a bash script in an environment where every Everruns API operation is a built-in command, including operations with side effects. Supports pipes, variables, loops, conditionals, jq, and direct access to the full builtin set. Prefer query for read-only inspection; use execute when you need create/update/delete or other mutating operations.";
+
+const SYSTEM_PROMPT: &str = r#"Use `discover` when an Everruns operation or schema is unknown. Use `query` for read-only inspection and validation. Use `execute` only for user-requested mutations, then validate the resulting state with `query`. Do not guess operation names. Platform commands are already scoped to the current organization.
+
+Everruns public documentation is available under `/workspace/docs`. Consult it when answering product or configuration questions."#;
+
+pub struct PlatformCapability;
+
+impl Capability for PlatformCapability {
+    fn id(&self) -> &str {
+        PLATFORM_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Platform"
+    }
+
+    fn description(&self) -> &str {
+        "Discover and execute the authorized Everruns command catalog."
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![CapabilityLocalization::text(
+            "uk",
+            "Платформа",
+            "Пошук і виконання дозволених команд Everruns.",
+        )]
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("terminal-square")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Platform")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(PlatformCommandTool::discover()),
+            Box::new(PlatformCommandTool::query()),
+            Box::new(PlatformCommandTool::execute()),
+        ]
+    }
+
+    fn mounts(&self) -> Vec<MountPoint> {
+        #[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
+        {
+            vec![MountPoint::new(
+                "/docs",
+                MountAccess::ReadOnly,
+                MountSource::Virtual {
+                    tree: super::platform_management::docs_tree(),
+                },
+                self.id(),
+            )]
+        }
+        #[cfg(not(all(feature = "embedded-platform-docs", everruns_has_workspace_docs)))]
+        {
+            Vec::new()
+        }
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        #[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
+        {
+            vec!["session_file_system"]
+        }
+        #[cfg(not(all(feature = "embedded-platform-docs", everruns_has_workspace_docs)))]
+        {
+            Vec::new()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PlatformCommandOperation {
+    Discover,
+    Query,
+    Execute,
+}
+
+struct PlatformCommandTool {
+    operation: PlatformCommandOperation,
+}
+
+impl PlatformCommandTool {
+    const fn discover() -> Self {
+        Self {
+            operation: PlatformCommandOperation::Discover,
+        }
+    }
+
+    const fn query() -> Self {
+        Self {
+            operation: PlatformCommandOperation::Query,
+        }
+    }
+
+    const fn execute() -> Self {
+        Self {
+            operation: PlatformCommandOperation::Execute,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for PlatformCommandTool {
+    fn name(&self) -> &str {
+        match self.operation {
+            PlatformCommandOperation::Discover => "discover",
+            PlatformCommandOperation::Query => "query",
+            PlatformCommandOperation::Execute => "execute",
+        }
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some(match self.operation {
+            PlatformCommandOperation::Discover => "Discover Operations",
+            PlatformCommandOperation::Query => "Query Commands",
+            PlatformCommandOperation::Execute => "Execute Commands",
+        })
+    }
+
+    fn description(&self) -> &str {
+        match self.operation {
+            PlatformCommandOperation::Discover => DISCOVER_DESCRIPTION,
+            PlatformCommandOperation::Query => QUERY_DESCRIPTION,
+            PlatformCommandOperation::Execute => EXECUTE_DESCRIPTION,
+        }
+    }
+
+    fn parameters_schema(&self) -> Value {
+        match self.operation {
+            PlatformCommandOperation::Discover => discover_input_schema(),
+            PlatformCommandOperation::Query => query_input_schema(),
+            PlatformCommandOperation::Execute => execute_input_schema(),
+        }
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Platform command context is required")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        if arguments.get("organization_id").is_some() {
+            return ToolExecutionResult::tool_error(
+                "organization_id is not accepted; Platform commands use the current session organization",
+            );
+        }
+        let Some(store) = context.platform_store.as_deref() else {
+            return ToolExecutionResult::tool_error("Platform command service is unavailable");
+        };
+        let result = match self.operation {
+            PlatformCommandOperation::Discover => store.platform_discover(arguments).await,
+            PlatformCommandOperation::Query => store.platform_query(arguments).await,
+            PlatformCommandOperation::Execute => store.platform_execute(arguments).await,
+        };
+        match result {
+            Ok(output) => ToolExecutionResult::success(output),
+            Err(error) => ToolExecutionResult::tool_error(error.to_string()),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    fn required_context_services(&self) -> &'static [ToolContextService] {
+        &[ToolContextService::PlatformStore]
+    }
+
+    fn hints(&self) -> ToolHints {
+        match self.operation {
+            PlatformCommandOperation::Discover | PlatformCommandOperation::Query => ToolHints {
+                readonly: Some(true),
+                destructive: Some(false),
+                idempotent: Some(true),
+                open_world: Some(false),
+                ..Default::default()
+            },
+            PlatformCommandOperation::Execute => ToolHints {
+                readonly: Some(false),
+                destructive: Some(true),
+                idempotent: Some(false),
+                open_world: Some(true),
+                ..Default::default()
+            },
+        }
+    }
+
+    fn deferrable_policy(&self) -> DeferrablePolicy {
+        DeferrablePolicy::Never
+    }
+}
+
+pub fn discover_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query to find API operations."
+            },
+            "all": {
+                "type": "boolean",
+                "description": "List all available operations grouped by category. When true, query is ignored."
+            },
+            "include_schemas": {
+                "type": "boolean",
+                "description": "Include input_schema and output_schema in results. Defaults to true for search and false for all."
+            }
+        }
+    })
+}
+
+pub fn query_input_schema() -> Value {
+    script_input_schema(
+        "Bash script to execute. Only read-only API operations are available as built-in commands.",
+    )
+}
+
+pub fn execute_input_schema() -> Value {
+    script_input_schema(
+        "Bash script to execute. API operations are available as built-in commands.",
+    )
+}
+
+fn script_input_schema(commands_description: &str) -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "commands": {
+                "type": "string",
+                "description": commands_description,
+                "minLength": 1
+            },
+            "timeout_ms": {
+                "type": "integer",
+                "description": "Execution timeout in milliseconds (default: 30000, max: 60000).",
+                "minimum": 1,
+                "maximum": 60000
+            }
+        },
+        "required": ["commands"]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform_store::tests::MockPlatformStore;
+    use crate::typed_id::SessionId;
+    use std::sync::Arc;
+
+    #[test]
+    fn schemas_do_not_allow_organization_override() {
+        assert!(
+            discover_input_schema()["properties"]
+                .get("organization_id")
+                .is_none()
+        );
+        assert!(
+            query_input_schema()["properties"]
+                .get("organization_id")
+                .is_none()
+        );
+        assert!(
+            execute_input_schema()["properties"]
+                .get("organization_id")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn tools_dispatch_to_platform_store() {
+        let store = Arc::new(MockPlatformStore::new());
+        let context = ToolContext::new(SessionId::new()).with_platform_store(store);
+        let result = PlatformCommandTool::query()
+            .execute_with_context(json!({ "commands": "list_models" }), &context)
+            .await;
+        assert!(result.is_success());
+    }
+
+    #[tokio::test]
+    async fn organization_override_is_rejected_even_if_injected() {
+        let store = Arc::new(MockPlatformStore::new());
+        let context = ToolContext::new(SessionId::new()).with_platform_store(store);
+        let result = PlatformCommandTool::query()
+            .execute_with_context(
+                json!({ "commands": "list_models", "organization_id": "org_other" }),
+                &context,
+            )
+            .await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+    }
+}

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -86,7 +86,7 @@ fn populate_tree(tree: &mut VirtualFileTree, dir: &Dir, prefix: &str) {
 
 /// Lazily-initialized shared tree (built once on first access).
 #[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
-fn docs_tree() -> Arc<VirtualFileTree> {
+pub(super) fn docs_tree() -> Arc<VirtualFileTree> {
     use std::sync::OnceLock;
     static TREE: OnceLock<Arc<VirtualFileTree>> = OnceLock::new();
     TREE.get_or_init(|| Arc::new(dir_to_tree(&DOCS_DIR, "/docs")))

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -46,11 +46,35 @@ pub struct PlatformCreateSessionRequest {
 
 /// Trait for platform-level management operations.
 ///
-/// Provides org-scoped CRUD for harnesses, agents, and sessions,
-/// plus session messaging and turn management. Used by the
-/// `platform_management` capability tools.
+/// Provides the catalog-backed `platform` surface plus legacy org-scoped CRUD
+/// used by `platform_management` compatibility tools.
 #[async_trait]
 pub trait PlatformStore: Send + Sync {
+    // =========================================================================
+    // Catalog-backed command surface
+    // =========================================================================
+
+    /// Search the authoritative domain-command catalog.
+    async fn platform_discover(&self, _arguments: serde_json::Value) -> Result<String> {
+        Err(crate::error::AgentLoopError::config(
+            "Platform command surface is not available in this host",
+        ))
+    }
+
+    /// Execute a bounded script against read-only domain commands.
+    async fn platform_query(&self, _arguments: serde_json::Value) -> Result<String> {
+        Err(crate::error::AgentLoopError::config(
+            "Platform command surface is not available in this host",
+        ))
+    }
+
+    /// Execute a bounded script against the full authorized command catalog.
+    async fn platform_execute(&self, _arguments: serde_json::Value) -> Result<String> {
+        Err(crate::error::AgentLoopError::config(
+            "Platform command surface is not available in this host",
+        ))
+    }
+
     // =========================================================================
     // Harness Operations
     // =========================================================================
@@ -534,6 +558,18 @@ pub mod tests {
 
     #[async_trait]
     impl PlatformStore for MockPlatformStore {
+        async fn platform_discover(&self, arguments: serde_json::Value) -> Result<String> {
+            Ok(arguments.to_string())
+        }
+
+        async fn platform_query(&self, arguments: serde_json::Value) -> Result<String> {
+            Ok(arguments.to_string())
+        }
+
+        async fn platform_execute(&self, arguments: serde_json::Value) -> Result<String> {
+            Ok(arguments.to_string())
+        }
+
         async fn list_harnesses(&self) -> Result<Vec<Harness>> {
             Ok(vec![self.harness.clone()])
         }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -254,6 +254,7 @@ service WorkerService {
     // Generic domain command transport for inventory-registered CRUD.
     rpc ExecuteCommand(ExecuteCommandRequest) returns (ExecuteCommandResponse);
     rpc ListCommands(ListCommandsRequest) returns (ListCommandsResponse);
+    rpc InvokePlatformCommandSurface(InvokePlatformCommandSurfaceRequest) returns (InvokePlatformCommandSurfaceResponse);
 
     // Harness operations
     rpc PlatformListHarnesses(PlatformListHarnessesRequest) returns (PlatformListHarnessesResponse);
@@ -1698,6 +1699,27 @@ message CommandCatalogEntry {
 
 message ListCommandsResponse {
     repeated CommandCatalogEntry commands = 1;
+}
+
+enum PlatformCommandSurfaceOperation {
+    PLATFORM_COMMAND_SURFACE_OPERATION_UNSPECIFIED = 0;
+    PLATFORM_COMMAND_SURFACE_OPERATION_DISCOVER = 1;
+    PLATFORM_COMMAND_SURFACE_OPERATION_QUERY = 2;
+    PLATFORM_COMMAND_SURFACE_OPERATION_EXECUTE = 3;
+}
+
+message InvokePlatformCommandSurfaceRequest {
+    Uuid session_id = 1;
+    int64 org_id = 2;
+    PlatformCommandSurfaceOperation operation = 3;
+    bytes arguments_json = 4;
+}
+
+message InvokePlatformCommandSurfaceResponse {
+    oneof result {
+        string output = 1;
+        string error = 2;
+    }
 }
 
 // === Harness operations ===

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -1,7 +1,7 @@
 // MCP scripting catalog — inventory is the only source of truth.
 
 use crate::domains::common::CommandError;
-use bashkit::{ScriptingToolSet, ToolArgs, ToolDef};
+use bashkit::{ScriptedTool, ToolArgs, ToolDef};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -10,8 +10,7 @@ use std::sync::LazyLock;
 /// Shared context for inventory-registered domain commands.
 #[derive(Clone)]
 pub struct CatalogContext {
-    pub state: super::AppState,
-    pub caller: everruns_core::permissions::Caller,
+    pub domain_ctx: crate::domains::common::Ctx,
     pub link_builder: crate::api::common::UrlBuilder,
 }
 
@@ -55,39 +54,13 @@ static INVENTORY_TOOL_DEFS: LazyLock<HashMap<&'static str, ToolDef>> = LazyLock:
 impl CatalogContext {
     /// Convert to a domain Ctx for inventory-registered command dispatch.
     pub fn to_domain_ctx(&self) -> crate::domains::common::Ctx {
-        let mut ctx = crate::domains::common::Ctx::new(
-            self.caller.clone(),
-            self.state.db.clone(),
-            self.state.capability_service.clone(),
-            self.state.encryption.clone(),
-            self.state.auth.permission_resolver.clone(),
-        )
-        .with_org_rate_limiter(self.state.org_rate_limiter.clone())
-        .with_session_service(self.state.session_service.clone())
-        .with_message_service(self.state.message_service.clone())
-        .with_event_service(self.state.event_service.clone())
-        .with_session_file_service(self.state.session_file_service.clone())
-        .with_runner(self.state.runner.clone())
-        .with_fallback_harness_name(self.state.fallback_default_harness_name.clone())
-        .with_chat_harness_name(self.state.chat_harness_name.clone())
-        .with_chat_session_title(self.state.chat_session_title.clone())
-        .with_utility_llm_service(self.state.utility_llm_service.clone());
-        if let Some(service) = &self.state.health_check_service {
-            ctx = ctx.with_health_check_service(service.clone());
-        }
-        if let Some(service) = &self.state.session_sandbox_service {
-            ctx = ctx.with_session_sandbox_service(service.clone());
-        }
-        if let Some(store) = &self.state.sqldb_store {
-            ctx = ctx.with_sqldb_store(store.clone());
-        }
-        ctx.with_workflow_store(self.state.workflow_store.clone())
+        self.domain_ctx.clone()
     }
 }
 
-/// Build a ScriptingToolSet from inventory-registered commands only.
-pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet {
-    let mut builder = ScriptingToolSet::builder("everruns")
+/// Build one scripted tool from inventory-registered commands only.
+pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptedTool {
+    let mut builder = ScriptedTool::builder("everruns")
         .short_description(match mode {
             ToolsetMode::Full => "Everruns API operations as bash builtins",
             ToolsetMode::ReadOnly => "Read-only Everruns API operations as bash builtins",
@@ -100,7 +73,8 @@ pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet
                 .max_input_bytes(500_000)
                 .max_ast_depth(50)
                 .parser_timeout(std::time::Duration::from_secs(3)),
-        );
+        )
+        .sanitize_errors(false);
 
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
         // THREAT[TM-MCP-002]: MCP `query` must not expose mutating server
@@ -116,6 +90,9 @@ pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet
         }
         let def = command_descriptor_to_def(desc);
         let callback = make_inventory_callback(desc, ctx.clone());
+        // THREAT[TM-MCP-002]: Domain errors are sanitized by
+        // `format_dispatch_error`; disabling Bashkit's blanket replacement
+        // preserves actionable kind tokens without exposing internal details.
         builder = builder.async_tool_fn(def, callback);
     }
 
@@ -145,7 +122,9 @@ fn command_descriptor_to_def(desc: &crate::domains::common::CommandDescriptor) -
 //    attempts (which still don't reach into `allOf`/`$ref` composition;
 //    bashkit#1516/#1527 only coerces top-level array/object schemas).
 // 2. `coerce_json_text_params` parses those JSON strings back into typed
-//    values before the domain dispatcher sees them.
+//    values before the domain dispatcher sees them. It also repairs scalar
+//    values in composed schemas because bashkit does not coerce flags reached
+//    through `allOf`/`$ref` (for example `--enabled true` on Agent Triggers).
 //
 // Both passes walk `$ref` into `$defs`/`definitions`, traverse `allOf`,
 // `oneOf`, `anyOf` branches, and recurse into nested `$defs` entries — this
@@ -232,8 +211,8 @@ fn retype_aggregate_properties_in_place(
 }
 
 /// Walk the original param schema and parse JSON-text values for properties
-/// whose declared type is array or object back into structured JSON. Bashkit's
-/// flag parser keeps these as raw strings; the domain dispatcher expects the
+/// whose declared type is array/object, or a scalar type that bashkit left as
+/// text because it lives under composition. The domain dispatcher expects the
 /// typed shape.
 ///
 /// Empty / whitespace-only strings are left untouched so optional fields that
@@ -258,7 +237,9 @@ fn coerce_json_text_params(
         let Some(property) = all_properties.get(name) else {
             continue;
         };
-        if !property_is_aggregate(property, defs, 0) {
+        let should_parse = property_is_aggregate(property, defs, 0)
+            || property_has_json_scalar_type(property, defs, 0);
+        if !should_parse {
             continue;
         }
         let serde_json::Value::String(text) = value else {
@@ -272,6 +253,51 @@ fn coerce_json_text_params(
         *value = parsed;
     }
     Ok(())
+}
+
+fn property_has_json_scalar_type(
+    schema: &serde_json::Value,
+    defs: Option<&serde_json::Map<String, serde_json::Value>>,
+    depth: u8,
+) -> bool {
+    if depth >= SCHEMA_WALK_MAX_DEPTH {
+        return false;
+    }
+    if let Some(value) = schema.get("type") {
+        if let Some(name) = value.as_str()
+            && matches!(name, "boolean" | "integer" | "number")
+        {
+            return true;
+        }
+        if let Some(types) = value.as_array()
+            && types.iter().any(|entry| {
+                entry
+                    .as_str()
+                    .is_some_and(|name| matches!(name, "boolean" | "integer" | "number"))
+            })
+        {
+            return true;
+        }
+    }
+    if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str())
+        && let Some(name) = reference
+            .strip_prefix("#/$defs/")
+            .or_else(|| reference.strip_prefix("#/definitions/"))
+        && let Some(defs) = defs
+        && let Some(resolved) = defs.get(name)
+    {
+        return property_has_json_scalar_type(resolved, Some(defs), depth + 1);
+    }
+    ["allOf", "oneOf", "anyOf"].iter().any(|key| {
+        schema
+            .get(key)
+            .and_then(|value| value.as_array())
+            .is_some_and(|branches| {
+                branches
+                    .iter()
+                    .any(|branch| property_has_json_scalar_type(branch, defs, depth + 1))
+            })
+    })
 }
 
 /// Merge property maps across `$ref`, `allOf`, `oneOf`, and `anyOf` branches
@@ -392,6 +418,10 @@ fn command_error_kind(err: &CommandError) -> &'static str {
 /// `<kind>: <message>` wire is a documented contract. Surfacing extensions
 /// over MCP is tracked as an additive contract change.
 fn format_dispatch_error(err: &CommandError) -> String {
+    if let crate::domains::common::CommandErrorKind::Internal(inner) = &err.kind {
+        tracing::error!(error = %inner, "Platform command failed");
+        return "internal: Internal server error".to_string();
+    }
     format!("{}: {err}", command_error_kind(err))
 }
 
@@ -545,6 +575,39 @@ mod tests {
             serde_json::json!([{"ref": "current_time"}]),
         );
         assert_eq!(params["tags"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn coerce_parses_scalar_flags_from_composed_schema() {
+        let schema = serde_json::json!({
+            "$defs": {
+                "Trigger": {
+                    "properties": {
+                        "enabled": { "type": "boolean" },
+                        "limit": { "type": "integer" },
+                        "ratio": { "type": "number" },
+                        "session_mode": { "type": "string" }
+                    }
+                }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/Trigger" },
+                { "properties": { "agent_id": { "type": "string" } } }
+            ]
+        });
+        let mut params = serde_json::json!({
+            "enabled": "true",
+            "limit": "5",
+            "ratio": "1.5",
+            "session_mode": "session_per_invocation"
+        });
+
+        coerce_json_text_params(&schema, &mut params).expect("coerce");
+
+        assert_eq!(params["enabled"], true);
+        assert_eq!(params["limit"], 5);
+        assert_eq!(params["ratio"], 1.5);
+        assert_eq!(params["session_mode"], "session_per_invocation");
     }
 
     #[test]
@@ -782,7 +845,8 @@ mod tests {
             "database connection refused"
         )));
         let forbidden = format_dispatch_error(&CommandError::forbidden("permission denied"));
-        assert!(internal.starts_with("internal:"));
+        assert_eq!(internal, "internal: Internal server error");
+        assert!(!internal.contains("database connection refused"));
         assert!(forbidden.starts_with("forbidden:"));
         assert_ne!(internal, forbidden);
     }

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -49,7 +49,6 @@ use axum::{
     response::{IntoResponse, Response},
     routing::post,
 };
-use bashkit::ScriptingToolSet;
 use everruns_core::mcp_server::{McpErrorCode, McpExecuteError, classify_mcp_execute_error};
 use everruns_core::session_sqldb::SessionSqlDbStore;
 use everruns_core::{Caller, OrgRole, PlatformDefinition, validate_org_public_id};
@@ -61,8 +60,8 @@ use std::sync::Arc;
 
 use super::common::impl_auth_state;
 
-mod catalog;
-mod positional;
+pub(crate) mod catalog;
+pub(crate) mod positional;
 
 // ============================================================================
 // JSON-RPC 2.0 types
@@ -1765,114 +1764,15 @@ async fn tool_agent_get_card(
 
 async fn tool_discover(
     args: &Value,
-    _org: &ResolvedOrg,
-    _state: &AppState,
+    org: &ResolvedOrg,
+    state: &AppState,
 ) -> Result<String, String> {
-    let show_all = args.get("all").and_then(|v| v.as_bool()).unwrap_or(false);
-    let include_schemas = args
-        .get("include_schemas")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(!show_all);
-
-    let mut entries = crate::domains::common::catalog_entries_with_schemas(include_schemas);
-    entries.sort_by_key(|entry| (entry.category, entry.name));
-
-    if !show_all {
-        let query = args
-            .get("query")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim();
-        if query.is_empty() {
-            return Err(
-                "Provide a 'query' to search or set 'all: true' to list everything.".into(),
-            );
-        }
-
-        entries.retain(|entry| catalog_entry_matches(entry, query));
-    }
-
-    let operation_json = |entry: &crate::domains::common::CommandCatalogEntry| {
-        let mut value = json!({
-            "name": entry.name,
-            "category": entry.category,
-            "description": entry.description,
-            "read_only": entry.read_only,
-            "output_shape": entry.output_shape,
-        });
-        if let Some(positional_arg) = entry.positional_arg {
-            value["positional_arg"] = json!(positional_arg);
-        }
-        if include_schemas {
-            value["input_schema"] = entry.input_schema.clone();
-            value["output_schema"] = entry.output_schema.clone();
-        }
-        value
-    };
-
-    if show_all {
-        let mut by_category: std::collections::BTreeMap<&str, Vec<Value>> =
-            std::collections::BTreeMap::new();
-        for entry in &entries {
-            by_category
-                .entry(entry.category)
-                .or_default()
-                .push(operation_json(entry));
-        }
-
-        let categories: Vec<Value> = by_category
-            .into_iter()
-            .map(|(category, operations)| {
-                json!({
-                    "category": category,
-                    "count": operations.len(),
-                    "operations": operations,
-                })
-            })
-            .collect();
-
-        pretty_json(&json!({
-            "count": entries.len(),
-            "include_schemas": include_schemas,
-            "categories": categories,
-            "shape_hints": output_shape_hints(),
-        }))
-    } else {
-        pretty_json(&json!({
-            "count": entries.len(),
-            "include_schemas": include_schemas,
-            "operations": entries.iter().map(operation_json).collect::<Vec<_>>(),
-            "shape_hints": output_shape_hints(),
-        }))
-    }
-}
-
-fn catalog_entry_matches(entry: &crate::domains::common::CommandCatalogEntry, query: &str) -> bool {
-    let haystack = format!(
-        "{} {} {} {}",
-        entry.name,
-        entry.name.replace('_', " "),
-        entry.category,
-        entry.description
+    crate::services::platform_command_surface::invoke(
+        crate::services::platform_command_surface::Operation::Discover,
+        args,
+        catalog_context(org, state),
     )
-    .to_lowercase();
-
-    let normalized_query = query.replace('_', " ").to_lowercase();
-    query
-        .to_lowercase()
-        .split_whitespace()
-        .all(|term| haystack.contains(term))
-        || normalized_query
-            .split_whitespace()
-            .all(|term| haystack.contains(term))
-}
-
-fn output_shape_hints() -> Value {
-    json!({
-        "array": "Root JSON value is an array. Use jq '.[]'.",
-        "paginated": "Root JSON value is an object with data/total/offset/limit. Use jq '.data[]'.",
-        "unknown": "Inspect output_schema or run a small sample before choosing a jq path."
-    })
+    .await
 }
 
 // ============================================================================
@@ -1880,121 +1780,63 @@ fn output_shape_hints() -> Value {
 // ============================================================================
 
 async fn tool_query(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
-    tool_script(args, org, state, catalog::ToolsetMode::ReadOnly).await
+    crate::services::platform_command_surface::invoke(
+        crate::services::platform_command_surface::Operation::Query,
+        args,
+        catalog_context(org, state),
+    )
+    .await
 }
 
 async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
-    tool_script(args, org, state, catalog::ToolsetMode::Full).await
-}
-
-async fn tool_script(
-    args: &Value,
-    org: &ResolvedOrg,
-    state: &AppState,
-    mode: catalog::ToolsetMode,
-) -> Result<String, String> {
-    let command = args
-        .get("commands")
-        .and_then(|v| v.as_str())
-        .ok_or("Missing required parameter: commands")?;
-
-    let timeout_ms = args
-        .get("timeout_ms")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(30000)
-        .min(60000);
-
-    // EVE-323: rewrite `<cmd> <id>` → `<cmd> --<positional> <id>` so LLM
-    // callers don't hit bashkit's "expected --flag" rejection.
-    let rewritten = positional::rewrite(command, positional::positional_map());
-
-    let toolset = build_toolset(org, state, mode);
-    execute_script(&toolset, &rewritten, timeout_ms).await
+    crate::services::platform_command_surface::invoke(
+        crate::services::platform_command_surface::Operation::Execute,
+        args,
+        catalog_context(org, state),
+    )
+    .await
 }
 
 // ============================================================================
-// ScriptingToolSet helpers
+// Catalog command-context helpers
 // ============================================================================
 
 /// Build a CatalogContext for the given org.
 fn catalog_context(org: &ResolvedOrg, state: &AppState) -> catalog::CatalogContext {
     catalog::CatalogContext {
-        state: state.clone(),
-        caller: Caller::from(org),
+        domain_ctx: domain_context(Caller::from(org), state),
         link_builder: link_builder(state),
     }
 }
 
-/// Build a ScriptingToolSet for the given org context.
-/// All scripted tools dispatch inventory-registered domain commands — no HTTP.
-fn build_toolset(
-    org: &ResolvedOrg,
-    state: &AppState,
-    mode: catalog::ToolsetMode,
-) -> ScriptingToolSet {
-    catalog::build_toolset(catalog_context(org, state), mode)
-}
-
-/// Execute a script through a ScriptingToolSet and return formatted output.
-async fn execute_script(
-    toolset: &ScriptingToolSet,
-    command: &str,
-    timeout_ms: u64,
-) -> Result<String, String> {
-    let tools = toolset.tools();
-    let tool = tools
-        .first()
-        .ok_or_else(|| "No tools registered in toolset".to_string())?;
-    let request = bashkit::ToolRequest::new(command);
-
-    let result = tokio::time::timeout(
-        std::time::Duration::from_millis(timeout_ms),
-        tool.execute(request),
+pub(crate) fn domain_context(caller: Caller, state: &AppState) -> crate::domains::common::Ctx {
+    let mut ctx = crate::domains::common::Ctx::new(
+        caller,
+        state.db.clone(),
+        state.capability_service.clone(),
+        state.encryption.clone(),
+        state.auth.permission_resolver.clone(),
     )
-    .await;
-
-    match result {
-        Ok(response) => {
-            if response.exit_code == 0 {
-                Ok(response.stdout)
-            } else {
-                let combined = if response.stderr.is_empty() {
-                    response.stdout
-                } else if response.stdout.is_empty() {
-                    response.stderr
-                } else {
-                    format!("{}\n{}", response.stdout, response.stderr)
-                };
-                let trimmed = combined.trim();
-                if trimmed.is_empty() {
-                    Err(format!(
-                        "Command failed with exit code {}",
-                        response.exit_code
-                    ))
-                } else {
-                    Err(sanitize_script_error(trimmed))
-                }
-            }
-        }
-        Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
+    .with_org_rate_limiter(state.org_rate_limiter.clone())
+    .with_session_service(state.session_service.clone())
+    .with_message_service(state.message_service.clone())
+    .with_event_service(state.event_service.clone())
+    .with_session_file_service(state.session_file_service.clone())
+    .with_runner(state.runner.clone())
+    .with_fallback_harness_name(state.fallback_default_harness_name.clone())
+    .with_chat_harness_name(state.chat_harness_name.clone())
+    .with_chat_session_title(state.chat_session_title.clone())
+    .with_utility_llm_service(state.utility_llm_service.clone());
+    if let Some(service) = &state.health_check_service {
+        ctx = ctx.with_health_check_service(service.clone());
     }
-}
-
-fn sanitize_script_error(message: &str) -> String {
-    if message.contains("jq: runtime error")
-        || (message.contains("jq: error") && message.contains("Cannot index"))
-    {
-        let cause = if message.to_lowercase().contains("cannot index") {
-            "cannot index input with requested path"
-        } else {
-            "filter failed against input value"
-        };
-        return format!(
-            "jq: runtime error: {cause}. Input value omitted; use discover output_shape/output_schema to choose the jq path."
-        );
+    if let Some(service) = &state.session_sandbox_service {
+        ctx = ctx.with_session_sandbox_service(service.clone());
     }
-
-    message.to_string()
+    if let Some(store) = &state.sqldb_store {
+        ctx = ctx.with_sqldb_store(store.clone());
+    }
+    ctx.with_workflow_store(state.workflow_store.clone())
 }
 
 #[cfg(test)]

--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -336,40 +336,10 @@ fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoin
         protocol_version,
         "discover",
         "Discover Operations",
-        "Search the Everruns API catalog to find available operations. Returns matching operations with input/output schemas and jq-oriented output shape hints. Use all: true to list every operation grouped by category. Read-only operations are available as bash builtins in query; the full catalog is available in execute.",
-        object_schema(
-            vec![
-                (
-                    "query",
-                    json!({
-                        "type": "string",
-                        "description": "Search query to find API operations."
-                    }),
-                ),
-                (
-                    "all",
-                    json!({
-                        "type": "boolean",
-                        "description": "List all available operations grouped by category. When true, query is ignored."
-                    }),
-                ),
-                (
-                    "include_schemas",
-                    json!({
-                        "type": "boolean",
-                        "description": "Include input_schema and output_schema in results. Defaults to true for search and false for all."
-                    }),
-                ),
-                (
-                    "organization_id",
-                    json!({
-                        "type": "string",
-                        "description": org_id_description,
-                        "pattern": "^org_[0-9a-f]{32}$"
-                    }),
-                ),
-            ],
-            vec![],
+        everruns_core::capabilities::PLATFORM_DISCOVER_DESCRIPTION,
+        with_organization_id(
+            everruns_core::capabilities::discover_input_schema(),
+            org_id_description,
         ),
         Some(discover_output_schema()),
         Some(read_only_annotations()),
@@ -382,36 +352,10 @@ fn query_tool(protocol_version: &str, org_id_description: &str) -> McpEndpointTo
         protocol_version,
         "query",
         "Query Commands",
-        "Execute a bash script in an environment where only read-only Everruns API operations are available as built-in commands. Supports pipes, variables, loops, conditionals, jq, and direct access to safe builtins. Mutating commands are intentionally unavailable.",
-        object_schema(
-            vec![
-                (
-                    "commands",
-                    json!({
-                        "type": "string",
-                        "description": "Bash script to execute. Only read-only API operations are available as built-in commands.",
-                        "minLength": 1
-                    }),
-                ),
-                (
-                    "timeout_ms",
-                    json!({
-                        "type": "integer",
-                        "description": "Execution timeout in milliseconds (default: 30000, max: 60000).",
-                        "minimum": 1,
-                        "maximum": 60000
-                    }),
-                ),
-                (
-                    "organization_id",
-                    json!({
-                        "type": "string",
-                        "description": org_id_description,
-                        "pattern": "^org_[0-9a-f]{32}$"
-                    }),
-                ),
-            ],
-            vec!["commands"],
+        everruns_core::capabilities::PLATFORM_QUERY_DESCRIPTION,
+        with_organization_id(
+            everruns_core::capabilities::query_input_schema(),
+            org_id_description,
         ),
         None,
         Some(read_only_annotations()),
@@ -424,36 +368,10 @@ fn execute_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoint
         protocol_version,
         "execute",
         "Execute Commands",
-        "Execute a bash script in an environment where every Everruns API operation is a built-in command, including operations with side effects. Supports pipes, variables, loops, conditionals, jq, and direct access to the full builtin set. Prefer query for read-only inspection; use execute when you need create/update/delete or other mutating operations.",
-        object_schema(
-            vec![
-                (
-                    "commands",
-                    json!({
-                        "type": "string",
-                        "description": "Bash script to execute. API operations are available as built-in commands.",
-                        "minLength": 1
-                    }),
-                ),
-                (
-                    "timeout_ms",
-                    json!({
-                        "type": "integer",
-                        "description": "Execution timeout in milliseconds (default: 30000, max: 60000).",
-                        "minimum": 1,
-                        "maximum": 60000
-                    }),
-                ),
-                (
-                    "organization_id",
-                    json!({
-                        "type": "string",
-                        "description": org_id_description,
-                        "pattern": "^org_[0-9a-f]{32}$"
-                    }),
-                ),
-            ],
-            vec!["commands"],
+        everruns_core::capabilities::PLATFORM_EXECUTE_DESCRIPTION,
+        with_organization_id(
+            everruns_core::capabilities::execute_input_schema(),
+            org_id_description,
         ),
         None,
         Some(McpToolAnnotations {
@@ -547,6 +465,15 @@ fn object_schema(properties: Vec<(&str, Value)>, required: Vec<&str>) -> Value {
         "properties": props,
         "required": required
     })
+}
+
+fn with_organization_id(mut schema: Value, description: &str) -> Value {
+    schema["properties"]["organization_id"] = json!({
+        "type": "string",
+        "description": description,
+        "pattern": "^org_[0-9a-f]{32}$"
+    });
+    schema
 }
 
 fn id_property<'a>(name: &'a str, description: &str) -> (&'a str, Value) {
@@ -664,4 +591,44 @@ fn discover_output_schema() -> Value {
         },
         "required": ["count", "include_schemas", "shape_hints"]
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn without_organization_id(mut schema: Value) -> Value {
+        schema["properties"]
+            .as_object_mut()
+            .expect("object schema properties")
+            .remove("organization_id");
+        schema
+    }
+
+    #[test]
+    fn platform_and_mcp_command_tool_contracts_match() {
+        let org_description = "organization";
+        let cases = [
+            (
+                discover_tool("2026-07-28", org_description),
+                everruns_core::capabilities::PLATFORM_DISCOVER_DESCRIPTION,
+                everruns_core::capabilities::discover_input_schema(),
+            ),
+            (
+                query_tool("2026-07-28", org_description),
+                everruns_core::capabilities::PLATFORM_QUERY_DESCRIPTION,
+                everruns_core::capabilities::query_input_schema(),
+            ),
+            (
+                execute_tool("2026-07-28", org_description),
+                everruns_core::capabilities::PLATFORM_EXECUTE_DESCRIPTION,
+                everruns_core::capabilities::execute_input_schema(),
+            ),
+        ];
+
+        for (mcp, description, platform_schema) in cases {
+            assert_eq!(mcp.description, description);
+            assert_eq!(without_organization_id(mcp.input_schema), platform_schema);
+        }
+    }
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2714,6 +2714,21 @@ impl DirectPlatformStore {
         }
     }
 
+    async fn invoke_platform_command_surface(
+        &self,
+        operation: crate::services::platform_command_surface::Operation,
+        arguments: serde_json::Value,
+    ) -> everruns_core::error::Result<String> {
+        let base_url = Self::base_url_from_env();
+        let context = crate::api::mcp_endpoint::catalog::CatalogContext {
+            domain_ctx: self.command_ctx().await?,
+            link_builder: crate::api::common::UrlBuilder::new(&base_url, &base_url),
+        };
+        crate::services::platform_command_surface::invoke(operation, &arguments, context)
+            .await
+            .map_err(AgentLoopError::tool)
+    }
+
     async fn latest_terminal_turn_status(&self, session_id: SessionId) -> Result<Option<String>> {
         const TURN_COMPLETED: &str = "turn.completed";
         const TURN_FAILED: &str = "turn.failed";
@@ -2782,6 +2797,39 @@ impl SessionCreationAuthority for DirectPlatformStore {
 
 #[async_trait]
 impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
+    async fn platform_discover(
+        &self,
+        arguments: serde_json::Value,
+    ) -> everruns_core::error::Result<String> {
+        self.invoke_platform_command_surface(
+            crate::services::platform_command_surface::Operation::Discover,
+            arguments,
+        )
+        .await
+    }
+
+    async fn platform_query(
+        &self,
+        arguments: serde_json::Value,
+    ) -> everruns_core::error::Result<String> {
+        self.invoke_platform_command_surface(
+            crate::services::platform_command_surface::Operation::Query,
+            arguments,
+        )
+        .await
+    }
+
+    async fn platform_execute(
+        &self,
+        arguments: serde_json::Value,
+    ) -> everruns_core::error::Result<String> {
+        self.invoke_platform_command_surface(
+            crate::services::platform_command_surface::Operation::Execute,
+            arguments,
+        )
+        .await
+    }
+
     // =========================================================================
     // Harness Operations
     // =========================================================================
@@ -4011,6 +4059,29 @@ mod tests {
         let session_id =
             seed_platform_session(&adapters.db, org.org_id, harness_id, Some(user.id)).await;
         let store = adapters.platform_store(org.org_id, session_id);
+
+        let discovered = store
+            .platform_discover(serde_json::json!({ "query": "models" }))
+            .await
+            .expect("members may inspect the command catalog");
+        assert!(discovered.contains("list_models"));
+
+        store
+            .platform_query(serde_json::json!({ "commands": "list_models" }))
+            .await
+            .expect("members may run read-only platform queries");
+
+        let script_error = store
+            .platform_execute(serde_json::json!({
+                "commands": "create_harness --name forbidden-script"
+            }))
+            .await
+            .expect_err("member should not mutate through the command surface");
+        assert!(
+            script_error.to_string().contains("forbidden")
+                || script_error.to_string().contains("Access denied"),
+            "unexpected authorization error: {script_error}"
+        );
 
         let err = store
             .create_harness("forbidden", None, None, Some("prompt"), None, &[])

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -128,6 +128,8 @@ use everruns_internal_protocol::proto::{
     HeartbeatDurableWorkerResponse,
     InvokeAgentTriggerRequest,
     InvokeAgentTriggerResponse,
+    InvokePlatformCommandSurfaceRequest,
+    InvokePlatformCommandSurfaceResponse,
     InvokeScheduledAppChannelRequest,
     InvokeScheduledAppChannelResponse,
     ListCommandsRequest,
@@ -155,6 +157,7 @@ use everruns_internal_protocol::proto::{
     OptionalSessionTaskResponse,
     OrphanedSessionTaskEntry, // orphan-scan entry for ListOrphanedSessionTasks
     PlatformCapabilityInfo,
+    PlatformCommandSurfaceOperation,
     PlatformCopyHarnessRequest,
     PlatformCopyHarnessResponse,
     PlatformCreateAgentRequest,

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -776,6 +776,155 @@ async fn test_execute_command_uses_user_permissions() {
     assert!(error.message.contains("Access denied"));
 }
 
+#[tokio::test]
+async fn platform_command_surface_uses_session_owner_and_org() {
+    use crate::storage::models::{CreateSessionRow, CreateUserRow};
+
+    let service = test_worker_service().await;
+    let user = service
+        .db
+        .create_user(CreateUserRow {
+            email: "platform-surface-member@example.com".to_string(),
+            name: "Platform Surface Member".to_string(),
+            avatar_url: None,
+            external_id: None,
+            roles: vec![],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: Some("test".to_string()),
+            auth_provider_id: None,
+        })
+        .await
+        .expect("create user");
+    service
+        .db
+        .ensure_membership(user.id, everruns_core::DEFAULT_ORG_ID, "member")
+        .await
+        .expect("ensure membership");
+    let session = service
+        .db
+        .create_session(CreateSessionRow {
+            workspace_id: None,
+            org_id: everruns_core::DEFAULT_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            agent_version_id: None,
+            agent_config_hash: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(2),
+            resolved_owner_user_id: Some(user.id),
+            title: Some("platform surface".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            budget_root_session_id: None,
+        })
+        .await
+        .expect("create session");
+
+    let response = service
+        .invoke_platform_command_surface(Request::new(InvokePlatformCommandSurfaceRequest {
+            session_id: Some(proto::Uuid {
+                value: session.id.uuid().to_string(),
+            }),
+            org_id: session.org_id,
+            operation: PlatformCommandSurfaceOperation::Discover as i32,
+            arguments_json: serde_json::to_vec(&serde_json::json!({
+                "query": "models"
+            }))
+            .unwrap(),
+        }))
+        .await
+        .expect("discover succeeds")
+        .into_inner();
+    let proto::invoke_platform_command_surface_response::Result::Output(output) =
+        response.result.expect("discover result")
+    else {
+        panic!("expected discover output");
+    };
+    assert!(output.contains("list_models"));
+
+    for (query, expected) in [
+        ("create agent", ["create_agent", "default_model_id"]),
+        ("agent trigger", ["create_agent_trigger", "cron_expression"]),
+    ] {
+        let response = service
+            .invoke_platform_command_surface(Request::new(InvokePlatformCommandSurfaceRequest {
+                session_id: Some(proto::Uuid {
+                    value: session.id.uuid().to_string(),
+                }),
+                org_id: session.org_id,
+                operation: PlatformCommandSurfaceOperation::Discover as i32,
+                arguments_json: serde_json::to_vec(&serde_json::json!({ "query": query })).unwrap(),
+            }))
+            .await
+            .expect("command discovery succeeds")
+            .into_inner();
+        let proto::invoke_platform_command_surface_response::Result::Output(output) =
+            response.result.expect("discover result")
+        else {
+            panic!("expected discover output");
+        };
+        for needle in expected {
+            assert!(
+                output.contains(needle),
+                "{query} discovery omitted {needle}"
+            );
+        }
+    }
+
+    let denied = service
+        .invoke_platform_command_surface(Request::new(InvokePlatformCommandSurfaceRequest {
+            session_id: Some(proto::Uuid {
+                value: session.id.uuid().to_string(),
+            }),
+            org_id: session.org_id,
+            operation: PlatformCommandSurfaceOperation::Execute as i32,
+            arguments_json: serde_json::to_vec(&serde_json::json!({
+                "commands": "create_harness --name forbidden"
+            }))
+            .unwrap(),
+        }))
+        .await
+        .expect("authorization denial is a tool result")
+        .into_inner();
+    let proto::invoke_platform_command_surface_response::Result::Error(error) =
+        denied.result.expect("execute result")
+    else {
+        panic!("member mutation must be denied");
+    };
+    assert!(
+        error.contains("forbidden") || error.contains("Access denied"),
+        "unexpected authorization error: {error}"
+    );
+
+    let foreign = service
+        .invoke_platform_command_surface(Request::new(InvokePlatformCommandSurfaceRequest {
+            session_id: Some(proto::Uuid {
+                value: session.id.uuid().to_string(),
+            }),
+            org_id: session.org_id + 1,
+            operation: PlatformCommandSurfaceOperation::Discover as i32,
+            arguments_json: br#"{"query":"models"}"#.to_vec(),
+        }))
+        .await
+        .expect_err("cross-org session lookup must fail");
+    assert_eq!(foreign.code(), tonic::Code::NotFound);
+}
+
 /// Acquire env lock, tolerating poison from #[should_panic] tests.
 fn lock_env() -> std::sync::MutexGuard<'static, ()> {
     ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3567,6 +3567,100 @@ impl WorkerService for WorkerServiceImpl {
         Ok(Response::new(ListCommandsResponse { commands }))
     }
 
+    async fn invoke_platform_command_surface(
+        &self,
+        request: Request<InvokePlatformCommandSurfaceRequest>,
+    ) -> Result<Response<InvokePlatformCommandSurfaceResponse>, Status> {
+        // THREAT[TM-AGENT-017]: The worker supplies only the bound session and
+        // org. Reload the session and resolve its persisted owner server-side;
+        // never accept a caller identity across this trust boundary.
+        let req = request.into_inner();
+        if req.arguments_json.len() > MAX_EXECUTE_COMMAND_PARAMS_BYTES {
+            return Err(Status::resource_exhausted(format!(
+                "Platform command arguments exceed {} byte limit",
+                MAX_EXECUTE_COMMAND_PARAMS_BYTES
+            )));
+        }
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let session = self
+            .session_service
+            .get(
+                &everruns_core::Caller::internal(req.org_id),
+                session_id,
+                None,
+            )
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, %session_id, org_id = req.org_id, "Failed to load Platform command session");
+                Status::internal("Failed to load Platform command session")
+            })?
+            .ok_or_else(|| Status::not_found("Session not found"))?;
+        let user_id = session.resolved_owner_user_id.ok_or_else(|| {
+            Status::permission_denied(
+                "Platform command execution requires a user-owned session with a resolved owner",
+            )
+        })?;
+        let caller = crate::auth::caller_resolution::caller_for_user(&self.db, req.org_id, user_id)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, %session_id, org_id = req.org_id, %user_id, "Failed to resolve Platform command caller");
+                Status::permission_denied("Failed to resolve Platform command caller")
+            })?;
+        let operation = match PlatformCommandSurfaceOperation::try_from(req.operation) {
+            Ok(PlatformCommandSurfaceOperation::Discover) => {
+                crate::services::platform_command_surface::Operation::Discover
+            }
+            Ok(PlatformCommandSurfaceOperation::Query) => {
+                crate::services::platform_command_surface::Operation::Query
+            }
+            Ok(PlatformCommandSurfaceOperation::Execute) => {
+                crate::services::platform_command_surface::Operation::Execute
+            }
+            _ => {
+                return Err(Status::invalid_argument(
+                    "Invalid platform command operation",
+                ));
+            }
+        };
+        let arguments = if req.arguments_json.is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_slice::<serde_json::Value>(&req.arguments_json).map_err(|error| {
+                Status::invalid_argument(format!("Invalid arguments_json: {error}"))
+            })?
+        };
+        if !arguments.is_object() {
+            return Err(Status::invalid_argument(
+                "Platform command arguments must be a JSON object",
+            ));
+        }
+
+        let api_base = self
+            .api_base_url
+            .clone()
+            .unwrap_or_else(|| "http://localhost:9300".to_string());
+        let ui_base = std::env::var("PUBLIC_APP_URL")
+            .or_else(|_| std::env::var("FRONTEND_URL"))
+            .unwrap_or_else(|_| api_base.clone());
+        let context = crate::api::mcp_endpoint::catalog::CatalogContext {
+            domain_ctx: self.domain_ctx_for_caller(caller),
+            link_builder: crate::api::common::UrlBuilder::new(&api_base, &ui_base),
+        };
+        let result =
+            crate::services::platform_command_surface::invoke(operation, &arguments, context).await;
+        let result = match result {
+            Ok(output) => {
+                Some(proto::invoke_platform_command_surface_response::Result::Output(output))
+            }
+            Err(error) => {
+                Some(proto::invoke_platform_command_surface_response::Result::Error(error))
+            }
+        };
+        Ok(Response::new(InvokePlatformCommandSurfaceResponse {
+            result,
+        }))
+    }
+
     async fn platform_list_harnesses(
         &self,
         request: Request<PlatformListHarnessesRequest>,

--- a/crates/server/src/harnesses/platform_chat.rs
+++ b/crates/server/src/harnesses/platform_chat.rs
@@ -1,6 +1,6 @@
 //! Platform Chat harness — conversational interface for managing the Everruns platform.
 //!
-//! Keep `platform_management` here. Permission enforcement belongs in the
+//! Keep `platform` here. Permission enforcement belongs in the
 //! platform tool execution path, not in harness amputation.
 
 use everruns_core::{BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole};
@@ -15,7 +15,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
     .with_parent_name("generic")
     .with_tags(["chat", "built-in"])
     .with_roles([BuiltInHarnessRole::Chat])
-    .with_capabilities([BuiltInCapabilityDefinition::new("platform_management")])
+    .with_capabilities([BuiltInCapabilityDefinition::new("platform")])
 }
 
 const SYSTEM_PROMPT: &str = "\
@@ -34,16 +34,24 @@ Examples:
 ## Running agents
 
 When asked to \"run an agent\" or \"run X with agent Y\", follow these steps:
-1. Create a session for the agent (use `manage_sessions` with operation \"create\"). You can omit `harness_id` — it defaults to the built-in Generic harness.
-2. Send the user's message/task to the session (use `session_send_message`)
-3. Wait for the turn to complete (use `session_read_response`)
-4. Retrieve and relay the results (use `session_read_messages`)
+1. Discover the relevant session commands if needed.
+2. Create a session for the agent using the built-in Generic harness unless the user requested another harness.
+3. Send the user's task to that session.
+4. Wait for completion and retrieve the result.
 
 When creating sessions, the `harness_id` parameter is optional. If not specified, it defaults to the built-in Generic harness which includes file system, bash, storage, schedules, context compaction, and other standard capabilities.
 
 ## Harness creation
 
-Avoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `read_harnesses`) which already includes file system, bash, storage, schedules, long-context support, context compaction, session, agent instructions, and skills capabilities.
+Avoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, query the built-in \"Generic\" harness, which already includes file system, bash, storage, schedules, long-context support, context compaction, session, agent instructions, and skills capabilities.
+
+## Scheduled autonomous work
+
+Create an Agent Trigger for recurring autonomous work. Do not schedule the Platform Chat session itself.
+
+## Final answers
+
+Lead with the outcome. Do not include internal reasoning, planning narration, or tool-selection commentary in the final answer.
 
 ## Confirmation guidelines
 

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -599,7 +599,7 @@ mod tests {
             .iter()
             .map(|cap| cap.capability_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(chat_cap_ids, vec!["platform_management"]);
+        assert_eq!(chat_cap_ids, vec!["platform"]);
     }
 
     #[tokio::test]

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1060,59 +1060,12 @@ Verify each action by re-listing the affected resource type.
         name: "platform-manager",
         display_name: "Platform Manager",
         description: "Manages Everruns entities: harnesses, agents, and sessions. Can create, update, delete, copy harnesses and agents, start sessions, send messages, and retrieve results.",
-        system_prompt: r#"You are a Platform Manager Agent for Everruns. You can manage the entire platform
-programmatically using the management tools available to you.
+        system_prompt: r#"You are a Platform Manager Agent for Everruns. Use the catalog-backed platform tools to inspect and manage Everruns resources.
 
-## What You Can Do
-
-### Harness Management
-- List all harnesses to see what's available
-- Get details of a specific harness (including system prompt and capabilities)
-- Create new harnesses with custom system prompts and capabilities
-- Update existing harnesses (name, description, system prompt)
-- Copy a harness and modify the copy
-- Delete (archive) harnesses that are no longer needed
-
-### Agent Management
-- List all agents to see what's available
-- Get details of a specific agent
-- Create new agents with custom configurations
-- Update existing agents
-- Delete (archive) agents that are not active or needed
-
-### Session Management
-- List sessions (optionally filter by agent)
-- Create new sessions with specific harness and agent
-- Get session details and status
-- Delete old sessions
-
-### Session Interaction
-- Send messages to any session to trigger agent responses
-- Get messages from a session (default: last 10)
-- Wait for a session's turn to complete before reading the response
-
-## Common Workflows
-
-### Run an agent and get results:
-1. Create a session with the desired agent
-2. Send a message to the session
-3. Wait for idle (turn completion)
-4. Get messages to read the response
-
-### Copy and modify a harness:
-1. Get the source harness details
-2. Copy it with a new name
-3. Update the copy's system prompt or other fields
-
-### Clean up inactive agents:
-1. List all agents
-2. Identify agents with "Archived" status or that match criteria
-3. Delete the ones that should be removed
-
-All tool results include UI links so you can point users to the web interface."#,
+Discover command names and schemas instead of guessing. Use read-only queries for inspection, execute only user-requested mutations, and validate resulting state. Create Agent Triggers for recurring autonomous work instead of scheduling this management session. Include returned UI links when reporting resources. Lead final answers with the outcome and omit internal reasoning or tool-selection narration."#,
         tags: &["platform", "management", "admin", "seed"],
         capabilities: &[
-            SeedCapability::new("platform_management"),
+            SeedCapability::new("platform"),
             SeedCapability::new("session_file_system"),
             SeedCapability::new("session_storage"),
             SeedCapability::new("session"),

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -23,6 +23,7 @@ pub mod generation_reconciler;
 pub mod model_sync;
 pub mod openrouter_generation;
 pub mod org_feature_flags;
+pub mod platform_command_surface;
 pub mod principal;
 pub mod provider_resolver;
 pub mod usage_tracking;

--- a/crates/server/src/services/platform_command_surface.rs
+++ b/crates/server/src/services/platform_command_surface.rs
@@ -1,0 +1,199 @@
+//! Transport-neutral implementation of the catalog-backed platform tools.
+//!
+//! MCP and the built-in Platform capability both delegate here so command
+//! discovery, Bashkit behavior, limits, and error sanitization stay identical.
+
+use crate::api::mcp_endpoint::{catalog, positional};
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    Discover,
+    Query,
+    Execute,
+}
+
+pub async fn invoke(
+    operation: Operation,
+    arguments: &Value,
+    context: catalog::CatalogContext,
+) -> Result<String, String> {
+    match operation {
+        Operation::Discover => discover(arguments),
+        Operation::Query => script(arguments, context, catalog::ToolsetMode::ReadOnly).await,
+        Operation::Execute => script(arguments, context, catalog::ToolsetMode::Full).await,
+    }
+}
+
+fn discover(arguments: &Value) -> Result<String, String> {
+    let show_all = arguments
+        .get("all")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let include_schemas = arguments
+        .get("include_schemas")
+        .and_then(Value::as_bool)
+        .unwrap_or(!show_all);
+
+    let mut entries = crate::domains::common::catalog_entries_with_schemas(include_schemas);
+    entries.sort_by_key(|entry| (entry.category, entry.name));
+
+    if !show_all {
+        let query = arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        if query.is_empty() {
+            return Err(
+                "Provide a 'query' to search or set 'all: true' to list everything.".into(),
+            );
+        }
+        entries.retain(|entry| catalog_entry_matches(entry, query));
+    }
+
+    let operation_json = |entry: &crate::domains::common::CommandCatalogEntry| {
+        let mut value = json!({
+            "name": entry.name,
+            "category": entry.category,
+            "description": entry.description,
+            "read_only": entry.read_only,
+            "output_shape": entry.output_shape,
+        });
+        if let Some(positional_arg) = entry.positional_arg {
+            value["positional_arg"] = json!(positional_arg);
+        }
+        if include_schemas {
+            value["input_schema"] = entry.input_schema.clone();
+            value["output_schema"] = entry.output_schema.clone();
+        }
+        value
+    };
+
+    let value = if show_all {
+        let mut by_category: std::collections::BTreeMap<&str, Vec<Value>> =
+            std::collections::BTreeMap::new();
+        for entry in &entries {
+            by_category
+                .entry(entry.category)
+                .or_default()
+                .push(operation_json(entry));
+        }
+        let categories = by_category
+            .into_iter()
+            .map(|(category, operations)| {
+                json!({
+                    "category": category,
+                    "count": operations.len(),
+                    "operations": operations,
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({
+            "count": entries.len(),
+            "include_schemas": include_schemas,
+            "categories": categories,
+            "shape_hints": output_shape_hints(),
+        })
+    } else {
+        json!({
+            "count": entries.len(),
+            "include_schemas": include_schemas,
+            "operations": entries.iter().map(operation_json).collect::<Vec<_>>(),
+            "shape_hints": output_shape_hints(),
+        })
+    };
+
+    serde_json::to_string_pretty(&value).map_err(|error| format!("Internal error: {error}"))
+}
+
+fn catalog_entry_matches(entry: &crate::domains::common::CommandCatalogEntry, query: &str) -> bool {
+    let haystack = format!(
+        "{} {} {} {}",
+        entry.name,
+        entry.name.replace('_', " "),
+        entry.category,
+        entry.description
+    )
+    .to_lowercase();
+    let normalized_query = query.replace('_', " ").to_lowercase();
+    query
+        .to_lowercase()
+        .split_whitespace()
+        .all(|term| haystack.contains(term))
+        || normalized_query
+            .split_whitespace()
+            .all(|term| haystack.contains(term))
+}
+
+fn output_shape_hints() -> Value {
+    json!({
+        "array": "Root JSON value is an array. Use jq '.[]'.",
+        "paginated": "Root JSON value is an object with data/total/offset/limit. Use jq '.data[]'.",
+        "unknown": "Inspect output_schema or run a small sample before choosing a jq path."
+    })
+}
+
+async fn script(
+    arguments: &Value,
+    context: catalog::CatalogContext,
+    mode: catalog::ToolsetMode,
+) -> Result<String, String> {
+    let commands = arguments
+        .get("commands")
+        .and_then(Value::as_str)
+        .ok_or("Missing required parameter: commands")?;
+    let timeout_ms = arguments
+        .get("timeout_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(30_000)
+        .min(60_000);
+
+    let rewritten = positional::rewrite(commands, positional::positional_map());
+    let tool = catalog::build_toolset(context, mode);
+    let request = bashkit::ToolRequest::new(rewritten);
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(timeout_ms),
+        bashkit::Tool::execute(&tool, request),
+    )
+    .await;
+
+    match result {
+        Ok(response) if response.exit_code == 0 => Ok(response.stdout),
+        Ok(response) => {
+            let combined = if response.stderr.is_empty() {
+                response.stdout
+            } else if response.stdout.is_empty() {
+                response.stderr
+            } else {
+                format!("{}\n{}", response.stdout, response.stderr)
+            };
+            let trimmed = combined.trim();
+            if trimmed.is_empty() {
+                Err(format!(
+                    "Command failed with exit code {}",
+                    response.exit_code
+                ))
+            } else {
+                Err(sanitize_script_error(trimmed))
+            }
+        }
+        Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
+    }
+}
+
+fn sanitize_script_error(message: &str) -> String {
+    if message.contains("jq: runtime error")
+        || (message.contains("jq: error") && message.contains("Cannot index"))
+    {
+        let cause = if message.to_lowercase().contains("cannot index") {
+            "cannot index input with requested path"
+        } else {
+            "filter failed against input value"
+        };
+        return format!(
+            "jq: runtime error: {cause}. Input value omitted; use discover output_shape/output_schema to choose the jq path."
+        );
+    }
+    message.to_string()
+}

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3398,7 +3398,7 @@ async fn test_chat_harness_exists_in_seed() {
 }
 
 #[tokio::test]
-async fn test_chat_harness_includes_platform_management() {
+async fn test_chat_harness_includes_platform_capability() {
     let server = TestServer::new().await;
 
     let harness: Harness = server
@@ -3422,8 +3422,8 @@ async fn test_chat_harness_includes_platform_management() {
 
     assert_eq!(
         cap_ids,
-        vec!["platform_management"],
-        "Platform Chat should keep platform management locally"
+        vec!["platform"],
+        "Platform Chat should keep the catalog-backed platform capability locally"
     );
 
     let preview: Value = server
@@ -3450,9 +3450,15 @@ async fn test_chat_harness_includes_platform_management() {
         tool_names.contains(&"web_fetch"),
         "Platform Chat preview should include inherited Generic tools"
     );
+    for expected in ["discover", "query", "execute"] {
+        assert!(
+            tool_names.contains(&expected),
+            "Platform Chat preview should include {expected}"
+        );
+    }
     assert!(
-        tool_names.contains(&"manage_harnesses"),
-        "Platform Chat preview should include platform management tools"
+        !tool_names.contains(&"manage_harnesses"),
+        "Platform Chat should use the catalog surface, not legacy management tools"
     );
 }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -687,6 +687,38 @@ impl GrpcOrgAdapter {
         }
     }
 
+    async fn invoke_platform_command_surface(
+        &self,
+        operation: proto::PlatformCommandSurfaceOperation,
+        arguments: serde_json::Value,
+    ) -> Result<String> {
+        let session_id = self.platform_session_id.ok_or_else(|| {
+            AgentLoopError::store("Platform command surface requires a platform session context")
+        })?;
+        let mut client = self.client.inner.lock().await;
+        let response = client
+            .invoke_platform_command_surface(proto::InvokePlatformCommandSurfaceRequest {
+                session_id: Some(uuid_to_proto(session_id.uuid())),
+                org_id: self.org_id,
+                operation: operation as i32,
+                arguments_json: serde_json::to_vec(&arguments).map_err(|error| {
+                    AgentLoopError::store(format!("JSON serialization failed: {error}"))
+                })?,
+            })
+            .await
+            .map_err(grpc_status_to_error)?
+            .into_inner();
+        match response
+            .result
+            .ok_or_else(|| grpc_missing_field("No platform command surface result"))?
+        {
+            proto::invoke_platform_command_surface_response::Result::Output(output) => Ok(output),
+            proto::invoke_platform_command_surface_response::Result::Error(error) => {
+                Err(AgentLoopError::tool(error))
+            }
+        }
+    }
+
     async fn execute_platform_command<T>(&self, name: &str, params: serde_json::Value) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
@@ -2961,6 +2993,30 @@ impl everruns_core::traits::SessionScheduleStore for GrpcOrgAdapter {
 
 #[async_trait]
 impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
+    async fn platform_discover(&self, arguments: serde_json::Value) -> Result<String> {
+        self.invoke_platform_command_surface(
+            proto::PlatformCommandSurfaceOperation::Discover,
+            arguments,
+        )
+        .await
+    }
+
+    async fn platform_query(&self, arguments: serde_json::Value) -> Result<String> {
+        self.invoke_platform_command_surface(
+            proto::PlatformCommandSurfaceOperation::Query,
+            arguments,
+        )
+        .await
+    }
+
+    async fn platform_execute(&self, arguments: serde_json::Value) -> Result<String> {
+        self.invoke_platform_command_surface(
+            proto::PlatformCommandSurfaceOperation::Execute,
+            arguments,
+        )
+        .await
+    }
+
     // =========================================================================
     // Harness Operations
     // =========================================================================

--- a/docs/built-ins/harnesses/platform-chat.md
+++ b/docs/built-ins/harnesses/platform-chat.md
@@ -1,6 +1,6 @@
 ---
 title: Platform Chat Harness
-description: Extends the Generic harness with platform management capabilities for the global chat interface.
+description: Extends the Generic harness with catalog-backed platform tools for the global chat interface.
 ---
 
 The **Platform Chat** harness extends the [Generic harness](/built-ins/harnesses/generic/) with platform management capabilities. It powers the global chat interface where users interact with agents that can manage the Everruns platform itself.
@@ -25,10 +25,15 @@ All [Generic harness capabilities](/built-ins/harnesses/generic/#bundled-capabil
 
 | Capability | What it provides |
 |------------|-----------------|
-| [Platform Management](/capabilities/platform-management/) | Tools to list and manage agents, harnesses, providers, and other platform resources |
+| [Platform](/capabilities/platform/) | `discover`, read-only `query`, and mutating `execute` over the authoritative Everruns command catalog |
+
+Platform Chat discovers current command names and schemas before acting. It
+uses `query` for inspection, `execute` only for requested mutations, and then
+queries the final state. For recurring autonomous work it creates an Agent
+Trigger rather than scheduling the Platform Chat session.
 
 ## See Also
 
 - [Generic Harness](/built-ins/harnesses/generic/) — the base this harness extends
-- [Platform Management capability](/capabilities/platform-management/) — the additional capability
+- [Platform capability](/capabilities/platform/) — the additional capability
 - [Harnesses feature guide](/features/harnesses/) — harness selection and API management

--- a/docs/built-ins/index.md
+++ b/docs/built-ins/index.md
@@ -14,7 +14,7 @@ A harness defines the base environment for sessions — system prompt, default m
 | [Base](/built-ins/harnesses/base/) | Empty harness, full control | None |
 | [Generic](/built-ins/harnesses/generic/) | Recommended default with core tools | 16 configured, including 14 user-facing defaults |
 | [Data Analyst](/built-ins/harnesses/data-analyst/) | SQL databases, charts, persistent memory | Generic + 5 data capabilities; available as a built-in example |
-| [Platform Chat](/built-ins/harnesses/platform-chat/) | Extends Generic for global chat | Generic + Platform Management |
+| [Platform Chat](/built-ins/harnesses/platform-chat/) | Extends Generic for global chat | Generic + Platform |
 
 See the [Harnesses feature guide](/features/harnesses/) for harness selection, API management, and the prompt stack model.
 

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -94,7 +94,8 @@ Agent self-management and platform control.
 
 | Capability | ID | Tools |
 |---|---|---|
-| [Platform Management](/capabilities/platform-management/) | `platform_management` | 14 |
+| [Platform](/capabilities/platform/) | `platform` | 3 |
+| [Platform Management (legacy)](/capabilities/platform-management/) | `platform_management` | 14 |
 
 ### Optimization
 

--- a/docs/capabilities/platform-management.md
+++ b/docs/capabilities/platform-management.md
@@ -3,6 +3,10 @@ title: Platform Management
 description: Programmatic management of harnesses, agents, and sessions from within a running session. Agents can read, create, update, and delete platform resources via tools.
 ---
 
+> This is the legacy handwritten compatibility capability. New built-in
+> Platform Chat sessions use the catalog-backed [Platform capability](/capabilities/platform/),
+> whose `discover`, `query`, and `execute` tools stay aligned with Everruns MCP.
+
 | | |
 |---|---|
 | **ID** | `platform_management` |
@@ -144,6 +148,7 @@ Read the latest estimated context-token breakdown for a session. Returns total e
 
 ## See Also
 
+- [Platform](/capabilities/platform/) — current catalog-backed capability
 - [Concepts](/getting-started/concepts/) — Harness, Agent, Session model
 - [Agent Skills](/capabilities/agent-skills/) — skill discovery
 - [API Reference](/api/) — full REST API

--- a/docs/capabilities/platform.md
+++ b/docs/capabilities/platform.md
@@ -1,0 +1,92 @@
+---
+title: Platform
+description: Discover, inspect, and manage Everruns resources through the authoritative command catalog.
+---
+
+| | |
+|---|---|
+| **ID** | `platform` |
+| **Category** | Platform |
+| **Risk** | High |
+| **Tools** | `discover`, `query`, `execute` |
+| **Dependencies** | `session_file_system` when embedded docs are enabled |
+
+The Platform capability gives an agent the same catalog-backed command surface
+as Everruns' `/mcp` endpoint. Operations come from the server's registered
+command inventory, so models can discover current names and schemas instead of
+guessing them or relying on a separate handwritten API.
+
+Platform Chat includes this capability by default. Other agents and harnesses
+must be assigned it explicitly. Because `execute` can mutate platform resources,
+the capability is high-risk and follows the normal admin-only assignment rule.
+
+## Tools
+
+### `discover`
+
+Search for operations by name, category, description, or schema terms. Results
+include command metadata, input/output schemas, read-only classification, and
+output-shape hints. Use `all: true` to list the entire scriptable catalog.
+
+```json
+{ "query": "models" }
+```
+
+### `query`
+
+Run a bounded Bashkit script with only read-only Everruns commands available as
+builtins. It supports pipes, variables, loops, conditionals, and `jq`.
+
+```json
+{ "commands": "list_models | jq '.data[] | {id, model_id, display_name}'" }
+```
+
+Commands with mutations or open-world side effects are not available in
+`query`. Use it to inspect current state and validate changes.
+
+### `execute`
+
+Run a bounded Bashkit script with the full scriptable command catalog. Use it
+for requested create, update, delete, and other mutating operations.
+
+```json
+{
+  "commands": "create_agent --name 'support-agent' --system_prompt 'Help users.' --default_model_id 'model_...'"
+}
+```
+
+`execute` is not transactional. If a later command in a script fails, earlier
+commands may already have succeeded. Inspect the resulting state with `query`
+before retrying.
+
+## Scope and authorization
+
+Platform tools are always bound to the current session's organization. Their
+schemas do not accept `organization_id`, and an injected override is rejected.
+The server resolves the session's human owner for every distributed call and
+applies that caller's normal command permissions. Attaching this capability
+does not grant authority the owner does not already have.
+
+## Autonomous workflows
+
+For recurring autonomous work, create an Agent and an Agent Trigger. Do not use
+a schedule on the Platform Chat session: that would wake the management chat,
+not provision an independently owned worker workflow.
+
+Credentials are not transferred from Platform Chat session secrets into a new
+Agent. Configure integrations through their supported Agent-scoped credential
+or connection flow; do not paste credentials into command scripts.
+
+## Embedded documentation
+
+When embedded platform docs are enabled, public Markdown documentation is
+mounted read-only at `/workspace/docs`. Files come from the repository `docs/`
+directory at compile time and do not create per-session database rows.
+
+## See also
+
+- [Platform Chat harness](/built-ins/harnesses/platform-chat/)
+- [MCP](/features/mcp/)
+- [Agent Triggers](/features/agent-triggers/)
+- [Platform Management](/capabilities/platform-management/) — legacy
+  handwritten compatibility capability

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -62,5 +62,5 @@ Use the generic `session_tasks` tools to monitor and steer subagents after spawn
 - [`knowledge/runtime-resources/session-tasks.md`](https://github.com/everruns/everruns/blob/main/knowledge/runtime-resources/session-tasks.md) — generic task monitoring and control (`list_tasks`, `get_task`, `message_task`, `cancel_task`, `wait_task`)
 - [GitHub Scout](/capabilities/github-scout/) — blueprint-only GitHub repository exploration
 - [Session](/capabilities/session/) — session metadata and lifecycle
-- [Platform Management](/capabilities/platform-management/) — agent and platform configuration
+- [Platform](/capabilities/platform/) — agent and platform configuration
 - [Capabilities Overview](/capabilities/) — full list of available capabilities

--- a/knowledge/execution/capabilities.md
+++ b/knowledge/execution/capabilities.md
@@ -1092,11 +1092,50 @@ See `crates/core/src/capabilities/sample_data.rs` for a concrete example of `mou
 - **Icon**: "database"
 - **Category**: "Data"
 
-#### PlatformManagement
+#### Platform
+
+- **Status**: Available
+- **ID**: `platform`
+- **Purpose**: Expose the registered Everruns command catalog to an agent through
+  the same `discover`, `query`, and `execute` contract as the `/mcp` endpoint.
+- **Risk**: High. Assignment follows the admin-only capability gate; command
+  execution also applies the resolved session owner's normal command policy.
+- **Tools**:
+  - `discover` searches authoritative command metadata and schemas.
+  - `query` runs bounded Bashkit scripts with read-only commands only.
+  - `execute` runs bounded Bashkit scripts with the full scriptable catalog.
+- **Scope**: Tool schemas never accept `organization_id`. The in-process adapter
+  is bound to the session owner and org. The distributed adapter sends the
+  session and org to the server, which reloads the session, resolves its owner,
+  and constructs the authenticated command context. The worker cannot nominate
+  a user or elevate the caller.
+- **Command contract**: MCP and capability adapters share catalog search,
+  positional rewriting, script limits, output formatting, and safe error
+  classification in `crates/server/src/services/platform_command_surface.rs`.
+  Registered domain commands remain the source of truth and execute through
+  `Command::run`.
+- **Mounts**: `/docs` — Everruns public documentation (virtual, readonly). The
+  stored/normalized mount path is `/docs`; agents/tools access it as
+  `/workspace/docs`. Markdown files (`.md`, `.mdx`) from the repository `docs/`
+  directory are embedded at compile time.
+
+The built-in `platform-chat` harness uses `platform`. Its prompt tells the model
+to discover unknown operations, inspect with `query`, mutate only when requested
+with `execute`, and validate afterward. Recurring autonomous work is represented
+by an Agent plus an Agent Trigger; Platform Chat must not schedule its own
+session.
+
+The surface deliberately provides commands, not a persisted provisioning plan.
+Models compose the authoritative operations directly. Multi-command `execute`
+scripts are not transactional: callers must inspect state after a partial
+failure and avoid blindly repeating mutations.
+
+#### PlatformManagement (compatibility)
 
 - **Status**: Available
 - **ID**: `platform_management`
-- **Purpose**: Programmatic management of Everruns entities (harnesses, agents, sessions) via tool calls
+- **Purpose**: Legacy handwritten management tools retained for compatibility
+  with existing custom agents and harnesses. New built-ins use `platform`.
 - **System Prompt**: Describes available management tools, common workflows, and platform docs availability
 - **Mounts**: `/docs` — Everruns platform documentation (virtual, readonly). The stored/normalized mount path is `/docs`; agents/tools access it as `/workspace/docs`. Embedded at compile time via `include_dir!` from the repo `docs/` directory. Only markdown files (`.md`, `.mdx`) are included in the virtual tree.
 - **Lifecycle Parity**: Must enforce the same archive/delete, assignment, and read-only rules as the public API and UI. Agents using these tools may not bypass lifecycle restrictions.
@@ -1130,7 +1169,10 @@ The `PlatformStore` trait (in `everruns-core`) defines the org-scoped management
 
 ##### Design Decision: Authorization Happens In Tool Execution, Not Harness Removal
 
-`platform_management` remains assigned to the built-in `platform-chat` harness. Authorization must be enforced when platform tools execute, using the session owner's caller context plus the active `PermissionResolver`. Do not "fix" permission bugs by stripping the capability from Platform Chat; that removes the feature instead of fixing the broken auth boundary.
+Both `platform` and compatibility `platform_management` tools must enforce
+authorization using the session owner's caller context plus the active
+`PermissionResolver`. Do not fix permission bugs by removing platform access
+from Platform Chat; repair the execution boundary instead.
 
 ### Experimental Capabilities
 

--- a/knowledge/foundations/domains.md
+++ b/knowledge/foundations/domains.md
@@ -29,8 +29,10 @@ operation the unit of reuse and registration.
 - [`crates/server/src/api/dispatch.rs`](../../crates/server/src/api/dispatch.rs)
   owns the HTTP adapter chokepoint.
 - [`crates/server/src/api/mcp_endpoint/catalog.rs`](../../crates/server/src/api/mcp_endpoint/catalog.rs)
-  owns MCP discovery, scripted-tool schema adaptation, and dispatch error
-  formatting.
+  owns scripted-tool schema adaptation and safe dispatch error formatting.
+- [`crates/server/src/services/platform_command_surface.rs`](../../crates/server/src/services/platform_command_surface.rs)
+  owns transport-neutral catalog discovery and bounded `query`/`execute`
+  behavior shared by MCP and the built-in `platform` capability.
 - [`crates/internal-protocol/proto/`](../../crates/internal-protocol/proto) owns
   exact gRPC messages.
 - [`crates/server/tests/command_policy_enforcement_test.rs`](../../crates/server/tests/command_policy_enforcement_test.rs)
@@ -117,6 +119,11 @@ migrated.
 
 The source registry is authoritative for current commands. Do not maintain a
 parallel catalog.
+
+The `/mcp` endpoint and `platform` capability are adapters over the same command
+surface. MCP may accept an organization selector because it is a stateless
+external protocol. The capability must not: its organization and caller are
+re-established from the active session by the server.
 
 ## Errors
 

--- a/knowledge/harnesses/harness-types.md
+++ b/knowledge/harnesses/harness-types.md
@@ -99,7 +99,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 
 ### Platform Chat
 
-Conversational harness for the global chat interface. Inherits Generic capabilities, adds `platform_management`, and is tagged separately to support the per-user singleton session pattern.
+Conversational harness for the global chat interface. Inherits Generic capabilities, adds `platform`, and is tagged separately to support the per-user singleton session pattern.
 
 | Property | Value |
 |----------|-------|
@@ -109,12 +109,16 @@ Conversational harness for the global chat interface. Inherits Generic capabilit
 | System Prompt | See `crates/server/src/harnesses/platform_chat.rs` for full prompt |
 | Tags | `chat`, `built-in` |
 
-**Effective capabilities:** Inherits Generic harness capabilities and adds local `platform_management`.
+**Effective capabilities:** Inherits Generic harness capabilities and adds local `platform`.
 
-**Authorization rule:** Do not remove `platform_management` from Platform Chat to paper over authorization bugs. Platform tools must enforce the session owner's permissions at execution time via the normal command/policy path.
+**Authorization rule:** Do not remove `platform` from Platform Chat to paper over authorization bugs. Platform tools must reload the session owner and enforce that caller's permissions via the normal command/policy path.
 
 **System prompt guidance includes:**
 - "Run agent" workflow: create session → send message → wait for idle → get results
+- Catalog workflow: `discover` unknown commands → `query` state → `execute`
+  requested changes → `query` final state
+- Recurring autonomous workflow: create an Agent Trigger; never schedule the
+  Platform Chat session itself
 - Prefer built-in Generic harness over creating new ones
 - Confirm before creating harnesses or agents; use common sense for sessions
 

--- a/knowledge/integrations/mcp.md
+++ b/knowledge/integrations/mcp.md
@@ -188,6 +188,13 @@ the `handle_tools_call` augmentation).
 
 ## Architecture
 
+The Tier-2 `discover`, `query`, and `execute` tools share their catalog search,
+Bashkit execution, positional rewriting, limits, and output/error formatting
+with the built-in `platform` capability. The shared implementation is
+`crates/server/src/services/platform_command_surface.rs`; MCP authentication and
+organization selection remain endpoint-adapter concerns. This prevents the
+agent-facing platform catalog from drifting from `/mcp`.
+
 ### Crate Map
 
 | Crate | Module | Responsibility |

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,11 @@
 
 ## 2026-08-06
 
+* **Platform command surface**: Added the high-risk built-in `platform`
+  capability with MCP-parity `discover`, read-only `query`, and mutating
+  `execute` tools. Platform Chat now uses the shared command inventory, and the
+  worker transport re-establishes the session owner's authorization server-side.
+
 * **Main synchronization**: Migrated the newly landed Sans-IO turn-state and WebMCP
   specifications into the OKF bundle and incorporated their feature-flag and threat-model updates.
 * **Migration**: Moved the canonical `specs/` corpus into an OKF v0.2 bundle under

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -790,15 +790,15 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-006 | Cost runaway — unbounded LLM calls | High | Max iterations per turn (default 100); configurable per agent | MITIGATED |
 | TM-AGENT-007 | Cost runaway — many tools per iteration | Medium | No per-iteration tool call limit; agent can invoke many tools in a single LLM response | **OPEN** |
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
-| TM-AGENT-009 | Agent self-modification | Medium | Agents with `platform_management` capability can modify agents/sessions via tools; capability must be explicitly assigned; org-scoped | **OPEN** |
-| TM-AGENT-010 | Agent spawning agent chains | Medium | Agents with `platform_management` capability can create agents/sessions; capability must be explicitly assigned; no recursive depth limit | **OPEN** |
+| TM-AGENT-009 | Agent self-modification | Medium | Agents with `platform` or legacy `platform_management` can modify agents/sessions via tools; each capability must be explicitly assigned and is org-scoped | **OPEN** |
+| TM-AGENT-010 | Agent spawning agent chains | Medium | Agents with `platform` or legacy `platform_management` can create agents/sessions; each capability must be explicitly assigned; no recursive depth limit | **OPEN** |
 | TM-AGENT-011 | Sensitive data in system prompt | Medium | PII must not be placed in system prompts; no encryption at rest for prompts | **OPEN** |
 | TM-AGENT-012 | Tool result size amplification | Medium | 64 KiB hard limit on tool results via `OutputHardLimitHook` (EVE-225); always-on final hook in ActAtom | MITIGATED |
 | TM-AGENT-013 | Exfiltration via web_fetch | Medium | Agent with web_fetch capability can send session data to arbitrary URLs | **ACCEPTED** |
 | TM-AGENT-014 | Confused deputy — tool call with wrong session | Low | Tool context includes session_id; tools scoped to active session only | MITIGATED |
 | TM-AGENT-015 | Dangling tool calls cause LLM confusion | Low | Patched with synthetic "cancelled" results before LLM call; prevents API errors | MITIGATED |
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | When agent asks user for API key in chat, plaintext value stored in events table as message content; session secrets encrypt separately but chat retains plaintext | **OPEN** |
-| TM-AGENT-017 | Agent-initiated entity management | High | Agents with `platform_management` can create/update/delete harnesses, agents, sessions org-wide; no fine-grained RBAC within org; capability must be explicitly assigned | **OPEN** |
+| TM-AGENT-017 | Agent-initiated entity management | High | `platform` exposes the full scriptable command catalog and legacy `platform_management` exposes a smaller handwritten subset. Both are high-risk and explicitly assigned. Each call uses the session owner's real caller and active permission resolver; the distributed adapter reloads the org-scoped session and never accepts a worker-supplied user identity. No fine-grained ownership RBAC exists within commands the caller is otherwise allowed to use. | **OPEN** |
 | TM-AGENT-018 | Outbound URL filtering on web_fetch | Medium | Per-layer `NetworkAccessList` (harness ∩ agent ∩ session, narrow-only merge) plus optional deployment-wide system allowlist, both enforced at the `EgressService` boundary; web_fetch routes through egress with per-redirect-hop re-validation | MITIGATED |
 | TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High | `daytona` and `e2b` provide full network access by design; `docker_container` uses host networking in dev mode; all rely on Admin-only assignment plus infrastructure egress isolation | **ACCEPTED** |
 | TM-AGENT-020 | Cross-session resource reuse via stale or guessed external IDs | Critical | Provider-owned resource IDs are checked against the active session's leased-resource/session-resource ownership before tool execution; raw sandbox list endpoints are filtered to owned IDs only | MITIGATED |
@@ -869,12 +869,16 @@ When an agent tool (e.g., Daytona) doesn't find an API key, it may instruct the 
 - **Priority:** High
 
 **TM-AGENT-017 — Agent-Initiated Entity Management (OPEN):**
-Agents with the `platform_management` capability can create, update, and delete harnesses, agents, and sessions within their organization. They can also send messages to any session and read responses.
+Agents with the `platform` capability can invoke every command exposed to the
+scripted platform catalog; the legacy `platform_management` capability exposes
+a smaller handwritten set. Depending on caller permissions, this includes
+creating, updating, and deleting platform entities and interacting with
+sessions.
 
 - **Impact:** An agent could escalate privileges by creating a new agent with dangerous capabilities, modify other agents' system prompts, or spawn session chains. No fine-grained RBAC exists within the org scope.
-- **Current mitigations:** (1) Capability must be explicitly assigned by an org member. (2) All operations are org-scoped — cross-org access blocked by tenant isolation (TM-TENANT-001). (3) Platform tool execution resolves the owning session's user into a real `Caller` and evaluates command policy with the active `PermissionResolver`, so member-owned Platform Chat sessions do not inherit internal/owner bypass. (4) Both in-process (`DirectPlatformStore`) and gRPC (`ExecuteCommand`) platform paths route mutating operations through the normal command/policy boundary instead of raw storage writes. (5) `WorkerAdapters::platform_store(org_id, session_id)` receives the session's actual org_id and session_id from activity context, preventing cross-org access via hardcoded defaults and preserving session-owner authorization.
+- **Current mitigations:** (1) Capability is high-risk and must be explicitly assigned by an authorized org member. (2) All operations are org-scoped — cross-org access is blocked by tenant isolation (TM-TENANT-001), and Platform tool schemas reject `organization_id`. (3) Platform execution resolves the owning session's user into a real `Caller` and evaluates every registered command through `Command::run` with the active `PermissionResolver`, so member-owned Platform Chat sessions do not inherit internal/owner bypass. (4) The in-process adapter uses its owner-bound command context. The dedicated gRPC command-surface RPC reloads the session from the requested org and resolves its persisted owner server-side; it never accepts a worker-supplied user identity. (5) Bashkit bounds commands, loops, input, AST depth, and timeout; read-only `query` omits mutating and open-world commands. (6) Internal command details are logged but redacted from tool errors.
 - **Recommendation:** Add audit logging for all platform management tool calls. Consider RBAC (e.g., "can only manage own sessions") and approval workflows for dangerous operations (creating agents with `bashkit_shell`). Add recursion depth limits for agent-spawned session chains.
-- **Code:** `// THREAT[TM-AGENT-017]` at `PlatformManagementCapability` registration and `DirectPlatformStore` implementation.
+- **Code:** `// THREAT[TM-AGENT-017]` at the Platform capability registration, direct adapter, and worker RPC authorization boundary.
 - **Priority:** High
 
 **TM-AGENT-018 — Outbound URL Filtering on web_fetch (MITIGATED):**

--- a/proposals/platform-capability.md
+++ b/proposals/platform-capability.md
@@ -1,0 +1,410 @@
+# Proposal: Platform capability backed by the Everruns command surface
+
+Status: implemented command surface. Agent-scoped credential binding and
+runtime-loop hardening remain separate follow-ups. Follow-up to
+[`platform-chat-yolop-parity-investigation.md`](platform-chat-yolop-parity-investigation.md).
+Validated against `origin/main` at `afe3a8ea6ffe9d09cc3cea4bb0971c090b0eca20`.
+
+## Decision
+
+Add a built-in `platform` capability that exposes the same catalog-backed
+management interface as the Everruns MCP endpoint:
+
+- `discover`
+- `query`
+- `execute`
+
+The model discovers authoritative command names and schemas, uses `query` for
+read-only inspection, and uses `execute` for mutations. There is no
+intermediate workflow state or growing collection of bespoke Platform Chat
+CRUD tools.
+
+Both surfaces must share one implementation:
+
+```text
+Everruns MCP ───────┐
+                    ├─> command catalog + ScriptedTool + Command::run
+Platform capability ┘
+```
+
+The command inventory is already the source of truth for operations such as
+`list_models`, `create_mcp_server`, `create_agent`, and
+`create_agent_trigger`. Exposing that inventory to Platform Chat solves the
+surface drift that caused the incident.
+
+## Why this is enough
+
+The existing domain commands already own the behavior Platform Chat was
+missing:
+
+- model listing and lookup;
+- MCP server CRUD and tool refresh;
+- Agent creation with `default_model_id`, harness, capabilities, and scoped MCP
+  configuration;
+- Agent Trigger CRUD and manual invocation;
+- plugin, capability, App, session, and other platform operations.
+
+The current `platform_management` capability re-expresses a small subset of
+those commands through handwritten tools and a separate `PlatformStore` trait.
+That adapter has drifted: for example, its Agent tool omits the model field and
+advertises a capability update it cannot execute. The MCP command surface does
+not have that problem because `discover`, `query`, and `execute` are generated
+from the registered domain-command inventory.
+
+Smart models can compose these primitives directly. Everruns should provide
+accurate schemas, authorization, safe execution, and bounded errors—not a
+second orchestration layer.
+
+## Tool contract
+
+### `discover`
+
+Same behavior as Everruns MCP `discover`:
+
+- search the registered command catalog by name, category, description, and
+  schema terms;
+- return matching commands with input/output schemas and output-shape hints;
+- support listing the complete catalog when explicitly requested;
+- describe whether each operation is read-only or mutating;
+- return only commands exposed to the scripted platform surface.
+
+This is how Platform Chat learns that the correct operations are
+`list_models`, `create_agent`, `create_mcp_server`, and
+`create_agent_trigger`. It never guesses `read_models` again.
+
+### `query`
+
+Same behavior as Everruns MCP `query`:
+
+- run a bounded Bashkit script;
+- expose only inventory commands classified as read-only;
+- support variables, pipes, conditionals, loops, and `jq`;
+- preserve the existing exclusions for nominally read-only commands with
+  outbound or other side effects;
+- return the same formatted output and sanitized errors.
+
+One `query` call can inspect models, existing MCP servers, Agents, capabilities,
+and Triggers without repeatedly calling separate list tools.
+
+### `execute`
+
+Same behavior as Everruns MCP `execute`:
+
+- run a bounded Bashkit script with the full scriptable command catalog;
+- dispatch every builtin through the registered domain command;
+- call `Command::run`, never `Command::execute` directly;
+- preserve command validation, active `PermissionResolver`, auditing,
+  resource limits, error classification, and response decoration;
+- support multi-command scripts so the model can create related resources in
+  dependency order and then validate them.
+
+`execute` is not atomic. If command three fails after commands one and two
+succeed, the result must make that partial state clear. Platform Chat reads the
+state with `query`, reuses existing resources, and reports honest links rather
+than blindly retrying creation.
+
+## Shared implementation
+
+Today the reusable behavior is located under
+`crates/server/src/api/mcp_endpoint/`:
+
+- `catalog.rs` builds the Bashkit toolset from `CommandDescriptor` inventory;
+- `positional.rs` adapts scripted positional arguments;
+- `mod.rs::{tool_discover,tool_query,tool_execute}` owns the Tier-2 execution
+  path;
+- `tool_registry.rs` owns the MCP tool definitions.
+
+Move the transport-neutral Tier-2 behavior into a shared server component,
+tentatively `platform_command_surface`:
+
+- catalog search and schema shaping;
+- read-only/full `ScriptedTool` construction;
+- positional and aggregate-argument rewriting;
+- script limits and timeout enforcement;
+- result decoration and sanitized error formatting;
+- `discover`, `query`, and `execute` entrypoints over an authenticated command
+  context.
+
+The HTTP MCP endpoint becomes one adapter to this component. The `platform`
+capability becomes another. Do not copy the catalog, schemas, allowlists,
+positional rewriting, or error classifier.
+
+### Runtime service seam
+
+The capability runs inside the worker/runtime while the command inventory and
+authorized domain context live on the server. The existing `PlatformStore`
+runtime service owns the three transport-neutral methods:
+
+```text
+PlatformCommandSurface
+  discover(arguments) -> structured catalog result
+  query(script, timeout) -> result
+  execute(script, timeout) -> result
+```
+
+Exact Rust types belong in source. The important contract is that the service
+is already bound to the current Platform Chat session's org and caller; the
+model cannot provide either.
+
+Do not reuse `CommandHost`: that service handles capability slash commands and
+out-of-band LLM completions, not authenticated domain-command dispatch.
+
+- The in-process adapter calls the shared server component directly.
+- The distributed worker adapter uses an internal RPC that forwards the
+  operation and owning session ID to the server.
+- The server reloads the session, resolves its effective human owner, builds
+  the real `Caller`, and applies the active `PermissionResolver`.
+- The RPC must not use `Caller::internal` for user-initiated Platform Chat
+  execution.
+
+This follows the authorization pattern already enforced by
+`DirectPlatformStore`, but avoids extending its domain-by-domain CRUD methods.
+
+### Tool definitions
+
+Extract neutral definitions for `discover`, `query`, and `execute` so the MCP
+adapter and Capability registry derive from the same owners. MCP protocol
+version decoration (`title`, `outputSchema`, annotations) remains an adapter
+concern; the operation names, descriptions, input constraints, and execution
+limits do not fork.
+
+Add a parity test that compares the MCP and Platform definitions after removing
+only transport-specific fields.
+
+Remote MCP tool names are server-prefixed, so they do not collide with these
+built-ins. General duplicate built-in tool rejection is a registry-wide concern
+and is not part of this change.
+
+## Scope and organization behavior
+
+Everruns MCP accepts `organization_id` because an external, stateless MCP client
+can belong to multiple orgs and has no current-org session. Platform Chat
+already runs inside one org-scoped session.
+
+Therefore the Platform tools use the same methods and command surface but are
+strictly bound to the session org:
+
+- `organization_id` is omitted from Platform tool schemas;
+- an injected org override is rejected;
+- every command context uses the session org and session owner's caller;
+- entity IDs are still revalidated under that org.
+
+This is the only intentional semantic difference from the MCP Tier-2 tools. It
+prevents a prompt-injected Platform Chat turn from using the worker boundary as
+a cross-org switch.
+
+## Capability lifecycle
+
+Introduce built-in capability ID `platform` for the built-in Platform Chat
+harness and the existing seeded Platform Manager Agent.
+
+Migration:
+
+1. Register `platform` alongside the existing `platform_management` capability.
+2. Switch Platform Chat and the seeded Platform Manager Agent to `platform` and
+   update their prompts.
+3. Keep `platform_management` available temporarily for embedded users and
+   compatibility tests.
+4. Remove or deprecate the handwritten capability after parity and migration
+   coverage prove no required Tier-1 behavior is lost.
+
+The existing MCP convenience tools such as `agent_run`,
+`session_send_message`, and `session_get_status` are not duplicated in the
+first Platform capability version. Their underlying session/Agent commands are
+available through `discover/query/execute`. If a hot path later needs a
+dedicated tool, it should wrap the same command and be justified by measured
+latency or model reliability.
+
+## Platform Chat workflow
+
+Update `crates/server/src/harnesses/platform_chat.rs::SYSTEM_PROMPT` to describe
+three rules, without copying command schemas:
+
+1. Use `discover` when the command name or schema is unknown.
+2. Use `query` for inspection and validation.
+3. Use `execute` only for requested mutations, then validate with `query`.
+
+For the dad-joke request, the model should use the surface in this order:
+
+1. discover the model, MCP server, Agent, and Agent Trigger operations;
+2. query the model catalog and existing Visti/MCP/Agent state;
+3. confirm the requested reusable mutations once;
+4. execute the necessary MCP server and Agent commands in dependency order;
+5. configure the Agent-owned credential through the secure path described
+   below;
+6. execute the Agent Trigger command last;
+7. query the final Agent and Trigger state;
+8. return entity links and no internal narration.
+
+The model must use an Agent Trigger for autonomous work, never a Session
+Schedule on Platform Chat.
+
+## Credential boundary
+
+`discover/query/execute` solve platform discovery and mutations, but they must
+not carry secret values supplied through chat. The Visti channel key is a tool
+argument, not standard MCP bearer authentication, and future trigger sessions
+cannot read Platform Chat's session `secret_store`.
+
+This change intentionally does not add a credential tool. A follow-up should
+add one host-interactive tool alongside the three shared methods:
+
+- `request_agent_credential`
+
+It accepts the target Agent, MCP server, tool, argument path, label, and purpose
+but no value. The authenticated UI shows the exact destination and sends the
+secret directly to a credential endpoint. The tool returns only configured or
+cancelled plus an opaque binding ID.
+
+The stored binding is Agent-identity-owned. At MCP tool assembly/execution the
+runtime removes the bound argument from the model-visible schema, rejects a
+model override, decrypts and injects the value immediately before the outbound
+call, and redacts known-value echoes before persistence. Wrong Agent, principal,
+tool, endpoint, schema, or revoked credentials fail closed.
+
+This tool is intentionally Platform-host-specific and is not forced into the
+public Everruns MCP interface. An MCP client without the authenticated Everruns
+UI cannot safely service the prompt; it receives a link to the normal Agent
+credential page instead.
+
+If the user already pasted a key into chat, Platform Chat must refuse to reuse
+it and ask for rotation plus secure re-entry.
+
+## Security and authorization
+
+The `platform` capability is high impact: `execute` exposes every scriptable
+mutation allowed to the caller. Preserve these boundaries:
+
+- capability assigned by default only to the Platform Chat harness and seeded
+  Platform Manager Agent;
+- session owner, org, and custom permission resolver re-established server-side
+  for every call;
+- each builtin dispatched through `Command::run`;
+- read-only `query` catalog generated from authoritative command metadata plus
+  the current side-effect exclusions;
+- Bashkit command, loop, AST, input, output, and timeout limits identical to
+  Everruns MCP;
+- internal errors sanitized before reaching the model;
+- `execute` declared mutating/open-world so narration and any future tool
+  approval treat it accordingly;
+- scripts and command names recorded for audit, with secret values prohibited
+  and redacted;
+- no cross-org override and no internal-caller authorization bypass.
+
+`execute` can batch several mutations. Domain policy still evaluates per
+command, so a script stops at the unauthorized command without broadening the
+caller's grants.
+
+## Runtime and cost controls
+
+The generic surface greatly reduces tool count, but retain incident hardening:
+
+- enable `progress_guard` for Platform Chat;
+- enable `prompt_caching` after Anthropic trace coverage;
+- set a Platform Chat-specific iteration/tool/cost ceiling below Generic's
+  500-iteration default;
+- treat repeated identical `discover`/`query` scripts and unchanged results as
+  no progress;
+- instruct the model to run one decisive validation query rather than repeated
+  catalog scans;
+- keep final output separate from commentary through prompt/eval coverage.
+
+## Target end-to-end scenario after the credential follow-up
+
+Given an authorized user and no Visti MCP server:
+
+1. `discover` returns the real schemas for the necessary registered commands.
+2. `query` finds the exact GPT-5.6 Terra model and confirms Visti/Agent/Trigger
+   do not already exist.
+3. Platform Chat asks once for the requested shared mutations.
+4. `execute` registers `https://visti.sh/mcp` and creates the Agent with the
+   exact model and returned MCP virtual capability.
+5. `request_agent_credential` securely binds the rotated channel key to that
+   Agent's `visti_send.channel_key` destination without exposing the value.
+6. `execute` creates the hourly `session_per_invocation` Agent Trigger.
+7. `query` verifies the Agent model/capability and enabled Trigger.
+8. The final answer links the resources and contains no internal narration.
+9. No notification is sent until the Trigger fires or the user explicitly
+   invokes the existing manual-trigger command.
+
+No `read_models` guess, repeated capability search, Bash networking workaround,
+Platform Chat Session Schedule, or cross-session secret copy occurs.
+
+## Tests
+
+### Shared-surface parity
+
+- MCP and Platform `discover/query/execute` definitions match after documented
+  transport-specific fields are removed;
+- both adapters return the same catalog entries, output shapes, positional
+  rewriting, structured parameters, decorations, and sanitized errors;
+- every inventory command appears or is excluded identically;
+- read-only exclusions remain identical;
+- catalog/schema-hash changes invalidate both surfaces together.
+- duplicate built-in tool names fail capability assembly deterministically.
+
+### Authorization and isolation
+
+- Platform calls execute as the session owner under default and custom
+  `PermissionResolver` implementations;
+- member/admin distinctions match HTTP and MCP command execution;
+- `organization_id` is absent and injection is rejected;
+- cross-org entity IDs fail;
+- distributed RPC cannot select `Caller::internal`;
+- a multi-command execute script stops on the first denied command and does not
+  run later statements when fail-fast shell behavior is requested.
+
+### Script execution
+
+- query exposes only read-only builtins;
+- execute exposes the full scriptable catalog;
+- time, command, loop, AST, input, and output limits match MCP;
+- partial mutation output is preserved and actionable;
+- model/MCP/Agent/Trigger commands work through the generic catalog without
+  bespoke Platform tools.
+
+### Credential and end to end (follow-up)
+
+- secret value is absent from chat, tool calls/results, events, logs, traces,
+  audit payloads, and ATIF export;
+- mock Visti receives the injected value while the model-visible tool schema
+  omits it;
+- wrong-Agent, override, revocation, and schema-drift cases fail closed;
+- the full Terra + Visti + Agent Trigger flow completes in a bounded number of
+  model iterations and produces one clean final answer;
+- the scheduled session runs the created Agent, not Platform Chat.
+
+## Delivered boundary
+
+This implementation combines the three inseparable command-surface layers in
+one PR: shared MCP execution, direct/distributed runtime adapters, and the
+capability that consumes them. Splitting them would leave dead transport APIs
+or a capability that cannot execute.
+
+Separate follow-up PRs:
+
+1. **Add Agent credential binding.** Secure UI prompt, Agent-identity encrypted
+   credential, MCP argument schema rewrite/injection/redaction, and threat-model
+   tests.
+2. **Land the Visti eval and hardening.** Full autonomous-Agent scenario,
+   progress guard, prompt caching traces, Platform ceilings, and output-quality
+   evals.
+
+The credential PR is the only new secret-handling architecture. The generic
+Platform capability removes the need for separate model, MCP, Agent, plugin,
+and Trigger tool PRs.
+
+## Success criteria
+
+- Platform Chat manages the full command inventory through the same
+  `discover/query/execute` behavior as Everruns MCP.
+- A newly registered domain command becomes available to both surfaces without
+  another Platform adapter change.
+- The Terra + hourly Agent request can discover and create the correct model,
+  Agent, MCP, and Trigger resources without guessed tools or a second
+  orchestration subsystem. Visti credential injection remains gated on the
+  separate Agent-scoped credential follow-up.
+- Domain permissions and org isolation match HTTP/MCP behavior.
+- No credential byte enters model-visible or persisted conversation data.
+- `platform_management` can be deprecated after compatibility coverage, ending
+  the handwritten adapter drift.

--- a/proposals/platform-chat-yolop-parity-investigation.md
+++ b/proposals/platform-chat-yolop-parity-investigation.md
@@ -1,0 +1,437 @@
+# Investigation: failed Platform Chat autonomous-agent provisioning
+
+Status: evidence-backed investigation and PR plan. This is intentionally not a
+port of Yolop. The incident crosses independent control-plane, credential,
+scheduling, and runtime-control boundaries, so no single safe PR-sized root fix
+exists.
+
+## Baselines and primary evidence
+
+The source baselines were fetched before analysis:
+
+- Everruns `origin/main`: `afe3a8ea6ffe9d09cc3cea4bb0971c090b0eca20`
+  (`docs(guardrails): add capability page and refresh gallery blurb (#2979)`).
+  The findings and proposal were revalidated after the intervening changes; the
+  command and Platform Chat behavior described below is unchanged.
+- Yolop `origin/main`: `ab206f533965a270d996493937d3efbdee990ee7`
+  (`refactor(runtime): adopt everruns 0.17.23 primitives (#544)`).
+
+The primary trace is Everruns session
+`session_019fd99697c5728285b44ddc10b51df8`, turn
+`turn_019fd9c9c1ea75d3a6aeb6c8f9890783`, from
+2026-08-07 01:15:06Z through 01:22:39Z. `turn.completed` records:
+
+| Signal | Value |
+|---|---:|
+| Iterations / LLM calls | 30 |
+| Tool calls | 42 |
+| Duration | 454,454 ms |
+| Input / output tokens | 510,197 / 23,434 |
+| Cache read / creation tokens | 0 / 0 |
+| Effective cost | $3.136835 |
+
+The tool sequence was Bash 22, `read_capabilities` 11, `read_file` 3,
+`secret_store` 2, and one each of `web_fetch`, nonexistent `read_models`,
+`read_harnesses`, and `grep_files`. Every generation used Anthropic
+`claude-opus-5`; hosted tool search was enabled at threshold 15. The trace's
+35-tool catalog never contained `read_models`.
+
+The turn's facts reproduce the reported failure:
+
+- sequence 445: `read_models` failed with `Tool definition not found:
+  read_models`;
+- sequences 669 and 680: the first `secret_store` used `key` and failed because
+  `name` is required, then the retry succeeded;
+- sequence 695: Bash networking failed because the `http_client` feature and
+  URL allowlist were not configured;
+- the final provider completion itself began with internal narration before the
+  user-facing answer. This was one `stop` completion, not UI concatenation of a
+  reason-phase message;
+- the live model API returned model row
+  `model_01933b5a000070008000000000000227`, `model_id = gpt-5.6-terra`, display
+  name `GPT-5.6 Terra`, provider OpenAI.
+
+No credential value is reproduced in this document.
+
+## Executive diagnosis
+
+Platform Chat was asked to provision one durable autonomous workflow, but its
+model-visible management API can only create a partial agent. It cannot discover
+models, set `default_model_id`, discover/install/attach MCP or plugins, bind a
+credential to the future execution principal, or create an agent-owned trigger.
+The model repeatedly searched a capability catalog that cannot contain those
+operations, guessed `read_models`, and eventually stored the credential in the
+wrong session before giving up.
+
+Runtime controls amplified the product-surface failure. Literal loop detection
+was present, but the newer semantic progress guard was not enabled. Anthropic
+prompt-cache support existed but the harness did not opt in. Cumulative-cost
+compaction existed, but durable provider compaction is unavailable on this
+driver; masking bounded individual requests without avoiding 30 uncached prompt
+replays. The default per-turn ceiling is 500 iterations, so 30 iterations was
+not close to a hard stop.
+
+Yolop solves adjacent parts with conversational model tools, always-on prompt
+caching, a persistent progress guard, mutable MCP/extension configuration, and
+out-of-band secret prompts. Its local, single-user trust model is materially
+different. The MCP and secret mechanisms cannot be copied into a hosted,
+multi-tenant control plane.
+
+## Pipeline findings
+
+### 1. Platform Chat prompt and planning
+
+**Classification: genuinely missing workflow contract; no proven historical
+regression.**
+
+`crates/server/src/harnesses/platform_chat.rs::definition` inherits `generic`
+and adds only `platform_management`. Its `SYSTEM_PROMPT` explains entity links,
+running an existing agent, generic harness reuse, and creation confirmations.
+It says nothing about model resolution, integration provisioning, credential
+scope, agent triggers, progress checkpoints, or keeping internal narration out
+of the final answer.
+
+Yolop's `src/runtime/system.md` is shorter but has explicit workflow and output
+contracts: tool schemas are authoritative, hidden schemas are loaded through
+tool search, validation should be decisive, and output should lead with the
+result while hiding internal tool names. This reduces guessing but does not
+create absent tools.
+
+Recommendation: add a Platform Chat-specific provisioning contract only after
+the required tools exist. Add a trace/eval fixture for “create an hourly agent
+using model X and MCP Y” and assert one clean final answer. Prompt changes alone
+would merely fail earlier.
+
+### 2. Reason/act catalog, tool search, and invalid calls
+
+**Classification: catalog parity is working; unknown-tool repair is genuinely
+missing; Bash disclosure regression already fixed on latest main.**
+
+The incident's reason requests advertised the same registered tool names that
+act could execute. `read_models` was absent, then act failed closed at
+`crates/core/src/atoms/act.rs` with `Tool definition not found`. This is a model
+hallucination against an incomplete surface, not evidence that reason advertised
+a tool act lacked.
+
+`crates/core/src/capabilities/tool_search.rs` preserves the full registered
+schema behind deferred disclosure. `ToolCallRepair` only repairs malformed
+arguments; it does not map unknown names. Yolop latest has no host-level
+unknown-tool alias or semantic repair either; it also relies on exact dispatch.
+Its advantage is that `src/capabilities/host.rs::SearchModelsTool` actually
+exists and is named in `MODELS_PROMPT`.
+
+There is one real schema/execution parity bug inside the registered management
+surface: `ManageAgentsTool::parameters_schema` advertises `capabilities` for the
+shared create/update tool, but `manage_agents_impl` reads that field only in the
+`create` branch. The `update` branch and `PlatformStore::update_agent` silently
+have no capability parameter. An agent therefore cannot attach an already
+installed capability after creation even though the schema implies it can.
+
+Everruns commit `5c0325bf` (`fix(tools): keep bash schema loaded (#2959)`) landed
+after the incident. It makes Bash never deferrable and adds
+`test_anthropic_opus5_hosted_search_calls_bash_contract`, addressing Claude's
+observed tendency to invent `bash_run` or the wrong Bash arguments. Commit
+`a33bf3d4` (`fix(chat): summarize repeated tool activity (#2960)`) also landed
+afterward, but only improves activity narration; it does not stop semantic
+loops.
+
+Recommendation: retain exact fail-closed dispatch. Add a bounded “unknown tool;
+available close matches are …” result and count it as no progress. Do not
+silently alias mutating tools.
+
+### 3. Model discovery and agent model selection
+
+**Classification: provider search primitive already fixed; Platform Chat
+surface is genuinely missing and has drifted behind the public agent API.**
+
+The product model is already correct:
+
+- `crates/core/src/agent.rs::Agent` owns `default_model_id`;
+- `crates/server/src/domains/agents/types.rs::{CreateAgentRequest,
+  UpdateAgentRequest}` and `crates/server/src/api/agents.rs` accept
+  `default_model_id` and `mcpServers`;
+- `knowledge/foundations/models.md` and
+  `knowledge/integrations/model-router.md` define agent default and session
+  override behavior.
+
+The conversational adapter is not: `crates/core/src/capabilities/
+platform_management.rs::{ReadAgentsTool, ManageAgentsTool}` omits model and MCP
+fields, and `crates/core/src/platform_store.rs::PlatformStore::{create_agent,
+update_agent}` cannot carry them. There is no models tool.
+
+Commit `8dc932c1` (`feat(provider): search model catalogs across providers
+(#2961)`) landed after the incident and added
+`crates/provider/src/model_discovery.rs::{match_models,
+search_provider_models}`. It did not wire Platform Chat or agent management.
+
+Yolop commit `5b50b9b` (`feat(models): search provider catalogs
+conversationally (#540)`) supplies the host pattern:
+`src/capabilities/host.rs::{SearchModelsTool, SetModelTool}` calls
+`src/capabilities/model_discovery.rs` and resolves before applying. Everruns
+should reuse its own provider primitive, not Yolop host state.
+
+### 4. MCP/plugin discovery, installation, attachment, and configuration
+
+**Classification: backend already exists; Platform Chat surface genuinely
+missing; hosted/local differences intentional.**
+
+Everruns already has the control-plane primitives:
+
+- org MCP CRUD and encrypted API keys in
+  `crates/server/src/domains/mcp_servers/commands.rs`;
+- decrypt-at-use and redacted reads in
+  `crates/server/src/domains/mcp_servers/{service.rs,queries.rs}`;
+- scoped remote MCP resolution and SSRF checks in
+  `crates/server/src/domains/mcp_servers/scoped_mcp.rs` and
+  `knowledge/integrations/mcp-servers.md`;
+- plugin installation in `crates/server/src/domains/plugins/commands.rs`, with
+  `mcpServers` compilation in `crates/core/src/plugins/compiler.rs`.
+
+`PlatformManagementCapability::tools` exposes none of MCP-server search/CRUD,
+plugin search/install, or attachment. `ManageAgentsTool` cannot set
+`mcpServers`. Repeating `read_capabilities` could therefore never find Visti:
+MCP servers and plugins are not capability rows.
+
+Yolop `knowledge/specs/mcp.md` and `src/capabilities/mcp.rs` support global or
+workspace `.mcp.json`, environment expansion, authenticated server upsert, and
+live reload (commits `546df40` and `cfef0de`). That is appropriate for a local
+user controlling their workspace and process. Hosted Everruns intentionally
+supports remote HTTP MCP, validates outbound destinations, separates org
+permissions, and audits mutation. `knowledge/security/threat-model.md`
+TM-PLUGIN-001 through
+TM-PLUGIN-008 document the supply-chain, OAuth-confusion, and SSRF boundaries.
+
+Recommendation: expose read/search first. Keep plugin installation admin-gated
+and confirmation-gated. Route every mutation through existing commands and the
+session owner's caller; never add raw store writes or local stdio semantics.
+
+### 5. Secret lifecycle and target binding
+
+**Classification: session isolation and no model-visible plaintext transfer are
+intentional; a safe target-binding workflow is genuinely missing.**
+
+`secret_store` is session-scoped by contract
+(`knowledge/execution/capabilities.md`,
+SessionStorage). A credential written by Platform Chat cannot be read by a
+future agent session. This isolation is correct. Although
+`crates/server/src/domains/session_storage/commands.rs::BatchSetSessionSecrets`
+can address an owned target session through the authenticated API, Platform
+Chat has no such tool, and forwarding a value already present in model context
+would be a weak provisioning design.
+
+Org-managed MCP `api_key` is encrypted at rest, decrypted only during MCP use,
+and never returned. Scoped `mcpServers.headers`, however, are literal;
+`${ENV}` is intentionally not expanded. Persisting the Visti channel key there
+would put plaintext into agent-authored configuration. Moreover, the Visti
+contract observed in the incident passes `channel_key` as a `visti_send` tool
+argument, not necessarily as standard bearer authentication. A generic MCP
+header/API-key field is not automatically a compatible binding.
+
+Yolop's safer interaction pattern is in commit `c32e644`:
+`src/extensions/manage.rs::SetSecret` refuses an agent-supplied value and asks
+the UI out of band; `src/extensions/secrets.rs::{Secret,ExtensionSecrets}`
+redacts debug output and stores credentials separately; and
+`src/extensions/capability.rs` injects the value host-to-extension while
+stripping secret config. The test
+`set_extension_secret_refuses_agent_value_and_needs_a_prompt` locks this down.
+
+Recommendation: design a hosted equivalent that prompts the authenticated user
+outside model context, stores an encrypted typed credential, binds it to the
+specific MCP server plus agent (or execution identity), and injects it only on
+the server-to-MCP call path. It needs an adapter for argument-style credentials
+such as Visti or an explicit decision that such servers are unsupported. Do not
+add a general cross-session secret-copy tool as the primary UX.
+
+### 6. Agent versus session scheduling
+
+**Classification: durable agent scheduling already exists; conversational
+management is genuinely missing; Yolop scheduling is intentionally different.**
+
+The correct Everruns object is an agent-owned trigger. The contract is explicit
+in `crates/server/src/domains/agent_triggers/{mod.rs,commands.rs}`: a durable
+cron schedule wakes the agent on its own harness. `CreateAgentTrigger` and the
+routes in `crates/server/src/api/agent_triggers.rs` already support it, with cron
+validation, limits, policy enforcement, and run history tests in
+`domains/agent_triggers/tests.rs`.
+
+The inherited `create_schedule` tool in
+`crates/core/src/capabilities/session_schedule.rs` schedules a task in the
+current session. Used by Platform Chat, it would wake Platform Chat—not the new
+dad-joke agent. Platform management exposes no agent-trigger CRUD.
+
+Yolop's `knowledge/specs/background.md` schedules local session wakes and
+monitors. It does not model a reusable hosted agent plus durable control-plane
+trigger. That mechanism should not be ported.
+
+### 7. Loops, progress accounting, and budgets
+
+**Classification: semantic guard implementation already ported but not enabled;
+literal loop detector is intentionally narrow; completion gate exists but is
+not wired to this host; per-turn budget is too permissive for Platform Chat.**
+
+`crates/server/src/harnesses/generic.rs::definition` enables
+`loop_detection`, which catches identical batches/results/read ranges. Eleven
+similar searches with changing arguments/results need semantic state, so this
+incident stayed outside its contract.
+
+Commit `fa3da598` (`feat(capabilities): progress guard (#2930)`) ported Yolop's
+semantic guard into `crates/core/src/capabilities/progress_guard.rs`. It detects
+repeated exploration and unchanged observations, warns at 24 tool calls, and
+requests a checkpoint at 48. `knowledge/execution/capabilities.md`
+intentionally makes it
+opt-in, and Generic/Platform Chat do not enable it. Yolop latest registers
+`ProgressGuardCapability::open` in `src/runtime/mod.rs`; its history includes
+`639fcbc`, `a606aec`, `ea3b82c`, and `ada7967`.
+
+Everruns commit `eb3e1273` ported Yolop's cheap completion classifier and
+continuation budget to `crates/core/src/turn_completion.rs` (from Yolop commit
+`c54c85a`). Yolop latest commit `ab206f5` now removes its duplicate
+implementation: `src/session_state/task_completion.rs` re-exports Everruns'
+`CompletionState`, `GateDecision`, and `ContinuationBudget` while retaining
+host policy. A repository-wide Everruns call-site search finds only the core
+unit tests: no Everruns host calls `gate_turn` or `ContinuationBudget` yet. In
+any case it is an inter-turn continuation gate, not an in-turn semantic-loop
+breaker.
+
+`crates/core/src/runtime_agent.rs::default_max_iterations` is 500. The incident
+ended voluntarily at 30, not because a meaningful Platform Chat budget fired.
+`knowledge/security/threat-model.md` TM-AGENT-007 still marks the lack of a
+per-response tool
+call cap open.
+
+Recommendation: enable progress guard for Platform Chat first, with trace tests
+covering repeated catalog reads and unknown tools. Then set a Platform Chat
+iteration/tool budget and emit a structured “blocked with missing capability”
+checkpoint before cost balloons. Do not globally lower Generic's budget without
+long-running-agent data.
+
+### 8. Context growth, caching, compaction, and cost
+
+**Classification: Anthropic cache support and cumulative-cost compaction already
+exist; harness cache activation is genuinely missing; provider-native compaction
+difference is intentional.**
+
+Everruns has `crates/core/src/capabilities/prompt_caching.rs` and Anthropic
+`cache_control` support/tests in `crates/anthropic/src/driver.rs`. Generic does
+not include `prompt_caching`, so every incident generation recorded zero cache
+reads and creations. Yolop always registers `PromptCachingCapability::new()` in
+`src/runtime/mod.rs`.
+
+Commit `92fe74ea` (`feat(compaction): trigger checkpoints from cumulative cost
+(#2933)`) already added uncached cumulative-cost thresholds in
+`crates/core/src/capabilities/compaction.rs` and the reason atom. It corresponds
+to Yolop commit `54fe36d`. The incident trace shows no context-compaction event.
+The reason path only requests durable proactive compaction when the driver
+supports compact; Anthropic does not expose that provider-native operation.
+Older results were masked, bounding each individual prompt, but the growing
+conversation was still replayed uncached 30 times.
+
+Recommendation: enable `prompt_caching` on Generic/Platform Chat after an
+Anthropic trace regression test proves cache creation then cache reads across a
+tool loop. Keep cumulative-cost masking/compaction as a backstop, not a
+substitute. Add per-turn cumulative input/cost soft limits to Platform Chat.
+
+### 9. Final-answer separation
+
+**Classification: prompt/eval gap, not a reason/act transport regression.**
+
+The final narration and answer were emitted in one provider completion and
+stored as one final message. Everruns correctly separated phases; the model did
+not honor an absent output contract. Yolop's `src/runtime/system.md` explicitly
+constrains final output, and its continuation prompt asks for exactly one final
+answer. Neither codebase has a reliable semantic sanitizer for prose like “let
+me do a final check.”
+
+Recommendation: add an explicit Platform Chat output contract and regression
+eval. Avoid brittle prefix stripping, which can delete legitimate answers.
+
+### 10. Authorization constraints on any port
+
+**Classification: intentionally different and security-critical.**
+
+Platform management is model-triggered org mutation.
+`knowledge/harnesses/harness-types.md` and
+`knowledge/security/threat-model.md` TM-AGENT-017 require execution as the owning
+session's real caller, through the active permission resolver and command
+boundary. TM-AUTHZ-013 separates MCP/plugin permissions; plugin management
+remains admin-only. MCP/plugin installation additionally crosses external
+fetch, SSRF, OAuth-token selection, and prompt-injection boundaries.
+
+Yolop is a local, single-user application that may treat workspace-file edits
+and process environment as user consent. Everruns must preserve org scope,
+auditing, explicit confirmation, encrypted storage, redacted reads, and remote
+network policy. A direct port of `.mcp.json`, `${ENV}`, local stdio, or extension
+connection files would be unsafe.
+
+## Classification summary
+
+| Finding | Classification on latest Everruns main |
+|---|---|
+| Bash schema lost behind hosted search | Already fixed by `5c0325bf` |
+| Repeated activity overwhelms chat UI | Already fixed cosmetically by `a33bf3d4` |
+| Provider-neutral model catalog matching | Already fixed at library layer by `8dc932c1` |
+| Cumulative uncached-cost compaction trigger | Already fixed by `92fe74ea` |
+| Semantic progress guard implementation | Already ported by `fa3da598`; intentionally opt-in, missing on Platform Chat |
+| Model search plus `default_model_id` in Platform Chat | Domain command exists; generic Platform command adapter is genuinely missing |
+| MCP/plugin search, install, and agent attachment | Domain commands exist; generic Platform command adapter is genuinely missing |
+| Secure out-of-band target credential binding | Genuinely missing |
+| Agent-trigger management from Platform Chat | Domain command exists; generic Platform command adapter is genuinely missing |
+| Prompt caching in Generic/Platform Chat | Genuinely missing activation |
+| Unknown-tool suggestions/semantic no-progress accounting | Genuinely missing; exact failure is intentional |
+| `manage_agents(update)` advertises but ignores `capabilities` | Regression / schema-execution drift |
+| Session-scoped secrets; GET/HEAD web fetch; Bash allowlist; hosted remote-only MCP | Intentionally different security boundaries |
+| Platform Chat narration prefix | Missing prompt/eval coverage; no evidence of phase regression |
+| Completion gate implementation without host integration | Port landed, integration genuinely missing |
+
+## Prioritized port matrix and PR boundaries
+
+| Priority / PR | Scope | Expected impact | Risk | Dependencies | Required tests |
+|---|---|---|---|---|---|
+| P0-A | Extract MCP Tier-2 catalog/search/script execution into one transport-neutral command surface; leave MCP behavior unchanged | Gives MCP and Platform one authoritative `discover/query/execute` implementation | Medium: broad command inventory and error-shape compatibility | Existing MCP endpoint catalog, Bashkit, and `Command::run` | MCP before/after snapshots; catalog parity; read-only exclusions; positional rewriting; limits; sanitized errors |
+| P0-B | Add a Platform runtime service bound server-side to the owning session, org, and effective human caller | Makes the shared command surface usable from workers without an internal-caller bypass | High: authorization and cross-org isolation | P0-A; direct and distributed runtime adapters | default/custom policy; member/admin matrix; cross-org denial; caller reconstruction; RPC tampering |
+| P0-C | Register built-in `platform` capability with shared `discover/query/execute`; attach it to Platform Chat and retain `platform_management` temporarily | Solves model, MCP, Agent, plugin, and Trigger drift without bespoke CRUD tools | Medium: high-impact generic mutation surface | P0-A and P0-B | tool-definition parity; Terra/model selection; MCP + Agent + Trigger round trip; partial failure; prompt eval |
+| P0-D (design first) | Typed, encrypted, out-of-band integration credential binding to MCP server + Agent/execution identity; define argument-style credential adapters | Makes Visti usable without exposing or marooning its key | High: secret disclosure and confused deputy | Product/UI prompt seam; MCP credential contract; audit model | value never enters transcript/tool args/events; redacted reads; wrong-Agent denial; rotation/revocation; Visti adapter integration |
+| P1-A | Enable `progress_guard` for Platform Chat; add a Platform-specific iteration/tool/cost ceiling | Stops repeated catalog/query exploration and fails with a useful blocker | Low–medium: false positives on long tasks | None | replay-derived repeated-read loop; similar-but-progressing reads; unknown tool; checkpoint finalization |
+| P1-B | Enable `prompt_caching` for Generic/Platform Chat | Large Anthropic input-cost reduction; incident had 510k uncached input tokens | Low–medium: provider semantics/cost accounting | Existing Anthropic driver support | two-generation Anthropic cache trace; stable breakpoint; usage/cost accounting; unsupported-provider no-op |
+| P1-C | Platform command-use/output prompt plus end-to-end Visti eval | Uses `discover/query/execute` in dependency order and emits one clean final answer | Low, but ineffective before P0-C/P0-D | P0-C and P0-D | hourly Visti+Terra happy path; missing credential; denied command; partial mutation; no narration prefix |
+| P2-A | Unknown-tool error with bounded close matches; count unchanged calls as no progress | Faster self-correction without unsafe aliases | Low | Progress accounting useful but optional | typo/no-match; mutating names never auto-substituted; registered deferred tool still executes |
+| P2-B | Integrate `gate_turn`/continuation budget in the relevant Everruns hosts | Avoids premature tool-only completion in other workflows | Medium: extra turns/cost | Host-specific semantic evaluator decision | achieved/blocked/in-progress; 6-turn/64k/10m limits; no duplicate mutations |
+
+P0-A through P0-C form one staged feature but remain separate reviewable PRs:
+refactor without behavior change, establish the authorization seam, then expose
+the capability. P0-D remains an independent security design and PR because no
+generic command surface should carry a plaintext credential through model
+context. Runtime controls P1-A/P1-B remain separate from control-plane access.
+
+## Focused validation performed
+
+- Exported and filtered the exact 772-event session trace; verified turn
+  timestamps, tool counts/order, failures, provider request options, cache
+  usage, and single-completion final narration.
+- Queried the running `/api/v1/models` catalog and matched
+  `gpt-5.6-terra` exactly.
+- Compared every incident tool name against the generation catalog; only the
+  attempted `read_models` was unregistered.
+- Read the current tool schemas and store traits; verified
+  `ManageAgentsTool`/`PlatformStore` cannot carry `default_model_id` or
+  `mcpServers` while the public agent domain can.
+- Searched all Everruns Rust call sites for `gate_turn` and
+  `ContinuationBudget`; only unit tests currently use them.
+- Ran focused `everruns-core` unit tests: all 24 progress-guard tests, all 5
+  prompt-caching tests, and all 11 turn-completion tests passed. This validates
+  the existing primitives, not their activation in Platform Chat.
+
+## Decision
+
+Do not implement or ship a mixed fix from this investigation. The minimum true
+end-to-end solution spans at least model/agent management, durable triggers,
+MCP/plugin management, and a new hosted credential-binding design. Combining
+those would obscure authorization review and make rollback unsafe.
+
+Prefer one generic `platform` capability backed by the same command inventory as
+Everruns MCP over separate model/MCP/Agent/Trigger adapters. Its
+`discover/query/execute` tools expose the existing domain commands while
+retaining `Command::run` authorization. Agent-owned credential binding remains
+a separate security primitive. Progress guarding and prompt caching can
+proceed independently as cost/runaway hardening, but neither should be
+represented as fixing the autonomous Visti workflow.

--- a/test_cases/agents/platform_chat/TC001_create_and_run_agent_via_chat.md
+++ b/test_cases/agents/platform_chat/TC001_create_and_run_agent_via_chat.md
@@ -4,7 +4,9 @@
 
 Verify that a user can use the Platform Chat global session to create a new agent end-to-end and then ask Platform Chat to invoke that agent — all from a single conversation. The chat must surface the new agent through clickable navigation links (not raw prefixed IDs), the run-agent flow must produce a coherent reply with structured tool blocks, and no harness-deletion error banners or raw tool-call leakage may appear.
 
-This test exercises the Platform Chat harness's `platform_management` capability path (create harness/agent, create session, send message, wait for idle, fetch reply) plus the chat UI's link rendering, tool-call formatting, and error-banner suppression.
+This test exercises the Platform Chat harness's catalog-backed `platform`
+capability path (`discover`, `query`, and `execute`) plus the chat UI's link
+rendering, tool-call formatting, and error-banner suppression.
 
 ## Preconditions
 
@@ -76,8 +78,11 @@ This test exercises the Platform Chat harness's `platform_management` capability
 
 ### Capability Wiring
 
-- Platform Chat session uses the `platform-chat` built-in harness (which inherits from `generic` and adds `platform_management`).
-- Platform Chat tool calls (`manage_agents`, `manage_sessions`, `session_send_message`, `session_read_response`, `session_read_messages`) succeed without auth, multitenancy, or quota errors.
+- Platform Chat session uses the `platform-chat` built-in harness (which inherits from `generic` and adds `platform`).
+- The trace uses `discover` when command names or schemas are unknown, `query`
+  for reads, and `execute` for the requested mutations.
+- Underlying agent/session commands succeed without authorization,
+  multitenancy, or quota errors.
 
 ### Happy Path Rendering
 
@@ -108,7 +113,7 @@ This test exercises the Platform Chat harness's `platform_management` capability
 
 | Failure | What to look for |
 |---------|-----------------|
-| Raw IDs in chat prose | Reply contains `agent_01...` or `session_01...` instead of clickable links — check Platform Chat link-rendering helpers and the `platform_management` tool result formatter |
+| Raw IDs in chat prose | Reply contains `agent_01...` or `session_01...` instead of clickable links — check command response decoration and Platform Chat link rendering |
 | Literal `to=functions.X` text | Tool calls leak as raw assistant text — check `message-content.tsx` tool-call detection / streaming parser |
 | `Execution stopped because the assigned harness was deleted` | Session was created against a stale/missing `harness_id`. Check org init, harness reconciliation, and that Platform Chat is resolving `generic` by name (not a stale UUID) |
 | 500 / red banner on empty name | `create_agent` validation missing — server should return 4xx with a structured error that the chat surfaces as plain text |

--- a/test_cases/agents/platform_chat/TC002_discover_and_execute_via_mcp.md
+++ b/test_cases/agents/platform_chat/TC002_discover_and_execute_via_mcp.md
@@ -4,6 +4,10 @@
 
 Verify that an external client can use Everruns' MCP Tier 2 `discover` and `execute` tools together: first search the catalog to find the right operations, then execute those operations to inspect harnesses, create an agent, and fetch it back.
 
+The same command surface backs the built-in `platform` capability. Contract
+parity is covered by automated tests; this manual case verifies the external
+MCP adapter independently.
+
 This test exercises the `/mcp` endpoint's catalog search path plus the bashkit-backed execution path where discovered operations become built-in shell commands. It also validates the positional-ID rewrite for `get_agent <id>`.
 
 ## Preconditions

--- a/test_cases/agents/platform_chat/TC003_answer_from_embedded_platform_docs.md
+++ b/test_cases/agents/platform_chat/TC003_answer_from_embedded_platform_docs.md
@@ -4,7 +4,10 @@
 
 Verify that Platform Chat answers a repo-specific product question by consulting the embedded platform docs mounted at `/workspace/docs`, not by relying only on generic model knowledge.
 
-This test exercises the `platform_management` capability's embedded-docs mount together with the inherited file-system and bash tools from the `generic` harness. The question is chosen so the correct answer depends on implementation details documented in Everruns' own docs.
+This test exercises the `platform` capability's embedded-docs mount together
+with the inherited file-system and bash tools from the `generic` harness. The
+question is chosen so the correct answer depends on implementation details
+documented in Everruns' own docs.
 
 ## Preconditions
 
@@ -91,5 +94,5 @@ This test exercises the `platform_management` capability's embedded-docs mount t
 ## Notes
 
 - The exact wording may vary by model. Judge against the factual content, the docs lookup behavior, and the persisted transcript.
-- This case is intentionally repo-specific. A correct answer should line up with `docs/capabilities/platform-management.md` and the `platform_management` capability implementation.
+- This case is intentionally repo-specific. A correct answer should line up with `docs/capabilities/platform.md` and the `platform` capability implementation.
 - If the environment falls back to `llmsim-default`, treat the run as invalid for this case: the simulated model returns canned text and does not prove embedded-docs retrieval.

--- a/test_cases/agents/platform_chat/TC004_create_scheduled_agent_via_platform.md
+++ b/test_cases/agents/platform_chat/TC004_create_scheduled_agent_via_platform.md
@@ -1,0 +1,67 @@
+# TC004: Create a Scheduled Agent via Platform Chat
+
+## Description
+
+Verify that Platform Chat can discover models and control-plane operations,
+create an Agent with an explicit default model, and create an Agent Trigger for
+recurring autonomous work. This is the regression case for the failed
+dad-joke/Visti provisioning turn.
+
+Credential entry is intentionally outside this test. Use an MCP server that
+requires no secret, or preconfigure its Agent-scoped connection. A secret stored
+in Platform Chat's session must never be treated as available to the new Agent.
+
+## Preconditions
+
+- Control plane running with a real tool-calling model for Platform Chat
+- Signed-in user is authorized to assign the requested Agent capabilities
+- At least one active model exists
+- A reusable no-secret MCP server is available, or omit MCP from the prompt
+
+## Steps
+
+1. Open Platform Chat at `/chat`.
+
+2. Send:
+
+   ```text
+   Create an agent named hourly-joke that tells a short dad joke. Use the active
+   model whose model ID is gpt-5.6-terra. Run it hourly using an Agent Trigger.
+   Inspect existing resources first, reuse them where possible, and show me the
+   final agent and trigger links.
+   ```
+
+3. Inspect the tool trace. Verify that Platform Chat:
+   - uses `discover` to find model, Agent, and Agent Trigger operations rather
+     than calling an invented tool such as `read_models`;
+   - uses `query` to resolve `gpt-5.6-terra` and inspect existing resources;
+   - uses `execute` for the requested creates;
+   - queries the final Agent and Trigger state before answering.
+
+4. Open the returned Agent link and verify its `default_model_id` points to the
+   model whose provider model ID is `gpt-5.6-terra`.
+
+5. Open the returned Trigger link and verify it targets the new Agent and uses
+   an hourly schedule.
+
+6. Verify no Session Schedule was added to the Platform Chat session.
+
+## Expected Result
+
+- The Agent and Agent Trigger exist and are linked from the final answer.
+- The Agent has the requested default model.
+- The trigger, not Platform Chat, owns the recurring autonomous execution.
+- No `read_models`, `prepare_agent_provisioning`, or other invented planning
+  tool appears.
+- Tool calls render as structured blocks and the final answer begins with the
+  outcome, without internal reasoning or narration.
+
+## Negative paths
+
+- If `gpt-5.6-terra` is absent or inactive, Platform Chat reports that fact and
+  does not silently choose another model.
+- If the caller cannot assign a requested high-risk capability, `execute`
+  returns a permission error and no elevated Agent is created.
+- Supplying `organization_id` to any Platform tool is rejected.
+- A partial multi-command failure is followed by `query`; already-created
+  resources are reused or reported instead of blindly duplicated.


### PR DESCRIPTION
## What changed

Platform Chat now manages Everruns through a built-in `platform` capability with the same catalog-backed `discover`, read-only `query`, and mutating `execute` contracts as the Everruns MCP endpoint.

The capability and MCP endpoint share command discovery, Bashkit execution, positional/schema adaptation, limits, output decoration, and safe error formatting. Platform Chat and the seeded Platform Manager Agent now use this surface; the handwritten `platform_management` capability remains available for compatibility.

The change also adds the supporting specification, threat-model update, public capability and harness documentation, investigation/proposal, and Platform Chat regression cases.

## Why

The previous Platform Chat surface drifted behind the public API. It could not discover models, set an Agent's `default_model_id`, manage MCP resources, or create Agent Triggers, which caused the reported autonomous-agent request to guess nonexistent tools, loop, and finish without creating the requested workflow.

Registered domain commands already own those operations and their authorization. Exposing that inventory removes the duplicate management API and lets capable models compose current primitives directly without a provisioning-plan domain.

## Before / After

Before: Platform Chat exposed handwritten CRUD tools, had no model-discovery or Agent Trigger path, and could not create an Agent pinned to GPT-5.6 Terra.

After, verified against the in-memory stack:

- `platform-chat` is seeded with `platform`.
- `platform` reports high risk and exactly `discover`, `query`, and `execute`; none accepts `organization_id`.
- `discover` returns `create_agent.default_model_id` and `create_agent_trigger.cron_expression`.
- `query` resolves `gpt-5.6-terra` to `model_01933b5a000070008000000000000227`.
- `execute` creates an Agent with that default model and an hourly `session_per_invocation` Agent Trigger.
- Composed-schema scalar flags such as `--enabled true` are repaired before domain dispatch.

## Risk

- High.
- `execute` exposes every scriptable mutation the resolved caller is permitted to perform. Incorrect context binding, read-only classification, or error sanitization could affect authorization or disclosure.
- MCP `query`/`execute` now use the direct `ScriptedTool` builder so actionable domain error kinds survive Bashkit's blanket callback masking; internal details are redacted first.
- Existing custom users of `platform_management` remain compatible.

## Security

- Threat categories reviewed: TM-AGENT, TM-AUTHZ, TM-TENANT, TM-MCP, TM-TOOL, and secret lifecycle/TM-AGENT-016.
- Findings and resolutions:
  - The worker RPC accepts session and org only. The server reloads the org-scoped session and resolves its persisted human owner; the worker cannot supply a user or internal caller.
  - Every builtin dispatches through `Command::run` with the active `PermissionResolver`.
  - Platform schemas omit and runtime rejects `organization_id`; cross-org session lookup is tested.
  - `query` includes read-only commands only and retains existing open-world exclusions.
  - Bashkit command/loop/parser/input/time limits are shared with MCP.
  - Internal command details are logged and returned only as `internal: Internal server error`.
  - Credentials are intentionally not transferred through this surface. Agent-scoped credential binding remains a separate security-sensitive follow-up.

## Follow-ups

- Add Agent-scoped interactive credential binding and MCP argument injection/redaction; this is intentionally separate because it introduces a new secret lifecycle.
- Add Platform Chat-specific semantic progress/cost controls and provider prompt-cache tracing after the command surface lands; these are independent runtime-policy changes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

