### PR TITLE
fix(session-files): exclude private memory before grep

### DIFF
--- a/crates/server/src/api/workspace_files.rs
+++ b/crates/server/src/api/workspace_files.rs
@@ -543,6 +543,7 @@ pub async fn grep_files(
             GrepInput {
                 pattern: req.pattern,
                 path_pattern: req.path_pattern,
+                excluded_path_prefix: None,
             },
         )
         .await

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1241,7 +1241,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 .map(everruns_core::session_path::GrepPathPattern::new)
                 .transpose()
                 .unwrap_or(None);
-            let virtual_matches = registry.grep(&session_id, &regex, None, 512 * 1024);
+            let virtual_matches = registry.grep(&session_id, &regex, None, None, 512 * 1024);
             matches.extend(
                 virtual_matches
                     .into_iter()

--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -520,6 +520,8 @@ impl Command for GrepWorkspaceFiles {
                 GrepInput {
                     pattern: self.req.pattern,
                     path_pattern: self.req.path_pattern,
+                    excluded_path_prefix: (!access.user_memory_allowed)
+                        .then(|| q::USER_MEMORY_MOUNT_PATH.to_string()),
                 },
             )
             .await
@@ -531,11 +533,8 @@ impl Command for GrepWorkspaceFiles {
                     q::classify_storage(error)
                 }
             })?;
-        // Non-owners must not see matches under the private `/memory/user`
-        // subtree. Redact those results (consistent with recursive `list`)
-        // instead of failing the whole scan, so workspace-wide grep stays
-        // available to callers that can't be resolved as the session owner
-        // (e.g. no-auth/dev deployments).
+        // Defense in depth: storage already excludes private memory before
+        // matching or scan accounting, but keep response redaction here too.
         let results = if access.user_memory_allowed {
             results
         } else {

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -59,6 +59,8 @@ pub struct CopyFileInput {
 pub struct GrepInput {
     pub pattern: String,
     pub path_pattern: Option<String>,
+    /// Subtree that storage must exclude before evaluating the content regex.
+    pub excluded_path_prefix: Option<String>,
 }
 
 /// Factory for the server-backed session filesystem.
@@ -743,11 +745,12 @@ impl WorkspaceFileService {
 
     /// Search files using grep-like pattern matching (delegates to shared helper).
     pub async fn grep(&self, session_id: Uuid, req: GrepInput) -> Result<Vec<GrepResult>> {
-        let mut results = grep_session_files(
+        let mut results = grep_session_files_excluding(
             &self.db,
             session_id,
             &req.pattern,
             req.path_pattern.as_deref(),
+            req.excluded_path_prefix.as_deref(),
         )
         .await?;
 
@@ -760,8 +763,13 @@ impl WorkspaceFileService {
                 .map(everruns_core::session_path::GrepPathPattern::new)
                 .transpose()?;
             // Apply the shared path matcher after reading virtual entries.
-            let virtual_matches =
-                registry.grep(&session_id, &regex, None, MAX_GREP_FILE_BYTES as usize);
+            let virtual_matches = registry.grep(
+                &session_id,
+                &regex,
+                None,
+                req.excluded_path_prefix.as_deref(),
+                MAX_GREP_FILE_BYTES as usize,
+            );
             for vm in virtual_matches.into_iter().filter(|vm| {
                 path_matcher
                     .as_ref()
@@ -1287,6 +1295,7 @@ impl SessionFileSystem for WorkspaceFileService {
                 GrepInput {
                     pattern: pattern.to_string(),
                     path_pattern: path_pattern.map(ToString::to_string),
+                    excluded_path_prefix: None,
                 },
             )
             .await
@@ -1363,6 +1372,16 @@ pub async fn grep_session_files(
     pattern: &str,
     path_pattern: Option<&str>,
 ) -> Result<Vec<GrepResult>> {
+    grep_session_files_excluding(db, session_id, pattern, path_pattern, None).await
+}
+
+async fn grep_session_files_excluding(
+    db: &StorageBackend,
+    session_id: Uuid,
+    pattern: &str,
+    path_pattern: Option<&str>,
+    excluded_path_prefix: Option<&str>,
+) -> Result<Vec<GrepResult>> {
     // TM-DOS-008: cap content/path pattern lengths, then cap content-regex NFA size.
     anyhow::ensure!(
         pattern.len() <= MAX_GREP_PATTERN_LEN,
@@ -1386,7 +1405,13 @@ pub async fn grep_session_files(
     // scanning content. The shared matcher below then narrows those candidates
     // before content is fetched and charged to the total scan budget.
     let files = db
-        .grep_session_files(session_id, pattern, path_pattern, MAX_GREP_FILE_BYTES)
+        .grep_session_files(
+            session_id,
+            pattern,
+            path_pattern,
+            excluded_path_prefix,
+            MAX_GREP_FILE_BYTES,
+        )
         .await?;
 
     let mut results = Vec::new();
@@ -1483,6 +1508,7 @@ pub(crate) async fn grep_session_files_with_options(
             session_id,
             pattern,
             options.path_pattern.as_deref(),
+            None,
             MAX_GREP_FILE_BYTES,
         )
         .await?;
@@ -1762,6 +1788,35 @@ mod tests {
         assert!(
             msg.contains("maximum scan size"),
             "Expected 'maximum scan size' in: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn grep_excludes_private_subtree_before_scan_limit_accounting() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let chunk = "x".repeat(MAX_GREP_FILE_BYTES as usize);
+        let files_at_limit = MAX_GREP_TOTAL_SCAN_BYTES / MAX_GREP_FILE_BYTES as usize;
+        for i in 0..files_at_limit {
+            seed_file(&db, sid, &format!("/public_{i:02}.txt"), &chunk).await;
+        }
+        seed_file(&db, sid, "/memory/user/secret.md", "x").await;
+
+        let result = grep_session_files_excluding(
+            &db,
+            sid,
+            "x",
+            None,
+            Some(crate::domains::session_files::queries::USER_MEMORY_MOUNT_PATH),
+        )
+        .await
+        .expect("excluded private files must not count against the scan limit");
+
+        assert_eq!(result.len(), files_at_limit);
+        assert!(
+            result
+                .iter()
+                .all(|entry| !entry.path.starts_with("/memory/user"))
         );
     }
 

--- a/crates/server/src/domains/session_files/virtual_mount_registry.rs
+++ b/crates/server/src/domains/session_files/virtual_mount_registry.rs
@@ -129,6 +129,7 @@ impl VirtualMountRegistry {
         session_id: &Uuid,
         pattern: &regex::Regex,
         path_filter: Option<&str>,
+        excluded_path_prefix: Option<&str>,
         max_file_bytes: usize,
     ) -> Vec<VirtualGrepMatch> {
         let mut results = Vec::new();
@@ -138,6 +139,11 @@ impl VirtualMountRegistry {
         };
         for mount in session_mounts {
             for (file_path, file) in mount.tree.all_files() {
+                if excluded_path_prefix.is_some_and(|prefix| {
+                    file_path == prefix || file_path.starts_with(&format!("{prefix}/"))
+                }) {
+                    continue;
+                }
                 // TM-DOS-008: skip virtual files exceeding the per-file size cap.
                 if file.content.len() > max_file_bytes {
                     continue;
@@ -360,7 +366,7 @@ mod tests {
         registry.register(sid, "/docs".into(), Arc::new(tree), "cap".into());
 
         let pattern = regex::Regex::new("find me").unwrap();
-        let results = registry.grep(&sid, &pattern, None, usize::MAX);
+        let results = registry.grep(&sid, &pattern, None, None, usize::MAX);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].line_number, 2);
         assert_eq!(results[0].line, "find me");

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2332,6 +2332,7 @@ impl StorageBackend {
         session_id: Uuid,
         pattern: &str,
         path_prefix: Option<&str>,
+        excluded_path_prefix: Option<&str>,
         max_file_bytes: i64,
     ) -> Result<Vec<SessionFileInfoRow>> {
         dispatch!(
@@ -2340,6 +2341,7 @@ impl StorageBackend {
             session_id,
             pattern,
             path_prefix,
+            excluded_path_prefix,
             max_file_bytes
         )
     }

--- a/crates/server/src/storage/memory/session_files.rs
+++ b/crates/server/src/storage/memory/session_files.rs
@@ -295,6 +295,7 @@ impl InMemoryDatabase {
         session_id: Uuid,
         pattern: &str,
         path_pattern: Option<&str>,
+        excluded_path_prefix: Option<&str>,
         max_file_bytes: i64,
     ) -> Result<Vec<SessionFileInfoRow>> {
         let session_id = SessionId::from_uuid(session_id);
@@ -311,8 +312,13 @@ impl InMemoryDatabase {
                 if f.size_bytes > max_file_bytes {
                     return false;
                 }
+                if excluded_path_prefix.is_some_and(|prefix| {
+                    f.path == prefix || f.path.starts_with(&format!("{prefix}/"))
+                }) {
+                    return false;
+                }
                 // The service applies glob semantics before fetching content.
-                // Return metadata only so excluded paths are never regex-scanned.
+                // Return metadata only after private paths have been excluded.
                 if path_pattern.is_some() {
                     return true;
                 }

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -776,6 +776,7 @@ impl Database {
         session_id: Uuid,
         pattern: &str,
         path_pattern: Option<&str>,
+        excluded_path_prefix: Option<&str>,
         max_file_bytes: i64,
     ) -> Result<Vec<SessionFileInfoRow>> {
         // Offload path: content is in the object store, so PostgreSQL cannot grep
@@ -793,11 +794,13 @@ impl Database {
                 WHERE workspace_id = $1
                     AND is_directory = FALSE
                     AND size_bytes <= $2
+                    AND ($3::text IS NULL OR (path <> $3 AND path NOT LIKE $3 || '/%'))
                 ORDER BY path ASC
                 "#,
             )
             .bind(session_id)
             .bind(max_file_bytes)
+            .bind(excluded_path_prefix)
             .fetch_all(&self.pool)
             .await?;
             return Ok(rows);
@@ -816,11 +819,13 @@ impl Database {
                 WHERE workspace_id = $1
                     AND is_directory = FALSE
                     AND size_bytes <= $2
+                    AND ($3::text IS NULL OR (path <> $3 AND path NOT LIKE $3 || '/%'))
                 ORDER BY path ASC
                 "#,
             )
             .bind(session_id)
             .bind(max_file_bytes)
+            .bind(excluded_path_prefix)
             .fetch_all(&self.pool)
             .await?
         } else {
@@ -831,12 +836,14 @@ impl Database {
                 WHERE workspace_id = $1
                     AND is_directory = FALSE
                     AND size_bytes <= $2
-                    AND convert_from(content, 'UTF8') ~ $3
+                    AND ($3::text IS NULL OR (path <> $3 AND path NOT LIKE $3 || '/%'))
+                    AND convert_from(content, 'UTF8') ~ $4
                 ORDER BY path ASC
                 "#,
             )
             .bind(session_id)
             .bind(max_file_bytes)
+            .bind(excluded_path_prefix)
             .bind(pattern)
             .fetch_all(&self.pool)
             .await?

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -539,6 +539,7 @@ impl SessionFileSystem for DbSessionFileStore {
                 session_id.uuid(),
                 pattern,
                 path_pattern,
+                None,
                 GREP_MAX_FILE_BYTES,
             )
             .await
@@ -601,6 +602,7 @@ impl SessionFileSystem for DbSessionFileStore {
                 session_id.uuid(),
                 pattern,
                 options.path_pattern.as_deref(),
+                None,
                 GREP_MAX_FILE_BYTES,
             )
             .await


### PR DESCRIPTION
## What changed
Non-owner session-file grep now excludes the private `/memory/user` subtree before storage matching, file reads, or scan-budget accounting. The exclusion is propagated through PostgreSQL, blob-backed, in-memory, session-store, and virtual-mount paths, with response redaction retained as defense in depth.

During the rebase, the exclusion was reconciled with main's shared glob matcher: storage returns path-filtered metadata candidates, private paths are removed first, and glob semantics remain centralized in the service layer.

## Why
Previously, private files were matched and counted before response redaction. Their presence could change success versus scan-limit error behavior for a non-owner, creating a confidentiality oracle.

## Before / After
Before: a private `/memory/user` file could influence regex work and total-scan accounting even though its matches were later hidden.

After: `grep_excludes_private_subtree_before_scan_limit_accounting` proves an excluded private file neither consumes the public scan budget nor appears in results. The branch was rebased onto current `origin/main`; the focused regression test and all 10 `just pre-push` gates pass.

## Risk
- Medium
- The grep storage API changed across all backends. Rebase resolution preserves current glob semantics and adds the exclusion independently, before content access.
- Owners and trusted internal callers retain existing private-memory access.

## Security
- Threat categories reviewed: TM-TENANT, TM-FS, TM-DOS, TM-API
- Findings and resolutions: private candidates are excluded before matching, content reads, and scan accounting across every backend; response redaction remains defense in depth. SQL stays parameterized, path matching remains bounded, and no cross-session behavior changes.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review comments)