### PR TITLE
fix(ui): prioritize detail actions responsively

### DIFF
--- a/apps/ui/e2e/page-masthead-responsive.spec.ts
+++ b/apps/ui/e2e/page-masthead-responsive.spec.ts
@@ -98,37 +98,80 @@ test.describe("Page masthead responsive layout", () => {
     await mockAgentDetailApi(page);
   });
 
+  test("uses overflow-only actions at mobile width", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/agents/${AGENT_ID}`);
+
+    const title = page.getByRole("heading", { name: "Jokes Agent" });
+    const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
+    const identity = masthead.locator('[data-slot="page-masthead-identity"]');
+    const actions = page
+      .getByRole("button", { name: "New session" })
+      .locator("xpath=ancestor::div[@data-slot='page-masthead-compact-actions'][1]");
+    await expect(title).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open navigation" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "More actions" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy", exact: true })).toBeHidden();
+    await expect(page.getByRole("button", { name: "Observe this agent" })).toBeHidden();
+
+    await page.getByRole("button", { name: "Open navigation" }).click();
+    await expect(page.locator('[data-slot="drawer-content"]')).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator('[data-slot="drawer-content"]')).toBeHidden();
+
+    await page.getByRole("button", { name: "More actions" }).click();
+    await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Export" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Create app" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Observe this agent" })).toBeVisible();
+
+    const mastheadBox = await masthead.boundingBox();
+    const identityBox = await identity.boundingBox();
+    const actionsBox = await actions.boundingBox();
+
+    expect(mastheadBox).not.toBeNull();
+    expect(identityBox).not.toBeNull();
+    expect(actionsBox).not.toBeNull();
+    expect(mastheadBox!.width).toBeGreaterThanOrEqual(300);
+    expect(identityBox!.width).toBeGreaterThanOrEqual(Math.min(320, mastheadBox!.width));
+    expect(actionsBox!.x + actionsBox!.width).toBeLessThanOrEqual(
+      mastheadBox!.x + mastheadBox!.width,
+    );
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+      await page.evaluate(() => document.documentElement.clientWidth),
+    );
+  });
+
   for (const viewport of [
     { name: "compact desktop", width: 1024, height: 900 },
     { name: "tablet", width: 768, height: 900 },
-    { name: "mobile", width: 390, height: 844 },
   ]) {
-    test(`protects identity content and contains actions at ${viewport.name} width`, async ({
-      page,
-    }) => {
+    test(`keeps frequent actions in a second row at ${viewport.name} width`, async ({ page }) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await page.goto(`/agents/${AGENT_ID}`);
 
       const title = page.getByRole("heading", { name: "Jokes Agent" });
       const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
-      const identity = masthead.locator('[data-slot="page-masthead-identity"]');
-      const actions = page
-        .getByRole("button", { name: "New session" })
-        .locator("xpath=ancestor::div[@data-slot='page-masthead-actions'][1]");
-      await expect(title).toBeVisible();
-      await expect(page.getByRole("button", { name: "Observe this agent" })).toBeVisible();
+      const actionStrip = masthead.locator('[data-slot="page-masthead-compact-action-strip"]');
+
+      await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "More actions" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Copy", exact: true })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Export", exact: true })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Create app" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Observe this agent" })).toBeHidden();
+
+      await page.getByRole("button", { name: "More actions" }).click();
+      await expect(page.getByRole("menuitem", { name: "Observe this agent" })).toBeVisible();
+      await expect(page.getByRole("menuitem", { name: "Copy" })).toHaveCount(0);
 
       const mastheadBox = await masthead.boundingBox();
-      const identityBox = await identity.boundingBox();
-      const actionsBox = await actions.boundingBox();
-
+      const stripBox = await actionStrip.boundingBox();
       expect(mastheadBox).not.toBeNull();
-      expect(identityBox).not.toBeNull();
-      expect(actionsBox).not.toBeNull();
-      expect(identityBox!.width).toBeGreaterThanOrEqual(Math.min(320, mastheadBox!.width));
-      expect(actionsBox!.x + actionsBox!.width).toBeLessThanOrEqual(
-        mastheadBox!.x + mastheadBox!.width,
-      );
+      expect(stripBox).not.toBeNull();
+      expect(stripBox!.width).toBeLessThanOrEqual(mastheadBox!.width);
       expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
         await page.evaluate(() => document.documentElement.clientWidth),
       );
@@ -149,5 +192,8 @@ test.describe("Page masthead responsive layout", () => {
     expect(titleBox).not.toBeNull();
     expect(actionsBox).not.toBeNull();
     expect(actionsBox!.y).toBeLessThan(titleBox!.y + titleBox!.height);
+    await expect(page.getByRole("button", { name: "Open navigation" })).toBeHidden();
+    await expect(page.getByRole("button", { name: "More actions" })).toBeHidden();
+    await expect(page.getByRole("button", { name: "Observe this agent" })).toBeVisible();
   });
 });

--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -231,7 +231,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
   it("renders copy button", async () => {
     await renderWithSuspense({ agentId: "agent-1" });
 
-    expect(screen.getByText("Copy")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Copy" }).length).toBeGreaterThan(0);
   });
 
   it("shows copying state when copy is pending", async () => {
@@ -239,7 +239,9 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
 
     await renderWithSuspense({ agentId: "agent-1" });
 
-    expect(screen.getByText("Copying...")).toBeInTheDocument();
+    const copyingButtons = screen.getAllByRole("button", { name: "Copying..." });
+    expect(copyingButtons.length).toBeGreaterThan(0);
+    copyingButtons.forEach((button) => expect(button).toBeDisabled());
   });
 
   it("renders agent details correctly", async () => {

--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -48,6 +48,7 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("@/components/layout/sidebar", () => ({
   Sidebar: () => <div data-testid="sidebar">Sidebar</div>,
+  MobileSidebar: () => <div data-testid="mobile-sidebar">Mobile Sidebar</div>,
 }));
 
 jest.mock("@/components/command-palette", () => ({

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -15,7 +15,7 @@ import {
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ResourceNotFound } from "@/components/resource-not-found";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -41,6 +41,7 @@ import {
   Terminal,
   Boxes,
   Clock3,
+  MoreHorizontal,
 } from "lucide-react";
 import { AgentTriggersPanel } from "@/components/agents/agent-triggers-panel";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -76,6 +77,13 @@ import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import { useWebMcpTool } from "@/hooks/use-webmcp-tool";
 import { useWebMcp } from "@/providers/webmcp-context";
 import type { WebMcpToolDefinition } from "@/lib/webmcp/types";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPositioner,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 // Helper function to calculate total tokens
 function totalTokens(usage: TokenUsage): number {
@@ -339,6 +347,122 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
             >
               <Plus className="size-4" />
               {createSession.isPending ? "Creating..." : "New session"}
+            </Button>
+          </>
+        }
+        compactActions={
+          <>
+            <Button
+              variant="accent"
+              onClick={handleNewSession}
+              disabled={createSession.isPending || agent.status !== "active"}
+            >
+              <Plus className="size-4" />
+              {createSession.isPending ? "Creating..." : "New session"}
+            </Button>
+            {observersEnabled && agent.status === "active" && (
+              <div className="hidden @sm/masthead:block">
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    className={buttonVariants({ variant: "outline", size: "icon" })}
+                    aria-label="More actions"
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuPositioner align="end">
+                    <DropdownMenuContent>
+                      <DropdownMenuItem
+                        render={
+                          <Link
+                            href={{ pathname: "/observers/new", query: { agent_id: agentId } }}
+                          />
+                        }
+                      >
+                        <Telescope className="size-4" />
+                        Observe this agent
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenuPositioner>
+                </DropdownMenu>
+              </div>
+            )}
+            <div className="@sm/masthead:hidden">
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  className={buttonVariants({ variant: "outline", size: "icon" })}
+                  aria-label="More actions"
+                >
+                  <MoreHorizontal className="size-4" />
+                </DropdownMenuTrigger>
+                <DropdownMenuPositioner align="end">
+                  <DropdownMenuContent>
+                    <DropdownMenuItem onClick={handleCopy} disabled={copyAgent.isPending}>
+                      <Copy className="size-4" />
+                      {copyAgent.isPending ? "Copying..." : "Copy"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleExport} disabled={exportAgent.isPending}>
+                      <Download className="size-4" />
+                      {exportAgent.isPending ? "Exporting..." : "Export"}
+                    </DropdownMenuItem>
+                    {agent.status === "active" && (
+                      <DropdownMenuItem render={<Link href={`/agents/${agentId}/edit`} />}>
+                        <Pencil className="size-4" />
+                        Edit
+                      </DropdownMenuItem>
+                    )}
+                    {agent.status === "active" && (
+                      <DropdownMenuItem
+                        render={
+                          <Link href={{ pathname: "/apps/new", query: { agent_id: agentId } }} />
+                        }
+                      >
+                        <Rocket className="size-4" />
+                        Create app
+                      </DropdownMenuItem>
+                    )}
+                    {observersEnabled && agent.status === "active" && (
+                      <DropdownMenuItem
+                        render={
+                          <Link
+                            href={{ pathname: "/observers/new", query: { agent_id: agentId } }}
+                          />
+                        }
+                      >
+                        <Telescope className="size-4" />
+                        Observe this agent
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenuPositioner>
+              </DropdownMenu>
+            </div>
+          </>
+        }
+        compactActionStrip={
+          <>
+            {agent.status === "active" && (
+              <Link href={`/agents/${agentId}/edit`}>
+                <Button variant="outline">
+                  <Pencil className="size-4" />
+                  Edit
+                </Button>
+              </Link>
+            )}
+            {agent.status === "active" && (
+              <Link href={{ pathname: "/apps/new", query: { agent_id: agentId } }}>
+                <Button variant="outline">
+                  <Rocket className="size-4" />
+                  Create app
+                </Button>
+              </Link>
+            )}
+            <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>
+              <Copy className="size-4" />
+              {copyAgent.isPending ? "Copying..." : "Copy"}
+            </Button>
+            <Button variant="outline" onClick={handleExport} disabled={exportAgent.isPending}>
+              <Download className="size-4" />
+              {exportAgent.isPending ? "Exporting..." : "Export"}
             </Button>
           </>
         }

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -4,7 +4,7 @@
 import { Suspense, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
-import { Sidebar } from "@/components/layout/sidebar";
+import { MobileSidebar, Sidebar } from "@/components/layout/sidebar";
 import { EarlyAccessBanner } from "@/components/layout/early-access-banner";
 import { VerifyEmailBanner } from "@/components/layout/verify-email-banner";
 import { CommandPalette } from "@/components/command-palette";
@@ -135,9 +135,10 @@ function MainLayoutInner({ children }: MainLayoutProps) {
     <div className="flex h-screen flex-col">
       <EarlyAccessBanner />
       <VerifyEmailBanner />
-      <div className="flex min-h-0 flex-1">
-        <Sidebar />
-        <main className="flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+        <Sidebar className="hidden md:flex" />
+        <MobileSidebar />
+        <main className="min-w-0 flex-1 overflow-auto bg-background bg-brand-dots">{children}</main>
       </div>
       <CommandPalette />
     </div>

--- a/apps/ui/src/components/layout/main-layout.tsx
+++ b/apps/ui/src/components/layout/main-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Sidebar } from "./sidebar";
+import { MobileSidebar, Sidebar } from "./sidebar";
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -8,9 +8,10 @@ interface MainLayoutProps {
 
 export function MainLayout({ children }: MainLayoutProps) {
   return (
-    <div className="flex h-screen">
-      <Sidebar />
-      <main className="flex-1 overflow-auto bg-background text-[15px]">{children}</main>
+    <div className="flex h-screen flex-col md:flex-row">
+      <Sidebar className="hidden md:flex" />
+      <MobileSidebar />
+      <main className="min-w-0 flex-1 overflow-auto bg-background text-[15px]">{children}</main>
     </div>
   );
 }

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -3,7 +3,7 @@
 // Zones (numbered ①–⑤ in the design source):
 //   1. Breadcrumb     — PageBreadcrumb: the context line (root → name → mode).
 //   2. Header         — PageMasthead: icon tile · title · status badge · meta, then a
-//                       right-aligned action cluster (primary verb first).
+//                       right-aligned action cluster.
 //   3. Control strip   — the shape-shifter: filters on list, stats on view, section nav
 //                       on edit. Same slot, always. Compose with PageControlStrip plus
 //                       SectionTabs / StatGrid as needed.
@@ -135,8 +135,12 @@ interface PageMastheadProps {
   description?: ReactNode;
   /** Meta run — small key/value spans rendered below the description. */
   meta?: ReactNode;
-  /** Right-aligned action cluster, primary verb first. */
+  /** Full right-aligned action cluster shown when the masthead has enough room. */
   actions?: ReactNode;
+  /** Prioritized actions shown instead of `actions` in constrained mastheads. */
+  compactActions?: ReactNode;
+  /** Frequent secondary actions shown on a separate row at tablet-like widths. */
+  compactActionStrip?: ReactNode;
   className?: string;
 }
 
@@ -151,12 +155,17 @@ export function PageMasthead({
   description,
   meta,
   actions,
+  compactActions,
+  compactActionStrip,
   className,
 }: PageMastheadProps) {
   return (
     <div
       data-slot="page-masthead"
-      className={cn("flex flex-wrap items-start gap-4 border-b pb-4", className)}
+      className={cn(
+        "@container/masthead flex flex-wrap items-start gap-4 border-b pb-4",
+        className,
+      )}
     >
       <div
         data-slot="page-masthead-identity"
@@ -183,9 +192,28 @@ export function PageMasthead({
       {actions && (
         <div
           data-slot="page-masthead-actions"
-          className="ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+          className={cn(
+            "ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal",
+            compactActions && "hidden @5xl/masthead:flex",
+          )}
         >
           {actions}
+        </div>
+      )}
+      {compactActions && (
+        <div
+          data-slot="page-masthead-compact-actions"
+          className="ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 @5xl/masthead:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+        >
+          {compactActions}
+        </div>
+      )}
+      {compactActionStrip && (
+        <div
+          data-slot="page-masthead-compact-action-strip"
+          className="hidden w-full flex-wrap items-center gap-2 @sm/masthead:flex @5xl/masthead:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+        >
+          {compactActionStrip}
         </div>
       )}
     </div>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import packageJson from "../../../package.json";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import {
   Boxes,
   BookOpen,
@@ -43,6 +44,7 @@ import {
   Workflow,
   Cog,
   Cpu,
+  Menu,
 } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { useCommandPalette } from "@/hooks/use-command-palette";
@@ -55,6 +57,9 @@ import { SidebarNavigation } from "./sidebar-navigation";
 import { SidebarOrganizationMenu } from "./sidebar-organization-menu";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import type { SidebarUserMenuItemsRenderer } from "./sidebar-user-menu";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 
 const { version } = packageJson;
 
@@ -155,7 +160,13 @@ function isDurableSection(section: NavigationSection) {
   );
 }
 
-export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
+export function Sidebar({
+  config,
+  className,
+}: {
+  config?: Partial<SidebarConfig>;
+  className?: string;
+}) {
   const pathname = usePathname();
   const {
     user,
@@ -196,7 +207,10 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const useDefaultCreateOrgDialog = !config?.orgActions?.createOrg && !createOrgOverride;
 
   return (
-    <div className="flex h-full w-60 flex-col border-r border-border/70 bg-background">
+    <div
+      data-slot="app-sidebar"
+      className={cn("flex h-full w-60 flex-col border-r border-border/70 bg-background", className)}
+    >
       <div className="flex h-14 items-center justify-between border-b border-border/70 bg-card px-4">
         <Link href="/dashboard" prefetch={false} className="flex items-center gap-2">
           <Image src="/logo.svg" alt="Everruns" width={28} height={28} />
@@ -239,6 +253,40 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
           version={version}
         />
       </div>
+    </div>
+  );
+}
+
+export function MobileSidebar({ config }: { config?: Partial<SidebarConfig> }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border/70 bg-card px-3 md:hidden">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Open navigation"
+        onClick={() => setOpen(true)}
+      >
+        <Menu className="size-5" />
+      </Button>
+      <Link href="/dashboard" prefetch={false} className="flex items-center gap-2">
+        <Image src="/logo.svg" alt="" width={24} height={24} />
+        <span className="text-sm font-semibold tracking-[-0.02em]">Everruns</span>
+      </Link>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent
+          side="left"
+          className="w-60 max-w-none gap-0 p-0 sm:max-w-none"
+          onClick={(event) => {
+            if ((event.target as Element).closest("a")) setOpen(false);
+          }}
+        >
+          <DrawerTitle className="sr-only">Navigation</DrawerTitle>
+          <Sidebar config={config} className="w-full border-r-0" />
+        </DrawerContent>
+      </Drawer>
     </div>
   );
 }

--- a/apps/ui/src/components/ui/drawer.tsx
+++ b/apps/ui/src/components/ui/drawer.tsx
@@ -29,9 +29,11 @@ function DrawerContent({
   className,
   children,
   showCloseButton = true,
+  side = "right",
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
+  side?: "left" | "right";
 }) {
   return (
     <DrawerPortal data-slot="drawer-portal">
@@ -39,7 +41,10 @@ function DrawerContent({
       <DialogPrimitive.Popup
         data-slot="drawer-content"
         className={cn(
-          "bg-background data-[open]:animate-in data-[open]:slide-in-from-right-8 data-[closed]:animate-out data-[closed]:slide-out-to-right-8 data-[open]:fade-in-0 data-[closed]:fade-out-0 fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md flex-col gap-4 border-l p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[open]:animate-in data-[closed]:animate-out data-[open]:fade-in-0 data-[closed]:fade-out-0 fixed inset-y-0 z-50 flex h-full w-full max-w-md flex-col gap-4 p-6 shadow-lg duration-200 sm:max-w-lg",
+          side === "right"
+            ? "right-0 border-l data-[open]:slide-in-from-right-8 data-[closed]:slide-out-to-right-8"
+            : "left-0 border-r data-[open]:slide-in-from-left-8 data-[closed]:slide-out-to-left-8",
           className,
         )}
         {...props}

--- a/test_cases/ui/page_layout/TC001_responsive_masthead.md
+++ b/test_cases/ui/page_layout/TC001_responsive_masthead.md
@@ -24,9 +24,12 @@ when the app content area narrows.
 
 1. Open the agent detail page at the wide desktop viewport.
 2. Confirm the action cluster is right-aligned beside the title, description, badges, and metadata.
-3. Resize to the compact desktop viewport and confirm the action cluster moves below the identity
-   content instead of squeezing it.
-4. Resize to the tablet and mobile viewports and confirm actions wrap within the masthead.
+3. Resize to the compact desktop and tablet viewports. Confirm `New session` and `More actions`
+   remain prioritized while Edit, Create app, Copy, and Export move to a second row. Open the
+   overflow menu and confirm Observe this agent is available.
+4. Resize to the mobile viewport. Confirm only `New session` and `More actions` remain visible.
+   Open the overflow menu and confirm Copy, Export, Edit, Create app, and Observe this agent are
+   available. Open the mobile navigation drawer and close it with Escape.
 5. Repeat with a long title, a long description, expanded button labels, badges, and metadata.
 6. Inspect representative detail pages for agents, harnesses, apps, capabilities, skills, memory,
    knowledge indexes, agent identities, and sessions.
@@ -34,7 +37,12 @@ when the app content area narrows.
 ## Expected Result
 
 - Identity content keeps a readable width instead of collapsing into a single-word column.
-- Actions remain visible, usable, and contained by the masthead at every viewport.
+- Wide screens show the full action cluster beside the identity content.
+- Compact desktop and tablet widths show the prioritized controls and secondary action strip.
+- Mobile widths keep the primary action visible and expose every secondary action through the
+  keyboard-accessible overflow menu.
+- The desktop sidebar becomes an accessible navigation drawer on mobile, leaving the page a
+  readable content width.
 - Long text wraps without horizontal page overflow.
 - Wide desktop mastheads retain right-aligned actions and the established visual hierarchy.
 - All consumers of the shared masthead follow the same responsive behavior without page-local


### PR DESCRIPTION
## What changed
Agent detail actions now follow the supplied responsive hierarchy:
- wide mastheads keep the complete right-aligned toolbar
- compact desktop and tablet mastheads prioritize New session and More actions, with frequent actions on a second row
- mobile mastheads keep New session visible and move every secondary action into an accessible overflow menu
- the shared app shell replaces the fixed desktop sidebar with a mobile navigation drawer, preserving readable page width

The shared PageMasthead owns the container-responsive action slots, so other detail pages retain the existing safe wrapping fallback and can opt into an explicit action hierarchy without fixed page widths.

## Why
Wrapping prevented catastrophic overflow, but a large flat action set remained visually noisy and true mobile viewports still had only 102px of content because the desktop sidebar never collapsed. The supplied 1280px/720px model establishes a clear primary, secondary, and overflow hierarchy.

## Before / After
Before at 390px: the fixed 240px sidebar left a 102px masthead, producing single-word content columns. At constrained desktop widths all six actions remained equally prominent.

After at 390px: the masthead measures 342px, document scrollWidth equals clientWidth at 390px, New session remains visible, and Copy, Export, Edit, Create app, and Observe this agent are keyboard-accessible through More actions. At 1024px and 768px, frequent actions occupy a second row while Observe this agent moves to overflow. At 1440px, the complete toolbar remains aligned beside identity content.

Screenshots were captured locally at 1440, 1024, 768, and 390px. Upload configuration is unavailable in this environment; no screenshots were committed.

## Risk
- Medium
- The shared app shell changes navigation presentation below the md breakpoint, and agent actions have three container-dependent presentations. Risks are hidden/unreachable actions, focus regressions, or breakpoint overflow. Focused Playwright covers visibility, complete menu contents, Escape dismissal, readable masthead width, and document containment across representative widths. Full Playwright passed 35/35.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No findings. Text remains React-escaped; action URLs are fixed internal routes; Base UI retains menu/drawer focus management and Escape dismissal. No auth, API, trust-boundary, dependency, raw-HTML, or request-controlled URL surface changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
