### PR TITLE
fix(ui): align compact actions with masthead icon

### DIFF
--- a/apps/ui/e2e/page-masthead-responsive.spec.ts
+++ b/apps/ui/e2e/page-masthead-responsive.spec.ts
@@ -105,6 +105,7 @@ test.describe("Page masthead responsive layout", () => {
     const title = page.getByRole("heading", { name: "Jokes Agent" });
     const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
     const identity = masthead.locator('[data-slot="page-masthead-identity"]');
+    const icon = identity.locator('[data-slot="icon-tile"]');
     const actions = page
       .getByRole("button", { name: "New session" })
       .locator("xpath=ancestor::div[@data-slot='page-masthead-compact-actions'][1]");
@@ -128,11 +129,19 @@ test.describe("Page masthead responsive layout", () => {
 
     const mastheadBox = await masthead.boundingBox();
     const identityBox = await identity.boundingBox();
+    const iconBox = await icon.boundingBox();
     const actionsBox = await actions.boundingBox();
+    const titleBox = await title.boundingBox();
 
     expect(mastheadBox).not.toBeNull();
     expect(identityBox).not.toBeNull();
+    expect(iconBox).not.toBeNull();
     expect(actionsBox).not.toBeNull();
+    expect(titleBox).not.toBeNull();
+    expect(Math.abs(actionsBox!.y - iconBox!.y)).toBeLessThanOrEqual(1);
+    expect(Math.max(actionsBox!.y + actionsBox!.height, iconBox!.y + iconBox!.height)).toBeLessThan(
+      titleBox!.y,
+    );
     expect(mastheadBox!.width).toBeGreaterThanOrEqual(300);
     expect(identityBox!.width).toBeGreaterThanOrEqual(Math.min(320, mastheadBox!.width));
     expect(actionsBox!.x + actionsBox!.width).toBeLessThanOrEqual(
@@ -147,12 +156,16 @@ test.describe("Page masthead responsive layout", () => {
     { name: "compact desktop", width: 1024, height: 900 },
     { name: "tablet", width: 768, height: 900 },
   ]) {
-    test(`keeps frequent actions in a second row at ${viewport.name} width`, async ({ page }) => {
+    test(`places prioritized actions above identity at ${viewport.name} width`, async ({ page }) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await page.goto(`/agents/${AGENT_ID}`);
 
       const title = page.getByRole("heading", { name: "Jokes Agent" });
       const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
+      const identity = masthead.locator('[data-slot="page-masthead-identity"]');
+      const actions = page
+        .getByRole("button", { name: "New session" })
+        .locator("xpath=ancestor::div[@data-slot='page-masthead-compact-actions'][1]");
       const actionStrip = masthead.locator('[data-slot="page-masthead-compact-action-strip"]');
 
       await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
@@ -168,9 +181,14 @@ test.describe("Page masthead responsive layout", () => {
       await expect(page.getByRole("menuitem", { name: "Copy" })).toHaveCount(0);
 
       const mastheadBox = await masthead.boundingBox();
+      const identityBox = await identity.boundingBox();
+      const actionsBox = await actions.boundingBox();
       const stripBox = await actionStrip.boundingBox();
       expect(mastheadBox).not.toBeNull();
+      expect(identityBox).not.toBeNull();
+      expect(actionsBox).not.toBeNull();
       expect(stripBox).not.toBeNull();
+      expect(actionsBox!.y + actionsBox!.height).toBeLessThanOrEqual(identityBox!.y);
       expect(stripBox!.width).toBeLessThanOrEqual(mastheadBox!.width);
       expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
         await page.evaluate(() => document.documentElement.clientWidth),

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -2,8 +2,8 @@
 //
 // Zones (numbered ①–⑤ in the design source):
 //   1. Breadcrumb     — PageBreadcrumb: the context line (root → name → mode).
-//   2. Header         — PageMasthead: icon tile · title · status badge · meta, then a
-//                       right-aligned action cluster.
+//   2. Header         — PageMasthead: icon tile · title · status badge · meta, with a
+//                       right-aligned action cluster that moves above the title when compact.
 //   3. Control strip   — the shape-shifter: filters on list, stats on view, section nav
 //                       on edit. Same slot, always. Compose with PageControlStrip plus
 //                       SectionTabs / StatGrid as needed.
@@ -112,6 +112,7 @@ export function IconTile({
 }) {
   return (
     <span
+      data-slot="icon-tile"
       className={cn(
         "inline-flex flex-none items-center justify-center border bg-accent/20 text-foreground",
         size === "lg" ? "size-11 [&_svg]:size-[22px]" : "size-8 [&_svg]:size-4",
@@ -137,7 +138,7 @@ interface PageMastheadProps {
   meta?: ReactNode;
   /** Full right-aligned action cluster shown when the masthead has enough room. */
   actions?: ReactNode;
-  /** Prioritized actions shown instead of `actions` in constrained mastheads. */
+  /** Prioritized actions shown above the title instead of `actions` in constrained mastheads. */
   compactActions?: ReactNode;
   /** Frequent secondary actions shown on a separate row at tablet-like widths. */
   compactActionStrip?: ReactNode;
@@ -146,7 +147,7 @@ interface PageMastheadProps {
 
 /**
  * Zone ② — header anatomy shared by every page: gold icon tile · title · status
- * badge · meta run, then a right-aligned action cluster.
+ * badge · meta run, with a right-aligned action cluster above the title when compact.
  */
 export function PageMasthead({
   icon,
@@ -169,10 +170,18 @@ export function PageMasthead({
     >
       <div
         data-slot="page-masthead-identity"
-        className="flex min-w-0 flex-[1_1_20rem] items-start gap-4 max-sm:flex-col"
+        className="flex min-w-0 flex-[1_1_20rem] flex-wrap items-start gap-4 sm:flex-nowrap"
       >
         {icon && <IconTile icon={icon} />}
-        <div className="min-w-0 flex-1">
+        {compactActions && (
+          <div
+            data-slot="page-masthead-compact-actions"
+            className="ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 sm:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+          >
+            {compactActions}
+          </div>
+        )}
+        <div className="min-w-0 flex-1 max-sm:w-full max-sm:flex-none">
           <div className="flex min-w-0 flex-wrap items-center gap-2.5">
             <h1 className="min-w-0 break-words text-2xl font-semibold tracking-tight text-foreground">
               {title}
@@ -203,7 +212,7 @@ export function PageMasthead({
       {compactActions && (
         <div
           data-slot="page-masthead-compact-actions"
-          className="ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 @5xl/masthead:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+          className="order-first ml-auto hidden w-full max-w-full flex-none flex-wrap items-center justify-end gap-2 sm:flex @5xl/masthead:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
         >
           {compactActions}
         </div>

--- a/test_cases/ui/page_layout/TC001_responsive_masthead.md
+++ b/test_cases/ui/page_layout/TC001_responsive_masthead.md
@@ -25,11 +25,12 @@ when the app content area narrows.
 1. Open the agent detail page at the wide desktop viewport.
 2. Confirm the action cluster is right-aligned beside the title, description, badges, and metadata.
 3. Resize to the compact desktop and tablet viewports. Confirm `New session` and `More actions`
-   remain prioritized while Edit, Create app, Copy, and Export move to a second row. Open the
-   overflow menu and confirm Observe this agent is available.
+   appear above the identity while Edit, Create app, Copy, and Export move to a second row. Open
+   the overflow menu and confirm Observe this agent is available.
 4. Resize to the mobile viewport. Confirm only `New session` and `More actions` remain visible.
-   Open the overflow menu and confirm Copy, Export, Edit, Create app, and Observe this agent are
-   available. Open the mobile navigation drawer and close it with Escape.
+   Confirm they share the icon row above the title. Open the overflow menu and confirm Copy,
+   Export, Edit, Create app, and Observe this agent are available. Open the mobile navigation
+   drawer and close it with Escape.
 5. Repeat with a long title, a long description, expanded button labels, badges, and metadata.
 6. Inspect representative detail pages for agents, harnesses, apps, capabilities, skills, memory,
    knowledge indexes, agent identities, and sessions.
@@ -38,9 +39,10 @@ when the app content area narrows.
 
 - Identity content keeps a readable width instead of collapsing into a single-word column.
 - Wide screens show the full action cluster beside the identity content.
-- Compact desktop and tablet widths show the prioritized controls and secondary action strip.
+- Compact desktop and tablet widths show the prioritized controls above the identity and the
+  secondary action strip below it.
 - Mobile widths keep the primary action visible and expose every secondary action through the
-  keyboard-accessible overflow menu.
+  keyboard-accessible overflow menu on the icon row above the title.
 - The desktop sidebar becomes an accessible navigation drawer on mobile, leaving the page a
   readable content width.
 - Long text wraps without horizontal page overflow.


### PR DESCRIPTION
## What changed
Compact detail-page actions now share the masthead icon row above the title on mobile. Tablet and compact desktop keep prioritized actions above the identity, while wide desktop preserves the full right-aligned toolbar.

The shared `PageMasthead` contract owns this composition, so consumers do not need page-local positioning.

## Why
The initial responsive fix placed mobile actions on a separate row above the icon. Keeping the icon and primary actions together creates a clearer top-level hierarchy and matches the approved responsive model.

## Before / After
Before: at 390px, compact actions started 48px above the icon (`actions y=187`, `icon y=235`).

After: the icon and compact actions both start at `y=187`; the title begins beneath them at `y=247`. The open overflow menu remains contained with `scrollWidth=clientWidth=390`.

Screenshots were captured locally at `/tmp/masthead-icon-actions-row-mobile-390.png` and `/tmp/masthead-icon-actions-row-mobile-390-menu.png`. Upload was unavailable because `CLOUDINARY_URL` and `GITHUB_TOKEN` are not configured in this environment.

## Risk
- Low
- Responsive visibility or ordering could regress at a breakpoint. Playwright now asserts the mobile icon/action alignment, constrained-width ordering, wide-screen alignment, and absence of horizontal overflow.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No findings. The change only alters responsive layout and reuses the existing escaped React action tree. It adds no HTML injection, request-controlled URLs, authentication behavior, API surface, or dependency changes. Hidden responsive variants use CSS display state and retain the existing keyboard-accessible menu implementation.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
