### PR TITLE
fix(server): reject unsafe OKF export paths

### DIFF
--- a/crates/server/src/domains/knowledge_bases/okf.rs
+++ b/crates/server/src/domains/knowledge_bases/okf.rs
@@ -528,6 +528,9 @@ pub fn encode_tar_gz(files: &[(String, String)]) -> Result<Vec<u8>> {
     {
         let mut builder = tar::Builder::new(&mut encoder);
         for (path, content) in files {
+            if is_unsafe_path(path) {
+                anyhow::bail!("refusing to archive unsafe path: {path}");
+            }
             let mut header = tar::Header::new_gnu();
             header.set_size(content.len() as u64);
             header.set_mode(0o644);
@@ -900,5 +903,16 @@ tags: [sales]\n\
         let decoded = decode_tar_gz_bundle(&bytes).unwrap();
         assert!(decoded.iter().any(|(p, _)| p == "tables/orders.md"));
         assert!(decoded.iter().any(|(p, _)| p == "index.md"));
+    }
+
+    #[test]
+    fn export_rejects_unsafe_archive_paths() {
+        for path in ["../escape.md", "/absolute.md", "notes/../../escape.md"] {
+            let files = vec![(path.to_string(), "content".to_string())];
+            assert!(
+                encode_tar_gz(&files).is_err(),
+                "expected unsafe archive path to be rejected: {path}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What changed
OKF tarball encoding now rejects absolute and parent-traversing member paths before appending archive data. A regression test covers malicious paths supplied through stored export metadata.

## Why
User-controlled `okf:path=` tags could reach the exporter and produce a tarball with traversing members, putting vulnerable downstream extractors at risk.

## Before / After
Before: values such as `../escape.md`, `/absolute.md`, and `notes/../../escape.md` reached tar archive construction.

After: `encode_tar_gz` returns an error for each of those paths, while the existing OKF import/export round-trip remains unchanged for safe paths.

## Risk
- Low
- Export now fails when a knowledge base contains an unsafe stored OKF path instead of emitting a malicious archive.

## Security
- Threat categories reviewed: TM-API, TM-FS
- Findings and resolutions: closed the export trust-boundary path traversal by applying the existing unsafe-path validator immediately before tar member creation. No auth, tenancy, SQL, dependency, or resource-bound changes.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
