### PR TITLE
fix(provider): harden model discovery fallback

### DIFF
--- a/crates/provider/src/model_discovery.rs
+++ b/crates/provider/src/model_discovery.rs
@@ -11,6 +11,7 @@
 //! no catalog to offer" and callers should keep their curated suggestions,
 //! while `Err` means the catalog request itself failed.
 
+use crate::driver_helpers::shared_request_http_client;
 use crate::driver_registry::{DiscoveredModel, DriverId, DriverRegistry, ProviderConfig};
 use crate::error::{AgentLoopError, Result};
 use crate::model_profiles::get_model_profile;
@@ -144,8 +145,20 @@ pub async fn list_openai_compatible_models(
     base_url: &str,
     api_key: Option<&str>,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
+    // THREAT[TM-API-013]: Provider base URLs are org-configurable. Use the
+    // shared client so redirects, private DNS results, and hung responses are
+    // rejected at request time.
+    list_openai_compatible_models_with_client(&shared_request_http_client(), base_url, api_key)
+        .await
+}
+
+async fn list_openai_compatible_models_with_client(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: Option<&str>,
+) -> Result<Option<Vec<DiscoveredModel>>> {
     let url = format!("{}/models", base_url.trim_end_matches('/'));
-    let mut request = reqwest::Client::new().get(&url);
+    let mut request = client.get(&url);
     if let Some(key) = api_key {
         request = request.bearer_auth(key);
     }
@@ -565,10 +578,17 @@ mod tests {
                 .expect("write response");
         });
 
-        let discovered = list_openai_compatible_models(&format!("http://{addr}/v1"), None)
-            .await
-            .expect("fallback discovery should succeed")
-            .expect("endpoint lists models");
+        let discovered = list_openai_compatible_models_with_client(
+            &reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("build mock HTTP client"),
+            &format!("http://{addr}/v1"),
+            None,
+        )
+        .await
+        .expect("fallback discovery should succeed")
+        .expect("endpoint lists models");
         server.join().expect("mock server thread");
 
         let presented = normalize_and_enrich(&DriverId::OpenAI, discovered);
@@ -576,6 +596,13 @@ mod tests {
         assert!(ids.contains(&"llama3.2:latest"), "ids: {ids:?}");
         // Gemini-style `models/` prefixes are normalized to bare ids.
         assert!(ids.contains(&"qwen3"), "ids: {ids:?}");
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_fallback_blocks_internal_addresses() {
+        list_openai_compatible_models("http://127.0.0.1:9/v1", None)
+            .await
+            .expect_err("model discovery must use the provider SSRF guard");
     }
 
     fn presented(id: &str, display_name: Option<&str>) -> DiscoveredProviderModel {


### PR DESCRIPTION
## What changed
Model discovery now sends OpenAI-compatible catalog requests through the shared hardened request client. The fallback rejects private/internal DNS results and redirects and applies the bounded non-streaming request timeout while preserving catalog parsing and bearer authentication.

A regression test verifies that the public fallback rejects an internal IP literal. The existing catalog-response test now injects a local-only test client so response parsing remains covered without bypassing production hardening.

## Why
The newly exported discovery fallback used a default `reqwest` client for an organization-configurable provider URL. That bypassed the provider egress protections and exposed downstream callers to redirect SSRF, DNS rebinding, and indefinitely hung catalog responses.

## Before / After
Before: `list_openai_compatible_models` created `reqwest::Client::new()`, which followed redirects and had neither the provider DNS guard nor an overall request timeout.

After: `cargo test -p everruns-provider --lib model_discovery` passes 15 focused tests, including `openai_compatible_fallback_blocks_internal_addresses` and the successful OpenAI-compatible response path.

## Risk
- Low
- Model catalog calls to internal/private addresses or endpoints requiring redirects now fail by design. Valid public endpoints retain the same request and response behavior.

## Security
- Threat categories reviewed: TM-API and TM-DOS.
- Findings and resolutions: Resolved the TM-API-013 egress bypass by reusing `shared_request_http_client`, which disables redirects and guards request-time DNS resolution. Its overall timeout also bounds stalled model-catalog reads. No credentials are newly stored or logged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
