### PR TITLE
fix(server): cascade org seed resources on rollback

### DIFF
--- a/crates/server/migrations/113_cascade_org_seed_resources.sql
+++ b/crates/server/migrations/113_cascade_org_seed_resources.sql
@@ -1,0 +1,12 @@
+-- Org creation provisions these rows before required embedder initializers run.
+-- They must not prevent the creation rollback when an initializer fails.
+
+ALTER TABLE harnesses
+    DROP CONSTRAINT harnesses_org_id_fkey,
+    ADD CONSTRAINT harnesses_org_id_fkey
+        FOREIGN KEY (org_id) REFERENCES organizations(org_id) ON DELETE CASCADE;
+
+ALTER TABLE plugin_marketplaces
+    DROP CONSTRAINT plugin_marketplaces_org_id_fkey,
+    ADD CONSTRAINT plugin_marketplaces_org_id_fkey
+        FOREIGN KEY (org_id) REFERENCES organizations(org_id) ON DELETE CASCADE;

--- a/crates/server/migrations/114_cascade_org_seed_resources.sql
+++ b/crates/server/migrations/114_cascade_org_seed_resources.sql
@@ -1,5 +1,5 @@
--- Org creation provisions these rows before required embedder initializers run.
--- They must not prevent the creation rollback when an initializer fails.
+-- Org creation provisions settings and seed resources before required embedder
+-- initializers run. They must not prevent rollback when an initializer fails.
 
 ALTER TABLE harnesses
     DROP CONSTRAINT harnesses_org_id_fkey,
@@ -9,4 +9,9 @@ ALTER TABLE harnesses
 ALTER TABLE plugin_marketplaces
     DROP CONSTRAINT plugin_marketplaces_org_id_fkey,
     ADD CONSTRAINT plugin_marketplaces_org_id_fkey
+        FOREIGN KEY (org_id) REFERENCES organizations(org_id) ON DELETE CASCADE;
+
+ALTER TABLE organization_settings
+    DROP CONSTRAINT organization_settings_org_id_fkey,
+    ADD CONSTRAINT organization_settings_org_id_fkey
         FOREIGN KEY (org_id) REFERENCES organizations(org_id) ON DELETE CASCADE;

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -2282,7 +2282,14 @@ async fn test_organization_crud() {
         .expect("Failed to list organizations");
     assert!(orgs.iter().any(|o| o.org_id == org.org_id));
 
-    // Delete organization
+    // Org creation provisions both resources before required initializers run.
+    // They must not block rollback if a required initializer fails.
+    org_init::initialize_org_harnesses(&backend, org.org_id)
+        .await
+        .expect("Failed to initialize org harnesses");
+    org_init::seed_default_plugin_marketplace(&backend, org.org_id).await;
+
+    // Delete organization, including its provisioned resources.
     let deleted = backend
         .delete_organization(org.org_id)
         .await

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -2289,7 +2289,7 @@ async fn test_organization_crud() {
         .expect("Failed to initialize org harnesses");
     org_init::seed_default_plugin_marketplace(&backend, org.org_id).await;
 
-    // Delete organization, including its provisioned resources.
+    // Delete organization, including its settings and provisioned resources.
     let deleted = backend
         .delete_organization(org.org_id)
         .await


### PR DESCRIPTION
## What changed
Organization deletion now cascades through the organization settings, built-in harnesses, and default plugin marketplace owned by the organization. A PostgreSQL repository integration test provisions the normal seed resources before deleting the organization.

## Why
A required post-create initializer failure calls `delete_organization`, but PostgreSQL rejected that delete because normally provisioned child rows had non-cascading foreign keys. The failed request could therefore leave a user-visible organization without required host resources.

## Before / After
Before: the PostgreSQL integration flow failed to delete a normally provisioned organization, first on seed resources and then on `organization_settings_org_id_fkey`.

After: `test_organization_crud` provisions built-in harnesses and the default marketplace, then deletes the organization together with its settings and provisioned resources. Local `just pre-push` passes all 10 gates and migration ordering reports `migrations sequential (001..113)`. Final PostgreSQL validation is delegated to CI because Docker is unavailable locally.

## Risk
- Low
- Explicit organization deletion now removes settings, built-in harnesses, and marketplace rows owned by that organization. Unrelated organizations and cross-org rows are unaffected.

## Security
- Threat categories reviewed: TM-TENANT, TM-API, TM-SQL
- Findings and resolutions: Fixed the fail-open tenant provisioning state by making organization-owned child rows follow their parent lifecycle. Foreign keys remain org-scoped, the migration uses fixed DDL, and cascades cannot cross organization boundaries.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review comments)