### PR TITLE
test(llm-tests): require captured reasoning before accepting extended-thinking attempt

### DIFF
--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -87,7 +87,25 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 
         skip_if_quota!(result, config.label());
 
-        if result.success && result.response.contains("503") {
+        // Adaptive-thinking models occasionally answer correctly without emitting
+        // a thinking block; for providers that keep reasoning on the private
+        // `thinking` field, require it in the acceptance check so we retry rather
+        // than accept an attempt that would fail the reasoning assertions below.
+        let reasoning_captured = if config.reasoning_on_thinking_field {
+            runner
+                .messages()
+                .await
+                .ok()
+                .and_then(|msgs| {
+                    msgs.into_iter()
+                        .find(|m| m.role == MessageRole::Agent)
+                        .map(|m| m.thinking.is_some_and(|t| !t.is_empty()))
+                })
+                .unwrap_or(false)
+        } else {
+            true
+        };
+        if result.success && result.response.contains("503") && reasoning_captured {
             accepted = Some((runner, result));
             break;
         }
@@ -104,12 +122,13 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
                 .is_some_and(is_transient_transport_error);
         eprintln!(
             "{}: attempt {attempt}/{} extended-thinking not accepted \
-             (success={}, transient_transport={}, contains_503={}, error={:?}); retrying",
+             (success={}, transient_transport={}, contains_503={}, reasoning_captured={}, error={:?}); retrying",
             config.label(),
             MAX_ATTEMPTS,
             result.success,
             transient,
             result.response.contains("503"),
+            reasoning_captured,
             result.error,
         );
     }


### PR DESCRIPTION
## What changed

`test_extended_thinking` (crates/llm-tests) already retries up to 3 attempts, but its acceptance predicate was answer-only — `result.success && result.response.contains("503")`. It then asserts, after the loop, that the stored assistant message carries reasoning on the private `thinking` field.

Adaptive-thinking models (Claude Opus 4.7+) occasionally answer the prompt correctly **without** emitting a thinking block. When that happened the retry accepted the attempt (503 present) and the subsequent `assistant_msg.thinking.is_some()` assertion failed — reddening main CI (observed failing on run #10007 attempts 1 and 2; the same-model `test_thinking_with_tool_call` case passed, confirming the model *can* emit thinking and this is non-determinism, not a regression).

This folds a `reasoning_captured` check into the acceptance predicate for `reasoning_on_thinking_field` providers, so an attempt that answers correctly but without a captured thinking block is **retried** instead of accepted. The final-attempt fallthrough is preserved, so a genuinely broken provider still fails after 3 attempts with the precise existing assertion message.

## Why

Main CI's `Integration Tests (PostgreSQL)` → LLM integration tests step was going red on this flake. Live-LLM tests only run on push-to-main (API keys are push-gated), so this only affects post-merge main CI, not PR CI.

## Testing

Test-only change; validated by CI compilation + clippy. The live assertion path is unchanged — only the retry acceptance condition is tightened.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY1aHVu1se5CZUqCUhmsKd)_