### PR TITLE
test(llm-tests): widen extended-thinking retry budget to 6

### DIFF
--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -44,7 +44,14 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
     // non-determinism, but keep the accepted attempt's `runner` because the
     // reasoning-field assertions below inspect `runner.messages()` — so this
     // cannot use the `run_live_turn!` macro (which only returns the result).
-    const MAX_ATTEMPTS: usize = 3;
+    //
+    // The acceptance predicate below requires success + the answer + captured
+    // reasoning, so a single attempt can miss on any of three independent axes
+    // (streaming/transport error, answer not yet emitted, reasoning surfaced as
+    // public text instead of the private field). Opus in particular flaked all
+    // three in one run on `main`, so the budget is generous enough to absorb a
+    // couple of bad draws while still failing a genuinely broken provider.
+    const MAX_ATTEMPTS: usize = 6;
     let mut accepted: Option<(InMemoryAgenticLoop, TurnResult)> = None;
     for attempt in 1..=MAX_ATTEMPTS {
         let model = config.model().expect("model set (checked above)");


### PR DESCRIPTION
## What changed

Raises `MAX_ATTEMPTS` in `test_extended_thinking` from 3 to 6.

## Why

Follow-up to #3006. That change correctly folded the reasoning-captured check into the retry acceptance predicate, but on `main` run #10007/#31161477332 the Anthropic **Opus** case (`claude-opus-4-7`) flaked on all three independent transient axes within 3 attempts:
- attempt 1: `success=true, contains_503=true, reasoning_captured=false` (model surfaced its reasoning as public text with an empty private `thinking` field);
- attempt 2: transient transport error (`error decoding response body`);
- attempt 3: response truncated before emitting the answer.

The **Sonnet** extended-thinking case passes reliably in the same run, confirming the private-reasoning mechanism works and Opus is merely flakier. Because the acceptance predicate legitimately requires success + answer + captured reasoning, a small attempt budget can be exhausted by a couple of unlucky transient draws. Widening to 6 absorbs that while still failing a genuinely broken provider (the final-attempt fallthrough preserves the precise assertion message).

Live-LLM tests run only on push-to-main (keys are push-gated), so this only affects post-merge main CI.

## Testing

Test-only change; retry-budget constant. Validated by CI compilation + clippy.

## Follow-ups

If Opus continues to flake even at 6 attempts, the root cause is likely `claude-opus-4-7`-specific model behavior (surfacing reasoning as public text rather than the private field) and warrants either pinning the Anthropic thinking case to a current Opus model or relaxing the private-field assertion for it — a maintainer call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY1aHVu1se5CZUqCUhmsKd)_