### PR TITLE
test(llm-tests): use Opus 5 for extended-thinking reasoning assertion

### DIFF
--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -28,7 +28,11 @@ use everruns_core::message_retriever::InputMessage;
 // ============================================================================
 
 #[rstest]
-#[case::anthropic_opus(ANTHROPIC_OPUS)]
+// Uses Opus 5 rather than the `claude-opus-4-7` alias: that alias now returns
+// its reasoning as public response text with an empty private `thinking` field
+// (observed 6/6 on main), which is not what this private-field assertion checks.
+// Current Opus/Sonnet models surface reasoning on the private field.
+#[case::anthropic_opus5(ANTHROPIC_OPUS5)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]


### PR DESCRIPTION
## What changed

Points the Anthropic case of `test_extended_thinking` at `ANTHROPIC_OPUS5` (`claude-opus-5`) instead of `ANTHROPIC_OPUS` (`claude-opus-4-7`).

## Why — root cause

Follow-up to #3006 and #3007. Those improved the retry logic, but the retry diagnostics on main run #31166046735 were conclusive: across **all 6 attempts**, `claude-opus-4-7` returned `success=true` with `reasoning_captured=false` — it surfaces its reasoning as **public response text** with an empty private `thinking` field (the matrix even notes `claude-opus-4-7` is a bare alias the API no longer serves a dated id for). No retry budget can fix a deterministic 0/6.

`test_extended_thinking::case_2_anthropic_sonnet` (`claude-sonnet-4-6`) passes reliably in the same runs, confirming current Anthropic models surface reasoning on the private `thinking` field that this assertion checks. `ANTHROPIC_OPUS5` is already defined in the matrix, so this switches the case to the current flagship Opus rather than the retired alias.

The `test_thinking_with_tool_call` Opus case is left on `ANTHROPIC_OPUS` (it does not assert private reasoning and passes today); the retry-budget/acceptance improvements from #3006/#3007 remain as defense-in-depth.

Live-LLM tests run only on push-to-main (keys are push-gated), so this only affects post-merge main CI.

## Testing

Test-only change. Validated by CI compilation + clippy; the live assertion path is unchanged, only the model under test.

## Follow-ups

No follow-ups. (If a future run shows `claude-opus-5` also surfacing reasoning as public text, the private-field assertion itself would need revisiting — but Sonnet 4-6 behaving correctly makes that unlikely.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY1aHVu1se5CZUqCUhmsKd)_