### PR TITLE
fix(ui): remove duplicate compact masthead actions

### DIFF
--- a/apps/ui/e2e/page-masthead-responsive.spec.ts
+++ b/apps/ui/e2e/page-masthead-responsive.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 
 const DEFAULT_ORG_ID = "org_00000000000000000000000000000001";
 const AGENT_ID = "agent_019fd9b43fa37512b8f25226b21c2c8b";
+const HARNESS_ID = "harness_019fd9b43fa37512b8f25226b21c2c8b";
 
 async function mockAgentDetailApi(page: Page) {
   await page.route("**/api/v1/**", async (route) => {
@@ -65,6 +66,29 @@ async function mockAgentDetailApi(page: Page) {
         input_tokens: 1200,
         output_tokens: 600,
       };
+    } else if (pathname === `/api/v1/harnesses/${HARNESS_ID}`) {
+      json = {
+        id: HARNESS_ID,
+        name: "responsive-harness",
+        display_name: "Responsive Harness",
+        description: "A representative detail page using the standard masthead action cluster.",
+        system_prompt: "Help the user.",
+        default_model_id: null,
+        parent_harness_id: null,
+        tags: [],
+        capabilities: [],
+        initial_files: [],
+        is_built_in: false,
+        status: "active",
+        session_count: 4,
+        app_count: 2,
+        created_at: "2026-08-01T00:00:00Z",
+        updated_at: "2026-08-01T00:00:00Z",
+        archived_at: null,
+        deleted_at: null,
+      };
+    } else if (pathname === `/api/v1/harnesses/${HARNESS_ID}/stats`) {
+      json = { sessions: 4, messages: 8, input_tokens: 400, output_tokens: 200 };
     } else if (pathname === "/api/v1/sessions") {
       json = { data: [], has_more: false, total: 0, offset: 0, limit: 10 };
     } else if (
@@ -106,12 +130,12 @@ test.describe("Page masthead responsive layout", () => {
     const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
     const identity = masthead.locator('[data-slot="page-masthead-identity"]');
     const icon = identity.locator('[data-slot="icon-tile"]');
-    const actions = page
-      .getByRole("button", { name: "New session" })
-      .locator("xpath=ancestor::div[@data-slot='page-masthead-compact-actions'][1]");
+    const actions = masthead.locator('[data-slot="page-masthead-compact-actions"]');
+    const moreActions = page.getByRole("button", { name: "More actions" });
     await expect(title).toBeVisible();
     await expect(page.getByRole("button", { name: "Open navigation" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "More actions" })).toBeVisible();
+    await expect(actions).toHaveCount(1);
+    await expect(moreActions).toBeVisible();
     await expect(page.getByRole("button", { name: "Copy", exact: true })).toBeHidden();
     await expect(page.getByRole("button", { name: "Observe this agent" })).toBeHidden();
 
@@ -120,12 +144,20 @@ test.describe("Page masthead responsive layout", () => {
     await page.keyboard.press("Escape");
     await expect(page.locator('[data-slot="drawer-content"]')).toBeHidden();
 
-    await page.getByRole("button", { name: "More actions" }).click();
+    await moreActions.click({ trial: true });
+    await moreActions.click();
     await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Export" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Create app" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Observe this agent" })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(moreActions).toBeFocused();
+    await moreActions.press("Enter");
+    await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Observe this agent" })).toBeVisible();
+    await page.keyboard.press("Escape");
 
     const mastheadBox = await masthead.boundingBox();
     const identityBox = await identity.boundingBox();
@@ -162,7 +194,7 @@ test.describe("Page masthead responsive layout", () => {
 
       const title = page.getByRole("heading", { name: "Jokes Agent" });
       const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
-      const identity = masthead.locator('[data-slot="page-masthead-identity"]');
+      const icon = masthead.locator('[data-slot="icon-tile"]');
       const actions = page
         .getByRole("button", { name: "New session" })
         .locator("xpath=ancestor::div[@data-slot='page-masthead-compact-actions'][1]");
@@ -181,14 +213,14 @@ test.describe("Page masthead responsive layout", () => {
       await expect(page.getByRole("menuitem", { name: "Copy" })).toHaveCount(0);
 
       const mastheadBox = await masthead.boundingBox();
-      const identityBox = await identity.boundingBox();
+      const iconBox = await icon.boundingBox();
       const actionsBox = await actions.boundingBox();
       const stripBox = await actionStrip.boundingBox();
       expect(mastheadBox).not.toBeNull();
-      expect(identityBox).not.toBeNull();
+      expect(iconBox).not.toBeNull();
       expect(actionsBox).not.toBeNull();
       expect(stripBox).not.toBeNull();
-      expect(actionsBox!.y + actionsBox!.height).toBeLessThanOrEqual(identityBox!.y);
+      expect(actionsBox!.y + actionsBox!.height).toBeLessThanOrEqual(iconBox!.y);
       expect(stripBox!.width).toBeLessThanOrEqual(mastheadBox!.width);
       expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
         await page.evaluate(() => document.documentElement.clientWidth),
@@ -213,5 +245,30 @@ test.describe("Page masthead responsive layout", () => {
     await expect(page.getByRole("button", { name: "Open navigation" })).toBeHidden();
     await expect(page.getByRole("button", { name: "More actions" })).toBeHidden();
     await expect(page.getByRole("button", { name: "Observe this agent" })).toBeVisible();
+  });
+
+  test("keeps a representative standard-action consumer contained on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/harnesses/${HARNESS_ID}`);
+
+    const title = page.getByRole("heading", { name: "Responsive Harness" });
+    const masthead = title.locator("xpath=ancestor::div[@data-slot='page-masthead'][1]");
+    const edit = page.getByRole("link", { name: "Edit" });
+
+    await expect(title).toBeVisible();
+    await expect(page.getByRole("link", { name: "Create app" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy", exact: true })).toBeVisible();
+    await expect(edit).toBeVisible();
+    await expect(page.getByRole("button", { name: "Archive" })).toBeVisible();
+    await edit.click({ trial: true });
+
+    const mastheadBox = await masthead.boundingBox();
+    expect(mastheadBox).not.toBeNull();
+    expect(mastheadBox!.x + mastheadBox!.width).toBeLessThanOrEqual(
+      await page.evaluate(() => document.documentElement.clientWidth),
+    );
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+      await page.evaluate(() => document.documentElement.clientWidth),
+    );
   });
 });

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -170,18 +170,37 @@ export function PageMasthead({
     >
       <div
         data-slot="page-masthead-identity"
-        className="flex min-w-0 flex-[1_1_20rem] flex-wrap items-start gap-4 sm:flex-nowrap"
+        className={cn(
+          "grid min-w-0 flex-[1_1_20rem] items-start gap-4",
+          icon ? "grid-cols-[auto_minmax(0,1fr)]" : "grid-cols-1",
+        )}
       >
-        {icon && <IconTile icon={icon} />}
+        {icon && (
+          <IconTile
+            icon={icon}
+            className={compactActions ? "sm:row-start-2 @5xl/masthead:row-start-1" : undefined}
+          />
+        )}
         {compactActions && (
           <div
             data-slot="page-masthead-compact-actions"
-            className="ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 sm:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
+            className={cn(
+              "row-start-1 ml-auto flex max-w-full flex-none flex-wrap items-center justify-end gap-2 sm:col-span-full @5xl/masthead:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal",
+              icon ? "col-start-2 sm:col-start-1" : "col-start-1",
+            )}
           >
             {compactActions}
           </div>
         )}
-        <div className="min-w-0 flex-1 max-sm:w-full max-sm:flex-none">
+        <div
+          className={cn(
+            "min-w-0",
+            icon && !compactActions && "col-start-2",
+            compactActions &&
+              "col-span-full row-start-2 sm:col-span-1 sm:row-start-2 @5xl/masthead:row-start-1",
+            compactActions && icon && "sm:col-start-2",
+          )}
+        >
           <div className="flex min-w-0 flex-wrap items-center gap-2.5">
             <h1 className="min-w-0 break-words text-2xl font-semibold tracking-tight text-foreground">
               {title}
@@ -207,14 +226,6 @@ export function PageMasthead({
           )}
         >
           {actions}
-        </div>
-      )}
-      {compactActions && (
-        <div
-          data-slot="page-masthead-compact-actions"
-          className="order-first ml-auto hidden w-full max-w-full flex-none flex-wrap items-center justify-end gap-2 sm:flex @5xl/masthead:hidden [&>a]:max-w-full [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-8 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal"
-        >
-          {compactActions}
         </div>
       )}
       {compactActionStrip && (

--- a/test_cases/ui/page_layout/TC001_responsive_masthead.md
+++ b/test_cases/ui/page_layout/TC001_responsive_masthead.md
@@ -28,9 +28,10 @@ when the app content area narrows.
    appear above the identity while Edit, Create app, Copy, and Export move to a second row. Open
    the overflow menu and confirm Observe this agent is available.
 4. Resize to the mobile viewport. Confirm only `New session` and `More actions` remain visible.
-   Confirm they share the icon row above the title. Open the overflow menu and confirm Copy,
-   Export, Edit, Create app, and Observe this agent are available. Open the mobile navigation
-   drawer and close it with Escape.
+   Confirm they share the icon row above the title. Click `More actions` at its visible center and
+   confirm Copy, Export, Edit, Create app, and Observe this agent are available. Close the menu,
+   focus `More actions`, open it with Enter, then close it with Escape and confirm focus returns to
+   the trigger. Open the mobile navigation drawer and close it with Escape.
 5. Repeat with a long title, a long description, expanded button labels, badges, and metadata.
 6. Inspect representative detail pages for agents, harnesses, apps, capabilities, skills, memory,
    knowledge indexes, agent identities, and sessions.
@@ -42,7 +43,9 @@ when the app content area narrows.
 - Compact desktop and tablet widths show the prioritized controls above the identity and the
   secondary action strip below it.
 - Mobile widths keep the primary action visible and expose every secondary action through the
-  keyboard-accessible overflow menu on the icon row above the title.
+  clickable, keyboard-accessible overflow menu on the icon row above the title.
+- The masthead renders one compact action tree, so browser automation and keyboard focus cannot
+  target a hidden breakpoint-specific duplicate.
 - The desktop sidebar becomes an accessible navigation drawer on mobile, leaving the page a
   readable content width.
 - Long text wraps without horizontal page overflow.


### PR DESCRIPTION
## What changed
The shared responsive PageMasthead now renders one compact action tree and lays it out with a responsive grid. Mobile keeps New session and More actions on the icon row; constrained widths place prioritized actions above the identity; wide screens retain the full action cluster.

## Why
At 390px, duplicate responsive action trees could leave browser automation targeting a hidden More actions trigger, while the visible trigger was covered or opened an incomplete Observe-only menu. Secondary actions must remain reachable and consistent on every detail page.

## Before / After
Before: the masthead rendered two compact action trees. The new regression test fails with `compact-actions` count 2, and manual browser automation reports the visible trigger covered by a `div.flex.h-11`.

After: the shared masthead renders exactly one compact action tree. Playwright passes 5/5, including a real pointer click trial and click, all five mobile menu items (Copy, Export, Edit, Create app, Observe this agent), Enter/Escape focus behavior, compact/tablet layout, no horizontal overflow, and an agent plus harness consumer. Production UI build passes. Manual smoke at 390x844 passes against a real DEV_MODE stack; local screenshots: `/tmp/masthead-mobile.png` and `/tmp/masthead-mobile-menu.png` (upload unavailable because CLOUDINARY_URL/GITHUB_TOKEN are not configured).

## Risk
- Low
- The change is isolated to shared masthead layout mechanics. Breakpoint ordering, action wrapping, or consumers that provide compactActions could regress; responsive E2E coverage covers those paths.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No findings. This is presentational React/CSS and test coverage only; it adds no request-controlled HTML or URLs, authentication behavior, API surface, or dependencies.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)