### PR TITLE
fix(ui): refine responsive mobile chrome

### DIFF
--- a/apps/ui/src/__tests__/dashboard-catalog-requests.test.tsx
+++ b/apps/ui/src/__tests__/dashboard-catalog-requests.test.tsx
@@ -12,7 +12,7 @@
 // the exact catalog request set for empty, agents-only, sessions-only, and
 // populated dashboards.
 
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { createAppQueryClient } from "@/lib/query-client";
@@ -151,6 +151,24 @@ const sessionWithoutModel = {
 };
 
 describe("dashboard catalog requests (EVE-783)", () => {
+  it("provides the new-session action to compact masthead layouts", () => {
+    renderDashboard();
+
+    const heading = screen.getByRole("heading", { name: "Dashboard" });
+    const masthead = heading.closest('[data-slot="page-masthead"]');
+    expect(masthead).not.toBeNull();
+
+    const compactActionGroups = masthead!.querySelectorAll(
+      '[data-slot="page-masthead-compact-actions"]',
+    );
+    expect(compactActionGroups).toHaveLength(1);
+    for (const group of compactActionGroups) {
+      expect(
+        within(group as HTMLElement).getByRole("button", { name: "New session" }),
+      ).toBeDisabled();
+    }
+  });
+
   it("empty dashboard requests neither capabilities nor models", async () => {
     dataset = { agents: [], sessions: [] };
     renderDashboard();

--- a/apps/ui/src/__tests__/early-access-banner.test.tsx
+++ b/apps/ui/src/__tests__/early-access-banner.test.tsx
@@ -23,8 +23,7 @@ jest.mock("@/hooks/use-user-preferences", () => ({
 import { EarlyAccessBanner } from "@/components/layout/early-access-banner";
 
 function getBanner(): HTMLElement | null {
-  // The banner row carries the fixed 44px height; its absence means no shell gap.
-  return document.querySelector(".h-11");
+  return document.querySelector('[data-slot="early-access-banner"]');
 }
 
 beforeEach(() => {
@@ -39,7 +38,19 @@ describe("EarlyAccessBanner (EVE-794)", () => {
     render(<EarlyAccessBanner />);
 
     expect(getBanner()).not.toBeNull();
-    expect(screen.getByText("Early access.")).toBeInTheDocument();
+    expect(screen.getByText("Early access")).toBeInTheDocument();
+  });
+
+  it("collapses to the short label on small screens", () => {
+    preferenceData = null;
+    render(<EarlyAccessBanner />);
+
+    expect(getBanner()).toHaveClass("h-9", "md:h-11");
+    expect(screen.getByText(/Everruns is still stabilizing/)).toHaveClass("hidden", "md:inline");
+    expect(screen.getByRole("link", { name: /Follow along on GitHub/i })).toHaveClass(
+      "hidden",
+      "md:inline-flex",
+    );
   });
 
   it("does not render during loading when the local cache says dismissed", () => {

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -81,21 +81,20 @@ export default function DashboardPage() {
     }
   };
 
+  const newSessionAction = (
+    <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={agents.length === 0}>
+      <Plus className="size-4" />
+      New session
+    </Button>
+  );
+
   const dashboardMasthead = (
     <PageMasthead
       icon={<LayoutDashboard />}
       title="Dashboard"
       description="Your agents, recent sessions, and activity at a glance."
-      actions={
-        <Button
-          variant="accent"
-          onClick={handleOpenNewSessionDialog}
-          disabled={agents.length === 0}
-        >
-          <Plus className="size-4" />
-          New session
-        </Button>
-      }
+      actions={newSessionAction}
+      compactActions={newSessionAction}
     />
   );
 

--- a/apps/ui/src/components/layout/early-access-banner.tsx
+++ b/apps/ui/src/components/layout/early-access-banner.tsx
@@ -81,20 +81,25 @@ export function EarlyAccessBanner() {
   };
 
   return (
-    <div className="flex h-11 flex-none items-center gap-2.5 border-b border-[hsl(var(--accent)/0.35)] bg-[hsl(var(--accent)/0.12)] px-[18px] text-primary">
+    <div
+      data-slot="early-access-banner"
+      className="flex h-9 flex-none items-center gap-2.5 border-b border-[hsl(var(--accent)/0.35)] bg-[hsl(var(--accent)/0.12)] px-3 text-primary md:h-11 md:px-[18px]"
+    >
       <span className="inline-flex text-accent-foreground">
         <FlaskConical className="h-[15px] w-[15px]" />
       </span>
       <span className="text-[13px] tracking-[-0.01em]">
-        <strong className="font-semibold">Early access.</strong> Everruns is still stabilizing —
-        expect breaking changes and rough edges.
+        <strong className="font-semibold">Early access</strong>
+        <span className="hidden md:inline">
+          . Everruns is still stabilizing — expect breaking changes and rough edges.
+        </span>
       </span>
       <span className="flex-1" />
       <a
         href={GITHUB_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 whitespace-nowrap text-[13px] font-medium text-primary hover:underline hover:underline-offset-[3px]"
+        className="hidden items-center gap-1 whitespace-nowrap text-[13px] font-medium text-primary hover:underline hover:underline-offset-[3px] md:inline-flex"
       >
         <GithubIcon className="h-[14px] w-[14px]" /> Follow along on GitHub{" "}
         <ArrowRight className="h-[13px] w-[13px]" />


### PR DESCRIPTION
## What changed

The early-access banner now collapses to a 36px icon, “Early access” label, and dismiss control below the app’s mobile breakpoint. Its explanatory copy and GitHub link remain available on desktop.

The Dashboard “New session” action now uses the shared compact masthead slot, keeping it aligned with the icon on mobile while preserving the right-aligned desktop action.

## Why

The full early-access copy competed with the compact navigation header on narrow screens. After the responsive masthead changes landed on main, Dashboard still supplied only the wide action slot, which placed its primary action below the identity content at mobile widths.

## Before / After

- Before: the 44px early-access row retained its full sentence and GitHub link on narrow screens; Dashboard’s primary action wrapped below the masthead identity.
- After at 390px: the banner is 36px and displays only the flask icon, “Early access,” and dismiss control. Browser measurement placed the masthead icon and visible “New session” action on the same row at `y=108`; one action was visible and `scrollWidth=clientWidth=390`.
- After at 1440px: the visible “New session” action remained right-aligned at `x=1291`, level with the title at `y=68`; one action was visible and `scrollWidth=clientWidth=1440`.
- Local Chromium screenshots were captured at `/tmp/dashboard-mobile-rebased.png` and `/tmp/dashboard-desktop-rebased.png`; the updated resize video is retained outside the repository as validation evidence.

## Risk

- Low
- Responsive visibility and action ordering could regress at CSS breakpoints. Focused component tests, a production UI build, and real-browser checks at mobile and desktop widths cover the affected paths.

## Security

- Threat categories reviewed: TM-WEB
- Findings and resolutions: No findings. The change uses static responsive classes and ordinary React event wiring; it introduces no request-controlled HTML or URLs, authentication behavior, API surface, trust-boundary changes, or dependencies. Existing React escaping and browser controls remain unchanged.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
