### PR TITLE
feat(ui): standardize entity ID affordances

### DIFF
--- a/apps/ui/src/__tests__/entity-card.test.tsx
+++ b/apps/ui/src/__tests__/entity-card.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import { EntityCard, EntityCardIdentifier } from "@/components/ui/entity-card";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { EntityCard } from "@/components/ui/entity-card";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 
 describe("EntityCard", () => {
   it("keeps long titles shrinkable beside header actions", () => {
@@ -9,7 +10,7 @@ describe("EntityCard", () => {
       </EntityCard>,
     );
 
-    expect(screen.getByText("A very long entity name")).toHaveClass("truncate");
+    expect(screen.getByText("A very long entity name")).toHaveClass("block", "truncate");
     expect(container.querySelector('[data-slot="entity-card-heading"]')).toHaveClass(
       "min-w-0",
       "flex-1",
@@ -17,13 +18,55 @@ describe("EntityCard", () => {
   });
 });
 
-describe("EntityCardIdentifier", () => {
-  it("truncates a long identifier while keeping its copy action visible", () => {
-    const value = "identity_019fda100f037c008024046d6b3d74c0";
+describe("EntityIdentity", () => {
+  it("keeps a long ID out of the layout and exposes its full value accessibly", async () => {
+    const value = "plugin:plugin_019fda100f037c008024046d6b3d74c0";
 
-    render(<EntityCardIdentifier value={value} />);
+    render(<EntityIdentity value={value}>Resend</EntityIdentity>);
 
-    expect(screen.getByText(value)).toHaveClass("min-w-0", "truncate");
-    expect(screen.getByTitle("Copy ID")).toHaveClass("shrink-0");
+    expect(screen.queryByText(value)).not.toBeInTheDocument();
+    expect(screen.getByText("Resend").closest('[data-slot="entity-identity"]')).toHaveClass(
+      "min-w-0",
+      "max-w-full",
+    );
+    expect(screen.getByText("Resend")).toHaveClass("truncate");
+    const button = screen.getByRole("button", { name: `Copy ID: ${value}` });
+    expect(button).toHaveClass("shrink-0");
+
+    fireEvent.focus(button);
+    expect(await screen.findByText(`Copy ID: ${value}`)).toBeInTheDocument();
+  });
+
+  it("copies the exact namespace-prefixed ID and announces feedback", async () => {
+    jest.useFakeTimers();
+    const value = "plugin:plugin_019fda100f037c008024046d6b3d74c0";
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<EntityIdentity value={value}>Resend</EntityIdentity>);
+
+    const button = screen.getByRole("button", { name: `Copy ID: ${value}` });
+    act(() => button.focus());
+    expect(button).toHaveFocus();
+    await act(async () => fireEvent.click(button));
+
+    expect(writeText).toHaveBeenCalledWith(value);
+    expect(screen.getByRole("status")).toHaveTextContent("Copied");
+
+    act(() => jest.runOnlyPendingTimers());
+    await waitFor(() => expect(screen.getByRole("status")).toBeEmptyDOMElement());
+    jest.useRealTimers();
+  });
+
+  it("wraps a page-heading label without exposing the long ID to the layout", () => {
+    const value = "entity_019fda100f037c008024046d6b3d74c0";
+
+    render(
+      <EntityIdentity value={value} truncate={false}>
+        A deliberately long readable entity heading for a narrow viewport
+      </EntityIdentity>,
+    );
+
+    expect(screen.getByText(/deliberately long readable/)).toHaveClass("break-words", "min-w-0");
+    expect(screen.queryByText(value)).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/entity-identity-consumers.test.tsx
+++ b/apps/ui/src/__tests__/entity-identity-consumers.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AgentCard } from "@/components/agents/agent-card";
+import { AgentIdentityCard } from "@/app/(main)/agent-identities/page";
+import { InstalledPluginCard } from "@/app/(main)/plugins/page";
+import type { Agent, AgentIdentity, InstalledPlugin } from "@/lib/api/types";
+
+jest.mock("@/providers/locale-provider", () => ({
+  useLocale: () => ({ locale: "en" }),
+}));
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({ currentOrg: { public_id: "org-1" }, isLoading: false }),
+}));
+
+jest.mock("@/components/chat/streamdown-message", () => ({
+  InlineStreamdownMessage: ({ children }: { children: string }) => <>{children}</>,
+}));
+
+const agent: Agent = {
+  id: "agent_019fda100f037c008024046d6b3d74c0",
+  name: "deep-research",
+  display_name: "Deep Research",
+  description: "Research agent",
+  system_prompt: "Research carefully",
+  harness_id: "harness_generic",
+  default_model_id: null,
+  tags: [],
+  capabilities: [],
+  status: "active",
+  created_at: "2026-08-07T00:00:00Z",
+  updated_at: "2026-08-07T00:00:00Z",
+  archived_at: null,
+  deleted_at: null,
+};
+
+const identity: AgentIdentity = {
+  id: "identity_019fda100f037c008024046d6b3d74c0",
+  name: "Researcher",
+  description: "Research identity",
+  locale: "en-US",
+  timezone: "America/Chicago",
+  status: "active",
+  created_at: "2026-08-07T00:00:00Z",
+  updated_at: "2026-08-07T00:00:00Z",
+};
+
+const plugin: InstalledPlugin = {
+  id: "plugin_019fda100f037c008024046d6b3d74c0",
+  name: "resend",
+  display_name: "Resend",
+  description: "Send transactional email",
+  version: "1.0.0",
+  pinned_sha: "e807ff60",
+  marketplace: "everruns",
+  capability_ref: "plugin:plugin_019fda100f037c008024046d6b3d74c0",
+  status: "active",
+  warnings: [],
+  update_available: false,
+  created_at: "2026-08-07T00:00:00Z",
+  updated_at: "2026-08-07T00:00:00Z",
+};
+
+describe("entity identity consumers", () => {
+  it("places the agent ID action beside the readable agent name", () => {
+    render(<AgentCard agent={agent} />);
+
+    const identityLine = screen.getByText("Deep Research").closest('[data-slot="entity-identity"]');
+    expect(identityLine).toContainElement(
+      screen.getByRole("button", { name: `Copy ID: ${agent.id}` }),
+    );
+  });
+
+  it("uses the shared identity line without a duplicate raw agent identity ID", () => {
+    render(<AgentIdentityCard identity={identity} />);
+
+    expect(screen.queryByText(identity.id)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: `Copy ID: ${identity.id}` })).toBeInTheDocument();
+  });
+
+  it("keeps the full namespace-prefixed plugin ID out of the card layout", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <InstalledPluginCard plugin={plugin} onUninstall={jest.fn()} />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText(plugin.capability_ref)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Copy ID: ${plugin.capability_ref}` }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/settings-organization.test.tsx
+++ b/apps/ui/src/__tests__/settings-organization.test.tsx
@@ -115,14 +115,15 @@ describe("OrganizationPage", () => {
     expect(screen.getByRole("heading", { name: "Organizations" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Organizations" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Organization" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "ID" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "ID" })).not.toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Role" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Status" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Actions" })).toBeInTheDocument();
     expect(screen.getAllByText("Current Org").length).toBeGreaterThan(0);
     expect(screen.getByText("Second Org")).toBeInTheDocument();
-    expect(screen.getByText("org-1")).toBeInTheDocument();
-    expect(screen.getByText("org-2")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("org-1")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Copy ID: org-1" })).not.toHaveLength(0);
+    expect(screen.getByRole("button", { name: "Copy ID: org-2" })).toBeInTheDocument();
     expect(screen.getByText("Current")).toBeInTheDocument();
   });
 

--- a/apps/ui/src/__tests__/work-view.test.tsx
+++ b/apps/ui/src/__tests__/work-view.test.tsx
@@ -131,7 +131,7 @@ describe("Work view", () => {
 
     // The shared TaskCard is now shown (its expand control appears).
     expect(screen.getByRole("button", { name: /show task details/i })).toBeInTheDocument();
-    expect(screen.getByText(/ID: t_sel/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy ID: t_sel" })).toBeInTheDocument();
     expect(screen.queryByText(/Select a task to see its detail/)).not.toBeInTheDocument();
   });
 

--- a/apps/ui/src/__tests__/workers-page.test.tsx
+++ b/apps/ui/src/__tests__/workers-page.test.tsx
@@ -385,7 +385,7 @@ describe("WorkersPage", () => {
     it("shows Drain button for active workers", () => {
       render(<WorkersPage />, { wrapper });
 
-      const drainButton = screen.getByRole("button", { name: /Drain/i });
+      const drainButton = screen.getByRole("button", { name: /^Drain$/i });
       expect(drainButton).toBeInTheDocument();
     });
 
@@ -406,7 +406,7 @@ describe("WorkersPage", () => {
 
       render(<WorkersPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole("button", { name: /Drain/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^Drain$/i }));
       expect(mockConfirm).toHaveBeenCalled();
       expect(mockDrainMutate).toHaveBeenCalledWith("w-active-1");
     });
@@ -421,7 +421,7 @@ describe("WorkersPage", () => {
 
       render(<WorkersPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole("button", { name: /Drain/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^Drain$/i }));
       expect(mockConfirm).toHaveBeenCalled();
       expect(mockDrainMutate).not.toHaveBeenCalled();
     });
@@ -453,7 +453,7 @@ describe("WorkersPage", () => {
 
       render(<WorkersPage />, { wrapper });
 
-      expect(screen.queryByRole("button", { name: /Drain/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /^Drain$/i })).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /Resume/i })).not.toBeInTheDocument();
     });
   });

--- a/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
@@ -18,7 +18,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CopyButton } from "@/components/ui/copy-button";
 import {
   Dialog,
   DialogContent,
@@ -163,10 +162,10 @@ export default function AgentIdentityDetailPage({
 
       <PageMasthead
         icon={<UserRound />}
+        entityId={identity.id}
         title={<span className={getEntityNameClassName(identity.status)}>{identity.name}</span>}
         badges={
           <>
-            <CopyButton value={identity.id} />
             <Badge variant={getEntityStatusBadgeVariant(identity.status)}>{identity.status}</Badge>
             {!isReadOnly && (
               <Badge variant="accent">

--- a/apps/ui/src/app/(main)/agent-identities/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/page.tsx
@@ -6,7 +6,7 @@ import { Plus, UserRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Badge } from "@/components/ui/badge";
-import { EntityCardIdentifier } from "@/components/ui/entity-card";
+import { EntityCard } from "@/components/ui/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAgentIdentities } from "@/hooks/use-agent-identities";
 import { usePageTitle } from "@/hooks";
@@ -34,6 +34,30 @@ import { cn } from "@/lib/utils";
 import type { AgentIdentity } from "@/lib/api/types";
 
 type StatusTab = "all" | "active" | "archived";
+
+export function AgentIdentityCard({ identity }: { identity: AgentIdentity }) {
+  return (
+    <EntityCard
+      icon={<IconTile size="md" icon={<UserRound />} />}
+      title={identity.name}
+      href={`/agent-identities/${identity.id}`}
+      titleClassName={getEntityNameClassName(identity.status)}
+      copyValue={identity.id}
+      headerActions={
+        <Badge variant={getEntityStatusBadgeVariant(identity.status)}>{identity.status}</Badge>
+      }
+    >
+      <div className="space-y-3">
+        {identity.description && (
+          <p className="line-clamp-2 text-sm text-muted-foreground">{identity.description}</p>
+        )}
+        <p className="text-[13px] text-muted-foreground">
+          {identity.locale || "No locale"} · {identity.timezone || "No timezone"}
+        </p>
+      </div>
+    </EntityCard>
+  );
+}
 
 export default function AgentIdentitiesPage() {
   usePageTitle("Agent Identities");
@@ -175,39 +199,7 @@ export default function AgentIdentitiesPage() {
           ) : (
             <div className="grid gap-4 md:grid-cols-2">
               {filteredIdentities.map((identity) => (
-                <Link
-                  key={identity.id}
-                  href={`/agent-identities/${identity.id}`}
-                  className="group flex flex-col gap-3 border bg-card p-4 transition-colors hover:border-accent/50"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <IconTile size="md" icon={<UserRound />} />
-                      <div className="min-w-0">
-                        <h3
-                          className={cn(
-                            "truncate text-base font-semibold",
-                            getEntityNameClassName(identity.status),
-                          )}
-                        >
-                          {identity.name}
-                        </h3>
-                        <EntityCardIdentifier value={identity.id} className="mt-0.5" />
-                      </div>
-                    </div>
-                    <Badge variant={getEntityStatusBadgeVariant(identity.status)}>
-                      {identity.status}
-                    </Badge>
-                  </div>
-                  {identity.description && (
-                    <p className="line-clamp-2 text-sm text-muted-foreground">
-                      {identity.description}
-                    </p>
-                  )}
-                  <p className="text-[13px] text-muted-foreground">
-                    {identity.locale || "No locale"} · {identity.timezone || "No timezone"}
-                  </p>
-                </Link>
+                <AgentIdentityCard key={identity.id} identity={identity} />
               ))}
             </div>
           )}

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -44,7 +44,6 @@ import {
   MoreHorizontal,
 } from "lucide-react";
 import { AgentTriggersPanel } from "@/components/agents/agent-triggers-panel";
-import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
 import {
   PageContainer,
@@ -274,15 +273,11 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
 
       <PageMasthead
         icon={<Boxes />}
+        entityId={agent.id}
         title={
           <span className={getEntityNameClassName(agent.status)}>{getDisplayName(agent)}</span>
         }
-        badges={
-          <>
-            <CopyButton value={agent.id} />
-            <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
-          </>
-        }
+        badges={<Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>}
         description={agent.description || undefined}
         meta={
           <>

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -19,7 +19,6 @@ import {
   Bot,
   Layers,
 } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
 import type { CapabilityStatus, ToolDefinition } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -147,14 +146,12 @@ export default function CapabilityDetailPage({
 
       <PageMasthead
         icon={<CapabilityIcon icon={capability.icon} />}
+        entityId={capability.id}
         title={localizedCapabilityName(capability, locale)}
         badges={
-          <>
-            <CopyButton value={capability.id} />
-            <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
-              {getStatusLabel(capability.status)}
-            </Badge>
-          </>
+          <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
+            {getStatusLabel(capability.status)}
+          </Badge>
         }
         meta={
           <>

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -14,7 +14,8 @@ import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
 import { CircleOff, Bot, Layers, Plus, Pencil, Puzzle } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityCard } from "@/components/ui/entity-card";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import type { Capability, CapabilityStatus, DeclarativeCapability } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -59,18 +60,19 @@ function DeclarativeCapabilityRow({ capability }: { capability: DeclarativeCapab
   const deleteCapability = useDeleteDeclarativeCapability();
   return (
     <div className="flex items-center justify-between gap-3 border p-3">
-      <Link href={`/capabilities/declarative/${capability.id}`} className="min-w-0 flex-1 group">
-        <div className="flex items-center gap-2">
-          <p className="font-medium truncate group-hover:underline">
-            {capability.display_name ?? localizedCapabilityName(capability, locale)}
-          </p>
+      <div className="min-w-0 flex-1">
+        <div className="font-medium">
+          <EntityIdentity value={capability.capability_id}>
+            <Link href={`/capabilities/declarative/${capability.id}`} className="hover:underline">
+              {capability.display_name ?? localizedCapabilityName(capability, locale)}
+            </Link>
+          </EntityIdentity>
         </div>
         <p className="text-sm text-muted-foreground line-clamp-1">
           {localizedCapabilityDescription(capability, locale)}
         </p>
-      </Link>
+      </div>
       <div className="flex items-center gap-2 shrink-0">
-        <CopyButton value={capability.capability_id} />
         <Link href={`/capabilities/declarative/${capability.id}`}>
           <Button type="button" variant="outline" size="sm">
             <Pencil className="mr-1.5 h-3.5 w-3.5" />
@@ -111,41 +113,34 @@ function CapabilityStats({ capability }: { capability: Capability }) {
 function CapabilityCard({ capability }: { capability: Capability }) {
   const { locale } = useLocale();
   return (
-    <Link href={`/capabilities/${capability.id}`}>
-      <Card className="h-full cursor-pointer bg-background transition-colors hover:bg-card">
-        <CardHeader className="flex flex-row items-start justify-between space-y-0">
-          <div className="flex items-center gap-3 min-w-0">
-            <IconTile size="md" icon={<CapabilityIcon icon={capability.icon} />} />
-            <div className="flex items-center gap-2 min-w-0">
-              <CardTitle className="text-lg truncate">
-                {localizedCapabilityName(capability, locale)}
-              </CardTitle>
-              <CopyButton value={capability.id} />
-            </div>
-          </div>
-          <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
-            {getStatusLabel(capability.status)}
+    <EntityCard
+      className="h-full"
+      icon={<IconTile size="md" icon={<CapabilityIcon icon={capability.icon} />} />}
+      title={localizedCapabilityName(capability, locale)}
+      href={`/capabilities/${capability.id}`}
+      copyValue={capability.id}
+      headerActions={
+        <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
+          {getStatusLabel(capability.status)}
+        </Badge>
+      }
+    >
+      <div className="text-sm text-muted-foreground mb-3 line-clamp-3">
+        <InlineStreamdownMessage>
+          {localizedCapabilityDescription(capability, locale)}
+        </InlineStreamdownMessage>
+      </div>
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        {capability.category ? (
+          <Badge variant="outline" className="text-xs">
+            {capability.category}
           </Badge>
-        </CardHeader>
-        <CardContent>
-          <div className="text-sm text-muted-foreground mb-3 line-clamp-3">
-            <InlineStreamdownMessage>
-              {localizedCapabilityDescription(capability, locale)}
-            </InlineStreamdownMessage>
-          </div>
-          <div className="flex items-center justify-between gap-2 flex-wrap">
-            {capability.category ? (
-              <Badge variant="outline" className="text-xs">
-                {capability.category}
-              </Badge>
-            ) : (
-              <span />
-            )}
-            <CapabilityStats capability={capability} />
-          </div>
-        </CardContent>
-      </Card>
-    </Link>
+        ) : (
+          <span />
+        )}
+        <CapabilityStats capability={capability} />
+      </div>
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -27,7 +27,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { getHealthBadgeVariant, getWorkflowStatusBadgeVariant } from "@/lib/status-utils";
 
 // `recharts` is heavy and only rendered once metrics load on this page. Load it
@@ -338,10 +338,12 @@ export default function DurableDashboardPage() {
                                   : "bg-red-500"
                             }`}
                           />
-                          <span className="text-sm font-medium truncate max-w-[150px]">
+                          <EntityIdentity
+                            value={worker.id}
+                            labelClassName="max-w-[150px] text-sm font-medium"
+                          >
                             {worker.hostname || worker.id.slice(0, 12)}
-                          </span>
-                          <CopyButton value={worker.id} />
+                          </EntityIdentity>
                         </div>
                         <div className="flex items-center gap-2">
                           <span className="text-xs text-muted-foreground">
@@ -384,22 +386,25 @@ export default function DurableDashboardPage() {
               {workflowsData && workflowsData.data.length > 0 ? (
                 <div className="space-y-2">
                   {workflowsData.data.map((workflow) => (
-                    <Link
+                    <div
                       key={workflow.id}
-                      href={`/durable/workflows/${workflow.id}`}
-                      className="flex items-center justify-between p-2 bg-muted/50 hover:bg-muted transition-colors"
+                      className="flex items-center justify-between gap-2 bg-muted/50 p-2"
                     >
                       <div className="flex items-center gap-2">
                         <WorkflowStatusIcon status={workflow.status} />
-                        <div>
-                          <p className="text-sm font-medium">{workflow.workflow_type}</p>
-                          <CopyButton value={workflow.id} />
-                        </div>
+                        <EntityIdentity value={workflow.id} labelClassName="text-sm font-medium">
+                          <Link
+                            href={`/durable/workflows/${workflow.id}`}
+                            className="hover:underline"
+                          >
+                            {workflow.workflow_type}
+                          </Link>
+                        </EntityIdentity>
                       </div>
                       <Badge variant={getWorkflowStatusBadgeVariant(workflow.status)}>
                         {workflow.status}
                       </Badge>
-                    </Link>
+                    </div>
                   ))}
                 </div>
               ) : (

--- a/apps/ui/src/app/(main)/durable/queues/dlq-row.tsx
+++ b/apps/ui/src/app/(main)/durable/queues/dlq-row.tsx
@@ -8,6 +8,7 @@ import { RotateCcw, Trash2, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { formatDistanceToNow } from "@/lib/formatting";
 import type { DlqEntry } from "@/lib/api/types";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 
 export function DlqRow({
   entry,
@@ -22,7 +23,9 @@ export function DlqRow({
     <TableRow>
       <TableCell>
         <div>
-          <p className="font-medium">{entry.activity_type}</p>
+          <p className="font-medium">
+            <EntityIdentity value={entry.id}>{entry.activity_type}</EntityIdentity>
+          </p>
           <p className="text-xs text-muted-foreground">{entry.activity_id}</p>
         </div>
       </TableCell>

--- a/apps/ui/src/app/(main)/durable/queues/task-row.tsx
+++ b/apps/ui/src/app/(main)/durable/queues/task-row.tsx
@@ -6,7 +6,7 @@ import { TableCell, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AlertTriangle, CheckCircle, Clock, XCircle, Activity, ExternalLink } from "lucide-react";
 import Link from "next/link";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatDistanceToNow } from "@/lib/formatting";
 import { getTaskStatusBadgeVariant } from "@/lib/status-utils";
 import type { DurableTask, TaskStatus } from "@/lib/api/types";
@@ -35,7 +35,9 @@ export function TaskRow({ task }: { task: DurableTask }) {
         <div className="flex items-center gap-2">
           {getTaskStatusIcon(task.status)}
           <div>
-            <p className="font-medium">{task.activity_type}</p>
+            <p className="font-medium">
+              <EntityIdentity value={task.id}>{task.activity_type}</EntityIdentity>
+            </p>
             <p className="text-xs text-muted-foreground">{task.activity_id}</p>
           </div>
         </div>
@@ -93,7 +95,6 @@ export function TaskRow({ task }: { task: DurableTask }) {
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-1">
-          <CopyButton value={task.id} />
           {task.workflow_id ? (
             <Link href={`/durable/workflows/${task.workflow_id}`}>
               <Button variant="ghost" size="sm">

--- a/apps/ui/src/app/(main)/durable/schedules/[scheduleId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/[scheduleId]/page.tsx
@@ -69,7 +69,7 @@ import {
   SkipForward,
 } from "lucide-react";
 import Link from "next/link";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatDistanceToNow } from "@/lib/formatting";
 import { getScheduleExecutionBadgeVariant } from "@/lib/status-utils";
 
@@ -417,9 +417,8 @@ export default function ScheduleDetailPage() {
                   className={`h-6 w-6 ${schedule.enabled ? "text-green-500" : "text-gray-400"}`}
                 />
                 <div>
-                  <CardTitle className="flex items-center gap-2">
-                    {schedule.name}
-                    <CopyButton value={schedule.id} />
+                  <CardTitle>
+                    <EntityIdentity value={schedule.id}>{schedule.name}</EntityIdentity>
                   </CardTitle>
                   {schedule.description && (
                     <CardDescription>{schedule.description}</CardDescription>

--- a/apps/ui/src/app/(main)/durable/schedules/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/page.tsx
@@ -58,7 +58,7 @@ import {
   Settings,
 } from "lucide-react";
 import Link from "next/link";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatDistanceToNow } from "@/lib/formatting";
 
 function ScheduleRow({
@@ -82,17 +82,17 @@ function ScheduleRow({
             className={`h-4 w-4 shrink-0 ${schedule.enabled ? "text-green-500" : "text-gray-400"}`}
           />
           <div className="min-w-0 flex-1">
-            <Link
-              href={`/durable/schedules/${schedule.id}`}
-              className="font-medium hover:underline truncate block"
-            >
-              {schedule.name}
-            </Link>
+            <div className="font-medium">
+              <EntityIdentity value={schedule.id}>
+                <Link href={`/durable/schedules/${schedule.id}`} className="hover:underline">
+                  {schedule.name}
+                </Link>
+              </EntityIdentity>
+            </div>
             {schedule.description && (
               <p className="text-xs text-muted-foreground truncate">{schedule.description}</p>
             )}
           </div>
-          <CopyButton value={schedule.id} />
         </div>
       </TableCell>
       <TableCell>

--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -25,7 +25,7 @@ import {
   Play,
   CheckCircle,
 } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatDistanceToNow, formatDurationCompact } from "@/lib/formatting";
 import { getWorkerStatusBadgeVariant } from "@/lib/status-utils";
 
@@ -61,9 +61,10 @@ function WorkerRow({
       <TableCell>
         <div className="flex items-center gap-2">
           <div className={`w-2 h-2 rounded-full ${getStatusColor(worker.status)}`} />
-          <div>
-            <p className="font-medium">{worker.hostname || worker.id.slice(0, 20)}</p>
-            <CopyButton value={worker.id} />
+          <div className="font-medium">
+            <EntityIdentity value={worker.id}>
+              {worker.hostname || worker.id.slice(0, 20)}
+            </EntityIdentity>
           </div>
         </div>
       </TableCell>

--- a/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
@@ -31,7 +31,7 @@ import {
   Zap,
   MessageSquare,
 } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import Link from "next/link";
 import { formatDistanceToNow } from "@/lib/formatting";
 import { getWorkflowStatusBadgeVariant } from "@/lib/status-utils";
@@ -235,10 +235,9 @@ export default function WorkflowDetailPage({
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-4">
             {getStatusIcon(workflow.status, "lg")}
-            <div className="flex items-center gap-2">
-              <h2 className="text-2xl font-bold">{workflow.workflow_type}</h2>
-              <CopyButton value={workflow.id} />
-            </div>
+            <h2 className="text-2xl font-bold">
+              <EntityIdentity value={workflow.id}>{workflow.workflow_type}</EntityIdentity>
+            </h2>
           </div>
           <div className="flex items-center gap-2">
             <Badge

--- a/apps/ui/src/app/(main)/durable/workflows/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/page.tsx
@@ -46,7 +46,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatDistanceToNow } from "@/lib/formatting";
 import { getWorkflowStatusBadgeVariant } from "@/lib/status-utils";
 
@@ -79,8 +79,9 @@ function WorkflowRow({
       <TableCell>
         <div className="flex items-center gap-2">
           {getStatusIcon(workflow.status)}
-          <p className="font-medium">{workflow.workflow_type}</p>
-          <CopyButton value={workflow.id} />
+          <p className="font-medium">
+            <EntityIdentity value={workflow.id}>{workflow.workflow_type}</EntityIdentity>
+          </p>
         </div>
       </TableCell>
       <TableCell>
@@ -160,7 +161,9 @@ function TaskRow({ task }: { task: DurableTask }) {
     <TableRow>
       <TableCell>
         <div>
-          <p className="font-medium">{task.activity_type}</p>
+          <p className="font-medium">
+            <EntityIdentity value={task.id}>{task.activity_type}</EntityIdentity>
+          </p>
           <p className="text-xs text-muted-foreground">{task.activity_id}</p>
         </div>
       </TableCell>
@@ -224,7 +227,9 @@ function DlqRow({ entry, onRequeue }: { entry: DlqEntry; onRequeue: (id: string)
     <TableRow>
       <TableCell>
         <div>
-          <p className="font-medium">{entry.activity_type}</p>
+          <p className="font-medium">
+            <EntityIdentity value={entry.id}>{entry.activity_type}</EntityIdentity>
+          </p>
           <p className="text-xs text-muted-foreground">{entry.activity_id}</p>
         </div>
       </TableCell>

--- a/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
@@ -21,7 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { ArrowLeft, Pencil, Play, Plus, Trash2, ListChecks, BarChart3 } from "lucide-react";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import type { EvalCase, EvalRun, Scorer, EvalInputMessage, EvalTarget } from "@/lib/api/types";
@@ -409,9 +409,10 @@ export default function EvalDetailPage({ params }: { params: Promise<{ evalId: s
 
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(ev.status)}>{ev.name}</span>
-            <CopyButton value={ev.id} />
+          <h1 className="flex min-w-0 flex-wrap items-center gap-2 text-2xl font-bold">
+            <EntityIdentity value={ev.id} labelClassName={getEntityNameClassName(ev.status)}>
+              {ev.name}
+            </EntityIdentity>
             <Badge variant={getEntityStatusBadgeVariant(ev.status)}>{ev.status}</Badge>
           </h1>
           {ev.description && <p className="text-muted-foreground mt-1">{ev.description}</p>}

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -4,7 +4,7 @@ import { useEvals } from "@/hooks";
 import { useAgents, usePageTitle } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { Plus } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
@@ -37,51 +37,51 @@ function EvalCard({ eval: ev, agentMap }: { eval: Eval; agentMap: Map<string, st
   const label = targetLabel(ev.target, agentMap);
 
   return (
-    <Link href={`/evals/${ev.id}`}>
-      <Card className="hover:border-primary/50 transition-colors cursor-pointer h-full">
-        <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-base truncate">{ev.name}</CardTitle>
-            <Badge variant={ev.status === "active" ? "default" : "secondary"}>{ev.status}</Badge>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {ev.description && (
-            <p className="text-sm text-muted-foreground line-clamp-2">{ev.description}</p>
+    <EntityCard
+      className="h-full"
+      title={ev.name}
+      href={`/evals/${ev.id}`}
+      copyValue={ev.id}
+      headerActions={
+        <Badge variant={ev.status === "active" ? "default" : "secondary"}>{ev.status}</Badge>
+      }
+    >
+      <div className="space-y-2">
+        {ev.description && (
+          <p className="text-sm text-muted-foreground line-clamp-2">{ev.description}</p>
+        )}
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          {label && <span>{label}</span>}
+          {ev.target?.type && (
+            <Badge variant="outline" className="text-xs">
+              {ev.target.type}
+            </Badge>
           )}
-          <div className="flex items-center gap-4 text-xs text-muted-foreground">
-            {label && <span>{label}</span>}
-            {ev.target?.type && (
-              <Badge variant="outline" className="text-xs">
-                {ev.target.type}
-              </Badge>
+          <span>{ev.case_count} cases</span>
+        </div>
+        {ev.last_run && (
+          <div className="flex items-center gap-3 text-xs">
+            <Badge variant={ev.last_run.status === "completed" ? "default" : "outline"}>
+              {ev.last_run.status}
+            </Badge>
+            {ev.last_run.summary && (
+              <span className={passRateColor(ev.last_run.summary.pass_rate)}>
+                {(ev.last_run.summary.pass_rate * 100).toFixed(0)}% pass rate
+              </span>
             )}
-            <span>{ev.case_count} cases</span>
           </div>
-          {ev.last_run && (
-            <div className="flex items-center gap-3 text-xs">
-              <Badge variant={ev.last_run.status === "completed" ? "default" : "outline"}>
-                {ev.last_run.status}
+        )}
+        {ev.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {ev.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
               </Badge>
-              {ev.last_run.summary && (
-                <span className={passRateColor(ev.last_run.summary.pass_rate)}>
-                  {(ev.last_run.summary.pass_rate * 100).toFixed(0)}% pass rate
-                </span>
-              )}
-            </div>
-          )}
-          {ev.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1">
-              {ev.tags.map((tag) => (
-                <Badge key={tag} variant="outline" className="text-xs">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -35,8 +35,8 @@ import {
   Terminal,
   Shield,
 } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import {
   PageContainer,
   PageBreadcrumb,
@@ -161,12 +161,12 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
 
       <PageMasthead
         icon={<Shield />}
+        entityId={harness.id}
         title={
           <span className={getEntityNameClassName(harness.status)}>{getDisplayName(harness)}</span>
         }
         badges={
           <>
-            <CopyButton value={harness.id} />
             {harness.is_built_in && <Badge variant="outline">Built-in</Badge>}
             <Badge variant={getEntityStatusBadgeVariant(harness.status)}>{harness.status}</Badge>
           </>
@@ -330,14 +330,20 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                   <div>
                     <p className="text-sm font-medium">Inherits From</p>
                     {parentHarness ? (
-                      <Link
-                        href={`/harnesses/${parentHarness.id}`}
-                        className="text-sm text-primary hover:underline"
+                      <EntityIdentity
+                        value={parentHarness.id}
+                        labelClassName="text-sm text-primary"
                       >
-                        {getDisplayName(parentHarness)}
-                      </Link>
+                        <Link href={`/harnesses/${parentHarness.id}`} className="hover:underline">
+                          {getDisplayName(parentHarness)}
+                        </Link>
+                      </EntityIdentity>
                     ) : (
-                      <p className="text-sm text-muted-foreground">{harness.parent_harness_id}</p>
+                      <p className="text-sm text-muted-foreground">
+                        <EntityIdentity value={harness.parent_harness_id}>
+                          {harness.parent_harness_id}
+                        </EntityIdentity>
+                      </p>
                     )}
                   </div>
                 )}

--- a/apps/ui/src/app/(main)/knowledge-indexes/[indexId]/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/[indexId]/page.tsx
@@ -14,7 +14,6 @@ import { KnowledgeIndexFormDialog } from "@/components/knowledge-indexes/knowled
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CopyButton } from "@/components/ui/copy-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -135,10 +134,10 @@ export default function KnowledgeIndexDetailPage({
 
       <PageMasthead
         icon={<Library />}
+        entityId={index.id}
         title={<span className={getEntityNameClassName(index.status)}>{index.name}</span>}
         badges={
           <>
-            <CopyButton value={index.id} />
             <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
             <KnowledgeIndexDiagnosticBadge diagnostic={diagnostic} />
           </>

--- a/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
@@ -10,7 +10,7 @@ import { KnowledgeIndexDiagnosticBadge } from "@/components/knowledge-indexes/kn
 import { KnowledgeIndexFormDialog } from "@/components/knowledge-indexes/knowledge-index-form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { SearchInput } from "@/components/ui/search-input";
 import {
   Table,
@@ -351,13 +351,14 @@ function KnowledgeIndexRow({
   return (
     <TableRow>
       <TableCell>
-        <div className="flex items-start gap-2">
-          <Link
-            href={`/knowledge-indexes/${index.id}`}
-            className={cn("font-medium hover:underline", getEntityNameClassName(index.status))}
-          >
-            {index.name}
-          </Link>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <div className="font-medium">
+            <EntityIdentity value={index.id} labelClassName={getEntityNameClassName(index.status)}>
+              <Link href={`/knowledge-indexes/${index.id}`} className="hover:underline">
+                {index.name}
+              </Link>
+            </EntityIdentity>
+          </div>
           <Badge variant={getEntityStatusBadgeVariant(index.status)}>{index.status}</Badge>
         </div>
         {index.description && (
@@ -365,10 +366,6 @@ function KnowledgeIndexRow({
             {index.description}
           </div>
         )}
-        <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
-          <span className="truncate font-mono">{index.id}</span>
-          <CopyButton value={index.id} />
-        </div>
       </TableCell>
       <TableCell>
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -75,6 +75,7 @@ import {
 } from "@/components/layout";
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { pluralize } from "@/lib/formatting";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 
 const McpIcon = capabilityIconMap.mcp;
 
@@ -116,8 +117,13 @@ function McpServerRow({
         <div className="flex items-center gap-3">
           <IconTile size="md" icon={<McpIcon />} />
           <div className="min-w-0">
-            <div className={`font-medium ${getEntityNameClassName(server.status)}`}>
-              {server.name}
+            <div className="font-medium">
+              <EntityIdentity
+                value={server.id}
+                labelClassName={getEntityNameClassName(server.status)}
+              >
+                {server.name}
+              </EntityIdentity>
             </div>
             <div className="max-w-[42ch] truncate text-xs text-muted-foreground">
               {server.description || server.url}

--- a/apps/ui/src/app/(main)/memory/[memoryId]/page.tsx
+++ b/apps/ui/src/app/(main)/memory/[memoryId]/page.tsx
@@ -9,7 +9,6 @@ import { MemoryFormDialog } from "@/components/memory/memory-form-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CopyButton } from "@/components/ui/copy-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   PageContainer,
@@ -71,17 +70,16 @@ export default function MemoryDetailPage({ params }: { params: Promise<{ memoryI
 
       <PageMasthead
         icon={<Brain />}
+        entityId={memory.id}
         title={<span className={getEntityNameClassName(memory.status)}>{memory.name}</span>}
         badges={
           <>
-            <CopyButton value={memory.id} />
             <Badge variant={getEntityStatusBadgeVariant(memory.status)}>{memory.status}</Badge>
             {memory.is_readonly && <Badge variant="secondary">Read-only</Badge>}
           </>
         }
         meta={
           <>
-            <span className="font-mono">{memory.id}</span>
             <span>
               Source <span className="text-foreground">{sourceLabel(memory)}</span>
             </span>

--- a/apps/ui/src/app/(main)/observers/[observerId]/page.tsx
+++ b/apps/ui/src/app/(main)/observers/[observerId]/page.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { Notice, NoticeDescription } from "@/components/ui/notice";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
@@ -322,9 +322,13 @@ export default function ObserverDetailPage({
 
       <div className="mb-6 flex items-start justify-between">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold">
-            <span className={getEntityNameClassName(observer.status)}>{observer.name}</span>
-            <CopyButton value={observer.id} />
+          <h1 className="flex min-w-0 flex-wrap items-center gap-2 text-2xl font-bold">
+            <EntityIdentity
+              value={observer.id}
+              labelClassName={getEntityNameClassName(observer.status)}
+            >
+              {observer.name}
+            </EntityIdentity>
             <Badge variant={getEntityStatusBadgeVariant(observer.status)}>{observer.status}</Badge>
           </h1>
           {observer.description && (

--- a/apps/ui/src/app/(main)/observers/observers-page-client.tsx
+++ b/apps/ui/src/app/(main)/observers/observers-page-client.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Plus } from "lucide-react";
 import { useObservers, usePageTitle } from "@/hooks";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
@@ -15,27 +15,27 @@ import type { Observer } from "@/lib/api/types";
 
 function ObserverCard({ observer }: { observer: Observer }) {
   return (
-    <Link href={`/observers/${observer.id}`}>
-      <Card className="h-full cursor-pointer transition-colors hover:border-primary/50">
-        <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
-            <CardTitle className="truncate text-base">{observer.name}</CardTitle>
-            <Badge variant={getEntityStatusBadgeVariant(observer.status)}>{observer.status}</Badge>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {observer.description && (
-            <p className="line-clamp-2 text-sm text-muted-foreground">{observer.description}</p>
-          )}
-          <div className="flex items-center gap-4 text-xs text-muted-foreground">
-            <span>{Math.round(observer.sampling_rate * 100)}% sampled</span>
-            <span>
-              {observer.scorers.length} {pluralize(observer.scorers.length, "scorer")}
-            </span>
-          </div>
-        </CardContent>
-      </Card>
-    </Link>
+    <EntityCard
+      className="h-full"
+      title={observer.name}
+      href={`/observers/${observer.id}`}
+      copyValue={observer.id}
+      headerActions={
+        <Badge variant={getEntityStatusBadgeVariant(observer.status)}>{observer.status}</Badge>
+      }
+    >
+      <div className="space-y-2">
+        {observer.description && (
+          <p className="line-clamp-2 text-sm text-muted-foreground">{observer.description}</p>
+        )}
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          <span>{Math.round(observer.sampling_rate * 100)}% sampled</span>
+          <span>
+            {observer.scorers.length} {pluralize(observer.scorers.length, "scorer")}
+          </span>
+        </div>
+      </div>
+    </EntityCard>
   );
 }
 

--- a/apps/ui/src/app/(main)/plugins/page.tsx
+++ b/apps/ui/src/app/(main)/plugins/page.tsx
@@ -23,7 +23,7 @@ import {
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import {
   PageContainer,
   PageBreadcrumb,
@@ -108,14 +108,19 @@ function MarketplaceCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
+      <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3 space-y-0">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center bg-primary/10">
             <Store className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <CardTitle className={`text-lg ${isDisabled ? "text-muted-foreground" : ""}`}>
-              {marketplace.name}
+          <div className="min-w-0">
+            <CardTitle className="text-lg">
+              <EntityIdentity
+                value={marketplace.id}
+                labelClassName={isDisabled ? "text-muted-foreground" : undefined}
+              >
+                {marketplace.name}
+              </EntityIdentity>
             </CardTitle>
             <CardDescription className="text-sm truncate max-w-xs">
               {marketplaceSourceLabel(marketplace)}
@@ -550,7 +555,7 @@ function MarketplaceCatalogDialog({
 // Installed plugin card
 // ============================================
 
-function InstalledPluginCard({
+export function InstalledPluginCard({
   plugin,
   onUninstall,
 }: {
@@ -572,19 +577,24 @@ function InstalledPluginCard({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
+      <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3 space-y-0">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center bg-primary/10">
             <Package className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <CardTitle className={`text-lg ${!isEnabled ? "text-muted-foreground" : ""}`}>
-              {plugin.display_name ?? plugin.name}
+          <div className="min-w-0">
+            <CardTitle className="text-lg">
+              <EntityIdentity
+                value={plugin.capability_ref}
+                labelClassName={!isEnabled ? "text-muted-foreground" : undefined}
+              >
+                {plugin.display_name ?? plugin.name}
+              </EntityIdentity>
             </CardTitle>
             <CardDescription className="text-sm font-mono">{plugin.name}</CardDescription>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex max-w-full shrink-0 flex-wrap items-center justify-end gap-2">
           {plugin.warnings.length > 0 && (
             <Badge variant="outline" className="text-amber-600 border-amber-400 text-xs gap-1">
               <AlertTriangle className="h-3 w-3" />
@@ -605,12 +615,6 @@ function InstalledPluginCard({
                 SHA: <span className="font-mono">{truncateSha(plugin.pinned_sha)}</span>
               </span>
             )}
-          </div>
-          <div className="flex items-center gap-1 mt-1">
-            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">
-              {plugin.capability_ref}
-            </span>
-            <CopyButton value={plugin.capability_ref} />
           </div>
         </div>
 

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
@@ -16,6 +16,7 @@ import { useSessionContext } from "../session-context";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatRelativeTime } from "@/lib/formatting";
 import type { SessionResourceEntry } from "@/lib/api/types";
 
@@ -108,7 +109,9 @@ function ResourceCard({ resource }: { resource: SessionResourceEntry }) {
             {statusIcon(resource.status)}
             <div>
               <CardTitle className="text-base">
-                {resource.display_name || resource.resource_id}
+                <EntityIdentity value={resource.resource_id}>
+                  {resource.display_name || resource.resource_id}
+                </EntityIdentity>
               </CardTitle>
               <CardDescription>{resource.kind}</CardDescription>
             </div>
@@ -119,7 +122,6 @@ function ResourceCard({ resource }: { resource: SessionResourceEntry }) {
       <CardContent className="space-y-2 text-sm text-muted-foreground">
         <div className="grid gap-1">
           <div>Registered: {formatRelativeTime(resource.created_at)}</div>
-          <div className="truncate">ID: {resource.resource_id}</div>
           {statusText ? <div>Status: {statusText}</div> : null}
           {progressLine ? <div>Progress: {progressLine}</div> : null}
           {summary ? <div className="text-foreground">Summary: {summary}</div> : null}

--- a/apps/ui/src/app/(main)/settings/organization/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organization/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import {
   Dialog,
   DialogContent,
@@ -309,7 +310,11 @@ export default function OrganizationPage() {
                     readOnly
                     className="w-full font-mono text-sm bg-muted"
                   />
-                  <CopyButton value={organization?.id || currentOrg?.public_id || ""} />
+                  <CopyButton
+                    value={organization?.id || currentOrg?.public_id || ""}
+                    label={`Copy ID: ${organization?.id || currentOrg?.public_id || ""}`}
+                    kind="id"
+                  />
                 </div>
               </SettingsRow>
             </SettingsGroup>
@@ -436,7 +441,6 @@ export default function OrganizationPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>Organization</TableHead>
-                    <TableHead>ID</TableHead>
                     <TableHead>Role</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
@@ -447,9 +451,8 @@ export default function OrganizationPage() {
                     const isCurrent = currentOrg?.public_id === org.public_id;
                     return (
                       <TableRow key={org.public_id} data-state={isCurrent ? "selected" : undefined}>
-                        <TableCell className="font-medium">{org.name}</TableCell>
-                        <TableCell className="font-mono text-xs text-muted-foreground">
-                          {org.public_id}
+                        <TableCell className="font-medium">
+                          <EntityIdentity value={org.public_id}>{org.name}</EntityIdentity>
                         </TableCell>
                         <TableCell>{ROLE_LABELS[org.role]}</TableCell>
                         <TableCell>

--- a/apps/ui/src/app/(main)/settings/payments/page.tsx
+++ b/apps/ui/src/app/(main)/settings/payments/page.tsx
@@ -35,6 +35,7 @@ import {
   usePaymentPolicies,
 } from "@/hooks/use-payments";
 import type { PaymentOwnerType, PaymentRail, PaymentPolicy } from "@/lib/api/types";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 
 const railLabels: Record<PaymentRail, string> = {
   mpp_tempo: "MPP / Tempo",
@@ -242,7 +243,9 @@ export default function PaymentSettingsPage() {
             <TableBody>
               {accounts.map((account) => (
                 <TableRow key={account.id}>
-                  <TableCell className="font-medium">{account.label}</TableCell>
+                  <TableCell className="font-medium">
+                    <EntityIdentity value={account.id}>{account.label}</EntityIdentity>
+                  </TableCell>
                   <TableCell>
                     {ownerLabels[account.owner_type]} · {account.owner_id}
                   </TableCell>
@@ -375,7 +378,9 @@ export default function PaymentSettingsPage() {
               {policies.map((policy) => (
                 <TableRow key={policy.id}>
                   <TableCell>
-                    {policy.subject_type} · {policy.subject_id}
+                    <EntityIdentity value={policy.id}>
+                      {policy.subject_type} · {policy.subject_id}
+                    </EntityIdentity>
                   </TableCell>
                   <TableCell>{policy.allowed_capabilities.join(", ") || "Any"}</TableCell>
                   <TableCell>{policy.allowed_hosts.join(", ") || "Any"}</TableCell>

--- a/apps/ui/src/app/(main)/settings/personal-access-tokens/page.tsx
+++ b/apps/ui/src/app/(main)/settings/personal-access-tokens/page.tsx
@@ -29,6 +29,7 @@ import type {
   PersonalAccessTokenListItem,
   CreatePersonalAccessTokenRequest,
 } from "@/lib/api/types";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 
 const TOKEN_EXPIRY_OPTIONS = [
   {
@@ -82,7 +83,9 @@ function PersonalAccessTokenRow({
       <div className="flex items-center gap-3">
         <Key className="h-5 w-5 text-muted-foreground" />
         <div>
-          <div className="font-medium">{token.name}</div>
+          <div className="font-medium">
+            <EntityIdentity value={token.id}>{token.name}</EntityIdentity>
+          </div>
           <div className="text-sm text-muted-foreground font-mono">{token.token_prefix}</div>
         </div>
       </div>

--- a/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
@@ -12,6 +12,7 @@ import { Switch } from "@/components/ui/switch";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageBody, PageHeader, PageShell } from "@/components/layout";
 import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { useModels, useProvider, useUpdateProvider } from "@/hooks/use-providers";
 import { usePageTitle } from "@/hooks";
@@ -102,7 +103,7 @@ export default function ProviderDetailPage({
         title={
           <>
             <ProviderIcon providerType={provider.provider_type} size="md" />
-            {provider.name}
+            <EntityIdentity value={provider.id}>{provider.name}</EntityIdentity>
             {provider.managed && (
               <Badge
                 variant="outline"

--- a/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
@@ -42,6 +42,7 @@ export function ProviderCard({
       icon={<ProviderIcon providerType={provider.provider_type} size="md" />}
       title={provider.name}
       href={`/settings/providers/${provider.id}`}
+      copyValue={provider.id}
       subtitle={
         <span className="text-sm text-muted-foreground">
           {getProviderLabel(provider.provider_type)}

--- a/apps/ui/src/app/(main)/skills/[skillId]/page.tsx
+++ b/apps/ui/src/app/(main)/skills/[skillId]/page.tsx
@@ -4,7 +4,6 @@ import { use } from "react";
 import { Archive, FileText } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CopyButton } from "@/components/ui/copy-button";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { SkillDetailView } from "@/components/skills/skill-detail-view";
 import { SkillUsageRow } from "@/components/skills/skill-usage-row";
@@ -75,12 +74,12 @@ export default function SkillDetailPage({ params }: { params: Promise<{ skillId:
 
       <PageMasthead
         icon={skill.source_type === "archive" ? <Archive /> : <FileText />}
+        entityId={skill.id}
         title={
           <span className={getEntityNameClassName(skill.status)}>{getDisplayName(skill)}</span>
         }
         badges={
           <>
-            <CopyButton value={skill.id} />
             <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
             <Badge variant="secondary" className="text-xs">
               {skill.source_type}

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -78,6 +78,7 @@ function SkillRow({
       title={getDisplayName(skill)}
       href={`/skills/${skill.id}`}
       titleClassName={getEntityNameClassName(skill.status)}
+      copyValue={skill.id}
       inlineBadges={
         <>
           <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>

--- a/apps/ui/src/components/agents/knowledge-index-config-editor.tsx
+++ b/apps/ui/src/components/agents/knowledge-index-config-editor.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { useKnowledgeIndexes } from "@/hooks/use-knowledge-indexes";
 import type { KnowledgeIndex } from "@/lib/api/types";
 
@@ -127,12 +128,13 @@ export function KnowledgeIndexConfigEditor({
                   disabled={disabled}
                   onCheckedChange={(value) => toggleIndex(index.id, value)}
                 />
-                <Label htmlFor={checkboxId} className="min-w-0 flex-1 cursor-pointer font-normal">
-                  <span className="block truncate">{index.name}</span>
-                  <span className="block truncate font-mono text-xs text-muted-foreground">
-                    {index.id}
-                  </span>
-                </Label>
+                <div className="min-w-0 flex-1">
+                  <EntityIdentity value={index.id}>
+                    <Label htmlFor={checkboxId} className="cursor-pointer font-normal">
+                      {index.name}
+                    </Label>
+                  </EntityIdentity>
+                </div>
               </div>
             );
           })}

--- a/apps/ui/src/components/apps/a2a-agent-card-preview.tsx
+++ b/apps/ui/src/components/apps/a2a-agent-card-preview.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
 import type { InvocationSessionMode } from "@/lib/api/types";
 import { Bot, FileJson } from "lucide-react";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 
 type JsonObject = Record<string, unknown>;
 
@@ -177,8 +178,13 @@ export function A2aAgentCardPreview(props: A2aAgentCardPreviewProps) {
             card.skills.map((skill, index) => (
               <div key={`${skill.id ?? "skill"}-${index}`} className="rounded-md border p-2">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium">{skill.name || skill.id || "Skill"}</span>
-                  {skill.id && <Badge variant="outline">{skill.id}</Badge>}
+                  <span className="text-sm font-medium">
+                    {skill.id ? (
+                      <EntityIdentity value={skill.id}>{skill.name || skill.id}</EntityIdentity>
+                    ) : (
+                      skill.name || "Skill"
+                    )}
+                  </span>
                 </div>
                 {skill.description && (
                   <p className="mt-1 text-sm text-muted-foreground">{skill.description}</p>

--- a/apps/ui/src/components/apps/app-detail.tsx
+++ b/apps/ui/src/components/apps/app-detail.tsx
@@ -19,7 +19,6 @@ import { queryKeys } from "@/lib/query-keys";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { CopyButton } from "@/components/ui/copy-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { ChannelRow } from "@/components/apps/channel-row";
@@ -140,13 +139,9 @@ export function AppDetail({ appId }: { appId: string }) {
 
       <PageMasthead
         icon={<Rocket />}
+        entityId={app.id}
         title={<span className={getEntityNameClassName(app.status)}>{app.name}</span>}
-        badges={
-          <>
-            <CopyButton value={app.id} />
-            <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
-          </>
-        }
+        badges={<Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>}
         description={app.description || undefined}
         meta={
           <>

--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -61,7 +61,7 @@ export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconP
         <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
           <dt className="text-muted-foreground">{t("message_info_id")}</dt>
           <dd>
-            <CopyButton value={event.id} />
+            <CopyButton value={event.id} label={`Copy ID: ${event.id}`} kind="id" />
           </dd>
           {model && (
             <>

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -90,6 +90,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                   variant="row"
                   href={`/sessions/${session.id}`}
                   title={session.title || `Session ${shortenId(session.id)}`}
+                  copyValue={session.id}
                   icon={
                     isRunning(session) ? (
                       <Loader2 className="w-4 h-4 text-primary animate-spin" />

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -17,6 +17,7 @@
 import { Fragment, type ReactNode } from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { cn } from "@/lib/utils";
 
 /* ─────────────────────────────── Container ─────────────────────────────── */
@@ -130,6 +131,8 @@ interface PageMastheadProps {
   /** Leading icon, wrapped in an IconTile automatically. */
   icon?: ReactNode;
   title: ReactNode;
+  /** Exact API-facing entity ID copied beside the title. */
+  entityId?: string;
   /** Status badges / counts shown inline after the title. */
   badges?: ReactNode;
   /** One-line description under the title. */
@@ -152,6 +155,7 @@ interface PageMastheadProps {
 export function PageMasthead({
   icon,
   title,
+  entityId,
   badges,
   description,
   meta,
@@ -202,8 +206,14 @@ export function PageMasthead({
           )}
         >
           <div className="flex min-w-0 flex-wrap items-center gap-2.5">
-            <h1 className="min-w-0 break-words text-2xl font-semibold tracking-tight text-foreground">
-              {title}
+            <h1 className="min-w-0 text-2xl font-semibold tracking-tight text-foreground">
+              {entityId ? (
+                <EntityIdentity value={entityId} truncate={false}>
+                  {title}
+                </EntityIdentity>
+              ) : (
+                title
+              )}
             </h1>
             {badges}
           </div>

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import {
   Bot,
   User,
@@ -47,8 +48,9 @@ function ToolCallContentPart({
     <div className="border p-2 bg-muted/50">
       <div className="flex items-center gap-2 mb-1">
         <Wrench className="w-3 h-3 text-muted-foreground" />
-        <span className="text-xs font-medium">{toolCall.name}</span>
-        <span className="text-xs text-muted-foreground font-mono">({toolCall.id})</span>
+        <span className="text-xs font-medium">
+          <EntityIdentity value={toolCall.id}>{toolCall.name}</EntityIdentity>
+        </span>
       </div>
       <pre className="text-xs bg-background rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap break-all">
         {JSON.stringify(toolCall.arguments, null, 2)}
@@ -101,8 +103,9 @@ function ToolResultContentPart({
         ) : (
           <CheckCircle className="w-3 h-3 text-green-500" />
         )}
-        <span className="text-xs font-medium">Tool Result</span>
-        <span className="text-xs text-muted-foreground font-mono">({toolCallId})</span>
+        <span className="text-xs font-medium">
+          <EntityIdentity value={toolCallId}>Tool Result</EntityIdentity>
+        </span>
       </div>
       {error ? (
         <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
@@ -480,7 +483,7 @@ export function LlmHistoryViewer({
             {eventId && (
               <span className="text-xs text-muted-foreground font-mono flex items-center gap-1">
                 {eventId.slice(0, 8)}...
-                <CopyButton value={eventId} />
+                <CopyButton value={eventId} label={`Copy ID: ${eventId}`} kind="id" />
               </span>
             )}
           </div>

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import {
   Brain,
   Wrench,
@@ -89,7 +90,9 @@ export function ModelRow({
           />
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2 font-medium">
-              <span className="break-words">{model.display_name}</span>
+              <EntityIdentity value={model.id} truncate={false}>
+                {model.display_name}
+              </EntityIdentity>
               {model.enabled && (
                 <Badge
                   variant="outline"

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn, shortenId } from "@/lib/utils";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
-import { CopyButton } from "@/components/ui/copy-button";
 import { useLocale } from "@/providers/locale-provider";
 import type { Session, SessionStatus, ModelWithProvider, TokenUsage } from "@/lib/api/types";
 import type { SessionExportFormat } from "@/lib/api/sessions";
@@ -114,10 +113,6 @@ function SessionInfoIcon({ session }: { session: Session }) {
       </TooltipTrigger>
       <TooltipContent className="max-w-sm">
         <div className="space-y-1 text-xs">
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">ID:</span>
-            <CopyButton value={session.id} />
-          </div>
           <div className="flex gap-2">
             <span className="text-muted-foreground">Status:</span>
             <span className="capitalize">{session.status}</span>

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -13,7 +13,7 @@ import { useRouter } from "next/navigation";
 import type { Agent, ModelWithProvider, Session, SessionStatus, TokenUsage } from "@/lib/api/types";
 import { buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -141,8 +141,8 @@ function EditableSessionTitle({
   }
 
   return (
-    <h1 className="flex items-center gap-2 text-xl font-bold">
-      {title || fallback}
+    <h1 className="flex min-w-0 flex-wrap items-center gap-2 text-xl font-bold">
+      <EntityIdentity value={sessionId}>{title || fallback}</EntityIdentity>
       {editable && (
         <button
           onClick={() => setEditing(true)}
@@ -152,7 +152,6 @@ function EditableSessionTitle({
           <Pencil className="h-3.5 w-3.5" />
         </button>
       )}
-      <CopyButton value={sessionId} />
     </h1>
   );
 }

--- a/apps/ui/src/components/session/task-detail.tsx
+++ b/apps/ui/src/components/session/task-detail.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { formatRelativeTime } from "@/lib/formatting";
 import { isTerminalTaskState } from "@/lib/api/types";
 import type { SessionTask, SessionTaskState, TaskMessage } from "@/lib/api/types";
@@ -221,7 +222,9 @@ export function TaskCard({
           <div className="flex items-center gap-2">
             <ListTodo className="h-4 w-4 text-muted-foreground" />
             <div>
-              <CardTitle className="text-base">{task.display_name || task.id}</CardTitle>
+              <CardTitle className="text-base">
+                <EntityIdentity value={task.id}>{task.display_name || task.id}</EntityIdentity>
+              </CardTitle>
               <CardDescription>
                 <Badge variant="outline">{task.kind}</Badge>
               </CardDescription>
@@ -261,7 +264,6 @@ export function TaskCard({
       <CardContent className="space-y-2 text-sm text-muted-foreground">
         <div className="grid gap-1">
           <div>Created: {formatRelativeTime(task.created_at)}</div>
-          <div className="truncate">ID: {task.id}</div>
           {task.state_detail ? <div>Status: {task.state_detail}</div> : null}
         </div>
         <TaskProgressBar task={task} />

--- a/apps/ui/src/components/ui/copy-button.tsx
+++ b/apps/ui/src/components/ui/copy-button.tsx
@@ -1,39 +1,68 @@
 "use client";
 
-import { useState } from "react";
-import { Hash, Check } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Copy, Hash, Check } from "lucide-react";
 import { Button } from "./button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
 import { cn } from "@/lib/utils";
 
 interface CopyButtonProps {
   value: string;
+  /** Accessible name and tooltip text. Entity IDs must include the full exact value. */
+  label?: string;
+  kind?: "value" | "id";
   className?: string;
 }
 
-export function CopyButton({ value, className }: CopyButtonProps) {
+export function CopyButton({ value, label = "Copy", kind = "value", className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
 
   const handleCopy = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     await navigator.clipboard.writeText(value);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopied(false), 1500);
   };
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className={cn("h-5 w-5 p-0", className)}
-      onClick={handleCopy}
-      title={copied ? "Copied!" : "Copy ID"}
-    >
-      {copied ? (
-        <Check className="h-3 w-3 text-green-500" />
-      ) : (
-        <Hash className="h-3 w-3 text-muted-foreground" />
-      )}
-    </Button>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className={cn("-my-1 shrink-0 p-0", className)}
+            onClick={handleCopy}
+            aria-label={label}
+          >
+            {copied ? (
+              <Check className="h-3 w-3 text-green-500" />
+            ) : kind === "id" ? (
+              <Hash className="h-3 w-3 text-muted-foreground" />
+            ) : (
+              <Copy className="h-3 w-3 text-muted-foreground" />
+            )}
+            <span className="sr-only" role="status" aria-live="polite">
+              {copied ? "Copied" : ""}
+            </span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[min(40rem,calc(100vw-2rem))] break-all font-mono">
+          <span>{label}</span>
+          {copied && <span className="ml-2 text-green-600">Copied</span>}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/apps/ui/src/components/ui/entity-card.tsx
+++ b/apps/ui/src/components/ui/entity-card.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CopyButton } from "@/components/ui/copy-button";
+import { EntityIdentity } from "@/components/ui/entity-identity";
 import { cn } from "@/lib/utils";
 
 /**
@@ -43,20 +43,6 @@ export interface EntityCardProps {
   /** Footer content (grid only). Use {@link EntityCardFooter} for the common split. */
   footer?: React.ReactNode;
   className?: string;
-}
-
-export function EntityCardIdentifier({ value, className }: { value: string; className?: string }) {
-  return (
-    <div
-      data-slot="entity-card-identifier"
-      className={cn("flex min-w-0 max-w-full items-center gap-1.5", className)}
-    >
-      <span className="min-w-0 truncate font-mono text-xs text-muted-foreground" title={value}>
-        {value}
-      </span>
-      <CopyButton value={value} className="shrink-0" />
-    </div>
-  );
 }
 
 function EntityCardTitleLink({
@@ -106,14 +92,22 @@ export function EntityCard({
         <div className="flex min-w-0 flex-1 items-start gap-3">
           {icon && <div className="mt-0.5 flex-shrink-0">{icon}</div>}
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <EntityCardTitleLink
-                href={href}
-                className={cn("truncate font-medium", titleClassName)}
-              >
-                {title}
-              </EntityCardTitleLink>
-              {copyValue && <CopyButton value={copyValue} className="shrink-0" />}
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              {copyValue ? (
+                <EntityIdentity
+                  value={copyValue}
+                  labelClassName={cn("font-medium", titleClassName)}
+                >
+                  <EntityCardTitleLink href={href}>{title}</EntityCardTitleLink>
+                </EntityIdentity>
+              ) : (
+                <EntityCardTitleLink
+                  href={href}
+                  className={cn("truncate font-medium", titleClassName)}
+                >
+                  {title}
+                </EntityCardTitleLink>
+              )}
               {inlineBadges}
             </div>
             {children}
@@ -133,10 +127,17 @@ export function EntityCard({
           {icon && <div className="flex-shrink-0">{icon}</div>}
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
             <div className="flex min-w-0 items-center gap-2">
-              <CardTitle className={cn("min-w-0 flex-1 truncate text-lg", titleClassName)}>
-                <EntityCardTitleLink href={href}>{title}</EntityCardTitleLink>
+              <CardTitle className="min-w-0 flex-1 text-lg">
+                {copyValue ? (
+                  <EntityIdentity value={copyValue} labelClassName={titleClassName}>
+                    <EntityCardTitleLink href={href}>{title}</EntityCardTitleLink>
+                  </EntityIdentity>
+                ) : (
+                  <EntityCardTitleLink href={href} className={cn("block truncate", titleClassName)}>
+                    {title}
+                  </EntityCardTitleLink>
+                )}
               </CardTitle>
-              {copyValue && <CopyButton value={copyValue} className="shrink-0" />}
             </div>
             {subtitle && <div className="min-w-0">{subtitle}</div>}
           </div>

--- a/apps/ui/src/components/ui/entity-identity.tsx
+++ b/apps/ui/src/components/ui/entity-identity.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { CopyButton } from "@/components/ui/copy-button";
+import { cn } from "@/lib/utils";
+
+interface EntityIdentityProps {
+  /** Human-readable identity rendered as the primary content. */
+  children: ReactNode;
+  /** Exact API-facing ID copied to the clipboard, including any namespace prefix. */
+  value: string;
+  /** Keep the readable label to one line. Disable for page-level headings. */
+  truncate?: boolean;
+  className?: string;
+  labelClassName?: string;
+}
+
+/**
+ * Canonical entity identity line: a readable name followed immediately by a
+ * compact, accessible exact-ID copy action. The ID stays out of the layout.
+ */
+export function EntityIdentity({
+  children,
+  value,
+  truncate = true,
+  className,
+  labelClassName,
+}: EntityIdentityProps) {
+  if (!truncate) {
+    return (
+      <span
+        data-slot="entity-identity"
+        className={cn("min-w-0 max-w-full align-middle", className)}
+      >
+        <span
+          data-slot="entity-identity-label"
+          className={cn("min-w-0 break-words", labelClassName)}
+        >
+          {children}
+        </span>
+        <CopyButton
+          value={value}
+          label={`Copy ID: ${value}`}
+          kind="id"
+          className="ml-1.5 align-middle"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-slot="entity-identity"
+      className={cn("inline-flex min-w-0 max-w-full items-center gap-1.5 align-middle", className)}
+    >
+      <span data-slot="entity-identity-label" className={cn("min-w-0 truncate", labelClassName)}>
+        {children}
+      </span>
+      <CopyButton value={value} label={`Copy ID: ${value}`} kind="id" />
+    </span>
+  );
+}

--- a/test_cases/ui/entity_identity/TC001_copy_entity_id.md
+++ b/test_cases/ui/entity_identity/TC001_copy_entity_id.md
@@ -1,0 +1,46 @@
+# TC001: Copy an entity ID from the canonical identity line
+
+## Description
+
+Verifies that entity cards and detail headers keep the readable name primary while exposing a
+compact, accessible copy-ID action with the complete API-facing identifier.
+
+## Preconditions
+
+- Development stack running in auth mode `none`.
+- At least one agent and one installed plugin are available.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| Agent | Any named agent |
+| Installed plugin | A plugin whose capability reference includes the `plugin:` namespace |
+| Desktop viewport | 1440 x 900 |
+| Mobile viewport | 390 x 844 |
+
+## Steps
+
+1. Open `/agents` at the desktop viewport.
+2. Verify each agent card shows its readable name followed immediately by a compact `#` button and
+   does not show a separate raw ID line.
+3. Focus the `#` button using the keyboard and verify the tooltip and accessible name are
+   `Copy ID: <full ID>` with no truncation.
+4. Activate the button and verify the clipboard contains the exact ID and the control announces
+   copied feedback.
+5. Open the agent detail page and repeat the identity, tooltip, clipboard, and feedback checks in
+   the page masthead.
+6. Open `/plugins`, locate an installed plugin, and verify its readable name and `#` button share
+   one identity line without a duplicate raw capability reference.
+7. Verify the plugin tooltip exposes the complete namespace-prefixed capability reference and the
+   clipboard receives that exact value.
+8. Repeat the agent-card and plugin-card layout checks at the mobile viewport.
+9. Verify long names/IDs do not create horizontal overflow or collide with badges and actions.
+
+## Expected Result
+
+- Readable names remain primary at desktop and mobile widths.
+- Every ID action has the complete `Copy ID: <full ID>` tooltip and accessible name.
+- Keyboard activation copies the exact API-facing value and exposes consistent copied feedback.
+- Namespace prefixes are preserved.
+- No duplicate/raw long ID line crowds a card and no horizontal page overflow is introduced.


### PR DESCRIPTION
## What changed

Introduces one shared entity identity line for cards, lists, and page mastheads: the readable name stays primary and an adjacent compact `#` action copies the exact API-facing ID. Every ID action now exposes the complete `Copy ID: <full ID>` tooltip and accessible name, preserves namespace prefixes, supports keyboard focus, and announces consistent copied feedback.

Migrates the product-wide entity surfaces to the shared contract, including agents, identities, plugins and marketplaces, capabilities, harnesses, sessions, skills, memory and knowledge indexes, MCP servers, apps, evals, observers, providers/models, organizations, durable entities, and related detail metadata. Generic endpoint/token copy actions retain the ordinary copy icon so `#` has one consistent meaning.

## Why

Entity IDs were presented inconsistently. Some cards showed raw long identifiers that crowded responsive layouts, while `#` buttons had ambiguous labels, incomplete tooltips, or distant placement. The installed Resend plugin reproduced the worst case with a full `plugin:plugin_…` line competing with card actions.

## Before / After

Before: the Resend card rendered its long namespace-prefixed capability ID as a separate raw line with a distant copy action. Agent cards had the desired adjacent placement but lacked the complete tooltip/accessibility and consistent feedback contract.

After: agent, agent identity, and Resend cards use the same name-plus-`#` identity line at desktop and mobile widths. The full ID is available on keyboard focus without entering layout, exact namespace-prefixed values are copied, and no tested route overflows horizontally.

Screenshots will be attached in a PR comment immediately after creation.

## Risk

- Medium
- Broad frontend-only presentation migration could affect card/header spacing or nested interaction behavior. Focused consumer tests, the complete UI unit suite, a production build, and desktop/mobile manual coverage mitigate this.

## Security

- Threat categories reviewed: TM-WEB-001 (stored/reflected XSS and frontend data exposure).
- Findings and resolutions: IDs and labels remain React text nodes (no raw HTML or URL construction), clipboard writes require an explicit user action, and tooltips expose only the same authorized entity IDs already returned to these views. Secrets, tokens, and endpoint values are not migrated into the entity-ID affordance. No auth, API, dependency, or tenancy behavior changes.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)