### PR TITLE
chore(deps): refresh frontend security overrides

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,23 +31,5 @@
     "starlight-sidebar-topics": "^0.8.0",
     "typescript": "^6.0.3",
     "zod": "^4.4.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@astrojs/mdx": "6.0.2",
-      "esbuild": "0.28.1",
-      "fast-uri": "3.1.5",
-      "form-data": "4.0.6",
-      "lodash": "4.17.23",
-      "postcss": "8.5.23",
-      "yaml": "2.8.4"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ],
-    "patchedDependencies": {
-      "starlight-llms-txt@0.11.0": "patches/starlight-llms-txt@0.11.0.patch"
-    }
   }
 }

--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -14,9 +14,7 @@ overrides:
   yaml: 2.8.4
 
 patchedDependencies:
-  starlight-llms-txt@0.11.0:
-    hash: 1ca7e0e89ac905820711e0fae1f771ed4bd2e0fdf8c37a1b24a980f293905128
-    path: patches/starlight-llms-txt@0.11.0.patch
+  starlight-llms-txt@0.11.0: 1ca7e0e89ac905820711e0fae1f771ed4bd2e0fdf8c37a1b24a980f293905128
 
 importers:
 

--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -14,7 +14,9 @@ overrides:
   yaml: 2.8.4
 
 patchedDependencies:
-  starlight-llms-txt@0.11.0: 1ca7e0e89ac905820711e0fae1f771ed4bd2e0fdf8c37a1b24a980f293905128
+  starlight-llms-txt@0.11.0:
+    hash: 1ca7e0e89ac905820711e0fae1f771ed4bd2e0fdf8c37a1b24a980f293905128
+    path: patches/starlight-llms-txt@0.11.0.patch
 
 importers:
 

--- a/apps/docs/pnpm-workspace.yaml
+++ b/apps/docs/pnpm-workspace.yaml
@@ -1,11 +1,26 @@
 packages: []
+overrides:
+  '@astrojs/mdx': 6.0.2
+  esbuild: 0.28.1
+  fast-uri: 3.1.5
+  form-data: 4.0.6
+  lodash: 4.17.23
+  postcss: 8.5.23
+  yaml: 2.8.4
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+patchedDependencies:
+  starlight-llms-txt@0.11.0: patches/starlight-llms-txt@0.11.0.patch
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 # Security patches adopted before the maturity window (Dependabot GHSA fixes):
 # form-data 4.0.6 (GHSA-hmw2-7cc7-3qxx), esbuild 0.28.1 (GHSA-g7r4-m6w7-qqqr),
-# fast-uri 3.1.4 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6; only
+# fast-uri 3.1.5 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6; only
 # patched release, still inside the 7-day window). Exact-pinned via overrides.
 minimumReleaseAgeExclude:
   - form-data
   - esbuild
   - fast-uri
+allowBuilds:
+  esbuild: true

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -75,26 +75,5 @@
     "playwright": "^1.61.1",
     "tailwindcss": "^4.3.2",
     "typescript": "6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@babel/core": "7.29.6",
-      "brace-expansion@1": "1.1.18",
-      "brace-expansion@2": "2.1.4",
-      "dompurify": "3.4.12",
-      "fast-uri": "3.1.5",
-      "js-yaml": "4.3.0",
-      "postcss": "8.5.23",
-      "prismjs": "1.30.0",
-      "sharp": "0.35.3",
-      "uuid": "11.1.1",
-      "ws": "^8.21.0"
-    },
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "esbuild",
-      "sharp",
-      "unrs-resolver"
-    ]
   }
 }

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -1,12 +1,12 @@
 packages: []
 overrides:
   '@babel/core': 7.29.6
-  brace-expansion@1: 1.1.17
-  brace-expansion@2: 2.1.3
+  brace-expansion@1: 1.1.18
+  brace-expansion@2: 2.1.4
   dompurify: 3.4.12
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   js-yaml: 4.3.0
-  postcss: 8.5.18
+  postcss: 8.5.23
   prismjs: 1.30.0
   sharp: 0.35.3
   uuid: 11.1.1
@@ -19,11 +19,11 @@ onlyBuiltDependencies:
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 # Security fixes for GHSA advisories, pinned to exact patched versions via the
-# overrides above: dompurify 3.4.12 (GHSA-c2j3-45gr-mqc4), postcss 8.5.18
+# overrides above: dompurify 3.4.12 (GHSA-c2j3-45gr-mqc4), postcss 8.5.23
 # (GHSA-r28c-9q8g-f849), sharp 0.35.3 — all matured past the 7-day window.
-# fast-uri 3.1.4 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6) is the
+# fast-uri 3.1.5 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6) is the
 # only patched release for that advisory and is still inside the 7-day window,
-# so it needs an exemption. brace-expansion 1.1.17 / 2.1.3 (GHSA-mh99-v99m-4gvg
+# so it needs an exemption. brace-expansion 1.1.18 / 2.1.4 (GHSA-mh99-v99m-4gvg
 # — DoS via unbounded expansion, transitive dev-dep via jest/openapi-typescript)
 # are the patched releases and are likewise still inside the maturity window.
 # All exact-pinned via the overrides above, so an exemption cannot pull any other


### PR DESCRIPTION
## Summary

- move pnpm overrides, lifecycle-script allowlists, and docs patch configuration from deprecated `package.json#pnpm` fields into workspace configuration
- update vulnerable transitive pins for `brace-expansion`, `fast-uri`, and `postcss`
- refresh the docs lockfile for the resolved dependency graph

## Validation

- `just pre-push`
- frozen pnpm installs for docs and UI
- docs production build
- UI lint and production build

## Security review

- no new network, credential, authentication, or runtime trust-boundary behavior
- dependency resolution is constrained to reviewed versions
- lifecycle scripts remain restricted to the explicit build allowlists

## Smoke test

Skipped: this is dependency/configuration-only maintenance. Production builds exercise the affected docs and UI dependency graphs without requiring a running stack.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
