### PR TITLE
fix(ui): make page layouts responsive

### DIFF
--- a/apps/ui/e2e/knowledge-indexes-responsive.spec.ts
+++ b/apps/ui/e2e/knowledge-indexes-responsive.spec.ts
@@ -1,0 +1,223 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const DEFAULT_ORG_ID = "org_00000000000000000000000000000001";
+const INDEX_ID = "kidx_019fda06ccf67d618776620713254657";
+
+async function mockAppApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    let json: unknown;
+
+    if (pathname === "/api/v1/auth/config") {
+      json = {
+        mode: "none",
+        password_auth_enabled: false,
+        oauth_providers: [],
+        signup_enabled: false,
+      };
+    } else if (pathname === "/api/v1/auth/me") {
+      json = {
+        id: "user-1",
+        email: "dev@example.com",
+        name: "Dev User",
+        roles: [],
+        email_verified: true,
+        organizations: [{ public_id: DEFAULT_ORG_ID, name: "Default", role: "owner" }],
+      };
+    } else if (pathname.endsWith("/feature-flags")) {
+      json = {
+        global_chat: false,
+        notifications: false,
+        evals: false,
+        app_budgets: false,
+        agent_versions: false,
+        voice: false,
+        agent_delegation: false,
+        observers: false,
+        public_chat: false,
+      };
+    } else if (pathname.endsWith("/switch-org")) {
+      json = { success: true, org_id: DEFAULT_ORG_ID };
+    } else if (pathname === "/api/v1/user/connections") {
+      json = [];
+    } else if (pathname === "/api/v1/models") {
+      json = {
+        data: [
+          {
+            id: "model-embedding",
+            model_id: "text-embedding-3-small",
+            display_name: "text-embedding-3-small",
+            provider_id: "provider-openai",
+            provider_name: "OpenAI",
+            provider_type: "openai",
+            healthy: true,
+            enabled: true,
+            capabilities: ["embeddings"],
+          },
+        ],
+        has_more: false,
+        total: 1,
+      };
+    } else if (/^\/api\/v1\/orgs\/[^/]+$/.test(pathname)) {
+      json = {
+        id: DEFAULT_ORG_ID,
+        name: "Default",
+        default_model_id: null,
+        default_harness_id: null,
+        base_harness_id: null,
+      };
+    } else {
+      json = { data: [], has_more: false, total: 0 };
+    }
+
+    if (pathname === "/api/v1/knowledge-indexes") {
+      json = {
+        data: [
+          {
+            id: INDEX_ID,
+            name: "Bashkit Knowledge",
+            description:
+              "A deliberately long knowledge index description that must remain readable on narrow screens.",
+            source_type: "github",
+            source_config: {
+              provider: "github",
+              repository: "everruns/bashkit",
+              branch: "main",
+            },
+            embedding_model_id: "model-embedding",
+            vector_dim: 1536,
+            document_count: 0,
+            status: "active",
+            sync_status: "pending",
+            last_synced_at: null,
+            last_sync_error: null,
+            created_at: "2026-08-01T00:00:00Z",
+            updated_at: "2026-08-01T00:00:00Z",
+            archived_at: null,
+            deleted_at: null,
+          },
+        ],
+        has_more: false,
+        total: 1,
+      };
+    }
+
+    await route.fulfill({ json });
+  });
+}
+
+test.describe("Knowledge indexes responsive records", () => {
+  test.beforeEach(async ({ context, page, baseURL }) => {
+    const origin = new URL(baseURL ?? "http://localhost:9100");
+    await context.addCookies([
+      { name: "access_token", value: "e2e-only", domain: origin.hostname, path: "/" },
+    ]);
+    await mockAppApi(page);
+  });
+
+  for (const viewport of [
+    { name: "320 mobile", width: 320, height: 900 },
+    { name: "375 mobile", width: 375, height: 900 },
+    { name: "390 mobile", width: 390, height: 900 },
+    { name: "tablet", width: 768, height: 1000 },
+    { name: "compact desktop", width: 1024, height: 1000 },
+  ]) {
+    test(`stacks fields and contains every action at ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto("/knowledge-indexes");
+
+      const table = page.getByRole("table", { name: "Knowledge indexes" });
+      const row = table.locator('[data-slot="responsive-table-row"]');
+      await expect(row).toBeVisible();
+      await expect(table.getByRole("columnheader", { name: "Name" })).toBeHidden();
+      await expect(row.getByText("Source", { exact: true })).toBeVisible();
+      await expect(row.getByText("Index state", { exact: true })).toBeVisible();
+      await expect(row.getByText(INDEX_ID, { exact: true })).toHaveCount(0);
+      await expect(row.getByRole("button", { name: `Copy ID: ${INDEX_ID}` })).toBeVisible();
+
+      for (const action of ["Open", "Edit", "Archive"]) {
+        const control = row.getByRole(action === "Open" ? "link" : "button", {
+          name: action,
+          exact: true,
+        });
+        await expect(control).toBeVisible();
+        await control.click({ trial: true });
+        const controlBox = await control.boundingBox();
+        const rowBox = await row.boundingBox();
+        expect(controlBox).not.toBeNull();
+        expect(rowBox).not.toBeNull();
+        expect(controlBox!.x).toBeGreaterThanOrEqual(rowBox!.x);
+        expect(controlBox!.x + controlBox!.width).toBeLessThanOrEqual(rowBox!.x + rowBox!.width);
+      }
+
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        await page.evaluate(() => document.documentElement.clientWidth),
+      );
+    });
+  }
+
+  test("retains the dense table at normal desktop width", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/knowledge-indexes");
+
+    const table = page.getByRole("table", { name: "Knowledge indexes" });
+    const row = table.locator('[data-slot="responsive-table-row"]');
+    await expect(table.getByRole("columnheader", { name: "Name" })).toBeVisible();
+    await expect(row.getByText("Source", { exact: true })).toBeHidden();
+    await expect(row.getByRole("link", { name: "Open" })).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+      await page.evaluate(() => document.documentElement.clientWidth),
+    );
+  });
+});
+
+test.describe("Developer showcase containment", () => {
+  for (const route of ["/dev/markdown", "/dev/tool-activity"]) {
+    test(`${route} contains production previews at 320px`, async ({ page }) => {
+      await page.setViewportSize({ width: 320, height: 900 });
+      await page.goto(route);
+
+      await expect(page.locator("h1")).toBeVisible();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        await page.evaluate(() => document.documentElement.clientWidth),
+      );
+    });
+  }
+});
+
+test.describe("Auth page containment", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/v1/auth/config", (route) =>
+      route.fulfill({
+        json: {
+          mode: "full",
+          password_auth_enabled: true,
+          oauth_providers: ["google", "github"],
+          signup_enabled: true,
+          signup_email_confirm: true,
+        },
+      }),
+    );
+  });
+
+  for (const viewport of [
+    { name: "320 mobile", width: 320, height: 900 },
+    { name: "375 mobile", width: 375, height: 900 },
+    { name: "390 mobile", width: 390, height: 900 },
+    { name: "tablet", width: 768, height: 1000 },
+    { name: "compact desktop", width: 1024, height: 1000 },
+    { name: "desktop", width: 1440, height: 1000 },
+  ]) {
+    test(`contains auth and recovery forms at ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+
+      for (const route of ["/login", "/signup", "/forgot-password", "/verify-email"]) {
+        await page.goto(route);
+        await expect(page.locator("h1")).toBeVisible();
+        expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+          await page.evaluate(() => document.documentElement.clientWidth),
+        );
+      }
+    });
+  }
+});

--- a/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
+++ b/apps/ui/src/__tests__/knowledge-indexes-page.test.tsx
@@ -217,6 +217,21 @@ describe("KnowledgeIndexesPage", () => {
     );
   });
 
+  it("provides one responsive record with labeled mobile fields", () => {
+    render(<KnowledgeIndexesPage />);
+
+    const table = screen.getByRole("table", { name: "Knowledge indexes" });
+    const row = within(table).getByRole("row", { name: /Product Docs/i });
+
+    expect(row).toHaveAttribute("data-slot", "responsive-table-row");
+    expect(within(row).getByText("Source", { selector: "span" })).toBeInTheDocument();
+    expect(within(row).getByText("Index state", { selector: "span" })).toBeInTheDocument();
+    expect(within(row).queryByText(indexes[0].id)).not.toBeInTheDocument();
+    expect(
+      within(row).getByRole("button", { name: `Copy ID: ${indexes[0].id}` }),
+    ).toBeInTheDocument();
+  });
+
   it("surfaces an invalid model and requires repair before sync", () => {
     mockUseModels.mockReturnValue({ data: [], isLoading: false });
     render(<KnowledgeIndexesPage />);

--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -73,7 +73,7 @@ describe("McpServersPage", () => {
       .getByRole("heading", { level: 1, name: "MCP Servers" })
       .closest("div.container");
 
-    expect(pageShell).toHaveClass("container", "mx-auto", "p-6");
+    expect(pageShell).toHaveClass("container", "mx-auto", "max-w-full", "p-4", "sm:p-6");
   });
 
   it("renders configured MCP servers", () => {

--- a/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
+++ b/apps/ui/src/app/(main)/knowledge-indexes/page.tsx
@@ -153,7 +153,7 @@ export default function KnowledgeIndexesPage() {
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           aria-label="Search knowledge indexes"
-          containerClassName="w-64"
+          containerClassName="w-64 max-w-full"
         />
         <div className="flex-1" />
         <SectionTabs
@@ -192,9 +192,9 @@ export default function KnowledgeIndexesPage() {
             }
           >
             {(items) => (
-              <div className="border">
-                <Table className="min-w-[960px]">
-                  <TableHeader>
+              <div className="min-w-0 border">
+                <Table aria-label="Knowledge indexes" className="xl:min-w-[960px]">
+                  <TableHeader className="hidden xl:table-header-group">
                     <TableRow>
                       <TableHead>Name</TableHead>
                       <TableHead>Source</TableHead>
@@ -349,8 +349,11 @@ function KnowledgeIndexRow({
   const canSync = index.status === "active" && !knowledgeIndexDiagnosticBlocksSync(diagnostic);
 
   return (
-    <TableRow>
-      <TableCell>
+    <TableRow
+      data-slot="responsive-table-row"
+      className="grid grid-cols-2 gap-x-4 gap-y-4 p-4 hover:bg-transparent sm:grid-cols-4 xl:table-row xl:p-0 xl:hover:bg-muted/50"
+    >
+      <TableCell className="col-span-2 block min-w-0 whitespace-normal p-0 sm:col-span-4 xl:table-cell xl:p-1.5">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <div className="font-medium">
             <EntityIdentity value={index.id} labelClassName={getEntityNameClassName(index.status)}>
@@ -367,7 +370,10 @@ function KnowledgeIndexRow({
           </div>
         )}
       </TableCell>
-      <TableCell>
+      <TableCell className="col-span-2 block min-w-0 whitespace-normal p-0 sm:col-span-1 xl:table-cell xl:p-1.5">
+        <span className="mb-1 block font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground xl:hidden">
+          Source
+        </span>
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">
           {index.source_type === "github" ? (
             <Github className="size-3.5" />
@@ -377,8 +383,11 @@ function KnowledgeIndexRow({
           {index.source_type}
         </span>
       </TableCell>
-      <TableCell>
-        <div className="w-64 space-y-1.5 whitespace-normal">
+      <TableCell className="col-span-2 block min-w-0 whitespace-normal p-0 sm:col-span-3 xl:table-cell xl:p-1.5">
+        <span className="mb-1 block font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground xl:hidden">
+          Index state
+        </span>
+        <div className="min-w-0 space-y-1.5 whitespace-normal xl:w-64">
           <KnowledgeIndexDiagnosticBadge diagnostic={diagnostic} />
           <p className="text-xs text-muted-foreground">{diagnostic.description}</p>
           {diagnostic.failureReason && (
@@ -405,14 +414,23 @@ function KnowledgeIndexRow({
           )}
         </div>
       </TableCell>
-      <TableCell className="text-muted-foreground">
+      <TableCell className="col-span-1 block whitespace-normal p-0 text-muted-foreground xl:table-cell xl:p-1.5">
+        <span className="mb-1 block font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground xl:hidden">
+          Last synced
+        </span>
         {index.last_synced_at ? formatRelativeTime(index.last_synced_at) : "Never"}
       </TableCell>
-      <TableCell className="text-muted-foreground">
+      <TableCell className="col-span-1 block whitespace-normal p-0 text-muted-foreground xl:table-cell xl:p-1.5">
+        <span className="mb-1 block font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground xl:hidden">
+          Updated
+        </span>
         {formatRelativeTime(index.updated_at)}
       </TableCell>
-      <TableCell>
-        <div className="flex items-center justify-end gap-2">
+      <TableCell className="col-span-2 block whitespace-normal p-0 sm:col-span-4 xl:table-cell xl:p-1.5">
+        <span className="mb-1 block font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground xl:hidden">
+          Actions
+        </span>
+        <div className="flex flex-wrap items-center justify-start gap-2 xl:justify-end">
           {canSync && (
             <Button
               variant="outline"

--- a/apps/ui/src/app/dev/_components/dev-page-shell.tsx
+++ b/apps/ui/src/app/dev/_components/dev-page-shell.tsx
@@ -39,8 +39,8 @@ export function DevPageShell({
   }
 
   return (
-    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
-      <div className={`mx-auto ${widthClassName}`}>
+    <div className="min-h-screen min-w-0 max-w-full bg-background bg-brand-dots px-4 py-8">
+      <div className={`mx-auto min-w-0 max-w-full ${widthClassName}`}>
         <Link
           href="/dev"
           className="mb-6 inline-flex items-center gap-2 border border-border bg-card px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted/35 hover:text-foreground"

--- a/apps/ui/src/app/dev/markdown/page.tsx
+++ b/apps/ui/src/app/dev/markdown/page.tsx
@@ -26,21 +26,21 @@ function ShowcaseSection({
   children: React.ReactNode;
 }) {
   return (
-    <Card>
+    <Card className="min-w-0">
       <CardHeader>
         <CardTitle className="text-lg">{title}</CardTitle>
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
-      <CardContent className="space-y-4">{children}</CardContent>
+      <CardContent className="min-w-0 space-y-4">{children}</CardContent>
     </Card>
   );
 }
 
 function ShowcaseItem({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="space-y-2">
+    <div className="min-w-0 space-y-2">
       <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border p-4 bg-background">{children}</div>
+      <div className="min-w-0 border bg-background p-4">{children}</div>
     </div>
   );
 }
@@ -248,9 +248,9 @@ function IncompleteMarkdownDemo() {
   return (
     <div className="space-y-3">
       {incompleteExamples.map((example) => (
-        <div key={example.label} className="flex gap-4">
-          <div className="w-40 text-sm text-muted-foreground shrink-0">{example.label}</div>
-          <div className="flex-1 border rounded p-2 bg-muted/30">
+        <div key={example.label} className="flex min-w-0 flex-col gap-2 sm:flex-row sm:gap-4">
+          <div className="text-sm text-muted-foreground sm:w-40 sm:shrink-0">{example.label}</div>
+          <div className="min-w-0 flex-1 rounded border bg-muted/30 p-2">
             <StreamdownMessage variant="inline" isAnimating={true}>
               {example.content}
             </StreamdownMessage>

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -41,7 +41,7 @@ export default function ToolActivityDevPage() {
             </p>
           </div>
 
-          <div className="grid gap-4 xl:grid-cols-2">
+          <div className="grid min-w-0 gap-4 xl:grid-cols-2 [&>*]:min-w-0">
             <div className="space-y-2">
               <p className="text-sm font-medium text-foreground">Bash output</p>
               <BashToolCallCard

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -38,7 +38,7 @@ export function PageContainer({ children, fullWidth = false, className }: PageCo
     <div
       className={cn(
         fullWidth ? "w-full" : "container mx-auto",
-        "flex flex-col gap-6 p-6",
+        "flex min-w-0 max-w-full flex-col gap-5 p-4 sm:gap-6 sm:p-6",
         className,
       )}
     >
@@ -263,7 +263,7 @@ export function PageControlStrip({
   children: ReactNode;
   className?: string;
 }) {
-  return <div className={className}>{children}</div>;
+  return <div className={cn("min-w-0 max-w-full", className)}>{children}</div>;
 }
 
 export interface SectionTabItem {
@@ -288,7 +288,10 @@ export function SectionTabs({
   className?: string;
 }) {
   return (
-    <div className={cn("flex items-center border-b", className)} role="tablist">
+    <div
+      className={cn("flex max-w-full items-center overflow-x-auto border-b", className)}
+      role="tablist"
+    >
       {items.map((item) => {
         const isActive = item.value === value;
         return (
@@ -299,7 +302,7 @@ export function SectionTabs({
             aria-selected={isActive}
             onClick={() => onValueChange(item.value)}
             className={cn(
-              "-mb-px inline-flex items-center gap-2 border-b-2 px-3.5 py-2 text-[13px] font-medium transition-colors",
+              "-mb-px inline-flex shrink-0 items-center gap-2 border-b-2 px-3.5 py-2 text-[13px] font-medium transition-colors",
               isActive
                 ? "border-primary text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
@@ -405,7 +408,11 @@ export function PageColumns({ children, className }: { children: ReactNode; clas
 
 /** The primary column inside {@link PageColumns}. */
 export function PageMain({ children, className }: { children: ReactNode; className?: string }) {
-  return <div className={cn("flex min-w-0 flex-col gap-4", className)}>{children}</div>;
+  return (
+    <div className={cn("@container/page-main flex min-w-0 flex-col gap-4", className)}>
+      {children}
+    </div>
+  );
 }
 
 /** The fixed right rail inside {@link PageColumns}. */
@@ -446,7 +453,7 @@ export function PageFooter({ children, className }: { children: ReactNode; class
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-4 border-t pt-3.5 text-[13px] text-muted-foreground",
+        "flex flex-wrap items-center justify-between gap-4 border-t pt-3.5 text-[13px] text-muted-foreground",
         className,
       )}
     >

--- a/apps/ui/src/components/layout/page-shell.tsx
+++ b/apps/ui/src/components/layout/page-shell.tsx
@@ -14,7 +14,13 @@ interface PageShellProps {
 
 export function PageShell({ children, fullWidth = false, className }: PageShellProps) {
   return (
-    <div className={cn(fullWidth ? "w-full p-6" : "container mx-auto p-6", className)}>
+    <div
+      className={cn(
+        fullWidth ? "w-full" : "container mx-auto",
+        "min-w-0 max-w-full p-4 sm:p-6",
+        className,
+      )}
+    >
       {children}
     </div>
   );
@@ -29,12 +35,23 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
   return (
-    <div className={cn("flex items-start justify-between gap-4 mb-6", className)}>
+    <div
+      className={cn(
+        "mb-6 flex min-w-0 flex-col items-start justify-between gap-4 sm:flex-row",
+        className,
+      )}
+    >
       <div className="min-w-0">
-        <h1 className="text-2xl font-bold flex items-center gap-3">{title}</h1>
-        {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+        <h1 className="flex min-w-0 flex-wrap items-center gap-3 break-words text-2xl font-bold">
+          {title}
+        </h1>
+        {description && (
+          <p className="mt-1 break-words text-sm text-muted-foreground">{description}</p>
+        )}
       </div>
-      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+      {actions && (
+        <div className="flex max-w-full flex-wrap items-center gap-2 sm:shrink-0">{actions}</div>
+      )}
     </div>
   );
 }

--- a/test_cases/ui/knowledge_indexes/TC002_responsive_list.md
+++ b/test_cases/ui/knowledge_indexes/TC002_responsive_list.md
@@ -1,0 +1,38 @@
+# Responsive knowledge-index list
+
+## Description
+
+Verify that populated knowledge-index records preserve readable identity, source, diagnostic state,
+timestamps, and actions when the app content column narrows.
+
+## Preconditions
+
+- Everruns is running on the full DB-backed stack with authentication disabled.
+- A knowledge index exists with a long name, description, ID, provider diagnostic, and every
+  lifecycle action available.
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| Route | `/knowledge-indexes` |
+| Viewports | 320, 375, 390, 768, 1024, and 1440 pixels wide |
+
+## Steps
+
+1. Open `/knowledge-indexes` at each viewport.
+2. Confirm the mobile/tablet record presents labeled Source, Index state, Last synced, Updated, and
+   Actions fields instead of squeezing desktop columns.
+3. Confirm the name, description, ID affordance, diagnostic text, and provider action remain inside
+   the record.
+4. Activate Open with pointer input. Focus Edit and Archive with the keyboard and confirm each is
+   reachable without horizontal scrolling.
+5. Confirm the page document does not overflow horizontally.
+6. At desktop width, confirm the column headers and dense table presentation return.
+
+## Expected Result
+
+- Narrow records stack in content-priority order and every action remains visible and operable.
+- Long text truncates or wraps inside the record without widening the page; the complete ID remains
+  available through its copy affordance.
+- Desktop retains the established table density and column headings.

--- a/test_cases/ui/page_layout/TC002_responsive_route_matrix.md
+++ b/test_cases/ui/page_layout/TC002_responsive_route_matrix.md
@@ -1,0 +1,62 @@
+# Responsive route matrix
+
+## Description
+
+Verify that first-party routes keep their content and actions reachable across the supported narrow
+and desktop widths. Check shared layout behavior first, then the representative consumers below.
+
+## Preconditions
+
+- Everruns is running on the full DB-backed stack with authentication disabled.
+- Representative agents, harnesses, sessions, apps, identities, memories, and knowledge indexes
+  exist so list, detail, edit, and session subroutes contain real data.
+
+## Test Data
+
+| Surface | Representative routes |
+|---|---|
+| Dashboard and reporting | `/dashboard`, `/reports`, `/work` |
+| Lists | `/sessions`, `/agents`, `/harnesses`, `/agent-identities`, `/skills`, `/memory`, `/knowledge-indexes`, `/models`, `/capabilities`, `/mcp-servers`, `/plugins`, `/apps`, `/evals`, `/observers` |
+| Detail and edit | Representative agent, harness, identity, memory, knowledge index, capability, app, provider, and session detail/edit routes |
+| Create forms | New agent, harness, identity, declarative capability, app, eval, observer, and app-channel routes |
+| Session and chat | `/chat` plus session chat, events, files, storage, trajectory, resources, context, and schedules |
+| Settings | Organization, members, providers, connections, personal access tokens, profile, features, and payments |
+| Durable execution | Overview, workers, workflows, queues, schedules, and circuit breakers |
+| Auth and onboarding | Login, signup/register, password reset, verification, onboarding, connection completion, and invite error state |
+| Developer previews | Developer index and each linked component showcase |
+
+| Viewport | Size |
+|---|---|
+| Small mobile | 320 × 900 |
+| Mobile | 375 × 900 |
+| Mobile wide | 390 × 900 |
+| Tablet | 768 × 1000 |
+| Compact desktop | 1024 × 1000 |
+| Desktop | 1440 × 1000 |
+
+## Steps
+
+1. At each viewport, open every reachable route in the matrix and wait for its data, empty, error,
+   or loading state to settle.
+2. Confirm the document has no horizontal page overflow. For intentionally wide tables or code,
+   confirm horizontal scrolling is contained inside the component and can be reached by keyboard.
+3. Check page shells, mastheads, breadcrumbs, descriptions, badges, tabs, filter/action rows, forms,
+   and right rails. Confirm content wraps or stacks in priority order without clipping.
+4. Check long names, identifiers, URLs, provider errors, and status descriptions. Confirm the full
+   value remains available through the component's copy, title, or expanded-detail affordance.
+5. Exercise every visible primary action and each overflow menu with pointer and keyboard input.
+6. Recheck loading, empty, error, and populated list states on representative routes.
+7. At desktop width, confirm responsive adaptations do not reduce established data density or hide
+   actions that fit.
+
+## Expected Result
+
+- The page document never scrolls horizontally by accident.
+- Mobile list records use labeled stacked content, responsive columns, or a deliberately scrollable
+  region selected for the content semantics; desktop-shaped rows are not squeezed into unreadable
+  columns.
+- Titles, descriptions, statuses, tabs, forms, rails, and actions remain readable and reachable by
+  touch and keyboard at every viewport.
+- Long values cannot force their parent wider and retain an accessible full-value affordance.
+- Empty, loading, and error states obey the same containment contract as populated content.
+- Desktop layouts retain their normal density and action hierarchy.


### PR DESCRIPTION
## What changed
Makes shared page containers, mastheads, tabs, footers, and developer preview shells shrink and wrap intentionally from 320px through desktop. Knowledge Indexes now presents one semantic table as labeled stacked records through compact desktop, then restores the dense desktop table at 1440px. Adds unit, Playwright, and durable manual route-matrix coverage.

## Why
At narrow widths, the Knowledge Indexes desktop row squeezed long IDs, source, diagnostics, timestamps, and actions into incompatible columns. A full seeded-stack audit also found intrinsic-width overflow in shared shells and two developer preview surfaces.

## Before / After
- Before: the supplied narrow Knowledge Indexes capture showed a desktop-shaped row with crowded identity, state, and actions. The page also used a 960px minimum table width.
- After: document width equals viewport width at 320, 375, 390, 768, 1024, and 1440px. Knowledge rows are labeled stacked records through 1024px and a dense table at 1440px.
- Full seeded-stack audit: 85 reachable first-party routes at 320px; 19 representative route-family consumers at 375/390/768/1024/1440; 14 additional dynamic loading/not-found/shared/onboarding states at 320/1440. No remaining responsive overflow.
- Manual screenshots captured locally for Knowledge Indexes at all six widths plus the corrected 320px Markdown and tool-activity previews.

## Risk
- Low
- Shared shell spacing and wrapping changes affect many consumers; the route matrix, unit coverage, Playwright coverage, full UI test suite, and production build guard desktop and compact behavior.

## Security
- Threat categories reviewed: TM-WEB and TM-DOS.
- Findings and resolutions: no findings. Presentation-only DOM/CSS and bounded test changes add no HTML injection, trust boundary, auth behavior, state mutation, dependency, request, or unbounded work. React escaping and existing action handlers are unchanged.

## Follow-ups
- `/settings` alias: pre-existing React hook-order error prevents its redirect. `/settings/organization`, the intended destination, passes at every required width. Deferred to a focused runtime fix because it is unrelated to responsive layout and overlaps separately owned organization settings work.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)