### PR TITLE
fix(ui): keep local user actions in sidebar

### DIFF
--- a/apps/ui/src/__tests__/auth-provider.test.tsx
+++ b/apps/ui/src/__tests__/auth-provider.test.tsx
@@ -99,6 +99,40 @@ describe("AuthProvider pluggable actions", () => {
     expect(result.current.logoutPending).toBe(false);
   });
 
+  it("exposes the anonymous current user without claiming authentication is required", () => {
+    mockUseAuthConfig.mockReturnValue({
+      data: { mode: "none", oauth_providers: [] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      data: { id: "anonymous", email: "anonymous@local", name: "Anonymous", roles: ["admin"] },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
+
+    expect(result.current.user?.name).toBe("Anonymous");
+    expect(result.current.requiresAuth).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("keeps the provider loading until the current user request settles", () => {
+    mockUseAuthConfig.mockReturnValue({
+      data: { mode: "none", oauth_providers: [] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+  });
+
   it("marks auth as unavailable when auth config bootstrap fails", () => {
     mockUseAuthConfig.mockReturnValue({
       data: undefined,

--- a/apps/ui/src/__tests__/mcp-connect-button.test.tsx
+++ b/apps/ui/src/__tests__/mcp-connect-button.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { McpConnectDialog } from "@/components/layout/mcp-connect-button";
+
+const mockUseAuth = jest.fn();
+jest.mock("@/providers/auth-provider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe("McpConnectDialog", () => {
+  it("explains that local no-auth connections require no authentication", () => {
+    mockUseAuth.mockReturnValue({ requiresAuth: false });
+
+    render(<McpConnectDialog open onOpenChange={jest.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Connect via MCP" })).toHaveTextContent(
+      "This local Everruns server does not require authentication.",
+    );
+  });
+
+  it("preserves OAuth guidance when authentication is required", () => {
+    mockUseAuth.mockReturnValue({ requiresAuth: true });
+
+    render(<McpConnectDialog open onOpenChange={jest.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Connect via MCP" })).toHaveTextContent(
+      "Authentication is handled automatically via OAuth",
+    );
+  });
+});

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -68,10 +68,20 @@ jest.mock("@/hooks/use-organizations", () => ({
   }),
 }));
 
+const mockMcpEndpointEnabled = jest.fn(() => true);
 jest.mock("@/components/layout/mcp-connect-button", () => ({
   McpConnectButton: () => <button type="button" aria-label="Connect via MCP" />,
-  McpConnectDialog: () => null,
-  McpConnectMenuItem: () => <div>Connect via MCP</div>,
+  McpConnectDialog: ({ open }: { open: boolean }) =>
+    open ? (
+      <div role="dialog" aria-label="MCP connection details">
+        MCP connection details
+      </div>
+    ) : null,
+  McpConnectMenuItem: ({ onSelect }: { onSelect: () => void }) => (
+    <button role="menuitem" onClick={onSelect}>
+      Connect via MCP
+    </button>
+  ),
 }));
 
 jest.mock("@/components/layout/notification-bell", () => ({
@@ -93,7 +103,8 @@ jest.mock("@/providers/feature-flags-provider", () => ({
     observers: true,
     mcp_endpoint: true,
   }),
-  useFeatureFlag: (flag: string) => flag === "mcp_endpoint" || flag === "notifications",
+  useFeatureFlag: (flag: string) =>
+    flag === "mcp_endpoint" ? mockMcpEndpointEnabled() : flag === "notifications",
 }));
 
 /// Mock LLM providers hook (default: providers configured, no warning)
@@ -122,6 +133,7 @@ describe("Sidebar", () => {
     mockPathname.mockReturnValue("/dashboard");
     mockPush.mockClear();
     mockPrefetch.mockClear();
+    mockMcpEndpointEnabled.mockReturnValue(true);
     mockUsePolicies.mockReturnValue({
       data: { policies: { "durable.view": true } },
       can: (policyId: string) => policyId === "durable.view",
@@ -180,6 +192,85 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: /test user/i }));
     expect(screen.getByText("Notifications")).toBeInTheDocument();
     expect(screen.getByText("Connect via MCP")).toBeInTheDocument();
+  });
+
+  it("renders a local identity menu with applicable actions in no-auth mode", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { name: "Anonymous", email: "anonymous@local", avatar_url: null },
+      requiresAuth: false,
+      isAuthenticated: true,
+      config: { mode: "none" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
+
+    render(<Sidebar />);
+
+    const footer = screen.getByRole("contentinfo", { name: "Sidebar footer" });
+    const trigger = within(footer).getByRole("button", { name: /anonymous/i });
+    expect(trigger).toHaveTextContent("Local user");
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menuitem", { name: "Profile" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Connect via MCP" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /personal access tokens/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /sign out/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Connect via MCP" }));
+    expect(
+      await screen.findByRole("dialog", { name: /mcp connection details/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides MCP Connect when the endpoint capability is disabled", () => {
+    mockMcpEndpointEnabled.mockReturnValue(false);
+    mockUseAuth.mockReturnValue({
+      user: { name: "Anonymous", email: "anonymous@local", avatar_url: null },
+      requiresAuth: false,
+      isAuthenticated: true,
+      config: { mode: "none" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
+
+    render(<Sidebar />);
+    fireEvent.click(screen.getByRole("button", { name: /anonymous/i }));
+
+    expect(screen.queryByRole("menuitem", { name: "Connect via MCP" })).not.toBeInTheDocument();
+  });
+
+  it("preserves authentication-only actions in authenticated mode", () => {
+    mockUseAuth.mockReturnValue({
+      user: { name: "Test User", email: "test@example.com", avatar_url: null },
+      requiresAuth: true,
+      isAuthenticated: true,
+      config: { mode: "password" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
+
+    render(<Sidebar />);
+    fireEvent.click(screen.getByRole("button", { name: /test user/i }));
+
+    expect(screen.getByRole("menuitem", { name: /personal access tokens/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /sign out/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Connect via MCP" })).toBeInTheDocument();
+  });
+
+  it("renders only the version when no current user is available", () => {
+    render(<Sidebar />);
+
+    const footer = screen.getByRole("contentinfo", { name: "Sidebar footer" });
+    expect(within(footer).getByText(/^Everruns v\d+\.\d+\.\d+$/)).toBeInTheDocument();
+    expect(within(footer).queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("routes the Profile menu item to /settings/profile", () => {

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAuth } from "@/providers/auth-provider";
 
 const McpIcon = capabilityIconMap.mcp;
 
@@ -65,6 +66,8 @@ function McpConnectDialogContent({
   mcpUrl: string;
   configSnippet: string;
 }) {
+  const { requiresAuth } = useAuth();
+
   return (
     <DialogContent className="sm:max-w-md">
       <DialogHeader>
@@ -100,7 +103,9 @@ function McpConnectDialogContent({
         </div>
 
         <p className="text-xs text-muted-foreground">
-          Authentication is handled automatically via OAuth when connecting from an MCP client.
+          {requiresAuth
+            ? "Authentication is handled automatically via OAuth when connecting from an MCP client."
+            : "This local Everruns server does not require authentication."}
         </p>
       </div>
     </DialogContent>

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -1,8 +1,8 @@
 /**
  * Decisions:
- * - User footer owns auth-only actions; anonymous mode stays a simple version label.
+ * - A resolved user always gets an identity menu; authentication gates only actions that require it.
  * - Route pushes happen inside menu actions so parent layout does not coordinate menu details.
- * - Forks can append profile menu items via a render prop instead of replacing this component.
+ * - Forks can append authenticated profile menu items via a render prop instead of replacing this component.
  */
 "use client";
 
@@ -71,7 +71,7 @@ export function SidebarUserMenu({
     navigate("/login");
   };
 
-  if (!requiresAuth || !user) {
+  if (!user) {
     return <p className="px-2.5 text-[11px] text-muted-foreground">Everruns v{version}</p>;
   }
 
@@ -87,9 +87,11 @@ export function SidebarUserMenu({
           </Avatar>
           <div className="flex-1 text-left">
             <p className="truncate font-semibold leading-5">{user.name || user.email}</p>
-            {user.name && (
+            {!requiresAuth ? (
+              <p className="truncate text-[11px] text-muted-foreground">Local user</p>
+            ) : user.name ? (
               <p className="truncate text-[11px] text-muted-foreground">{user.email}</p>
-            )}
+            ) : null}
           </div>
           <NotificationIndicator />
           <ChevronUp className="icon-sharp h-4 w-4 text-muted-foreground" />
@@ -97,24 +99,36 @@ export function SidebarUserMenu({
         <DropdownMenuPositioner side="top" align="start">
           <DropdownMenuContent className="w-56">
             <DropdownMenuGroup>
-              <DropdownMenuLabel>My Account</DropdownMenuLabel>
+              <DropdownMenuLabel>{requiresAuth ? "My Account" : "Local Account"}</DropdownMenuLabel>
               <NotificationMenuSub />
               <DropdownMenuItem onClick={() => navigate("/settings/profile")}>
                 <User className="icon-sharp mr-2 h-4 w-4" />
                 Profile
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate("/settings/personal-access-tokens")}>
-                <Key className="icon-sharp mr-2 h-4 w-4" />
-                Personal access tokens
-              </DropdownMenuItem>
+              {requiresAuth && (
+                <DropdownMenuItem onClick={() => navigate("/settings/personal-access-tokens")}>
+                  <Key className="icon-sharp mr-2 h-4 w-4" />
+                  Personal access tokens
+                </DropdownMenuItem>
+              )}
               {mcpEndpointEnabled && <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />}
-              {renderExtraItems?.({ user, navigate })}
+              {requiresAuth && renderExtraItems?.({ user, navigate })}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onClick={handleLogout} disabled={logoutPending}>
-              <LogOut className="icon-sharp mr-2 h-4 w-4" />
-              {logoutPending ? "Signing out..." : "Sign out"}
-            </DropdownMenuItem>
+            <p className="px-2 py-1 text-[11px] text-muted-foreground">Everruns v{version}</p>
+            {requiresAuth && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={handleLogout}
+                  disabled={logoutPending}
+                >
+                  <LogOut className="icon-sharp mr-2 h-4 w-4" />
+                  {logoutPending ? "Signing out..." : "Sign out"}
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenuPositioner>
       </DropdownMenu>

--- a/test_cases/ui/sidebar_footer/TC001_local_user_actions.md
+++ b/test_cases/ui/sidebar_footer/TC001_local_user_actions.md
@@ -1,0 +1,41 @@
+# TC001: Local User Sidebar Actions
+
+## Description
+
+Verify the sidebar footer exposes actions supported by the current server capabilities in no-auth
+mode without presenting the local user as authenticated, and preserves the authenticated menu.
+
+## Preconditions
+
+- Everruns stack available in `AUTH_MODE=none`
+- A second Everruns stack available with authentication enabled
+- `mcp_endpoint` enabled for the first pass and disabled for the capability-gating pass
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Local user | Server-provided anonymous user |
+| Viewports | Desktop and mobile |
+
+## Steps
+
+1. Open the no-auth stack on desktop and inspect the sidebar footer.
+2. Open the local identity menu with a pointer, then close and reopen it with the keyboard.
+3. Verify Profile is present and Personal access tokens and Sign out are absent.
+4. Open Connect via MCP and verify the server URL, configuration snippet, copy controls, and
+   no-auth guidance are visible.
+5. Open the mobile navigation drawer and repeat steps 2–4.
+6. Disable `mcp_endpoint`, reload, and verify Connect via MCP is absent while Profile remains.
+7. Open the authenticated stack, sign in, and inspect the identity menu on desktop and mobile.
+8. Verify Profile, Personal access tokens, Connect via MCP, and Sign out are present and the MCP
+   dialog retains its OAuth guidance.
+
+## Expected Result
+
+- The local footer identifies the server-provided user as a local user and displays the version.
+- Profile and feature-enabled MCP connection details are reachable in both desktop and mobile UI.
+- Authentication-only Personal access tokens and Sign out actions are absent in no-auth mode.
+- MCP Connect follows the `mcp_endpoint` capability in either auth mode.
+- The authenticated menu and logout behavior are unchanged.
+- Menu and dialog controls are keyboard-operable, labeled, and remain within the mobile viewport.


### PR DESCRIPTION
## What changed

The sidebar footer now renders the server-provided current user in local/no-auth mode and keeps
capability-backed actions available. Local mode labels the identity as a local user, exposes Profile
and feature-enabled MCP Connect, hides authentication-only Personal access tokens and Sign out, and
keeps the Everruns version visible. Authenticated behavior remains intact. MCP connection guidance
now accurately distinguishes local no-auth servers from OAuth-enabled servers.

## Why

`AuthProvider` already resolves the seeded anonymous user when `AUTH_MODE=none`, but the sidebar
discarded that user whenever `requiresAuth` was false. This hid important local actions, especially
the MCP endpoint connection details.

## Before / After

Before: no-auth mode rendered only `Everruns v…`, with no identity or action menu.

After: no-auth mode renders `Anonymous · Local user` with Profile and capability-gated MCP Connect;
authenticated mode retains its full menu. Desktop/mobile and both MCP dialogs are shown in the
screenshot evidence comment below.

Manual evidence:

- `PORT_PREFIX=288 AUTH_MODE=none just start-dev --no-watch`
- `PORT_PREFIX=289 AUTH_MODE=admin ... just start-all --no-watch`
- Keyboard and pointer activation verified in desktop sidebar and mobile drawer
- `mcp_endpoint` enabled and disabled states verified

## Risk

- Low
- Risk is limited to sidebar menu visibility and explanatory MCP copy. Existing server feature
  gates and authorization remain authoritative.

## Security

- Threat categories reviewed: TM-AUTH, TM-AUTHZ, TM-MCP, TM-WEB
- Findings and resolutions: no new trust boundary or authorization path. Menu visibility mirrors
  the resolved user, deployment auth requirement, and effective `mcp_endpoint` capability. PAT and
  logout stay auth-only; Profile uses the existing anonymous-user API path; MCP remains protected by
  its existing server-side feature/auth/org enforcement. React text rendering adds no injection
  surface. No threat-model update required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
