### PR TITLE
fix(settings): persist organization default model

### DIFF
--- a/apps/ui/src/__tests__/settings-organization.test.tsx
+++ b/apps/ui/src/__tests__/settings-organization.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import OrganizationPage from "@/app/(main)/settings/organization/page";
+import { ApiError } from "@/lib/api/client";
 
 const mockPush = jest.fn();
 const mockSetCurrentOrg = jest.fn();
@@ -66,6 +67,7 @@ jest.mock("@/components/models/model-picker", () => ({
     <select aria-label="Default Model" value={value} onChange={(e) => onChange(e.target.value)}>
       <option value="">No default model</option>
       <option value="model-1">Default Model</option>
+      <option value="model-2">Alternate Model</option>
     </select>
   ),
 }));
@@ -178,12 +180,149 @@ describe("OrganizationPage", () => {
     await waitFor(() => {
       expect(mockUpdateOrganization).toHaveBeenCalledWith({
         name: "Renamed Org",
-        default_model_id: "model-1",
-        default_harness_id: "harness-generic",
-        base_harness_id: "harness-base",
       });
     });
 
+    jest.useRealTimers();
+  });
+
+  it("autosaves only the changed model setting", async () => {
+    jest.useFakeTimers();
+
+    render(<OrganizationPage />);
+
+    fireEvent.change(screen.getByLabelText("Default Model"), {
+      target: { value: "model-2" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateOrganization).toHaveBeenLastCalledWith({
+      default_model_id: "model-2",
+    });
+
+    jest.useRealTimers();
+  });
+
+  it("keeps model errors next to Models without changing Harnesses status", async () => {
+    jest.useFakeTimers();
+    mockUpdateOrganization.mockRejectedValueOnce(
+      new ApiError(400, "Bad Request", "Model not found"),
+    );
+
+    render(<OrganizationPage />);
+
+    fireEvent.change(screen.getByLabelText("Default Model"), {
+      target: { value: "model-2" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Model not found"));
+    expect(screen.getByRole("region", { name: "Models" })).toHaveTextContent("Model not found");
+    expect(screen.getByRole("region", { name: "Harnesses" })).not.toHaveTextContent(
+      "Model not found",
+    );
+
+    jest.useRealTimers();
+  });
+
+  it.each([
+    [
+      new ApiError(403, "Forbidden", "Only organization admins can update organization settings"),
+      "Only organization admins can update organization settings",
+    ],
+    [new TypeError("Failed to fetch"), "Unable to reach the server"],
+  ])("shows actionable model save errors contextually", async (error, message) => {
+    jest.useFakeTimers();
+    mockUpdateOrganization.mockRejectedValueOnce(error);
+
+    render(<OrganizationPage />);
+    fireEvent.change(screen.getByLabelText("Default Model"), {
+      target: { value: "model-2" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(message));
+    expect(screen.getByRole("region", { name: "Models" })).toHaveTextContent(message);
+    expect(screen.getByRole("region", { name: "Harnesses" })).not.toHaveTextContent(message);
+
+    jest.useRealTimers();
+  });
+
+  it("saves model and harness changes independently while requests overlap", async () => {
+    jest.useFakeTimers();
+    let resolveModel: () => void = () => {};
+    let resolveHarness: () => void = () => {};
+    mockUpdateOrganization.mockImplementation((payload) => {
+      return new Promise<void>((resolve) => {
+        if ("default_model_id" in payload) resolveModel = resolve;
+        else resolveHarness = resolve;
+      });
+    });
+
+    render(<OrganizationPage />);
+    fireEvent.change(screen.getByLabelText("Default Model"), {
+      target: { value: "model-2" },
+    });
+    fireEvent.change(screen.getByLabelText("Select default harness"), {
+      target: { value: "harness-base" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateOrganization).toHaveBeenCalledWith({ default_model_id: "model-2" });
+    expect(mockUpdateOrganization).toHaveBeenCalledWith({
+      default_harness_id: "harness-base",
+      base_harness_id: "harness-base",
+    });
+    expect(screen.getByRole("region", { name: "Models" })).toHaveTextContent("Saving");
+    expect(screen.getByRole("region", { name: "Harnesses" })).toHaveTextContent("Saving");
+
+    await act(async () => {
+      resolveHarness();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("region", { name: "Harnesses" })).toHaveTextContent("Saved");
+    expect(screen.getByRole("region", { name: "Models" })).toHaveTextContent("Saving");
+
+    await act(async () => {
+      resolveModel();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("region", { name: "Models" })).toHaveTextContent("Saved");
+
+    jest.useRealTimers();
+  });
+
+  it("replaces a removed model selection with a valid model", async () => {
+    jest.useFakeTimers();
+    mockOrganization = { ...mockOrganization, default_model_id: "model-removed" };
+
+    render(<OrganizationPage />);
+    fireEvent.change(screen.getByLabelText("Default Model"), {
+      target: { value: "model-2" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateOrganization).toHaveBeenCalledWith({ default_model_id: "model-2" });
     jest.useRealTimers();
   });
 
@@ -208,8 +347,6 @@ describe("OrganizationPage", () => {
     await waitFor(() => {
       expect(mockUpdateOrganization).toHaveBeenCalledWith({
         name: "Renamed Org",
-        default_harness_id: "harness-generic",
-        base_harness_id: "harness-base",
       });
     });
 

--- a/apps/ui/src/__tests__/use-organizations.test.tsx
+++ b/apps/ui/src/__tests__/use-organizations.test.tsx
@@ -161,6 +161,21 @@ describe("useUpdateOrganization", () => {
     });
   });
 
+  it("updates only the currently selected organization", async () => {
+    const updatedOrg = { id: "org-123", name: "Existing Org", default_model_id: "model-2" };
+    mockUpdateOrganization.mockResolvedValueOnce(updatedOrg as never);
+
+    const { result } = renderHook(() => useUpdateOrganization(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ default_model_id: "model-2" });
+    });
+
+    expect(mockUpdateOrganization).toHaveBeenCalledWith("org-123", {
+      default_model_id: "model-2",
+    });
+  });
+
   it("invalidates resolved session data after updating the default model", async () => {
     const updatedOrg = { id: "org-123", name: "Updated Org" };
     mockUpdateOrganization.mockResolvedValueOnce(updatedOrg as never);

--- a/apps/ui/src/app/(main)/settings/organization/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organization/page.tsx
@@ -37,6 +37,7 @@ import {
 import { useHarnesses, usePageTitle } from "@/hooks";
 import { useOrg } from "@/providers/org-provider";
 import { cn } from "@/lib/utils";
+import { ApiError } from "@/lib/api/client";
 import type { OrgRole } from "@/lib/api/types";
 
 const ROLE_LABELS: Record<OrgRole, string> = {
@@ -48,6 +49,11 @@ const ROLE_LABELS: Record<OrgRole, string> = {
 type SettingsGroupKey = "identity" | "models" | "harnesses";
 type AutoSaveState = "idle" | "dirty" | "saving" | "saved" | "error";
 
+interface GroupSaveState {
+  state: AutoSaveState;
+  error: string | null;
+}
+
 interface OrganizationDraft {
   name: string;
   defaultModelId: string;
@@ -57,6 +63,11 @@ interface OrganizationDraft {
 
 const CONTROL_CLASS_NAME = "w-full";
 const AUTOSAVE_DELAY_MS = 700;
+const INITIAL_SAVE_STATES: Record<SettingsGroupKey, GroupSaveState> = {
+  identity: { state: "idle", error: null },
+  models: { state: "idle", error: null },
+  harnesses: { state: "idle", error: null },
+};
 
 export default function OrganizationPage() {
   usePageTitle("Organization", "Settings");
@@ -78,11 +89,7 @@ export default function OrganizationPage() {
   const [defaultModelId, setDefaultModelId] = useState("");
   const [defaultHarnessId, setDefaultHarnessId] = useState("");
   const [baseHarnessId, setBaseHarnessId] = useState("");
-  const [dirtyGroups, setDirtyGroups] = useState<SettingsGroupKey[]>([]);
-  const [savingGroups, setSavingGroups] = useState<SettingsGroupKey[]>([]);
-  const [recentlySavedGroups, setRecentlySavedGroups] = useState<SettingsGroupKey[]>([]);
-  const [autoSaveState, setAutoSaveState] = useState<AutoSaveState>("idle");
-  const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
+  const [saveStates, setSaveStates] = useState(INITIAL_SAVE_STATES);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newOrgName, setNewOrgName] = useState("");
 
@@ -92,19 +99,33 @@ export default function OrganizationPage() {
     defaultHarnessId: "",
     baseHarnessId: "",
   });
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const saveVersionRef = useRef(0);
+  const saveTimersRef = useRef<Partial<Record<SettingsGroupKey, ReturnType<typeof setTimeout>>>>(
+    {},
+  );
+  const saveVersionsRef = useRef<Record<SettingsGroupKey, number>>({
+    identity: 0,
+    models: 0,
+    harnesses: 0,
+  });
+  const loadedOrganizationIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-    }
-    saveVersionRef.current += 1;
-
-    if (!organizationId || !organizationName) {
+    if (
+      !organizationId ||
+      !organizationName ||
+      loadedOrganizationIdRef.current === organizationId
+    ) {
       return;
     }
+
+    for (const group of Object.keys(saveTimersRef.current) as SettingsGroupKey[]) {
+      clearTimeout(saveTimersRef.current[group]);
+      delete saveTimersRef.current[group];
+    }
+    for (const group of Object.keys(saveVersionsRef.current) as SettingsGroupKey[]) {
+      saveVersionsRef.current[group] += 1;
+    }
+    loadedOrganizationIdRef.current = organizationId;
 
     setName(organizationName);
     setDefaultModelId(organizationDefaultModelId);
@@ -118,11 +139,7 @@ export default function OrganizationPage() {
     };
 
     draftRef.current = draft;
-    setDirtyGroups([]);
-    setSavingGroups([]);
-    setRecentlySavedGroups([]);
-    setAutoSaveState("idle");
-    setAutoSaveError(null);
+    setSaveStates(INITIAL_SAVE_STATES);
   }, [
     organizationId,
     organizationName,
@@ -132,12 +149,13 @@ export default function OrganizationPage() {
   ]);
 
   useEffect(() => {
+    const saveTimers = saveTimersRef.current;
+    const saveVersions = saveVersionsRef.current;
     return () => {
-      if (saveTimerRef.current) {
-        clearTimeout(saveTimerRef.current);
-        saveTimerRef.current = null;
+      for (const group of Object.keys(saveTimers) as SettingsGroupKey[]) {
+        clearTimeout(saveTimers[group]);
+        saveVersions[group] += 1;
       }
-      saveVersionRef.current += 1;
     };
   }, []);
 
@@ -149,60 +167,71 @@ export default function OrganizationPage() {
     setBaseHarnessId(nextDraft.baseHarnessId);
   };
 
-  const scheduleAutoSave = (groups: SettingsGroupKey[], nextDraft: OrganizationDraft) => {
+  const scheduleAutoSave = (group: SettingsGroupKey, nextDraft: OrganizationDraft) => {
     draftRef.current = nextDraft;
-    saveVersionRef.current += 1;
-    const saveVersion = saveVersionRef.current;
+    saveVersionsRef.current[group] += 1;
+    const saveVersion = saveVersionsRef.current[group];
 
-    setRecentlySavedGroups([]);
-    setDirtyGroups((current) => mergeGroups(current, groups));
-    setAutoSaveError(null);
+    setSaveStates((current) => ({
+      ...current,
+      [group]: { state: "dirty", error: null },
+    }));
 
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
+    if (saveTimersRef.current[group]) {
+      clearTimeout(saveTimersRef.current[group]);
     }
 
-    if (!nextDraft.name.trim() || !nextDraft.defaultHarnessId || !nextDraft.baseHarnessId) {
-      setAutoSaveState("dirty");
+    if (
+      (group === "identity" && !nextDraft.name.trim()) ||
+      (group === "models" && !nextDraft.defaultModelId) ||
+      (group === "harnesses" && (!nextDraft.defaultHarnessId || !nextDraft.baseHarnessId))
+    ) {
       return;
     }
 
-    setAutoSaveState("dirty");
-    saveTimerRef.current = setTimeout(async () => {
-      saveTimerRef.current = null;
-      setAutoSaveState("saving");
-      setSavingGroups(groups);
+    saveTimersRef.current[group] = setTimeout(async () => {
+      delete saveTimersRef.current[group];
+      setSaveStates((current) => ({
+        ...current,
+        [group]: { state: "saving", error: null },
+      }));
+
+      const payload =
+        group === "identity"
+          ? { name: nextDraft.name.trim() }
+          : group === "models"
+            ? { default_model_id: nextDraft.defaultModelId }
+            : {
+                default_harness_id: nextDraft.defaultHarnessId,
+                base_harness_id: nextDraft.baseHarnessId,
+              };
 
       try {
-        await updateOrganization.mutateAsync({
-          name: nextDraft.name.trim(),
-          ...(nextDraft.defaultModelId ? { default_model_id: nextDraft.defaultModelId } : {}),
-          default_harness_id: nextDraft.defaultHarnessId,
-          base_harness_id: nextDraft.baseHarnessId,
-        });
+        await updateOrganization.mutateAsync(payload);
 
-        if (saveVersionRef.current !== saveVersion) {
+        if (saveVersionsRef.current[group] !== saveVersion) {
           return;
         }
 
-        const savedDraft = {
-          ...nextDraft,
-          name: nextDraft.name.trim(),
-        };
-
-        setDraft(savedDraft);
-        setDirtyGroups([]);
-        setSavingGroups([]);
-        setRecentlySavedGroups(groups);
-        setAutoSaveState("saved");
+        if (group === "identity") {
+          setDraft({ ...draftRef.current, name: nextDraft.name.trim() });
+        }
+        setSaveStates((current) => ({
+          ...current,
+          [group]: { state: "saved", error: null },
+        }));
       } catch (err) {
-        if (saveVersionRef.current !== saveVersion) {
+        if (saveVersionsRef.current[group] !== saveVersion) {
           return;
         }
 
-        setSavingGroups([]);
-        setAutoSaveState("error");
-        setAutoSaveError(err instanceof Error ? err.message : "Failed to save organization");
+        setSaveStates((current) => ({
+          ...current,
+          [group]: {
+            state: "error",
+            error: getOrganizationSaveError(err),
+          },
+        }));
       }
     }, AUTOSAVE_DELAY_MS);
   };
@@ -211,14 +240,14 @@ export default function OrganizationPage() {
     const nextName = e.target.value;
     const nextDraft = { ...draftRef.current, name: nextName };
     setName(nextName);
-    scheduleAutoSave(["identity"], nextDraft);
+    scheduleAutoSave("identity", nextDraft);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-      scheduleAutoSave(["identity"], draftRef.current);
+    if (e.key === "Enter" && saveTimersRef.current.identity) {
+      clearTimeout(saveTimersRef.current.identity);
+      delete saveTimersRef.current.identity;
+      scheduleAutoSave("identity", draftRef.current);
     }
   };
 
@@ -273,15 +302,8 @@ export default function OrganizationPage() {
             <SettingsGroup
               title="Identity"
               description="Name and stable identifier for this organization."
-              status={
-                <AutoSaveBadge
-                  group="identity"
-                  state={autoSaveState}
-                  dirtyGroups={dirtyGroups}
-                  savingGroups={savingGroups}
-                  recentlySavedGroups={recentlySavedGroups}
-                />
-              }
+              status={<AutoSaveBadge saveState={saveStates.identity} />}
+              error={saveStates.identity.error}
             >
               <SettingsRow
                 label="Organization Name"
@@ -322,15 +344,8 @@ export default function OrganizationPage() {
             <SettingsGroup
               title="Models"
               description="Model fallbacks applied when agents or sessions do not set their own model."
-              status={
-                <AutoSaveBadge
-                  group="models"
-                  state={autoSaveState}
-                  dirtyGroups={dirtyGroups}
-                  savingGroups={savingGroups}
-                  recentlySavedGroups={recentlySavedGroups}
-                />
-              }
+              status={<AutoSaveBadge saveState={saveStates.models} />}
+              error={saveStates.models.error}
             >
               <SettingsRow
                 label="Default Model"
@@ -343,7 +358,7 @@ export default function OrganizationPage() {
                   onChange={(value) => {
                     const nextDraft = { ...draftRef.current, defaultModelId: value };
                     setDefaultModelId(value);
-                    scheduleAutoSave(["models"], nextDraft);
+                    scheduleAutoSave("models", nextDraft);
                   }}
                   placeholder="No default model"
                   className={CONTROL_CLASS_NAME}
@@ -354,15 +369,8 @@ export default function OrganizationPage() {
             <SettingsGroup
               title="Harnesses"
               description="Harness fallbacks applied when sessions do not set their own runtime environment."
-              status={
-                <AutoSaveBadge
-                  group="harnesses"
-                  state={autoSaveState}
-                  dirtyGroups={dirtyGroups}
-                  savingGroups={savingGroups}
-                  recentlySavedGroups={recentlySavedGroups}
-                />
-              }
+              status={<AutoSaveBadge saveState={saveStates.harnesses} />}
+              error={saveStates.harnesses.error}
             >
               <SettingsRow
                 label="Default Harness"
@@ -375,7 +383,7 @@ export default function OrganizationPage() {
                   onValueChange={(value) => {
                     const nextDraft = { ...draftRef.current, defaultHarnessId: value };
                     setDefaultHarnessId(value);
-                    scheduleAutoSave(["harnesses"], nextDraft);
+                    scheduleAutoSave("harnesses", nextDraft);
                   }}
                   placeholder="Select default harness"
                   className={CONTROL_CLASS_NAME}
@@ -393,7 +401,7 @@ export default function OrganizationPage() {
                   onValueChange={(value) => {
                     const nextDraft = { ...draftRef.current, baseHarnessId: value };
                     setBaseHarnessId(value);
-                    scheduleAutoSave(["harnesses"], nextDraft);
+                    scheduleAutoSave("harnesses", nextDraft);
                   }}
                   placeholder="Select base harness"
                   className={CONTROL_CLASS_NAME}
@@ -406,10 +414,6 @@ export default function OrganizationPage() {
                 </div>
               )}
             </SettingsGroup>
-
-            {(autoSaveState === "error" || autoSaveError) && (
-              <p className="text-sm text-destructive">{autoSaveError}</p>
-            )}
           </div>
         )}
       </section>
@@ -525,22 +529,38 @@ export default function OrganizationPage() {
   );
 }
 
+function getOrganizationSaveError(error: unknown): string {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+  if (error instanceof TypeError) {
+    return "Unable to reach the server";
+  }
+  return "Could not save this setting";
+}
+
 function SettingsGroup({
   title,
   description,
   status,
+  error,
   children,
 }: {
   title: string;
   description: string;
   status: React.ReactNode;
+  error: string | null;
   children: React.ReactNode;
 }) {
+  const headingId = `organization-settings-${title.toLowerCase()}`;
   return (
-    <div>
+    <section aria-labelledby={headingId}>
       <div className="mb-3 flex items-start justify-between gap-4">
         <div>
-          <h3 className="text-sm font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          <h3
+            id={headingId}
+            className="text-sm font-semibold uppercase tracking-[0.08em] text-muted-foreground"
+          >
             {title}
           </h3>
           <p className="mt-1 text-sm text-muted-foreground">{description}</p>
@@ -548,7 +568,12 @@ function SettingsGroup({
         {status}
       </div>
       <Card className="overflow-hidden p-0 gap-0">{children}</Card>
-    </div>
+      {error && (
+        <p role="alert" className="mt-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+    </section>
   );
 }
 
@@ -576,52 +601,37 @@ function SettingsRow({
   );
 }
 
-function AutoSaveBadge({
-  group,
-  state,
-  dirtyGroups,
-  savingGroups,
-  recentlySavedGroups,
-}: {
-  group: SettingsGroupKey;
-  state: AutoSaveState;
-  dirtyGroups: SettingsGroupKey[];
-  savingGroups: SettingsGroupKey[];
-  recentlySavedGroups: SettingsGroupKey[];
-}) {
-  const isSaving = state === "saving" && savingGroups.includes(group);
-  const isDirty = dirtyGroups.includes(group);
-  const isRecentlySaved = state === "saved" && recentlySavedGroups.includes(group);
-  const isError = state === "error" && isDirty;
-
-  if (isSaving) {
+function AutoSaveBadge({ saveState }: { saveState: GroupSaveState }) {
+  if (saveState.state === "saving") {
     return (
-      <Badge variant="outline" className="text-muted-foreground">
+      <Badge role="status" aria-live="polite" variant="outline" className="text-muted-foreground">
         <Loader2 className="h-3 w-3 animate-spin" />
         Saving
       </Badge>
     );
   }
 
-  if (isError) {
-    return <Badge variant="destructive">Save failed</Badge>;
+  if (saveState.state === "error") {
+    return <Badge variant="destructive">Not saved</Badge>;
   }
 
-  if (isDirty) {
-    return <Badge variant="secondary">Unsaved changes</Badge>;
+  if (saveState.state === "dirty") {
+    return (
+      <Badge role="status" aria-live="polite" variant="secondary">
+        Unsaved changes
+      </Badge>
+    );
   }
 
   return (
-    <Badge variant="outline" className={cn(isRecentlySaved && "text-green-700")}>
+    <Badge
+      role="status"
+      aria-live="polite"
+      variant="outline"
+      className={cn(saveState.state === "saved" && "text-green-700")}
+    >
       <Check className="h-3 w-3" />
       Saved
     </Badge>
   );
-}
-
-function mergeGroups(
-  current: SettingsGroupKey[],
-  incoming: SettingsGroupKey[],
-): SettingsGroupKey[] {
-  return Array.from(new Set([...current, ...incoming]));
 }

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -574,8 +574,11 @@ pub async fn update_organization(
         .log_internal_error_json("get organization")?
         .ok_or_not_found_json("Organization")?;
 
-    // Cannot update default organization name
-    if org_row.org_id == DEFAULT_ORG_ID && req.name.is_some() {
+    // The built-in organization's name is protected, but an idempotent PATCH
+    // that repeats the current name must not block unrelated settings updates.
+    if org_row.org_id == DEFAULT_ORG_ID
+        && req.name.as_deref().is_some_and(|name| name != org_row.name)
+    {
         return Err(ErrorResponse::new("Cannot update default organization")
             .into_response(StatusCode::BAD_REQUEST));
     }
@@ -1248,6 +1251,93 @@ mod tests {
             .header("content-type", "application/json")
             .body(Body::from(format!(r#"{{"name":"{name}"}}"#)))
             .unwrap()
+    }
+
+    fn update_default_org_request(name: &str) -> Request<Body> {
+        update_default_org_json_request(format!(r#"{{"name":"{name}"}}"#))
+    }
+
+    fn update_default_org_json_request(body: impl Into<Body>) -> Request<Body> {
+        Request::builder()
+            .method("PATCH")
+            .uri("/v1/orgs/org_00000000000000000000000000000001")
+            .header("Authorization", "Bearer test-token")
+            .header("content-type", "application/json")
+            .body(body.into())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn default_organization_accepts_unchanged_name() {
+        let (app, db, user_id) = create_org_app(None);
+        db.add_organization_member(DEFAULT_ORG_ID, user_id, "owner")
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(update_default_org_request("Default Organization"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn default_organization_still_rejects_renames() {
+        let (app, db, user_id) = create_org_app(None);
+        db.add_organization_member(DEFAULT_ORG_ID, user_id, "owner")
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(update_default_org_request("Renamed"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn organization_settings_require_database_admin_role() {
+        let (app, db, user_id) = create_org_app(None);
+        db.add_organization_member(DEFAULT_ORG_ID, user_id, "member")
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(update_default_org_json_request(
+                r#"{"default_model_id":"model_01933b5a00007000800000000000030b"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["detail"],
+            "Only organization admins can update organization settings"
+        );
+    }
+
+    #[tokio::test]
+    async fn organization_rejects_stale_default_model() {
+        let (app, db, user_id) = create_org_app(None);
+        db.add_organization_member(DEFAULT_ORG_ID, user_id, "owner")
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(update_default_org_json_request(
+                r#"{"default_model_id":"model_01933b5a00007000800000000000030b"}"#,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["detail"], "Model not found");
     }
 
     #[tokio::test]

--- a/test_cases/ui/organization_settings/TC001_default_model_autosave.md
+++ b/test_cases/ui/organization_settings/TC001_default_model_autosave.md
@@ -1,0 +1,33 @@
+# Default model autosave
+
+## Description
+
+Verify that organization default-model changes save independently, remain scoped to the selected organization, and show contextual status and errors.
+
+## Preconditions
+
+- DB-backed stack with at least one enabled model
+- User is an owner or admin of the selected organization
+- Organization settings page is open
+
+## Test Data
+
+| Field | Value |
+|---|---|
+| Default model | Any enabled model other than the current default |
+
+## Steps
+
+1. Change Default Model and observe the Models status.
+2. Confirm the PATCH payload contains only `default_model_id`.
+3. Reload the page and confirm the selected model remains selected.
+4. Change a Harness setting while a model save is pending and confirm each section reports its own status.
+5. Trigger a model validation, authorization, or network failure.
+6. Repeat at a mobile viewport.
+
+## Expected Result
+
+- The model change saves and persists after reload for only the selected organization.
+- Models and Harnesses save independently during rapid or overlapping changes.
+- Model errors render directly with Models in an accessible alert; Harness errors render with Harnesses.
+- No detached page-level save error appears and the page has no mobile horizontal overflow.


### PR DESCRIPTION
## What changed
Organization Default Model autosaves now persist for the selected organization. Models, Harnesses, and Identity use independent debounced mutation state, minimal section-specific PATCH payloads, and contextual accessible errors. The backend still protects the built-in organization name while accepting idempotent unchanged-name PATCHes.

## Why
Changing Default Model on the built-in organization sent the unchanged protected name and both harness fields. The API rejected the request before model validation, and the UI rendered generic status at Models plus the API detail below Harnesses.

## Before / After
Before, the DB-backed browser sent:

```json
{"name":"Default Organization","default_model_id":"model_01933b5a00007000800000000000030b","default_harness_id":"harness_019fddaf4f87778484befcbae9b255f9","base_harness_id":"harness_019fddaf4f70725385f842b73a784611"}
```

The API returned `400` with `Cannot update default organization`; the Models heading showed `Save failed` while the detail appeared after Harnesses.

After, the browser sends only:

```json
{"default_model_id":"model_01933b5a00007000800000000000030b"}
```

The API returns `200`; `GET /v1/orgs/{org}` and a full page reload both retain the new model. Harness IDs remain unchanged. At 390px, document width equals viewport width (`390`) with no horizontal overflow. Desktop/mobile before-and-after screenshots are attached in the PR comments.

Validation:
- `just pre-push` (all 10 gates)
- 16 organization API handler tests
- 19 focused organization UI/hook tests
- UI format, lint, typecheck, and production build
- DB-backed PostgreSQL/Valkey/NATS/API/worker/UI/Caddy smoke test on `PORT_PREFIX=296`
- AUTH_MODE=none live success/reload; full-auth owner/member/stale-model handler coverage

## Risk
- Medium
- Autosave concurrency and default-organization protection are the main surfaces. Per-section timers/versioning prevent stale completions from crossing sections; API tests retain rename denial and DB-authoritative admin enforcement.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API, TM-SQL, TM-WEB
- Findings and resolutions: DB membership/admin checks remain authoritative; model validation remains org-scoped; cross-org and removed IDs fail; no SQL changed; React renders errors as text; only sanitized RFC 9457 details are shown while network/unknown failures use safe copy. No new threat-model entry is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)