### PR TITLE
fix(harnesses): show inheritance on summary cards

### DIFF
--- a/apps/ui/src/__tests__/harness-card.test.tsx
+++ b/apps/ui/src/__tests__/harness-card.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { HarnessCard } from "@/components/harnesses/harness-card";
+import type { Harness } from "@/lib/api/types";
+import { resolveHarnessInheritance } from "@/lib/harness-inheritance";
+
+jest.mock("@/components/chat/streamdown-message", () => ({
+  InlineStreamdownMessage: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function harness(overrides: Partial<Harness> = {}): Harness {
+  return {
+    id: "harness-child",
+    name: "child",
+    display_name: "Child",
+    description: "Child harness",
+    parent_harness_id: null,
+    default_model_id: null,
+    tags: [],
+    capabilities: [],
+    is_built_in: false,
+    status: "active",
+    created_at: "2026-08-07T00:00:00Z",
+    updated_at: "2026-08-07T00:00:00Z",
+    archived_at: null,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe("HarnessCard inheritance", () => {
+  it("keeps root cards quiet", () => {
+    const root = harness();
+
+    render(<HarnessCard harness={root} inheritance={resolveHarnessInheritance(root, new Map())} />);
+
+    expect(screen.queryByText("Inherits from")).not.toBeInTheDocument();
+  });
+
+  it("links the direct parent and keeps built-in status separate", () => {
+    const parent = harness({ id: "harness-parent", name: "generic", display_name: "Generic" });
+    const child = harness({ parent_harness_id: parent.id, is_built_in: true });
+    const inheritance = resolveHarnessInheritance(child, new Map([[parent.id, parent]]));
+
+    render(<HarnessCard harness={child} inheritance={inheritance} />);
+
+    expect(screen.getByText("Inherits from")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Generic" })).toHaveAttribute(
+      "href",
+      "/harnesses/harness-parent",
+    );
+    expect(screen.getByText("Built-in")).toBeInTheDocument();
+  });
+
+  it("marks archived parents and handles unavailable parents without a link", () => {
+    const archivedParent = harness({
+      id: "harness-archived",
+      display_name: "Archived Parent",
+      status: "archived",
+    });
+    const archivedChild = harness({ parent_harness_id: archivedParent.id });
+    const { rerender } = render(
+      <HarnessCard
+        harness={archivedChild}
+        inheritance={resolveHarnessInheritance(
+          archivedChild,
+          new Map([[archivedParent.id, archivedParent]]),
+        )}
+      />,
+    );
+    expect(screen.getByText("(archived)")).toBeInTheDocument();
+
+    const missingChild = harness({ parent_harness_id: "harness-missing" });
+    rerender(
+      <HarnessCard
+        harness={missingChild}
+        inheritance={resolveHarnessInheritance(missingChild, new Map())}
+      />,
+    );
+    expect(screen.getByText("unavailable harness")).toHaveAttribute("title", "harness-missing");
+    expect(screen.queryByRole("link", { name: "unavailable harness" })).not.toBeInTheDocument();
+  });
+
+  it("truncates long parent names and labels local capability chips", () => {
+    const longName = "A parent harness with a deliberately very long display name";
+    const parent = harness({ id: "harness-parent", display_name: longName });
+    const child = harness({
+      parent_harness_id: parent.id,
+      capabilities: [{ ref: "platform", config: {} }],
+    });
+
+    render(
+      <HarnessCard
+        harness={child}
+        inheritance={resolveHarnessInheritance(child, new Map([[parent.id, parent]]))}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: longName })).toHaveClass("min-w-0", "truncate");
+    expect(screen.getByText("Declared capabilities")).toBeInTheDocument();
+    expect(screen.getByLabelText("Locally declared capabilities")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/harness-inheritance.test.ts
+++ b/apps/ui/src/__tests__/harness-inheritance.test.ts
@@ -1,0 +1,66 @@
+import type { Harness } from "@/lib/api/types";
+import { resolveHarnessInheritance } from "@/lib/harness-inheritance";
+
+function harness(id: string, parentId: string | null = null): Harness {
+  return {
+    id,
+    name: id,
+    display_name: id,
+    description: null,
+    parent_harness_id: parentId,
+    default_model_id: null,
+    tags: [],
+    capabilities: [],
+    is_built_in: false,
+    status: "active",
+    created_at: "2026-08-07T00:00:00Z",
+    updated_at: "2026-08-07T00:00:00Z",
+    archived_at: null,
+    deleted_at: null,
+  };
+}
+
+describe("resolveHarnessInheritance", () => {
+  it("distinguishes roots, direct parents, and multi-level ancestry", () => {
+    const root = harness("root");
+    const child = harness("child", root.id);
+    const leaf = harness("leaf", child.id);
+    const byId = new Map([root, child, leaf].map((item) => [item.id, item]));
+
+    expect(resolveHarnessInheritance(root, byId)).toMatchObject({
+      directParent: null,
+      chain: [root],
+      missingParentId: null,
+      hasCycle: false,
+    });
+    expect(resolveHarnessInheritance(child, byId)).toMatchObject({
+      directParent: root,
+      chain: [root, child],
+    });
+    expect(resolveHarnessInheritance(leaf, byId)).toMatchObject({
+      directParent: child,
+      chain: [root, child, leaf],
+    });
+  });
+
+  it("reports missing or deleted ancestors without following unsafe links", () => {
+    const missingChild = harness("missing-child", "missing-parent");
+    const deletedParent = { ...harness("deleted-parent"), status: "deleted" as const };
+    const deletedChild = harness("deleted-child", deletedParent.id);
+    const byId = new Map([[deletedParent.id, deletedParent]]);
+
+    expect(resolveHarnessInheritance(missingChild, byId).missingParentId).toBe("missing-parent");
+    expect(resolveHarnessInheritance(deletedChild, byId)).toMatchObject({
+      directParent: deletedParent,
+      missingParentId: deletedParent.id,
+    });
+  });
+
+  it("bounds malformed cyclic ancestry", () => {
+    const first = harness("first", "second");
+    const second = harness("second", "first");
+    const byId = new Map([first, second].map((item) => [item.id, item]));
+
+    expect(resolveHarnessInheritance(first, byId).hasCycle).toBe(true);
+  });
+});

--- a/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
+++ b/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
@@ -35,6 +35,7 @@ import { isArchivedStatus } from "@/lib/entity-lifecycle";
 import { normalizeTags } from "@/lib/tags";
 import { pluralize } from "@/lib/formatting";
 import { cn } from "@/lib/utils";
+import { resolveHarnessInheritance } from "@/lib/harness-inheritance";
 
 const EXAMPLE_PREVIEW_LIMIT = 6;
 type StatusTab = "all" | "active" | "archived";
@@ -72,6 +73,11 @@ export default function HarnessesPageClient() {
     const archived = list.filter((h) => isArchivedStatus(h.status)).length;
     return { all: list.length, active: list.length - archived, archived };
   }, [harnesses]);
+
+  const harnessesById = useMemo(
+    () => new Map((harnesses ?? []).map((harness) => [harness.id, harness])),
+    [harnesses],
+  );
 
   const capabilityFacets = useMemo(() => {
     const tally = new Map<string, number>();
@@ -239,6 +245,7 @@ export default function HarnessesPageClient() {
                     harness={harness}
                     allCapabilities={allCapabilities}
                     showEditButton
+                    inheritance={resolveHarnessInheritance(harness, harnessesById)}
                   />
                 ))}
               </div>

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Pencil, Shield } from "lucide-react";
+import { GitBranch, Pencil, Shield } from "lucide-react";
 import { IconTile } from "@/components/layout/page-layout";
 import type { Harness, Capability, CapabilityId } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
@@ -22,12 +22,14 @@ import {
 } from "@/lib/entity-lifecycle";
 import { formatCountLabel } from "@/lib/formatting";
 import { normalizeTags } from "@/lib/tags";
+import type { HarnessInheritance } from "@/lib/harness-inheritance";
 
 interface HarnessCardProps {
   harness: Harness;
   allCapabilities?: Capability[];
   showEditButton?: boolean;
   compact?: boolean;
+  inheritance?: HarnessInheritance;
 }
 
 export function HarnessCard({
@@ -35,6 +37,7 @@ export function HarnessCard({
   allCapabilities,
   showEditButton = false,
   compact = false,
+  inheritance,
 }: HarnessCardProps) {
   const { locale } = useLocale();
   const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
@@ -44,6 +47,15 @@ export function HarnessCard({
   const tags = normalizeTags(harness.tags);
   const sessionCount = harness.session_count ?? 0;
   const appCount = harness.app_count ?? 0;
+  const directParent = inheritance?.directParent;
+  const directParentName = directParent ? getDisplayName(directParent) : null;
+  const inheritanceSummary = inheritance?.hasCycle
+    ? "Inheritance chain unavailable because it contains a cycle"
+    : inheritance?.missingParentId
+      ? `Parent harness unavailable (${inheritance.missingParentId})`
+      : inheritance && inheritance.chain.length > 1
+        ? `Inheritance chain: ${inheritance.chain.map(getDisplayName).join(" → ")}`
+        : null;
 
   return (
     <EntityCard
@@ -95,9 +107,46 @@ export function HarnessCard({
         <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
       )}
 
+      {harness.parent_harness_id && (
+        <div className="mb-3 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger
+                aria-label="Show harness inheritance chain"
+                className="inline-flex shrink-0 items-center"
+              >
+                <GitBranch className="icon-sharp size-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{inheritanceSummary ?? "Direct parent harness"}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <span className="shrink-0">Inherits from</span>
+          {directParent && directParent.status !== "deleted" ? (
+            <Link
+              href={`/harnesses/${directParent.id}`}
+              className="min-w-0 truncate font-medium text-foreground hover:underline"
+              title={directParentName ?? undefined}
+            >
+              {directParentName}
+            </Link>
+          ) : (
+            <span className="min-w-0 truncate italic" title={harness.parent_harness_id}>
+              unavailable harness
+            </span>
+          )}
+          {directParent?.status === "archived" && <span className="shrink-0">(archived)</span>}
+        </div>
+      )}
+
       {/* Capabilities display */}
       {harnessCapabilities.length > 0 && (
-        <div className="flex flex-wrap gap-1 mb-3">
+        <div
+          className="flex flex-wrap items-center gap-1 mb-3"
+          aria-label="Locally declared capabilities"
+        >
+          <span className="mr-1 text-[11px] text-muted-foreground">Declared capabilities</span>
           <TooltipProvider>
             {harnessCapabilities.map((capConfig) => {
               const cap = getCapabilityInfo(capConfig.ref);

--- a/apps/ui/src/lib/harness-inheritance.ts
+++ b/apps/ui/src/lib/harness-inheritance.ts
@@ -1,0 +1,43 @@
+import type { Harness } from "@/lib/api/types";
+
+export interface HarnessInheritance {
+  directParent: Harness | null;
+  chain: Harness[];
+  missingParentId: string | null;
+  hasCycle: boolean;
+}
+
+/**
+ * Resolve display-only ancestry from the already-loaded harness list. Runtime
+ * configuration continues to use the server's canonical effective resolver.
+ */
+export function resolveHarnessInheritance(
+  harness: Harness,
+  harnessesById: ReadonlyMap<string, Harness>,
+): HarnessInheritance {
+  const directParent = harness.parent_harness_id
+    ? (harnessesById.get(harness.parent_harness_id) ?? null)
+    : null;
+  const chain = [harness];
+  const visited = new Set([harness.id]);
+  let missingParentId: string | null = null;
+  let hasCycle = false;
+  let parentId = harness.parent_harness_id;
+
+  while (parentId) {
+    if (visited.has(parentId)) {
+      hasCycle = true;
+      break;
+    }
+    visited.add(parentId);
+    const parent = harnessesById.get(parentId);
+    if (!parent || parent.status === "deleted") {
+      missingParentId = parentId;
+      break;
+    }
+    chain.unshift(parent);
+    parentId = parent.parent_harness_id;
+  }
+
+  return { directParent, chain, missingParentId, hasCycle };
+}

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -20,7 +20,6 @@ use everruns_core::{
     AgentCapabilityConfig, Caller, DeploymentGrade, Harness, PlatformDefinition,
     ResourceConfigResponse, evaluate_policies_with,
 };
-use futures::{StreamExt, TryStreamExt, stream};
 
 use super::common::{
     ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, ResourceStatsResponse,
@@ -28,7 +27,7 @@ use super::common::{
 };
 use super::dispatch::{Dispatchable, impl_dispatchable};
 use serde::Deserialize;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use utoipa::{IntoParams, ToSchema};
 
 use crate::services::CapabilityService;
@@ -108,21 +107,37 @@ async fn add_harness_counts(
     })
 }
 
-const HARNESS_COUNT_CONCURRENCY_LIMIT: usize = 8;
-
 async fn add_harnesses_counts(
     db: &StorageBackend,
     org_id: i64,
     harnesses: Vec<Harness>,
 ) -> Result<Vec<ResourceWithCounts<Harness>>, (StatusCode, Json<ErrorResponse>)> {
-    stream::iter(
-        harnesses
-            .into_iter()
-            .map(|harness| add_harness_counts(db, org_id, harness)),
-    )
-    .buffered(HARNESS_COUNT_CONCURRENCY_LIMIT)
-    .try_collect::<Vec<_>>()
-    .await
+    let harness_ids = harnesses
+        .iter()
+        .map(|harness| harness.id)
+        .collect::<Vec<_>>();
+    let session_counts = async {
+        db.count_sessions_for_harnesses(org_id, &harness_ids)
+            .await
+            .log_internal_error_json("count harness sessions")
+    };
+    let app_counts = async {
+        db.count_apps_for_harnesses(org_id, &harness_ids)
+            .await
+            .log_internal_error_json("count harness apps")
+    };
+    let (session_counts, app_counts) = tokio::try_join!(session_counts, app_counts)?;
+    let session_counts = session_counts.into_iter().collect::<HashMap<_, _>>();
+    let app_counts = app_counts.into_iter().collect::<HashMap<_, _>>();
+
+    Ok(harnesses
+        .into_iter()
+        .map(|harness| ResourceWithCounts {
+            session_count: session_counts.get(&harness.id).copied().unwrap_or(0) as u64,
+            app_count: app_counts.get(&harness.id).copied().unwrap_or(0) as u64,
+            inner: harness,
+        })
+        .collect())
 }
 
 /// Create harness routes

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -9,7 +9,7 @@ use everruns_core::{
     AgentCapabilityConfig, Harness, HarnessId, HarnessStatus, InitialFile,
     is_declarative_capability, merge_harness,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use super::types::HarnessRow;
@@ -212,9 +212,31 @@ pub async fn load_harnesses_list(
     db: &StorageBackend,
     rows: Vec<HarnessRow>,
 ) -> anyhow::Result<Vec<Harness>> {
+    let Some(org_id) = rows.first().map(|row| row.org_id) else {
+        return Ok(Vec::new());
+    };
+    let harness_ids = rows.iter().map(|row| row.id).collect::<Vec<_>>();
+    let capability_rows = db
+        .get_harness_capabilities_by_harness_ids(org_id, &harness_ids)
+        .await?;
+    let mut capabilities_by_harness = HashMap::<HarnessId, Vec<AgentCapabilityConfig>>::new();
+    for row in capability_rows {
+        capabilities_by_harness
+            .entry(row.harness_id)
+            .or_default()
+            .push(AgentCapabilityConfig::with_config(
+                row.capability_id,
+                row.config,
+            ));
+    }
+
     let mut harnesses = Vec::with_capacity(rows.len());
     for row in rows {
-        let caps = get_capabilities(db, row.org_id, row.id.uuid()).await?;
+        let caps = capabilities_by_harness.remove(&row.id).unwrap_or_default();
+        let caps = crate::domains::capabilities::queries::hydrate_declarative_capability_configs(
+            db, row.org_id, caps,
+        )
+        .await?;
         harnesses.push(row_to_harness(row, caps));
     }
     Ok(harnesses)
@@ -424,4 +446,66 @@ pub fn validate_harness_name(name: &str) -> Result<(), CommandError> {
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::models::CreateHarnessRow;
+
+    fn harness_row(name: &str, parent_harness_id: Option<HarnessId>) -> CreateHarnessRow {
+        CreateHarnessRow {
+            name: name.to_string(),
+            display_name: Some(name.to_string()),
+            description: None,
+            system_prompt: None,
+            parent_harness_id,
+            default_model_id: None,
+            tags: vec![],
+            initial_files: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            network_access: None,
+            embedder_metadata: serde_json::json!({}),
+            is_built_in: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn list_loads_local_capabilities_in_one_batched_lookup() {
+        let db = StorageBackend::in_memory();
+        let org_id = 1;
+        let root = db
+            .create_harness(org_id, harness_row("root", None))
+            .await
+            .unwrap();
+        let child = db
+            .create_harness(org_id, harness_row("child", Some(root.id)))
+            .await
+            .unwrap();
+        let _leaf = db
+            .create_harness(org_id, harness_row("leaf", Some(child.id)))
+            .await
+            .unwrap();
+        db.set_harness_capabilities(
+            child.id.uuid(),
+            vec![("web_fetch".to_string(), 0, serde_json::json!({}))],
+        )
+        .await
+        .unwrap();
+
+        let rows = db.list_harnesses(org_id, None, true).await.unwrap();
+        db.reset_session_list_lookup_count();
+        let harnesses = load_harnesses_list(&db, rows).await.unwrap();
+
+        assert_eq!(db.session_list_lookup_count(), 1);
+        let root = harnesses.iter().find(|h| h.name == "root").unwrap();
+        let child = harnesses.iter().find(|h| h.name == "child").unwrap();
+        let leaf = harnesses.iter().find(|h| h.name == "leaf").unwrap();
+        assert_eq!(root.parent_harness_id, None);
+        assert_eq!(child.parent_harness_id, Some(root.id));
+        assert_eq!(leaf.parent_harness_id, Some(child.id));
+        assert!(root.capabilities.is_empty());
+        assert_eq!(child.capabilities[0].capability_id(), "web_fetch");
+        assert!(leaf.capabilities.is_empty());
+    }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -763,6 +763,14 @@ impl StorageBackend {
         dispatch!(self, count_sessions_for_harness, org_id, harness_id)
     }
 
+    pub async fn count_sessions_for_harnesses(
+        &self,
+        org_id: i64,
+        harness_ids: &[HarnessId],
+    ) -> Result<Vec<(HarnessId, i64)>> {
+        dispatch!(self, count_sessions_for_harnesses, org_id, harness_ids)
+    }
+
     /// Count user-created harnesses in an org (for resource limits); excludes
     /// soft-deleted rows and system-seeded built-in harnesses.
     pub async fn count_harnesses_for_org(&self, org_id: i64) -> Result<i64> {
@@ -3948,6 +3956,14 @@ impl StorageBackend {
 
     pub async fn count_apps_for_harness(&self, org_id: i64, harness_id: HarnessId) -> Result<u64> {
         dispatch!(self, count_apps_for_harness, org_id, harness_id)
+    }
+
+    pub async fn count_apps_for_harnesses(
+        &self,
+        org_id: i64,
+        harness_ids: &[HarnessId],
+    ) -> Result<Vec<(HarnessId, i64)>> {
+        dispatch!(self, count_apps_for_harnesses, org_id, harness_ids)
     }
 
     pub async fn update_app(

--- a/crates/server/src/storage/memory/apps.rs
+++ b/crates/server/src/storage/memory/apps.rs
@@ -126,6 +126,22 @@ impl InMemoryDatabase {
             .count() as u64)
     }
 
+    pub async fn count_apps_for_harnesses(
+        &self,
+        org_id: i64,
+        harness_ids: &[HarnessId],
+    ) -> Result<Vec<(HarnessId, i64)>> {
+        let mut counts = std::collections::HashMap::<HarnessId, i64>::new();
+        for app in self.apps.read().values() {
+            let harness_id = HarnessId::from_uuid(app.harness_id);
+            if app.org_id == org_id && app.status != "deleted" && harness_ids.contains(&harness_id)
+            {
+                *counts.entry(harness_id).or_default() += 1;
+            }
+        }
+        Ok(counts.into_iter().collect())
+    }
+
     pub async fn update_app(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -224,6 +224,23 @@ impl InMemoryDatabase {
             .count() as u64)
     }
 
+    pub async fn count_sessions_for_harnesses(
+        &self,
+        org_id: i64,
+        harness_ids: &[HarnessId],
+    ) -> Result<Vec<(HarnessId, i64)>> {
+        let mut counts = std::collections::HashMap::<HarnessId, i64>::new();
+        for session in self.sessions.read().values() {
+            if session.org_id == org_id
+                && let Some(harness_id) = session.harness_id
+                && harness_ids.contains(&harness_id)
+            {
+                *counts.entry(harness_id).or_default() += 1;
+            }
+        }
+        Ok(counts.into_iter().collect())
+    }
+
     /// Count sessions in an org (for resource limits). Sessions are hard-deleted
     /// (no soft-delete status), so every stored row counts toward the cap.
     pub async fn count_sessions_for_org(&self, org_id: i64) -> Result<i64> {

--- a/crates/server/src/storage/repositories/apps.rs
+++ b/crates/server/src/storage/repositories/apps.rs
@@ -153,6 +153,26 @@ impl Database {
         Ok(count as u64)
     }
 
+    pub async fn count_apps_for_harnesses(
+        &self,
+        org_id: i64,
+        harness_ids: &[HarnessId],
+    ) -> Result<Vec<(HarnessId, i64)>> {
+        let harness_ids = harness_ids.iter().map(|id| id.uuid()).collect::<Vec<_>>();
+        Ok(sqlx::query_as(
+            r#"
+            SELECT harness_id, COUNT(*)::bigint
+            FROM apps
+            WHERE org_id = $1 AND harness_id = ANY($2) AND status != 'deleted'
+            GROUP BY harness_id
+            "#,
+        )
+        .bind(org_id)
+        .bind(&harness_ids)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
     pub async fn update_app(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -354,6 +354,26 @@ impl Database {
         Ok(count as u64)
     }
 
+    pub async fn count_sessions_for_harnesses(
+        &self,
+        org_id: i64,
+        harness_ids: &[HarnessId],
+    ) -> Result<Vec<(HarnessId, i64)>> {
+        let harness_ids = harness_ids.iter().map(|id| id.uuid()).collect::<Vec<_>>();
+        Ok(sqlx::query_as(
+            r#"
+            SELECT harness_id, COUNT(*)::bigint
+            FROM sessions
+            WHERE org_id = $1 AND harness_id = ANY($2)
+            GROUP BY harness_id
+            "#,
+        )
+        .bind(org_id)
+        .bind(&harness_ids)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
     /// Count sessions in an org (for resource limits). Sessions are hard-deleted
     /// (no soft-delete status), so every stored row counts toward the cap.
     pub async fn count_sessions_for_org(&self, org_id: i64) -> Result<i64> {

--- a/test_cases/ui/harnesses/TC001_inheritance_relationships.md
+++ b/test_cases/ui/harnesses/TC001_inheritance_relationships.md
@@ -1,0 +1,40 @@
+# TC001: Harness Inheritance Relationships
+
+## Description
+
+Verify harness cards identify their direct parent, expose deeper ancestry, and distinguish locally
+declared capabilities from inherited effective configuration in grid and list layouts.
+
+## Preconditions
+
+- DB-backed stack is running with the built-in `base`, `generic`, and `platform-chat` harnesses
+- A custom child of `platform-chat` exists with a long display name and a locally declared capability
+
+## Test Data
+
+| Harness | Parent | Expected card relationship |
+|---------|--------|----------------------------|
+| Base | None | No inheritance row |
+| Generic | None | No inheritance row |
+| Platform Chat | Generic | `Inherits from Generic` |
+| Long custom child | Platform Chat | `Inherits from Platform Chat`; tooltip shows Generic → Platform Chat → child |
+
+## Steps
+
+1. Open `/harnesses` at desktop width and select grid view.
+2. Verify the built-in and custom cards against the table above.
+3. Focus the custom child's branch icon and inspect the ancestry tooltip.
+4. Verify capability chips are introduced by the label `Declared capabilities`.
+5. Select list view and repeat the relationship checks.
+6. Set the viewport to a mobile width and repeat grid/list checks.
+7. Follow a parent relationship link, then use keyboard navigation to focus the relationship link
+   and branch tooltip trigger.
+
+## Expected Result
+
+- Every non-root card names and links its direct parent; built-in status remains a separate badge.
+- Root cards do not show a redundant root label.
+- Multi-level ancestry is available from the branch tooltip without replacing the direct-parent label.
+- Long names truncate without overflowing and remain available through the link title/tooltip.
+- Capability chips are clearly described as locally declared, not effective inherited capabilities.
+- Grid/list and desktop/mobile layouts remain readable and keyboard-operable.


### PR DESCRIPTION
## What changed
Harness summary cards now show their direct inheritance relationship with a branch icon and same-origin parent link. Deep ancestry is available in an accessible tooltip, archived/unavailable parents degrade safely, long names truncate, and root cards stay quiet.

Capability chips are now explicitly labeled as locally declared so users do not mistake them for the effective inherited set. The harness list also batches capability and session/app count loading instead of issuing per-harness queries.

## Why
The harness list showed built-in status and capability chips but omitted the parent/base relationship, making Platform Chat and custom descendants look self-contained and making locally declared capabilities appear effective.

## Before / After
Before: Platform Chat, Generic, and Base cards showed no inheritance metadata; Platform Chat's lone `Platform` chip was not identified as locally declared.

After: DB-backed manual validation showed:
- Platform Chat: `Inherits from Generic`
- custom Generic → Platform Chat → child chain: direct parent on-card and full chain in the tooltip
- `Declared capabilities` label before local chips
- no redundant relationship row on Generic/Base roots
- working grid/list layouts at 1440×1000 and 390×844, long-name truncation, keyboard focus/navigation, and no browser errors

Screenshots were captured during DB-backed validation and are available from the shipping run.

## Risk
- Medium
- Card layout or parent resolution could regress for malformed ancestry; list count aggregation could return incorrect zero/default counts. Cycle/missing/deleted/archived/long-name tests and DB-backed manual verification cover these paths.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API, TM-SQL, TM-WEB, TM-DOS
- Findings and resolutions: authorization and API exposure are unchanged; all new aggregate queries remain parameterized and org-scoped; work is bounded by the existing per-org harness cap; React escapes names/IDs and links only to same-origin typed harness routes; ancestry traversal is cycle-protected and bounded by the loaded list. No new threat-model entry required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

