### PR TITLE
fix(agents): surface terminal diagnostic failures

### DIFF
--- a/apps/ui/src/__tests__/agent-health-check.test.tsx
+++ b/apps/ui/src/__tests__/agent-health-check.test.tsx
@@ -3,12 +3,16 @@ import { AgentHealthCheck } from "@/components/agents/agent-health-check";
 import type { HealthCheckRun, LatestHealthCheckRun } from "@/lib/api/types";
 
 const mockTrigger = jest.fn(() => ({ mutate: jest.fn(), isPending: false, error: null }));
+const mockUseHealthCheckRun = jest.fn((_agentId: string, _runId: string | null) => ({
+  data: mockRun,
+}));
 let mockRun: HealthCheckRun | undefined;
 let mockLatest: LatestHealthCheckRun | undefined;
 
 jest.mock("@/hooks/use-agents", () => ({
   useTriggerHealthCheck: () => mockTrigger(),
-  useHealthCheckRun: () => ({ data: mockRun }),
+  useHealthCheckRun: (agentId: string, runId: string | null) =>
+    mockUseHealthCheckRun(agentId, runId),
   useLatestHealthCheckRun: () => ({ data: mockLatest }),
 }));
 
@@ -57,6 +61,7 @@ const completedRun: HealthCheckRun = {
 
 describe("AgentHealthCheck", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockRun = undefined;
     mockLatest = undefined;
   });
@@ -147,5 +152,34 @@ describe("AgentHealthCheck", () => {
     };
     render(<AgentHealthCheck agentId="agent_1" />);
     expect(screen.getByRole("button", { name: /running/i })).toBeDisabled();
+    expect(mockUseHealthCheckRun).toHaveBeenCalledWith("agent_1", "healthcheck_3");
+  });
+
+  it("renders a polled terminal failure live and clears the running state", () => {
+    mockLatest = {
+      run: {
+        id: "healthcheck_4",
+        config_hash: "abc",
+        status: "running",
+        created_at: "2026-06-13T00:00:00Z",
+      },
+      config_changed: false,
+    };
+    const view = render(<AgentHealthCheck agentId="agent_1" />);
+    expect(screen.getByRole("button", { name: /running/i })).toBeDisabled();
+
+    mockRun = {
+      id: "healthcheck_4",
+      config_hash: "abc",
+      status: "failed",
+      created_at: "2026-06-13T00:00:00Z",
+      error_message:
+        "The AI provider account is out of credits or quota. Add credits or raise the provider account limits to continue.",
+    };
+    view.rerender(<AgentHealthCheck agentId="agent_1" />);
+
+    expect(screen.getByText(/out of credits or quota/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /run health check/i })).toBeEnabled();
+    expect(screen.queryByText(/generating and running cases/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -31,13 +31,17 @@ interface AgentHealthCheckProps {
 export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
   const trigger = useTriggerHealthCheck();
   const [runId, setRunId] = useState<string | null>(null);
-  const { data: triggeredRun } = useHealthCheckRun(agentId, runId);
   const { data: latest } = useLatestHealthCheckRun(agentId);
+  const latestRun = latest?.run;
+  const latestActiveRunId =
+    latestRun?.status === "pending" || latestRun?.status === "running" ? latestRun.id : null;
+  const activeRunId = runId ?? latestActiveRunId;
+  const { data: triggeredRun } = useHealthCheckRun(agentId, activeRunId);
 
   // Show a freshly triggered run if there is one; otherwise fall back to the
   // latest persisted run loaded on mount so prior results appear immediately
   // without triggering a new LLM run (EVE-588).
-  const run = triggeredRun ?? latest?.run;
+  const run = triggeredRun ?? (runId ? trigger.data : latestRun);
   // Only hint staleness for the mounted latest run, not one we just triggered.
   const configChanged = !runId && !!latest?.run && latest.config_changed;
 

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -162,7 +162,7 @@ export function useHealthCheckRun(agentId: string, runId: string | null) {
     enabled: !!runId,
     refetchInterval: (query) => {
       const status = query.state.data?.status;
-      return status === "completed" || status === "failed" ? false : 3000;
+      return !status || status === "pending" || status === "running" ? 3000 : false;
     },
   });
 }

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -18459,6 +18459,15 @@ export interface operations {
           "application/json": components["schemas"]["ErrorResponse"];
         };
       };
+      /** @description Utility LLM provider rejected the analysis */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
       /** @description Internal server error */
       500: {
         headers: {

--- a/crates/provider/src/error.rs
+++ b/crates/provider/src/error.rs
@@ -42,9 +42,10 @@ impl LlmErrorKind {
     pub fn from_provider_code(code: &str) -> Option<Self> {
         let code = code.trim().to_ascii_lowercase();
         match code.as_str() {
-            "insufficient_quota" | "billing_hard_limit_reached" | "credit_balance_too_low" => {
-                Some(Self::QuotaExhausted)
-            }
+            "insufficient_quota"
+            | "billing_hard_limit_reached"
+            | "credit_balance_too_low"
+            | "credit_balance_exhausted" => Some(Self::QuotaExhausted),
             "authentication_error" | "invalid_api_key" | "permission_denied" => {
                 Some(Self::Authentication)
             }
@@ -929,6 +930,13 @@ mod tests {
             LlmErrorKind::from_provider_status(
                 429,
                 "{\"error\":{\"type\":\"insufficient_quota\"}}"
+            ),
+            LlmErrorKind::QuotaExhausted
+        );
+        assert_eq!(
+            LlmErrorKind::from_provider_status(
+                429,
+                "{\"error\":{\"code\":\"credit_balance_exhausted\"}}"
             ),
             LlmErrorKind::QuotaExhausted
         );

--- a/crates/provider/src/user_facing_error.rs
+++ b/crates/provider/src/user_facing_error.rs
@@ -97,6 +97,7 @@ pub fn is_provider_quota_message(message: &str) -> bool {
     lower.contains("insufficient_quota")
         || lower.contains("insufficient quota")
         || lower.contains("exceeded your current quota")
+        || lower.contains("credit_balance_exhausted")
         || lower.contains("credit balance is too low")
 }
 
@@ -661,6 +662,21 @@ mod tests {
         );
 
         assert_eq!(error.code, codes::PROVIDER_QUOTA_EXHAUSTED);
+    }
+
+    #[test]
+    fn classify_credit_balance_exhausted_as_provider_quota_exhausted() {
+        let error = classify_runtime_error_message(
+            "LLM error: credit_balance_exhausted: You have no credits remaining. secret=hidden",
+            &UserFacingErrorContext::default(),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_QUOTA_EXHAUSTED);
+        assert_eq!(
+            error.fallback_message(),
+            "The AI provider account is out of credits or quota. Add credits or raise the provider account limits to continue."
+        );
+        assert!(!error.fallback_message().contains("secret"));
     }
 
     #[test]

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1374,6 +1374,7 @@ pub async fn preview_agent(
     responses(
         (status = 200, description = "Agent analysis completed", body = AgentAnalysisResponse),
         (status = 400, description = "Utility LLM service not configured", body = ErrorResponse),
+        (status = 422, description = "Utility LLM provider rejected the analysis", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "agents"

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -1775,7 +1775,10 @@ impl Command for AnalyzeAgent {
             &preview.tools,
         )
         .await
-        .map_err(|e| CommandError::internal(anyhow::anyhow!(e)))?;
+        .map_err(|e| {
+            let safe = super::safe_agent_check_error(&e);
+            CommandError::unprocessable(safe.fallback_message()).with_code(safe.code)
+        })?;
         drop(analysis_permit);
         let mut findings = preview.findings;
         findings.extend(llm_findings);
@@ -1867,9 +1870,11 @@ mod tests {
     use crate::services::CapabilityService;
     use crate::storage::StorageBackend;
     use crate::storage::models::CreateHarnessRow;
+    use async_trait::async_trait;
     use everruns_core::{
-        Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, FeatureFlags,
-        OrgRole,
+        AgentLoopError, Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver,
+        FeatureFlags, LlmResponse, LlmResponseStream, OrgRole, Result as CoreResult,
+        UtilityLlmRequest, UtilityLlmService,
     };
     use std::sync::Arc;
     use uuid::Uuid;
@@ -1920,6 +1925,56 @@ mod tests {
                 ..FeatureFlags::default()
             },
         )
+    }
+
+    struct ExhaustedUtilityLlm;
+
+    #[async_trait]
+    impl UtilityLlmService for ExhaustedUtilityLlm {
+        fn is_configured(&self) -> bool {
+            true
+        }
+
+        async fn chat_completion(&self, _request: UtilityLlmRequest) -> CoreResult<LlmResponse> {
+            Err(AgentLoopError::llm(
+                "credit_balance_exhausted: credits depleted; api_key=secret",
+            ))
+        }
+
+        async fn chat_completion_stream(
+            &self,
+            _request: UtilityLlmRequest,
+        ) -> CoreResult<LlmResponseStream> {
+            unreachable!("agent analysis does not stream")
+        }
+    }
+
+    #[tokio::test]
+    async fn analyze_maps_provider_quota_failure_to_safe_actionable_error() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db, OrgRole::Owner)
+            .with_utility_llm_service(Arc::new(ExhaustedUtilityLlm));
+
+        let error = AnalyzeAgent {
+            system_prompt: Some("Be helpful.".to_string()),
+            capabilities: Vec::new(),
+            tools: Vec::new(),
+            mcp_servers: Default::default(),
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("exhausted provider must fail analysis");
+
+        let (status, axum::Json(body)): (
+            axum::http::StatusCode,
+            axum::Json<crate::api::common::ErrorResponse>,
+        ) = error.into();
+        assert_eq!(status, axum::http::StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body.code.as_deref(), Some("provider_quota_exhausted"));
+        let detail = body.detail.expect("safe actionable detail");
+        assert!(detail.contains("out of credits or quota"));
+        assert!(!detail.contains("api_key"));
+        assert!(!detail.contains("secret"));
     }
 
     fn high_risk_agent_request(name: String) -> CreateAgentRequest {

--- a/crates/server/src/domains/agents/health_check/mod.rs
+++ b/crates/server/src/domains/agents/health_check/mod.rs
@@ -29,6 +29,22 @@ pub(crate) fn strip_code_fences(raw: &str) -> &str {
 }
 
 #[cfg(test)]
+mod error_tests {
+    #[test]
+    fn provider_failure_is_safe_for_persisted_health_run() {
+        let error = super::super::safe_agent_check_error(
+            "case generation failed: LLM error: credit_balance_exhausted; token=secret",
+        );
+
+        assert_eq!(error.code, "provider_quota_exhausted");
+        let message = error.fallback_message();
+        assert!(message.contains("out of credits or quota"));
+        assert!(!message.contains("token"));
+        assert!(!message.contains("secret"));
+    }
+}
+
+#[cfg(test)]
 pub(crate) mod test_support {
     use async_trait::async_trait;
     use everruns_core::{

--- a/crates/server/src/domains/agents/health_check/runner.rs
+++ b/crates/server/src/domains/agents/health_check/runner.rs
@@ -62,13 +62,14 @@ pub fn spawn_health_check_run(ctx: Arc<HealthCheckRunContext>, target: HealthChe
     tokio::spawn(async move {
         if let Err(e) = execute_run(&ctx, &target).await {
             tracing::warn!(error = %e, run_id = %target.run_id, "health check run failed");
+            let safe_error = super::super::safe_agent_check_error(&e).fallback_message();
             let _ = ctx
                 .db
                 .update_agent_health_check_run(
                     target.run_id,
                     UpdateAgentHealthCheckRunRow {
                         status: Some("failed".to_string()),
-                        error_message: Some(e),
+                        error_message: Some(safe_error),
                         ..Default::default()
                     },
                 )

--- a/crates/server/src/domains/agents/mod.rs
+++ b/crates/server/src/domains/agents/mod.rs
@@ -15,6 +15,16 @@ pub mod types;
 pub use commands::*;
 pub use health_check::{AgentHealthCheckService, HealthCheckRunContext};
 
+/// Reduce utility-provider failures to the shared actionable error taxonomy.
+/// Raw provider text is for server logs only: it can contain request context or
+/// credential-adjacent details and must never reach agent-check API responses.
+pub(crate) fn safe_agent_check_error(error: &str) -> everruns_core::UserFacingError {
+    everruns_core::classify_runtime_error_message(
+        error,
+        &everruns_core::UserFacingErrorContext::default(),
+    )
+}
+
 /// Policy: View agents (read-only).
 pub const AGENT_VIEW: Policy = Policy {
     id: "agent.view",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -185,6 +185,16 @@
               }
             }
           },
+          "422": {
+            "description": "Utility LLM provider rejected the analysis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {

--- a/knowledge/evaluation/agent-checks.md
+++ b/knowledge/evaluation/agent-checks.md
@@ -126,6 +126,12 @@ Decided ordering (Option A → C → B from the design review):
    health checks are not `Eval` entities). Gated on the utility LLM and the
    org default harness being available.
 
+   The editor polls any displayed non-terminal run, including a latest run
+   discovered on mount, until it becomes terminal. Analyze and health-check
+   provider failures use the shared safe user-facing error taxonomy: they give
+   actionable operator guidance without exposing raw provider responses, and
+   a failed Analyze attempt does not replace built-in findings.
+
    The background task is fire-and-forget, so a run is made durable against
    process death two ways: a **boot reaper** transitions every non-terminal
    (`pending`/`running`) row to `failed` on server startup (a fresh process has

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -611,7 +611,7 @@ never treated as permission to bypass the egress boundary.
 |----|--------|----------|------------|--------|
 | TM-LLM-001 | API key at rest exposure | Critical | Encrypted via envelope encryption (AES-256-GCM); stored in `llm_providers.api_key_encrypted` | MITIGATED |
 | TM-LLM-002 | API key in logs | High | Never logged; tracing filters sensitive fields; generic error messages only | MITIGATED |
-| TM-LLM-003 | API key in error messages | High | Provider errors sanitized before returning to user; full errors logged server-side | MITIGATED |
+| TM-LLM-003 | API key in error messages | High | Provider errors are sanitized before returning to users; full errors remain server-side. Agent Analyze responses and persisted health-check terminal errors use the shared user-facing provider taxonomy, which preserves actionable failure categories without copying raw provider bodies. | MITIGATED |
 | TM-LLM-004 | API key lifetime in memory | Medium | Decrypted per-request; key dropped after LLM call completes | MITIGATED |
 | TM-LLM-005 | Provider failure retry amplifies cost or hides permanent account errors | Medium | Provider-boundary semantic classification separates transient transport/stall/overload/rate-limit/server failures from credentials, billing quota, unavailable models, invalid requests, and long-horizon usage limits. Automatic recovery is allowed only before assistant output commits, uses jittered exponential backoff, and is bounded by shared attempt and elapsed-time budgets; lower layers report consumed retries so nested loops cannot multiply attempts. Permanent classes fail fast. | MITIGATED |
 | TM-LLM-006 | Provider MITM | High | HTTPS required for all LLM provider communication | MITIGATED |

--- a/test_cases/ui/agent_checks/TC002_terminal_provider_errors.md
+++ b/test_cases/ui/agent_checks/TC002_terminal_provider_errors.md
@@ -1,0 +1,31 @@
+# TC002 Terminal Provider Errors
+
+## Description
+
+Verifies that utility-provider failures remain actionable in the agent Edit rail and that a
+terminal health-check run replaces its live loading state without a page reload.
+
+## Preconditions
+
+- Development stack is running.
+- At least one editable agent exists.
+- `UTILITY_OPENAI_API_KEY` is configured for an account that returns
+  `credit_balance_exhausted`.
+
+## Steps
+
+1. Open an editable agent and select Edit.
+2. Confirm at least one built-in finding is visible in Checks, then select Analyze.
+3. Wait for Analyze to finish.
+4. Select Run health check and remain on the Edit page.
+5. Wait for the health-check run to reach a terminal state.
+
+## Expected Result
+
+- Analyze reports that the AI provider account is out of credits or quota and suggests adding
+  credits or raising provider limits.
+- The Analyze error contains no provider response body, API key, token, or other secret detail.
+- The built-in finding remains visible after Analyze fails.
+- Health check changes live from Running / Generating and running cases to the same safe,
+  actionable quota message without a page reload.
+- The Run health check button is enabled again after the terminal failure.


### PR DESCRIPTION
## What changed
Analyze now returns a safe, actionable provider-quota error instead of a generic internal-server error, while built-in findings remain visible. Health-check failures persist the same safe provider guidance. The edit rail polls latest non-terminal runs and clears loading as soon as a run reaches any terminal status.

## Why
When the utility provider returned `credit_balance_exhausted`, Analyze hid the operator action behind `Internal server error`, and a failed health run could leave the editor showing Running until reload.

## Before / After
Before: Analyze showed `Analysis failed: Internal server error`; failed health checks could remain at `Running… / Generating and running cases…` until reload.

After: provider quota failures surface `provider_quota_exhausted` guidance to add credits or raise limits, with raw provider details excluded. Built-in findings remain visible. Latest and freshly triggered health runs are polled live until terminal; the UI then shows the terminal result and re-enables the action.

Evidence:
- `just pre-push` passed all 10 checks after rebasing onto latest `origin/main`.
- Focused UI tests: 18 passed; UI typecheck, lint, and format passed.
- Provider/server regression tests passed for classification, safe Analyze HTTP error mapping, safe persisted Health error, and live terminal UI state.
- Positive-path DB-backed smoke supplied from the current stack: Analyze returned `llm.tool_guidance`; Health transitioned live without reload to completed (60% pass rate, 3/5 passed, avg score 0.66, avg turns 1.0).
- A manual regression case was added at `test_cases/ui/agent_checks/TC002_terminal_provider_errors.md`. A fresh local browser run was unavailable because Doppler credentials were not present in this worktree.

## Risk
- Medium
- Changes utility-provider error mapping and the agent-edit polling state. Incorrect classification could make a provider failure less actionable; polling changes are isolated to health-check runs.

## Security
- Threat categories reviewed: TM-LLM-002, TM-LLM-003, TM-LLM-005, TM-LLM-021, TM-API, TM-WEB.
- Findings and resolutions: Raw provider text is retained only for server-side logs. Analyze responses and persisted health-run errors use the shared safe provider taxonomy, and the exact secret-bearing regression test asserts that API key-like text is not returned. No new auth, tenancy, or tool surface was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by the PR diff
- [ ] All review comments addressed