### PR TITLE
feat(ui): add Slate component showcase

### DIFF
--- a/apps/ui/DESIGN.md
+++ b/apps/ui/DESIGN.md
@@ -26,9 +26,8 @@ colors:
   input: "hsl(0 0% 85%)"
   ring: "hsl(43 60% 53%)"
 typography:
-  # Font families come from CSS variables: --font-sans (Geist Sans),
-  # --font-mono (Geist Mono), and --font-caveat (Caveat, used only for the
-  # hand-drawn experimental badge). Body copy carries -0.01em global tracking.
+  # Font families come from CSS variables: --font-sans (Geist Sans) and
+  # --font-mono (Geist Mono). Body copy carries -0.01em global tracking.
   headline-lg:
     fontFamily: Geist Sans
     fontSize: 1.875rem
@@ -70,11 +69,6 @@ typography:
     fontSize: 0.875rem
     fontWeight: 400
     lineHeight: 1.6
-  accent-script:
-    fontFamily: Caveat
-    fontSize: 1.05rem
-    fontWeight: 600
-    lineHeight: 1
 rounded:
   # Sharp corners are a defining brand trait: every radius is 0.
   none: 0px
@@ -99,7 +93,7 @@ components:
     typography: "{typography.label-md}"
     padding: "0.5rem 1rem"
   button-primary-hover:
-    backgroundColor: "hsl(220 62% 18%)"
+    backgroundColor: "hsl(220 62% 13% / 0.9)"
   button-secondary:
     backgroundColor: "{colors.secondary}"
     textColor: "{colors.secondary-foreground}"
@@ -123,6 +117,28 @@ components:
 Slate is the Everruns design system. The normative token values live in the YAML
 front matter above and in `src/app/design-system.css` (the runtime source of
 truth); the prose below explains how to apply them.
+
+## Reference and authority
+
+Use the [Everruns design project](https://claude.ai/design/p/019e0a57-7d4b-70aa-a3c2-8c3d3746126e)
+as a visual reference for Slate's page archetypes, density, and component anatomy. Exported design
+project archives are snapshots for review; they are not copied into the application and do not
+override repository sources.
+
+The reviewed ZIP export is pinned by filename, SHA-256 checksum, and review date in
+`design-reference.json`. Update that manifest whenever a newer export is adopted, then reconcile
+intent here and verify both `/dev/design-reference` and `/dev/ui-components`.
+
+When references disagree, use this order:
+
+1. `src/app/design-system.css` for runtime tokens, utilities, and animation.
+2. This file for visual intent, hierarchy, and composition rules.
+3. Production components in `src/components/` for exact behavior and component APIs.
+4. `/dev/ui-components` for an interactive rendering of those production components.
+5. The external design project for visual comparison and page-level examples.
+
+The external project should stay recognizably close to the product, but application code remains
+canonical. Reconcile meaningful drift here rather than introducing parallel CSS or mock components.
 
 ## Overview
 
@@ -158,8 +174,8 @@ capture the light theme as the canonical reference.
 ## Typography
 
 Two families carry the system: **Geist Sans** for everything structural and
-**Geist Mono** for code, logs, and telemetry. **Caveat** appears in exactly one
-place — the hand-drawn "experimental" page badge — and should not be reused.
+**Geist Mono** for code, logs, and telemetry. Do not introduce handwritten or display fonts.
+Experimental features use the Lucide flask marker in navigation rather than a page-title stamp.
 
 - **Headlines (`headline-lg`, `headline-md`):** Geist Sans Semi-Bold with tight
   negative tracking for an engineered, condensed feel.
@@ -182,24 +198,28 @@ background.
 ## Elevation & Depth
 
 Slate is intentionally **flat**. Hierarchy comes from tonal layering and
-borders, not shadows: a near-white background, pure-white cards, and 1px borders
-(`colors.border`). Focus and active emphasis is signaled with the gold `ring`
-rather than elevation. Subtle motion (row-enter, tool-pulse, loading-wave, and a
-progress sheen) conveys state changes in place.
+borders rather than decorative elevation: a near-white background, pure-white
+cards, and 1px borders (`colors.border`). Inputs and buttons may use `shadow-xs`;
+popovers and dialogs may rise as far as `shadow-md`. Content cards do not cast
+shadows. Focus and active emphasis is signaled with the gold `ring`. Subtle
+motion (row-enter, tool-pulse, loading-wave, and a progress sheen) conveys state
+changes in place.
 
 ## Shapes
 
 The shape language is **uncompromisingly sharp**: every corner radius is `0px`
 (`--radius` and all `--radius-*` tokens). Icons reinforce this with squared
-line caps and mitered joins (`.icon-sharp`). The single deliberate exception is
-the hand-drawn experimental badge, whose organic border is a one-off accent.
+line caps and mitered joins (`.icon-sharp`). The only round elements are semantic
+status dots, circular Lucide glyphs, and the rings in the Everruns logo.
 
 ## Components
 
 - **Buttons:** `button-primary` is navy with near-white label text and sharp
-  corners; it darkens on hover (`button-primary-hover`). `button-secondary` uses
+  corners; it uses 90% opacity on hover (`button-primary-hover`). `button-secondary` uses
   the light gray `secondary` surface for lower-emphasis actions. Both use the
-  `label-md` token.
+  `label-md` token. Action hierarchy is semantic: `accent` creates a new entity,
+  `default` commits changes, `outline` handles secondary actions, and destructive
+  list actions use a red ghost icon rather than a filled button.
 - **Inputs:** White surface, `input` border color, sharp corners, comfortable
   padding; focus draws the gold `ring`.
 - **Cards:** White surface on the textured background, 1px border, no radius,
@@ -207,15 +227,33 @@ the hand-drawn experimental badge, whose organic border is a one-off accent.
   collapse secondary or destructive actions into an ellipsis menu when the
   card is too narrow for the full action row.
 
+### Composition invariants
+
+- Top-level entity screens compose the five-zone primitives in
+  `src/components/layout/page-layout.tsx`: breadcrumb, masthead, control strip,
+  body columns, and footer. List, detail, and edit pages supply content without
+  inventing a parallel shell.
+- Domain cards compose shared primitives. For example, `AgentCard` composes
+  `EntityCard`, which composes `Card`; previews must render `AgentCard` when they
+  claim to show an agent card.
+- Entity-specific styling belongs in the domain component, while navigation,
+  identifiers, responsive action behavior, border treatment, and card anatomy
+  belong in the shared primitive.
+- Create actions use one `accent` button at the far right. Edit forms use one
+  `default` commit button followed by an `outline` discard action. Read-only
+  action clusters are otherwise `outline` or `ghost`.
+- Headings, buttons, menu items, and badges use sentence case. API-facing names
+  and identifiers remain verbatim and use Geist Mono when code-adjacent.
+
 ## Do's and Don'ts
 
-- **Do** keep every corner sharp — never introduce a non-zero radius outside the
-  experimental badge.
+- **Do** keep every corner sharp.
 - **Do** reserve gold (`accent`) for active states, focus rings, and highlights;
   use navy (`primary`) for the single most important action per screen.
 - **Don't** place dark text on a gold surface or use gold for body text — its
   contrast is too low for WCAG AA.
-- **Don't** add drop shadows; convey hierarchy with tone and borders instead.
+- **Don't** add decorative shadows to content cards or exceed `shadow-md` on overlays.
 - **Do** edit `src/app/design-system.css` and this file together — they must
   stay in sync.
-- **Don't** reuse the Caveat font outside the experimental badge.
+- **Don't** create lookalike domain examples from lower-level primitives; render
+  the real domain component.

--- a/apps/ui/design-reference.json
+++ b/apps/ui/design-reference.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "name": "Everruns Design System",
+  "archiveFile": "Everruns Design System.zip",
+  "archiveSha256": "8b03485591d45d275f3a9fa33fdb2dd5d9a6920e66e6bde2f1ad86a8ad3c1501",
+  "sourceUrl": "https://claude.ai/design/p/019e0a57-7d4b-70aa-a3c2-8c3d3746126e",
+  "reviewedOn": "2026-08-07",
+  "canonicalRuntime": "src/app/design-system.css",
+  "canonicalGuidance": "DESIGN.md",
+  "referenceShowcase": "/dev/design-reference",
+  "componentShowcase": "/dev/ui-components"
+}

--- a/apps/ui/src/__tests__/avatar.test.tsx
+++ b/apps/ui/src/__tests__/avatar.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+
+describe("Avatar", () => {
+  it("uses Slate's sharp-cornered shape by default", () => {
+    const { container } = render(
+      <Avatar>
+        <AvatarFallback>ER</AvatarFallback>
+      </Avatar>,
+    );
+
+    expect(container.querySelector('[data-slot="avatar"]')).not.toHaveClass("rounded-full");
+    expect(screen.getByText("ER")).not.toHaveClass("rounded-full");
+  });
+});

--- a/apps/ui/src/__tests__/design-reference.test.ts
+++ b/apps/ui/src/__tests__/design-reference.test.ts
@@ -1,0 +1,13 @@
+import reference from "../../design-reference.json";
+
+describe("design reference provenance", () => {
+  it("pins the adopted archive and its review surfaces", () => {
+    expect(reference.archiveFile).toBe("Everruns Design System.zip");
+    expect(reference.archiveSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(reference.sourceUrl).toMatch(/^https:\/\/claude\.ai\/design\/p\//);
+    expect(reference.canonicalRuntime).toBe("src/app/design-system.css");
+    expect(reference.canonicalGuidance).toBe("DESIGN.md");
+    expect(reference.referenceShowcase).toBe("/dev/design-reference");
+    expect(reference.componentShowcase).toBe("/dev/ui-components");
+  });
+});

--- a/apps/ui/src/__tests__/global-chat-page.test.tsx
+++ b/apps/ui/src/__tests__/global-chat-page.test.tsx
@@ -20,10 +20,6 @@ jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
   SessionProvider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-jest.mock("@/components/ui/experimental-badge", () => ({
-  ExperimentalPageBadge: () => <div>badge</div>,
-}));
-
 const mockUseFeatureFlag = jest.mocked(useFeatureFlag);
 const mockUseGlobalChat = jest.mocked(useGlobalChat);
 

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -6,7 +6,6 @@ import { SessionProvider } from "@/app/(main)/sessions/[sessionId]/session-conte
 import { useGlobalChat } from "@/hooks/use-global-chat";
 import { usePageTitle } from "@/hooks";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
-import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 
 function GlobalChatEnabledContent() {
@@ -33,10 +32,7 @@ function GlobalChatEnabledContent() {
   return (
     <div className="flex h-full flex-col bg-background bg-brand-dots">
       <div className="flex items-center justify-between border-b border-border/70 bg-background/70 px-6 py-3.5 backdrop-blur-[1px]">
-        <h1 className="flex items-center gap-3 text-xl font-semibold tracking-tight">
-          Chat
-          <ExperimentalPageBadge />
-        </h1>
+        <h1 className="text-xl font-semibold tracking-tight">Chat</h1>
       </div>
       <SessionProvider sessionId={sessionId}>
         <ChatPanel />

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -8,7 +8,6 @@ import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { Plus } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
-import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import type { Eval, EvalTarget } from "@/lib/api/types";
 import { getDisplayName } from "@/lib/entity-lifecycle";
@@ -108,10 +107,7 @@ export default function EvalsPage() {
     <div className="container mx-auto p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold flex items-center gap-3">
-          Evals
-          <ExperimentalPageBadge />
-        </h1>
+        <h1 className="text-2xl font-bold">Evals</h1>
         <Link href="/evals/new">
           <Button variant="accent">
             <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/observers/observers-page-client.tsx
+++ b/apps/ui/src/app/(main)/observers/observers-page-client.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { EntityCard } from "@/components/ui/entity-card";
 import { Badge } from "@/components/ui/badge";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
-import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import { getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { pluralize } from "@/lib/formatting";
@@ -65,10 +64,7 @@ export default function ObserversPageClient() {
   return (
     <div className="container mx-auto space-y-6 p-6">
       <div className="flex items-center justify-between">
-        <h1 className="flex items-center gap-3 text-2xl font-bold">
-          Observers
-          <ExperimentalPageBadge />
-        </h1>
+        <h1 className="text-2xl font-bold">Observers</h1>
         <Link href="/observers/new">
           <Button variant="accent">
             <Plus className="mr-2 h-4 w-4" />

--- a/apps/ui/src/app/design-system.css
+++ b/apps/ui/src/app/design-system.css
@@ -133,29 +133,6 @@
   shape-rendering: geometricPrecision;
 }
 
-/* Experimental page badge — hand-drawn stamp with Caveat font */
-.experimental-page-badge {
-  font-family: var(--font-caveat), "Caveat", cursive;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: #d97706;
-  position: relative;
-  display: inline-block;
-  padding: 0 0.5rem;
-  cursor: default;
-  user-select: none;
-  transform: rotate(-1.5deg);
-  vertical-align: middle;
-}
-.experimental-page-badge::before {
-  content: "";
-  position: absolute;
-  inset: -2px -5px;
-  border: 1.5px solid #d97706;
-  border-radius: 50% 40% 45% 42% / 50% 45% 40% 48%;
-  opacity: 0.45;
-}
-
 @keyframes tool-row-enter {
   from {
     opacity: 0;

--- a/apps/ui/src/app/dev/design-reference/page.tsx
+++ b/apps/ui/src/app/dev/design-reference/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowRight,
+  Blocks,
+  Box,
+  Check,
+  CirclePlus,
+  ExternalLink,
+  FileCode2,
+  Gauge,
+  LayoutTemplate,
+  Palette,
+  Save,
+  Type,
+} from "lucide-react";
+import reference from "../../../../design-reference.json";
+import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+
+const foundations = [
+  { name: "Background", token: "--background", className: "bg-background" },
+  { name: "Card", token: "--card", className: "bg-card" },
+  { name: "Primary", token: "--primary", className: "bg-primary" },
+  { name: "Accent", token: "--accent", className: "bg-accent" },
+  { name: "Muted", token: "--muted", className: "bg-muted" },
+  { name: "Destructive", token: "--destructive", className: "bg-destructive" },
+];
+
+const invariants = [
+  {
+    icon: Box,
+    title: "Sharp geometry",
+    text: "All component radii are zero. Round forms are reserved for semantic status dots, circular glyphs, and the logo rings.",
+  },
+  {
+    icon: Palette,
+    title: "Color has a job",
+    text: "Grayscale carries content, navy marks commit actions, and full gold is reserved for the single create action.",
+  },
+  {
+    icon: Type,
+    title: "Geist only",
+    text: "Geist Sans carries interface copy; Geist Mono carries code, telemetry, identifiers, and compact metadata.",
+  },
+  {
+    icon: Gauge,
+    title: "Dense and calm",
+    text: "Use the 4px spacing scale, 32px controls, compact labels, flat cards, muted hovers, and restrained motion.",
+  },
+];
+
+const archetypes = [
+  {
+    title: "List page",
+    zones: ["Breadcrumb", "Masthead + create", "Filters", "Results + facets", "Count footer"],
+  },
+  {
+    title: "Detail page",
+    zones: ["Breadcrumb", "Masthead + actions", "Section tabs", "Blocks + sidecar", "Back footer"],
+  },
+  {
+    title: "Edit page",
+    zones: [
+      "Breadcrumb + Edit",
+      "Masthead + consequence",
+      "Section tabs",
+      "Checks + form",
+      "Save + Discard",
+    ],
+  },
+];
+
+const checklist = [
+  "Render production components in previews; never recreate lookalikes.",
+  "Compose domain cards from shared primitives: AgentCard → EntityCard → Card.",
+  "Compose entity screens from the five-zone page-layout primitives.",
+  "Use sentence case for headings, actions, menus, and badges.",
+  "Use one accent create action or one navy commit action per page—never both.",
+  "Use muted hover states, a gold focus ring, 1px borders, and no content-card shadow.",
+  "Keep the dot grid on page surfaces and flat card backgrounds on content surfaces.",
+  "Keep experimental indication in navigation with the Lucide flask marker.",
+];
+
+function ReferenceSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="border bg-card">
+      <div className="border-b px-4 py-3">
+        <h2 className="text-base font-semibold text-foreground">{title}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+export default function DevDesignReferencePage() {
+  return (
+    <DevPageShell
+      eyebrow="Pinned design export"
+      title="Slate Reference"
+      description="A review surface for the adopted Everruns Design System export and its production implementation contract."
+      widthClassName="max-w-7xl"
+    >
+      <div className="space-y-6">
+        <Notice variant="info" icon={<FileCode2 />}>
+          <NoticeTitle>{reference.name}</NoticeTitle>
+          <NoticeDescription>
+            Reviewed {reference.reviewedOn} from <code>{reference.archiveFile}</code>. SHA-256{" "}
+            <code className="break-all text-foreground">{reference.archiveSha256}</code>. The export
+            is a pinned visual reference; <code>{reference.canonicalRuntime}</code> and{" "}
+            <code>{reference.canonicalGuidance}</code> remain canonical.
+          </NoticeDescription>
+        </Notice>
+
+        <div className="flex flex-wrap gap-2">
+          <Link href={reference.componentShowcase}>
+            <Button variant="accent">
+              <Blocks /> Production components <ArrowRight />
+            </Button>
+          </Link>
+          <a href={reference.sourceUrl} target="_blank" rel="noreferrer">
+            <Button variant="outline">
+              External design project <ExternalLink />
+            </Button>
+          </a>
+        </div>
+
+        <ReferenceSection
+          title="Visual foundations"
+          description="These swatches resolve from the runtime CSS variables—not copied values from the export."
+        >
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {foundations.map((foundation) => (
+              <div
+                key={foundation.token}
+                className="flex items-center gap-3 border bg-background p-3"
+              >
+                <span className={`size-10 shrink-0 border ${foundation.className}`} />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-foreground">{foundation.name}</p>
+                  <code className="text-xs text-muted-foreground">{foundation.token}</code>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            <div className="border bg-background p-4">
+              <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                Geist Sans
+              </p>
+              <p className="mt-3 text-2xl font-semibold tracking-[-0.02em] text-foreground">
+                Durable agents, calm controls.
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Compact interface typography with clear hierarchy and direct language.
+              </p>
+            </div>
+            <div className="border bg-background p-4 font-mono">
+              <p className="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+                Geist Mono
+              </p>
+              <p className="mt-3 text-sm text-foreground">agent_019fda100f037c008024046d6b3d74c0</p>
+              <p className="mt-2 text-xs leading-6 text-muted-foreground">
+                turn=42 · tools=7 · latency=1.8s
+              </p>
+            </div>
+          </div>
+        </ReferenceSection>
+
+        <ReferenceSection
+          title="Non-negotiable invariants"
+          description="The highest-signal decisions from the export, retained in DESIGN.md."
+        >
+          <div className="grid gap-3 md:grid-cols-2">
+            {invariants.map((item) => (
+              <Card key={item.title}>
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <span className="flex size-8 items-center justify-center border bg-accent/20">
+                      <item.icon className="size-4" />
+                    </span>
+                    <CardTitle>{item.title}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="leading-6">{item.text}</CardDescription>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </ReferenceSection>
+
+        <ReferenceSection
+          title="Action hierarchy"
+          description="Button variants communicate intent, not decoration."
+        >
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-3 border bg-background p-4">
+              <Badge variant="accent">Create</Badge>
+              <Button variant="accent">
+                <CirclePlus /> New agent
+              </Button>
+              <p className="text-xs leading-5 text-muted-foreground">
+                One gold action, last in a read-only page header.
+              </p>
+            </div>
+            <div className="space-y-3 border bg-background p-4">
+              <Badge>Commit</Badge>
+              <Button>
+                <Save /> Save changes
+              </Button>
+              <p className="text-xs leading-5 text-muted-foreground">
+                One navy action on edit surfaces; pair with outline Discard.
+              </p>
+            </div>
+            <div className="space-y-3 border bg-background p-4">
+              <Badge variant="outline">Secondary</Badge>
+              <Button variant="outline">Export</Button>
+              <p className="text-xs leading-5 text-muted-foreground">
+                Copy, export, edit, analyze, disable, and discard stay neutral.
+              </p>
+            </div>
+          </div>
+        </ReferenceSection>
+
+        <ReferenceSection
+          title="Component composition"
+          description="Domain components inherit Slate behavior through shared primitives."
+        >
+          <div className="grid items-stretch gap-2 md:grid-cols-[1fr_auto_1fr_auto_1fr]">
+            {[
+              ["AgentCard", "src/components/agents/agent-card.tsx"],
+              ["EntityCard", "src/components/ui/entity-card.tsx"],
+              ["Card", "src/components/ui/card.tsx"],
+            ].map(([name, path], index) => (
+              <div key={name} className="contents">
+                {index > 0 && (
+                  <div className="hidden items-center justify-center text-muted-foreground md:flex">
+                    <ArrowRight className="size-4" />
+                  </div>
+                )}
+                <div className="border bg-background p-4">
+                  <p className="font-semibold text-foreground">{name}</p>
+                  <code className="mt-2 block break-all text-xs text-muted-foreground">{path}</code>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Read left-to-right as “composes.” The domain component remains the preview target.
+          </p>
+        </ReferenceSection>
+
+        <ReferenceSection
+          title="Page archetypes"
+          description="Entities supply content to shared list, detail, and edit structures."
+        >
+          <div className="grid gap-3 lg:grid-cols-3">
+            {archetypes.map((archetype) => (
+              <Card key={archetype.title}>
+                <CardHeader>
+                  <div className="flex items-center gap-2">
+                    <LayoutTemplate className="size-4 text-muted-foreground" />
+                    <CardTitle>{archetype.title}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <ol className="space-y-2">
+                    {archetype.zones.map((zone, index) => (
+                      <li
+                        key={zone}
+                        className="flex items-center gap-2 border bg-background px-2.5 py-2 text-sm"
+                      >
+                        <span className="font-mono text-[11px] text-muted-foreground">
+                          0{index + 1}
+                        </span>
+                        <span>{zone}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </ReferenceSection>
+
+        <ReferenceSection
+          title="Review checklist"
+          description="Use this during UI implementation and visual review."
+        >
+          <div className="grid gap-x-6 gap-y-3 md:grid-cols-2">
+            {checklist.map((item) => (
+              <div key={item} className="flex items-start gap-2 text-sm leading-6">
+                <Check className="mt-1 size-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                <span>{item}</span>
+              </div>
+            ))}
+          </div>
+        </ReferenceSection>
+      </div>
+    </DevPageShell>
+  );
+}

--- a/apps/ui/src/app/dev/page.tsx
+++ b/apps/ui/src/app/dev/page.tsx
@@ -13,12 +13,27 @@ import {
   FileCode,
   Sparkles,
   IdCard,
+  Blocks,
+  Palette,
 } from "lucide-react";
 
 // Check if we're in development mode
 const isDev = process.env.NODE_ENV === "development";
 
 const devPages = [
+  {
+    title: "Slate Reference",
+    description:
+      "Pinned design-export rules, visual foundations, hierarchy, and conformance checks",
+    href: "/dev/design-reference",
+    icon: Palette,
+  },
+  {
+    title: "Core UI Components",
+    description: "Layouts, cards, buttons, identifiers, menus, forms, and feedback primitives",
+    href: "/dev/ui-components",
+    icon: Blocks,
+  },
   {
     title: "Chat UI",
     description: "Real chat runtime scenes plus empty-state and composer showcases",

--- a/apps/ui/src/app/dev/ui-components/page.tsx
+++ b/apps/ui/src/app/dev/ui-components/page.tsx
@@ -1,0 +1,658 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  Bot,
+  Boxes,
+  Check,
+  ChevronDown,
+  CirclePlus,
+  Clock3,
+  Ellipsis,
+  Info,
+  Layers3,
+  LayoutGrid,
+  List as ListIcon,
+  Play,
+  Plus,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
+import { AgentCard } from "@/components/agents/agent-card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPositioner,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { EntityCard } from "@/components/ui/entity-card";
+import { EntityIdentity } from "@/components/ui/entity-identity";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+import { SearchInput } from "@/components/ui/search-input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  EmptyState,
+  IconTile,
+  PageBreadcrumb,
+  PageColumns,
+  PageContainer,
+  PageControlStrip,
+  PageFooter,
+  PageMain,
+  PageMasthead,
+  PageRail,
+  RailSection,
+  SectionTabs,
+} from "@/components/layout/page-layout";
+import type { Agent } from "@/lib/api/types";
+
+const sampleId = "agent_019fda100f037c008024046d6b3d74c0";
+const sampleAgent: Agent = {
+  id: sampleId,
+  name: "research-assistant",
+  display_name: "Research assistant",
+  description: "Answers questions using indexed product knowledge.",
+  system_prompt: "Answer questions using the available product knowledge.",
+  harness_id: "harness_generic",
+  default_model_id: "model_gpt_5",
+  tags: ["research", "production"],
+  capabilities: [],
+  status: "active",
+  created_at: "2026-08-04T14:30:00Z",
+  updated_at: "2026-08-07T16:10:00Z",
+  archived_at: null,
+  deleted_at: null,
+  session_count: 12,
+  app_count: 2,
+};
+
+function ShowcaseSection({
+  id,
+  title,
+  description,
+  sources,
+  children,
+}: {
+  id: string;
+  title: string;
+  description: string;
+  sources: string[];
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="scroll-mt-6 border border-border/70 bg-card/90">
+      <div className="border-b border-border/70 px-4 py-3">
+        <h2 className="text-base font-semibold text-foreground">{title}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+            Source
+          </span>
+          {sources.map((source) => (
+            <code
+              key={source}
+              className="border border-border/70 bg-background px-1.5 py-0.5 text-[11px] text-muted-foreground"
+            >
+              {source}
+            </code>
+          ))}
+        </div>
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+function SampleIconTile() {
+  return <IconTile size="md" icon={<Bot />} />;
+}
+
+export default function DevUiComponentsPage() {
+  const [environment, setEnvironment] = useState("development");
+  const [showArchived, setShowArchived] = useState(true);
+  const [notifications, setNotifications] = useState(true);
+  const [checked, setChecked] = useState(true);
+  const [tab, setTab] = useState("overview");
+  const [sectionTab, setSectionTab] = useState("all");
+
+  return (
+    <DevPageShell
+      eyebrow="Slate design system"
+      title="Core UI Components"
+      description="Interactive reference for the shared primitives and composition patterns used across Everruns."
+      widthClassName="max-w-7xl"
+    >
+      <div className="space-y-6">
+        <nav className="flex flex-wrap gap-2" aria-label="Component groups">
+          {[
+            ["layout", "Layout"],
+            ["buttons", "Buttons"],
+            ["identity", "IDs & badges"],
+            ["cards", "Cards"],
+            ["menus", "Menus"],
+            ["forms", "Forms"],
+            ["feedback", "Feedback"],
+          ].map(([href, label]) => (
+            <a
+              key={href}
+              href={`#${href}`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              {label}
+            </a>
+          ))}
+        </nav>
+
+        <ShowcaseSection
+          id="layout"
+          title="Application page composition"
+          description="A compact rendering of the same components and content hierarchy used by the Agents list page."
+          sources={[
+            "src/app/(main)/agents/page.tsx",
+            "src/components/layout/page-layout.tsx",
+            "src/components/agents/agent-card.tsx",
+          ]}
+        >
+          <div className="overflow-hidden border bg-background">
+            <PageContainer className="gap-4 p-4">
+              <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Agents" }]} />
+              <PageMasthead
+                icon={<Boxes />}
+                title="Agents"
+                badges={
+                  <Badge variant="outline" className="font-mono">
+                    12
+                  </Badge>
+                }
+                description="Reusable agent definitions — instructions, capabilities, and model."
+                meta={
+                  <>
+                    <span>10 active</span>
+                    <span>2 archived</span>
+                  </>
+                }
+                actions={
+                  <>
+                    <Button variant="outline">
+                      <Upload /> Import
+                    </Button>
+                    <Button variant="accent">
+                      <Plus /> New agent
+                    </Button>
+                  </>
+                }
+              />
+              <PageControlStrip className="flex flex-wrap items-center gap-3">
+                <SearchInput placeholder="Search agents…" containerClassName="w-64" />
+                <div className="flex-1" />
+                <SectionTabs
+                  value={sectionTab}
+                  onValueChange={setSectionTab}
+                  items={[
+                    { value: "all", label: "All" },
+                    { value: "active", label: "Active" },
+                    { value: "archived", label: "Archived" },
+                  ]}
+                />
+                <div className="flex border">
+                  <button
+                    type="button"
+                    aria-label="Grid view"
+                    aria-pressed={true}
+                    className="inline-flex size-8 items-center justify-center border-r bg-muted text-foreground"
+                  >
+                    <LayoutGrid className="size-4" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="List view"
+                    aria-pressed={false}
+                    className="inline-flex size-8 items-center justify-center text-muted-foreground hover:bg-muted/50"
+                  >
+                    <ListIcon className="size-4" />
+                  </button>
+                </div>
+              </PageControlStrip>
+              <PageColumns>
+                <PageMain>
+                  <div className="grid gap-4">
+                    <AgentCard agent={sampleAgent} showEditButton />
+                  </div>
+                </PageMain>
+                <PageRail>
+                  <RailSection label="Status">
+                    <div className="flex flex-col gap-1.5 text-[13px]">
+                      <div className="flex items-center justify-between text-foreground">
+                        <span>Active</span>
+                        <span className="text-muted-foreground">10</span>
+                      </div>
+                      <div className="flex items-center justify-between text-muted-foreground">
+                        <span>Archived</span>
+                        <span>2</span>
+                      </div>
+                    </div>
+                  </RailSection>
+                  <RailSection label="Tags">
+                    <div className="flex flex-wrap gap-1.5">
+                      <span className="border bg-muted px-2 py-0.5 text-xs">research</span>
+                      <span className="border bg-muted px-2 py-0.5 text-xs">production</span>
+                    </div>
+                  </RailSection>
+                </PageRail>
+              </PageColumns>
+              <PageFooter>
+                <span>Showing 10 of 12 agents</span>
+                <span className="text-primary">View archived →</span>
+              </PageFooter>
+            </PageContainer>
+          </div>
+        </ShowcaseSection>
+
+        <ShowcaseSection
+          id="buttons"
+          title="Buttons"
+          description="All semantic variants, supported sizes, icon buttons, and disabled states."
+          sources={["src/components/ui/button.tsx", "src/components/ui/tooltip.tsx"]}
+        >
+          <div className="space-y-5">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button>Default</Button>
+              <Button variant="secondary">Secondary</Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="ghost">Ghost</Button>
+              <Button variant="accent">
+                <Sparkles /> Accent
+              </Button>
+              <Button variant="destructive">
+                <Trash2 /> Destructive
+              </Button>
+              <Button variant="link">Link button</Button>
+              <Button disabled>Disabled</Button>
+            </div>
+            <Separator />
+            <TooltipProvider>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button size="sm">
+                  <CirclePlus /> Small
+                </Button>
+                <Button>
+                  <CirclePlus /> Default
+                </Button>
+                <Button size="lg">
+                  <CirclePlus /> Large
+                </Button>
+                {(["icon-sm", "icon", "icon-lg"] as const).map((size) => (
+                  <Tooltip key={size}>
+                    <TooltipTrigger asChild>
+                      <Button size={size} variant="outline" aria-label={`Settings, ${size}`}>
+                        <Settings />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{size}</TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
+            </TooltipProvider>
+          </div>
+        </ShowcaseSection>
+
+        <ShowcaseSection
+          id="identity"
+          title="Identifiers and badges"
+          description="Readable entity names with exact-ID copy actions, avatars, status badges, and icon tiles."
+          sources={[
+            "src/components/ui/entity-identity.tsx",
+            "src/components/ui/entity-card.tsx",
+            "src/components/ui/copy-button.tsx",
+            "src/components/ui/badge.tsx",
+            "src/components/ui/avatar.tsx",
+          ]}
+        >
+          <div className="grid gap-5 lg:grid-cols-2">
+            <div className="space-y-3">
+              <Label>EntityIdentity</Label>
+              <div className="max-w-md border bg-background p-3">
+                <EntityIdentity value={sampleId}>Research assistant</EntityIdentity>
+              </div>
+              <Label>Standalone copy-ID button</Label>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Research assistant</span>
+                <CopyButton value={sampleId} label={`Copy ID: ${sampleId}`} kind="id" />
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge>Default</Badge>
+                <Badge variant="secondary">Secondary</Badge>
+                <Badge variant="outline">Outline</Badge>
+                <Badge variant="accent">Experimental</Badge>
+                <Badge variant="success">
+                  <Check /> Healthy
+                </Badge>
+                <Badge variant="destructive">Failed</Badge>
+              </div>
+              <div className="flex items-center gap-3">
+                <Avatar>
+                  <AvatarFallback>ER</AvatarFallback>
+                </Avatar>
+                <SampleIconTile />
+                <IconTile icon={<Layers3 />} />
+                <span className="text-sm text-muted-foreground">
+                  Avatar · small tile · masthead tile
+                </span>
+              </div>
+            </div>
+          </div>
+        </ShowcaseSection>
+
+        <ShowcaseSection
+          id="cards"
+          title="Cards"
+          description="The production AgentCard plus the lower-level card primitives it composes."
+          sources={[
+            "src/components/agents/agent-card.tsx",
+            "src/components/ui/card.tsx",
+            "src/components/ui/entity-card.tsx",
+          ]}
+        >
+          <div className="grid gap-4 lg:grid-cols-3">
+            <div className="space-y-2">
+              <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                Card primitive
+              </p>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Card title</CardTitle>
+                  <CardDescription>Header, content, action, and footer slots.</CardDescription>
+                  <CardAction>
+                    <Badge variant="outline">Draft</Badge>
+                  </CardAction>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground">
+                  Flexible content stays deliberately unopinionated.
+                </CardContent>
+                <CardFooter className="border-t text-xs text-muted-foreground">
+                  Updated just now
+                </CardFooter>
+              </Card>
+            </div>
+
+            <div className="space-y-2">
+              <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                Production AgentCard
+              </p>
+              <AgentCard agent={sampleAgent} showEditButton />
+            </div>
+
+            <div className="space-y-2">
+              <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                EntityCard row variant
+              </p>
+              <EntityCard
+                variant="row"
+                icon={<SampleIconTile />}
+                title="Support triage"
+                copyValue="agent_support_triage"
+                inlineBadges={<Badge variant="outline">Idle</Badge>}
+                headerActions={
+                  <Button size="icon-sm" variant="ghost" aria-label="More options">
+                    <Ellipsis />
+                  </Button>
+                }
+              >
+                <p className="mt-1 text-xs text-muted-foreground">Last run 8 minutes ago</p>
+              </EntityCard>
+              <EntityCard
+                variant="row"
+                icon={<SampleIconTile />}
+                title="Incident responder"
+                inlineBadges={<Badge variant="success">Running</Badge>}
+                headerActions={
+                  <Button size="sm" variant="outline">
+                    View
+                  </Button>
+                }
+              />
+            </div>
+          </div>
+        </ShowcaseSection>
+
+        <ShowcaseSection
+          id="menus"
+          title="Menus and tabs"
+          description="Dropdown actions, labeled selects, segmented tabs, and section navigation."
+          sources={[
+            "src/components/ui/dropdown-menu.tsx",
+            "src/components/ui/select.tsx",
+            "src/components/ui/tabs.tsx",
+            "src/components/layout/page-layout.tsx",
+          ]}
+        >
+          <div className="space-y-5">
+            <div className="flex flex-wrap items-end gap-4">
+              <DropdownMenu>
+                <DropdownMenuTrigger className={buttonVariants({ variant: "outline" })}>
+                  Actions <ChevronDown />
+                </DropdownMenuTrigger>
+                <DropdownMenuPositioner align="start">
+                  <DropdownMenuContent className="w-52">
+                    <DropdownMenuGroup>
+                      <DropdownMenuLabel>Agent actions</DropdownMenuLabel>
+                      <DropdownMenuItem>
+                        <Play /> Start session <DropdownMenuShortcut>⌘↵</DropdownMenuShortcut>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem>
+                        <Settings /> Configure
+                      </DropdownMenuItem>
+                      <DropdownMenuCheckboxItem
+                        checked={showArchived}
+                        onCheckedChange={setShowArchived}
+                      >
+                        Show archived
+                      </DropdownMenuCheckboxItem>
+                    </DropdownMenuGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem variant="destructive">
+                      <Trash2 /> Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenuPositioner>
+              </DropdownMenu>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="showcase-environment">Environment</Label>
+                <Select value={environment} onValueChange={setEnvironment}>
+                  <SelectTrigger id="showcase-environment" className="w-48">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Runtime</SelectLabel>
+                      <SelectItem value="development">Development</SelectItem>
+                      <SelectItem value="staging">Staging</SelectItem>
+                      <SelectSeparator />
+                      <SelectItem value="production">Production</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabsList>
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="activity">Activity</TabsTrigger>
+                <TabsTrigger value="disabled" disabled>
+                  Disabled
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                value="overview"
+                className="border bg-background p-3 text-sm text-muted-foreground"
+              >
+                Overview panel content
+              </TabsContent>
+              <TabsContent
+                value="activity"
+                className="border bg-background p-3 text-sm text-muted-foreground"
+              >
+                Activity panel content
+              </TabsContent>
+            </Tabs>
+
+            <SectionTabs
+              value={sectionTab}
+              onValueChange={setSectionTab}
+              items={[
+                { value: "all", label: "All" },
+                { value: "active", label: "Active", icon: <Activity className="size-4" /> },
+                { value: "scheduled", label: "Scheduled", icon: <Clock3 className="size-4" /> },
+              ]}
+            />
+          </div>
+        </ShowcaseSection>
+
+        <ShowcaseSection
+          id="forms"
+          title="Form controls"
+          description="Inputs, search, textarea, checkbox, switch, validation, and disabled states."
+          sources={[
+            "src/components/ui/input.tsx",
+            "src/components/ui/search-input.tsx",
+            "src/components/ui/textarea.tsx",
+            "src/components/ui/checkbox.tsx",
+            "src/components/ui/switch.tsx",
+          ]}
+        >
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="showcase-name">Name</Label>
+                <Input id="showcase-name" defaultValue="Research assistant" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="showcase-search">Search</Label>
+                <SearchInput id="showcase-search" placeholder="Search agents…" />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="showcase-error">Invalid value</Label>
+                <Input id="showcase-error" defaultValue="Duplicate name" aria-invalid />
+                <p className="text-xs text-destructive">This name is already in use.</p>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="showcase-instructions">Instructions</Label>
+                <Textarea
+                  id="showcase-instructions"
+                  defaultValue="Be concise, verify sources, and surface uncertainty."
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox id="showcase-checkbox" checked={checked} onCheckedChange={setChecked} />
+                <Label htmlFor="showcase-checkbox">Allow tool calls</Label>
+              </div>
+              <div className="flex items-center justify-between border bg-background p-3">
+                <div>
+                  <Label htmlFor="showcase-switch">Notifications</Label>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Notify when a run needs attention.
+                  </p>
+                </div>
+                <Switch
+                  id="showcase-switch"
+                  checked={notifications}
+                  onCheckedChange={setNotifications}
+                />
+              </div>
+              <Input value="Disabled input" disabled readOnly />
+            </div>
+          </div>
+        </ShowcaseSection>
+
+        <ShowcaseSection
+          id="feedback"
+          title="Notices and empty states"
+          description="Reusable inline feedback variants and the canonical zero-state composition."
+          sources={["src/components/ui/notice.tsx", "src/components/layout/page-layout.tsx"]}
+        >
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="space-y-3">
+              <Notice icon={<Info />}>
+                <NoticeTitle>Information</NoticeTitle>
+                <NoticeDescription>
+                  Configuration changes apply to the next session.
+                </NoticeDescription>
+              </Notice>
+              <Notice variant="warning" icon={<AlertTriangle />}>
+                <NoticeTitle>Review required</NoticeTitle>
+                <NoticeDescription>This agent can call tools with side effects.</NoticeDescription>
+              </Notice>
+              <Notice variant="success" icon={<ShieldCheck />}>
+                <NoticeTitle>Connection healthy</NoticeTitle>
+                <NoticeDescription>Credentials were verified successfully.</NoticeDescription>
+              </Notice>
+              <Notice variant="destructive" icon={<AlertTriangle />}>
+                <NoticeTitle>Run failed</NoticeTitle>
+                <NoticeDescription>The provider rejected the request.</NoticeDescription>
+              </Notice>
+            </div>
+            <EmptyState
+              icon={<Bot />}
+              title="No agents yet"
+              description="Create an agent to start a session and see activity here."
+              action={
+                <Button>
+                  <CirclePlus /> Create agent
+                </Button>
+              }
+              className="h-full min-h-64 bg-background"
+            />
+          </div>
+        </ShowcaseSection>
+      </div>
+    </DevPageShell>
+  );
+}

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
 import { cookies } from "next/headers";
 import "./globals.css";
 import { QueryProvider } from "@/providers/query-provider";
@@ -7,16 +6,6 @@ import { FeatureFlagsProvider } from "@/providers/feature-flags-provider";
 import { AuthProvider } from "@/providers/auth-provider";
 import { OrgProvider } from "@/providers/org-provider";
 import { LocaleProvider } from "@/providers/locale-provider";
-
-// Self-hosted via next/font/local to avoid any runtime or build-time dependency
-// on fonts.googleapis.com. Downstream apps with strict CSP (font-src 'self')
-// won't break.
-const caveat = localFont({
-  src: "./fonts/Caveat-SemiBold.woff2",
-  weight: "600",
-  display: "swap",
-  variable: "--font-caveat",
-});
 
 // Default title — individual pages override via usePageTitle.
 // See knowledge/foundations/code-organization.md (Page Titles) for the format.
@@ -35,7 +24,7 @@ export default async function RootLayout({
   const webMcpOriginTrialToken = process.env.WEBMCP_ORIGIN_TRIAL_TOKEN?.trim();
 
   return (
-    <html lang="en" className={caveat.variable}>
+    <html lang="en">
       {webMcpOriginTrialToken ? (
         <head>
           <meta httpEquiv="origin-trial" content={webMcpOriginTrialToken} />

--- a/apps/ui/src/components/ui/avatar.tsx
+++ b/apps/ui/src/components/ui/avatar.tsx
@@ -5,7 +5,7 @@ function Avatar({ className, ...props }: AvatarPrimitive.Root.Props) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
-      className={cn("relative flex size-8 shrink-0 overflow-hidden rounded-full", className)}
+      className={cn("relative flex size-8 shrink-0 overflow-hidden", className)}
       {...props}
     />
   );
@@ -25,10 +25,7 @@ function AvatarFallback({ className, ...props }: AvatarPrimitive.Fallback.Props)
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
-      className={cn(
-        "bg-muted flex items-center justify-center size-full rounded-full text-sm",
-        className,
-      )}
+      className={cn("bg-muted flex size-full items-center justify-center text-sm", className)}
       {...props}
     />
   );

--- a/apps/ui/src/components/ui/experimental-badge.tsx
+++ b/apps/ui/src/components/ui/experimental-badge.tsx
@@ -21,22 +21,3 @@ export function ExperimentalBadge() {
     </TooltipProvider>
   );
 }
-
-/**
- * Page-level experimental badge — small Caveat-font label
- * with a subtle hand-drawn circle. Sits inline next to page titles.
- */
-export function ExperimentalPageBadge() {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="experimental-page-badge">experimental</span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>This feature is experimental. Expect changes and rough edges.</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,9 @@
 
 ## 2026-08-07
 
+* **Slate fidelity**: Retired the handwritten experimental page stamp; experimental
+  navigation now uses the single Lucide flask marker defined by the design system.
+
 * **Platform behavioral eval**: Replaced the legacy tool-name study with a
   live-server Mira eval for `platform` command sequencing, safety, loop budgets,
   and persisted hourly Agent/MCP/model/trigger state.

--- a/knowledge/security/feature-flags.md
+++ b/knowledge/security/feature-flags.md
@@ -111,12 +111,12 @@ passed via gRPC turn context.
 
 ## UI Indication
 
-Features gated behind experimental flags display visual badges to signal their status:
+Features gated behind experimental flags display a visual marker to signal their status:
 
 - **Sidebar**: Flask icon (`FlaskConical`) next to the nav item name, with tooltip on hover
-- **Page header**: Handwritten-style "experimental" label (Caveat font) with hand-drawn circle border, placed inline next to the page title
 
-Both are driven by `experimental: true` on the `NavItem` type in the sidebar, and `<ExperimentalPageBadge />` on individual pages. See `apps/ui/src/components/ui/experimental-badge.tsx`.
+The marker is driven by `experimental: true` on the `NavItem` type in the sidebar. See
+`apps/ui/src/components/ui/experimental-badge.tsx`.
 
 ## Future Extensions
 


### PR DESCRIPTION
## What changed
Added two development-only Slate review surfaces:

- `/dev/ui-components` renders production layouts, AgentCard/EntityCard composition, buttons, entity identity actions, menus, forms, notices, and empty states with source paths.
- `/dev/design-reference` records the adopted design-export provenance, foundations, action hierarchy, composition rules, page archetypes, and conformance checklist.

Also aligned production presentation with the adopted Slate guidance by making avatars sharp by default and retiring the handwritten experimental page stamp in favor of the existing navigation flask marker.

## Why
The UI lacked a trustworthy place to inspect reusable production components and compare their composition with the adopted Everruns design reference. Previous one-off examples could drift from the components actually used by the application.

## Before / After
Before: no consolidated production-component showcase or pinned design-reference review page; the experimental status appeared both in navigation and as a handwritten page-title stamp.

After: both dev routes render successfully in the local UI, the component page uses the production `AgentCard`, `EntityCard`, and `EntityIdentity` APIs, and experimental status has one consistent navigation marker. Full-page screenshots of both routes were captured and visually reviewed during validation; they are not committed to the repository.

## Risk
- Low
- Runtime behavior changes are limited to avatar corner shape and removal of redundant experimental page-title labels.
- The new pages are development-only review surfaces.
- The external design link is a fixed repository-authored HTTPS URL opened with `rel="noreferrer"`.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new trust boundary, user-controlled HTML, authentication/authorization path, API mutation, or dependency was introduced. All page content is repository-authored and React-escaped. External navigation uses a fixed HTTPS URL with opener isolation. No threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)