### PR TITLE
chore(dev): canonicalize agent startup

### DIFF
--- a/.agents/skills/manual-ui-testing/SKILL.md
+++ b/.agents/skills/manual-ui-testing/SKILL.md
@@ -23,12 +23,9 @@ auth → org → features.
 ## Stack
 
 Full auth mode needs the real stack, not DEV_MODE. Start it with a unique per-worktree prefix and
-wait for PostgreSQL, Valkey, API, worker, UI, and Caddy to come up:
-
-```bash
-PORT_PREFIX=<prefix> doppler run -- just start-all
-curl -s http://localhost:<prefix>00/healthz
-```
+wait for PostgreSQL, Valkey, NATS, API, worker, UI, and Caddy to come up. Follow the canonical
+coding-agent startup contract in the root [`AGENTS.md`](../../../AGENTS.md), selecting the auth mode
+required by the test case. Verify it through the documented `/health` endpoint before testing.
 
 If a stack is already running, confirm its `PORT_PREFIX` and auth mode before using it.
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -26,8 +26,9 @@ change is ready; do not walk this file as a fixed checklist.
    [`references/security-review.md`](references/security-review.md).
 5. **Sync artifacts** the change actually affects: `knowledge/`, `knowledge/security/threat-model.md`, `AGENTS.md`,
    `test_cases/`, `apps/docs/`, OpenAPI exports.
-6. **Smoke test the affected flows** end to end — `just start-dev --no-watch`, or
-   `just start-all --no-watch` when database, migration, infra, or API integration risk exists.
+6. **Smoke test the affected flows** end to end. For a coding-agent stack, follow the canonical
+   startup contract in the root `AGENTS.md`; it includes the DB-backed infrastructure required for
+   database, migration, infra, or API integration risk.
    Stop anything you started. Docs- or config-only changes may skip this with a stated reason.
 7. **Decide follow-ups explicitly.** Prefer implementing in-scope work now. List anything deferred
    under **Follow-ups** in the PR body with a one-line rationale, or state "No follow-ups." — a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,41 @@ closer `AGENTS.md` (`apps/ui/`, `crates/server/migrations/`, `plugins/`, `.deeps
 ### Local dev
 
 ```bash
-PORT_PREFIX=271 just start-dev   # in-memory, no external services
-PORT_PREFIX=271 just start-all   # PostgreSQL + Valkey + NATS
-cd apps/ui && ./node_modules/.bin/next dev --port 9120   # UI only
+# Canonical coding-agent stack; choose a distinct prefix per worktree.
+PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh
 ```
 
-Use a distinct `PORT_PREFIX` per worktree so parallel stacks do not collide.
+This is the single agent startup contract. The script preserves the caller's `PORT_PREFIX` and
+`AUTH_MODE` through Doppler, then runs `just start-all --no-watch`. It starts PostgreSQL, Valkey,
+and NATS as local processes (no Docker), plus the API, worker, UI, and Caddy. The proxy is
+`http://localhost/<PORT_PREFIX>00` (prefix `271` → `http://localhost:27100`). Pick an unused prefix
+from `1` through `654`; never reuse one across concurrent worktrees.
+
+Prerequisites: Rust and Node.js, a configured Doppler CLI, and the repository dependencies. On a
+first checkout run `./scripts/init-cloud-env.sh` and then `just init`. The first Rust and Next.js
+build can take several minutes.
+
+`AUTH_MODE=none` is local-development-only and gives the anonymous user admin access. For
+authenticated testing, explicitly select `admin`, `full`, or `external` and configure that mode's
+variables per `docs/sre/runbooks/authentication.md`.
+
+`start-all` maps Doppler's `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to
+`DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY`. Analyze/Health additionally requires
+`UTILITY_OPENAI_API_KEY`; no extra setup is needed when Doppler already supplies it. If Doppler does
+not supply `SECRETS_ENCRYPTION_KEY`, the wrapper creates a mode-`0600`, per-prefix key under
+`.local/agent-dev/`; it never prints the value.
+
+PostgreSQL and NATS data persist under `.local/data/`, isolated by the derived ports. Valkey is
+started without snapshots. Stop the foreground stack with Ctrl+C, or from another shell with
+`PORT_PREFIX=271 just stop-all`; that command also stops the prefix's infrastructure processes.
+Delete persistent data only with the explicit, prefix-scoped `PORT_PREFIX=271 just reset` command.
+
+Verify the selected stack and auth contract with the actual `/health` endpoint:
+
+```bash
+curl -fsS http://localhost:27100/health
+curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:27100/
+```
 
 ### Cloud agents and secrets
 
@@ -57,7 +86,7 @@ Use a distinct `PORT_PREFIX` per worktree so parallel stacks do not collide.
 ```bash
 ./scripts/init-cloud-env.sh
 export CARGO_INCREMENTAL=0
-doppler run -- just start-dev --no-watch
+# Then use the canonical command in "Local dev" above.
 ```
 
 Failing GitHub auth means the token was not passed through, not that it expired:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Then open:
 
 See the [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/) for the full guide.
 
+Contributors and coding agents can instead run the PostgreSQL, Valkey, and NATS-backed development
+stack locally without Docker. The canonical per-worktree command, prerequisites, ports, and cleanup
+instructions live in [`AGENTS.md`](./AGENTS.md#local-dev).
+
 ## API example
 
 ```bash

--- a/knowledge/project/shipping.md
+++ b/knowledge/project/shipping.md
@@ -67,7 +67,7 @@ The command menu lives in the ship skill; it picks the smallest set that fits th
 rather than running every check mechanically. Whatever set is chosen, the evidence must show that:
 
 - the changed surface built, linted, and tested cleanly, including important negative paths
-- impacted flows were smoke tested against `just start-dev` or `just start-all` as risk dictates
+- impacted flows were smoke tested against the repository's canonical local startup contract
 - performance impact was considered where relevant: indexes, scans, N+1 patterns, pagination, and
   bounded result sets
 - UI changes were captured as screenshots in validation or PR comments — never committed to the repo

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -329,8 +329,8 @@ main() {
     echo ""
     echo "Next steps:"
     echo "  just --list              # See available commands"
-    echo "  just start-dev --no-watch  # Quick start (recommended for cloud)"
     echo "  just init                # Full dev environment setup (for local dev)"
+    echo "  See AGENTS.md            # Canonical coding-agent startup command"
     echo "  doppler run -- bash -lc 'GH_TOKEN=\"\$GITHUB_TOKEN\" gh auth status'"
     echo "================================================"
 }

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -463,6 +463,7 @@ case "$cmd" in
       done
       signal_recorded_pids KILL
       signal_port_bound_services KILL
+      "$PROJECT_ROOT/scripts/lib/infra.sh" stop 2>/dev/null || true
       clear_run_state_dir
 
       # Restore terminal state

--- a/scripts/start-agent-dev.sh
+++ b/scripts/start-agent-dev.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Canonical DB-backed local stack for coding agents. Operational guidance lives in AGENTS.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+usage() {
+  cat <<'EOF'
+Usage: PORT_PREFIX=<1-654> AUTH_MODE=<none|admin|full|external> ./scripts/start-agent-dev.sh
+
+See AGENTS.md for prerequisites, port layout, auth setup, persistence, verification, and shutdown.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ -n "${1:-}" ] && [ "${1:-}" != "--doppler-injected" ]; then
+  usage >&2
+  exit 2
+fi
+
+if ! [[ "${PORT_PREFIX:-}" =~ ^[1-9][0-9]{0,2}$ ]] || [ "$PORT_PREFIX" -gt 654 ]; then
+  echo "PORT_PREFIX must be an integer from 1 through 654 (for example, 271)." >&2
+  exit 2
+fi
+
+case "${AUTH_MODE:-}" in
+  none|admin|full|external) ;;
+  *)
+    echo "AUTH_MODE must be explicit: none, admin, full, or external." >&2
+    exit 2
+    ;;
+esac
+
+if [ "${1:-}" != "--doppler-injected" ]; then
+  if ! command -v doppler >/dev/null 2>&1; then
+    echo "doppler is required. Run ./scripts/init-cloud-env.sh, then configure Doppler." >&2
+    exit 1
+  fi
+
+  # Doppler secrets normally win over the caller environment. Preserve the two
+  # caller-owned selectors so a Doppler config cannot silently move or re-auth the stack.
+  exec doppler run --preserve-env="PORT_PREFIX,AUTH_MODE" -- \
+    "$PROJECT_ROOT/scripts/start-agent-dev.sh" --doppler-injected
+fi
+
+for command_name in cargo node just sqlx pnpm caddy nats-server; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "$command_name is required. Run: just init" >&2
+    exit 1
+  fi
+done
+
+if ! command -v pg_ctl >/dev/null 2>&1 && [ ! -d /usr/lib/postgresql ]; then
+  echo "PostgreSQL is required. Run: just init" >&2
+  exit 1
+fi
+
+if ! command -v valkey-server >/dev/null 2>&1 && ! command -v redis-server >/dev/null 2>&1; then
+  echo "Valkey (or Redis) is required. Run: just init" >&2
+  exit 1
+fi
+
+if [ ! -x "$PROJECT_ROOT/apps/ui/node_modules/.bin/next" ]; then
+  echo "UI dependencies are required. Run: just init" >&2
+  exit 1
+fi
+
+if [ -z "${SECRETS_ENCRYPTION_KEY:-}" ]; then
+  key_dir="$PROJECT_ROOT/.local/agent-dev"
+  key_file="$key_dir/secrets-encryption-key-${PORT_PREFIX}"
+  umask 077
+  mkdir -p "$key_dir"
+  chmod 700 "$key_dir"
+  if [ ! -s "$key_file" ]; then
+    generated_key="$(head -c 32 /dev/urandom | base64 | tr -d '\n\r')"
+    printf 'kek-v1:%s\n' "$generated_key" > "$key_file"
+  fi
+  chmod 600 "$key_file"
+  SECRETS_ENCRYPTION_KEY="$(<"$key_file")"
+  export SECRETS_ENCRYPTION_KEY
+  echo "Using the private per-prefix encryption key in .local/agent-dev/."
+fi
+
+cd "$PROJECT_ROOT"
+exec just start-all --no-watch

--- a/scripts/test-agent-dev-startup.sh
+++ b/scripts/test-agent-dev-startup.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_DIR="$(mktemp -d)"
+NEXT_BIN="$PROJECT_ROOT/apps/ui/node_modules/.bin/next"
+CREATED_NEXT_BIN=false
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+  if [ "$CREATED_NEXT_BIN" = true ]; then
+    rm -f "$NEXT_BIN"
+    rmdir "$PROJECT_ROOT/apps/ui/node_modules/.bin" 2>/dev/null || true
+    rmdir "$PROJECT_ROOT/apps/ui/node_modules" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT
+
+mkdir -p "$TEST_DIR/bin"
+
+cat > "$TEST_DIR/bin/doppler" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+preserve=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    run) shift ;;
+    --preserve-env=*) preserve="${1#*=}"; shift ;;
+    --) shift; break ;;
+    *) echo "unexpected doppler argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[ "$preserve" = "PORT_PREFIX,AUTH_MODE" ] || {
+  echo "caller selectors were not preserved through Doppler" >&2
+  exit 1
+}
+
+caller_prefix="$PORT_PREFIX"
+caller_auth_mode="$AUTH_MODE"
+export PORT_PREFIX=93 AUTH_MODE=full OPENAI_API_KEY=injected-openai ANTHROPIC_API_KEY=injected-anthropic
+export PORT_PREFIX="$caller_prefix" AUTH_MODE="$caller_auth_mode"
+exec "$@"
+EOF
+
+cat > "$TEST_DIR/bin/just" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$PORT_PREFIX|$AUTH_MODE|${OPENAI_API_KEY:-}|${ANTHROPIC_API_KEY:-}|$*" > "$AGENT_START_CAPTURE"
+EOF
+
+for command_name in sqlx pnpm caddy nats-server pg_ctl valkey-server; do
+  cat > "$TEST_DIR/bin/$command_name" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+done
+chmod +x "$TEST_DIR/bin/"*
+
+if [ ! -x "$NEXT_BIN" ]; then
+  mkdir -p "$(dirname "$NEXT_BIN")"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$NEXT_BIN"
+  chmod +x "$NEXT_BIN"
+  CREATED_NEXT_BIN=true
+fi
+
+capture="$TEST_DIR/capture"
+PATH="$TEST_DIR/bin:$PATH" \
+  PORT_PREFIX=271 \
+  AUTH_MODE=none \
+  SECRETS_ENCRYPTION_KEY='test-only-not-a-secret' \
+  AGENT_START_CAPTURE="$capture" \
+  "$PROJECT_ROOT/scripts/start-agent-dev.sh"
+
+expected='271|none|injected-openai|injected-anthropic|start-all --no-watch'
+actual="$(<"$capture")"
+[ "$actual" = "$expected" ] || {
+  echo "FAIL: expected '$expected', got '$actual'" >&2
+  exit 1
+}
+
+if PORT_PREFIX=655 AUTH_MODE=none "$PROJECT_ROOT/scripts/start-agent-dev.sh" >/dev/null 2>&1; then
+  echo "FAIL: invalid port prefix was accepted" >&2
+  exit 1
+fi
+
+if PORT_PREFIX=271 AUTH_MODE=production "$PROJECT_ROOT/scripts/start-agent-dev.sh" >/dev/null 2>&1; then
+  echo "FAIL: invalid auth mode was accepted" >&2
+  exit 1
+fi
+
+rg -qF 'PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh' "$PROJECT_ROOT/AGENTS.md"
+
+canonical_references="$(rg -oF './scripts/start-agent-dev.sh' \
+  "$PROJECT_ROOT/AGENTS.md" \
+  "$PROJECT_ROOT/.agents/skills/manual-ui-testing/SKILL.md" \
+  "$PROJECT_ROOT/.agents/skills/ship/SKILL.md" \
+  "$PROJECT_ROOT/scripts/init-cloud-env.sh" | wc -l | tr -d ' ')"
+[ "$canonical_references" = "1" ] || {
+  echo "FAIL: expected one canonical agent startup command, found $canonical_references" >&2
+  exit 1
+}
+
+if rg -n 'doppler run -- (just )?start-(all|dev)' \
+  "$PROJECT_ROOT/AGENTS.md" \
+  "$PROJECT_ROOT/.agents/skills/manual-ui-testing/SKILL.md" \
+  "$PROJECT_ROOT/.agents/skills/ship/SKILL.md" \
+  "$PROJECT_ROOT/scripts/init-cloud-env.sh"; then
+  echo "FAIL: stale direct Doppler startup command found" >&2
+  exit 1
+fi
+
+if rg -n '/healthz' \
+  "$PROJECT_ROOT/AGENTS.md" \
+  "$PROJECT_ROOT/.agents/skills/manual-ui-testing/SKILL.md"; then
+  echo "FAIL: stale health endpoint found in agent startup guidance" >&2
+  exit 1
+fi
+
+echo "agent development startup contract checks passed"


### PR DESCRIPTION
## What changed

Established one executable coding-agent startup contract:

```bash
PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh
```

The wrapper preserves the caller-selected prefix and auth mode through Doppler, requires the complete no-Docker local infrastructure, supplies a private per-prefix encryption key only when Doppler does not, and always runs `just start-all --no-watch`. Agent-facing guidance now points to the root contract instead of carrying competing commands. Ctrl+C cleanup now stops the prefix-scoped PostgreSQL and Valkey processes as well as the application processes.

## Why

Startup guidance was fragmented across AGENTS.md, the manual UI testing skill, and cloud initialization output. None of those commands combined Doppler, an explicit prefix, an explicit auth mode, the DB-backed stack, and no-watch behavior. In practice, a requested prefixed restart silently came up on the default 9300 stack.

## Before / After

Before, the agent-facing examples separately recommended commands such as:

```bash
PORT_PREFIX=271 just start-all
doppler run -- just start-dev --no-watch
```

Neither was the complete contract.

After, a clean prefix-296 live run of the exact wrapper proved:

```text
PostgreSQL  localhost:29632  accepting connections
Valkey      localhost:29679  PONG
NATS        localhost:29622  TCP ready
API         localhost:29601  200
Worker      target/debug/everruns-worker running
UI          localhost:29605  ready
Caddy       localhost:29600  ready
GET /health {"status":"ok","version":"0.17.23","auth_mode":"None"}
GET /        200 after redirect to /dashboard
9300/9301   no listeners
```

The first API build took 3m29s and the first worker build took 3m46s, matching the documented first-build warning. Ctrl+C was followed by a listener sweep across `29600`, `29601`, `29602`, `29603`, `29605`, `29622`, `29632`, and `29679`; all were closed.

Validation:

- `just test-shell`
- `just check-okf`
- `just pre-push` (again after rebasing onto latest `origin/main`)
- `bash -n scripts/start-agent-dev.sh scripts/test-agent-dev-startup.sh scripts/lib/services.sh`
- Live exact-command startup, health/auth/app checks, prefixed listener audit, and shutdown audit

## Risk

- Low
- The wrapper is additive. The only existing runtime behavior change is that Ctrl+C during `start-all` now stops that worktree prefix's local PostgreSQL, Valkey, and NATS infrastructure, matching `just stop-all` and the documented contract.

## Security

- Threat categories reviewed: TM-AUTH, TM-LLM, TM-FS, local command execution
- Findings and resolutions: `AUTH_MODE` is explicit and allowlisted; `none` remains gated to the existing dev deployment path. `PORT_PREFIX` is numeric and bounded, preventing path or command injection and invalid derived ports. Doppler preserves only the two caller-owned selectors while injecting provider secrets. Secret values are never printed. The fallback encryption key is randomly generated, isolated by worktree/prefix in the gitignored `.local/` tree, and enforced to directory mode 0700/file mode 0600. No dependency or production threat-model surface changed.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)