### PR TITLE
fix(dev): preserve local encryption key across startups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,13 @@ variables per `docs/sre/runbooks/authentication.md`.
 `start-all` maps Doppler's `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to
 `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY`. Analyze/Health additionally requires
 `UTILITY_OPENAI_API_KEY`; no extra setup is needed when Doppler already supplies it. If Doppler does
-not supply `SECRETS_ENCRYPTION_KEY`, the wrapper creates a mode-`0600`, per-prefix key under
-`.local/agent-dev/`; it never prints the value.
+not supply `SECRETS_ENCRYPTION_KEY`, startup uses the stable repository local-development key.
 
-PostgreSQL and NATS data persist under `.local/data/`, isolated by the derived ports. Valkey is
-started without snapshots. Stop the foreground stack with Ctrl+C, or from another shell with
+PostgreSQL and NATS data persist under `.local/data/`, isolated by the derived ports. Encrypted
+database records depend on the encryption key remaining stable: the default is the public,
+non-production key from `scripts/lib/local-development-secrets.sh`. Do not change that default
+without migrating or explicitly resetting affected local data. Valkey is started without
+snapshots. Stop the foreground stack with Ctrl+C, or from another shell with
 `PORT_PREFIX=271 just stop-all`; that command also stops the prefix's infrastructure processes.
 Delete persistent data only with the explicit, prefix-scoped `PORT_PREFIX=271 just reset` command.
 

--- a/knowledge/security/encryption.md
+++ b/knowledge/security/encryption.md
@@ -89,7 +89,7 @@ Field descriptions:
 
 ### Security Requirements
 
-1. **Key Storage**: KEKs must never be committed to source control
+1. **Key Storage**: Production KEKs must never be committed to source control; the public local-development default is not valid for production
 2. **Key Length**: Minimum 256 bits (32 bytes)
 3. **Nonce**: Must be unique per encryption operation (12 bytes, randomly generated)
 4. **DEK**: Fresh random DEK generated for each encryption operation
@@ -101,6 +101,15 @@ Field descriptions:
 2. **Thread Safety**: Safe for concurrent use across async tasks
 3. **Error Handling**: Clear errors for key mismatch, tampering, or corruption
 4. **Backwards Compatibility**: Supports legacy non-versioned ciphertext during migration
+
+### Local Development
+
+Local databases persist encrypted provider credentials across process and worktree restarts, so
+the default local-development KEK must remain stable. Local launchers share the public,
+non-production default defined in
+[`scripts/lib/local-development-secrets.sh`](../../scripts/lib/local-development-secrets.sh) when
+`SECRETS_ENCRYPTION_KEY` is absent. Changing the effective key requires migrating or resetting the
+corresponding local database; otherwise existing encrypted records cannot be unwrapped.
 
 ### Encrypted Fields
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -160,7 +160,7 @@ Display:   evr_pat_<first-8-chars>...      (prefix for identification)
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-CRYPTO-001 | KEK compromise | Critical | Stored in env var `SECRETS_ENCRYPTION_KEY`; never in source control | MITIGATED |
+| TM-CRYPTO-001 | KEK compromise | Critical | Production KEKs are stored in `SECRETS_ENCRYPTION_KEY` and never committed; the repository's public local-development KEK is explicitly non-production and stable for persisted local data | MITIGATED |
 | TM-CRYPTO-002 | Nonce reuse in AES-GCM | Critical | Fresh 12-byte random nonce per encryption; 2^96 space | MITIGATED |
 | TM-CRYPTO-003 | Ciphertext tampering | High | GCM authentication tag detects modification | MITIGATED |
 | TM-CRYPTO-004 | Known-plaintext attack | Medium | Unique DEK per encryption; same plaintext produces different ciphertext | MITIGATED |

--- a/scripts/lib/local-development-secrets.sh
+++ b/scripts/lib/local-development-secrets.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This public, non-production key must stay stable so persisted local databases
+# remain decryptable across restarts and worktrees.
+DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY="kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY="
+
+configure_local_development_encryption_key() {
+  if [ -z "${SECRETS_ENCRYPTION_KEY:-}" ]; then
+    export SECRETS_ENCRYPTION_KEY="$DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY"
+    return 0
+  fi
+
+  return 1
+}

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -2,6 +2,7 @@
 # Service operations: server, worker, watch-*, start-dev, start-all, stop-all
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/local-development-secrets.sh"
 
 cmd="${1:-}"
 shift || true
@@ -302,9 +303,7 @@ case "$cmd" in
     export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export RUST_LOG=${RUST_LOG:-info}
 
-    # Set encryption key if not provided (standard dev key from .env.example)
-    if [ -z "${SECRETS_ENCRYPTION_KEY:-}" ]; then
-      export SECRETS_ENCRYPTION_KEY="kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY="
+    if configure_local_development_encryption_key; then
       echo "   ✅ Using default encryption key"
     fi
 

--- a/scripts/start-agent-dev.sh
+++ b/scripts/start-agent-dev.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/lib/local-development-secrets.sh"
 
 usage() {
   cat <<'EOF'
@@ -71,20 +72,8 @@ if [ ! -x "$PROJECT_ROOT/apps/ui/node_modules/.bin/next" ]; then
   exit 1
 fi
 
-if [ -z "${SECRETS_ENCRYPTION_KEY:-}" ]; then
-  key_dir="$PROJECT_ROOT/.local/agent-dev"
-  key_file="$key_dir/secrets-encryption-key-${PORT_PREFIX}"
-  umask 077
-  mkdir -p "$key_dir"
-  chmod 700 "$key_dir"
-  if [ ! -s "$key_file" ]; then
-    generated_key="$(head -c 32 /dev/urandom | base64 | tr -d '\n\r')"
-    printf 'kek-v1:%s\n' "$generated_key" > "$key_file"
-  fi
-  chmod 600 "$key_file"
-  SECRETS_ENCRYPTION_KEY="$(<"$key_file")"
-  export SECRETS_ENCRYPTION_KEY
-  echo "Using the private per-prefix encryption key in .local/agent-dev/."
+if configure_local_development_encryption_key; then
+  echo "Using the stable repository local-development encryption key."
 fi
 
 cd "$PROJECT_ROOT"

--- a/scripts/test-agent-dev-startup.sh
+++ b/scripts/test-agent-dev-startup.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+source "$PROJECT_ROOT/scripts/lib/local-development-secrets.sh"
 TEST_DIR="$(mktemp -d)"
 NEXT_BIN="$PROJECT_ROOT/apps/ui/node_modules/.bin/next"
 CREATED_NEXT_BIN=false
@@ -49,7 +50,7 @@ EOF
 cat > "$TEST_DIR/bin/just" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$PORT_PREFIX|$AUTH_MODE|${OPENAI_API_KEY:-}|${ANTHROPIC_API_KEY:-}|$*" > "$AGENT_START_CAPTURE"
+printf '%s\n' "$PORT_PREFIX|$AUTH_MODE|${OPENAI_API_KEY:-}|${ANTHROPIC_API_KEY:-}|${SECRETS_ENCRYPTION_KEY:-}|$*" > "$AGENT_START_CAPTURE"
 EOF
 
 for command_name in sqlx pnpm caddy nats-server pg_ctl valkey-server; do
@@ -75,10 +76,31 @@ PATH="$TEST_DIR/bin:$PATH" \
   AGENT_START_CAPTURE="$capture" \
   "$PROJECT_ROOT/scripts/start-agent-dev.sh"
 
-expected='271|none|injected-openai|injected-anthropic|start-all --no-watch'
+expected='271|none|injected-openai|injected-anthropic|test-only-not-a-secret|start-all --no-watch'
 actual="$(<"$capture")"
 [ "$actual" = "$expected" ] || {
   echo "FAIL: expected '$expected', got '$actual'" >&2
+  exit 1
+}
+
+env -u SECRETS_ENCRYPTION_KEY \
+  PATH="$TEST_DIR/bin:$PATH" \
+  PORT_PREFIX=272 \
+  AUTH_MODE=none \
+  AGENT_START_CAPTURE="$capture" \
+  "$PROJECT_ROOT/scripts/start-agent-dev.sh"
+
+expected="272|none|injected-openai|injected-anthropic|$DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY|start-all --no-watch"
+actual="$(<"$capture")"
+[ "$actual" = "$expected" ] || {
+  echo "FAIL: expected stable local encryption key, got '$actual'" >&2
+  exit 1
+}
+
+default_key_definitions="$(rg -lF "$DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY" \
+  "$PROJECT_ROOT/scripts" | wc -l | tr -d ' ')"
+[ "$default_key_definitions" = "1" ] || {
+  echo "FAIL: expected one local development encryption key definition, found $default_key_definitions" >&2
   exit 1
 }
 


### PR DESCRIPTION
## What changed
Canonical agent startup now reuses the established repository local-development encryption key when SECRETS_ENCRYPTION_KEY is absent. Direct local start-all startup shares the same definition, explicit overrides still win, and the persistence invariant is documented for future changes.

## Why
The canonical wrapper generated a new per-prefix key. Existing DB-backed local stacks contain provider credentials encrypted with the established development key, so model resolution failed with Failed to unwrap DEK after switching startup paths.

## Before / After
Before: the regression test observed a random per-prefix kek-v1 value when the variable was absent, matching the reported DEK unwrap failure on persisted data.

After: scripts/test-agent-dev-startup.sh observes the established stable fallback, preserves explicit overrides, and enforces one shell definition. A DB-backed smoke on prefix 419 created an encrypted provider credential, stopped the stack, restarted the same persisted database with SECRETS_ENCRYPTION_KEY absent, and confirmed the provider remained configured. Model sync reached the upstream API and received 401 Unauthorized for the intentionally fake credential, proving the stored DEK was unwrapped after restart rather than failing locally. The smoke database was reset afterward.

## Risk
- Low
- This affects local-development startup only. An incorrect default would prevent decryption of persisted local credentials; regression coverage and the persisted restart smoke exercise that path. Explicit environment and Doppler values remain authoritative.

## Security
- Threat categories reviewed: TM-CRYPTO
- Findings and resolutions: TM-CRYPTO-001 documentation previously stated all KEKs stay out of source control despite the existing public development key already being committed and used by tests/CI. The docs and threat model now distinguish production KEKs from the public, non-production local default. No production startup path changed, no new secret was introduced, and key material is not logged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)