### PR TITLE
feat(ui): restructure agent and harness editors

### DIFF
--- a/apps/ui/src/__tests__/editor-create-pages.test.tsx
+++ b/apps/ui/src/__tests__/editor-create-pages.test.tsx
@@ -1,0 +1,138 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import NewAgentPage from "@/app/(main)/agents/new/page";
+import NewHarnessPage from "@/app/(main)/harnesses/new/page";
+
+const push = jest.fn();
+const back = jest.fn();
+const createAgent = jest.fn();
+const createHarness = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push, back }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.ComponentPropsWithoutRef<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/hooks", () => ({
+  useCreateAgent: () => ({ mutateAsync: createAgent, isPending: false, error: null }),
+  useCreateHarness: () => ({ mutateAsync: createHarness, isPending: false, error: null }),
+  useCapabilities: () => ({ data: [] }),
+  useAgentNameAvailability: () => ({ isChecking: false, available: true }),
+  useHarnessNameAvailability: () => ({ isChecking: false, available: true }),
+  usePageTitle: () => undefined,
+}));
+
+jest.mock("@/components/ui/prompt-editor", () => ({
+  PromptEditor: ({
+    id,
+    value,
+    onChange,
+  }: {
+    id: string;
+    value: string;
+    onChange: (value: string) => void;
+  }) => <textarea id={id} value={value} onChange={(event) => onChange(event.target.value)} />,
+}));
+
+jest.mock("@/components/models/model-picker", () => ({
+  ModelPicker: () => <div data-testid="model-picker" />,
+}));
+
+jest.mock("@/components/harness/harness-select", () => ({
+  HarnessSelect: ({
+    id,
+    value,
+    onValueChange,
+  }: {
+    id?: string;
+    value: string;
+    onValueChange: (value: string) => void;
+  }) => (
+    <select id={id} value={value} onChange={(event) => onValueChange(event.target.value)}>
+      <option value="">None</option>
+      <option value="harness_123">Generic</option>
+    </select>
+  ),
+}));
+
+jest.mock("@/components/agents/capability-selector", () => ({
+  CapabilitySelector: () => <div data-testid="capability-selector" />,
+}));
+
+jest.mock("@/components/initial-files-editor", () => ({
+  InitialFilesEditor: () => <div data-testid="initial-files-editor" />,
+}));
+
+describe("create editor layouts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createAgent.mockResolvedValue({ id: "agent_123" });
+    createHarness.mockResolvedValue({ id: "harness_456" });
+  });
+
+  it("structures New Agent into navigable sections and submits network access", async () => {
+    render(<NewAgentPage />);
+
+    expect(screen.getByRole("navigation", { name: "Jump to section" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Identity" })).toHaveAttribute("href", "#identity");
+    expect(screen.getByRole("link", { name: "Network" })).toHaveAttribute("href", "#network");
+
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "Support Agent" },
+    });
+    fireEvent.change(screen.getByLabelText(/Harness/), { target: { value: "harness_123" } });
+    fireEvent.change(screen.getByLabelText("System Prompt"), {
+      target: { value: "You are helpful." },
+    });
+    fireEvent.change(screen.getByLabelText("Allowed hosts"), {
+      target: { value: "api.example.com" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+    });
+
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "support-agent",
+        harness_id: "harness_123",
+        network_access: { allowed: ["api.example.com"] },
+      }),
+    );
+    expect(push).toHaveBeenCalledWith("/agents/agent_123");
+  });
+
+  it("uses the same section structure for New Harness", async () => {
+    render(<NewHarnessPage />);
+
+    expect(screen.getByRole("navigation", { name: "Jump to section" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Behavior" })).toHaveAttribute("href", "#behavior");
+    expect(screen.getByRole("link", { name: "Files" })).toHaveAttribute("href", "#files");
+
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "Safe Harness" },
+    });
+    fireEvent.change(screen.getByLabelText("Blocked hosts"), {
+      target: { value: "internal.example.com" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Create Harness" }));
+    });
+
+    expect(createHarness).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "safe-harness",
+        network_access: { blocked: ["internal.example.com"] },
+      }),
+    );
+    expect(push).toHaveBeenCalledWith("/harnesses/harness_456");
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -28,6 +28,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  PageJumpNav,
   PageColumns,
   PageMain,
   PageRail,
@@ -305,7 +306,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
         }
       />
 
-      <PageControlStrip>
+      <PageControlStrip className="flex flex-col border-b lg:flex-row lg:items-end lg:justify-between">
         <SectionTabs
           value={activeTab}
           onValueChange={setActiveTab}
@@ -313,7 +314,19 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
             { value: "edit", label: "Edit", icon: <Edit2 className="size-4" /> },
             { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
           ]}
+          className="border-b-0"
         />
+        {activeTab === "edit" && (
+          <PageJumpNav
+            items={[
+              { href: "#identity", label: "Identity" },
+              { href: "#behavior", label: "Behavior" },
+              { href: "#files", label: "Files" },
+              { href: "#network", label: "Network" },
+            ]}
+            className="px-3.5"
+          />
+        )}
       </PageControlStrip>
 
       {activeTab === "edit" && (
@@ -321,9 +334,10 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
           <PageColumns>
             {/* Main form */}
             <PageMain>
-              <Card>
+              <Card id="identity" className="scroll-mt-6">
                 <CardHeader>
-                  <CardTitle>Agent Details</CardTitle>
+                  <CardTitle>Identity</CardTitle>
+                  <CardDescription>How the agent is named and found</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-6">
                   <div className="space-y-2">
@@ -408,38 +422,48 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                       Press Enter or comma to add a tag. Backspace removes the last tag.
                     </p>
                   </div>
+                </CardContent>
+              </Card>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="harness">
-                      Harness <span className="text-destructive">*</span>
-                    </Label>
-                    <HarnessSelect
-                      id="harness"
-                      value={formData.harness_id}
-                      onValueChange={(value) => handleFormChange("harness_id", value)}
-                      disabled={isSaving || isReadOnly}
-                      placeholder="Select a harness"
-                    />
-                    {fieldErrors.harness_id && (
-                      <p className="text-xs text-destructive">{fieldErrors.harness_id}</p>
-                    )}
-                    <p className="text-xs text-muted-foreground">
-                      The base execution harness this agent runs on. Sessions started from this
-                      agent inherit it.
-                    </p>
-                  </div>
+              <Card id="behavior" className="scroll-mt-6">
+                <CardHeader>
+                  <CardTitle>Behavior</CardTitle>
+                  <CardDescription>Execution target and instructions</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="grid gap-6 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="harness">
+                        Harness <span className="text-destructive">*</span>
+                      </Label>
+                      <HarnessSelect
+                        id="harness"
+                        value={formData.harness_id}
+                        onValueChange={(value) => handleFormChange("harness_id", value)}
+                        disabled={isSaving || isReadOnly}
+                        placeholder="Select a harness"
+                      />
+                      {fieldErrors.harness_id && (
+                        <p className="text-xs text-destructive">{fieldErrors.harness_id}</p>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        The base execution harness this agent runs on. Sessions started from this
+                        agent inherit it.
+                      </p>
+                    </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="model">Model (optional)</Label>
-                    <ModelPicker
-                      value={formData.default_model_id || ""}
-                      onChange={(value) => handleFormChange("default_model_id", value)}
-                      disabled={isSaving || isReadOnly}
-                      placeholder="Use default model"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Select a specific model or leave empty to use the default
-                    </p>
+                    <div className="space-y-2">
+                      <Label htmlFor="model">Model (optional)</Label>
+                      <ModelPicker
+                        value={formData.default_model_id || ""}
+                        onChange={(value) => handleFormChange("default_model_id", value)}
+                        disabled={isSaving || isReadOnly}
+                        placeholder="Use default model"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Select a specific model or leave empty to use the default
+                      </p>
+                    </div>
                   </div>
 
                   <div className="space-y-2">
@@ -459,14 +483,22 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                       Instructions for the AI model (supports Markdown)
                     </p>
                   </div>
+                </CardContent>
+              </Card>
 
+              <Card id="files" className="scroll-mt-6">
+                <CardContent className="pt-6">
                   <InitialFilesEditor
                     value={selectedInitialFiles}
                     onChange={setLocalInitialFiles}
                     disabled={isSaving || isReadOnly}
                     description="Files copied into each new session for this agent."
                   />
+                </CardContent>
+              </Card>
 
+              <Card id="network" className="scroll-mt-6">
+                <CardContent className="pt-6">
                   <NetworkAccessEditor
                     value={initialNetworkAccess}
                     onChange={setLocalNetworkAccess}

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -4,19 +4,37 @@ import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useCreateAgent, useCapabilities, useAgentNameAvailability, usePageTitle } from "@/hooks";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { TagInput } from "@/components/ui/tag-input";
 import { PromptEditor } from "@/components/ui/prompt-editor";
-import Link from "next/link";
-import { ArrowLeft, Check, X, Loader2 } from "lucide-react";
+import { Boxes, Check, X, Loader2 } from "lucide-react";
 import { ModelPicker } from "@/components/models/model-picker";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
-import { agentFormSchema, getFieldErrors, type FieldErrors } from "@/lib/form-validation";
-import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
+import { NetworkAccessEditor } from "@/components/network-access-editor";
+import {
+  BackLink,
+  PageBreadcrumb,
+  PageColumns,
+  PageContainer,
+  PageControlStrip,
+  PageFooter,
+  PageJumpNav,
+  PageMain,
+  PageMasthead,
+  PageRail,
+} from "@/components/layout";
+import {
+  agentFormSchema,
+  getFieldErrors,
+  parseTagList,
+  type FieldErrors,
+} from "@/lib/form-validation";
+import type { AgentCapabilityConfig, InitialFile, NetworkAccessList } from "@/lib/api/types";
 
 /** Convert a display name to a slug: lowercase, non-alphanumeric → hyphens, deduplicate, trim. */
 function slugify(value: string): string {
@@ -40,6 +58,7 @@ export default function NewAgentPage() {
     system_prompt: "",
     harness_id: "",
     default_model_id: "",
+    tags: "",
   });
 
   // Track whether the user has manually edited the slug
@@ -49,6 +68,7 @@ export default function NewAgentPage() {
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
+  const [networkAccess, setNetworkAccess] = useState<NetworkAccessList>({});
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
@@ -84,6 +104,7 @@ export default function NewAgentPage() {
     }
 
     try {
+      const tags = parseTagList(parsed.data.tags);
       const agent = await createAgent.mutateAsync({
         name: parsed.data.name,
         display_name: parsed.data.display_name,
@@ -91,8 +112,13 @@ export default function NewAgentPage() {
         system_prompt: parsed.data.system_prompt,
         harness_id: parsed.data.harness_id,
         default_model_id: parsed.data.default_model_id,
+        tags: tags.length > 0 ? tags : undefined,
         capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
         initial_files: initialFiles.length > 0 ? initialFiles : undefined,
+        network_access:
+          networkAccess.allowed?.length || networkAccess.blocked?.length
+            ? networkAccess
+            : undefined,
       });
 
       router.push(`/agents/${agent.id}`);
@@ -102,171 +128,239 @@ export default function NewAgentPage() {
   };
 
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/agents"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Agents
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Agents", href: "/agents" }, { label: "New" }]} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Create New Agent</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                placeholder="customer-support"
-                value={formData.name}
-                onChange={(e) => handleNameChange(e.target.value)}
-                aria-invalid={!!fieldErrors.name}
-                required
-              />
-              {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
-              {formData.name.length >= 2 && (
-                <div className="flex items-center gap-1.5 text-xs">
-                  {nameAvailability.isChecking ? (
-                    <>
-                      <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                      <span className="text-muted-foreground">Checking availability…</span>
-                    </>
-                  ) : nameAvailability.available === true ? (
-                    <>
-                      <Check className="w-3 h-3 text-green-600" />
-                      <span className="text-green-600">Name is available</span>
-                    </>
-                  ) : nameAvailability.available === false ? (
-                    <>
-                      <X className="w-3 h-3 text-destructive" />
-                      <span className="text-destructive">Name is already taken or invalid</span>
-                    </>
-                  ) : null}
+      <PageMasthead
+        icon={<Boxes />}
+        title="New Agent"
+        description="Define the identity, behavior, files, and network policy for new sessions."
+        actions={
+          <>
+            <Button type="submit" form="agent-create-form" disabled={createAgent.isPending}>
+              <Check className="size-4" />
+              {createAgent.isPending ? "Creating..." : "Create Agent"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Cancel
+            </Button>
+          </>
+        }
+      />
+
+      <PageControlStrip className="border-b">
+        <PageJumpNav
+          items={[
+            { href: "#identity", label: "Identity" },
+            { href: "#behavior", label: "Behavior" },
+            { href: "#files", label: "Files" },
+            { href: "#network", label: "Network" },
+          ]}
+          className="px-3.5"
+        />
+      </PageControlStrip>
+
+      <form id="agent-create-form" onSubmit={handleSubmit}>
+        <PageColumns>
+          <PageMain>
+            <Card id="identity" className="scroll-mt-6">
+              <CardHeader>
+                <CardTitle>Identity</CardTitle>
+                <CardDescription>How the agent is named and found</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    placeholder="customer-support"
+                    value={formData.name}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    aria-invalid={!!fieldErrors.name}
+                    required
+                  />
+                  {fieldErrors.name && (
+                    <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                  )}
+                  {formData.name.length >= 2 && (
+                    <div className="flex items-center gap-1.5 text-xs">
+                      {nameAvailability.isChecking ? (
+                        <>
+                          <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                          <span className="text-muted-foreground">Checking availability…</span>
+                        </>
+                      ) : nameAvailability.available === true ? (
+                        <>
+                          <Check className="w-3 h-3 text-green-600" />
+                          <span className="text-green-600">Name is available</span>
+                        </>
+                      ) : nameAvailability.available === false ? (
+                        <>
+                          <X className="w-3 h-3 text-destructive" />
+                          <span className="text-destructive">Name is already taken or invalid</span>
+                        </>
+                      ) : null}
+                    </div>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+                  </p>
                 </div>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
-              </p>
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="display_name">Display Name</Label>
-              <Input
-                id="display_name"
-                placeholder={formData.name ? undefined : "Customer Support Agent"}
-                value={formData.display_name}
-                onChange={(e) => handleDisplayNameChange(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Optional human-readable label shown in the UI. Defaults to name if empty.
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="display_name">Display Name</Label>
+                  <Input
+                    id="display_name"
+                    placeholder={formData.name ? undefined : "Customer Support Agent"}
+                    value={formData.display_name}
+                    onChange={(e) => handleDisplayNameChange(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Optional human-readable label shown in the UI. Defaults to name if empty.
+                  </p>
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
-              <Textarea
-                id="description"
-                placeholder="Describe what this agent does..."
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                rows={2}
-              />
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    placeholder="Describe what this agent does..."
+                    value={formData.description}
+                    onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                    rows={2}
+                  />
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="harness">
-                Harness <span className="text-destructive">*</span>
-              </Label>
-              <HarnessSelect
-                id="harness"
-                value={formData.harness_id}
-                onValueChange={(value) => {
-                  setFormData((prev) => ({ ...prev, harness_id: value }));
-                  setFieldErrors((prev) => ({ ...prev, harness_id: undefined }));
-                }}
-                placeholder="Select a harness"
-              />
-              {fieldErrors.harness_id && (
-                <p className="text-xs text-destructive">{fieldErrors.harness_id}</p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                The base execution harness this agent runs on. Sessions started from this agent
-                inherit it.
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="tags">Tags</Label>
+                  <TagInput
+                    id="tags"
+                    placeholder="Add a tag…"
+                    value={formData.tags}
+                    onChange={(value) => setFormData((prev) => ({ ...prev, tags: value }))}
+                    disabled={createAgent.isPending}
+                    aria-describedby="tags-help"
+                  />
+                  <p id="tags-help" className="text-xs text-muted-foreground">
+                    Press Enter or comma to add a tag. Backspace removes the last tag.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
 
-            <div className="space-y-2">
-              <Label htmlFor="model">Model (optional)</Label>
-              <ModelPicker
-                value={formData.default_model_id}
-                onChange={(value) => setFormData({ ...formData, default_model_id: value })}
-                placeholder="Use default model"
-              />
-              <p className="text-xs text-muted-foreground">
-                Select a specific model or leave empty to use the default
-              </p>
-            </div>
+            <Card id="behavior" className="scroll-mt-6">
+              <CardHeader>
+                <CardTitle>Behavior</CardTitle>
+                <CardDescription>Execution target and instructions</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid gap-6 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="harness">
+                      Harness <span className="text-destructive">*</span>
+                    </Label>
+                    <HarnessSelect
+                      id="harness"
+                      value={formData.harness_id}
+                      onValueChange={(value) => {
+                        setFormData((prev) => ({ ...prev, harness_id: value }));
+                        setFieldErrors((prev) => ({ ...prev, harness_id: undefined }));
+                      }}
+                      placeholder="Select a harness"
+                    />
+                    {fieldErrors.harness_id && (
+                      <p className="text-xs text-destructive">{fieldErrors.harness_id}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      The base execution harness this agent runs on. Sessions started from this
+                      agent inherit it.
+                    </p>
+                  </div>
 
-            <div className="space-y-2">
-              <Label>Capabilities (optional)</Label>
-              <CapabilitySelector
-                capabilities={allCapabilities}
-                selected={selectedCapabilities}
-                onChange={handleCapabilitiesChange}
-                disabled={createAgent.isPending}
-                label=""
-              />
-              <p className="text-xs text-muted-foreground">
-                Add capabilities to give your agent tools and specialized behaviors
-              </p>
-            </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="model">Model (optional)</Label>
+                    <ModelPicker
+                      value={formData.default_model_id}
+                      onChange={(value) => setFormData({ ...formData, default_model_id: value })}
+                      placeholder="Use default model"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Select a specific model or leave empty to use the default
+                    </p>
+                  </div>
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="system_prompt">System Prompt</Label>
-              <PromptEditor
-                id="system_prompt"
-                placeholder="You are a helpful assistant..."
-                value={formData.system_prompt}
-                onChange={(value) => {
-                  setFormData({ ...formData, system_prompt: value });
-                  setFieldErrors((prev) => ({ ...prev, system_prompt: undefined }));
-                }}
-                required
-              />
-              {fieldErrors.system_prompt && (
-                <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Instructions for the AI model (supports Markdown)
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="system_prompt">System Prompt</Label>
+                  <PromptEditor
+                    id="system_prompt"
+                    placeholder="You are a helpful assistant..."
+                    value={formData.system_prompt}
+                    onChange={(value) => {
+                      setFormData({ ...formData, system_prompt: value });
+                      setFieldErrors((prev) => ({ ...prev, system_prompt: undefined }));
+                    }}
+                    required
+                  />
+                  {fieldErrors.system_prompt && (
+                    <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Instructions for the AI model (supports Markdown)
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
 
-            <InitialFilesEditor
-              value={initialFiles}
-              onChange={setInitialFiles}
-              disabled={createAgent.isPending}
-              description="Seed skill files, helper scripts, configs, or binaries into each new session."
-            />
+            <Card id="files" className="scroll-mt-6">
+              <CardContent className="pt-6">
+                <InitialFilesEditor
+                  value={initialFiles}
+                  onChange={setInitialFiles}
+                  disabled={createAgent.isPending}
+                  description="Seed skill files, helper scripts, configs, or binaries into each new session."
+                />
+              </CardContent>
+            </Card>
 
-            <div className="flex gap-4">
-              <Button type="submit" disabled={createAgent.isPending}>
-                {createAgent.isPending ? "Creating..." : "Create Agent"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
-                Cancel
-              </Button>
-            </div>
+            <Card id="network" className="scroll-mt-6">
+              <CardContent className="pt-6">
+                <NetworkAccessEditor
+                  value={networkAccess}
+                  onChange={setNetworkAccess}
+                  disabled={createAgent.isPending}
+                  description="Control which hosts this agent's sessions can reach. The selected harness may narrow this policy further."
+                />
+              </CardContent>
+            </Card>
+          </PageMain>
+
+          <PageRail>
+            <Card>
+              <CardHeader>
+                <CardTitle>Capabilities</CardTitle>
+                <CardDescription>Tools and specialized behaviors</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <CapabilitySelector
+                  capabilities={allCapabilities}
+                  selected={selectedCapabilities}
+                  onChange={handleCapabilitiesChange}
+                  disabled={createAgent.isPending}
+                />
+              </CardContent>
+            </Card>
 
             {createAgent.error && (
               <p className="text-sm text-destructive">Error: {createAgent.error.message}</p>
             )}
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+          </PageRail>
+        </PageColumns>
+      </form>
+
+      <PageFooter>
+        <BackLink href="/agents">Back to Agents</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -29,6 +29,7 @@ import {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  PageJumpNav,
   PageColumns,
   PageMain,
   PageRail,
@@ -309,7 +310,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
         }
       />
 
-      <PageControlStrip>
+      <PageControlStrip className="flex flex-col border-b lg:flex-row lg:items-end lg:justify-between">
         <SectionTabs
           value={activeTab}
           onValueChange={setActiveTab}
@@ -317,7 +318,19 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
             { value: "edit", label: "Edit", icon: <Edit2 className="size-4" /> },
             { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
           ]}
+          className="border-b-0"
         />
+        {activeTab === "edit" && (
+          <PageJumpNav
+            items={[
+              { href: "#identity", label: "Identity" },
+              { href: "#behavior", label: "Behavior" },
+              { href: "#files", label: "Files" },
+              { href: "#network", label: "Network" },
+            ]}
+            className="px-3.5"
+          />
+        )}
       </PageControlStrip>
 
       {activeTab === "edit" && (
@@ -325,9 +338,10 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
           <PageColumns>
             {/* Main form */}
             <PageMain>
-              <Card>
+              <Card id="identity" className="scroll-mt-6">
                 <CardHeader>
-                  <CardTitle>Harness Details</CardTitle>
+                  <CardTitle>Identity</CardTitle>
+                  <CardDescription>How the harness is named and found</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-6">
                   <div className="space-y-2">
@@ -395,23 +409,6 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="parent-harness">Parent Harness</Label>
-                    <HarnessSelect
-                      value={formData.parent_harness_id}
-                      onValueChange={(value) => handleFormChange("parent_harness_id", value)}
-                      placeholder="No parent harness"
-                      includeNoneOption
-                      noneLabel="No parent harness"
-                      excludeIds={[harnessId]}
-                      disabled={isSaving || isReadOnly}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Inherit prompt, capabilities, initial files, and model fallback from a parent
-                      harness.
-                    </p>
-                  </div>
-
-                  <div className="space-y-2">
                     <Label htmlFor="tags">Tags</Label>
                     <TagInput
                       id="tags"
@@ -425,18 +422,46 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                       Press Enter or comma to add a tag. Backspace removes the last tag.
                     </p>
                   </div>
+                </CardContent>
+              </Card>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="model">Model (optional)</Label>
-                    <ModelPicker
-                      value={formData.default_model_id || ""}
-                      onChange={(value) => handleFormChange("default_model_id", value)}
-                      disabled={isSaving || isReadOnly}
-                      placeholder="Use default model"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Select a specific model or leave empty to use the default
-                    </p>
+              <Card id="behavior" className="scroll-mt-6">
+                <CardHeader>
+                  <CardTitle>Behavior</CardTitle>
+                  <CardDescription>Inheritance, model, and base instructions</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="grid gap-6 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="parent-harness">Parent Harness</Label>
+                      <HarnessSelect
+                        id="parent-harness"
+                        value={formData.parent_harness_id}
+                        onValueChange={(value) => handleFormChange("parent_harness_id", value)}
+                        placeholder="No parent harness"
+                        includeNoneOption
+                        noneLabel="No parent harness"
+                        excludeIds={[harnessId]}
+                        disabled={isSaving || isReadOnly}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Inherit prompt, capabilities, initial files, and model fallback from a
+                        parent harness.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="model">Model (optional)</Label>
+                      <ModelPicker
+                        value={formData.default_model_id || ""}
+                        onChange={(value) => handleFormChange("default_model_id", value)}
+                        disabled={isSaving || isReadOnly}
+                        placeholder="Use default model"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Select a specific model or leave empty to use the default
+                      </p>
+                    </div>
                   </div>
 
                   <div className="space-y-2">
@@ -457,14 +482,22 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                       capabilities still apply.
                     </p>
                   </div>
+                </CardContent>
+              </Card>
 
+              <Card id="files" className="scroll-mt-6">
+                <CardContent className="pt-6">
                   <InitialFilesEditor
                     value={selectedInitialFiles}
                     onChange={setLocalInitialFiles}
                     disabled={isSaving || isReadOnly}
                     description="Files copied into each new session created from this harness."
                   />
+                </CardContent>
+              </Card>
 
+              <Card id="network" className="scroll-mt-6">
+                <CardContent className="pt-6">
                   <NetworkAccessEditor
                     value={initialNetworkAccess}
                     onChange={setLocalNetworkAccess}

--- a/apps/ui/src/app/(main)/harnesses/new/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/new/page.tsx
@@ -9,24 +9,37 @@ import {
   usePageTitle,
 } from "@/hooks";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { TagInput } from "@/components/ui/tag-input";
 import { PromptEditor } from "@/components/ui/prompt-editor";
-import Link from "next/link";
-import { ArrowLeft, Check, X, Loader2 } from "lucide-react";
+import { Check, Loader2, Shield, X } from "lucide-react";
 import { ModelPicker } from "@/components/models/model-picker";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
+import { NetworkAccessEditor } from "@/components/network-access-editor";
+import {
+  BackLink,
+  PageBreadcrumb,
+  PageColumns,
+  PageContainer,
+  PageControlStrip,
+  PageFooter,
+  PageJumpNav,
+  PageMain,
+  PageMasthead,
+  PageRail,
+} from "@/components/layout";
 import {
   getFieldErrors,
   harnessFormSchema,
   type FieldErrors,
   parseTagList,
 } from "@/lib/form-validation";
-import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
+import type { AgentCapabilityConfig, InitialFile, NetworkAccessList } from "@/lib/api/types";
 
 /** Convert a display name to a slug: lowercase, non-alphanumeric → hyphens, deduplicate, trim. */
 function slugify(value: string): string {
@@ -80,6 +93,7 @@ export default function NewHarnessPage() {
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
+  const [networkAccess, setNetworkAccess] = useState<NetworkAccessList>({});
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
@@ -107,6 +121,10 @@ export default function NewHarnessPage() {
         tags: tags.length > 0 ? tags : undefined,
         capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
         initial_files: initialFiles.length > 0 ? initialFiles : undefined,
+        network_access:
+          networkAccess.allowed?.length || networkAccess.blocked?.length
+            ? networkAccess
+            : undefined,
       });
 
       router.push(`/harnesses/${harness.id}`);
@@ -116,176 +134,237 @@ export default function NewHarnessPage() {
   };
 
   return (
-    <div className="container mx-auto p-6">
-      <Link
-        href="/harnesses"
-        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
-      >
-        <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to Harnesses
-      </Link>
+    <PageContainer>
+      <PageBreadcrumb items={[{ label: "Harnesses", href: "/harnesses" }, { label: "New" }]} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Create New Harness</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                placeholder="my-harness"
-                value={formData.name}
-                onChange={(e) => handleNameChange(e.target.value)}
-                aria-invalid={!!fieldErrors.name}
-                required
-              />
-              {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
-              {formData.name.length >= 2 && (
-                <div className="flex items-center gap-1.5 text-xs">
-                  {nameAvailability.isChecking ? (
-                    <>
-                      <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                      <span className="text-muted-foreground">Checking availability…</span>
-                    </>
-                  ) : nameAvailability.available === true ? (
-                    <>
-                      <Check className="w-3 h-3 text-green-600" />
-                      <span className="text-green-600">Name is available</span>
-                    </>
-                  ) : nameAvailability.available === false ? (
-                    <>
-                      <X className="w-3 h-3 text-destructive" />
-                      <span className="text-destructive">Name is already taken or invalid</span>
-                    </>
-                  ) : null}
+      <PageMasthead
+        icon={<Shield />}
+        title="New Harness"
+        description="Define a reusable execution baseline for agents and sessions."
+        actions={
+          <>
+            <Button type="submit" form="harness-create-form" disabled={createHarness.isPending}>
+              <Check className="size-4" />
+              {createHarness.isPending ? "Creating..." : "Create Harness"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+              Cancel
+            </Button>
+          </>
+        }
+      />
+
+      <PageControlStrip className="border-b">
+        <PageJumpNav
+          items={[
+            { href: "#identity", label: "Identity" },
+            { href: "#behavior", label: "Behavior" },
+            { href: "#files", label: "Files" },
+            { href: "#network", label: "Network" },
+          ]}
+          className="px-3.5"
+        />
+      </PageControlStrip>
+
+      <form id="harness-create-form" onSubmit={handleSubmit}>
+        <PageColumns>
+          <PageMain>
+            <Card id="identity" className="scroll-mt-6">
+              <CardHeader>
+                <CardTitle>Identity</CardTitle>
+                <CardDescription>How the harness is named and found</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    placeholder="my-harness"
+                    value={formData.name}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    aria-invalid={!!fieldErrors.name}
+                    required
+                  />
+                  {fieldErrors.name && (
+                    <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                  )}
+                  {formData.name.length >= 2 && (
+                    <div className="flex items-center gap-1.5 text-xs">
+                      {nameAvailability.isChecking ? (
+                        <>
+                          <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                          <span className="text-muted-foreground">Checking availability…</span>
+                        </>
+                      ) : nameAvailability.available === true ? (
+                        <>
+                          <Check className="w-3 h-3 text-green-600" />
+                          <span className="text-green-600">Name is available</span>
+                        </>
+                      ) : nameAvailability.available === false ? (
+                        <>
+                          <X className="w-3 h-3 text-destructive" />
+                          <span className="text-destructive">Name is already taken or invalid</span>
+                        </>
+                      ) : null}
+                    </div>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+                  </p>
                 </div>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
-              </p>
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="display_name">Display Name</Label>
-              <Input
-                id="display_name"
-                placeholder={formData.name ? undefined : "My Harness"}
-                value={formData.display_name}
-                onChange={(e) => handleDisplayNameChange(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Optional human-readable label shown in the UI. Defaults to name if empty.
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="display_name">Display Name</Label>
+                  <Input
+                    id="display_name"
+                    placeholder={formData.name ? undefined : "My Harness"}
+                    value={formData.display_name}
+                    onChange={(e) => handleDisplayNameChange(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Optional human-readable label shown in the UI. Defaults to name if empty.
+                  </p>
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
-              <Textarea
-                id="description"
-                placeholder="Describe what this harness does..."
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                rows={2}
-              />
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    placeholder="Describe what this harness does..."
+                    value={formData.description}
+                    onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                    rows={2}
+                  />
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="tags">Tags</Label>
-              <Input
-                id="tags"
-                placeholder="tag1, tag2, tag3"
-                value={formData.tags}
-                onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
-              />
-              <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="tags">Tags</Label>
+                  <TagInput
+                    id="tags"
+                    placeholder="Add a tag…"
+                    value={formData.tags}
+                    onChange={(value) => setFormData((prev) => ({ ...prev, tags: value }))}
+                    disabled={createHarness.isPending}
+                    aria-describedby="tags-help"
+                  />
+                  <p id="tags-help" className="text-xs text-muted-foreground">
+                    Press Enter or comma to add a tag. Backspace removes the last tag.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
 
-            <div className="space-y-2">
-              <Label htmlFor="parent-harness">Parent Harness</Label>
-              <HarnessSelect
-                value={formData.parent_harness_id}
-                onValueChange={(value) => setFormData({ ...formData, parent_harness_id: value })}
-                placeholder="No parent harness"
-                includeNoneOption
-                noneLabel="No parent harness"
-                disabled={createHarness.isPending}
-              />
-              <p className="text-xs text-muted-foreground">
-                Inherit system prompt, capabilities, initial files, and default model from another
-                harness.
-              </p>
-            </div>
+            <Card id="behavior" className="scroll-mt-6">
+              <CardHeader>
+                <CardTitle>Behavior</CardTitle>
+                <CardDescription>Inheritance, model, and base instructions</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid gap-6 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="parent-harness">Parent Harness</Label>
+                    <HarnessSelect
+                      id="parent-harness"
+                      value={formData.parent_harness_id}
+                      onValueChange={(value) =>
+                        setFormData({ ...formData, parent_harness_id: value })
+                      }
+                      placeholder="No parent harness"
+                      includeNoneOption
+                      noneLabel="No parent harness"
+                      disabled={createHarness.isPending}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Inherit system prompt, capabilities, initial files, and default model from
+                      another harness.
+                    </p>
+                  </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="model">Model (optional)</Label>
-              <ModelPicker
-                value={formData.default_model_id}
-                onChange={(value) => setFormData({ ...formData, default_model_id: value })}
-                placeholder="Use default model"
-              />
-              <p className="text-xs text-muted-foreground">
-                Select a specific model or leave empty to use the default
-              </p>
-            </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="model">Model (optional)</Label>
+                    <ModelPicker
+                      value={formData.default_model_id}
+                      onChange={(value) => setFormData({ ...formData, default_model_id: value })}
+                      placeholder="Use default model"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Select a specific model or leave empty to use the default
+                    </p>
+                  </div>
+                </div>
 
-            <div className="space-y-2">
-              <Label>Capabilities (optional)</Label>
-              <CapabilitySelector
-                capabilities={allCapabilities}
-                selected={selectedCapabilities}
-                onChange={handleCapabilitiesChange}
-                disabled={createHarness.isPending}
-                label=""
-              />
-              <p className="text-xs text-muted-foreground">
-                Add capabilities to give your harness tools and specialized behaviors
-              </p>
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="system_prompt">System Prompt (optional)</Label>
+                  <PromptEditor
+                    id="system_prompt"
+                    placeholder="You are a helpful assistant..."
+                    value={formData.system_prompt}
+                    onChange={(value) => {
+                      setFormData({ ...formData, system_prompt: value });
+                      setFieldErrors((prev) => ({ ...prev, system_prompt: undefined }));
+                    }}
+                  />
+                  {fieldErrors.system_prompt && (
+                    <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Base instructions for the AI model (supports Markdown). Leave empty to
+                    contribute no base prompt — the parent harness, agent, session, and capabilities
+                    still apply.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
 
-            <div className="space-y-2">
-              <Label htmlFor="system_prompt">System Prompt (optional)</Label>
-              <PromptEditor
-                id="system_prompt"
-                placeholder="You are a helpful assistant..."
-                value={formData.system_prompt}
-                onChange={(value) => {
-                  setFormData({ ...formData, system_prompt: value });
-                  setFieldErrors((prev) => ({ ...prev, system_prompt: undefined }));
-                }}
-              />
-              {fieldErrors.system_prompt && (
-                <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Base instructions for the AI model (supports Markdown). Leave empty to contribute no
-                base prompt — the parent harness, agent, session, and capabilities still apply.
-              </p>
-            </div>
+            <Card id="files" className="scroll-mt-6">
+              <CardContent className="pt-6">
+                <InitialFilesEditor
+                  value={initialFiles}
+                  onChange={setInitialFiles}
+                  disabled={createHarness.isPending}
+                  description="Seed starter files into every session created from this harness."
+                />
+              </CardContent>
+            </Card>
 
-            <InitialFilesEditor
-              value={initialFiles}
-              onChange={setInitialFiles}
-              disabled={createHarness.isPending}
-              description="Seed starter files into every session created from this harness."
-            />
+            <Card id="network" className="scroll-mt-6">
+              <CardContent className="pt-6">
+                <NetworkAccessEditor
+                  value={networkAccess}
+                  onChange={setNetworkAccess}
+                  disabled={createHarness.isPending}
+                  description="Set the baseline network policy. Agents and sessions can only narrow it, never widen it."
+                />
+              </CardContent>
+            </Card>
+          </PageMain>
 
-            <div className="flex gap-4">
-              <Button type="submit" disabled={createHarness.isPending}>
-                {createHarness.isPending ? "Creating..." : "Create Harness"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
-                Cancel
-              </Button>
-            </div>
+          <PageRail>
+            <Card>
+              <CardHeader>
+                <CardTitle>Capabilities</CardTitle>
+                <CardDescription>Tools and specialized behaviors</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <CapabilitySelector
+                  capabilities={allCapabilities}
+                  selected={selectedCapabilities}
+                  onChange={handleCapabilitiesChange}
+                  disabled={createHarness.isPending}
+                />
+              </CardContent>
+            </Card>
 
             {createHarness.error && (
               <p className="text-sm text-destructive">Error: {createHarness.error.message}</p>
             )}
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+          </PageRail>
+        </PageColumns>
+      </form>
+
+      <PageFooter>
+        <BackLink href="/harnesses">Back to Harnesses</BackLink>
+      </PageFooter>
+    </PageContainer>
   );
 }

--- a/apps/ui/src/components/layout/index.ts
+++ b/apps/ui/src/components/layout/index.ts
@@ -17,6 +17,7 @@ export {
   PageMasthead,
   PageControlStrip,
   SectionTabs,
+  PageJumpNav,
   EmptyState,
   StatCard,
   StatGrid,
@@ -27,4 +28,4 @@ export {
   PageFooter,
   BackLink,
 } from "./page-layout";
-export type { BreadcrumbItem, SectionTabItem } from "./page-layout";
+export type { BreadcrumbItem, PageJumpNavItem, SectionTabItem } from "./page-layout";

--- a/apps/ui/src/components/layout/page-layout.tsx
+++ b/apps/ui/src/components/layout/page-layout.tsx
@@ -16,7 +16,7 @@
 
 import { Fragment, type ReactNode } from "react";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { EntityIdentity } from "@/components/ui/entity-identity";
 import { cn } from "@/lib/utils";
 
@@ -314,6 +314,44 @@ export function SectionTabs({
         );
       })}
     </div>
+  );
+}
+
+export interface PageJumpNavItem {
+  href: `#${string}`;
+  label: ReactNode;
+}
+
+/** Compact in-page navigation for long create and edit forms. */
+export function PageJumpNav({
+  items,
+  className,
+}: {
+  items: PageJumpNavItem[];
+  className?: string;
+}) {
+  return (
+    <nav
+      aria-label="Jump to section"
+      className={cn(
+        "flex max-w-full items-center gap-3 overflow-x-auto py-2 text-[13px] text-muted-foreground",
+        className,
+      )}
+    >
+      <span className="inline-flex shrink-0 items-center gap-1.5">
+        <ArrowRight className="size-3.5" />
+        Jump to
+      </span>
+      {items.map((item) => (
+        <a
+          key={item.href}
+          href={item.href}
+          className="shrink-0 transition-colors hover:text-foreground"
+        >
+          {item.label}
+        </a>
+      ))}
+    </nav>
   );
 }
 


### PR DESCRIPTION
## What changed
Restructures Agent and Harness create/edit pages around the shared five-zone page layout. Long forms are split into Identity, Behavior, Files, and Network cards with in-page jump navigation, a dedicated capabilities rail, masthead actions, and consistent footers.

New Agent now supports tags, and both create flows expose and submit the existing network-access policy fields.

## Why
The Agent Edit proposal had only been applied to the outer shell, leaving the form as a monolithic Details card. New Agent and Harness pages still used the older single-card layout. This completes the proposal and keeps create/edit experiences aligned.

## Before / After
Before: Agent/Harness edit forms grouped all fields into one Details card, while create pages used a standalone card without the shared masthead, control strip, rail, or footer.

After: live local captures confirmed the shared masthead, jump navigation, Identity/Capabilities columns, separate Behavior/Files/Network cards, and footer on New Agent, Agent Edit, and New Harness. Harness Edit uses the same section components and passed production build and type checks; the local fixture contained only built-in harnesses, which intentionally redirect away from edit.

Evidence:
- `pnpm exec jest --runInBand`: 162 suites, 1,325 tests passed
- `pnpm run typecheck`, `pnpm run lint`, and `pnpm run build` passed
- `just pre-push`: all 10 repository gates passed after rebasing onto latest `origin/main`
- Live local browser smoke test against a real backend covered `/agents/new`, `/agents/{id}/edit`, section jump navigation, `/harnesses/new`, and Files/Network sections

## Risk
- Low
- Visual layout or responsive stacking could regress on the four editor pages. Existing form state and mutations remain intact; new tests cover create-page structure and network payloads, and the full UI suite/build passed.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new security boundary was introduced. Labels and anchor targets are static React content, form values continue through existing validated JSON APIs, and no raw HTML, external URLs, auth/tenant behavior, secrets, dependencies, or unbounded work were added. No threat-model update required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
