### PR TITLE
feat(chat): address participants with mentions

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -10,6 +10,8 @@ const mockUseFeatureFlag = jest.fn((..._args: unknown[]) => false);
 const mockStartSessionVoice = jest.fn();
 const mockEndSessionVoice = jest.fn();
 const mockModelEffortMenu = jest.fn((_props: Record<string, unknown>) => null);
+const mockParticipants: Array<Record<string, unknown>> = [];
+const mockAgents: Array<Record<string, unknown>> = [];
 
 const mockSessionContext = {
   agentId: "agent-1",
@@ -62,8 +64,8 @@ jest.mock("@/components/session/session-participants-rail", () => ({
 jest.mock("@/hooks", () => ({
   useModels: () => ({ data: [], isLoading: false }),
   useProviders: () => ({ data: [] }),
-  useAgents: () => ({ data: [] }),
-  useSessionParticipants: () => ({ data: [] }),
+  useAgents: () => ({ data: mockAgents }),
+  useSessionParticipants: () => ({ data: mockParticipants }),
   useImageAttachments: () => ({
     pendingImages: [],
     allUploaded: true,
@@ -216,6 +218,8 @@ beforeEach(() => {
   mockUseFeatureFlag.mockReturnValue(false);
   mockStartSessionVoice.mockReset();
   mockEndSessionVoice.mockReset();
+  mockParticipants.length = 0;
+  mockAgents.length = 0;
 });
 
 describe("ChatPanel compaction divider", () => {
@@ -352,6 +356,116 @@ describe("ChatPanel placeholder", () => {
     expect(
       screen.getByPlaceholderText("Type a message or / for commands... (Enter to send)"),
     ).toBeInTheDocument();
+  });
+
+  it("addresses a message through an in-composer participant mention", async () => {
+    mockParticipants.push(
+      {
+        id: "part_host",
+        session_id: "session-1",
+        principal_id: "principal-host",
+        agent_id: "agent-1",
+        display_name: "Host",
+        kind: "agent",
+        role: "host",
+        joined_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "part_guest_123456",
+        session_id: "session-1",
+        principal_id: "principal-guest",
+        agent_id: "agent-2",
+        display_name: "Researcher",
+        kind: "agent",
+        role: "member",
+        joined_at: "2026-01-01T00:00:00Z",
+      },
+    );
+    mockSessionContext.sendMessage.mutateAsync.mockResolvedValueOnce(undefined);
+
+    render(<ChatPanel />);
+
+    const textarea = screen.getByPlaceholderText("Type a message... (Enter to send)");
+    fireEvent.change(textarea, { target: { value: "@", selectionStart: 1 } });
+
+    expect(screen.getByRole("listbox", { name: "Address a participant" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Researcher/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Host/ })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" });
+    expect(screen.getByTestId("participant-mention-token")).toHaveTextContent("Researcher");
+
+    fireEvent.change(textarea, { target: { value: "Summarize the findings", selectionStart: 22 } });
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" });
+
+    await waitFor(() =>
+      expect(mockSessionContext.sendMessage.mutateAsync).toHaveBeenCalledWith({
+        sessionId: "session-1",
+        content: "Summarize the findings",
+        controls: { locale: "en-US" },
+        addressedParticipantId: "part_guest_123456",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId("participant-mention-token")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("disambiguates duplicate participant display names and supports mention removal", () => {
+    mockParticipants.push(
+      {
+        id: "part_guest_aaaaaa",
+        session_id: "session-1",
+        principal_id: "principal-a",
+        display_name: "Helper",
+        kind: "agent",
+        role: "member",
+        joined_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "part_guest_bbbbbb",
+        session_id: "session-1",
+        principal_id: "principal-b",
+        display_name: "Helper",
+        kind: "agent",
+        role: "member",
+        joined_at: "2026-01-01T00:00:00Z",
+      },
+    );
+
+    render(<ChatPanel />);
+
+    const textarea = screen.getByPlaceholderText("Type a message... (Enter to send)");
+    fireEvent.change(textarea, { target: { value: "@help", selectionStart: 5 } });
+    fireEvent.click(screen.getByRole("option", { name: /Helper \(bbbbbb\)/ }));
+
+    expect(screen.getByTestId("participant-mention-token")).toHaveTextContent("Helper (bbbbbb)");
+    fireEvent.keyDown(textarea, { key: "Backspace", code: "Backspace" });
+    expect(screen.queryByTestId("participant-mention-token")).not.toBeInTheDocument();
+  });
+
+  it("shows mention empty states without interfering with slash commands", () => {
+    mockUseSessionCommands.mockReturnValue({
+      data: {
+        commands: [{ name: "clear", description: "Clear the session", source: "system" }],
+      },
+    });
+
+    render(<ChatPanel />);
+
+    const textarea = screen.getByPlaceholderText(
+      "Type a message or / for commands... (Enter to send)",
+    );
+    fireEvent.change(textarea, { target: { value: "@", selectionStart: 1 } });
+    expect(screen.getByText("No participants available")).toBeInTheDocument();
+
+    fireEvent.keyDown(textarea, { key: "Escape", code: "Escape" });
+    expect(screen.queryByText("No participants available")).not.toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: "/", selectionStart: 1 } });
+    expect(
+      screen.queryByRole("listbox", { name: "Address a participant" }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not render a top border between messages and composer", () => {

--- a/apps/ui/src/__tests__/participant-mention-autocomplete.test.tsx
+++ b/apps/ui/src/__tests__/participant-mention-autocomplete.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  getMentionQuery,
+  ParticipantMentionAutocomplete,
+} from "@/components/chat/participant-mention-autocomplete";
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+describe("getMentionQuery", () => {
+  it("finds a mention at the start or after whitespace", () => {
+    expect(getMentionQuery("@rese", 5)).toEqual({ start: 0, end: 5, query: "rese" });
+    expect(getMentionQuery("ask @help later", 9)).toEqual({ start: 4, end: 9, query: "help" });
+  });
+
+  it("does not treat email addresses or completed mention text as queries", () => {
+    expect(getMentionQuery("person@example.com", 18)).toBeNull();
+    expect(getMentionQuery("@helper continue", 16)).toBeNull();
+  });
+});
+
+describe("ParticipantMentionAutocomplete", () => {
+  it("supports keyboard navigation and selection", () => {
+    const onSelect = jest.fn();
+    render(
+      <ParticipantMentionAutocomplete
+        options={[
+          { id: "part_one", label: "Researcher" },
+          { id: "part_two", label: "Writer" },
+        ]}
+        query=""
+        visible
+        onDismiss={jest.fn()}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    fireEvent.keyDown(document, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledWith({ id: "part_two", label: "Writer" });
+  });
+
+  it("announces a no-match state and dismisses it with Escape", () => {
+    const onDismiss = jest.fn();
+    render(
+      <ParticipantMentionAutocomplete
+        options={[{ id: "part_one", label: "Researcher" }]}
+        query="writer"
+        visible
+        onDismiss={onDismiss}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No matching participants")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/src/components/chat/chat-composer.tsx
+++ b/apps/ui/src/components/chat/chat-composer.tsx
@@ -6,7 +6,7 @@
  */
 "use client";
 
-import { ImagePlus, Loader2, Mic, MicOff, Send, StopCircle } from "lucide-react";
+import { AtSign, ImagePlus, Loader2, Mic, MicOff, Send, StopCircle, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { ModelEffortMenu } from "@/components/chat/model-effort-menu";
@@ -15,7 +15,14 @@ import {
   CommandAutocomplete,
   shouldShowCommandAutocomplete,
 } from "@/components/chat/command-autocomplete";
+import {
+  getMentionQuery,
+  ParticipantMentionAutocomplete,
+  type MentionQuery,
+  type ParticipantMentionOption,
+} from "@/components/chat/participant-mention-autocomplete";
 import { chatSurfaceStyles } from "@/components/chat/chat-surface";
+import { COMPOSER_AUTOCOMPLETE_LISTBOX_ID } from "@/components/chat/composer-autocomplete";
 import { cn } from "@/lib/utils";
 import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
 import type {
@@ -36,6 +43,9 @@ export function ChatComposer({
   onInputChange,
   onSubmit,
   onCommandSelect,
+  mentionOptions = [],
+  selectedMention = null,
+  onMentionChange,
   pendingImages,
   hasImages,
   removeImage,
@@ -77,6 +87,9 @@ export function ChatComposer({
   onInputChange: (value: string) => void;
   onSubmit: (controls?: Controls) => Promise<void>;
   onCommandSelect: (cmd: CommandDescriptor, controls?: Controls) => Promise<void> | void;
+  mentionOptions?: ParticipantMentionOption[];
+  selectedMention?: ParticipantMentionOption | null;
+  onMentionChange?: (participant: ParticipantMentionOption | null) => void;
   pendingImages: PendingImage[];
   hasImages: boolean;
   removeImage: (tempId: string) => void;
@@ -115,6 +128,7 @@ export function ChatComposer({
   const { backendLocale, t } = useLocale();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showCommands, setShowCommands] = useState(false);
+  const [mentionQuery, setMentionQuery] = useState<MentionQuery | null>(null);
   const hasCommands = commands.length > 0;
   const inputPlaceholder = hasCommands ? t("type_message_or_commands") : t("type_message");
 
@@ -139,11 +153,22 @@ export function ChatComposer({
     if (!canSubmit) return;
     await onSubmit(buildControls());
     setShowCommands(false);
+    setMentionQuery(null);
     textareaRef.current?.focus();
   };
 
   const handleKeyDown = async (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (showCommands) return;
+    if (showCommands || mentionQuery) return;
+    if (
+      event.key === "Backspace" &&
+      selectedMention &&
+      inputValue.length === 0 &&
+      onMentionChange
+    ) {
+      event.preventDefault();
+      onMentionChange(null);
+      return;
+    }
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       await onSubmit(buildControls());
@@ -156,6 +181,18 @@ export function ChatComposer({
       addFiles(Array.from(files));
     }
     event.target.value = "";
+  };
+
+  const selectMention = (option: ParticipantMentionOption) => {
+    if (!mentionQuery || !onMentionChange) return;
+    const nextValue = `${inputValue.slice(0, mentionQuery.start)}${inputValue.slice(mentionQuery.end)}`;
+    onInputChange(nextValue);
+    onMentionChange(option);
+    setMentionQuery(null);
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      textareaRef.current?.setSelectionRange(mentionQuery.start, mentionQuery.start);
+    });
   };
 
   return (
@@ -180,6 +217,13 @@ export function ChatComposer({
           )}
           {...dropZoneProps}
         >
+          <ParticipantMentionAutocomplete
+            options={mentionOptions}
+            query={mentionQuery?.query ?? ""}
+            visible={mentionQuery !== null}
+            onSelect={selectMention}
+            onDismiss={() => setMentionQuery(null)}
+          />
           <CommandAutocomplete
             commands={commands}
             inputValue={inputValue}
@@ -190,18 +234,47 @@ export function ChatComposer({
             }}
             onDismiss={() => setShowCommands(false)}
           />
+          {selectedMention && onMentionChange && (
+            <div className="flex px-3 pt-3 sm:px-4" data-testid="participant-mention-token">
+              <span className="inline-flex max-w-full items-center gap-1 border border-accent/40 bg-[hsl(var(--accent)/0.08)] px-2 py-1 text-xs font-medium text-foreground">
+                <AtSign className="h-3 w-3 shrink-0 text-accent" />
+                <span className="truncate">{selectedMention.label}</span>
+                <button
+                  type="button"
+                  className="ml-1 inline-flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                  aria-label={`Remove mention of ${selectedMention.label}`}
+                  onClick={() => {
+                    onMentionChange(null);
+                    textareaRef.current?.focus();
+                  }}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            </div>
+          )}
           <Textarea
             ref={textareaRef}
             value={inputValue}
             onChange={(event) => {
               const value = event.target.value;
               onInputChange(value);
-              setShowCommands(hasCommands && shouldShowCommandAutocomplete(value));
+              const nextMentionQuery = getMentionQuery(value, event.target.selectionStart);
+              setMentionQuery(nextMentionQuery);
+              setShowCommands(
+                nextMentionQuery === null && hasCommands && shouldShowCommandAutocomplete(value),
+              );
             }}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             placeholder={inputPlaceholder}
             className={chatSurfaceStyles.composerTextarea}
+            role={mentionQuery || showCommands ? "combobox" : undefined}
+            aria-autocomplete={mentionQuery || showCommands ? "list" : undefined}
+            aria-expanded={mentionQuery !== null || showCommands}
+            aria-controls={
+              mentionQuery || showCommands ? COMPOSER_AUTOCOMPLETE_LISTBOX_ID : undefined
+            }
           />
         </div>
 

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -18,6 +18,8 @@ import {
   useTurnKeyboardNavigation,
 } from "@/hooks";
 import { getDisplayName } from "@/lib/entity-lifecycle";
+import { getSessionParticipantLabel } from "@/lib/session-participant-label";
+import type { ParticipantMentionOption } from "@/components/chat/participant-mention-autocomplete";
 import { useChatModelSelection } from "@/hooks/use-chat-model-selection";
 import { executeSessionCommand } from "@/lib/api/commands";
 import { ApiError } from "@/lib/api/client";
@@ -32,13 +34,6 @@ import { ChatComposer } from "@/components/chat/chat-composer";
 import { MessageContent } from "@/components/chat/message-content";
 import { SessionTaskChips } from "@/components/session/session-task-chips";
 import { SessionParticipantsRail } from "@/components/session/session-participants-rail";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { StreamingMessage } from "@/components/streaming-message";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { Button } from "@/components/ui/button";
@@ -470,9 +465,6 @@ export function ChatPanel() {
     [executeCommand, persistSelection, setInputValue],
   );
 
-  // Addressing: a compact selector lets the user route a turn to a specific
-  // guest agent. Only surfaced when the session has ≥2 active agent
-  // participants; the default (none) preserves host-responds behavior.
   const agentNameById = useMemo(() => {
     const map = new Map<string, string>();
     for (const agent of agents ?? []) {
@@ -489,10 +481,24 @@ export function ChatPanel() {
     () => activeAgentParticipants.filter((p) => p.role !== "host"),
     [activeAgentParticipants],
   );
-  const showAddressing = activeAgentParticipants.length >= 2 && addressableParticipants.length > 0;
+  const mentionOptions = useMemo<ParticipantMentionOption[]>(() => {
+    const labels = addressableParticipants.map((participant) =>
+      getSessionParticipantLabel(participant, agentNameById),
+    );
+    const labelCounts = new Map<string, number>();
+    for (const label of labels) labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
 
-  // Drop a stale selection if the addressed participant leaves or the session
-  // changes, so a departed guest can't silently keep receiving turns.
+    return addressableParticipants.map((participant, index) => {
+      const label = labels[index];
+      const suffix = participant.id.replace(/^part_/, "").slice(-6);
+      return {
+        id: participant.id,
+        label: labelCounts.get(label)! > 1 ? `${label} (${suffix})` : label,
+        description: `Guest agent · ${suffix}`,
+      };
+    });
+  }, [addressableParticipants, agentNameById]);
+
   useEffect(() => {
     if (
       addressedParticipantId &&
@@ -502,8 +508,8 @@ export function ChatPanel() {
     }
   }, [addressableParticipants, addressedParticipantId]);
 
-  const addressedParticipantLabel = (p: (typeof addressableParticipants)[number]): string =>
-    (p.agent_id && agentNameById.get(p.agent_id)) || "Agent";
+  const selectedMention =
+    mentionOptions.find((participant) => participant.id === addressedParticipantId) ?? null;
 
   const submitMessage = async (controls?: Controls) => {
     if (!canSubmit) return;
@@ -541,6 +547,7 @@ export function ChatPanel() {
 
       persistSelection();
       setInputValue("");
+      setAddressedParticipantId(null);
       setIsWaitingForResponse(true);
     } catch (error) {
       console.error("Failed to send message:", error);
@@ -658,37 +665,6 @@ export function ChatPanel() {
             hasTasksFeature={hasTasksFeature}
           />
 
-          {showAddressing && (
-            <div className="flex items-center gap-2 px-3 pt-2 sm:px-4">
-              <span className="text-xs text-muted-foreground">Address</span>
-              <Select
-                value={addressedParticipantId ?? "__host__"}
-                onValueChange={(value) =>
-                  setAddressedParticipantId(value === "__host__" ? null : value)
-                }
-              >
-                <SelectTrigger size="sm" className="h-7 w-auto min-w-40">
-                  <SelectValue>
-                    {addressedParticipantId
-                      ? addressedParticipantLabel(
-                          addressableParticipants.find((p) => p.id === addressedParticipantId) ??
-                            addressableParticipants[0],
-                        )
-                      : "Session host (default)"}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__host__">Session host (default)</SelectItem>
-                  {addressableParticipants.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {addressedParticipantLabel(p)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
           <ChatComposer
             commands={commands}
             models={models}
@@ -696,6 +672,9 @@ export function ChatPanel() {
             onInputChange={setInputValue}
             onSubmit={submitMessage}
             onCommandSelect={handleCommandSelect}
+            mentionOptions={mentionOptions}
+            selectedMention={selectedMention}
+            onMentionChange={(participant) => setAddressedParticipantId(participant?.id ?? null)}
             pendingImages={pendingImages}
             hasImages={hasImages}
             removeImage={removeImage}

--- a/apps/ui/src/components/chat/chat-surface.ts
+++ b/apps/ui/src/components/chat/chat-surface.ts
@@ -15,7 +15,7 @@ export const chatSurfaceStyles = {
     "animate-chat-row-in flex-1 space-y-1.5 border-l border-l-primary/65 bg-card/90 px-3 py-2.5 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
   composerSection: "bg-background/55 px-3 pb-3 pt-2.5 backdrop-blur-[1px] sm:px-4",
   composerInputShell:
-    "relative overflow-hidden border border-border/70 bg-background/95 shadow-[0_1px_0_hsl(var(--background)/0.88)] transition-[background-color,border-color,box-shadow] duration-200 focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/10",
+    "relative border border-border/70 bg-background/95 shadow-[0_1px_0_hsl(var(--background)/0.88)] transition-[background-color,border-color,box-shadow] duration-200 focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/10",
   composerControlChip:
     "flex h-8 items-center gap-1.5 border border-border/70 bg-card/85 px-2 text-[13px] shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
   composerIconButton: "h-8 w-8 border-border/70 bg-card/85 shadow-none hover:bg-muted/40",

--- a/apps/ui/src/components/chat/command-autocomplete.tsx
+++ b/apps/ui/src/components/chat/command-autocomplete.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
 import { Terminal, Sparkles } from "lucide-react";
-import { cn } from "@/lib/utils";
 import type { CommandDescriptor } from "@/lib/api/types";
+import { ComposerAutocomplete } from "@/components/chat/composer-autocomplete";
 
 interface CommandAutocompleteProps {
   commands: CommandDescriptor[];
@@ -20,80 +19,22 @@ export function CommandAutocomplete({
   onDismiss,
   visible,
 }: CommandAutocompleteProps) {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const listRef = useRef<HTMLDivElement>(null);
-
-  // Filter commands based on input after "/"
   const query = inputValue.startsWith("/") ? inputValue.slice(1).toLowerCase() : "";
   const filtered = commands.filter(
     (cmd) =>
       cmd.name.toLowerCase().includes(query) || cmd.description.toLowerCase().includes(query),
   );
 
-  // Reset selection when filter changes.
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [query]);
-
-  // Scroll selected item into view
-  useEffect(() => {
-    if (!listRef.current) return;
-    const items = listRef.current.querySelectorAll("[data-command-item]");
-    items[selectedIndex]?.scrollIntoView({ block: "nearest" });
-  }, [selectedIndex]);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (!visible || filtered.length === 0) return;
-
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSelectedIndex((i) => (i + 1) % filtered.length);
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSelectedIndex((i) => (i - 1 + filtered.length) % filtered.length);
-      } else if (e.key === "Enter" || e.key === "Tab") {
-        e.preventDefault();
-        onSelect(filtered[selectedIndex]);
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        onDismiss();
-      }
-    },
-    [visible, filtered, selectedIndex, onSelect, onDismiss],
-  );
-
-  useEffect(() => {
-    if (visible) {
-      document.addEventListener("keydown", handleKeyDown, true);
-      return () => document.removeEventListener("keydown", handleKeyDown, true);
-    }
-  }, [visible, handleKeyDown]);
-
-  if (!visible || filtered.length === 0) return null;
-
   return (
-    <div
-      ref={listRef}
-      className="absolute bottom-full left-0 right-0 z-50 mb-2 max-h-[240px] overflow-y-auto border border-border bg-card p-1"
-    >
-      {filtered.map((cmd, i) => (
-        <button
-          key={cmd.name}
-          data-command-item
-          type="button"
-          className={cn(
-            "flex w-full items-center gap-2 px-2 py-2 text-sm outline-none select-none",
-            i === selectedIndex
-              ? "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)] text-foreground"
-              : "text-popover-foreground",
-          )}
-          onMouseEnter={() => setSelectedIndex(i)}
-          onMouseDown={(e) => {
-            e.preventDefault(); // Keep textarea focus
-            onSelect(cmd);
-          }}
-        >
+    <ComposerAutocomplete
+      emptyMessage="No matching commands"
+      items={filtered.map((command) => ({ ...command, id: command.name }))}
+      label="Commands"
+      onDismiss={onDismiss}
+      onSelect={onSelect}
+      visible={visible}
+      renderItem={(cmd) => (
+        <>
           {cmd.source === "system" ? (
             <Terminal className="icon-sharp h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
           ) : (
@@ -101,9 +42,9 @@ export function CommandAutocomplete({
           )}
           <span className="font-mono text-xs text-foreground">/{cmd.name}</span>
           <span className="text-xs text-muted-foreground truncate">{cmd.description}</span>
-        </button>
-      ))}
-    </div>
+        </>
+      )}
+    />
   );
 }
 

--- a/apps/ui/src/components/chat/composer-autocomplete.tsx
+++ b/apps/ui/src/components/chat/composer-autocomplete.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ComposerAutocompleteItem {
+  id: string;
+}
+
+export const COMPOSER_AUTOCOMPLETE_LISTBOX_ID = "composer-autocomplete-listbox";
+
+interface ComposerAutocompleteProps<T extends ComposerAutocompleteItem> {
+  emptyMessage: string;
+  items: T[];
+  label: string;
+  onDismiss: () => void;
+  onSelect: (item: T) => void;
+  renderItem: (item: T) => React.ReactNode;
+  visible: boolean;
+}
+
+export function ComposerAutocomplete<T extends ComposerAutocompleteItem>({
+  emptyMessage,
+  items,
+  label,
+  onDismiss,
+  onSelect,
+  renderItem,
+  visible,
+}: ComposerAutocompleteProps<T>) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const itemIds = items.map((item) => item.id).join("\0");
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [itemIds, visible]);
+
+  useEffect(() => {
+    if (!listRef.current || items.length === 0) return;
+    const options = listRef.current.querySelectorAll("[role='option']");
+    options[selectedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [items.length, selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!visible) return;
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onDismiss();
+        return;
+      }
+
+      if (items.length === 0) return;
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelectedIndex((index) => (index + 1) % items.length);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelectedIndex((index) => (index - 1 + items.length) % items.length);
+      } else if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        event.stopPropagation();
+        onSelect(items[selectedIndex]);
+      }
+    },
+    [items, onDismiss, onSelect, selectedIndex, visible],
+  );
+
+  useEffect(() => {
+    if (!visible) return;
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleKeyDown, visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      ref={listRef}
+      id={COMPOSER_AUTOCOMPLETE_LISTBOX_ID}
+      role="listbox"
+      aria-label={label}
+      className="absolute bottom-full left-0 right-0 z-50 mb-2 max-h-[min(240px,40vh)] overflow-y-auto border border-border bg-card p-1 shadow-lg"
+    >
+      {items.length === 0 ? (
+        <div className="px-3 py-2 text-sm text-muted-foreground">{emptyMessage}</div>
+      ) : (
+        items.map((item, index) => (
+          <button
+            key={item.id}
+            id={`composer-option-${item.id}`}
+            type="button"
+            role="option"
+            aria-selected={index === selectedIndex}
+            className={cn(
+              "flex w-full items-center gap-2 px-2 py-2 text-left text-sm outline-none select-none",
+              index === selectedIndex
+                ? "border-l-2 border-l-accent bg-[hsl(var(--accent)/0.08)] text-foreground"
+                : "text-popover-foreground",
+            )}
+            onMouseEnter={() => setSelectedIndex(index)}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => onSelect(item)}
+          >
+            {renderItem(item)}
+          </button>
+        ))
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/participant-mention-autocomplete.tsx
+++ b/apps/ui/src/components/chat/participant-mention-autocomplete.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { AtSign, Bot } from "lucide-react";
+import { ComposerAutocomplete } from "@/components/chat/composer-autocomplete";
+
+export interface ParticipantMentionOption {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface MentionQuery {
+  end: number;
+  query: string;
+  start: number;
+}
+
+export function getMentionQuery(value: string, cursor: number): MentionQuery | null {
+  const beforeCursor = value.slice(0, cursor);
+  const match = /(?:^|\s)@([^\s@]*)$/.exec(beforeCursor);
+  if (!match) return null;
+  const atIndex = beforeCursor.lastIndexOf("@");
+  return { start: atIndex, end: cursor, query: match[1] };
+}
+
+export function ParticipantMentionAutocomplete({
+  options,
+  query,
+  visible,
+  onDismiss,
+  onSelect,
+}: {
+  options: ParticipantMentionOption[];
+  query: string;
+  visible: boolean;
+  onDismiss: () => void;
+  onSelect: (option: ParticipantMentionOption) => void;
+}) {
+  const normalizedQuery = query.toLocaleLowerCase();
+  const filtered = options.filter((option) =>
+    `${option.label} ${option.description ?? ""}`.toLocaleLowerCase().includes(normalizedQuery),
+  );
+  const emptyMessage =
+    options.length === 0 ? "No participants available" : "No matching participants";
+
+  return (
+    <ComposerAutocomplete
+      emptyMessage={emptyMessage}
+      items={filtered}
+      label="Address a participant"
+      onDismiss={onDismiss}
+      onSelect={onSelect}
+      visible={visible}
+      renderItem={(option) => (
+        <>
+          <Bot className="icon-sharp h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1 font-medium text-foreground">
+              <AtSign className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{option.label}</span>
+            </div>
+            {option.description && (
+              <div className="truncate text-xs text-muted-foreground">{option.description}</div>
+            )}
+          </div>
+        </>
+      )}
+    />
+  );
+}

--- a/test_cases/ui/session_participants/TC002_address_participant_with_mention.md
+++ b/test_cases/ui/session_participants/TC002_address_participant_with_mention.md
@@ -1,0 +1,49 @@
+# TC002 Address participant with composer mention
+
+## Description
+
+Verify that a message can address an active guest agent through an accessible `@` mention in the
+shared chat composer without changing default session routing.
+
+## Preconditions
+
+- A local (`AUTH_MODE=none`) or authenticated deployed Everruns UI is available
+- A session with a host agent and at least two active guest agents is open
+- Two guests share a display name; a third guest has a distinct display name
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Duplicate guest name | `Participant Specialist` |
+| Distinct guest name | `Participant Researcher` |
+| Addressed message | `Reply with exactly: mentioned reply` |
+| Unaddressed message | `Reply with exactly: default reply` |
+
+## Steps
+
+1. Focus the composer, type `@`, and verify an autocomplete list appears above the composer with
+   active guest agents only.
+2. Type part of a participant name and verify the list filters. Type a non-matching query and verify
+   the no-match state, then press Escape and verify the list closes.
+3. Open the list again and use Arrow Up/Down followed by Enter to select `Participant Researcher`.
+4. Verify the selected participant renders as a removable mention token inside the composer. Remove
+   it, then select it again.
+5. Enter the addressed message, send it, and verify the successful message request contains the
+   selected guest's `addressed_participant_id`.
+6. Verify the mention clears after the successful send. Send the unaddressed message and verify its
+   request omits `addressed_participant_id`, preserving default routing.
+7. Type `/` at the beginning of an empty composer and verify slash-command autocomplete still works.
+8. Repeat steps 1 and 3 with the viewport at 390 px wide and verify the list and token remain usable
+   without horizontal overflow.
+9. Open `@Participant Specialist` and verify duplicate names have distinct participant suffixes.
+
+## Expected Result
+
+- `@` mention autocomplete is keyboard accessible, dismissible, filterable, and reports empty or
+  no-match states.
+- Only active addressable guest agents appear; duplicate display names are distinguishable.
+- A selected mention is clear and removable, routes the next message to that participant, and clears
+  after a successful send.
+- Messages without a mention keep the existing default routing.
+- Mention autocomplete coexists with slash commands and fits the mobile composer.


### PR DESCRIPTION
## What changed

Replaces the separate participant `Address` dropdown with `@` mentions inside the shared chat composer. Typing `@` opens an accessible participant autocomplete; selection creates a removable per-message token and sends the existing `addressed_participant_id`. The shared autocomplete primitive now serves both participant mentions and slash commands.

Active guest agents are filterable, duplicate display names receive stable participant suffixes, successful sends clear the mention, and unaddressed messages keep default routing. Keyboard selection, Escape, backspace removal, empty/no-match states, and mobile sizing are covered.

## Why

Participant routing should be expressed where users compose the message instead of through a detached selector above it. This makes the target explicit per message and removes persistent routing state after a send.

## Before / After

Before: session chat rendered a separate `Address` dropdown above the composer.

After: `@` opens an in-composer list and selection renders a clear removable token. Desktop autocomplete, selected-token, and 390 px mobile screenshots were captured during the canonical-stack smoke test. The runner lacked Cloudinary credentials, and its signed-in browser did not permit local-file uploads, so the images could not be attached to GitHub; they were inspected locally before push.

Manual network evidence:

- Addressed POST returned `201` with `"addressed_participant_id":"part_019fdf159cce7e0c80b6ca51a76b6e1c"`.
- The following unaddressed POST omitted `addressed_participant_id`.
- At 390 px, both the document and listbox remained within the viewport.

## Risk

- Low
- Risk is limited to composer keyboard/focus behavior and participant label presentation. The message API and backend routing implementation are unchanged.

## Security

- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: Participant labels and IDs remain React-escaped text; no raw HTML or new trust boundary was introduced. The selected ID is still submitted through the existing validated message API. Filtering is bounded by the session participant response. No new threat-model entry is required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)