### PR TITLE
feat(library): add the publishable `everruns` facade crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,8 @@ jobs:
             -p everruns-integrations-daytona \
             -p everruns-integrations-e2b \
             -p everruns-integrations-parallel \
-            -p everruns-runtime
+            -p everruns-runtime \
+            -p everruns
 
   knowledge:
     name: Knowledge Bundle (OKF v0.2)
@@ -452,6 +453,10 @@ jobs:
           # picked up automatically rather than silently skipped. `--features lua`
           # so the lua code-mode integration test compiles and runs in the same pass.
           cargo test -p everruns-runtime --features lua -- --test-threads=1
+          # everruns facade (EVE-830): whole crate — the facade_smoke integration
+          # test and the lib doctest both build one session and run one llmsim turn
+          # importing only `everruns`. Pure, no network/credentials.
+          cargo test -p everruns
           cargo run -p everruns-runtime --features lua --example lua_code_mode_agent
           # Runnable demonstration of the EVE-660 mount resolver (/workspace mount + cwd).
           cargo run -p everruns-runtime --example mount_fs_workspace

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -142,6 +142,10 @@ jobs:
               "crates/runtime/Cargo.toml": [
                   "everruns-core",
               ],
+              "crates/everruns/Cargo.toml": [
+                  "everruns-core",
+                  "everruns-runtime",
+              ],
               "crates/local/Cargo.toml": [
                   "everruns-core",
                   "everruns-runtime",
@@ -251,6 +255,7 @@ jobs:
             everruns-integrations-sprites
             everruns-runtime
             everruns-local
+            everruns
           )
 
           publish_status() {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns"
+version = "0.17.23"
+dependencies = [
+ "everruns-core",
+ "everruns-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "everruns-a2ui"
 version = "0.17.23"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "crates/server",
     "crates/worker",
+    "crates/everruns",
     "crates/core",
     "crates/provider",
     "crates/bedrock",
@@ -161,6 +162,7 @@ everruns-mcp = { path = "crates/mcp", version = "0.17.23" }
 everruns-ard = { path = "crates/ard", version = "0.17.23" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
 everruns-runtime = { path = "crates/runtime", version = "0.17.23" }
+everruns = { path = "crates/everruns", version = "0.17.23" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -1,0 +1,44 @@
+# The application-facing `everruns` library: a thin, publishable facade over the
+# existing in-process runtime.
+#
+# Decision (EVE-830): the first public `everruns` crate is a compatibility facade
+# over `everruns-core` and `everruns-runtime`. It moves no engine code and only
+# re-exports the minimum needed to construct and run the in-process runtime.
+# Default features stay offline — no provider, MCP, filesystem, SQLx, server, or
+# worker integrations are activated by default. The escape-hatch `everruns::core`
+# and `everruns::runtime` modules expose the underlying crates for APIs not yet
+# promoted onto the facade.
+
+[package]
+name = "everruns"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns"
+description = "Build and run durable AI agents in Rust — the application-facing entrypoint to the Everruns agentic framework"
+readme = "README.md"
+keywords = ["agent", "agentic", "coding-agent", "llm", "ai"]
+categories = ["development-tools", "asynchronous"]
+
+[features]
+# Default features stay offline: the facade activates no provider, MCP,
+# filesystem, SQLx, server, or worker integrations. Embedders opt into the
+# heavier surfaces through the escape-hatch modules or a later, promoted API.
+default = []
+# Compile the experimental sandboxed Lua execution engine into the runtime.
+# Mirrors `everruns-runtime/lua`; off by default so the standard facade build
+# pulls in no interpreter.
+lua = ["everruns-runtime/lua"]
+# Enable local-process (stdio) MCP servers, mirroring `everruns-runtime/mcp-stdio`.
+mcp-stdio = ["everruns-runtime/mcp-stdio"]
+
+[dependencies]
+everruns-core.workspace = true
+everruns-runtime.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -1,0 +1,49 @@
+# everruns
+
+The application-facing entrypoint to the [Everruns](https://everruns.com) agentic framework.
+
+`everruns` is a thin, publishable facade over the in-process runtime. Add a single dependency and
+run an agent turn — without wiring up `everruns-core` or `everruns-runtime` directly.
+
+This first release is a **compatibility facade**: it moves no engine code and re-exports the
+minimum needed to construct and run an in-process session. Default features stay offline — no
+provider, MCP, filesystem, SQLx, server, or worker integrations are activated by default. APIs not
+yet promoted onto the facade remain reachable through the escape-hatch `everruns::core` and
+`everruns::runtime` modules.
+
+## Example
+
+```rust
+use everruns::{DriverId, InProcessRuntimeBuilder, InputMessage, LlmSimConfig, ResolvedModel};
+
+#[tokio::main]
+async fn main() -> Result<(), everruns::AgentLoopError> {
+    let runtime = InProcessRuntimeBuilder::new()
+        .single_session(|s| {
+            s.harness("assistant", "You are a helpful assistant.")
+                .agent("assistant-agent", "Answer the user.")
+        })
+        .llm_sim(LlmSimConfig::fixed("4"))
+        .default_model(ResolvedModel {
+            model: "llmsim-model".into(),
+            provider_type: DriverId::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+            provider_metadata: None,
+        })
+        .build()
+        .await?;
+
+    let session_id = runtime.default_session_id().expect("single_session id");
+    let result = runtime
+        .run_turn(session_id, InputMessage::user("What is 2 + 2?"))
+        .await?;
+
+    assert_eq!(result.response, "4");
+    Ok(())
+}
+```
+
+## License
+
+MIT

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -1,0 +1,81 @@
+//! The application-facing entrypoint to the [Everruns](https://everruns.com)
+//! agentic framework.
+//!
+//! `everruns` is a thin, publishable facade over the existing in-process
+//! runtime. It re-exports the minimum needed to construct and run a session
+//! without depending on `everruns-core` or `everruns-runtime` directly, so an
+//! application can add a single dependency and run an agent turn.
+//!
+//! This first release is a **compatibility facade**: it moves no engine code.
+//! Default features stay offline — no provider, MCP, filesystem, SQLx, server,
+//! or worker integrations are activated. Anything not yet promoted onto the
+//! facade is reachable through the escape-hatch [`core`] and [`runtime`]
+//! modules.
+//!
+//! # Example
+//!
+//! Build one in-process session and run one simulated turn, importing only
+//! `everruns`:
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), everruns::AgentLoopError> {
+//! use everruns::{
+//!     DriverId, InProcessRuntimeBuilder, InputMessage, LlmSimConfig, ResolvedModel,
+//! };
+//!
+//! let runtime = InProcessRuntimeBuilder::new()
+//!     .single_session(|s| {
+//!         s.harness("assistant", "You are a helpful assistant.")
+//!             .harness_display_name("Assistant")
+//!             .agent("assistant-agent", "Answer the user.")
+//!             .agent_display_name("Assistant Agent")
+//!             .agent_max_iterations(4)
+//!             .session_title("Facade Smoke")
+//!     })
+//!     .llm_sim(LlmSimConfig::fixed("4"))
+//!     .default_model(ResolvedModel {
+//!         model: "llmsim-model".into(),
+//!         provider_type: DriverId::LlmSim,
+//!         api_key: Some("fake-key".into()),
+//!         base_url: None,
+//!         provider_metadata: None,
+//!     })
+//!     .build()
+//!     .await?;
+//!
+//! let session_id = runtime.default_session_id().expect("single_session id");
+//! let result = runtime
+//!     .run_turn(session_id, InputMessage::user("What is 2 + 2?"))
+//!     .await?;
+//!
+//! assert!(result.success);
+//! assert_eq!(result.response, "4");
+//! # Ok(())
+//! # }
+//! ```
+
+// --- Runtime construction and execution ---------------------------------
+pub use everruns_runtime::{
+    AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, SessionBuilder,
+    SingleSessionBuilder, TurnResult,
+};
+
+// --- Portable message, model, and platform types ------------------------
+pub use everruns_core::{
+    AgentLoopError, CapabilityRegistry, DriverId, DriverRegistry, InputMessage, PlatformDefinition,
+    ResolvedModel,
+};
+
+// --- Deterministic in-process LLM simulator -----------------------------
+pub use everruns_core::llmsim_driver::LlmSimConfig;
+
+/// Escape hatch onto the underlying `everruns-core` crate for APIs not yet
+/// promoted onto the facade. Prefer the re-exports above; reach here only for
+/// types the facade does not yet surface directly.
+pub use everruns_core as core;
+
+/// Escape hatch onto the underlying `everruns-runtime` crate for APIs not yet
+/// promoted onto the facade. Prefer the re-exports above; reach here only for
+/// types the facade does not yet surface directly.
+pub use everruns_runtime as runtime;

--- a/crates/everruns/tests/facade_smoke.rs
+++ b/crates/everruns/tests/facade_smoke.rs
@@ -1,0 +1,41 @@
+//! Facade smoke test (EVE-830): a clean program that depends only on `everruns`
+//! must be able to build one session and run one turn without importing
+//! `everruns-core` or `everruns-runtime`.
+
+use everruns::{DriverId, InProcessRuntimeBuilder, InputMessage, LlmSimConfig, ResolvedModel};
+
+#[tokio::test]
+async fn facade_runs_one_simulated_turn() {
+    let runtime = InProcessRuntimeBuilder::new()
+        .single_session(|s| {
+            s.harness("assistant", "You are a helpful assistant.")
+                .harness_display_name("Assistant")
+                .agent("assistant-agent", "Answer the user.")
+                .agent_display_name("Assistant Agent")
+                .agent_max_iterations(4)
+                .session_title("Facade Smoke")
+        })
+        .llm_sim(LlmSimConfig::fixed("4"))
+        .default_model(ResolvedModel {
+            model: "llmsim-model".into(),
+            provider_type: DriverId::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+            provider_metadata: None,
+        })
+        .build()
+        .await
+        .expect("runtime builds");
+
+    let session_id = runtime
+        .default_session_id()
+        .expect("single_session yields a default session id");
+
+    let result = runtime
+        .run_turn(session_id, InputMessage::user("What is 2 + 2?"))
+        .await
+        .expect("turn runs");
+
+    assert!(result.success, "turn should succeed: {:?}", result.error);
+    assert_eq!(result.response, "4");
+}

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -33,6 +33,7 @@ INNER_PINS: dict[str, list[str]] = {
     ],
     "crates/mcp/Cargo.toml": ["everruns-core"],
     "crates/runtime/Cargo.toml": ["everruns-core"],
+    "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime"],
     "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
     "crates/openai/Cargo.toml": ["everruns-provider"],
     "crates/anthropic/Cargo.toml": ["everruns-provider"],
@@ -54,7 +55,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard", "everruns"]
 
 
 def workspace_version() -> str:


### PR DESCRIPTION
## What changed

Adds `crates/everruns` (package name `everruns`) — the application-facing library crate. An application can now depend on a single `everruns` package and run an agent turn without importing `everruns-core` or `everruns-runtime` directly.

This first release is a **compatibility facade**: it moves no engine code and only re-exports the minimum needed to construct and run the existing in-process runtime:

- `InProcessRuntime`, `InProcessRuntimeBuilder`, `TurnResult`
- the runtime builders (`AgentBuilder`, `HarnessBuilder`, `SessionBuilder`, `SingleSessionBuilder`)
- `LlmSimConfig` and the portable message/model/platform types (`InputMessage`, `ResolvedModel`, `DriverId`, `DriverRegistry`, `CapabilityRegistry`, `PlatformDefinition`, `AgentLoopError`)
- escape-hatch modules `everruns::core` and `everruns::runtime` for APIs not yet promoted onto the facade

Also registers the crate in the workspace members, `[workspace.dependencies]`, the publish pin/order scripts (`scripts/sync-publish-pin-versions.py` + `publish-crates.yml`, no publish triggered here), and the MSRV + unit-test CI jobs.

## Why

`EVE-830` — first step of the everruns library epic: give embedders a single, publishable, application-facing dependency, built as a thin facade over the runtime before any code is moved. Blocks EVE-832 (`everruns::AgentBuilder`).

## Before / After

Before: an application had to depend on `everruns-core` **and** `everruns-runtime` and know both crate layouts to run a turn.

After: `tests/facade_smoke.rs` and the lib doctest each import **only** `everruns`, build one session, run one simulated (`llmsim`) turn, and assert the response:

```
$ cargo test -p everruns
test facade_runs_one_simulated_turn ... ok
   Doc-tests everruns ... ok
```

Default dependency snapshot (`cargo tree -p everruns -e normal --depth 1`):

```
everruns
├── everruns-core
└── everruns-runtime
```

`cargo package -p everruns --allow-dirty` succeeds. The default tree contains **no** `sqlx`, `everruns-server`, `everruns-worker`, provider, or MCP crates. `reqwest`/`axum`/`tonic` appear only transitively via `everruns-core`'s default `a2a`/`web-fetch`/`telemetry` features — the same footprint `everruns-runtime` already carries; feature unification keeps them active through runtime regardless of the facade's own features.

## Risk

- Low
- Additive only: a new leaf crate plus CI/publish-script registration. No existing crate's code or public API changes. The facade re-exports existing, tested types.

## Security

- Threat categories reviewed: no security-relevant code changes. The crate contains only `pub use` re-exports of already-reviewed `everruns-core`/`everruns-runtime` items plus one llmsim-only integration test; it adds no logic, no I/O, no auth, no input parsing, and activates no network/database/provider features by default.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. Slimming `everruns-core`'s default `a2a`/`web-fetch`/`telemetry` footprint and promoting richer ergonomics onto the facade are tracked by the later library/platform epic tickets (EVE-832 and the platform-extraction issues), not this compatibility facade.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PvE9qW7MEnQ5x67ktwmNk)_