### PR TITLE
feat(library): add `Agent::session()` and multi-turn `Session::run()`

### DIFF
--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -51,6 +51,30 @@ impl Model {
     }
 }
 
+#[cfg(test)]
+impl Model {
+    /// Test-only: a simulated model that records the provider-visible messages
+    /// of every LLM call into `capture`, in call order. Lets session tests
+    /// assert what history reached the provider on the second turn.
+    pub(crate) fn simulated_capturing(
+        response: impl Into<String>,
+        capture: std::sync::Arc<std::sync::Mutex<Vec<Vec<everruns_core::LlmMessage>>>>,
+    ) -> Self {
+        let mut sim = LlmSimConfig::fixed(response);
+        sim.message_capture = Some(capture);
+        Self {
+            resolved: ResolvedModel {
+                model: "llmsim-model".to_string(),
+                provider_type: DriverId::LlmSim,
+                api_key: Some("fake-key".to_string()),
+                base_url: None,
+                provider_metadata: None,
+            },
+            sim: Some(sim),
+        }
+    }
+}
+
 impl fmt::Debug for Model {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Redact the resolved model's api key; report only the shape.
@@ -90,12 +114,9 @@ impl std::error::Error for BuildError {}
 /// The immutable, validated description of an agent.
 ///
 /// Produced by [`AgentBuilder::build`]. It holds the value-first configuration
-/// and can materialize independent in-process runtimes from it; the underlying
-/// runtime composition is kept in private fields.
-// The stored configuration and `build_runtime` seam are exercised by this
-// crate's tests and consumed by the forthcoming session API (EVE-831); they are
-// intentionally private and not otherwise read in a non-test build yet.
-#[allow(dead_code)]
+/// and materializes independent in-process runtimes from it, one per
+/// [`session`](Agent::session); the underlying runtime composition is kept in
+/// private fields.
 #[derive(Clone, Debug)]
 pub struct Agent {
     name: String,
@@ -127,16 +148,27 @@ impl Agent {
         AgentBuilder::default()
     }
 
-    /// Materialize a fresh, independent in-process runtime for this agent.
+    /// Open a new, independent multi-turn [`Session`](crate::Session) with this
+    /// agent.
     ///
-    /// Each call assembles a new `Harness`/`Agent`/`Session` composition with
-    /// freshly generated ids, so two calls yield two independent sessions. This
-    /// is the private seam the public session API builds on; running turns is
-    /// out of scope for this type.
-    #[allow(dead_code)] // Consumed by the forthcoming session API (EVE-831).
-    async fn build_runtime(
+    /// The session is lazy: the in-process runtime is assembled on the first
+    /// [`Session::run`](crate::Session::run). Each session gets a fresh id and
+    /// its own history, so two sessions from the same agent never share
+    /// conversation state, and cloning an `Agent` never shares history.
+    pub fn session(&self) -> crate::Session {
+        crate::Session::new(self.clone(), SessionId::new())
+    }
+
+    /// Materialize a fresh in-process runtime for this agent, seeded with the
+    /// given session id.
+    ///
+    /// Each call assembles a new `Harness`/`Agent`/`Session` composition, so
+    /// distinct session ids yield independent sessions. This is the private
+    /// seam [`Session`](crate::Session) builds on.
+    pub(crate) async fn build_runtime(
         &self,
-    ) -> Result<(InProcessRuntime, SessionId), everruns_core::AgentLoopError> {
+        session_id: SessionId,
+    ) -> Result<InProcessRuntime, everruns_core::AgentLoopError> {
         let mut harness = HarnessBuilder::new(&self.name, &self.instructions)
             .capabilities(self.capabilities.clone());
         if let Some(parallel) = self.parallel_tool_calls {
@@ -158,6 +190,7 @@ impl Agent {
         let agent = agent.build();
 
         let mut session = SessionBuilder::new(harness_id)
+            .id(session_id)
             .agent(agent_id)
             .capabilities(self.capabilities.clone());
         if let Some(parallel) = self.parallel_tool_calls {
@@ -166,7 +199,6 @@ impl Agent {
         for file in &self.initial_files {
             session = session.initial_file(file.clone());
         }
-        let session_id = session.session_id();
         let session = session.build();
 
         let mut builder = InProcessRuntimeBuilder::new()
@@ -177,8 +209,7 @@ impl Agent {
         if let Some(sim) = &self.model.sim {
             builder = builder.llm_sim(sim.clone());
         }
-        let runtime = builder.build().await?;
-        Ok((runtime, session_id))
+        builder.build().await
     }
 }
 
@@ -303,16 +334,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn one_agent_creates_two_independent_sessions() {
+    async fn build_runtime_seeds_the_requested_session_id() {
         let agent = Agent::builder()
             .instructions("You are concise.")
             .model(Model::simulated("Sure."))
             .build()
             .expect("valid agent");
 
-        let (_first, a) = agent.build_runtime().await.expect("first runtime");
-        let (_second, b) = agent.build_runtime().await.expect("second runtime");
-
-        assert_ne!(a, b, "each session must be independent");
+        let session_id = SessionId::new();
+        let runtime = agent
+            .build_runtime(session_id)
+            .await
+            .expect("runtime builds");
+        // The seeded session id is usable directly: a caller can run a turn
+        // against it without going through `default_session_id`.
+        let result = runtime
+            .run_turn(session_id, everruns_core::InputMessage::user("hi"))
+            .await
+            .expect("turn runs");
+        assert!(result.success);
+        assert_eq!(result.response, "Sure.");
     }
 }

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -55,9 +55,11 @@
 //! # }
 //! ```
 
-// --- Value-first agent description ---------------------------------------
+// --- Value-first agent description and execution -------------------------
 mod agent;
+mod session;
 pub use agent::{Agent, AgentBuilder, BuildError, Model};
+pub use session::{RunError, Session, Turn};
 
 // --- Runtime construction and execution ---------------------------------
 // Note: the value-first `AgentBuilder` above intentionally replaces the runtime
@@ -69,9 +71,10 @@ pub use everruns_runtime::{
 };
 
 // --- Portable message, model, and platform types ------------------------
+pub use everruns_core::turn::TurnStopReason;
 pub use everruns_core::{
-    AgentLoopError, CapabilityRegistry, DriverId, DriverRegistry, InputMessage, PlatformDefinition,
-    ResolvedModel,
+    AgentLoopError, CapabilityRegistry, ContentPart, DriverId, DriverRegistry, InputMessage,
+    MessageRole, PlatformDefinition, ResolvedModel,
 };
 
 // --- Deterministic in-process LLM simulator -----------------------------
@@ -86,3 +89,20 @@ pub use everruns_core as core;
 /// promoted onto the facade. Prefer the re-exports above; reach here only for
 /// types the facade does not yet surface directly.
 pub use everruns_runtime as runtime;
+
+/// The common path: everything needed to describe an agent and run turns.
+///
+/// ```
+/// use everruns::prelude::*;
+///
+/// let agent = Agent::builder()
+///     .instructions("You are concise.")
+///     .model(Model::simulated("Sure."))
+///     .build();
+/// assert!(agent.is_ok());
+/// ```
+pub mod prelude {
+    pub use crate::{Agent, AgentBuilder, BuildError, Model, RunError, Session, Turn};
+    pub use everruns_core::turn::TurnStopReason;
+    pub use everruns_core::{ContentPart, InputMessage, MessageRole};
+}

--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -1,0 +1,256 @@
+//! Multi-turn sessions (EVE-831).
+//!
+//! [`Agent::session`](crate::Agent::session) opens a [`Session`]; each
+//! [`Session::run`] executes one turn and appends to a conversation history that
+//! lives for as long as the `Session`. Two sessions from the same agent are
+//! independent and never share history.
+
+use everruns_core::turn::TurnStopReason;
+use everruns_core::{AgentLoopError, InputMessage, SessionId};
+use everruns_runtime::{InProcessRuntime, TurnResult};
+
+use crate::Agent;
+
+/// A live, multi-turn conversation with an [`Agent`](crate::Agent).
+///
+/// Open one with [`Agent::session`](crate::Agent::session). The first
+/// [`run`](Self::run) materializes an isolated in-process runtime; later runs
+/// reuse it, so history accumulates across turns. Move the `Session` to keep its
+/// history; drop it to discard the conversation.
+///
+/// # Example
+///
+/// ```
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use everruns::prelude::*;
+///
+/// let agent = Agent::builder()
+///     .instructions("You are concise.")
+///     .model(Model::simulated("Hello!"))
+///     .build()?;
+///
+/// let mut session = agent.session();
+/// let first = session.run("hi").await?;
+/// let second = session.run("continue").await?;
+///
+/// assert_eq!(first.response, "Hello!");
+/// assert!(second.success);
+/// # Ok(())
+/// # }
+/// ```
+pub struct Session {
+    agent: Agent,
+    session_id: SessionId,
+    runtime: Option<InProcessRuntime>,
+}
+
+impl Session {
+    pub(crate) fn new(agent: Agent, session_id: SessionId) -> Self {
+        Self {
+            agent,
+            session_id,
+            runtime: None,
+        }
+    }
+
+    /// An opaque identifier correlating this session's turns.
+    ///
+    /// It carries no organization, principal, or platform identity — it is only
+    /// useful to line up a session's turns in logs.
+    pub fn id(&self) -> String {
+        self.session_id.to_string()
+    }
+
+    /// Run one turn and return its [`Turn`] outcome.
+    ///
+    /// The first call materializes an isolated in-process runtime for this
+    /// session; later calls reuse it, so conversation history from earlier turns
+    /// is included in the next request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunError`] if the runtime cannot be built or the turn cannot be
+    /// executed. A turn that runs but ends unsuccessfully (e.g. a refusal or a
+    /// max-iteration stop) is returned as an `Ok(Turn)` with `success == false`
+    /// and the [`stop_reason`](Turn::stop_reason) preserved.
+    pub async fn run(&mut self, input: impl Into<InputMessage>) -> Result<Turn, RunError> {
+        if self.runtime.is_none() {
+            self.runtime = Some(self.agent.build_runtime(self.session_id).await?);
+        }
+        let runtime = self.runtime.as_ref().expect("runtime built above");
+        let result = runtime.run_turn(self.session_id, input).await?;
+        Ok(Turn::from(result))
+    }
+}
+
+/// The outcome of a single [`Session::run`] turn.
+///
+/// A small, stable projection of the runtime's turn result — no stores, session
+/// records, or platform identity.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Turn {
+    /// Final text response produced by the turn.
+    pub response: String,
+    /// Opaque id correlating this turn with emitted events.
+    pub turn_id: String,
+    /// Why the turn stopped.
+    pub stop_reason: TurnStopReason,
+    /// Number of reasoning iterations executed.
+    pub iterations: usize,
+    /// Number of tool calls executed during the turn.
+    pub tool_calls: usize,
+    /// Whether the turn completed without an unrecoverable failure.
+    pub success: bool,
+    /// Failure message when `success` is `false`.
+    pub error: Option<String>,
+}
+
+impl From<TurnResult> for Turn {
+    fn from(result: TurnResult) -> Self {
+        Self {
+            response: result.response,
+            turn_id: result.turn_id.to_string(),
+            stop_reason: result.stop_reason,
+            iterations: result.iterations,
+            tool_calls: result.tool_calls_count,
+            success: result.success,
+            error: result.error,
+        }
+    }
+}
+
+/// Why a [`Session::run`] could not complete.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RunError {
+    /// The in-process runtime failed to build or execute the turn.
+    Runtime(AgentLoopError),
+}
+
+impl std::fmt::Display for RunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RunError::Runtime(err) => write!(f, "session run failed: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for RunError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RunError::Runtime(err) => Some(err),
+        }
+    }
+}
+
+impl From<AgentLoopError> for RunError {
+    fn from(err: AgentLoopError) -> Self {
+        RunError::Runtime(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use everruns_core::turn::TurnStopReason;
+    use everruns_core::{ContentPart, InputMessage, MessageRole, TurnId};
+    use everruns_runtime::TurnResult;
+
+    use super::Turn;
+    use crate::{Agent, Model};
+
+    #[tokio::test]
+    async fn history_accumulates_across_turns() {
+        let capture = Arc::new(Mutex::new(Vec::new()));
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated_capturing("ok", capture.clone()))
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        session.run("hello").await.expect("first turn");
+        session.run("continue").await.expect("second turn");
+
+        let calls = capture.lock().unwrap();
+        assert_eq!(calls.len(), 2, "two turns => two LLM calls");
+        assert!(
+            calls[1].len() > calls[0].len(),
+            "the second turn's request must include the first turn's messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_sessions_do_not_share_history() {
+        let capture = Arc::new(Mutex::new(Vec::new()));
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated_capturing("ok", capture.clone()))
+            .build()
+            .expect("valid agent");
+
+        let mut first = agent.session();
+        first.run("a1").await.expect("a1");
+        first.run("a2").await.expect("a2");
+
+        let mut second = agent.session();
+        second.run("b1").await.expect("b1");
+
+        assert_ne!(first.id(), second.id(), "sessions have distinct ids");
+
+        let calls = capture.lock().unwrap();
+        assert_eq!(calls.len(), 3);
+        // The second session's first call starts fresh: same size as the first
+        // session's first call, and smaller than its accumulated second call.
+        assert_eq!(
+            calls[2].len(),
+            calls[0].len(),
+            "a second session must not inherit the first session's history"
+        );
+        assert!(calls[1].len() > calls[2].len());
+    }
+
+    #[tokio::test]
+    async fn accepts_multimodal_input() {
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        // A rich, multi-part InputMessage goes through unchanged.
+        let message = InputMessage {
+            role: MessageRole::User,
+            content: vec![
+                ContentPart::text("describe"),
+                ContentPart::text("this attachment"),
+            ],
+            controls: None,
+            metadata: None,
+            tags: vec![],
+        };
+        let turn = session.run(message).await.expect("turn runs");
+        assert!(turn.success);
+    }
+
+    #[test]
+    fn turn_preserves_failure_and_stop_reason() {
+        let result = TurnResult {
+            response: String::new(),
+            iterations: 3,
+            tool_calls_count: 0,
+            success: false,
+            error: Some("hit the ceiling".to_string()),
+            stop_reason: TurnStopReason::MaxTurnRequests,
+            turn_id: TurnId::new(),
+        };
+        let turn = Turn::from(result);
+        assert!(!turn.success);
+        assert_eq!(turn.stop_reason, TurnStopReason::MaxTurnRequests);
+        assert_eq!(turn.error.as_deref(), Some("hit the ceiling"));
+    }
+}


### PR DESCRIPTION
## What changed

Adds the normal library execution path to the `everruns` facade — build an agent, open a session, run turns:

```rust
use everruns::prelude::*;

let agent = Agent::builder()
    .instructions("You are concise.")
    .model(Model::simulated("Hello!"))
    .build()?;

let mut session = agent.session();
let first = session.run("hi").await?;
let second = session.run("continue").await?;
```

- `Agent::session()` opens a **lazy, isolated** `Session`: the in-process runtime is assembled on the first `run()` (seeded with a pre-generated session id) and reused after, so conversation history accumulates across turns.
- `Session::run(impl Into<InputMessage>)` delegates to `InProcessRuntime::run_turn` and maps `TurnResult` to a small public `Turn` — `response`, opaque `turn_id`, `stop_reason`, `iterations`, `tool_calls`, `success`, `error`.
- `Session::id()` is an **opaque** correlation string; no org/principal/platform identity.
- Turns that run but end unsuccessfully (refusal, max-iteration) return `Ok(Turn)` with `success == false` and the **stop reason preserved**; build/execute failures return the typed `RunError`.
- Adds `everruns::prelude`.

Behavioral guarantees: two sessions from one agent never share history; cloning an `Agent` never shares history; moving a `Session` retains it. The value-first `build_runtime` seam added in EVE-832 is now consumed here (no longer `#[allow(dead_code)]`).

## Why

`EVE-831` — third step of the everruns library epic (blocked by EVE-832, now merged). Gives embedders the everyday multi-turn execution API with only the `everruns` dependency. Unblocks EVE-833 (events/cancellation) and EVE-836 (JSONL save/resume).

## Before / After

Before: running a turn meant driving `InProcessRuntimeBuilder`/`run_turn` and threading the session id yourself (the EVE-830 smoke path).

After: `agent.session().run("…").await?` from the facade alone. Public signatures expose no stored `Session` record, `SessionStatus`, stores, `PlatformDefinition`, or runtime backend bundle.

```
$ cargo test -p everruns
running 8 tests   # lib unit: builder validation + session history/independence/multimodal/stop-reason mapping
running 2 tests   # tests/agent_builder.rs
running 1 test    # tests/facade_smoke.rs (EVE-830, still green)
Doc-tests everruns ... ok  # lib example, prelude example, Agent::builder, Session
```

History accumulation and session independence are asserted precisely via the llmsim `message_capture` sink (the second turn's provider request contains the first turn's messages; a second session's first request does not).

## Risk

- Low
- Additive within the `everruns` facade (no external consumers yet). No other crate's code or public API changes. Reuses already-reviewed runtime execution (`run_turn`) and the in-memory session store.

## Security

- Threat categories reviewed: no security-relevant code changes. Value construction + delegation to the already-reviewed in-process runtime; the only model backend is the offline `llmsim` simulator. No network/database/provider features are activated; `Session::id()` deliberately exposes no principal/org identity.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. Event streaming and cancellation are EVE-833; on-disk persistence/resume is EVE-836; durable worker execution is out of scope for the in-process facade.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PvE9qW7MEnQ5x67ktwmNk)_