### PR TITLE
fix(chat): render markdown in work logs

### DIFF
--- a/apps/ui/src/__tests__/chat-message-list-work-log.test.tsx
+++ b/apps/ui/src/__tests__/chat-message-list-work-log.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { ChatMessageList } from "@/components/chat/chat-message-list";
+import type { Event } from "@/lib/api/types";
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+jest.mock("@streamdown/code", () => ({ code: {} }));
+jest.mock("@streamdown/mermaid", () => ({ createMermaidPlugin: jest.fn(() => ({})) }));
+jest.mock("remark-gfm", () => jest.fn());
+jest.mock("remark-github-blockquote-alert", () => jest.fn());
+
+jest.mock("@/hooks", () => ({
+  useAgents: () => ({ data: [] }),
+  useProviders: () => ({ data: [] }),
+}));
+
+jest.mock("@/providers/locale-provider", () => ({
+  useLocale: () => ({
+    locale: "en",
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/components/chat/work-log-narration", () => ({
+  WorkLogNarration: ({ children }: { children: string }) => (
+    <div data-testid="work-log-narration">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/chat/message-content", () => ({
+  MessageContent: ({ text }: { text: string }) => <div>{text}</div>,
+}));
+
+jest.mock("@/components/chat/tool-activity-group", () => ({
+  ToolActivityGroup: () => <div data-testid="tool-output" />,
+}));
+
+function event(id: string, type: string, data: Record<string, unknown>): Event {
+  return {
+    id,
+    type,
+    ts: `2026-08-08T04:00:0${id.length}Z`,
+    session_id: "session-1",
+    context: { turn_id: "turn-1" },
+    data,
+    sequence: id.length,
+  };
+}
+
+describe("ChatMessageList work-log narration", () => {
+  it("routes human reason.item and reason.completed text through the narration renderer", () => {
+    const chatEvents = [
+      event("tool", "tool.call_requested", {
+        tool_calls: [{ id: "tool-1", name: "list_files", arguments: {} }],
+      }),
+      event("item", "reason.item", {
+        turn_id: "turn-1",
+        summary: ["Checked **configuration**"],
+      }),
+      event("done", "reason.completed", {
+        success: true,
+        text_preview: "Created [Hourly Dad Jokes](/agents/agent_123)",
+        has_tool_calls: true,
+        tool_call_count: 1,
+      }),
+    ];
+
+    render(
+      <ChatMessageList
+        events={chatEvents}
+        chatEvents={chatEvents}
+        sessionId="session-1"
+        toolResultsMap={new Map()}
+        toolProgressMap={new Map()}
+        toolOutputMap={new Map()}
+        eventsLoading={false}
+        hasMoreEvents={false}
+        loadingOlderEvents={false}
+        getMessageText={() => ""}
+        getToolCalls={() => []}
+      />,
+    );
+
+    expect(screen.getAllByTestId("work-log-narration")).toHaveLength(2);
+    expect(screen.getByText("Checked **configuration**")).toBeInTheDocument();
+    expect(screen.getByText("Created [Hourly Dad Jokes](/agents/agent_123)")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -212,6 +212,10 @@ jest.mock("@/components/chat/message-content", () => ({
   MessageContent: ({ text }: { text: string }) => <div>{text}</div>,
 }));
 
+jest.mock("@/components/chat/work-log-narration", () => ({
+  WorkLogNarration: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
 jest.mock("@/components/chat/tool-activity-group", () => ({
   ToolActivityGroup: () => null,
 }));

--- a/apps/ui/src/__tests__/streamdown-message.test.tsx
+++ b/apps/ui/src/__tests__/streamdown-message.test.tsx
@@ -31,7 +31,7 @@ jest.mock("remark-gfm", () => jest.fn());
 jest.mock("remark-github-blockquote-alert", () => jest.fn());
 
 import { StreamdownMessage, InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-import { getMarkdownLinkKind } from "@/components/markdown/markdown-link";
+import { getMarkdownLinkKind, MarkdownLink } from "@/components/markdown/markdown-link";
 
 describe("StreamdownMessage", () => {
   beforeEach(() => {
@@ -88,6 +88,16 @@ describe("StreamdownMessage", () => {
     expect(link).toHaveAttribute("title", "Example");
     expect(link).toHaveAttribute("target", "_blank");
   });
+
+  it.each(['javascript:alert("x")', "java\nscript:alert(1)", "data:text/html,<script />"])(
+    "MarkdownLink renders unsafe URL %s as inert text",
+    (href) => {
+      const { container } = render(<MarkdownLink href={href}>Unsafe destination</MarkdownLink>);
+
+      expect(screen.getByText("Unsafe destination")).toBeInTheDocument();
+      expect(container.querySelector("a")).toBeNull();
+    },
+  );
 
   it("MarkdownLink renders Everruns logo for internal links", () => {
     render(<StreamdownMessage>test</StreamdownMessage>);

--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -96,6 +96,43 @@ describe("ToolActivityGroup", () => {
     expect(screen.queryByText(/"stdout":/)).not.toBeInTheDocument();
   });
 
+  it("keeps Markdown-looking tool output as literal machine text", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-shell-markdown",
+        name: "bash",
+        arguments: { command: "printf output" },
+      },
+    ];
+    const stdout = "Created [Agent](/agents/agent_123) in **UTC**";
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-shell-markdown",
+        {
+          tool_call_id: "tool-shell-markdown",
+          tool_name: "bash",
+          success: true,
+          status: "success",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({ stdout, stderr: "", exit_code: 0, success: true }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const { container } = render(
+      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /\$ printf output/i }));
+
+    expect(screen.getByText(stdout)).toBeInTheDocument();
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.querySelector("strong")).toBeNull();
+  });
+
   it("renders MCP App resources in generic tool activity rows", () => {
     const html = "<!doctype html><html><body>Agent card</body></html>";
     const toolCalls: ToolCallContent[] = [

--- a/apps/ui/src/__tests__/work-log-narration.test.tsx
+++ b/apps/ui/src/__tests__/work-log-narration.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+
+let capturedStreamdownProps: Record<string, unknown> = {};
+
+jest.mock("streamdown", () => ({
+  Streamdown: (props: Record<string, unknown>) => {
+    capturedStreamdownProps = props;
+    return <div data-testid="streamdown-mock">{props.children as string}</div>;
+  },
+}));
+jest.mock("@streamdown/code", () => ({ code: { name: "mock-code-plugin" } }));
+jest.mock("@streamdown/mermaid", () => ({
+  createMermaidPlugin: jest.fn(() => ({ name: "mermaid", type: "diagram" })),
+}));
+jest.mock("remark-gfm", () => jest.fn());
+jest.mock("remark-github-blockquote-alert", () => jest.fn());
+
+import { WorkLogNarration } from "@/components/chat/work-log-narration";
+
+describe("WorkLogNarration", () => {
+  beforeEach(() => {
+    capturedStreamdownProps = {};
+  });
+
+  it("passes links, emphasis, and line breaks through the shared Markdown pipeline", () => {
+    const narration = "Created [Hourly Dad Jokes](/agents/agent_123).\nRuns every hour in **UTC**.";
+    const { container } = render(<WorkLogNarration>{narration}</WorkLogNarration>);
+
+    expect(screen.getByTestId("streamdown-mock")).toBeInTheDocument();
+    expect(capturedStreamdownProps.children).toBe(narration);
+    expect(container.querySelector(".streamdown-work-log")).toHaveClass("whitespace-pre-wrap");
+
+    const components = capturedStreamdownProps.components as Record<string, unknown>;
+    expect(components.a).toBeDefined();
+  });
+
+  it("disables raw HTML parsing while retaining Streamdown URL sanitization", () => {
+    render(
+      <WorkLogNarration>
+        {'Avoid [unsafe](javascript:alert("x")) and <img src=x onerror="alert(1)">.'}
+      </WorkLogNarration>,
+    );
+
+    expect(capturedStreamdownProps.skipHtml).toBe(true);
+    expect(capturedStreamdownProps.urlTransform).toBeUndefined();
+  });
+});

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -32,6 +32,7 @@ import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { TraceLink } from "@/components/chat/trace-link";
 import { MessageImage } from "@/components/chat/image-attachments";
 import { MessageContent } from "@/components/chat/message-content";
+import { WorkLogNarration } from "@/components/chat/work-log-narration";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import {
   getReasoningMultiIterationTurnIds,
@@ -102,7 +103,7 @@ function ReasoningLogRow({ text }: { text: string }) {
   return (
     <div className="flex items-start gap-2 py-1 text-[15px] leading-6 text-muted-foreground">
       <Sparkles className="mt-1 h-3.5 w-3.5 flex-shrink-0 text-primary/70" />
-      <p className="whitespace-pre-wrap">{text}</p>
+      <WorkLogNarration>{text}</WorkLogNarration>
     </div>
   );
 }

--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -20,6 +20,15 @@
 .streamdown p {
   margin: 0.5em 0;
 }
+.streamdown-work-log p {
+  margin: 0;
+}
+.streamdown-work-log p + p {
+  margin-top: 0.5em;
+}
+.streamdown-work-log > div {
+  white-space: pre-wrap;
+}
 .streamdown ul,
 .streamdown ol {
   margin: 0.5em 0;

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -100,6 +100,8 @@ export interface StreamdownMessageProps {
    * looked up in this map (keyed by 1-based source number).
    */
   citations?: Map<number, CitationSource>;
+  /** Do not parse raw HTML into DOM nodes. */
+  skipHtml?: boolean;
 }
 
 /**
@@ -119,6 +121,7 @@ export function StreamdownMessage({
   className,
   variant = "default",
   citations,
+  skipHtml = false,
 }: StreamdownMessageProps) {
   const mermaid = useMermaidPlugin();
 
@@ -145,6 +148,7 @@ export function StreamdownMessage({
         isAnimating={isAnimating}
         remarkPlugins={[remarkGfm, remarkGithubAlerts]}
         components={components}
+        skipHtml={skipHtml}
       >
         {children}
       </Streamdown>
@@ -160,10 +164,12 @@ export function InlineStreamdownMessage({
   children,
   className,
   isAnimating = false,
+  skipHtml = false,
 }: {
   children: string;
   className?: string;
   isAnimating?: boolean;
+  skipHtml?: boolean;
 }) {
   return (
     <StreamdownMessage
@@ -171,6 +177,7 @@ export function InlineStreamdownMessage({
       className={className}
       isAnimating={isAnimating}
       enableCodeHighlighting={false}
+      skipHtml={skipHtml}
     >
       {children}
     </StreamdownMessage>

--- a/apps/ui/src/components/chat/work-log-narration.tsx
+++ b/apps/ui/src/components/chat/work-log-narration.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+
+interface WorkLogNarrationProps {
+  children: string;
+}
+
+/** Renders human-readable work-log narration with the shared safe Markdown semantics. */
+export function WorkLogNarration({ children }: WorkLogNarrationProps) {
+  return (
+    <InlineStreamdownMessage
+      className="streamdown-work-log min-w-0 flex-1 whitespace-pre-wrap text-[15px] leading-6 text-muted-foreground"
+      skipHtml
+    >
+      {children}
+    </InlineStreamdownMessage>
+  );
+}

--- a/apps/ui/src/components/markdown/markdown-link.tsx
+++ b/apps/ui/src/components/markdown/markdown-link.tsx
@@ -8,6 +8,8 @@ import { cn } from "@/lib/utils";
 
 export type MarkdownLinkKind = "everruns" | "github" | "twitter" | "web";
 
+const SAFE_MARKDOWN_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
 const EVERRUNS_HOSTS = new Set([
   "everruns.com",
   "app.everruns.com",
@@ -27,6 +29,17 @@ function isEverrunsHost(hostname: string): boolean {
 
 function getCurrentOrigin(): string | undefined {
   return typeof window === "undefined" ? undefined : window.location.origin;
+}
+
+export function isSafeMarkdownHref(href?: string): boolean {
+  if (!href) return false;
+
+  try {
+    const url = new URL(href.trim(), getCurrentOrigin() ?? "https://everruns.invalid");
+    return SAFE_MARKDOWN_PROTOCOLS.has(url.protocol);
+  } catch {
+    return false;
+  }
 }
 
 export function getMarkdownLinkKind(href?: string): MarkdownLinkKind | null {
@@ -82,6 +95,8 @@ export const MarkdownLink: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>
   href,
   ...props
 }) => {
+  if (!isSafeMarkdownHref(href)) return <span className={className}>{children}</span>;
+
   const kind = getMarkdownLinkKind(href);
 
   return (


### PR DESCRIPTION
## What changed
Human-readable reasoning narration in Chat work logs now renders through the shared Markdown pipeline. Links, emphasis, and narration line breaks render while compact work-log grouping and tool output remain unchanged. Shared Markdown links also reject non-HTTP(S)/mailto/tel schemes as inert text.

## Why
`reason.item` and `reason.completed` rows bypassed the assistant Markdown renderer, exposing literal Markdown such as `[Hourly Dad Jokes](...)` and `**UTC**`.

## Before / After
Before: work-log narration displayed Markdown syntax literally (see source issue screenshot).

After: DB-backed Chat verification at 1440×1000 and 390×844 confirms the internal agent link, emphasis, and line break render correctly. Unsafe `javascript:`/raw-HTML payloads remain inert, while Markdown-looking shell stdout remains literal. Desktop and mobile screenshot evidence was captured during the DB-backed verification run.

## Risk
- Low
- Limited to human-readable reasoning narration and shared rejection of unsafe Markdown URL schemes. Tool stdout, JSON, and machine-result renderers remain on their existing literal paths.

## Security
- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: Stored narration is parsed as Markdown, so raw HTML is requested to be skipped and remains hardened/inert; MarkdownLink now permits only HTTP(S), mailto, tel, and relative URLs. No unbounded server work or new dependency was introduced; parsing remains client-side and limited to existing reasoning preview payloads.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
