### PR TITLE
refactor(platform): create everruns-platform crate and move organization/principal models out of core

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -136,6 +136,9 @@ jobs:
                   "everruns-a2ui",
                   "everruns-provider",
               ],
+              "crates/platform/Cargo.toml": [
+                  "everruns-core",
+              ],
               "crates/mcp/Cargo.toml": [
                   "everruns-core",
               ],
@@ -236,6 +239,7 @@ jobs:
             everruns-provider
             everruns-meta
             everruns-core
+            everruns-platform
             everruns-mcp
             everruns-openai
             everruns-anthropic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,6 +3201,18 @@ name = "everruns-openui"
 version = "0.17.23"
 
 [[package]]
+name = "everruns-platform"
+version = "0.17.23"
+dependencies = [
+ "chrono",
+ "everruns-core",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "uuid 1.24.0",
+]
+
+[[package]]
 name = "everruns-provider"
 version = "0.17.23"
 dependencies = [
@@ -3311,6 +3323,7 @@ dependencies = [
  "everruns-internal-protocol",
  "everruns-mcp",
  "everruns-observability",
+ "everruns-platform",
  "everruns-sdk",
  "everruns-session-sqldb",
  "everruns-turbopuffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/worker",
     "crates/everruns",
     "crates/core",
+    "crates/platform",
     "crates/provider",
     "crates/bedrock",
     "crates/mcp",
@@ -156,6 +157,7 @@ futures-util = "0.3"
 # Everruns SDK
 everruns-sdk = "0.2.0"
 everruns-core = { path = "crates/core", version = "0.17.23" }
+everruns-platform = { path = "crates/platform", version = "0.17.23" }
 everruns-provider = { path = "crates/provider", version = "0.17.23" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
 everruns-mcp = { path = "crates/mcp", version = "0.17.23" }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -511,16 +511,22 @@ pub use model_discovery::{
     normalize_and_enrich, rank_discovered_models, search_provider_models,
 };
 pub use model_profiles::{get_model_profile, get_model_vendor};
+// EVE-837: `Organization` moved to the `everruns-platform` crate. The role,
+// membership, and multitenancy constants stay here — the permissions/auth layer
+// and runtime fixtures depend on them.
 pub use organization::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, Organization, generate_org_public_id,
+    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, generate_org_public_id,
     org_public_id_from_internal, validate_org_public_id,
 };
 pub use payment::{
     MachinePaymentRequest, MachinePaymentResponse, PaymentAccount, PaymentAttempt, PaymentMethod,
     PaymentOwnerType, PaymentPolicy, PaymentRail, PaymentStatus,
 };
-pub use principal::{Principal, PrincipalKind, PrincipalStatus, PrincipalSummary};
+// EVE-837: `Principal` moved to the `everruns-platform` crate. The value types
+// below stay here — they are embedded by `Session`/`App`/`SessionSchedule` and
+// the agent-identity lifecycle.
+pub use principal::{PrincipalKind, PrincipalStatus, PrincipalSummary};
 pub use provider::{Provider, ProviderStatus, ProviderTraceConfig};
 pub use session::{
     Session, SessionParticipant, SessionParticipantKind, SessionParticipantRole, SessionSeedMode,

--- a/crates/core/src/organization.rs
+++ b/crates/core/src/organization.rs
@@ -4,11 +4,15 @@
 // Decision: Hierarchical org roles (Owner > Admin > Member) using PartialOrd.
 // External auth providers map their roles to OrgRole via AuthBackend trait.
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
+
+// EVE-837: the `Organization` aggregate entity moved to the `everruns-platform`
+// crate. The role/membership value types and multitenancy constants below stay
+// in core because the permissions layer, auth-facing membership, and runtime
+// fixtures depend on them.
 
 /// Default organization ID (internal, for DB queries)
 pub const DEFAULT_ORG_ID: i64 = 1;
@@ -28,18 +32,6 @@ pub const ANONYMOUS_USER_EMAIL: &str = "anonymous@local";
 
 /// Anonymous user display name
 pub const ANONYMOUS_USER_NAME: &str = "Anonymous";
-
-/// Organization entity (domain type)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct Organization {
-    /// External identifier (org_<32-hex-chars>)
-    pub public_id: String,
-    /// Display name
-    pub name: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
 
 /// Organization-level role with hierarchical permissions.
 /// Owner > Admin > Member — checked via `has_permission()`.

--- a/crates/core/src/principal.rs
+++ b/crates/core/src/principal.rs
@@ -1,12 +1,17 @@
-// Principal domain types
+// Principal domain value types.
 //
 // Design Decision:
 // - Principals are org-scoped durable owners/executors with structured metadata.
 // - Ownership resolves through principal lineage to exactly one human user.
 // - Execution provenance remains separate from ownership; principals only model
 //   who can own durable entities and who an unattended flow can act as.
+//
+// EVE-837: the `Principal` aggregate entity moved to the `everruns-platform`
+// crate. The value types below stay in core because they are embedded by core
+// domain models: `PrincipalSummary` is a field of `Session`/`App`/
+// `SessionSchedule`, `PrincipalKind` backs that summary, and `PrincipalStatus`
+// is shared with the agent-identity lifecycle.
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -89,39 +94,4 @@ pub struct PrincipalSummary {
     pub subject_id: Option<Uuid>,
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub metadata: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct Principal {
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "principal_01933b5a000070008000000000000001"))]
-    pub id: PrincipalId,
-    pub organization_id: String,
-    pub kind: PrincipalKind,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subject_id: Option<Uuid>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent_principal_id: Option<PrincipalId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolved_user_id: Option<Uuid>,
-    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
-    pub metadata: serde_json::Value,
-    pub status: PrincipalStatus,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub archived_at: Option<DateTime<Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deleted_at: Option<DateTime<Utc>>,
-}
-
-impl Principal {
-    pub fn summary(&self) -> PrincipalSummary {
-        PrincipalSummary {
-            id: self.id,
-            kind: self.kind.clone(),
-            subject_id: self.subject_id,
-            metadata: self.metadata.clone(),
-        }
-    }
 }

--- a/crates/core/tests/no_platform_dependency.rs
+++ b/crates/core/tests/no_platform_dependency.rs
@@ -1,0 +1,22 @@
+//! EVE-837 dependency-direction guard.
+//!
+//! The allowed identity-crate direction is `everruns-platform -> everruns-core`.
+//! `everruns-core` must never gain a dependency edge back on
+//! `everruns-platform`; if it did, the two crates would form a cycle and the
+//! platform aggregates could no longer be carved out of core. This test fails
+//! the core build the moment a manifest edit introduces the reverse edge.
+
+use std::path::Path;
+
+#[test]
+fn core_manifest_has_no_edge_to_platform() {
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", manifest_path.display()));
+
+    assert!(
+        !manifest.contains("everruns-platform"),
+        "everruns-core must not depend on everruns-platform \
+         (allowed direction is platform -> core)"
+    );
+}

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -1,0 +1,52 @@
+# Backend platform/identity domain entities for Everruns.
+#
+# Decision (EVE-837): the platform crate owns the durable backend identity
+# aggregates that were historically defined in `everruns-core` — starting with
+# the `Organization` and `Principal` entity structs. Cross-cutting value types
+# that core's runtime, permissions, and domain models embed (OrgRole,
+# OrgMembership, PrincipalKind, PrincipalStatus, PrincipalSummary, and the
+# multitenancy constants) remain in `everruns-core` and are re-exported here for
+# a unified consumer surface.
+#
+# Dependency direction is strictly `platform -> core`. Core never depends on
+# platform (enforced by crates/core/tests/no_platform_dependency.rs).
+
+[package]
+name = "everruns-platform"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-platform"
+description = "Backend platform identity entities (organizations, principals) for the Everruns agentic runtime"
+readme = "README.md"
+keywords = ["agent", "agentic", "multitenancy", "identity", "everruns"]
+categories = ["development-tools", "asynchronous"]
+
+[features]
+# Default build stays free of OpenAPI/SQLx subtrees, matching how provider-only
+# consumers depend on core.
+default = []
+# OpenAPI schema generation (utoipa ToSchema derives). Mirrors the server build,
+# which activates `everruns-core/openapi`.
+openapi = ["dep:utoipa", "everruns-core/openapi"]
+# SQLx support for the typed IDs embedded in these entities. Passthrough to core,
+# kept for parity with server builds that enable `everruns-core/sqlx`.
+sqlx = ["everruns-core/sqlx"]
+
+[dependencies]
+# Cross-cutting identity value types (PrincipalKind/PrincipalStatus/
+# PrincipalSummary), typed IDs, and multitenancy constants live in core; the
+# platform aggregates embed and re-export them. Direction is platform -> core.
+everruns-core = { workspace = true }
+
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+
+# OpenAPI schema generation (optional, enabled by everruns-server).
+utoipa = { workspace = true, optional = true }

--- a/crates/platform/README.md
+++ b/crates/platform/README.md
@@ -1,0 +1,22 @@
+# everruns-platform
+
+Backend platform identity entities for the [Everruns](https://everruns.com)
+agentic runtime.
+
+This crate owns the durable backend identity aggregates that were historically
+defined in `everruns-core`:
+
+- `Organization`
+- `Principal`
+
+Cross-cutting identity value types that core's runtime and permissions layer
+embed (`OrgRole`, `OrgMembership`, `PrincipalKind`, `PrincipalStatus`,
+`PrincipalSummary`) and the multitenancy constants remain in `everruns-core` and
+are re-exported here for a unified consumer surface.
+
+The dependency direction is strictly `platform -> core`; `everruns-core` never
+depends on `everruns-platform`.
+
+## License
+
+MIT

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -1,0 +1,38 @@
+//! Backend platform identity entities for Everruns.
+//!
+//! `everruns-platform` owns the durable backend identity aggregates that were
+//! historically defined in [`everruns-core`](https://docs.rs/everruns-core):
+//! [`Organization`] and [`Principal`]. It was carved out in EVE-837 to give the
+//! backend identity family its own crate without disturbing the runtime-facing
+//! contract in `everruns-core`.
+//!
+//! # Dependency direction
+//!
+//! The dependency edge is strictly `platform -> core`. `everruns-core` never
+//! depends on `everruns-platform`; that invariant is enforced by
+//! `crates/core/tests/no_platform_dependency.rs`.
+//!
+//! # Types that stay in core
+//!
+//! Cross-cutting value types that core's runtime, permissions layer, and domain
+//! models embed remain in `everruns-core` and are re-exported here so consumers
+//! can reach the whole identity surface through `everruns_platform`:
+//!
+//! - [`OrgRole`], [`OrgMembership`] and the multitenancy constants — used by
+//!   core's permissions/auth layer.
+//! - [`PrincipalKind`], [`PrincipalStatus`], [`PrincipalSummary`] — embedded in
+//!   `Session`/`App`/`SessionSchedule` and the agent-identity lifecycle.
+
+pub mod organization;
+pub mod principal;
+
+pub use organization::Organization;
+pub use principal::Principal;
+
+// Re-export the identity value types and multitenancy constants that remain in
+// `everruns-core`, so `everruns_platform` exposes the complete identity surface.
+pub use everruns_core::{
+    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
+    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, PrincipalKind, PrincipalStatus,
+    PrincipalSummary, generate_org_public_id, org_public_id_from_internal, validate_org_public_id,
+};

--- a/crates/platform/src/organization.rs
+++ b/crates/platform/src/organization.rs
@@ -1,0 +1,23 @@
+// Organization entity (platform domain aggregate).
+//
+// Moved out of `everruns-core` in EVE-837. The cross-cutting organization value
+// types and multitenancy constants (OrgRole, OrgMembership, DEFAULT_ORG_ID,
+// DEFAULT_ORG_PUBLIC_ID, ANONYMOUS_USER_*, and the org public-id helpers) remain
+// in `everruns-core` because core's permissions layer, auth-facing membership,
+// and runtime fixtures depend on them; they are re-exported from this crate's
+// root for a unified consumer surface.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Organization entity (domain type)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Organization {
+    /// External identifier (org_<32-hex-chars>)
+    pub public_id: String,
+    /// Display name
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/platform/src/principal.rs
+++ b/crates/platform/src/principal.rs
@@ -1,0 +1,53 @@
+// Principal entity (platform domain aggregate).
+//
+// Moved out of `everruns-core` in EVE-837. The principal value types embedded by
+// core domain models remain in `everruns-core`: `PrincipalSummary` is a field of
+// `Session`/`App`/`SessionSchedule`, `PrincipalKind` backs that summary, and
+// `PrincipalStatus` is shared with the agent-identity lifecycle. This aggregate
+// depends on them (direction: platform -> core) and re-exports them from the
+// crate root.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use everruns_core::typed_id::PrincipalId;
+use everruns_core::{PrincipalKind, PrincipalStatus, PrincipalSummary};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Principal {
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "principal_01933b5a000070008000000000000001"))]
+    pub id: PrincipalId,
+    pub organization_id: String,
+    pub kind: PrincipalKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_principal_id: Option<PrincipalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_user_id: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub metadata: serde_json::Value,
+    pub status: PrincipalStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl Principal {
+    pub fn summary(&self) -> PrincipalSummary {
+        PrincipalSummary {
+            id: self.id,
+            kind: self.kind.clone(),
+            subject_id: self.subject_id,
+            metadata: self.metadata.clone(),
+        }
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -86,6 +86,8 @@ tar.workspace = true
 bashkit = { version = "0.16.0", features = ["scripted_tool", "jq"] }
 
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }
+# Backend identity entities (Organization, Principal) — moved out of core in EVE-837.
+everruns-platform = { path = "../platform", features = ["openapi"] }
 # Observability exporters (Braintrust, OpenTelemetry event listeners). The OTLP
 # init these rely on stays in core's `telemetry` feature (on by default).
 everruns-observability = { workspace = true }

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -14,10 +14,11 @@ use axum::{
     routing::get,
 };
 use everruns_core::{
-    AuditEvent, BuiltInHarnessDefinition, DEFAULT_ORG_ID, ManagementAction, OrgRole, Organization,
+    AuditEvent, BuiltInHarnessDefinition, DEFAULT_ORG_ID, ManagementAction, OrgRole,
     generate_org_public_id, validate_org_public_id,
 };
 use everruns_durable::UpdateField;
+use everruns_platform::Organization;
 
 use super::common::{
     ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, impl_auth_state,

--- a/crates/server/src/services/principal.rs
+++ b/crates/server/src/services/principal.rs
@@ -5,10 +5,11 @@
 
 use anyhow::{Result, anyhow};
 use everruns_core::{
-    ANONYMOUS_USER_ID, Caller, ExternalActor, Principal, PrincipalId, PrincipalKind,
-    PrincipalStatus, PrincipalSummary, org_public_id_from_internal,
+    ANONYMOUS_USER_ID, Caller, ExternalActor, PrincipalId, PrincipalKind, PrincipalStatus,
+    PrincipalSummary, org_public_id_from_internal,
 };
 use everruns_durable::UpdateField;
+use everruns_platform::Principal;
 use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -31,6 +31,7 @@ INNER_PINS: dict[str, list[str]] = {
         "everruns-openui",
         "everruns-a2ui",
     ],
+    "crates/platform/Cargo.toml": ["everruns-core"],
     "crates/mcp/Cargo.toml": ["everruns-core"],
     "crates/runtime/Cargo.toml": ["everruns-core"],
     "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime"],
@@ -55,7 +56,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard", "everruns"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard", "everruns"]
 
 
 def workspace_version() -> str:


### PR DESCRIPTION
## What changed

Introduces a new workspace crate `everruns-platform` and carves the first backend identity aggregates out of `everruns-core`:

- `everruns_core::Organization` → `everruns_platform::Organization`
- `everruns_core::Principal` → `everruns_platform::Principal`

These two structs can no longer be imported from default `everruns-core`. The only two consumers (`crates/server/src/api/organizations.rs` and `crates/server/src/services/principal.rs`) now import them from `everruns_platform`. No serialized shapes or OpenAPI output change — the structs move verbatim with identical derives, and neither is registered in the server's `components(schemas(...))`.

### What stays in core (and why)

The issue also named the status/kind enums, the summary type, and `OrganizationSummary` (which does not exist in the codebase). These are **structurally anchored in core** and cannot move without either a forbidden `core → platform` edge or relocating out-of-scope modules:

- `OrgRole` / `OrgMembership` + multitenancy constants (`DEFAULT_ORG_ID`, `DEFAULT_ORG_PUBLIC_ID`, `ANONYMOUS_USER_*`, org public-id helpers) — used pervasively by core's `permissions.rs` and the server auth/membership layer (out of scope).
- `PrincipalKind` / `PrincipalStatus` / `PrincipalSummary` — `PrincipalSummary` is a non-test field of core's `Session`, `App`, and `SessionSchedule`; `PrincipalKind` backs it; `PrincipalStatus` is shared with the agent-identity lifecycle.

They remain in `everruns-core` and are **re-exported from `everruns-platform`** so consumers still get the whole identity surface through one crate. The typed IDs (`OrgId`, `PrincipalId`) were already in `everruns-provider`, so no ID moved.

## Why

EVE-837: begin removing the backend identity family from the runtime-facing `everruns-core` contract without changing API/database behavior, establishing `everruns-platform` and its publish wiring as the home for these entities.

## Before / After

Pure refactor — no observable runtime behavior change. Evidence from local validation:

```
cargo check -p everruns-core --no-default-features   # ok (1 pre-existing unrelated warning)
cargo test  -p everruns-platform                     # ok (0 tests + doctests)
cargo check -p everruns-server -p everruns-worker     # ok
cargo test  -p everruns-core --test no_platform_dependency  # ok (1 passed)
cargo fmt --all -- --check                            # clean
cargo clippy -p everruns-platform -p everruns-core --all-targets -- -D warnings  # clean
python3 scripts/sync-publish-pin-versions.py --check  # all path-dep pins at 0.17.23
cargo fetch --locked                                  # clean (Cargo.lock committed)
cargo tree -p everruns-core | grep everruns-platform  # 0 matches (no edge)
```

## Risk

- **Low**
- Blast radius is two import sites plus manifest/publish wiring. The workspace compiles (server + worker + full integration graph). Direction rule enforced by a build-failing dependency-assertion test.

## Security

- Threat categories reviewed: No security-relevant code changes. Type definitions relocated verbatim; no auth, permissions, serialization, or data-flow logic altered.
- Findings and resolutions: None.

## Follow-ups

- **Complete the identity move (blocked by out-of-scope core coupling).** Fully relocating `OrgRole`, the multitenancy constants, `PrincipalKind`, `PrincipalStatus`, and `PrincipalSummary` requires first moving `permissions.rs` and the `Session`/`App`/`SessionSchedule` `PrincipalSummary` fields off core — all explicitly out of scope here. Tracked as a dedicated follow-up issue.
- No `platform-compat` re-export feature was added to core: it would require a `core → platform` dependency (even feature-gated), which the direction rule forbids, and no incremental-merge need arose.

## Checklist
- [x] Tests added or updated (`crates/core/tests/no_platform_dependency.rs` dependency-direction guard)
- [x] Backward compatibility considered (internal crates; two import sites updated; serialized shapes unchanged)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)