### PR TITLE
feat(library): accept async Rust functions and closures as agent tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,8 +2563,10 @@ dependencies = [
 name = "everruns"
 version = "0.17.23"
 dependencies = [
+ "async-trait",
  "everruns-core",
  "everruns-runtime",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -39,6 +39,8 @@ mcp-stdio = ["everruns-runtime/mcp-stdio"]
 [dependencies]
 everruns-core.workspace = true
 everruns-runtime.workspace = true
+async-trait.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -10,6 +10,7 @@
 //! this type only describes an agent and can materialize independent in-process
 //! runtimes from that description.
 
+use std::collections::HashSet;
 use std::fmt;
 
 use everruns_core::llmsim_driver::LlmSimConfig;
@@ -18,6 +19,8 @@ use everruns_runtime::{
     AgentBuilder as RuntimeAgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder,
     SessionBuilder,
 };
+
+use crate::tool::{FunctionTool, IntoTool, Tool, validate_tool_name, validate_tool_schema};
 
 /// How an [`Agent`] talks to a model.
 ///
@@ -73,6 +76,26 @@ impl Model {
             sim: Some(sim),
         }
     }
+
+    /// Test-only: a simulated model that emits the given per-turn tool-call
+    /// sequence before replying with `response`. Lets a facade test drive the
+    /// end-to-end tool-execution loop for a function tool.
+    pub(crate) fn simulated_scripted(
+        response: impl Into<String>,
+        tool_call_sequence: Vec<Vec<everruns_core::ToolCall>>,
+    ) -> Self {
+        let sim = LlmSimConfig::fixed(response).with_tool_call_sequence(tool_call_sequence);
+        Self {
+            resolved: ResolvedModel {
+                model: "llmsim-model".to_string(),
+                provider_type: DriverId::LlmSim,
+                api_key: Some("fake-key".to_string()),
+                base_url: None,
+                provider_metadata: None,
+            },
+            sim: Some(sim),
+        }
+    }
 }
 
 impl fmt::Debug for Model {
@@ -96,6 +119,25 @@ pub enum BuildError {
     BlankInstructions,
     /// No model was selected.
     MissingModel,
+    /// A tool name is not a valid model-facing identifier.
+    InvalidToolName {
+        /// The rejected tool name.
+        name: String,
+        /// Why the name was rejected.
+        reason: String,
+    },
+    /// A tool's JSON argument schema is invalid.
+    InvalidToolSchema {
+        /// The tool whose schema was rejected.
+        name: String,
+        /// Why the schema was rejected.
+        reason: String,
+    },
+    /// Two tools were registered under the same name.
+    DuplicateTool {
+        /// The colliding tool name.
+        name: String,
+    },
 }
 
 impl fmt::Display for BuildError {
@@ -105,6 +147,15 @@ impl fmt::Display for BuildError {
                 write!(f, "agent instructions must not be blank")
             }
             BuildError::MissingModel => write!(f, "agent requires a model"),
+            BuildError::InvalidToolName { name, reason } => {
+                write!(f, "invalid tool name {name:?}: {reason}")
+            }
+            BuildError::InvalidToolSchema { name, reason } => {
+                write!(f, "invalid JSON schema for tool {name:?}: {reason}")
+            }
+            BuildError::DuplicateTool { name } => {
+                write!(f, "duplicate tool name {name:?}")
+            }
         }
     }
 }
@@ -123,6 +174,7 @@ pub struct Agent {
     instructions: String,
     model: Model,
     capabilities: Vec<AgentCapabilityConfig>,
+    function_tools: Vec<FunctionTool>,
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
 }
@@ -206,6 +258,12 @@ impl Agent {
             .agent(agent)
             .session(session)
             .default_model(self.model.resolved.clone());
+        // Register each function tool as a closure-backed, single-tool
+        // capability so the runtime can execute the model's calls; the matching
+        // capability ref was attached to the harness/agent/session above.
+        for tool in &self.function_tools {
+            builder = builder.capability(tool.clone().into_capability());
+        }
         if let Some(sim) = &self.model.sim {
             builder = builder.llm_sim(sim.clone());
         }
@@ -224,6 +282,7 @@ pub struct AgentBuilder {
     instructions: Option<String>,
     model: Option<Model>,
     capabilities: Vec<AgentCapabilityConfig>,
+    tools: Vec<Tool>,
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
 }
@@ -247,12 +306,36 @@ impl AgentBuilder {
         self
     }
 
-    /// Add a tool the agent can call, referenced by capability id.
+    /// Add a tool the agent can call.
     ///
-    /// Tools are wired through the capability system, so this is a
-    /// tool-flavored alias of [`capability`](Self::capability).
-    pub fn tool(mut self, tool: impl Into<AgentCapabilityConfig>) -> Self {
-        self.capabilities.push(tool.into());
+    /// Accepts anything that is [`IntoTool`](crate::IntoTool): a
+    /// [`FunctionTool`](crate::FunctionTool) backed by an async function or
+    /// closure, or a `&str`/`String` capability id for a capability-referenced
+    /// tool. Tool names and JSON schemas are validated, and duplicate names
+    /// rejected, at [`build`](Self::build).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use everruns::{Agent, FunctionTool, Model};
+    /// use serde_json::json;
+    ///
+    /// let agent = Agent::builder()
+    ///     .instructions("You are concise.")
+    ///     .model(Model::simulated("done"))
+    ///     .tool("test_math")
+    ///     .tool(FunctionTool::new(
+    ///         "roll",
+    ///         "Roll a die.",
+    ///         json!({ "type": "object", "properties": {} }),
+    ///         |_args: serde_json::Value| async move { Ok::<_, String>(json!({ "value": 4 })) },
+    ///     ))
+    ///     .build()?;
+    /// # let _ = agent;
+    /// # Ok::<(), everruns::BuildError>(())
+    /// ```
+    pub fn tool(mut self, tool: impl IntoTool) -> Self {
+        self.tools.push(tool.into_tool());
         self
     }
 
@@ -278,8 +361,14 @@ impl AgentBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`BuildError::BlankInstructions`] if instructions are missing or
-    /// only whitespace, or [`BuildError::MissingModel`] if no model was set.
+    /// - [`BuildError::BlankInstructions`] if instructions are missing or only
+    ///   whitespace.
+    /// - [`BuildError::MissingModel`] if no model was set.
+    /// - [`BuildError::InvalidToolName`] if a function tool's name is not a
+    ///   valid model-facing identifier.
+    /// - [`BuildError::InvalidToolSchema`] if a function tool's JSON schema is
+    ///   not a valid arguments schema.
+    /// - [`BuildError::DuplicateTool`] if two `.tool(..)` calls share a name.
     pub fn build(self) -> Result<Agent, BuildError> {
         let instructions = self.instructions.unwrap_or_default();
         if instructions.trim().is_empty() {
@@ -288,11 +377,44 @@ impl AgentBuilder {
         let model = self.model.ok_or(BuildError::MissingModel)?;
         let name = self.name.unwrap_or_else(|| "agent".to_string());
 
+        // Validate tools and split them into capability refs (attached to the
+        // agent) and function tools (also registered on the runtime). Names
+        // must be unique across all `.tool(..)` calls.
+        let mut capabilities = self.capabilities;
+        let mut function_tools = Vec::new();
+        let mut seen_tool_names: HashSet<String> = HashSet::new();
+        for tool in self.tools {
+            let tool_name = tool.name().to_string();
+            if !seen_tool_names.insert(tool_name.clone()) {
+                return Err(BuildError::DuplicateTool { name: tool_name });
+            }
+            match tool {
+                Tool::Capability(config) => capabilities.push(config),
+                Tool::Function(function_tool) => {
+                    validate_tool_name(function_tool.name()).map_err(|reason| {
+                        BuildError::InvalidToolName {
+                            name: tool_name.clone(),
+                            reason,
+                        }
+                    })?;
+                    validate_tool_schema(function_tool.schema()).map_err(|reason| {
+                        BuildError::InvalidToolSchema {
+                            name: tool_name.clone(),
+                            reason,
+                        }
+                    })?;
+                    capabilities.push(AgentCapabilityConfig::new(function_tool.name()));
+                    function_tools.push(function_tool);
+                }
+            }
+        }
+
         Ok(Agent {
             name,
             instructions,
             model,
-            capabilities: self.capabilities,
+            capabilities,
+            function_tools,
             initial_files: self.initial_files,
             parallel_tool_calls: self.parallel_tool_calls,
         })
@@ -301,7 +423,164 @@ impl AgentBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use everruns_core::ToolCall;
+    use serde_json::{Value, json};
+
     use super::*;
+    use crate::FunctionTool;
+
+    fn obj_schema() -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    #[test]
+    fn build_rejects_invalid_tool_name() {
+        let err = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .tool(FunctionTool::new(
+                "bad name",
+                "desc",
+                obj_schema(),
+                |_: Value| async move { Ok::<_, String>(json!({})) },
+            ))
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, BuildError::InvalidToolName { ref name, .. } if name == "bad name"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_rejects_invalid_tool_schema() {
+        let err = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .tool(FunctionTool::new(
+                "arr",
+                "desc",
+                json!({ "type": "array" }),
+                |_: Value| async move { Ok::<_, String>(json!({})) },
+            ))
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, BuildError::InvalidToolSchema { ref name, .. } if name == "arr"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_rejects_duplicate_tool_names() {
+        let make = || {
+            FunctionTool::new("dup", "desc", obj_schema(), |_: Value| async move {
+                Ok::<_, String>(json!({}))
+            })
+        };
+        let err = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .tool(make())
+            .tool(make())
+            .build()
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BuildError::DuplicateTool {
+                name: "dup".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn function_tool_executes_end_to_end() {
+        // Capture what the handler received to prove args flowed in.
+        let received: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+        let sink = received.clone();
+        let tool = FunctionTool::new(
+            "greet",
+            "Greet a person by name.",
+            json!({
+                "type": "object",
+                "properties": { "name": { "type": "string" } },
+                "required": ["name"],
+            }),
+            move |args: Value| {
+                let sink = sink.clone();
+                async move {
+                    *sink.lock().unwrap() = Some(args.clone());
+                    let name = args["name"].as_str().unwrap_or("world");
+                    Ok::<_, String>(json!({ "greeting": format!("Hello, {name}!") }))
+                }
+            },
+        );
+
+        let agent = Agent::builder()
+            .instructions("Call greet when asked to greet someone.")
+            .model(Model::simulated_scripted(
+                "All done.",
+                vec![
+                    vec![ToolCall {
+                        id: "call_greet_1".into(),
+                        name: "greet".into(),
+                        arguments: json!({ "name": "Ada" }),
+                    }],
+                    vec![],
+                ],
+            ))
+            .tool(tool)
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        let turn = session.run("Please greet Ada.").await.expect("turn runs");
+
+        assert!(turn.success, "turn should succeed: {:?}", turn.error);
+        assert_eq!(turn.tool_calls, 1, "the function tool must have executed");
+        assert_eq!(turn.response, "All done.");
+        assert_eq!(
+            received.lock().unwrap().as_ref().expect("handler ran")["name"],
+            json!("Ada"),
+            "handler must receive the model's call arguments",
+        );
+    }
+
+    #[tokio::test]
+    async fn function_tool_handler_error_is_model_visible_not_a_panic() {
+        let tool = FunctionTool::new(
+            "always_fails",
+            "Always returns an error.",
+            obj_schema(),
+            |_: Value| async move { Err::<Value, String>("boom".to_string()) },
+        );
+
+        let agent = Agent::builder()
+            .instructions("Call the tool.")
+            .model(Model::simulated_scripted(
+                "Handled.",
+                vec![
+                    vec![ToolCall {
+                        id: "call_fail_1".into(),
+                        name: "always_fails".into(),
+                        arguments: json!({}),
+                    }],
+                    vec![],
+                ],
+            ))
+            .tool(tool)
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        // The handler error becomes a tool result the model consumes; the turn
+        // still completes rather than panicking.
+        let turn = session.run("go").await.expect("turn runs");
+        assert!(turn.success, "turn should recover from a tool error");
+        assert_eq!(turn.tool_calls, 1);
+    }
 
     #[test]
     fn build_rejects_blank_instructions() {

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -58,8 +58,10 @@
 // --- Value-first agent description and execution -------------------------
 mod agent;
 mod session;
+mod tool;
 pub use agent::{Agent, AgentBuilder, BuildError, Model};
 pub use session::{RunError, Session, Turn};
+pub use tool::{FunctionTool, IntoTool, IntoToolResult, Tool, ToolResponse};
 
 // --- Runtime construction and execution ---------------------------------
 // Note: the value-first `AgentBuilder` above intentionally replaces the runtime
@@ -102,7 +104,10 @@ pub use everruns_runtime as runtime;
 /// assert!(agent.is_ok());
 /// ```
 pub mod prelude {
-    pub use crate::{Agent, AgentBuilder, BuildError, Model, RunError, Session, Turn};
+    pub use crate::{
+        Agent, AgentBuilder, BuildError, FunctionTool, IntoTool, IntoToolResult, Model, RunError,
+        Session, Tool, ToolResponse, Turn,
+    };
     pub use everruns_core::turn::TurnStopReason;
     pub use everruns_core::{ContentPart, InputMessage, MessageRole};
 }

--- a/crates/everruns/src/tool.rs
+++ b/crates/everruns/src/tool.rs
@@ -1,0 +1,526 @@
+//! Async functions and closures as agent tools (EVE-828).
+//!
+//! A library user adds a custom tool by handing the agent an async
+//! function or closure — no capability registry, tool record, or backend
+//! store. [`FunctionTool::new`] wraps a handler that receives the call
+//! arguments as a [`serde_json::Value`] and returns any [`IntoToolResult`]
+//! (a `serde_json::Value`, a `String`, or an explicit [`ToolResponse`]).
+//!
+//! [`AgentBuilder::tool`](crate::AgentBuilder::tool) accepts anything that is
+//! [`IntoTool`]: a [`FunctionTool`], or a `&str`/`String` capability id for the
+//! existing capability-referenced tools. The builder validates tool names and
+//! JSON schemas and rejects duplicate names before an [`Agent`](crate::Agent)
+//! is produced.
+//!
+//! Under the hood a `FunctionTool` is adapted to the core tool-execution
+//! contract ([`everruns_core::tools::Tool`]) and registered as a single-tool,
+//! closure-backed [`Capability`](everruns_core::capabilities::Capability) on the
+//! in-process runtime, so the model can call it and the result flows back like
+//! any built-in tool. Handler errors become model-visible tool errors; a handler
+//! never panics the turn.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns::{Agent, FunctionTool, Model};
+//! use serde_json::json;
+//!
+//! let weather = FunctionTool::new(
+//!     "get_weather",
+//!     "Look up the weather for a city.",
+//!     json!({
+//!         "type": "object",
+//!         "properties": { "city": { "type": "string" } },
+//!         "required": ["city"],
+//!     }),
+//!     |args: serde_json::Value| async move {
+//!         let city = args["city"].as_str().unwrap_or("unknown");
+//!         Ok::<_, String>(json!({ "city": city, "forecast": "sunny" }))
+//!     },
+//! );
+//!
+//! let agent = Agent::builder()
+//!     .instructions("You are a helpful weather assistant.")
+//!     .model(Model::simulated("It is sunny."))
+//!     .tool(weather)
+//!     .build()?;
+//! # let _ = agent;
+//! # Ok::<(), everruns::BuildError>(())
+//! ```
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use everruns_core::AgentCapabilityConfig;
+use everruns_core::capabilities::Capability;
+use everruns_core::tools::{Tool as CoreTool, ToolExecutionResult};
+use serde_json::Value;
+
+/// A ready-to-return structured tool result.
+///
+/// The explicit adapter for handlers that need the full tool-result shape
+/// rather than a bare `serde_json::Value` or `String`: return
+/// `ToolResponse::error(..)` to surface a model-visible tool error from an
+/// `Ok(..)` handler, or `ToolResponse::json(..)` / `ToolResponse::text(..)`
+/// for a success. It maps onto the engine's existing structured tool output
+/// without a library user importing any core type.
+pub struct ToolResponse(ToolExecutionResult);
+
+impl ToolResponse {
+    /// A successful result carrying a JSON value.
+    pub fn json(value: impl Into<Value>) -> Self {
+        Self(ToolExecutionResult::success(value))
+    }
+
+    /// A successful result carrying plain text.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self(ToolExecutionResult::success(Value::String(text.into())))
+    }
+
+    /// A model-visible tool error (the turn continues; the model sees the message).
+    pub fn error(message: impl Into<String>) -> Self {
+        Self(ToolExecutionResult::tool_error(message))
+    }
+}
+
+impl fmt::Debug for ToolResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ToolResponse").field(&self.0).finish()
+    }
+}
+
+/// Converts a handler's success value into the engine's tool-result shape.
+///
+/// Implemented for the ergonomic return types a handler may produce:
+/// [`serde_json::Value`], [`String`], and the explicit [`ToolResponse`]
+/// adapter. A handler returns `Result<T, E>` where `T: IntoToolResult`.
+pub trait IntoToolResult {
+    /// Consume `self` and produce the engine tool result.
+    fn into_tool_result(self) -> ToolExecutionResult;
+}
+
+impl IntoToolResult for Value {
+    fn into_tool_result(self) -> ToolExecutionResult {
+        ToolExecutionResult::Success(self)
+    }
+}
+
+impl IntoToolResult for String {
+    fn into_tool_result(self) -> ToolExecutionResult {
+        ToolExecutionResult::Success(Value::String(self))
+    }
+}
+
+impl IntoToolResult for ToolResponse {
+    fn into_tool_result(self) -> ToolExecutionResult {
+        self.0
+    }
+}
+
+/// The boxed, type-erased async handler behind a [`FunctionTool`].
+type HandlerFn =
+    Arc<dyn Fn(Value) -> Pin<Box<dyn Future<Output = ToolExecutionResult> + Send>> + Send + Sync>;
+
+/// A custom agent tool backed by an async function or closure.
+///
+/// Construct one with [`FunctionTool::new`] and hand it to
+/// [`AgentBuilder::tool`](crate::AgentBuilder::tool). The handler is invoked
+/// with the model's call arguments deserialized into a [`serde_json::Value`]
+/// and returns any [`IntoToolResult`]. A returned `Err` becomes a model-visible
+/// tool error — the turn is never panicked by a handler.
+///
+/// A `FunctionTool` is cheap to clone (the handler is reference-counted) and is
+/// `Send + Sync`, so the same tool can execute calls concurrently.
+#[derive(Clone)]
+pub struct FunctionTool {
+    name: String,
+    description: String,
+    schema: Value,
+    handler: HandlerFn,
+}
+
+impl FunctionTool {
+    /// Wrap an async handler as a callable tool.
+    ///
+    /// - `name` is the identifier the model calls (validated at
+    ///   [`Agent::build`](crate::AgentBuilder::build)).
+    /// - `description` tells the model when to use the tool.
+    /// - `json_schema` is the JSON Schema for the tool's arguments (validated
+    ///   at build time).
+    /// - `handler` is an async `Fn(serde_json::Value) -> Result<T, E>` where
+    ///   `T: IntoToolResult` (a `Value`, a `String`, or a [`ToolResponse`]) and
+    ///   `E: Display`. On `Err`, the error's `Display` text is returned to the
+    ///   model as a tool error.
+    pub fn new<F, Fut, T, E>(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        json_schema: Value,
+        handler: F,
+    ) -> Self
+    where
+        F: Fn(Value) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<T, E>> + Send + 'static,
+        T: IntoToolResult + 'static,
+        E: fmt::Display + 'static,
+    {
+        let handler: HandlerFn = Arc::new(move |args| {
+            let fut = handler(args);
+            Box::pin(async move {
+                match fut.await {
+                    Ok(value) => value.into_tool_result(),
+                    Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+                }
+            })
+        });
+        Self {
+            name: name.into(),
+            description: description.into(),
+            schema: json_schema,
+            handler,
+        }
+    }
+
+    /// The tool's name (the identifier the model calls).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The tool's argument JSON schema.
+    pub(crate) fn schema(&self) -> &Value {
+        &self.schema
+    }
+
+    /// Wrap this tool as a single-tool capability for runtime registration.
+    pub(crate) fn into_capability(self) -> FunctionCapability {
+        FunctionCapability { tool: self }
+    }
+}
+
+impl fmt::Debug for FunctionTool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FunctionTool")
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("schema", &self.schema)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl CoreTool for FunctionTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn parameters_schema(&self) -> Value {
+        self.schema.clone()
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        (self.handler)(arguments).await
+    }
+}
+
+/// A closure-backed [`Capability`] exposing exactly one [`FunctionTool`].
+///
+/// Its capability id equals the tool name, so a single
+/// [`AgentCapabilityConfig`] reference wires the tool onto the agent. This is
+/// the bridge from a library-user function to the core capability/tool contract.
+pub(crate) struct FunctionCapability {
+    tool: FunctionTool,
+}
+
+impl Capability for FunctionCapability {
+    fn id(&self) -> &str {
+        &self.tool.name
+    }
+
+    fn name(&self) -> &str {
+        &self.tool.name
+    }
+
+    fn description(&self) -> &str {
+        &self.tool.description
+    }
+
+    fn tools(&self) -> Vec<Box<dyn CoreTool>> {
+        vec![Box::new(self.tool.clone())]
+    }
+}
+
+/// An agent tool: either a reference to an existing capability id, or a
+/// closure-backed [`FunctionTool`].
+///
+/// This is the application-facing adapter that [`AgentBuilder::tool`] accepts
+/// via [`IntoTool`]. A `&str`/`String` names a capability-referenced tool; a
+/// [`FunctionTool`] carries its own handler.
+#[derive(Clone, Debug)]
+pub enum Tool {
+    /// A tool provided by an existing capability, referenced by id.
+    Capability(AgentCapabilityConfig),
+    /// A custom tool backed by an async function or closure.
+    Function(FunctionTool),
+}
+
+impl Tool {
+    /// The model-facing name of this tool.
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Tool::Capability(config) => config.capability_id(),
+            Tool::Function(tool) => &tool.name,
+        }
+    }
+}
+
+/// Conversion into a [`Tool`] for [`AgentBuilder::tool`](crate::AgentBuilder::tool).
+///
+/// Implemented for [`FunctionTool`], for `&str`/`String` (a capability id), and
+/// for [`AgentCapabilityConfig`], so the same `.tool(..)` call accepts both a
+/// custom function tool and an existing capability-referenced tool.
+pub trait IntoTool {
+    /// Convert `self` into a [`Tool`].
+    fn into_tool(self) -> Tool;
+}
+
+impl IntoTool for Tool {
+    fn into_tool(self) -> Tool {
+        self
+    }
+}
+
+impl IntoTool for FunctionTool {
+    fn into_tool(self) -> Tool {
+        Tool::Function(self)
+    }
+}
+
+impl IntoTool for AgentCapabilityConfig {
+    fn into_tool(self) -> Tool {
+        Tool::Capability(self)
+    }
+}
+
+impl IntoTool for &str {
+    fn into_tool(self) -> Tool {
+        Tool::Capability(AgentCapabilityConfig::new(self))
+    }
+}
+
+impl IntoTool for String {
+    fn into_tool(self) -> Tool {
+        Tool::Capability(AgentCapabilityConfig::new(self))
+    }
+}
+
+impl IntoTool for &String {
+    fn into_tool(self) -> Tool {
+        Tool::Capability(AgentCapabilityConfig::new(self.as_str()))
+    }
+}
+
+/// Validate a tool name for use as a model-facing tool identifier.
+///
+/// Accepts `[A-Za-z0-9_-]{1,64}` starting with a letter or underscore — the
+/// common intersection of provider tool-name rules. Returns a human-readable
+/// reason on rejection.
+pub(crate) fn validate_tool_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("tool name must not be empty".to_string());
+    }
+    if name.len() > 64 {
+        return Err(format!(
+            "tool name must be at most 64 characters (got {})",
+            name.len()
+        ));
+    }
+    let mut chars = name.chars();
+    let first = chars.next().expect("non-empty checked above");
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(format!(
+            "tool name must start with a letter or underscore (got {first:?})"
+        ));
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '-'))
+    {
+        return Err(format!(
+            "tool name may only contain letters, digits, '_' or '-' (got {bad:?})"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a tool's JSON argument schema.
+///
+/// The schema must be a JSON object, and when it declares a top-level `type`
+/// that type must be `"object"` (the model always calls a tool with an object
+/// of arguments).
+pub(crate) fn validate_tool_schema(schema: &Value) -> Result<(), String> {
+    let Some(object) = schema.as_object() else {
+        return Err("JSON schema must be a JSON object".to_string());
+    };
+    if let Some(type_value) = object.get("type") {
+        match type_value.as_str() {
+            Some("object") => {}
+            Some(other) => {
+                return Err(format!(
+                    "JSON schema top-level \"type\" must be \"object\" (got {other:?})"
+                ));
+            }
+            None => {
+                return Err("JSON schema \"type\" must be a string".to_string());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    // `CoreTool` (the core `Tool` trait) is in scope via `super::*`, so tool
+    // handlers can be driven directly through `execute`.
+    use super::*;
+    use serde_json::json;
+
+    fn obj_schema() -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    #[tokio::test]
+    async fn handler_receives_args_and_returns_json() {
+        let tool = FunctionTool::new(
+            "echo",
+            "Echo the input back.",
+            obj_schema(),
+            |args: Value| async move { Ok::<_, String>(json!({ "echoed": args })) },
+        );
+        let result = tool.execute(json!({ "a": 1, "b": "two" })).await;
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["echoed"]["a"], json!(1));
+                assert_eq!(value["echoed"]["b"], json!("two"));
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn string_result_maps_to_success() {
+        let tool = FunctionTool::new(
+            "shout",
+            "Return text.",
+            obj_schema(),
+            |_args: Value| async move { Ok::<_, String>("hello".to_string()) },
+        );
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::Success(Value::String(s)) => assert_eq!(s, "hello"),
+            other => panic!("expected string success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_error_maps_to_tool_error_without_panicking() {
+        let tool = FunctionTool::new(
+            "boom",
+            "Always fails.",
+            obj_schema(),
+            |_args: Value| async move { Err::<Value, String>("kaboom".to_string()) },
+        );
+        let result = tool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(message) => assert_eq!(message, "kaboom"),
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_response_adapter_can_return_error_from_ok() {
+        let tool = FunctionTool::new(
+            "structured",
+            "Returns a structured tool error from an Ok path.",
+            obj_schema(),
+            |_args: Value| async move { Ok::<_, String>(ToolResponse::error("not found")) },
+        );
+        match tool.execute(json!({})).await {
+            ToolExecutionResult::ToolError(message) => assert_eq!(message, "not found"),
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn function_tool_executes_concurrently() {
+        let tool = Arc::new(FunctionTool::new(
+            "double",
+            "Double a number.",
+            obj_schema(),
+            |args: Value| async move {
+                let n = args["n"].as_i64().unwrap_or(0);
+                Ok::<_, String>(json!({ "result": n * 2 }))
+            },
+        ));
+
+        let mut handles = Vec::new();
+        for n in 0..16i64 {
+            let tool = tool.clone();
+            handles.push(tokio::spawn(async move {
+                let result = tool.execute(json!({ "n": n })).await;
+                match result {
+                    ToolExecutionResult::Success(value) => value["result"].as_i64().unwrap(),
+                    other => panic!("expected success, got {other:?}"),
+                }
+            }));
+        }
+        for (n, handle) in handles.into_iter().enumerate() {
+            assert_eq!(handle.await.unwrap(), n as i64 * 2);
+        }
+    }
+
+    #[test]
+    fn into_tool_maps_str_to_capability_ref() {
+        match "test_math".into_tool() {
+            Tool::Capability(config) => assert_eq!(config.capability_id(), "test_math"),
+            other => panic!("expected capability ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn into_tool_maps_function_tool() {
+        let tool = FunctionTool::new("noop", "no-op", obj_schema(), |_: Value| async move {
+            Ok::<_, String>(json!({}))
+        });
+        match tool.into_tool() {
+            Tool::Function(f) => assert_eq!(f.name(), "noop"),
+            other => panic!("expected function tool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_tool_name_accepts_and_rejects() {
+        assert!(validate_tool_name("get_weather").is_ok());
+        assert!(validate_tool_name("Add-2").is_ok());
+        assert!(validate_tool_name("_x").is_ok());
+        assert!(validate_tool_name("").is_err());
+        assert!(validate_tool_name("2fast").is_err());
+        assert!(validate_tool_name("has space").is_err());
+        assert!(validate_tool_name("dot.name").is_err());
+        assert!(validate_tool_name(&"x".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn validate_tool_schema_accepts_and_rejects() {
+        assert!(validate_tool_schema(&json!({ "type": "object" })).is_ok());
+        assert!(validate_tool_schema(&json!({ "properties": {} })).is_ok());
+        assert!(validate_tool_schema(&json!({ "type": "array" })).is_err());
+        assert!(validate_tool_schema(&json!("nope")).is_err());
+        assert!(validate_tool_schema(&json!(42)).is_err());
+    }
+}

--- a/crates/everruns/tests/function_tools.rs
+++ b/crates/everruns/tests/function_tools.rs
@@ -1,0 +1,71 @@
+//! Consumer-facing test for function tools (EVE-828).
+//!
+//! Proves the "done when" criterion: a library user registers a custom tool by
+//! passing an async closure, importing only the `everruns` facade — never
+//! `CapabilityRegistry`, `ToolDefinition`, `ToolContextServices`, or
+//! `PlatformStore`.
+
+use everruns::{Agent, BuildError, FunctionTool, Model, ToolResponse};
+use serde_json::{Value, json};
+
+fn schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"],
+    })
+}
+
+#[test]
+fn registers_function_and_capability_tools_via_public_api() {
+    let weather = FunctionTool::new(
+        "get_weather",
+        "Look up the weather for a city.",
+        schema(),
+        |args: Value| async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            if city.is_empty() {
+                return Ok(ToolResponse::error("city must not be empty"));
+            }
+            Ok::<_, String>(ToolResponse::json(json!({ "city": city, "sky": "clear" })))
+        },
+    );
+
+    // A function tool and a capability-referenced tool coexist on the same
+    // builder, with no core/registry types in sight.
+    let agent = Agent::builder()
+        .instructions("You are a helpful weather assistant.")
+        .model(Model::simulated("Clear skies."))
+        .tool("test_math")
+        .tool(weather)
+        .build();
+
+    assert!(
+        agent.is_ok(),
+        "public-API registration must build: {agent:?}"
+    );
+}
+
+#[test]
+fn duplicate_tool_names_are_rejected_at_build() {
+    let make = || {
+        FunctionTool::new("lookup", "desc", schema(), |_: Value| async move {
+            Ok::<_, String>(json!({}))
+        })
+    };
+
+    let err = Agent::builder()
+        .instructions("Concise.")
+        .model(Model::simulated("ok"))
+        .tool(make())
+        .tool(make())
+        .build()
+        .expect_err("duplicate names must fail");
+
+    assert_eq!(
+        err,
+        BuildError::DuplicateTool {
+            name: "lookup".to_string()
+        }
+    );
+}


### PR DESCRIPTION
## What changed

A library user can now register a custom agent tool by handing `AgentBuilder::tool` an async function or closure — no `CapabilityRegistry`, `ToolDefinition`, `ToolContextServices`, `PlatformStore`, or backend store required.

- New `everruns::FunctionTool::new(name, description, json_schema, handler)` wraps an async handler that receives the model's call arguments as a `serde_json::Value` and returns any `IntoToolResult`: a `serde_json::Value`, a `String`, or the explicit `ToolResponse` structured adapter (`ToolResponse::json/text/error`). A handler `Err` becomes a model-visible tool error; a handler never panics the turn.
- New application-facing `Tool` adapter and `IntoTool` trait, implemented for `FunctionTool`, `&str`/`String` (a capability id), and `AgentCapabilityConfig`. `AgentBuilder::tool` now takes `impl IntoTool`, so the same call accepts both custom function tools and existing capability-referenced tools (`.tool("test_math")` still works).
- `AgentBuilder::build` validates tool names and JSON schemas and rejects duplicate names, via new typed `BuildError::{InvalidToolName, InvalidToolSchema, DuplicateTool}`.
- New public exports: `FunctionTool`, `Tool`, `IntoTool`, `IntoToolResult`, `ToolResponse` (also added to `prelude`).

All changes are contained within `crates/everruns`. No `everruns-core` or `everruns-runtime` code was modified.

### How the function bridges to the core tool-execution contract

`FunctionTool` implements the core `everruns_core::tools::Tool` trait (`name`/`description`/`parameters_schema`/`async execute`), delegating `execute` to the stored handler. At `Agent::session()` runtime assembly, each function tool is wrapped in a private single-tool `everruns_core::capabilities::Capability` (`FunctionCapability`, whose `id()` equals the tool name and whose `tools()` yields the adapter) and registered via `InProcessRuntimeBuilder::capability(..)`; a matching `AgentCapabilityConfig` ref is attached to the seeded harness/agent/session so the model can call it and the result flows back like any built-in tool.

## Why

EVE-828: adding a custom tool should require just a function, not authoring a capability or a backend tool record. This is the first ergonomic tool-authoring surface on the `everruns` facade.

## Before / After

**Before** — `AgentBuilder::tool` only accepted a capability id (`impl Into`); a custom tool meant implementing a `Capability` + `Tool` and registering it in a `CapabilityRegistry`.

**After** — a closure is enough:

```rust
let weather = FunctionTool::new(
    "get_weather",
    "Look up the weather for a city.",
    json!({ "type": "object", "properties": { "city": { "type": "string" } }, "required": ["city"] }),
    |args: serde_json::Value| async move {
        let city = args["city"].as_str().unwrap_or("unknown");
        Ok::<_, String>(json!({ "city": city, "forecast": "sunny" }))
    },
);

let agent = Agent::builder()
    .instructions("You are a helpful weather assistant.")
    .model(Model::simulated("It is sunny."))
    .tool(weather)
    .build()?;
```

Evidence — `cargo test -p everruns`: 22 lib tests + 2 (`agent_builder`) + 1 (`facade_smoke`) + 2 (`function_tools`) integration tests + 6 doctests, all passing (verified again after rebasing onto the merged `everruns-platform` change). Includes the end-to-end LLM-simulator scenario `function_tool_executes_end_to_end` (sim emits a tool call → function tool executes with the model's args → turn completes with `tool_calls == 1`) and `function_tool_handler_error_is_model_visible_not_a_panic`. `cargo clippy -p everruns --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; `cargo test -p everruns-runtime --lib` 63 passing (no runtime changes).

## Risk

- Low
- Surface is additive and contained to `crates/everruns`. The one behavior change is `AgentBuilder::tool`'s bound (`impl Into` → `impl IntoTool`); `IntoTool` is implemented for `&str`/`String`/`AgentCapabilityConfig`, so existing `.tool("id")` call sites keep compiling (verified by the unchanged `Agent::builder` doctest and existing tests). Default features stay offline; no new runtime/core code paths.

## Security

- Threat categories reviewed: no security-relevant engine changes. New code runs user-supplied handlers in-process on the existing tool-execution path. Handler `Err` text (via `Display`) is returned to the model as a tool error — it is the caller's own content, not internal system detail, and is documented as such. Tool names are validated to `[A-Za-z0-9_-]{1,64}` and schemas constrained to JSON objects at build time. No credentials, unsafe code, or new network egress introduced.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. Out of scope per the issue: the `#[everruns::tool]` proc macro (EVE-829) and hosted capability config.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)