### PR TITLE
fix(reporting): wire MCP report queries

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -36,6 +36,7 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::budgets::BudgetService;
 use crate::domains::common::{Command, CommandError, CommandErrorKind, Ctx};
 use crate::domains::messages::MessageService;
+use crate::domains::reporting::ReportingService;
 use crate::domains::session_files::WorkspaceFileService;
 use crate::domains::session_sandbox::SessionSandboxService;
 use crate::domains::sessions::SessionService;
@@ -303,6 +304,7 @@ pub struct AppState {
     pub session_sandbox_service: Option<Arc<SessionSandboxService>>,
     pub capability_service: Arc<CapabilityService>,
     pub budget_service: Arc<BudgetService>,
+    pub reporting_service: Arc<ReportingService>,
     pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
     pub org_rate_limiter: crate::auth::rate_limit::OrgRateLimiter,
@@ -362,6 +364,7 @@ impl AppState {
             session_sandbox_service: None,
             capability_service,
             budget_service: Arc::new(BudgetService::new(db.clone())),
+            reporting_service: Arc::new(ReportingService::new(db.clone())),
             db,
             runner,
             auth,
@@ -1830,6 +1833,7 @@ pub(crate) fn domain_context(caller: Caller, state: &AppState) -> crate::domains
     .with_session_service(state.session_service.clone())
     .with_message_service(state.message_service.clone())
     .with_event_service(state.event_service.clone())
+    .with_reporting_service(state.reporting_service.clone())
     .with_session_file_service(state.session_file_service.clone())
     .with_runner(state.runner.clone())
     .with_fallback_harness_name(state.fallback_default_harness_name.clone())

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -1002,8 +1002,16 @@ fn dispatch_for<C: Command>(
     ctx: &Ctx,
 ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + '_>> {
     Box::pin(async move {
-        let cmd: C =
-            serde_json::from_value(params).map_err(|e| CommandError::bad_request(e.to_string()))?;
+        // Command transports encode no arguments as `{}`, while serde represents
+        // Rust unit structs as `null`. Retry only the empty-object shape so
+        // commands with declared fields keep their original validation errors.
+        let empty_object = params.as_object().is_some_and(serde_json::Map::is_empty);
+        let cmd: C = match serde_json::from_value(params) {
+            Ok(cmd) => cmd,
+            Err(object_error) if empty_object => serde_json::from_value(serde_json::Value::Null)
+                .map_err(|_| CommandError::bad_request(object_error.to_string()))?,
+            Err(error) => return Err(CommandError::bad_request(error.to_string())),
+        };
 
         // `run` handles the policy check using the active resolver in `ctx`.
         let result = cmd.run(ctx).await?;
@@ -1247,6 +1255,35 @@ where
 #[cfg(test)]
 mod error_tests {
     use super::*;
+
+    #[tokio::test]
+    async fn dispatch_accepts_empty_object_for_unit_commands() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = Ctx::minimal_for_test(Caller::internal(1), db, None);
+
+        let result = dispatch("get_report_catalog", serde_json::json!({}), &ctx)
+            .await
+            .expect("empty MCP params should dispatch to a unit command");
+        let value: serde_json::Value = serde_json::from_str(&result).expect("catalog JSON");
+
+        assert!(value.get("datasets").is_some());
+    }
+
+    #[tokio::test]
+    async fn dispatch_does_not_coerce_nonempty_objects_for_unit_commands() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = Ctx::minimal_for_test(Caller::internal(1), db, None);
+
+        let error = dispatch(
+            "get_report_catalog",
+            serde_json::json!({ "unexpected": true }),
+            &ctx,
+        )
+        .await
+        .expect_err("non-empty params must remain invalid for a unit command");
+
+        assert!(matches!(error.kind, CommandErrorKind::BadRequest(_)));
+    }
 
     #[test]
     fn classify_anyhow_maps_bad_request_error() {

--- a/crates/server/src/domains/reporting/commands.rs
+++ b/crates/server/src/domains/reporting/commands.rs
@@ -33,6 +33,10 @@ impl Command for RunReportQuery {
         Some(&REPORT_VIEW)
     }
 
+    fn read_only() -> bool {
+        true
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ReportResult, CommandError> {
         let service = ctx.reporting_service.as_ref().ok_or_else(|| {
             CommandError::internal(anyhow::anyhow!("Reporting service not configured"))
@@ -265,6 +269,10 @@ impl Command for RunSavedReport {
         Some(&REPORT_VIEW)
     }
 
+    fn read_only() -> bool {
+        true
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ReportResult, CommandError> {
         let service = ctx.reporting_service.as_ref().ok_or_else(|| {
             CommandError::internal(anyhow::anyhow!("Reporting service not configured"))
@@ -301,6 +309,10 @@ impl Command for ExportReportQuery {
 
     fn policy() -> Option<&'static Policy> {
         Some(&REPORT_VIEW)
+    }
+
+    fn read_only() -> bool {
+        true
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ReportExport, CommandError> {
@@ -345,6 +357,10 @@ impl Command for ExportSavedReport {
 
     fn policy() -> Option<&'static Policy> {
         Some(&REPORT_VIEW)
+    }
+
+    fn read_only() -> bool {
+        true
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ReportExport, CommandError> {
@@ -465,3 +481,16 @@ impl Command for BackfillReporting {
 }
 
 inventory::submit! { CommandDescriptor::of::<BackfillReporting>() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semantic_report_reads_are_available_to_mcp_query() {
+        assert!(RunReportQuery::read_only());
+        assert!(RunSavedReport::read_only());
+        assert!(ExportReportQuery::read_only());
+        assert!(ExportSavedReport::read_only());
+    }
+}

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -640,8 +640,12 @@ const ALLOWED_PUBLIC: &[&str] = &[
 /// POST-style helpers intentionally available through MCP `query`.
 /// They do not persist state and each still declares a view policy.
 const ALLOWED_NON_GET_READ_ONLY: &[&str] = &[
+    "export_report_query",
+    "export_saved_report",
     "grep_workspace_files",
     "preview_agent",
     "preview_harness",
+    "run_report_query",
+    "run_saved_report",
     "stat_workspace_file",
 ];

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1376,6 +1376,61 @@ async fn test_mcp_query_list_harnesses() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_reporting_catalog_and_model_usage() {
+    let server = TestServer::in_memory().await;
+
+    let catalog = mcp_tool_call(
+        &server,
+        "query",
+        json!({ "commands": "get_report_catalog" }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&catalog),
+        "query get_report_catalog failed: {}",
+        tool_text(&catalog)
+    );
+    assert!(
+        tool_json(&catalog)["datasets"]
+            .as_array()
+            .expect("report datasets")
+            .iter()
+            .any(|dataset| dataset["name"] == "llm_generations")
+    );
+
+    let report = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "commands": "run_report_query --dataset llm_generations --time_range '{\"from\":\"2026-01-01T00:00:00Z\",\"to\":\"2026-08-09T00:00:00Z\"}' --dimensions '[\"provider\",\"model\"]' --measures '[\"input_tokens\",\"output_tokens\"]'"
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&report),
+        "query run_report_query failed: {}",
+        tool_text(&report)
+    );
+    let result = tool_json(&report);
+    assert_eq!(result["columns"][0]["name"], "provider");
+    assert_eq!(result["columns"][1]["name"], "model");
+    assert_eq!(result["columns"][2]["name"], "input_tokens");
+    assert_eq!(result["columns"][3]["name"], "output_tokens");
+    assert!(result["rows"].is_array());
+
+    let invalid = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "commands": "run_report_query --dataset llm_generations --time_range '{\"from\":\"2026-01-01T00:00:00Z\",\"to\":\"2026-08-09T00:00:00Z\"}' --dimensions '[\"not_a_dimension\"]' --measures '[\"input_tokens\"]'"
+        }),
+    )
+    .await;
+    assert!(tool_is_error(&invalid));
+    assert!(tool_text(&invalid).contains("bad_request:"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_query_missing_commands() {
     let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "query", json!({})).await;


### PR DESCRIPTION
## What changed
MCP scripted commands now receive the reporting service, accept empty-object arguments for Rust unit commands, and expose semantic report reads through the read-only `query` tool. This restores `get_report_catalog` and provider/model `llm_generations` usage queries without requiring session/message reconstruction.

## Why
MCP discovery advertised reporting commands, but execution failed because the MCP domain context omitted `ReportingService`. Zero-argument commands also received `{}` while serde unit structs require `null`, and read-only POST report operations were incorrectly limited to `execute`.

## Before / After
Before:
- `query run_report_query ...` returned `bash: run_report_query: command not found`.
- `execute get_report_catalog` returned `bad_request: invalid type: map, expected unit struct GetReportCatalog`.
- `execute run_report_query ...` returned `internal: Internal server error`; the server logged `Reporting service not configured`.

After, the canonical PostgreSQL stack returned a non-empty model-usage row through MCP `query`:

```json
{"provider":"openai","model":"gpt-smoke","input_tokens":120,"output_tokens":30,"total_tokens":150}
```

The equivalent REST query returned the same row. Invalid dimensions return HTTP 400 over REST and `bad_request: Invalid dimension for reporting dataset` over MCP.

## Risk
- Low
- The generic empty-object retry is limited to empty maps after normal deserialization fails; non-empty invalid arguments retain their original bad-request behavior.
- Newly read-only POST commands are constrained by the reviewed inventory allowlist and still enforce `REPORT_VIEW` through `Command::run`.

## Security
- Threat categories reviewed: TM-MCP, TM-TENANT, TM-API, TM-DOS
- Findings and resolutions: No new findings. MCP command policy and org scoping are unchanged; report SQL remains parameterized; internal errors remain sanitized; report dimensions, measures, filters, time range, row count, and MCP execution time remain bounded. The existing TM-MCP-002 allowlist test now explicitly covers the four read-only reporting POST operations.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)