### PR TITLE
fix(ui): simplify agent version history

### DIFF
--- a/apps/ui/src/__tests__/agent-version-history.test.tsx
+++ b/apps/ui/src/__tests__/agent-version-history.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AgentVersionHistory } from "@/components/agents/agent-version-history";
+import type { Agent, AgentVersion } from "@/lib/api/types";
+
+const push = jest.fn();
+const createVersion = jest.fn();
+const mockUseAgentVersionDiff = jest.fn(
+  (_agentId: string, _fromVersionId?: string, _toVersionId?: string) => ({ data: undefined }),
+);
+let versions: AgentVersion[] = [];
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+jest.mock("@/hooks/use-agents", () => ({
+  useAgentVersions: () => ({ data: versions, isLoading: false }),
+  useCreateAgentVersion: () => ({ mutateAsync: createVersion, isPending: false }),
+  useSetDefaultAgentVersion: () => ({ mutate: jest.fn(), isPending: false }),
+  useRollbackAgentVersion: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useForkAgentVersion: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useAgentVersionDiff: (agentId: string, fromVersionId?: string, toVersionId?: string) =>
+    mockUseAgentVersionDiff(agentId, fromVersionId, toVersionId),
+}));
+
+const agent = {
+  id: "agt_test",
+  default_version_id: null,
+} as unknown as Agent;
+
+function version(overrides: Partial<AgentVersion> = {}): AgentVersion {
+  return {
+    id: "ver_test",
+    version: "draft.1",
+    is_published: false,
+    change_kind: "auto",
+    summary: null,
+    created_at: "2026-08-07T15:37:28Z",
+    config_hash: "sha256:8b6be000000000000000",
+    ...overrides,
+  } as AgentVersion;
+}
+
+describe("AgentVersionHistory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    versions = [];
+    createVersion.mockResolvedValue(undefined);
+  });
+
+  it("prioritizes one clear action for an agent without saved versions", async () => {
+    versions = [version()];
+
+    render(<AgentVersionHistory agent={agent} />);
+
+    expect(screen.getByText("Save your first version")).toBeInTheDocument();
+    expect(screen.queryByText("Saved versions")).not.toBeInTheDocument();
+    expect(screen.queryByText("Compare versions")).not.toBeInTheDocument();
+    expect(screen.getByText("Recovery snapshots (1)").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.getByText("Version options").closest("details")).not.toHaveAttribute("open");
+
+    fireEvent.change(screen.getByLabelText("What changed? (optional)"), {
+      target: { value: "Updated the instructions" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save current version" }));
+
+    await waitFor(() =>
+      expect(createVersion).toHaveBeenCalledWith({
+        agentId: "agt_test",
+        request: { summary: "Updated the instructions", change_kind: "manual" },
+      }),
+    );
+  });
+
+  it("keeps the compare action hidden until revisions are selected", () => {
+    versions = [
+      version({ id: "ver_2", version: "0.1.1", is_published: true, change_kind: "patch" }),
+      version({ id: "ver_1", version: "0.1.0", is_published: true, change_kind: "manual" }),
+    ];
+
+    render(<AgentVersionHistory agent={agent} />);
+
+    expect(screen.getByText("Save a new version")).toBeInTheDocument();
+    expect(screen.getByText("Saved versions")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Compare versions"));
+    expect(screen.getByRole("combobox", { name: "From revision" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "To revision" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Compare revisions" })).not.toBeInTheDocument();
+    expect(mockUseAgentVersionDiff).toHaveBeenLastCalledWith("agt_test", undefined, undefined);
+  });
+});

--- a/apps/ui/src/components/agents/agent-version-history.tsx
+++ b/apps/ui/src/components/agents/agent-version-history.tsx
@@ -14,7 +14,7 @@ import {
 import type { Agent, AgentVersion, AgentVersionChangeKind } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -96,6 +96,10 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
   const [changeKind, setChangeKind] = useState<AgentVersionChangeKind>("manual");
   const [fromVersionId, setFromVersionId] = useState<string>("");
   const [toVersionId, setToVersionId] = useState<string>("");
+  const [comparedVersionIds, setComparedVersionIds] = useState<{
+    from: string;
+    to: string;
+  } | null>(null);
   const [rollbackVersion, setRollbackVersion] = useState<AgentVersion | null>(null);
   const [forkVersion, setForkVersion] = useState<AgentVersion | null>(null);
   const [forkName, setForkName] = useState("");
@@ -106,7 +110,7 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
   const setDefault = useSetDefaultAgentVersion();
   const rollback = useRollbackAgentVersion();
   const fork = useForkAgentVersion();
-  const diff = useAgentVersionDiff(agent.id, fromVersionId || undefined, toVersionId || undefined);
+  const diff = useAgentVersionDiff(agent.id, comparedVersionIds?.from, comparedVersionIds?.to);
   const publishedVersions = useMemo(
     () => versions.filter((version) => version.is_published),
     [versions],
@@ -118,13 +122,23 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
   const latest = publishedVersions[0];
 
   const selectedFrom = useMemo(
-    () => versions.find((version) => version.id === fromVersionId),
-    [fromVersionId, versions],
+    () => versions.find((version) => version.id === comparedVersionIds?.from),
+    [comparedVersionIds?.from, versions],
   );
   const selectedTo = useMemo(
-    () => versions.find((version) => version.id === toVersionId),
-    [toVersionId, versions],
+    () => versions.find((version) => version.id === comparedVersionIds?.to),
+    [comparedVersionIds?.to, versions],
   );
+
+  const selectFromVersion = (versionId: string) => {
+    setFromVersionId(versionId);
+    setComparedVersionIds(null);
+  };
+
+  const selectToVersion = (versionId: string) => {
+    setToVersionId(versionId);
+    setComparedVersionIds(null);
+  };
 
   const saveVersion = async () => {
     await createVersion.mutateAsync({
@@ -167,14 +181,70 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
   };
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-      <div className="space-y-6">
+    <div className="mx-auto w-full max-w-4xl space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {publishedVersions.length === 0 ? "Save your first version" : "Save a new version"}
+          </CardTitle>
+          <CardDescription>
+            {publishedVersions.length === 0
+              ? "Save the current configuration so you can return to it later."
+              : "Create a restore point for the current configuration."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+            <div>
+              <Label htmlFor="version-summary">What changed? (optional)</Label>
+              <Input
+                id="version-summary"
+                value={summary}
+                onChange={(event) => setSummary(event.target.value)}
+                placeholder="For example: Updated the instructions"
+              />
+            </div>
+            <Button onClick={saveVersion} disabled={createVersion.isPending}>
+              <Save className="mr-2 h-4 w-4" />
+              {createVersion.isPending ? "Saving..." : "Save current version"}
+            </Button>
+          </div>
+          <details className="text-sm">
+            <summary className="w-fit cursor-pointer text-muted-foreground hover:text-foreground">
+              Version options
+            </summary>
+            <div className="mt-3 max-w-xs space-y-1">
+              <Label>Type of change</Label>
+              <Select
+                value={changeKind}
+                onValueChange={(value) => setChangeKind(value as AgentVersionChangeKind)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="manual">Standard update</SelectItem>
+                  <SelectItem value="patch">Bug fix</SelectItem>
+                  <SelectItem value="minor">New feature</SelectItem>
+                  <SelectItem value="major">Breaking change</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                This controls how the version number changes.
+              </p>
+            </div>
+          </details>
+        </CardContent>
+      </Card>
+
+      {publishedVersions.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <History className="h-4 w-4" />
-              Version History
+              Saved versions
             </CardTitle>
+            <CardDescription>Versions you chose to keep.</CardDescription>
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -182,10 +252,6 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
                 <Skeleton className="h-14 w-full" />
                 <Skeleton className="h-14 w-full" />
               </div>
-            ) : publishedVersions.length === 0 ? (
-              <p className="py-8 text-center text-sm text-muted-foreground">
-                No saved versions yet.
-              </p>
             ) : (
               <div className="divide-y border">
                 {publishedVersions.map((version) => (
@@ -219,7 +285,7 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
                         disabled={version.id === agent.default_version_id || setDefault.isPending}
                       >
                         <Star className="mr-1 h-3 w-3" />
-                        Default
+                        Use by default
                       </Button>
                       <Button
                         size="sm"
@@ -227,11 +293,11 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
                         onClick={() => setRollbackVersion(version)}
                       >
                         <RotateCcw className="mr-1 h-3 w-3" />
-                        Rollback
+                        Restore
                       </Button>
                       <Button size="sm" variant="outline" onClick={() => setForkVersion(version)}>
                         <GitBranch className="mr-1 h-3 w-3" />
-                        Fork
+                        Create copy
                       </Button>
                     </div>
                   </div>
@@ -240,21 +306,22 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
             )}
           </CardContent>
         </Card>
+      )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Automatic Snapshots</CardTitle>
-          </CardHeader>
-          <CardContent>
+      {draftSnapshots.length > 0 && (
+        <details className="border bg-card text-card-foreground">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium hover:bg-muted/40">
+            Recovery snapshots ({draftSnapshots.length})
+          </summary>
+          <div className="space-y-3 border-t px-4 py-4">
+            <p className="text-sm text-muted-foreground">
+              Everruns saves these automatically in case you need to recover an earlier draft.
+            </p>
             {isLoading ? (
               <div className="space-y-2">
                 <Skeleton className="h-14 w-full" />
                 <Skeleton className="h-14 w-full" />
               </div>
-            ) : draftSnapshots.length === 0 ? (
-              <p className="py-8 text-center text-sm text-muted-foreground">
-                No automatic snapshots yet.
-              </p>
             ) : (
               <div className="divide-y border">
                 {draftSnapshots.map((version) => (
@@ -275,43 +342,55 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
                         onClick={() => setRollbackVersion(version)}
                       >
                         <RotateCcw className="mr-1 h-3 w-3" />
-                        Rollback
+                        Restore
                       </Button>
                       <Button size="sm" variant="outline" onClick={() => setForkVersion(version)}>
                         <GitBranch className="mr-1 h-3 w-3" />
-                        Fork
+                        Create copy
                       </Button>
                     </div>
                   </div>
                 ))}
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
+        </details>
+      )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Compare Versions</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
+      {versions.length >= 2 && (
+        <details className="border bg-card text-card-foreground">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium hover:bg-muted/40">
+            Compare versions
+          </summary>
+          <div className="space-y-4 border-t px-4 py-4">
             <div className="grid gap-3 md:grid-cols-2">
               <div>
                 <Label>From</Label>
                 <VersionSelect
+                  label="From revision"
                   value={fromVersionId}
                   versions={versions}
-                  onValueChange={setFromVersionId}
+                  onValueChange={selectFromVersion}
                 />
               </div>
               <div>
                 <Label>To</Label>
                 <VersionSelect
+                  label="To revision"
                   value={toVersionId}
                   versions={versions}
-                  onValueChange={setToVersionId}
+                  onValueChange={selectToVersion}
                 />
               </div>
             </div>
+            {fromVersionId && toVersionId && fromVersionId !== toVersionId && (
+              <Button
+                variant="outline"
+                onClick={() => setComparedVersionIds({ from: fromVersionId, to: toVersionId })}
+              >
+                Compare revisions
+              </Button>
+            )}
             {selectedFrom && selectedTo && diff.data && (
               <div className="space-y-5">
                 <p className="text-sm text-muted-foreground">
@@ -321,63 +400,25 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
                 <DiffBlock title="Resolved Configuration" diff={diff.data.resolved_diff} />
               </div>
             )}
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Save Version</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div>
-            <Label>Change type</Label>
-            <Select
-              value={changeKind}
-              onValueChange={(value) => setChangeKind(value as AgentVersionChangeKind)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="manual">Manual</SelectItem>
-                <SelectItem value="patch">Patch</SelectItem>
-                <SelectItem value="minor">Minor</SelectItem>
-                <SelectItem value="major">Major</SelectItem>
-              </SelectContent>
-            </Select>
           </div>
-          <div>
-            <Label htmlFor="version-summary">Summary</Label>
-            <Textarea
-              id="version-summary"
-              value={summary}
-              onChange={(event) => setSummary(event.target.value)}
-              placeholder="What changed in this agent configuration?"
-            />
-          </div>
-          <Button onClick={saveVersion} disabled={createVersion.isPending} className="w-full">
-            <Save className="mr-2 h-4 w-4" />
-            {createVersion.isPending ? "Saving..." : "Save Version"}
-          </Button>
-        </CardContent>
-      </Card>
+        </details>
+      )}
 
       <Dialog open={!!rollbackVersion} onOpenChange={(open) => !open && setRollbackVersion(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Rollback to {rollbackVersion?.version}</DialogTitle>
+            <DialogTitle>Restore {rollbackVersion?.version}?</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            The editable agent draft will be replaced with this version. A rollback version will be
-            saved so the history stays auditable.
+            This replaces the current editable configuration. Everruns will save the current state
+            first, so you can undo this restore later.
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setRollbackVersion(null)}>
               Cancel
             </Button>
             <Button onClick={submitRollback} disabled={rollback.isPending}>
-              {rollback.isPending ? "Rolling back..." : "Rollback"}
+              {rollback.isPending ? "Restoring..." : "Restore version"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -386,7 +427,7 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
       <Dialog open={!!forkVersion} onOpenChange={(open) => !open && setForkVersion(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Fork {forkVersion?.version}</DialogTitle>
+            <DialogTitle>Create a copy of {forkVersion?.version}</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div>
@@ -419,7 +460,7 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
               Cancel
             </Button>
             <Button onClick={submitFork} disabled={fork.isPending || !forkName.trim()}>
-              {fork.isPending ? "Forking..." : "Fork Agent"}
+              {fork.isPending ? "Creating..." : "Create agent copy"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -429,17 +470,19 @@ export function AgentVersionHistory({ agent }: { agent: Agent }) {
 }
 
 function VersionSelect({
+  label,
   value,
   versions,
   onValueChange,
 }: {
+  label: string;
   value: string;
   versions: AgentVersion[];
   onValueChange: (value: string) => void;
 }) {
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger>
+      <SelectTrigger aria-label={label}>
         <SelectValue placeholder="Select version" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## What changed

Simplifies the Agent Versions tab around one primary action: saving the current configuration.

- Prioritizes the save form and hides semantic version controls under optional version settings.
- Shows saved versions only when they exist and collapses recovery snapshots and comparison tools.
- Replaces versioning jargon with clearer restore and copy language.
- Reveals the compare action only after two distinct revisions are selected and waits for the explicit click before fetching the diff.

## Why

The previous screen gave empty history, automatic recovery data, comparison controls, and publishing equal visual weight. First-time users could not tell what they needed to do or how automatic snapshots differed from saved versions.

## Before / After

Before: four equally prominent panels exposed manual/patch/minor/major choices, rollback/fork actions, and empty comparison controls before they were useful.

After: the screen leads with **Save current version**, keeps advanced controls collapsed, and reveals **Compare revisions** only after two distinct revisions are selected. The end-to-end smoke test used mocked version and diff responses without mutating local data; it verified the button gating and rendered diff result.

Visual proof was captured during local validation in the before-selection, ready-to-compare, and rendered-diff states. The repository screenshot uploader could not attach it because `CLOUDINARY_URL` is unavailable in this environment; screenshots were not committed, per repository policy.

## Risk

- Low
- The changed surface is limited to Agent Versions presentation and client-side comparison gating. Existing API payloads and mutation behavior are unchanged.

## Security

- Threat categories reviewed: TM-WEB-001 (stored-content XSS), TM-WEB-002 (state-changing requests/CSRF)
- Findings and resolutions: No new trust boundary, HTML rendering, credential handling, or API mutation was introduced. User and API text remains rendered through React escaping, and existing mutation hooks are unchanged. No threat-model update is required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
