### PR TITLE
feat(library): add `openai` feature and `OpenAI::from_env()` model configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,7 @@ version = "0.17.23"
 dependencies = [
  "async-trait",
  "everruns-core",
+ "everruns-openai",
  "everruns-runtime",
  "serde_json",
  "tokio",

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -35,10 +35,19 @@ default = []
 lua = ["everruns-runtime/lua"]
 # Enable local-process (stdio) MCP servers, mirroring `everruns-runtime/mcp-stdio`.
 mcp-stdio = ["everruns-runtime/mcp-stdio"]
+# Configure real OpenAI-backed models via `everruns::providers::openai`. Off by
+# default so the standard facade build pulls in no provider or Reqwest edge; the
+# `OpenAI` config type and its driver wiring compile only with this feature.
+openai = ["dep:everruns-openai"]
 
 [dependencies]
 everruns-core.workspace = true
 everruns-runtime.workspace = true
+# Optional real-provider edge, activated by the `openai` feature. Referenced via
+# workspace inheritance; the workspace pin is a compatible lower bound, so this
+# is intentionally absent from the publish version-sync lists (unlike
+# everruns-core/everruns-runtime, which track the workspace version exactly).
+everruns-openai = { workspace = true, optional = true }
 async-trait.workspace = true
 serde_json.workspace = true
 

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -26,8 +26,10 @@ use crate::tool::{FunctionTool, IntoTool, Tool, validate_tool_name, validate_too
 ///
 /// A `Model` carries the driver selection and model configuration behind a
 /// value-first surface, so the public builder never exposes `ResolvedModel`,
-/// `DriverId`, or the simulator config. Today the only constructor is
-/// [`Model::simulated`]; real providers arrive in a later change.
+/// `DriverId`, or the simulator config. [`Model::simulated`] backs an offline
+/// simulator; with the `openai` feature, an
+/// [`OpenAI`](crate::providers::openai::OpenAI) configuration converts into a
+/// `Model` that targets the real provider.
 #[derive(Clone)]
 pub struct Model {
     resolved: ResolvedModel,
@@ -51,6 +53,33 @@ impl Model {
             },
             sim: Some(LlmSimConfig::fixed(response)),
         }
+    }
+
+    /// Build a `Model` that targets OpenAI's Responses API.
+    ///
+    /// Keeps `ResolvedModel`/`DriverId` off the public surface: the
+    /// [`OpenAI`](crate::providers::openai::OpenAI) config is the value-first
+    /// entry point, and `build_runtime` registers the OpenAI driver only for a
+    /// model produced here.
+    #[cfg(feature = "openai")]
+    pub(crate) fn openai(config: crate::providers::openai::OpenAI) -> Self {
+        let (model, api_key, base_url) = config.into_parts();
+        Self {
+            resolved: ResolvedModel {
+                model,
+                provider_type: DriverId::OpenAI,
+                api_key: Some(api_key),
+                base_url,
+                provider_metadata: None,
+            },
+            sim: None,
+        }
+    }
+
+    /// Whether this model needs the OpenAI driver registered on the runtime.
+    #[cfg(feature = "openai")]
+    fn is_openai(&self) -> bool {
+        self.resolved.provider_type == DriverId::OpenAI
     }
 }
 
@@ -267,6 +296,15 @@ impl Agent {
         if let Some(sim) = &self.model.sim {
             builder = builder.llm_sim(sim.clone());
         }
+        // A real OpenAI model needs its driver registered so a turn can reach the
+        // provider; setting `default_model` alone is not enough. Register only for
+        // an OpenAI model, so a simulated-model agent needs no provider wiring.
+        #[cfg(feature = "openai")]
+        if self.model.is_openai() {
+            let mut registry = everruns_core::DriverRegistry::new();
+            everruns_openai::register_driver(&mut registry);
+            builder = builder.driver_registry(registry);
+        }
         builder.build().await
     }
 }
@@ -295,8 +333,12 @@ impl AgentBuilder {
     }
 
     /// Select the model the agent talks to. Required.
-    pub fn model(mut self, model: Model) -> Self {
-        self.model = Some(model);
+    ///
+    /// Accepts a [`Model`] directly or anything convertible into one — for
+    /// example an [`OpenAI`](crate::providers::openai::OpenAI) configuration
+    /// under the `openai` feature.
+    pub fn model(mut self, model: impl Into<Model>) -> Self {
+        self.model = Some(model.into());
         self
     }
 
@@ -610,6 +652,41 @@ mod tests {
             .build()
             .expect("valid agent");
         assert_eq!(agent.name, "assistant");
+    }
+
+    #[cfg(feature = "openai")]
+    #[test]
+    fn openai_model_reports_provider_without_leaking_key() {
+        use crate::providers::openai::OpenAI;
+
+        let model = Model::openai(OpenAI::new("gpt-5-mini", "sk-super-secret"));
+        assert!(model.is_openai());
+        assert_eq!(model.resolved.model, "gpt-5-mini");
+        assert!(model.sim.is_none(), "an OpenAI model uses no simulator");
+        // The value-first `Debug` reports shape only, never the key.
+        let rendered = format!("{model:?}");
+        assert!(!rendered.contains("sk-super-secret"), "got {rendered}");
+    }
+
+    #[cfg(feature = "openai")]
+    #[tokio::test]
+    async fn openai_agent_builds_runtime_offline() {
+        use crate::providers::openai::OpenAI;
+
+        // Building the runtime registers the OpenAI driver and assembles the
+        // in-process composition without any network call — the provider is only
+        // contacted when a turn actually runs, which this test never does.
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(OpenAI::new("gpt-5-mini", "sk-test"))
+            .build()
+            .expect("valid agent");
+
+        let runtime = agent
+            .build_runtime(SessionId::new())
+            .await
+            .expect("openai runtime builds offline");
+        let _ = runtime;
     }
 
     #[tokio::test]

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -63,6 +63,13 @@ pub use agent::{Agent, AgentBuilder, BuildError, Model};
 pub use session::{RunError, Session, Turn};
 pub use tool::{FunctionTool, IntoTool, IntoToolResult, Tool, ToolResponse};
 
+// --- Real LLM provider configuration (feature-gated) --------------------
+// The default facade build stays offline; provider modules compile only when
+// their feature is enabled. `openai` adds `providers::openai::OpenAI`.
+pub mod providers;
+#[cfg(feature = "openai")]
+pub use providers::openai::{ModelError, OpenAI};
+
 // --- Runtime construction and execution ---------------------------------
 // Note: the value-first `AgentBuilder` above intentionally replaces the runtime
 // crate's low-level `AgentBuilder` at the facade root. The runtime builder
@@ -108,6 +115,8 @@ pub mod prelude {
         Agent, AgentBuilder, BuildError, FunctionTool, IntoTool, IntoToolResult, Model, RunError,
         Session, Tool, ToolResponse, Turn,
     };
+    #[cfg(feature = "openai")]
+    pub use crate::{ModelError, OpenAI};
     pub use everruns_core::turn::TurnStopReason;
     pub use everruns_core::{ContentPart, InputMessage, MessageRole};
 }

--- a/crates/everruns/src/providers.rs
+++ b/crates/everruns/src/providers.rs
@@ -1,0 +1,9 @@
+//! Real LLM provider configuration for the facade.
+//!
+//! Each provider lives behind its own cargo feature so the default facade build
+//! stays fully offline — no provider crate, no Reqwest edge. Enable the `openai`
+//! feature to configure OpenAI-backed models through
+//! [`openai::OpenAI`](crate::providers::openai::OpenAI).
+
+#[cfg(feature = "openai")]
+pub mod openai;

--- a/crates/everruns/src/providers/openai.rs
+++ b/crates/everruns/src/providers/openai.rs
@@ -1,0 +1,247 @@
+//! OpenAI-backed model configuration (requires the `openai` feature).
+//!
+//! [`OpenAI`] is the value-first entry point for talking to OpenAI's Responses
+//! API. Convert it into a [`Model`](crate::Model) — directly or via
+//! [`AgentBuilder::model`](crate::AgentBuilder::model) — and the agent's runtime
+//! registers the OpenAI driver automatically.
+//!
+//! The existing `everruns-openai` drivers are re-exported here
+//! ([`OpenAIChatDriver`], [`OpenAICompletionsChatDriver`], [`register_driver`])
+//! for embedders who need the low-level driver directly.
+
+use std::fmt;
+
+use crate::Model;
+
+/// API key environment variable, matching the repo-wide convention documented on
+/// `everruns_core::credential_provider::EnvCredentialProvider`.
+const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
+/// Optional base-URL override environment variable (OpenAI-compatible proxies,
+/// self-hosted endpoints, Azure gateways).
+const OPENAI_BASE_URL_ENV: &str = "OPENAI_BASE_URL";
+
+/// Re-exported `everruns-openai` drivers for direct, low-level use.
+pub use everruns_openai::{OpenAIChatDriver, OpenAICompletionsChatDriver, register_driver};
+
+/// Why an [`OpenAI`] configuration could not be produced.
+///
+/// Typed and cheap to match on. Credential values never appear in the error —
+/// only the name of the missing environment variable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ModelError {
+    /// A required environment variable was unset or empty.
+    MissingEnvVar {
+        /// The variable name that was expected (e.g. `OPENAI_API_KEY`).
+        var: &'static str,
+    },
+}
+
+impl fmt::Display for ModelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ModelError::MissingEnvVar { var } => {
+                write!(f, "required environment variable {var} is not set")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ModelError {}
+
+/// Configuration for an OpenAI-backed [`Model`](crate::Model).
+///
+/// Build one with [`OpenAI::new`] (explicit, deterministic — reads no
+/// environment) or [`OpenAI::from_env`] (reads `OPENAI_API_KEY` and, when set,
+/// `OPENAI_BASE_URL`). Both target OpenAI's Responses API via the recommended
+/// [`OpenAIChatDriver`].
+///
+/// The API key is redacted from [`Debug`] output.
+#[derive(Clone)]
+pub struct OpenAI {
+    model: String,
+    api_key: String,
+    base_url: Option<String>,
+}
+
+impl OpenAI {
+    /// Configure OpenAI with an explicit model id and API key.
+    ///
+    /// Deterministic: reads no environment. Use [`from_env`](Self::from_env)
+    /// to pick the key up from `OPENAI_API_KEY` instead.
+    ///
+    /// ```
+    /// use everruns::providers::openai::OpenAI;
+    ///
+    /// let model = OpenAI::new("gpt-5-mini", "sk-your-key");
+    /// # let _ = model;
+    /// ```
+    pub fn new(model: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            api_key: api_key.into(),
+            base_url: None,
+        }
+    }
+
+    /// Configure OpenAI, reading the API key (and optional base URL) from the
+    /// environment.
+    ///
+    /// Reads `OPENAI_API_KEY` (required) and `OPENAI_BASE_URL` (optional),
+    /// matching the repo-wide credential-variable convention. An unset or empty
+    /// `OPENAI_API_KEY` returns [`ModelError::MissingEnvVar`] rather than
+    /// panicking.
+    ///
+    /// This is the sanctioned standalone/dev entry point for env-based
+    /// credentials; explicit constructors stay environment-free.
+    ///
+    /// ```no_run
+    /// use everruns::{Agent, providers::openai::OpenAI};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// // Requires `OPENAI_API_KEY` in the environment.
+    /// let agent = Agent::builder()
+    ///     .instructions("You are concise.")
+    ///     .model(OpenAI::from_env("gpt-5-mini")?)
+    ///     .build()?;
+    /// # let _ = agent;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_env(model: impl Into<String>) -> Result<Self, ModelError> {
+        Self::from_lookup(model, |name| std::env::var(name).ok())
+    }
+
+    /// Resolve from an injectable variable lookup — the testable core of
+    /// [`from_env`](Self::from_env), so tests never mutate the process
+    /// environment.
+    fn from_lookup<F>(model: impl Into<String>, lookup: F) -> Result<Self, ModelError>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let non_empty = |s: String| (!s.is_empty()).then_some(s);
+        let api_key =
+            lookup(OPENAI_API_KEY_ENV)
+                .and_then(non_empty)
+                .ok_or(ModelError::MissingEnvVar {
+                    var: OPENAI_API_KEY_ENV,
+                })?;
+        let base_url = lookup(OPENAI_BASE_URL_ENV).and_then(non_empty);
+        Ok(Self {
+            model: model.into(),
+            api_key,
+            base_url,
+        })
+    }
+
+    /// Override the API base URL (OpenAI-compatible proxy, self-hosted endpoint,
+    /// or Azure gateway).
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+
+    /// Consume the config into its `(model, api_key, base_url)` parts for the
+    /// facade's `Model` constructor. Crate-internal so the public surface never
+    /// leaks the raw key.
+    pub(crate) fn into_parts(self) -> (String, String, Option<String>) {
+        (self.model, self.api_key, self.base_url)
+    }
+}
+
+impl fmt::Debug for OpenAI {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenAI")
+            .field("model", &self.model)
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl From<OpenAI> for Model {
+    fn from(config: OpenAI) -> Self {
+        Model::openai(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_environment_free_and_sets_no_base_url() {
+        let config = OpenAI::new("gpt-5-mini", "sk-explicit");
+        let (model, api_key, base_url) = config.into_parts();
+        assert_eq!(model, "gpt-5-mini");
+        assert_eq!(api_key, "sk-explicit");
+        assert_eq!(base_url, None);
+    }
+
+    #[test]
+    fn from_lookup_reads_key_and_optional_base_url() {
+        let config = OpenAI::from_lookup("gpt-5-mini", |name| match name {
+            "OPENAI_API_KEY" => Some("sk-env".to_string()),
+            "OPENAI_BASE_URL" => Some("https://proxy.example/v1".to_string()),
+            _ => None,
+        })
+        .expect("key present");
+        let (model, api_key, base_url) = config.into_parts();
+        assert_eq!(model, "gpt-5-mini");
+        assert_eq!(api_key, "sk-env");
+        assert_eq!(base_url, Some("https://proxy.example/v1".to_string()));
+    }
+
+    #[test]
+    fn from_lookup_missing_key_is_typed_error() {
+        let err = OpenAI::from_lookup("gpt-5-mini", |_| None).unwrap_err();
+        assert_eq!(
+            err,
+            ModelError::MissingEnvVar {
+                var: "OPENAI_API_KEY"
+            }
+        );
+    }
+
+    #[test]
+    fn from_lookup_empty_key_is_missing() {
+        let err = OpenAI::from_lookup("gpt-5-mini", |name| {
+            (name == "OPENAI_API_KEY").then(String::new)
+        })
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ModelError::MissingEnvVar {
+                var: "OPENAI_API_KEY"
+            }
+        );
+    }
+
+    #[test]
+    fn base_url_builder_overrides() {
+        let (_, _, base_url) = OpenAI::new("gpt-5-mini", "sk-explicit")
+            .base_url("https://custom.example/v1")
+            .into_parts();
+        assert_eq!(base_url, Some("https://custom.example/v1".to_string()));
+    }
+
+    #[test]
+    fn debug_redacts_api_key() {
+        let rendered = format!(
+            "{:?}",
+            OpenAI::new("gpt-5-mini", "sk-super-secret").base_url("https://x/v1")
+        );
+        assert!(!rendered.contains("sk-super-secret"), "got {rendered}");
+        assert!(rendered.contains("[REDACTED]"), "got {rendered}");
+        assert!(rendered.contains("gpt-5-mini"), "got {rendered}");
+    }
+
+    #[test]
+    fn model_error_display_names_the_variable_only() {
+        let rendered = ModelError::MissingEnvVar {
+            var: "OPENAI_API_KEY",
+        }
+        .to_string();
+        assert!(rendered.contains("OPENAI_API_KEY"), "got {rendered}");
+    }
+}


### PR DESCRIPTION
## What changed

A consumer can now configure a real OpenAI-backed model using only the `everruns` facade plus its new, non-default `openai` feature:

```toml
everruns = { version = "...", features = ["openai"] }
```

```rust
let agent = Agent::builder()
    .instructions("You are concise.")
    .model(OpenAI::from_env("gpt-5-mini")?)
    .build()?;
```

Public API added (all behind `#[cfg(feature = "openai")]`):

- `everruns::providers::openai::OpenAI` — value-first config for OpenAI's Responses API.
  - `OpenAI::new(model, api_key)` — explicit, deterministic, reads no environment.
  - `OpenAI::from_env(model)` — reads `OPENAI_API_KEY` (required) and `OPENAI_BASE_URL` (optional).
  - `.base_url(url)` — override the endpoint (proxy / self-hosted / Azure gateway).
- `everruns::providers::openai::ModelError` — typed error; `MissingEnvVar { var }` when the key is absent.
- `impl From<OpenAI> for Model`, and `AgentBuilder::model` now takes `impl Into<Model>` (source-compatible with existing `.model(Model::simulated(..))`).
- Re-exports of the existing drivers: `OpenAIChatDriver`, `OpenAICompletionsChatDriver`, `register_driver`.
- `OpenAI` and `ModelError` are also re-exported at the crate root and added to `prelude`, feature-gated.

Driver wiring: `Agent::build_runtime` registers the OpenAI driver on the runtime's `DriverRegistry` **only** when the model is an OpenAI model (`provider_type == DriverId::OpenAI`), mirroring the `openai_runtime` example. A simulated-model agent registers no provider. The public surface never exposes `ResolvedModel`, `DriverId`, or registry types.

## Why

EVE-834: the facade previously had only `Model::simulated`, so there was no first-class way to target a real provider. This adds the common real-provider path as a single opt-in dependency while preserving the facade's core invariant that the default build is fully offline (no provider, no Reqwest).

## Before / After

- **Before:** `everruns` had no way to configure OpenAI; an embedder had to drop down to `everruns::runtime` + `everruns-openai` and hand-build a `ResolvedModel`/`DriverRegistry`.
- **After:** `OpenAI::from_env("gpt-5-mini")?` (or `OpenAI::new(..)`) produces a `Model` that runs against OpenAI, with the driver registered automatically at runtime-build time.

Evidence (local):

- `cargo test -p everruns` (default) — pass (offline, no OpenAI edge).
- `cargo test -p everruns --features openai` — pass (31 unit + doctests, incl. the `no_run` provider example and an offline `build_runtime` assertion).
- `cargo build -p everruns --features openai` — pass.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p everruns --all-targets --all-features -- -D warnings` — clean.
- `python3 scripts/sync-publish-pin-versions.py --check` — `all path-dep pins at 0.17.23`.
- `cargo fetch --locked` — clean (Cargo.lock adds only the `everruns → everruns-openai` edge).

No live OpenAI network calls in tests: `from_env` is tested via an injectable lookup (no process-env mutation, no races), and the OpenAI runtime is asserted to **build** offline — the provider is only contacted when a turn runs, which the tests never do.

## Risk

- Low
- New code is entirely behind the non-default `openai` feature; the default feature graph is unchanged (verified by the default-feature test/clippy runs). Worst case is confined to consumers who opt into `openai`.

## Security

- Threat categories reviewed: TM-API / credential handling. The API key is stored only inside the private `OpenAI`/`ResolvedModel` fields, redacted as `[REDACTED]` in `OpenAI`'s and `Model`'s `Debug`, and never included in `ModelError` (which carries only the env-var name). No new network egress paths beyond the pre-existing `everruns-openai` driver; env reads happen only in `from_env`, the sanctioned standalone/dev seam.
- Findings and resolutions: none.

## Follow-ups

- Organization/project headers, retry, and timeout config (mentioned in the issue) are deferred: the `ResolvedModel → DriverDescriptor` factory path only consumes `api_key` and `base_url`, so surfacing those knobs today would be configuration that silently has no effect. Wiring them needs additive core/runtime support and is better done as its own change.
- Wiremock/fixture header-verification test deferred in favor of offline build/config assertions, consistent with the repo's avoidance of live/networked provider calls in unit tests.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)