### PR TITLE
feat(library): expose session events and cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
  "everruns-runtime",
  "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -50,6 +50,13 @@ everruns-runtime.workspace = true
 everruns-openai = { workspace = true, optional = true }
 async-trait.workspace = true
 serde_json.workspace = true
+# Session event streaming (broadcast channel) and cancellation (select). Only
+# the `sync` surface of tokio is needed on the non-dev build.
+tokio = { workspace = true, features = ["sync", "macros"] }
+# `CancellationToken` backs the facade's public cancellation handle without
+# leaking the tokio-util type onto the public surface. Matches the pin used by
+# everruns-core.
+tokio-util = { version = "0.7", default-features = false }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/everruns/examples/observe_and_cancel.rs
+++ b/crates/everruns/examples/observe_and_cancel.rs
@@ -1,0 +1,64 @@
+//! Observe a session's events and cancel a turn — using only `everruns`.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p everruns --example observe_and_cancel
+//! ```
+//!
+//! This example imports nothing but `everruns::prelude::*`: it renders streaming
+//! output from a turn's [`SessionEvent`] feed, then shows a turn resolving to a
+//! cancelled outcome through a [`CancellationToken`].
+
+use everruns::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let agent = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("Hello from Everruns!"))
+        .build()?;
+
+    // --- Observe a turn's events -----------------------------------------
+    let mut session = agent.session();
+    let mut events = session.events();
+
+    // Read the event stream on a background task while the turn runs.
+    let observer = tokio::spawn(async move {
+        let mut rendered = String::new();
+        while let Some(event) = events.recv().await {
+            match event.kind {
+                SessionEventKind::TurnStarted => println!("[turn started]"),
+                SessionEventKind::TextDelta { delta } => {
+                    rendered.push_str(&delta);
+                    print!("{delta}");
+                }
+                SessionEventKind::TurnCompleted => println!("\n[turn completed]"),
+                _ => {}
+            }
+        }
+        rendered
+    });
+
+    let turn = session.run("hi").await?;
+    println!("final response: {}", turn.response);
+
+    // Drop the session so the stream closes and the observer finishes.
+    drop(session);
+    let rendered = observer.await?;
+    assert_eq!(rendered, turn.response);
+
+    // --- Cancel a turn ---------------------------------------------------
+    let mut session = agent.session();
+    let token = CancellationToken::new();
+    token.cancel(); // cancel up front for a deterministic example
+
+    let cancelled = session
+        .run_with("hi", RunOptions::new().cancel_token(token))
+        .await?;
+    assert_eq!(cancelled.stop_reason, TurnStopReason::Cancelled);
+    assert!(!cancelled.success);
+    println!("cancelled turn stop reason: {:?}", cancelled.stop_reason);
+
+    Ok(())
+}

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -12,12 +12,13 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::sync::Arc;
 
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_core::{AgentCapabilityConfig, DriverId, InitialFile, ResolvedModel, SessionId};
 use everruns_runtime::{
-    AgentBuilder as RuntimeAgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder,
-    SessionBuilder,
+    AgentBuilder as RuntimeAgentBuilder, EventBus, HarnessBuilder, InProcessRuntime,
+    InProcessRuntimeBuilder, RuntimeBackends, SessionBuilder,
 };
 
 use crate::tool::{FunctionTool, IntoTool, Tool, validate_tool_name, validate_tool_schema};
@@ -94,6 +95,26 @@ impl Model {
     ) -> Self {
         let mut sim = LlmSimConfig::fixed(response);
         sim.message_capture = Some(capture);
+        Self {
+            resolved: ResolvedModel {
+                model: "llmsim-model".to_string(),
+                provider_type: DriverId::LlmSim,
+                api_key: Some("fake-key".to_string()),
+                base_url: None,
+                provider_metadata: None,
+            },
+            sim: Some(sim),
+        }
+    }
+
+    /// Test-only: a simulated model that waits `delay` (a TTFT delay) before
+    /// producing `response`. The open window lets a facade test cancel a turn
+    /// while it is parked, exercising the cancellation path deterministically.
+    pub(crate) fn simulated_delayed(
+        response: impl Into<String>,
+        delay: std::time::Duration,
+    ) -> Self {
+        let sim = LlmSimConfig::fixed(response).with_response_delay(delay);
         Self {
             resolved: ResolvedModel {
                 model: "llmsim-model".to_string(),
@@ -241,14 +262,27 @@ impl Agent {
     }
 
     /// Materialize a fresh in-process runtime for this agent, seeded with the
-    /// given session id.
+    /// given session id, routing the runtime's raw event bus through the supplied
+    /// facade sink so a [`Session`](crate::Session) can stream its events.
     ///
     /// Each call assembles a new `Harness`/`Agent`/`Session` composition, so
-    /// distinct session ids yield independent sessions. This is the private
-    /// seam [`Session`](crate::Session) builds on.
-    pub(crate) async fn build_runtime(
+    /// distinct session ids yield independent sessions. This is the private seam
+    /// [`Session`](crate::Session) builds on. The bus replaces the default
+    /// in-memory emitter; message persistence is unaffected because the bus
+    /// assigns event ids/sequences the same way.
+    pub(crate) async fn build_runtime_with_event_bus(
         &self,
         session_id: SessionId,
+        event_bus: Arc<dyn EventBus>,
+    ) -> Result<InProcessRuntime, everruns_core::AgentLoopError> {
+        self.build_runtime_with_backends(session_id, Some(event_bus))
+            .await
+    }
+
+    async fn build_runtime_with_backends(
+        &self,
+        session_id: SessionId,
+        event_bus: Option<Arc<dyn EventBus>>,
     ) -> Result<InProcessRuntime, everruns_core::AgentLoopError> {
         let mut harness = HarnessBuilder::new(&self.name, &self.instructions)
             .capabilities(self.capabilities.clone());
@@ -287,6 +321,12 @@ impl Agent {
             .agent(agent)
             .session(session)
             .default_model(self.model.resolved.clone());
+        // Route the runtime's raw event bus through the facade sink when one was
+        // supplied, so the session can stream events. Everything else stays on
+        // the default in-memory backends.
+        if let Some(event_bus) = event_bus {
+            builder = builder.backends(RuntimeBackends::in_memory().with_event_bus(event_bus));
+        }
         // Register each function tool as a closure-backed, single-tool
         // capability so the runtime can execute the model's calls; the matching
         // capability ref was attached to the harness/agent/session above.
@@ -683,7 +723,7 @@ mod tests {
             .expect("valid agent");
 
         let runtime = agent
-            .build_runtime(SessionId::new())
+            .build_runtime_with_backends(SessionId::new(), None)
             .await
             .expect("openai runtime builds offline");
         let _ = runtime;
@@ -699,7 +739,7 @@ mod tests {
 
         let session_id = SessionId::new();
         let runtime = agent
-            .build_runtime(session_id)
+            .build_runtime_with_backends(session_id, None)
             .await
             .expect("runtime builds");
         // The seeded session id is usable directly: a caller can run a turn

--- a/crates/everruns/src/events.rs
+++ b/crates/everruns/src/events.rs
@@ -1,0 +1,347 @@
+//! Observable and cancellable turns (EVE-833).
+//!
+//! This module promotes two capabilities onto the [`Session`](crate::Session)
+//! surface without leaking the runtime's event bus or the core event/store
+//! types:
+//!
+//! - **Observation.** [`Session::events`](crate::Session::events) returns an
+//!   [`EventStream`] — a live feed of [`SessionEvent`]s projected from the
+//!   runtime's in-process event bus. The stream is backed by a broadcast
+//!   channel, so a slow or dropped consumer can never stall the turn that
+//!   produces the events; it only lags and skips.
+//! - **Cancellation.** [`Session::run_with`](crate::Session::run_with) accepts a
+//!   [`RunOptions`] carrying an optional [`CancellationToken`]. Cancelling the
+//!   token stops the in-flight turn by dropping its future — the same
+//!   cooperative, drop-based cancellation the runtime already uses to tear down
+//!   tool work — and the turn resolves to a stable [`Turn`](crate::Turn) with
+//!   [`TurnStopReason::Cancelled`](everruns_core::turn::TurnStopReason::Cancelled).
+//!
+//! Only facade types appear on the public surface: no `EventBus`,
+//! `EventEmitter`, `EventRequest`, or core event/store types.
+
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use async_trait::async_trait;
+use everruns_core::error::Result as CoreResult;
+use everruns_core::events::{
+    self, Event, EventData, EventRequest, OutputMessageDeltaData, ToolCompletedData,
+    ToolStartedData, TurnFailedData,
+};
+use everruns_core::traits::EventEmitter;
+use everruns_core::typed_id::EventId;
+use everruns_runtime::EventBus;
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+/// Capacity of the per-session broadcast channel that backs [`EventStream`].
+///
+/// A turn emits well under this many events, so a consumer that keeps up never
+/// lags. A consumer that falls behind by more than this drops the oldest events
+/// (reported as a skip) rather than applying back-pressure to the turn — the
+/// runner must never block on an observer.
+const EVENT_CHANNEL_CAPACITY: usize = 4096;
+
+/// A single observed event from a running [`Session`](crate::Session).
+///
+/// A small, stable projection of one runtime event. The correlation ids
+/// (`event_id`, `session_id`, and the optional `turn_id`) are preserved on every
+/// event so a consumer can line events up with a [`Turn`](crate::Turn); the
+/// [`kind`](SessionEvent::kind) carries the event-specific payload.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct SessionEvent {
+    /// Opaque id uniquely identifying this event.
+    pub event_id: String,
+    /// Opaque id of the session that produced the event.
+    pub session_id: String,
+    /// Opaque id of the turn this event belongs to, when turn-scoped.
+    pub turn_id: Option<String>,
+    /// The event-specific projection.
+    pub kind: SessionEventKind,
+}
+
+/// The event-specific payload of a [`SessionEvent`].
+///
+/// Non-exhaustive on purpose: new hosted event types are surfaced through the
+/// [`Other`](SessionEventKind::Other) fallback, which carries the stable event
+/// type string and the raw JSON payload, so promoting a new event to a typed
+/// variant later never breaks a consumer that already matches with a wildcard.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum SessionEventKind {
+    /// A turn began executing.
+    TurnStarted,
+    /// A turn finished successfully.
+    TurnCompleted,
+    /// A turn ended with an unrecoverable failure.
+    TurnFailed {
+        /// Human-readable failure message.
+        error: String,
+    },
+    /// A turn was cancelled before completing.
+    TurnCancelled,
+    /// An incremental chunk of assistant output text.
+    TextDelta {
+        /// The new text appended by this delta.
+        delta: String,
+    },
+    /// A tool call started executing.
+    ToolStarted {
+        /// Opaque id of the tool call.
+        tool_call_id: String,
+        /// Name of the tool being invoked.
+        tool_name: String,
+    },
+    /// A tool call finished executing.
+    ToolCompleted {
+        /// Opaque id of the tool call.
+        tool_call_id: String,
+        /// Name of the tool that was invoked.
+        tool_name: String,
+        /// Whether the tool call succeeded.
+        success: bool,
+    },
+    /// Any other runtime event, carried through unprojected.
+    ///
+    /// `event_type` is the stable dot-notation type string (e.g.
+    /// `"reason.started"`); `payload` is the raw event data as JSON. This is the
+    /// forward-compatibility fallback — match it with a wildcard arm.
+    Other {
+        /// Stable dot-notation event type string.
+        event_type: String,
+        /// Raw event payload as JSON.
+        payload: Value,
+    },
+}
+
+impl SessionEvent {
+    /// The stable dot-notation type string for this event (e.g.
+    /// `"turn.started"`), matching the runtime event protocol.
+    pub fn event_type(&self) -> &str {
+        match &self.kind {
+            SessionEventKind::TurnStarted => events::TURN_STARTED,
+            SessionEventKind::TurnCompleted => events::TURN_COMPLETED,
+            SessionEventKind::TurnFailed { .. } => events::TURN_FAILED,
+            SessionEventKind::TurnCancelled => events::TURN_CANCELLED,
+            SessionEventKind::TextDelta { .. } => events::OUTPUT_MESSAGE_DELTA,
+            SessionEventKind::ToolStarted { .. } => events::TOOL_STARTED,
+            SessionEventKind::ToolCompleted { .. } => events::TOOL_COMPLETED,
+            SessionEventKind::Other { event_type, .. } => event_type,
+        }
+    }
+
+    /// Project a core [`Event`] into a facade [`SessionEvent`].
+    ///
+    /// Known event types map to typed [`SessionEventKind`] variants; every other
+    /// type is carried through the [`Other`](SessionEventKind::Other) fallback,
+    /// so no event is ever dropped.
+    fn from_core_event(event: &Event) -> Self {
+        let turn_id = event.context.turn_id.map(|id| id.to_string());
+        let kind = match event.event_type.as_str() {
+            events::TURN_STARTED => SessionEventKind::TurnStarted,
+            events::TURN_COMPLETED => SessionEventKind::TurnCompleted,
+            events::TURN_CANCELLED => SessionEventKind::TurnCancelled,
+            events::TURN_FAILED => {
+                let error = match &event.data {
+                    EventData::TurnFailed(TurnFailedData { error, .. }) => error.clone(),
+                    _ => String::new(),
+                };
+                SessionEventKind::TurnFailed { error }
+            }
+            events::OUTPUT_MESSAGE_DELTA => {
+                let delta = match &event.data {
+                    EventData::OutputMessageDelta(OutputMessageDeltaData { delta, .. }) => {
+                        delta.clone()
+                    }
+                    _ => String::new(),
+                };
+                SessionEventKind::TextDelta { delta }
+            }
+            events::TOOL_STARTED => match &event.data {
+                EventData::ToolStarted(ToolStartedData { tool_call, .. }) => {
+                    SessionEventKind::ToolStarted {
+                        tool_call_id: tool_call.id.clone(),
+                        tool_name: tool_call.name.clone(),
+                    }
+                }
+                _ => Self::other_kind(event),
+            },
+            events::TOOL_COMPLETED => match &event.data {
+                EventData::ToolCompleted(ToolCompletedData {
+                    tool_call_id,
+                    tool_name,
+                    success,
+                    ..
+                }) => SessionEventKind::ToolCompleted {
+                    tool_call_id: tool_call_id.clone(),
+                    tool_name: tool_name.clone(),
+                    success: *success,
+                },
+                _ => Self::other_kind(event),
+            },
+            _ => Self::other_kind(event),
+        };
+        Self {
+            event_id: event.id.to_string(),
+            session_id: event.session_id.to_string(),
+            turn_id,
+            kind,
+        }
+    }
+
+    fn other_kind(event: &Event) -> SessionEventKind {
+        SessionEventKind::Other {
+            event_type: event.event_type.clone(),
+            payload: serde_json::to_value(&event.data).unwrap_or(Value::Null),
+        }
+    }
+}
+
+/// A live feed of [`SessionEvent`]s for one [`Session`](crate::Session).
+///
+/// Obtain one from [`Session::events`](crate::Session::events) before running a
+/// turn. Consume it with [`recv`](Self::recv) in a loop. Backed by a broadcast
+/// channel: dropping the stream never affects a running turn, and a consumer
+/// that falls behind skips old events rather than blocking the runner.
+pub struct EventStream {
+    rx: broadcast::Receiver<SessionEvent>,
+}
+
+impl EventStream {
+    fn new(rx: broadcast::Receiver<SessionEvent>) -> Self {
+        Self { rx }
+    }
+
+    /// Await the next event.
+    ///
+    /// Returns `None` once the session is dropped and no further events can
+    /// arrive. If the consumer fell behind and the channel dropped events, those
+    /// events are skipped silently and the next available event is returned.
+    pub async fn recv(&mut self) -> Option<SessionEvent> {
+        loop {
+            match self.rx.recv().await {
+                Ok(event) => return Some(event),
+                // The consumer lagged; skip the dropped events and keep reading.
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+
+    /// Return the next already-available event without waiting.
+    ///
+    /// Returns `None` when no event is currently buffered (or the session has
+    /// ended). Skips past a lagged gap the same way [`recv`](Self::recv) does.
+    pub fn try_recv(&mut self) -> Option<SessionEvent> {
+        loop {
+            match self.rx.try_recv() {
+                Ok(event) => return Some(event),
+                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(broadcast::error::TryRecvError::Empty)
+                | Err(broadcast::error::TryRecvError::Closed) => return None,
+            }
+        }
+    }
+}
+
+/// Options controlling a single [`Session::run_with`](crate::Session::run_with).
+///
+/// Cheap to construct and clone; extend it over time without breaking callers.
+#[derive(Clone, Default)]
+pub struct RunOptions {
+    pub(crate) cancel: Option<CancellationToken>,
+}
+
+impl RunOptions {
+    /// Default options: no cancellation.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attach a cancellation token. Cancelling it stops the turn in flight.
+    pub fn cancel_token(mut self, token: CancellationToken) -> Self {
+        self.cancel = Some(token);
+        self
+    }
+}
+
+/// A handle for cancelling an in-flight turn.
+///
+/// Clone it to hold cancellation from another task; every clone shares one
+/// signal. Pass it into a run via [`RunOptions::cancel_token`], then call
+/// [`cancel`](Self::cancel) to stop the turn. Cancellation is cooperative and
+/// drop-based: the turn's future is dropped at the next await point, which tears
+/// down any in-flight tool work, and the run resolves to a cancelled
+/// [`Turn`](crate::Turn).
+#[derive(Clone, Default)]
+pub struct CancellationToken {
+    inner: tokio_util::sync::CancellationToken,
+}
+
+impl CancellationToken {
+    /// Create a fresh, un-cancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Request cancellation. Idempotent; safe to call from any task.
+    pub fn cancel(&self) {
+        self.inner.cancel();
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Resolve once cancellation has been requested. Facade-internal: the run
+    /// loop selects on this against the turn future.
+    pub(crate) async fn cancelled(&self) {
+        self.inner.cancelled().await;
+    }
+}
+
+/// Facade event bus: the raw in-process event sink handed to the runtime.
+///
+/// Implements the runtime's [`EventBus`] contract (and thus core's
+/// [`EventEmitter`]). It assigns each event an id and sequence exactly as the
+/// runtime's built-in in-memory emitter does — so downstream message
+/// persistence still works — then fans the event out to every live
+/// [`EventStream`] as a projected [`SessionEvent`]. Sending never blocks and
+/// never errors on a full or subscriber-less channel, so an observer can never
+/// stall or fail a turn.
+pub(crate) struct FacadeEventBus {
+    sender: broadcast::Sender<SessionEvent>,
+    sequence: AtomicI32,
+}
+
+impl FacadeEventBus {
+    pub(crate) fn new() -> Self {
+        let (sender, _rx) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        Self {
+            sender,
+            sequence: AtomicI32::new(0),
+        }
+    }
+
+    /// Subscribe a new [`EventStream`] to this bus.
+    pub(crate) fn subscribe(&self) -> EventStream {
+        EventStream::new(self.sender.subscribe())
+    }
+}
+
+#[async_trait]
+impl EventEmitter for FacadeEventBus {
+    async fn emit(&self, request: EventRequest) -> CoreResult<Event> {
+        let seq = self.sequence.fetch_add(1, Ordering::Relaxed) + 1;
+        let event = request.into_event(EventId::new(), seq);
+        // Ignore the send result: an error means there are simply no live
+        // subscribers, which must not affect the turn.
+        let _ = self.sender.send(SessionEvent::from_core_event(&event));
+        Ok(event)
+    }
+}
+
+// The default `collected_events` (empty) is correct: this bus streams rather
+// than retaining. Observers read the live `EventStream`, not a post-hoc buffer.
+impl EventBus for FacadeEventBus {}

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -57,9 +57,11 @@
 
 // --- Value-first agent description and execution -------------------------
 mod agent;
+mod events;
 mod session;
 mod tool;
 pub use agent::{Agent, AgentBuilder, BuildError, Model};
+pub use events::{CancellationToken, EventStream, RunOptions, SessionEvent, SessionEventKind};
 pub use session::{RunError, Session, Turn};
 pub use tool::{FunctionTool, IntoTool, IntoToolResult, Tool, ToolResponse};
 
@@ -112,8 +114,9 @@ pub use everruns_runtime as runtime;
 /// ```
 pub mod prelude {
     pub use crate::{
-        Agent, AgentBuilder, BuildError, FunctionTool, IntoTool, IntoToolResult, Model, RunError,
-        Session, Tool, ToolResponse, Turn,
+        Agent, AgentBuilder, BuildError, CancellationToken, EventStream, FunctionTool, IntoTool,
+        IntoToolResult, Model, RunError, RunOptions, Session, SessionEvent, SessionEventKind, Tool,
+        ToolResponse, Turn,
     };
     #[cfg(feature = "openai")]
     pub use crate::{ModelError, OpenAI};

--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -5,11 +5,15 @@
 //! lives for as long as the `Session`. Two sessions from the same agent are
 //! independent and never share history.
 
+use std::sync::Arc;
+
 use everruns_core::turn::TurnStopReason;
+use everruns_core::typed_id::TurnId;
 use everruns_core::{AgentLoopError, InputMessage, SessionId};
 use everruns_runtime::{InProcessRuntime, TurnResult};
 
 use crate::Agent;
+use crate::events::{EventStream, FacadeEventBus, RunOptions};
 
 /// A live, multi-turn conversation with an [`Agent`](crate::Agent).
 ///
@@ -43,6 +47,10 @@ pub struct Session {
     agent: Agent,
     session_id: SessionId,
     runtime: Option<InProcessRuntime>,
+    /// The session's event sink, created eagerly so [`events`](Session::events)
+    /// can subscribe before the first turn builds the runtime. Handed to the
+    /// runtime as its raw event bus on first [`run`](Session::run).
+    event_bus: Arc<FacadeEventBus>,
 }
 
 impl Session {
@@ -51,6 +59,7 @@ impl Session {
             agent,
             session_id,
             runtime: None,
+            event_bus: Arc::new(FacadeEventBus::new()),
         }
     }
 
@@ -60,6 +69,18 @@ impl Session {
     /// useful to line up a session's turns in logs.
     pub fn id(&self) -> String {
         self.session_id.to_string()
+    }
+
+    /// Subscribe to this session's live [`SessionEvent`](crate::SessionEvent)
+    /// feed.
+    ///
+    /// The returned [`EventStream`] observes every turn run *after* it is
+    /// created (subscribe before calling [`run`](Session::run)). Multiple streams
+    /// can observe the same session independently, and each session's events are
+    /// isolated — one session never sees another's. Dropping a stream, or letting
+    /// a consumer fall behind, never affects a running turn.
+    pub fn events(&self) -> EventStream {
+        self.event_bus.subscribe()
     }
 
     /// Run one turn and return its [`Turn`] outcome.
@@ -75,12 +96,56 @@ impl Session {
     /// max-iteration stop) is returned as an `Ok(Turn)` with `success == false`
     /// and the [`stop_reason`](Turn::stop_reason) preserved.
     pub async fn run(&mut self, input: impl Into<InputMessage>) -> Result<Turn, RunError> {
+        self.run_with(input, RunOptions::default()).await
+    }
+
+    /// Run one turn under the given [`RunOptions`], enabling cancellation.
+    ///
+    /// Identical to [`run`](Session::run) when the options carry no cancellation
+    /// token. When a [`CancellationToken`](crate::CancellationToken) is attached
+    /// and cancelled while the turn is in flight, the turn's future is dropped —
+    /// cooperatively tearing down any running tool work — and this returns an
+    /// `Ok(Turn)` with [`success == false`](Turn::success) and
+    /// [`stop_reason`](Turn::stop_reason) set to
+    /// [`TurnStopReason::Cancelled`]. A token already cancelled before the call
+    /// stops the turn before it starts.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`run`](Session::run): [`RunError`] if the runtime cannot be built
+    /// or the turn cannot be executed.
+    pub async fn run_with(
+        &mut self,
+        input: impl Into<InputMessage>,
+        options: RunOptions,
+    ) -> Result<Turn, RunError> {
         if self.runtime.is_none() {
-            self.runtime = Some(self.agent.build_runtime(self.session_id).await?);
+            self.runtime = Some(
+                self.agent
+                    .build_runtime_with_event_bus(self.session_id, self.event_bus.clone())
+                    .await?,
+            );
         }
         let runtime = self.runtime.as_ref().expect("runtime built above");
-        let result = runtime.run_turn(self.session_id, input).await?;
-        Ok(Turn::from(result))
+
+        match options.cancel {
+            None => {
+                let result = runtime.run_turn(self.session_id, input).await?;
+                Ok(Turn::from(result))
+            }
+            Some(token) => {
+                // Race the turn against cancellation. `biased` checks the token
+                // first, so a pre-cancelled token stops the turn before it runs.
+                // On cancellation the turn future is dropped, which is the
+                // runtime's own cooperative teardown path — no second stop
+                // mechanism is introduced.
+                tokio::select! {
+                    biased;
+                    () = token.cancelled() => Ok(Turn::cancelled()),
+                    result = runtime.run_turn(self.session_id, input) => Ok(Turn::from(result?)),
+                }
+            }
+        }
     }
 }
 
@@ -105,6 +170,27 @@ pub struct Turn {
     pub success: bool,
     /// Failure message when `success` is `false`.
     pub error: Option<String>,
+}
+
+impl Turn {
+    /// The stable outcome of a cancelled turn.
+    ///
+    /// Synthesized by [`Session::run_with`] when a turn is cancelled in flight:
+    /// its future is dropped before the runtime can report an outcome, so the
+    /// facade maps that to a non-success turn carrying
+    /// [`TurnStopReason::Cancelled`]. The `turn_id` is a fresh correlation id —
+    /// the dropped turn's own id is not recoverable.
+    fn cancelled() -> Self {
+        Self {
+            response: String::new(),
+            turn_id: TurnId::new().to_string(),
+            stop_reason: TurnStopReason::Cancelled,
+            iterations: 0,
+            tool_calls: 0,
+            success: false,
+            error: Some("turn cancelled".to_string()),
+        }
+    }
 }
 
 impl From<TurnResult> for Turn {
@@ -252,5 +338,144 @@ mod tests {
         assert!(!turn.success);
         assert_eq!(turn.stop_reason, TurnStopReason::MaxTurnRequests);
         assert_eq!(turn.error.as_deref(), Some("hit the ceiling"));
+    }
+
+    // --- Events and cancellation (EVE-833) -------------------------------
+    //
+    // These reach the crate-internal simulator helpers (`simulated_scripted`,
+    // `simulated_delayed`) that an external integration test cannot see. The
+    // public-surface event/cancellation behaviors live in
+    // `tests/session_events.rs`.
+
+    use std::time::Duration;
+
+    use everruns_core::ToolCall;
+    use serde_json::json;
+
+    use crate::{CancellationToken, RunOptions, SessionEvent, SessionEventKind};
+
+    async fn drain(mut stream: crate::EventStream) -> Vec<SessionEvent> {
+        let mut events = Vec::new();
+        while let Some(event) = stream.recv().await {
+            events.push(event);
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn tool_events_correlate_with_parent_turn() {
+        let tool = crate::FunctionTool::new(
+            "ping",
+            "Respond to a ping.",
+            json!({ "type": "object", "properties": {} }),
+            |_args: serde_json::Value| async move { Ok::<_, String>(json!({ "ok": true })) },
+        );
+        let agent = Agent::builder()
+            .instructions("Call ping when asked.")
+            .model(Model::simulated_scripted(
+                "done",
+                vec![
+                    vec![ToolCall {
+                        id: "call_ping_1".into(),
+                        name: "ping".into(),
+                        arguments: json!({}),
+                    }],
+                    vec![],
+                ],
+            ))
+            .tool(tool)
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        let stream = session.events();
+        let turn = session.run("please ping").await.expect("turn runs");
+        assert!(turn.success, "turn should succeed: {:?}", turn.error);
+        assert_eq!(turn.tool_calls, 1);
+
+        drop(session);
+        let events = drain(stream).await;
+
+        let tool_started = events
+            .iter()
+            .find(|e| matches!(e.kind, SessionEventKind::ToolStarted { .. }))
+            .expect("a tool.started event");
+        let tool_completed = events
+            .iter()
+            .find(|e| matches!(e.kind, SessionEventKind::ToolCompleted { .. }))
+            .expect("a tool.completed event");
+
+        // Both tool events carry the parent turn's id.
+        assert_eq!(tool_started.turn_id.as_deref(), Some(turn.turn_id.as_str()));
+        assert_eq!(
+            tool_completed.turn_id.as_deref(),
+            Some(turn.turn_id.as_str())
+        );
+
+        let SessionEventKind::ToolStarted {
+            tool_call_id: started_id,
+            tool_name,
+        } = &tool_started.kind
+        else {
+            unreachable!("matched ToolStarted above")
+        };
+        assert_eq!(tool_name, "ping");
+        let SessionEventKind::ToolCompleted {
+            tool_call_id: completed_id,
+            success,
+            ..
+        } = &tool_completed.kind
+        else {
+            unreachable!("matched ToolCompleted above")
+        };
+        assert_eq!(started_id, completed_id, "same tool call across the pair");
+        assert!(success, "the ping tool succeeded");
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_a_running_turn_with_cancelled_stop_reason() {
+        // A long TTFT delay parks the turn so we can cancel it mid-flight.
+        let agent = Agent::builder()
+            .instructions("You are slow.")
+            .model(Model::simulated_delayed(
+                "eventually",
+                Duration::from_secs(30),
+            ))
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        let token = CancellationToken::new();
+
+        let canceller = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            canceller.cancel();
+        });
+
+        let turn = session
+            .run_with("hi", RunOptions::new().cancel_token(token))
+            .await
+            .expect("run_with resolves");
+
+        assert!(!turn.success, "a cancelled turn is not a success");
+        assert_eq!(turn.stop_reason, TurnStopReason::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn an_uncancelled_run_with_matches_run() {
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .build()
+            .expect("valid agent");
+
+        let mut session = agent.session();
+        let turn = session
+            .run_with("hi", RunOptions::new())
+            .await
+            .expect("turn runs");
+        assert!(turn.success);
+        assert_eq!(turn.response, "ok");
     }
 }

--- a/crates/everruns/tests/session_events.rs
+++ b/crates/everruns/tests/session_events.rs
@@ -1,0 +1,170 @@
+//! Public-surface session events and cancellation (EVE-833).
+//!
+//! This file imports only `everruns::prelude::*` — no `everruns-core` or
+//! `everruns-runtime` — proving library code can render streaming output and
+//! cancel a turn using facade types alone. Behaviors that need the in-process
+//! simulator's scripting/delay knobs (tool events, mid-flight cancellation) are
+//! covered by the crate's unit tests, which reach those internal test helpers.
+
+use everruns::prelude::*;
+
+/// Collect every event from a stream until it closes (the session is dropped).
+async fn drain(mut stream: EventStream) -> Vec<SessionEvent> {
+    let mut events = Vec::new();
+    while let Some(event) = stream.recv().await {
+        events.push(event);
+    }
+    events
+}
+
+#[tokio::test]
+async fn stream_emits_ordered_start_delta_completion() {
+    let agent = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("Hello, world!"))
+        .build()
+        .expect("valid agent");
+
+    let mut session = agent.session();
+    // Subscribe before running so the turn's events are observed from the start.
+    let stream = session.events();
+
+    let turn = session.run("hi").await.expect("turn runs");
+    assert!(turn.success);
+    assert_eq!(turn.response, "Hello, world!");
+
+    // Drop the session so the stream closes and `drain` terminates.
+    drop(session);
+    let events = drain(stream).await;
+
+    let position = |pred: fn(&SessionEvent) -> bool| events.iter().position(pred);
+    let started = position(|e| matches!(e.kind, SessionEventKind::TurnStarted))
+        .expect("a turn.started event");
+    let delta = position(|e| matches!(e.kind, SessionEventKind::TextDelta { .. }))
+        .expect("at least one text delta");
+    let completed = position(|e| matches!(e.kind, SessionEventKind::TurnCompleted))
+        .expect("a turn.completed event");
+
+    assert!(
+        started < delta && delta < completed,
+        "expected ordered start < delta < completion, got indices {started}/{delta}/{completed}"
+    );
+
+    // The concatenated deltas reconstruct the assistant's response.
+    let streamed: String = events
+        .iter()
+        .filter_map(|e| match &e.kind {
+            SessionEventKind::TextDelta { delta } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(streamed, "Hello, world!");
+
+    // Correlation ids are preserved: turn-scoped events share one turn id, and
+    // every event carries the same session id.
+    let turn_ids: Vec<&String> = events.iter().filter_map(|e| e.turn_id.as_ref()).collect();
+    assert!(!turn_ids.is_empty(), "turn-scoped events carry a turn id");
+    assert!(
+        turn_ids.windows(2).all(|w| w[0] == w[1]),
+        "all turn-scoped events in one turn share a turn id"
+    );
+    let session_id = events[0].session_id.clone();
+    assert!(
+        events.iter().all(|e| e.session_id == session_id),
+        "every event carries the session id"
+    );
+    assert_eq!(session_id, session_id_from_turn_stream(&events));
+}
+
+/// The session id is stable across every event of a single session's stream.
+fn session_id_from_turn_stream(events: &[SessionEvent]) -> String {
+    events
+        .last()
+        .map(|e| e.session_id.clone())
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+async fn pre_cancelled_token_yields_cancelled_stop_reason() {
+    let agent = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("hi"))
+        .build()
+        .expect("valid agent");
+
+    let mut session = agent.session();
+    let token = CancellationToken::new();
+    token.cancel();
+    assert!(token.is_cancelled());
+
+    // A token cancelled before the call stops the turn before it starts.
+    let turn = session
+        .run_with("hi", RunOptions::new().cancel_token(token))
+        .await
+        .expect("run_with resolves");
+    assert!(!turn.success, "a cancelled turn is not a success");
+    assert_eq!(turn.stop_reason, TurnStopReason::Cancelled);
+}
+
+#[tokio::test]
+async fn dropped_and_slow_consumers_do_not_stall_the_runner() {
+    let agent = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("ok"))
+        .build()
+        .expect("valid agent");
+
+    let mut session = agent.session();
+
+    // One consumer subscribes then immediately drops its stream; another never
+    // reads. Neither must block or fail the turn.
+    let dropped = session.events();
+    drop(dropped);
+    let _never_read = session.events();
+
+    let turn = session
+        .run("hi")
+        .await
+        .expect("turn runs despite consumers");
+    assert!(turn.success);
+    assert_eq!(turn.response, "ok");
+}
+
+#[tokio::test]
+async fn two_sessions_do_not_receive_each_others_events() {
+    let agent = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("ok"))
+        .build()
+        .expect("valid agent");
+
+    let mut first = agent.session();
+    let second = agent.session();
+
+    let first_stream = first.events();
+    let second_stream = second.events();
+    let first_id = first.id();
+
+    // Only the first session runs a turn.
+    let turn = first.run("hi").await.expect("turn runs");
+    assert!(turn.success);
+
+    drop(first);
+    drop(second);
+
+    let first_events = drain(first_stream).await;
+    let second_events = drain(second_stream).await;
+
+    assert!(
+        !first_events.is_empty(),
+        "the session that ran a turn observes its events"
+    );
+    assert!(
+        second_events.is_empty(),
+        "a session that ran nothing observes no events from the other"
+    );
+    assert!(
+        first_events.iter().all(|e| e.session_id == first_id),
+        "every observed event belongs to the first session"
+    );
+}


### PR DESCRIPTION
## What changed
Adds observable and cancellable turns to the `everruns::Session` API, using only facade types — no `EventBus`, `EventEmitter`, `EventRequest`, or core event/store types on the public surface.

- `Session::events()` returns an `EventStream` — a live feed of `SessionEvent`s for that session. Subscribe before running a turn, then `stream.recv().await` in a loop.
- `SessionEvent` / `SessionEventKind` project the runtime's events into a small, stable enum: turn started/completed/failed/cancelled, text delta, and tool started/completed. Every event preserves the opaque `event_id`, `session_id`, and (turn-scoped) `turn_id`. A `#[non_exhaustive]` `Other { event_type, payload }` fallback carries any other runtime event as its stable type string plus raw JSON, so promoting a new hosted event later never breaks a consumer.
- `Session::run_with(input, RunOptions)` accepts an optional `CancellationToken`. Cancelling it stops the in-flight turn and resolves to a `Turn` with `success == false` and `stop_reason == TurnStopReason::Cancelled`.

Library code can now render streaming output and cancel a turn using only `everruns` public types (see `examples/observe_and_cancel.rs`).

## Why
EVE-833. The multi-turn `Session` (EVE-831) could run a turn but not observe it or stop it. Embedders need to stream output and cancel work without reaching into `everruns-runtime`/`everruns-core` internals (the event bus, observer traits, store types).

## Before / After
- Before: `Session` exposed only `run()`; observing a turn or cancelling it required the escape-hatch `everruns::runtime` / `everruns::core` modules and their internal types.
- After: `session.events()` streams `SessionEvent`s; `session.run_with(input, RunOptions::new().cancel_token(token))` returns a cancelled `Turn` when the token fires. New tests assert the event ordering (start < delta < completion), tool/turn correlation, the cancelled stop reason (mid-flight and pre-cancelled), that slow/dropped consumers never stall the runner, and that two sessions never see each other's events.

How it bridges to the runtime:
- Events: a facade-internal `FacadeEventBus` implements the runtime's `EventBus` (and thus core's `EventEmitter`) and is installed as the runtime's raw event sink via `RuntimeBackends::with_event_bus`. It assigns event ids/sequences exactly as the built-in in-memory emitter, so downstream message persistence is unaffected, then fans each event out to every `EventStream` over a per-session `tokio::sync::broadcast` channel (sends never block or error on a full/subscriber-less channel).
- Cancellation: `run_with` races `run_turn` against the token with `tokio::select! { biased; ... }`. On cancel the turn future is dropped — the runtime's own cooperative, drop-based teardown (which tears down in-flight tool work via the act atom's `CancellationToken`) — so no second stop mechanism is added.

## Risk
- Low
- Surface is additive: `run()` delegates to `run_with(.., RunOptions::default())`, so existing behavior is unchanged. The only wiring change is that a `Session`'s runtime now uses an explicit in-memory backend bundle carrying the facade event bus instead of the implicit default; ids/sequences/persistence are identical. A cancelled turn returns a synthesized `Turn` whose `turn_id` is a fresh correlation id (the dropped turn's own id is not recoverable) — documented on the constructor.

## Security
- Threat categories reviewed: No security-relevant code changes. No auth, network, or persistence surface is touched; default features stay offline and no new provider/network dependency is added. New deps are `tokio` (sync) and `tokio-util` (`CancellationToken`), both already in the workspace/transitive tree.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. Out of scope per the issue: SSE/NATS delivery, durable worker cancellation, event-store persistence, and server event compatibility.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-833