### PR TITLE
feat(macros): implement #[everruns::tool] for typed async functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,11 +2565,15 @@ version = "0.17.23"
 dependencies = [
  "async-trait",
  "everruns-core",
+ "everruns-macros",
  "everruns-openai",
  "everruns-runtime",
+ "schemars",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+ "trybuild",
 ]
 
 [[package]]
@@ -3101,6 +3105,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid 1.24.0",
+]
+
+[[package]]
+name = "everruns-macros"
+version = "0.17.23"
+dependencies = [
+ "proc-macro2 1.0.107",
+ "quote 1.0.47",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9154,6 +9167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9184,6 +9203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9840,6 +9868,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "tryhard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/server",
     "crates/worker",
     "crates/everruns",
+    "crates/everruns-macros",
     "crates/core",
     "crates/platform",
     "crates/provider",
@@ -83,6 +84,15 @@ tower-http = { version = "0.7", features = ["cors", "trace", "set-header"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# JSON Schema generation for the `#[everruns::tool]` argument structs (EVE-829).
+schemars = "1.0"
+
+# Procedural-macro toolchain (backs `everruns-macros`).
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+# Compile-pass / compile-fail fixtures for the proc-macro crate.
+trybuild = "1.0"
 
 # Database
 sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate", "uuid", "chrono", "macros"] }
@@ -165,6 +175,7 @@ everruns-ard = { path = "crates/ard", version = "0.17.23" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
 everruns-runtime = { path = "crates/runtime", version = "0.17.23" }
 everruns = { path = "crates/everruns", version = "0.17.23" }
+everruns-macros = { path = "crates/everruns-macros", version = "0.17.23" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/crates/everruns-macros/Cargo.toml
+++ b/crates/everruns-macros/Cargo.toml
@@ -1,0 +1,31 @@
+# Procedural macros for the application-facing `everruns` crate.
+#
+# Decision (EVE-829): the `#[everruns::tool]` attribute lives in its own
+# `proc-macro = true` crate because a crate cannot be both a proc-macro crate
+# and export ordinary items. `everruns` re-exports the attribute behind its
+# default-enabled `macros` feature; end users never depend on this crate
+# directly. The macro emits code that references `everruns` by path
+# (`::everruns::__macro_support::…`), so all runtime types stay in the facade.
+
+[package]
+name = "everruns-macros"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-macros"
+description = "Procedural macros for the Everruns agentic framework (re-exported by `everruns`)"
+readme = "README.md"
+keywords = ["agent", "agentic", "llm", "ai", "macros"]
+categories = ["development-tools", "rust-patterns"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }

--- a/crates/everruns-macros/README.md
+++ b/crates/everruns-macros/README.md
@@ -1,0 +1,8 @@
+# everruns-macros
+
+Procedural macros for the [`everruns`](https://docs.rs/everruns) agentic
+framework. This crate is an implementation detail: the `#[everruns::tool]`
+attribute is re-exported by `everruns` behind its default-enabled `macros`
+feature. Depend on `everruns`, not on this crate directly.
+
+See the [`everruns`](https://docs.rs/everruns) documentation for usage.

--- a/crates/everruns-macros/src/lib.rs
+++ b/crates/everruns-macros/src/lib.rs
@@ -1,0 +1,373 @@
+//! Procedural macros for the [`everruns`](https://docs.rs/everruns) agentic
+//! framework.
+//!
+//! This crate is an implementation detail of `everruns`: the
+//! [`macro@tool`] attribute is re-exported as `everruns::tool` behind the
+//! default-enabled `macros` feature, and end users depend on `everruns`, not on
+//! this crate. All code the macro emits is resolved through
+//! `::everruns::__macro_support::…`, so no direct dependency on `serde`,
+//! `schemars`, or `serde_json` is required in the calling crate.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{
+    Attribute, Expr, ExprLit, FnArg, GenericParam, Ident, ItemFn, Lit, LitStr, Pat, PatType,
+    ReturnType, Type, parse_macro_input,
+};
+
+/// Turn a typed async function into an agent tool.
+///
+/// `#[everruns::tool]` generates a JSON Schema for the function's arguments and
+/// wraps its body in an `everruns::FunctionTool`, so a library user hands a
+/// plain async function to `AgentBuilder::tool` without writing a schema or an
+/// adapter by hand.
+///
+/// The attribute **replaces** the annotated function with a zero-argument
+/// constructor of the same name that returns a
+/// [`FunctionTool`](../everruns/struct.FunctionTool.html); the original body
+/// runs when the model calls the tool.
+///
+/// ```ignore
+/// use everruns::{Agent, Model};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Serialize)]
+/// struct Weather { forecast: String }
+///
+/// /// Return the weather for a city.
+/// #[everruns::tool]
+/// async fn weather(city: String, fahrenheit: Option<bool>) -> Result<Weather, String> {
+///     Ok(Weather { forecast: format!("sunny in {city}") })
+/// }
+///
+/// let agent = Agent::builder()
+///     .instructions("Answer weather questions.")
+///     .model(Model::simulated("done"))
+///     .tool(weather()) // the generated constructor
+///     .build();
+/// ```
+///
+/// # Options
+///
+/// - `#[everruns::tool(name = "…")]` overrides the tool name (default: the
+///   function name).
+/// - `#[everruns::tool(description = "…")]` sets the description; otherwise the
+///   function's doc comment is used. A description is required.
+/// - `#[tool(rename = "…")]` on a parameter renames that argument in the schema
+///   and the accepted JSON.
+///
+/// # Supported signatures
+///
+/// Required arguments, `Option<T>` (optional), renamed arguments, a unit
+/// return, a plain `T` return, and `Result<T, E>` (where `E: Display` becomes a
+/// model-visible tool error). Argument types must implement `Deserialize` and
+/// `JsonSchema`; return values must implement `Serialize`.
+///
+/// The macro rejects, with a compile error: non-`async` functions, a `self`
+/// receiver, generic parameters, a missing description, and non-identifier
+/// parameter patterns.
+#[proc_macro_attribute]
+pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as ToolArgs);
+    let func = parse_macro_input!(item as ItemFn);
+    match expand(args, func) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Parsed `#[everruns::tool(...)]` attribute arguments.
+#[derive(Default)]
+struct ToolArgs {
+    name: Option<String>,
+    description: Option<String>,
+}
+
+impl syn::parse::Parse for ToolArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut args = ToolArgs::default();
+        let metas =
+            syn::punctuated::Punctuated::<syn::MetaNameValue, syn::Token![,]>::parse_terminated(
+                input,
+            )?;
+        for meta in metas {
+            let key = meta
+                .path
+                .get_ident()
+                .map(Ident::to_string)
+                .unwrap_or_default();
+            let value = lit_str(&meta.value)
+                .ok_or_else(|| syn::Error::new(meta.value.span(), "expected a string literal"))?;
+            match key.as_str() {
+                "name" => args.name = Some(value),
+                "description" => args.description = Some(value),
+                other => {
+                    return Err(syn::Error::new(
+                        meta.path.span(),
+                        format!(
+                            "unknown `everruns::tool` option `{other}`; expected `name` or `description`"
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(args)
+    }
+}
+
+/// Extract a `String` from a string-literal expression.
+fn lit_str(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => Some(s.value()),
+        _ => None,
+    }
+}
+
+/// One accepted function parameter, lowered to a generated-struct field.
+struct Field {
+    ident: Ident,
+    ty: Type,
+    rename: Option<LitStr>,
+}
+
+fn expand(args: ToolArgs, func: ItemFn) -> syn::Result<TokenStream2> {
+    let sig = &func.sig;
+
+    if sig.asyncness.is_none() {
+        return Err(syn::Error::new_spanned(
+            func.sig.fn_token,
+            "`#[everruns::tool]` requires an `async fn`",
+        ));
+    }
+
+    if let Some(param) = sig.generics.params.first() {
+        let span = match param {
+            GenericParam::Type(p) => p.span(),
+            GenericParam::Lifetime(p) => p.span(),
+            GenericParam::Const(p) => p.span(),
+        };
+        return Err(syn::Error::new(
+            span,
+            "`#[everruns::tool]` does not support generic parameters",
+        ));
+    }
+    if let Some(where_clause) = &sig.generics.where_clause {
+        return Err(syn::Error::new_spanned(
+            where_clause,
+            "`#[everruns::tool]` does not support `where` clauses",
+        ));
+    }
+
+    // Collect parameters, rejecting receivers and non-identifier patterns.
+    let mut fields: Vec<Field> = Vec::new();
+    for input in &sig.inputs {
+        match input {
+            FnArg::Receiver(receiver) => {
+                return Err(syn::Error::new_spanned(
+                    receiver,
+                    "`#[everruns::tool]` does not support a `self` receiver",
+                ));
+            }
+            FnArg::Typed(pat_type) => fields.push(lower_param(pat_type)?),
+        }
+    }
+
+    // Resolve the description: explicit option wins over doc comments.
+    let description = match args.description {
+        Some(text) => text,
+        None => doc_comment(&func.attrs),
+    };
+    if description.trim().is_empty() {
+        return Err(syn::Error::new_spanned(
+            &func.sig.ident,
+            "`#[everruns::tool]` requires a description: add a doc comment or \
+             `#[everruns::tool(description = \"…\")]`",
+        ));
+    }
+    let description = description.trim().to_string();
+
+    let fn_ident = &sig.ident;
+    let vis = &func.vis;
+    let tool_name = args.name.unwrap_or_else(|| fn_ident.to_string());
+
+    // Inner async fn carrying the original body and signature. The parameters
+    // are re-emitted with any `#[tool(...)]` helper attribute stripped — it is
+    // meaningful only to this macro and would not resolve in the output.
+    let impl_ident = format_ident!("__everruns_tool_impl_{}", fn_ident);
+    let inner_inputs = sig.inputs.iter().map(|input| match input {
+        FnArg::Typed(pat_type) => {
+            let mut cleaned = pat_type.clone();
+            cleaned.attrs.retain(|attr| !attr.path().is_ident("tool"));
+            FnArg::Typed(cleaned)
+        }
+        other => other.clone(),
+    });
+    let inner_inputs = quote! { #(#inner_inputs),* };
+    let orig_output = &sig.output;
+    let orig_body = &func.block;
+
+    // Generated arguments struct.
+    let field_decls = fields.iter().map(|f| {
+        let ident = &f.ident;
+        let ty = &f.ty;
+        let rename = f
+            .rename
+            .as_ref()
+            .map(|name| quote!(#[serde(rename = #name)]));
+        quote! { #rename pub #ident: #ty }
+    });
+    let field_idents: Vec<&Ident> = fields.iter().map(|f| &f.ident).collect();
+
+    let dispatch = result_dispatch(orig_output, &tool_name);
+
+    let expanded = quote! {
+        // `let __out = …await` binds `()` for unit-returning tools, which the
+        // `let_unit_value` lint flags; the binding is intentional here.
+        #[allow(clippy::let_unit_value)]
+        #vis fn #fn_ident() -> ::everruns::FunctionTool {
+            #[derive(
+                ::everruns::__macro_support::serde::Deserialize,
+                ::everruns::__macro_support::schemars::JsonSchema,
+            )]
+            #[serde(crate = "::everruns::__macro_support::serde")]
+            #[schemars(crate = "::everruns::__macro_support::schemars")]
+            #[allow(non_camel_case_types, dead_code)]
+            struct __Args {
+                #(#field_decls,)*
+            }
+
+            #[allow(clippy::used_underscore_items)]
+            async fn #impl_ident(#inner_inputs) #orig_output #orig_body
+
+            let __schema = ::everruns::__macro_support::schema_for::<__Args>();
+
+            ::everruns::FunctionTool::new(
+                #tool_name,
+                #description,
+                __schema,
+                move |__args: ::everruns::__macro_support::Value| async move {
+                    let __parsed: __Args = match ::everruns::__macro_support::from_value(__args) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            return ::core::result::Result::Err(::std::format!(
+                                "invalid arguments for tool `{}`: {}",
+                                #tool_name,
+                                __e,
+                            ));
+                        }
+                    };
+                    let __out = #impl_ident(#(__parsed.#field_idents),*).await;
+                    #dispatch
+                },
+            )
+        }
+    };
+
+    Ok(expanded)
+}
+
+/// Lower one typed parameter to a generated-struct field, rejecting patterns the
+/// adapter cannot express and extracting a `#[tool(rename = "…")]` override.
+fn lower_param(pat_type: &PatType) -> syn::Result<Field> {
+    let ident = match pat_type.pat.as_ref() {
+        Pat::Ident(pat_ident) => pat_ident.ident.clone(),
+        other => {
+            return Err(syn::Error::new_spanned(
+                other,
+                "`#[everruns::tool]` parameters must be plain identifiers (`name: Type`)",
+            ));
+        }
+    };
+    let rename = parse_rename(&pat_type.attrs)?;
+    Ok(Field {
+        ident,
+        ty: (*pat_type.ty).clone(),
+        rename,
+    })
+}
+
+/// Parse an optional `#[tool(rename = "…")]` attribute on a parameter.
+fn parse_rename(attrs: &[Attribute]) -> syn::Result<Option<LitStr>> {
+    let mut rename = None;
+    for attr in attrs {
+        if !attr.path().is_ident("tool") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename") {
+                let value = meta.value()?;
+                rename = Some(value.parse::<LitStr>()?);
+                Ok(())
+            } else {
+                Err(meta.error("expected `rename = \"…\"`"))
+            }
+        })?;
+    }
+    Ok(rename)
+}
+
+/// Join `#[doc = "…"]` lines into a single trimmed description.
+fn doc_comment(attrs: &[Attribute]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        if let syn::Meta::NameValue(nv) = &attr.meta
+            && let Some(text) = lit_str(&nv.value)
+        {
+            lines.push(text.trim().to_string());
+        }
+    }
+    lines.join("\n").trim().to_string()
+}
+
+/// Produce the tokens that turn the inner call's output into a
+/// `Result<ToolResponse, String>` for `FunctionTool::new`.
+///
+/// `Result<T, E>` returns map `Err(E: Display)` to a model-visible tool error;
+/// any other return type (including `()`) is serialized as a success.
+fn result_dispatch(output: &ReturnType, tool_name: &str) -> TokenStream2 {
+    let serialize = |value: TokenStream2| {
+        quote! {
+            ::everruns::__macro_support::to_value(&#value)
+                .map(::everruns::ToolResponse::json)
+                .map_err(|__e| ::std::format!(
+                    "failed to serialize result of tool `{}`: {}", #tool_name, __e,
+                ))
+        }
+    };
+    if returns_result(output) {
+        let serialize_ok = serialize(quote!(__ok));
+        quote! {
+            match __out {
+                ::core::result::Result::Ok(__ok) => { #serialize_ok }
+                ::core::result::Result::Err(__err) => ::core::result::Result::Ok(
+                    ::everruns::ToolResponse::error(::std::string::ToString::to_string(&__err)),
+                ),
+            }
+        }
+    } else {
+        let serialize_out = serialize(quote!(__out));
+        quote_spanned! {output.span()=> #serialize_out }
+    }
+}
+
+/// Whether a return type is syntactically `Result<…>`.
+fn returns_result(output: &ReturnType) -> bool {
+    let ReturnType::Type(_, ty) = output else {
+        return false;
+    };
+    let Type::Path(type_path) = ty.as_ref() else {
+        return false;
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "Result")
+}

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -26,9 +26,14 @@ categories = ["development-tools", "asynchronous"]
 
 [features]
 # Default features stay offline: the facade activates no provider, MCP,
-# filesystem, SQLx, server, or worker integrations. Embedders opt into the
-# heavier surfaces through the escape-hatch modules or a later, promoted API.
-default = []
+# filesystem, SQLx, server, or worker integrations. The `macros` surface is the
+# one default beyond the bare re-exports — it pulls in no network or I/O edge,
+# only the proc-macro and schema-generation toolchain.
+default = ["macros"]
+# Re-export `#[everruns::tool]` (EVE-829) and the hidden `__macro_support`
+# runtime helpers it expands into. Pulls in `everruns-macros`, `schemars` (JSON
+# Schema generation), and `serde` (derive). Kept out of `everruns-core`.
+macros = ["dep:everruns-macros", "dep:schemars", "dep:serde"]
 # Compile the experimental sandboxed Lua execution engine into the runtime.
 # Mirrors `everruns-runtime/lua`; off by default so the standard facade build
 # pulls in no interpreter.
@@ -57,6 +62,13 @@ tokio = { workspace = true, features = ["sync", "macros"] }
 # leaking the tokio-util type onto the public surface. Matches the pin used by
 # everruns-core.
 tokio-util = { version = "0.7", default-features = false }
+# Activated by the `macros` feature. `everruns-macros` provides the
+# `#[everruns::tool]` attribute; `schemars` and `serde` back the code it emits.
+everruns-macros = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+serde = { workspace = true }
+trybuild = { workspace = true }

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -55,6 +55,10 @@
 //! # }
 //! ```
 
+// Let code emitted by `#[everruns::tool]` resolve `::everruns::…` paths even
+// inside this crate's own tests and doctests.
+extern crate self as everruns;
+
 // --- Value-first agent description and execution -------------------------
 mod agent;
 mod events;
@@ -64,6 +68,48 @@ pub use agent::{Agent, AgentBuilder, BuildError, Model};
 pub use events::{CancellationToken, EventStream, RunOptions, SessionEvent, SessionEventKind};
 pub use session::{RunError, Session, Turn};
 pub use tool::{FunctionTool, IntoTool, IntoToolResult, Tool, ToolResponse};
+
+#[cfg(all(test, feature = "macros"))]
+mod tool_macro_tests;
+
+// --- Function-tool procedural macro (feature-gated) ---------------------
+/// Turn a typed async function into an agent tool.
+///
+/// `#[everruns::tool]` generates the argument JSON Schema and adapter for a
+/// plain async function so it can be handed to
+/// [`AgentBuilder::tool`](crate::AgentBuilder::tool) without writing either by
+/// hand. See the [`macro@tool`] documentation for supported signatures and
+/// options. Requires the default-enabled `macros` feature.
+#[cfg(feature = "macros")]
+pub use everruns_macros::tool;
+
+/// Runtime support for code emitted by [`macro@tool`]. Not a stable API — the
+/// expansion references these items by path so the calling crate needs no
+/// direct dependency on `serde`, `schemars`, or `serde_json`.
+#[cfg(feature = "macros")]
+#[doc(hidden)]
+pub mod __macro_support {
+    pub use schemars;
+    pub use serde;
+    pub use serde_json::{self, Value};
+
+    /// Serialize a type's JSON Schema to a `Value` for `FunctionTool::new`.
+    pub fn schema_for<T: schemars::JsonSchema>() -> Value {
+        serde_json::to_value(schemars::schema_for!(T)).unwrap_or(Value::Null)
+    }
+
+    /// Deserialize the model's call arguments into the generated struct.
+    pub fn from_value<T: serde::de::DeserializeOwned>(
+        value: Value,
+    ) -> Result<T, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+
+    /// Serialize a handler's success value to a `Value`.
+    pub fn to_value<T: serde::Serialize + ?Sized>(value: &T) -> Result<Value, serde_json::Error> {
+        serde_json::to_value(value)
+    }
+}
 
 // --- Real LLM provider configuration (feature-gated) --------------------
 // The default facade build stays offline; provider modules compile only when
@@ -113,6 +159,8 @@ pub use everruns_runtime as runtime;
 /// assert!(agent.is_ok());
 /// ```
 pub mod prelude {
+    #[cfg(feature = "macros")]
+    pub use crate::tool;
     pub use crate::{
         Agent, AgentBuilder, BuildError, CancellationToken, EventStream, FunctionTool, IntoTool,
         IntoToolResult, Model, RunError, RunOptions, Session, SessionEvent, SessionEventKind, Tool,

--- a/crates/everruns/src/tool_macro_tests.rs
+++ b/crates/everruns/src/tool_macro_tests.rs
@@ -1,0 +1,178 @@
+//! In-crate tests for `#[everruns::tool]` (EVE-829).
+//!
+//! These live inside the crate (not `tests/`) so they can read the generated
+//! tool's `pub(crate)` schema and drive a scripted tool call through the
+//! `pub(crate)` simulator hook. Compile-pass/compile-fail coverage of rejected
+//! signatures lives in `tests/ui/` via `trybuild`.
+
+use everruns_core::ToolCall;
+use everruns_core::tools::Tool as CoreTool;
+use serde_json::{Value, json};
+
+use crate::{Agent, Model};
+
+/// Look up weather for a city. Doc comment becomes the tool description.
+#[everruns::tool]
+async fn weather(
+    city: String,
+    #[tool(rename = "unit")] temperature_unit: Option<String>,
+) -> Result<Value, String> {
+    if city.is_empty() {
+        return Err("city must not be empty".to_string());
+    }
+    Ok(json!({ "city": city, "unit": temperature_unit, "forecast": "sunny" }))
+}
+
+/// Explicit options override the defaults; doc text here is ignored.
+#[everruns::tool(name = "adder", description = "Add one to a number.")]
+async fn add_one(n: i64) -> i64 {
+    n + 1
+}
+
+/// A tool with no return value.
+#[everruns::tool]
+async fn record(note: String) {
+    let _ = note;
+}
+
+#[test]
+fn schema_marks_required_optional_and_renamed_arguments() {
+    let tool = weather();
+    let schema = tool.schema();
+
+    assert_eq!(schema["type"], json!("object"), "schema: {schema}");
+
+    let properties = schema["properties"]
+        .as_object()
+        .expect("object schema has properties");
+    assert!(properties.contains_key("city"), "required arg present");
+    assert!(
+        properties.contains_key("unit"),
+        "renamed arg uses its new name: {schema}"
+    );
+    assert!(
+        !properties.contains_key("temperature_unit"),
+        "original name must not leak: {schema}"
+    );
+
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert!(required.contains(&"city"), "city is required: {schema}");
+    assert!(
+        !required.contains(&"unit"),
+        "Option<T> argument is optional: {schema}"
+    );
+}
+
+#[test]
+fn options_override_name_and_description() {
+    let tool = add_one();
+    assert_eq!(CoreTool::name(&tool), "adder");
+    assert_eq!(CoreTool::description(&tool), "Add one to a number.");
+}
+
+#[test]
+fn doc_comment_becomes_description() {
+    let tool = weather();
+    assert_eq!(
+        CoreTool::description(&tool),
+        "Look up weather for a city. Doc comment becomes the tool description."
+    );
+}
+
+#[tokio::test]
+async fn generated_tool_executes_through_agent_builder() {
+    let agent = Agent::builder()
+        .instructions("Call weather when asked.")
+        .model(Model::simulated_scripted(
+            "Done.",
+            vec![
+                vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "weather".into(),
+                    arguments: json!({ "city": "London", "unit": "C" }),
+                }],
+                vec![],
+            ],
+        ))
+        .tool(weather())
+        .build()
+        .expect("valid agent");
+
+    let mut session = agent.session();
+    let turn = session.run("weather in London?").await.expect("turn runs");
+
+    assert!(turn.success, "turn should succeed: {:?}", turn.error);
+    assert_eq!(turn.tool_calls, 1, "the generated tool executed");
+    assert_eq!(turn.response, "Done.");
+}
+
+#[tokio::test]
+async fn result_err_becomes_model_visible_tool_error() {
+    // The handler returns `Err(..)` for an empty city; the turn recovers rather
+    // than panicking, exactly like a hand-written `FunctionTool`.
+    let agent = Agent::builder()
+        .instructions("Call weather.")
+        .model(Model::simulated_scripted(
+            "Recovered.",
+            vec![
+                vec![ToolCall {
+                    id: "call_err".into(),
+                    name: "weather".into(),
+                    arguments: json!({ "city": "" }),
+                }],
+                vec![],
+            ],
+        ))
+        .tool(weather())
+        .build()
+        .expect("valid agent");
+
+    let mut session = agent.session();
+    let turn = session.run("go").await.expect("turn runs");
+    assert!(turn.success, "turn recovers from a tool error");
+    assert_eq!(turn.tool_calls, 1);
+}
+
+#[tokio::test]
+async fn unit_return_tool_executes() {
+    let agent = Agent::builder()
+        .instructions("Call record.")
+        .model(Model::simulated_scripted(
+            "Logged.",
+            vec![
+                vec![ToolCall {
+                    id: "call_rec".into(),
+                    name: "record".into(),
+                    arguments: json!({ "note": "hello" }),
+                }],
+                vec![],
+            ],
+        ))
+        .tool(record())
+        .build()
+        .expect("valid agent");
+
+    let mut session = agent.session();
+    let turn = session.run("record it").await.expect("turn runs");
+    assert!(turn.success, "unit-return tool succeeds: {:?}", turn.error);
+    assert_eq!(turn.tool_calls, 1);
+}
+
+#[tokio::test]
+async fn invalid_arguments_surface_as_a_tool_error() {
+    // Missing the required `city` field: deserialization fails and the adapter
+    // returns a tool error string instead of panicking.
+    let tool = weather();
+    match CoreTool::execute(&tool, json!({ "unit": "C" })).await {
+        everruns_core::tools::ToolExecutionResult::ToolError(message) => {
+            assert!(
+                message.contains("invalid arguments for tool `weather`"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected a tool error, got {other:?}"),
+    }
+}

--- a/crates/everruns/tests/trybuild.rs
+++ b/crates/everruns/tests/trybuild.rs
@@ -1,0 +1,19 @@
+//! Compile-pass and compile-fail coverage for `#[everruns::tool]` (EVE-829).
+//!
+//! Pass fixtures prove supported signatures expand and compile; fail fixtures
+//! pin the macro's own diagnostics for rejected signatures. The fail fixtures
+//! trip the macro's `compile_error!`s (stable text), not downstream type
+//! errors, so their `.stderr` is robust across compiler versions.
+
+#[cfg(feature = "macros")]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass_signatures.rs");
+    t.compile_fail("tests/ui/fail_not_async.rs");
+    t.compile_fail("tests/ui/fail_receiver.rs");
+    t.compile_fail("tests/ui/fail_generic.rs");
+    t.compile_fail("tests/ui/fail_missing_description.rs");
+    t.compile_fail("tests/ui/fail_tuple_param.rs");
+    t.compile_fail("tests/ui/fail_unknown_option.rs");
+}

--- a/crates/everruns/tests/ui/fail_generic.rs
+++ b/crates/everruns/tests/ui/fail_generic.rs
@@ -1,0 +1,7 @@
+/// Generic parameters are not supported.
+#[everruns::tool]
+async fn identity<T>(value: T) -> T {
+    value
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_generic.stderr
+++ b/crates/everruns/tests/ui/fail_generic.stderr
@@ -1,0 +1,5 @@
+error: `#[everruns::tool]` does not support generic parameters
+ --> tests/ui/fail_generic.rs:3:19
+  |
+3 | async fn identity<T>(value: T) -> T {
+  |                   ^

--- a/crates/everruns/tests/ui/fail_missing_description.rs
+++ b/crates/everruns/tests/ui/fail_missing_description.rs
@@ -1,0 +1,7 @@
+// No doc comment and no `description` option.
+#[everruns::tool]
+async fn undocumented(x: i64) -> i64 {
+    x
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_missing_description.stderr
+++ b/crates/everruns/tests/ui/fail_missing_description.stderr
@@ -1,0 +1,5 @@
+error: `#[everruns::tool]` requires a description: add a doc comment or `#[everruns::tool(description = "…")]`
+ --> tests/ui/fail_missing_description.rs:3:10
+  |
+3 | async fn undocumented(x: i64) -> i64 {
+  |          ^^^^^^^^^^^^

--- a/crates/everruns/tests/ui/fail_not_async.rs
+++ b/crates/everruns/tests/ui/fail_not_async.rs
@@ -1,0 +1,9 @@
+use everruns::tool;
+
+/// Not async.
+#[tool]
+fn not_async(x: i64) -> i64 {
+    x
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_not_async.stderr
+++ b/crates/everruns/tests/ui/fail_not_async.stderr
@@ -1,0 +1,5 @@
+error: `#[everruns::tool]` requires an `async fn`
+ --> tests/ui/fail_not_async.rs:5:1
+  |
+5 | fn not_async(x: i64) -> i64 {
+  | ^^

--- a/crates/everruns/tests/ui/fail_receiver.rs
+++ b/crates/everruns/tests/ui/fail_receiver.rs
@@ -1,0 +1,11 @@
+struct Calculator;
+
+impl Calculator {
+    /// Has a `self` receiver.
+    #[everruns::tool]
+    async fn add(&self, x: i64) -> i64 {
+        x
+    }
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_receiver.stderr
+++ b/crates/everruns/tests/ui/fail_receiver.stderr
@@ -1,0 +1,5 @@
+error: `#[everruns::tool]` does not support a `self` receiver
+ --> tests/ui/fail_receiver.rs:6:18
+  |
+6 |     async fn add(&self, x: i64) -> i64 {
+  |                  ^^^^^

--- a/crates/everruns/tests/ui/fail_tuple_param.rs
+++ b/crates/everruns/tests/ui/fail_tuple_param.rs
@@ -1,0 +1,7 @@
+/// A tuple-destructuring parameter pattern is not supported.
+#[everruns::tool]
+async fn add_pair((a, b): (i64, i64)) -> i64 {
+    a + b
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_tuple_param.stderr
+++ b/crates/everruns/tests/ui/fail_tuple_param.stderr
@@ -1,0 +1,5 @@
+error: `#[everruns::tool]` parameters must be plain identifiers (`name: Type`)
+ --> tests/ui/fail_tuple_param.rs:3:19
+  |
+3 | async fn add_pair((a, b): (i64, i64)) -> i64 {
+  |                   ^^^^^^

--- a/crates/everruns/tests/ui/fail_unknown_option.rs
+++ b/crates/everruns/tests/ui/fail_unknown_option.rs
@@ -1,0 +1,7 @@
+/// An unknown attribute option is rejected.
+#[everruns::tool(title = "nope")]
+async fn labelled(x: i64) -> i64 {
+    x
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_unknown_option.stderr
+++ b/crates/everruns/tests/ui/fail_unknown_option.stderr
@@ -1,0 +1,5 @@
+error: unknown `everruns::tool` option `title`; expected `name` or `description`
+ --> tests/ui/fail_unknown_option.rs:2:18
+  |
+2 | #[everruns::tool(title = "nope")]
+  |                  ^^^^^

--- a/crates/everruns/tests/ui/pass_signatures.rs
+++ b/crates/everruns/tests/ui/pass_signatures.rs
@@ -1,0 +1,29 @@
+//! Supported signatures must expand and compile.
+use everruns::{Agent, Model};
+
+/// A required argument and an optional one, returning a Result.
+#[everruns::tool]
+async fn weather(city: String, units: Option<String>) -> Result<serde_json::Value, String> {
+    Ok(serde_json::json!({ "city": city, "units": units }))
+}
+
+/// A renamed argument and an explicit name/description.
+#[everruns::tool(name = "add", description = "Add two numbers.")]
+async fn adder(#[tool(rename = "left")] a: i64, b: i64) -> i64 {
+    a + b
+}
+
+/// A unit return and no arguments.
+#[everruns::tool]
+async fn ping() {}
+
+fn main() {
+    let _agent = Agent::builder()
+        .instructions("Use the tools.")
+        .model(Model::simulated("ok"))
+        .tool(weather())
+        .tool(adder())
+        .tool(ping())
+        .build()
+        .expect("agent builds");
+}


### PR DESCRIPTION
## What changed

Adds `#[everruns::tool]`, an attribute macro that turns a typed async function into an agent tool. A library user writes a plain async function and hands it to `AgentBuilder::tool` — no hand-written JSON Schema and no adapter:

```rust
/// Return the weather for a city.
#[everruns::tool]
async fn weather(city: String, units: Option<String>) -> Result<Weather, String> { ... }

Agent::builder().model(m).instructions("…").tool(weather()).build()?;
```

The attribute **replaces** the annotated function with a zero-argument constructor of the same name returning a `FunctionTool`; the original body runs when the model calls the tool. The macro:

- generates a schemars-derived JSON Schema for the arguments (required vs. `Option<T>`, per-argument `#[tool(rename = "…")]`);
- deserializes the model's call arguments into a generated struct, dispatches to the original body, and serializes the result;
- maps `Result<T, E>`'s `Err` (`E: Display`) to a model-visible tool error, and serializes a unit or plain `T` return as success;
- rejects non-`async` functions, `self` receivers, generics, missing descriptions, and non-identifier parameter patterns with clear compile errors.

Implementation notes: the macro lives in a new `proc-macro = true` crate `everruns-macros` (a crate cannot both be a proc-macro crate and export ordinary items). `everruns` re-exports the attribute behind the default-enabled `macros` feature, which also pulls in `schemars` and `serde`. Generated code resolves entirely through `everruns::__macro_support::…`, so a calling crate needs no direct `serde`/`schemars`/`serde_json` dependency. `schemars` is kept out of `everruns-core`.

## Why

EVE-829. Building on EVE-828 (async functions/closures as `FunctionTool`s), this removes the remaining boilerplate — the argument schema and the argument-marshalling adapter — so defining a tool is just annotating a typed function. Unblocks EVE-844 (publish `everruns` preview) and EVE-835 (migrate `examples/coding-cli`).

## Before / After

**Before** — a custom tool required a hand-written schema and a `Value`-in/`Value`-out handler (`FunctionTool::new("weather", "…", json!({...}), |args| async { ... })`).

**After** — a typed async function with a doc comment is the whole definition. Evidence (local, rustc 1.96.0):

- `cargo test -p everruns --all-features`: lib unit tests incl. 7 new macro tests (schema shape for required/optional/renamed args, end-to-end execution through `AgentBuilder`, `Result` error mapping, unit return, invalid-args → tool error, name/description overrides), the `trybuild` `ui` suite (1 pass fixture + 6 compile-fail fixtures), and 8 doctests — all green.
- `cargo fmt --check`: clean.
- `cargo clippy -p everruns -p everruns-macros --all-targets --all-features -- -D warnings`: clean.

## Risk

- **Low**
- Additive: a new crate plus a default-on feature on `everruns`. No existing API changes. The generated code reuses the established `FunctionTool` execution path. The `macros` feature adds the proc-macro + schemars build cost to the default `everruns` build; it activates no network or I/O edge. `everruns` is in the MSRV (1.94) `cargo check` list — the new deps (syn 2, quote, proc-macro2, schemars 1.0) build under it.

## Security

- **Threat categories reviewed:** untrusted-input handling; information disclosure; macro hygiene / code injection; supply chain.
- **Findings and resolutions:**
  - *Untrusted input (model-controlled tool arguments):* deserialized via `serde_json::from_value` into a typed struct; missing/invalid fields become a returned tool-error string, never a panic — identical safety to a hand-written `FunctionTool`. No `unsafe`.
  - *Information disclosure:* a handler `Err(E)` surfaces `E`'s `Display` as a model-visible tool error, matching the existing `FunctionTool` contract; public-facing agents already collapse this via `ErrorDisclosure::Generic`. No new disclosure path.
  - *Macro hygiene:* generated code uses fully-qualified paths (`::everruns::__macro_support::…`, `::core::result::Result`); tool name/description are compile-time string literals from the developer's own source, not runtime input. No injection surface.
  - *Supply chain:* new deps (syn, quote, proc-macro2, schemars, trybuild) are permissively licensed and covered by `deny.toml`'s allowlist; the License Check CI job confirms.
  - No findings requiring changes.

## Follow-ups

No follow-ups. (EVE-844 and EVE-835 consume this macro and are tracked as their own issues, not deferred work from this PR.)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qu6A8Gwi1VYFfdVpnoxP6D)_