### PR TITLE
refactor(engine): extract the turn planner into everruns-engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,6 +2615,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-engine"
+version = "0.17.23"
+dependencies = [
+ "chrono",
+ "everruns-core",
+ "serde",
+ "serde_json",
+ "tracing",
+ "uuid 1.24.0",
+]
+
+[[package]]
 name = "everruns-fireworks"
 version = "0.17.23"
 dependencies = [
@@ -3088,6 +3100,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
+ "everruns-engine",
  "everruns-mcp",
  "everruns-openai",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/everruns",
     "crates/everruns-macros",
     "crates/core",
+    "crates/engine",
     "crates/platform",
     "crates/provider",
     "crates/bedrock",
@@ -167,6 +168,7 @@ futures-util = "0.3"
 # Everruns SDK
 everruns-sdk = "0.2.0"
 everruns-core = { path = "crates/core", version = "0.17.23" }
+everruns-engine = { path = "crates/engine", version = "0.17.23" }
 everruns-platform = { path = "crates/platform", version = "0.17.23" }
 everruns-provider = { path = "crates/provider", version = "0.17.23" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,0 +1,39 @@
+# The turn engine: the sans-IO turn planner for the Everruns agentic runtime.
+#
+# Decision (EVE-840, Sans-IO Turn State epic): the authoritative turn-planning
+# brain lives here as pure, deterministic functions — no stores, sockets,
+# process execution, event emission, or `Utc::now()`. Hosts (in-process,
+# durable, custom) resolve facts and perform the returned lifecycle effects.
+#
+# Dependency direction is strictly `engine -> core`. The engine never depends on
+# runtime/server/worker/platform/durable (enforced by
+# crates/engine/tests/dependency_direction.rs).
+
+[package]
+name = "everruns-engine"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-engine"
+description = "The sans-IO turn planner for the Everruns agentic runtime — pure, deterministic turn-state transitions"
+readme = "README.md"
+keywords = ["agent", "agentic", "llm", "ai", "state-machine"]
+categories = ["development-tools", "asynchronous"]
+
+[dependencies]
+# Domain value types the planner transitions over: turn state fields, the
+# reason/act atom I/O shapes, the event payloads returned as effects, the
+# user-facing error taxonomy, and the typed IDs. Direction is engine -> core.
+everruns-core = { workspace = true }
+
+chrono.workspace = true
+serde.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+uuid.workspace = true

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -1,0 +1,13 @@
+# everruns-engine
+
+The sans-IO turn planner for the [Everruns](https://everruns.com) agentic
+runtime.
+
+`everruns-engine` holds the authoritative, deterministic turn-planning brain:
+pure functions that take a serializable `TurnState` plus a parsed activity
+outcome and return the next `TurnPlan` and the lifecycle effects the host must
+perform. It does no I/O — no stores, sockets, process execution, event emission,
+or `Utc::now()`. Hosts (in-process, durable, custom) resolve those facts, pass
+`now` in, and apply the returned effects.
+
+See `knowledge/foundations/sans-io-turn-state.md` for the design intent.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,0 +1,25 @@
+//! The turn engine: the sans-IO turn planner for the Everruns agentic runtime.
+//!
+//! `everruns-engine` owns the authoritative, deterministic turn-planning brain
+//! for the Sans-IO Turn State epic
+//! (`knowledge/foundations/sans-io-turn-state.md`). Given a serializable
+//! [`TurnState`], a parsed [`ActivityOutcome`], and any host-resolved
+//! [`HostFacts`], its pure functions return the next [`TurnPlan`] together with
+//! the [`TurnLifecycleEffect`]s the host must perform.
+//!
+//! The engine performs no I/O: no stores, sockets, process execution, event
+//! emission, or `Utc::now()`. Hosts resolve those facts, pass `now` in, call the
+//! planner, and perform the returned effects. This makes the loop testable as
+//! table tests over values, and lets an in-process host and a durable host share
+//! one implementation of turn semantics.
+//!
+//! The dependency direction is strictly `engine -> core`; the engine never
+//! depends on runtime/server/worker/platform/durable.
+
+mod turn;
+
+pub use turn::{
+    ActOutcome, ActPlan, ActSchedulingFacts, ActivityOutcome, HostFacts, TurnLifecycleEffect,
+    TurnPlan, TurnState, plan_after_act, plan_after_process_input, plan_after_reason,
+    plan_next_turn, reason_schedules_act,
+};

--- a/crates/engine/src/turn.rs
+++ b/crates/engine/src/turn.rs
@@ -1,0 +1,491 @@
+// The sans-IO turn planner (EVE-840, Sans-IO Turn State epic).
+//
+// This is the authoritative turn-planning brain, extracted verbatim from
+// `everruns-runtime`'s `plan_next_host_turn`. Every function here is pure and
+// deterministic: it reads only its arguments and returns a `TurnPlan` (plus, for
+// terminal outcomes, a list of `TurnLifecycleEffect`s the host must perform). It
+// never touches a store, socket, process, event bus, or `Utc::now()` — the host
+// resolves those facts, passes `now` in, and performs the returned effects.
+
+use chrono::{DateTime, Utc};
+use everruns_core::atoms::{ActInput, AtomContext, ReasonResult};
+use everruns_core::events::{TokenUsage, TurnCompletedData};
+use everruns_core::turn::TurnStopReason;
+use everruns_core::typed_id::{
+    AgentId, ExecId, HarnessId, MessageId, SessionId, TurnId, WorkspaceId,
+};
+use everruns_core::{
+    ErrorDisclosure, UserFacingError, UserFacingErrorContext, classify_runtime_error_message,
+    user_facing_error_codes,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+/// Host-owned state carried across turn phases.
+///
+/// Durable hosts can persist this between activities; in-memory hosts can hold
+/// it directly in memory. The type itself is engine-level and has no host,
+/// store, or durable-engine coupling.
+///
+/// Hosts are expected to serialize this however they want. `everruns-engine`
+/// only defines the fields required to resume the next semantic step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnState {
+    pub org_id: i64,
+    pub session_id: SessionId,
+    pub harness_id: HarnessId,
+    pub agent_id: Option<AgentId>,
+    pub input_message_id: MessageId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<TurnId>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub previous_response_id: Option<String>,
+    #[serde(default = "default_iteration")]
+    pub iteration: u32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cumulative_usage: Option<TokenUsage>,
+    #[serde(default)]
+    pub tool_call_count: u32,
+    #[serde(default)]
+    pub llm_call_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub time_to_first_token_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub final_message_id: Option<MessageId>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub final_answer_preview: Option<String>,
+}
+
+fn default_iteration() -> u32 {
+    1
+}
+
+/// Engine-owned act scheduling payload.
+///
+/// Hosts enqueue or execute this immediately using their own worker model.
+#[derive(Debug, Clone)]
+pub struct ActPlan {
+    pub input: ActInput,
+    pub previous_response_id: Option<String>,
+    pub iteration: u32,
+    pub request_id: Option<String>,
+    pub resume_state: Box<TurnState>,
+}
+
+/// Generic next-step decision for a host turn.
+///
+/// This intentionally stops at the semantic boundary:
+/// - the engine decides what should happen next
+/// - the host decides how to persist, enqueue, retry, or resume it
+#[derive(Debug, Clone)]
+pub enum TurnPlan {
+    ScheduleReason(TurnState),
+    ScheduleAct(ActPlan),
+    Complete {
+        stop_reason: TurnStopReason,
+        error: Option<String>,
+    },
+    WaitForToolResults {
+        resume: TurnState,
+    },
+}
+
+/// A lifecycle side effect the engine decided must be recorded, described as
+/// data rather than performed.
+///
+/// The engine never emits events or fires hooks — it *returns* these, and the
+/// host applies them (in list order) through its own lifecycle machinery. This
+/// keeps planning deterministic while preserving the exact event stream. These
+/// are NOT part of the public [`TurnPlan`]; they travel alongside it.
+#[derive(Debug, Clone)]
+pub enum TurnLifecycleEffect {
+    /// Emit `turn.completed` with the summarized turn fields.
+    TurnCompleted {
+        input_message_id: MessageId,
+        data: TurnCompletedData,
+    },
+    /// Idle the session and emit `session.idled`.
+    SessionIdled {
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        iterations: Option<u32>,
+        usage: Option<TokenUsage>,
+    },
+    /// Fail the turn with the already-disclosure-filtered error, emitting
+    /// `turn.failed` + `session.idled`.
+    TurnFailedWithDisclosure {
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        text: String,
+        user_error: Option<UserFacingError>,
+        disclosure: Option<ErrorDisclosure>,
+    },
+    /// Fire the advisory `turn_end` lifecycle hooks.
+    FireTurnEndHooks {
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        turn_id: TurnId,
+        success: bool,
+    },
+    /// Mark the session `waiting_for_tool_results`.
+    WaitingForToolResults,
+}
+
+/// Parsed `act` activity output the planner decides over.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ActOutcome {
+    pub blocked: bool,
+    pub waiting_for_tool_results: bool,
+}
+
+/// Session facts the host pre-resolves for the reason→act scheduling case.
+///
+/// The host fetches these (from its session store) only when
+/// [`reason_schedules_act`] is true, mirroring the original conditional fetch:
+/// `blueprint_id` scopes blueprint tool resolution, and `workspace_id` points
+/// tool file I/O at the (possibly shared) workspace rather than the session's
+/// own keyspace.
+#[derive(Debug, Clone, Default)]
+pub struct ActSchedulingFacts {
+    pub blueprint_id: Option<String>,
+    pub workspace_id: Option<WorkspaceId>,
+}
+
+/// Typed, parsed activity output the engine plans the next step from.
+///
+/// The host parses the raw serialized activity output into this before calling
+/// [`plan_next_turn`]; unknown activity kinds are rejected by the host, so the
+/// engine stays total.
+pub enum ActivityOutcome {
+    ProcessInput { turn_id: Option<TurnId> },
+    // Boxed: `ReasonResult` dwarfs the other variants (clippy::large_enum_variant).
+    Reason(Box<ReasonResult>),
+    Act(ActOutcome),
+}
+
+/// Host-resolved facts the engine needs but cannot fetch itself.
+///
+/// The host populates only the field relevant to the completed activity, doing
+/// I/O in exactly the same conditions as the original planner:
+/// `act_scheduling` only when [`reason_schedules_act`] is true, and
+/// `setup_connection_hint_enabled` only when the act paused for tool results.
+#[derive(Debug, Clone, Default)]
+pub struct HostFacts {
+    pub act_scheduling: Option<ActSchedulingFacts>,
+    pub setup_connection_hint_enabled: bool,
+}
+
+fn preview_final_answer(text: &str) -> Option<String> {
+    if text.is_empty() {
+        return None;
+    }
+
+    Some(text.chars().take(2000).collect())
+}
+
+fn add_usage(current: &mut Option<TokenUsage>, next: &TokenUsage) {
+    match current {
+        Some(current) => current.add(next),
+        None => *current = Some(next.clone()),
+    }
+}
+
+impl TurnState {
+    fn with_reason_summary(&self, reason_result: &ReasonResult) -> Self {
+        let mut next = self.clone();
+        next.llm_call_count = next.llm_call_count.saturating_add(1);
+        next.tool_call_count = next
+            .tool_call_count
+            .saturating_add(reason_result.tool_calls.len() as u32);
+        if let Some(usage) = &reason_result.usage {
+            add_usage(&mut next.cumulative_usage, usage);
+        }
+        if next.time_to_first_token_ms.is_none() {
+            next.time_to_first_token_ms = reason_result.time_to_first_token_ms;
+        }
+        next.final_message_id = reason_result.output_message_id;
+        next.final_answer_preview = preview_final_answer(&reason_result.text);
+        next
+    }
+
+    /// Wall-clock duration since `started_at`, measured against the host-supplied
+    /// `now` so the calculation stays deterministic.
+    fn duration_ms(&self, now: DateTime<Utc>) -> Option<u64> {
+        self.started_at
+            .map(|started_at| now.signed_duration_since(started_at))
+            .and_then(|duration| u64::try_from(duration.num_milliseconds()).ok())
+    }
+}
+
+fn classify_reason_failure(reason_result: &ReasonResult) -> UserFacingError {
+    // The reason atom already classified and disclosure-filtered the failure.
+    // Reuse it so the turn.failed event matches what the session message
+    // showed; re-classifying strings here could leak past a generic mode.
+    if let Some(user_error) = &reason_result.user_facing_error {
+        return user_error.clone();
+    }
+
+    let from_text =
+        classify_runtime_error_message(&reason_result.text, &UserFacingErrorContext::default());
+
+    let Some(error) = reason_result.error.as_deref() else {
+        return from_text;
+    };
+
+    let from_error = classify_runtime_error_message(error, &UserFacingErrorContext::default());
+
+    if from_error.code == user_facing_error_codes::PROCESSING_ERROR {
+        return from_text;
+    }
+
+    if from_error.code == from_text.code
+        && from_error.fields.is_empty()
+        && !from_text.fields.is_empty()
+    {
+        return from_text;
+    }
+
+    from_error
+}
+
+/// Does this reason outcome schedule an act phase?
+///
+/// The host consults this predicate to decide whether to resolve
+/// [`ActSchedulingFacts`] (a session fetch) before calling [`plan_after_reason`]
+/// — the same condition under which the original planner fetched the session.
+/// The reason planner branches on this same function, so the rule has exactly
+/// one definition.
+pub fn reason_schedules_act(state: &TurnState, reason_result: &ReasonResult) -> bool {
+    let max_turn_requests_reached = state.iteration >= reason_result.max_iterations as u32;
+    reason_result.has_tool_calls && reason_result.success && !max_turn_requests_reached
+}
+
+/// Plan the next host step after an activity finishes.
+///
+/// The authoritative, deterministic turn-planning entry point. Given the carried
+/// [`TurnState`], the parsed [`ActivityOutcome`], the count of queued steering
+/// messages, the host-supplied `now`, and any [`HostFacts`] the host pre-resolved,
+/// it returns the [`TurnPlan`] together with the [`TurnLifecycleEffect`]s the
+/// host must perform (in order). It performs no I/O of its own.
+pub fn plan_next_turn(
+    state: &TurnState,
+    outcome: ActivityOutcome,
+    pending_user_message_count: usize,
+    now: DateTime<Utc>,
+    facts: HostFacts,
+) -> (TurnPlan, Vec<TurnLifecycleEffect>) {
+    match outcome {
+        ActivityOutcome::ProcessInput { turn_id } => {
+            (plan_after_process_input(state, turn_id, now), Vec::new())
+        }
+        ActivityOutcome::Reason(reason_result) => plan_after_reason(
+            state,
+            *reason_result,
+            pending_user_message_count,
+            now,
+            facts.act_scheduling,
+        ),
+        ActivityOutcome::Act(outcome) => {
+            plan_after_act(state, outcome, facts.setup_connection_hint_enabled)
+        }
+    }
+}
+
+/// Plan the reason step that follows a completed `process_input` activity.
+pub fn plan_after_process_input(
+    state: &TurnState,
+    turn_id: Option<TurnId>,
+    now: DateTime<Utc>,
+) -> TurnPlan {
+    let next = TurnState {
+        turn_id,
+        previous_response_id: None,
+        iteration: 1,
+        started_at: state.started_at.or(Some(now)),
+        ..state.clone()
+    };
+    debug!(session_id = %state.session_id, turn_id = ?turn_id, "planned reason step");
+    TurnPlan::ScheduleReason(next)
+}
+
+/// Plan the next step after a `reason` activity finishes.
+///
+/// When [`reason_schedules_act`] holds, `act_scheduling` supplies the session
+/// facts the host resolved for the act phase; it is ignored otherwise. A
+/// terminal reason outcome returns the lifecycle effects the host must perform;
+/// the continuing outcomes return an empty effect list.
+pub fn plan_after_reason(
+    state: &TurnState,
+    reason_result: ReasonResult,
+    pending_user_message_count: usize,
+    now: DateTime<Utc>,
+    act_scheduling: Option<ActSchedulingFacts>,
+) -> (TurnPlan, Vec<TurnLifecycleEffect>) {
+    let response_id = reason_result.response_id.clone();
+    let summarized_state = state.with_reason_summary(&reason_result);
+    let max_turn_requests_reached = state.iteration >= reason_result.max_iterations as u32;
+
+    if reason_schedules_act(state, &reason_result) {
+        let facts = act_scheduling.unwrap_or_default();
+        let plan = ActPlan {
+            input: ActInput {
+                org_id: Some(state.org_id),
+                context: AtomContext {
+                    session_id: state.session_id,
+                    turn_id: state.turn_id.unwrap_or_default(),
+                    input_message_id: state.input_message_id,
+                    exec_id: ExecId::new(),
+                    workspace_id: facts.workspace_id,
+                },
+                harness_id: state.harness_id,
+                agent_id: state.agent_id,
+                tool_calls: reason_result.tool_calls,
+                tool_definitions: reason_result.tool_definitions,
+                locale: reason_result.locale,
+                blueprint_id: facts.blueprint_id,
+                network_access: reason_result.network_access,
+                // Request-level parallel tool calling preference, carried
+                // from agent config through the reason path (EVE-598).
+                parallel_tool_calls: reason_result.parallel_tool_calls,
+            },
+            previous_response_id: response_id,
+            iteration: state.iteration,
+            request_id: state.request_id.clone(),
+            resume_state: Box::new(summarized_state),
+        };
+        return (TurnPlan::ScheduleAct(plan), Vec::new());
+    }
+
+    if reason_result.success && pending_user_message_count > 0 && !max_turn_requests_reached {
+        if pending_user_message_count > 1 {
+            info!(
+                session_id = %state.session_id,
+                pending_user_message_count,
+                "multiple steering messages arrived during turn"
+            );
+        }
+
+        let next = TurnState {
+            previous_response_id: response_id,
+            iteration: state.iteration.saturating_add(1),
+            ..summarized_state
+        };
+        return (TurnPlan::ScheduleReason(next), Vec::new());
+    }
+
+    let turn_id = state.turn_id.unwrap_or_default();
+    let mut effects = Vec::new();
+
+    if reason_result.success {
+        effects.push(TurnLifecycleEffect::TurnCompleted {
+            input_message_id: state.input_message_id,
+            data: TurnCompletedData {
+                turn_id,
+                iterations: state.iteration,
+                duration_ms: summarized_state.duration_ms(now),
+                usage: summarized_state.cumulative_usage.clone(),
+                input_content: None,
+                final_message_id: summarized_state.final_message_id,
+                final_answer_preview: summarized_state.final_answer_preview.clone(),
+                time_to_first_token_ms: summarized_state.time_to_first_token_ms,
+                tool_call_count: Some(summarized_state.tool_call_count),
+                llm_call_count: Some(summarized_state.llm_call_count),
+                status: Some("completed".to_string()),
+            },
+        });
+        effects.push(TurnLifecycleEffect::SessionIdled {
+            turn_id,
+            input_message_id: state.input_message_id,
+            iterations: Some(state.iteration),
+            usage: summarized_state.cumulative_usage.clone(),
+        });
+    } else {
+        let user_error = classify_reason_failure(&reason_result);
+        effects.push(TurnLifecycleEffect::TurnFailedWithDisclosure {
+            turn_id,
+            input_message_id: state.input_message_id,
+            text: reason_result.text.clone(),
+            user_error: Some(user_error),
+            disclosure: reason_result.error_disclosure,
+        });
+    }
+
+    // turn_end lifecycle hooks (advisory). Fired once the turn reaches a
+    // terminal reason outcome on the durable/strategy path.
+    effects.push(TurnLifecycleEffect::FireTurnEndHooks {
+        harness_id: state.harness_id,
+        agent_id: state.agent_id,
+        turn_id,
+        success: reason_result.success,
+    });
+
+    let stop_reason = if !reason_result.success {
+        match TurnStopReason::from_provider_finish_reason(reason_result.finish_reason.as_deref()) {
+            TurnStopReason::Refusal => TurnStopReason::Refusal,
+            _ => TurnStopReason::Error,
+        }
+    } else if max_turn_requests_reached
+        && (reason_result.has_tool_calls || pending_user_message_count > 0)
+    {
+        TurnStopReason::MaxTurnRequests
+    } else {
+        TurnStopReason::from_provider_finish_reason(reason_result.finish_reason.as_deref())
+    };
+
+    (
+        TurnPlan::Complete {
+            stop_reason,
+            error: reason_result.error,
+        },
+        effects,
+    )
+}
+
+/// Plan the next step after an `act` activity finishes.
+///
+/// `setup_connection_hint_enabled` is the resolved session hint; the host reads
+/// it only when the act reported `waiting_for_tool_results`, so passing `false`
+/// otherwise matches the original short-circuit exactly.
+pub fn plan_after_act(
+    state: &TurnState,
+    outcome: ActOutcome,
+    setup_connection_hint_enabled: bool,
+) -> (TurnPlan, Vec<TurnLifecycleEffect>) {
+    if outcome.blocked {
+        return (
+            TurnPlan::Complete {
+                stop_reason: TurnStopReason::EndTurn,
+                error: None,
+            },
+            Vec::new(),
+        );
+    }
+
+    let should_pause_for_tool_results =
+        outcome.waiting_for_tool_results && setup_connection_hint_enabled;
+
+    let next = TurnState {
+        iteration: state.iteration.saturating_add(1),
+        ..state.clone()
+    };
+
+    if should_pause_for_tool_results {
+        return (
+            TurnPlan::WaitForToolResults { resume: next },
+            vec![TurnLifecycleEffect::WaitingForToolResults],
+        );
+    }
+
+    if outcome.waiting_for_tool_results {
+        info!(
+            session_id = %state.session_id,
+            "setup_connection hint absent, continuing turn instead of pausing"
+        );
+    }
+
+    (TurnPlan::ScheduleReason(next), Vec::new())
+}

--- a/crates/engine/tests/dependency_direction.rs
+++ b/crates/engine/tests/dependency_direction.rs
@@ -1,0 +1,31 @@
+//! EVE-840 dependency-direction guard.
+//!
+//! The allowed direction is `everruns-engine -> everruns-core`. The engine is
+//! the pure, sans-IO turn planner: it must never depend on the hosts that drive
+//! it (runtime/server/worker) or the backend crates (platform/durable). If it
+//! did, the planning brain could no longer be shared by every host without
+//! dragging a host's I/O in with it. This test fails the engine build the moment
+//! a manifest edit introduces one of those reverse edges.
+
+use std::path::Path;
+
+#[test]
+fn engine_manifest_has_no_edge_to_hosts_or_backends() {
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", manifest_path.display()));
+
+    for forbidden in [
+        "everruns-runtime",
+        "everruns-server",
+        "everruns-worker",
+        "everruns-platform",
+        "everruns-durable",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "everruns-engine must not depend on {forbidden} \
+             (the engine is a pure, sans-IO planner; hosts depend on it, not the reverse)"
+        );
+    }
+}

--- a/crates/engine/tests/planner_test.rs
+++ b/crates/engine/tests/planner_test.rs
@@ -1,0 +1,380 @@
+//! Pure turn-planner unit tests (EVE-840).
+//!
+//! These drive the engine as table tests over values — no adapter, store,
+//! provider, or clock. They cover the branch outcomes the runtime host relies
+//! on (unknown tool, parallel tool batch, completion, failure, cancellation,
+//! max-iteration, act pause/continue) plus a serialize → deserialize → plan
+//! round-trip proving determinism.
+
+use chrono::{DateTime, Utc};
+use everruns_core::ToolCall;
+use everruns_core::atoms::ReasonResult;
+use everruns_core::events::TokenUsage;
+use everruns_core::turn::TurnStopReason;
+use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId, WorkspaceId};
+use everruns_engine::{
+    ActOutcome, ActSchedulingFacts, TurnLifecycleEffect, TurnPlan, TurnState, plan_after_act,
+    plan_after_reason, reason_schedules_act,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+fn fixed_now() -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(1_700_000_000, 0).expect("valid timestamp")
+}
+
+fn turn_state() -> TurnState {
+    TurnState {
+        org_id: 1,
+        session_id: SessionId::from_uuid(Uuid::now_v7()),
+        harness_id: HarnessId::from_uuid(Uuid::now_v7()),
+        agent_id: None,
+        input_message_id: MessageId::from_uuid(Uuid::now_v7()),
+        turn_id: Some(TurnId::from_uuid(Uuid::now_v7())),
+        previous_response_id: None,
+        iteration: 1,
+        request_id: None,
+        started_at: None,
+        cumulative_usage: None,
+        tool_call_count: 0,
+        llm_call_count: 0,
+        time_to_first_token_ms: None,
+        final_message_id: None,
+        final_answer_preview: None,
+    }
+}
+
+fn reason_result() -> ReasonResult {
+    ReasonResult {
+        success: true,
+        text: String::new(),
+        tool_calls: vec![],
+        has_tool_calls: false,
+        tool_definitions: vec![],
+        max_iterations: 8,
+        error: None,
+        user_facing_error: None,
+        error_disclosure: None,
+        usage: None,
+        output_message_id: None,
+        time_to_first_token_ms: None,
+        response_id: None,
+        finish_reason: Some("stop".into()),
+        locale: None,
+        network_access: None,
+        parallel_tool_calls: None,
+    }
+}
+
+fn tool_call(id: &str, name: &str) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: json!({}),
+    }
+}
+
+/// A reason outcome that requests a tool call (even one the executor may not
+/// know) schedules an act phase carrying the calls, with the host-resolved
+/// blueprint + workspace and no lifecycle effects.
+#[test]
+fn reason_with_tool_call_schedules_act() {
+    let state = turn_state();
+    let workspace_id = WorkspaceId::from_uuid(Uuid::now_v7());
+    let result = ReasonResult {
+        text: "calling an unknown tool".into(),
+        tool_calls: vec![tool_call("call_1", "mystery_tool")],
+        has_tool_calls: true,
+        response_id: Some("resp_1".into()),
+        finish_reason: Some("tool_calls".into()),
+        parallel_tool_calls: Some(true),
+        ..reason_result()
+    };
+
+    assert!(reason_schedules_act(&state, &result));
+
+    let (plan, effects) = plan_after_reason(
+        &state,
+        result,
+        0,
+        fixed_now(),
+        Some(ActSchedulingFacts {
+            blueprint_id: Some("blueprint.private".into()),
+            workspace_id: Some(workspace_id),
+        }),
+    );
+    assert!(effects.is_empty());
+    match plan {
+        TurnPlan::ScheduleAct(act) => {
+            assert_eq!(act.input.tool_calls.len(), 1);
+            assert_eq!(act.input.tool_calls[0].name, "mystery_tool");
+            assert_eq!(act.input.blueprint_id.as_deref(), Some("blueprint.private"));
+            assert_eq!(act.input.context.workspace_id, Some(workspace_id));
+            assert_eq!(act.previous_response_id.as_deref(), Some("resp_1"));
+            assert_eq!(act.iteration, 1);
+            assert_eq!(act.input.parallel_tool_calls, Some(true));
+        }
+        other => panic!("expected ScheduleAct, got {other:?}"),
+    }
+}
+
+/// A parallel batch of tool calls threads through into one act phase intact.
+#[test]
+fn reason_with_parallel_tool_batch_schedules_single_act() {
+    let state = turn_state();
+    let result = ReasonResult {
+        text: "parallel work".into(),
+        tool_calls: vec![
+            tool_call("call_a", "search"),
+            tool_call("call_b", "read"),
+            tool_call("call_c", "write"),
+        ],
+        has_tool_calls: true,
+        finish_reason: Some("tool_calls".into()),
+        ..reason_result()
+    };
+
+    let (plan, effects) = plan_after_reason(&state, result, 0, fixed_now(), None);
+    assert!(effects.is_empty());
+    match plan {
+        TurnPlan::ScheduleAct(act) => {
+            assert_eq!(act.input.tool_calls.len(), 3);
+            // Facts absent -> no blueprint/workspace attached.
+            assert_eq!(act.input.blueprint_id, None);
+            assert_eq!(act.input.context.workspace_id, None);
+        }
+        other => panic!("expected ScheduleAct, got {other:?}"),
+    }
+}
+
+/// A successful reason with no tool calls and no pending steering completes the
+/// turn and returns the completion lifecycle effects in order.
+#[test]
+fn reason_success_completes_turn_with_effects() {
+    let mut state = turn_state();
+    state.started_at = Some(fixed_now() - chrono::Duration::milliseconds(1_234));
+    let final_message_id = MessageId::from_uuid(Uuid::now_v7());
+    let result = ReasonResult {
+        text: "the final answer".into(),
+        usage: Some(TokenUsage::new(20, 8)),
+        output_message_id: Some(final_message_id),
+        time_to_first_token_ms: Some(50),
+        finish_reason: Some("stop".into()),
+        ..reason_result()
+    };
+
+    let (plan, effects) = plan_after_reason(&state, result, 0, fixed_now(), None);
+    assert!(matches!(
+        plan,
+        TurnPlan::Complete {
+            stop_reason: TurnStopReason::EndTurn,
+            error: None,
+        }
+    ));
+    assert_eq!(effects.len(), 3);
+    match &effects[0] {
+        TurnLifecycleEffect::TurnCompleted {
+            input_message_id,
+            data,
+        } => {
+            assert_eq!(*input_message_id, state.input_message_id);
+            assert_eq!(data.final_message_id, Some(final_message_id));
+            assert_eq!(
+                data.final_answer_preview.as_deref(),
+                Some("the final answer")
+            );
+            assert_eq!(data.llm_call_count, Some(1));
+            assert_eq!(data.duration_ms, Some(1_234));
+            let usage = data.usage.as_ref().expect("usage aggregated");
+            assert_eq!(usage.input_tokens, 20);
+            assert_eq!(usage.output_tokens, 8);
+        }
+        other => panic!("expected TurnCompleted first, got {other:?}"),
+    }
+    assert!(matches!(
+        effects[1],
+        TurnLifecycleEffect::SessionIdled { .. }
+    ));
+    assert!(matches!(
+        effects[2],
+        TurnLifecycleEffect::FireTurnEndHooks { success: true, .. }
+    ));
+}
+
+/// A failed reason completes with an error stop reason and returns the
+/// turn-failed + turn-end-hook effects (no completion/idle pair).
+#[test]
+fn reason_failure_completes_with_failure_effect() {
+    let state = turn_state();
+    let result = ReasonResult {
+        success: false,
+        text: "budget exhausted".into(),
+        has_tool_calls: false,
+        error: Some("Budget exhausted".into()),
+        finish_reason: None,
+        ..reason_result()
+    };
+
+    let (plan, effects) = plan_after_reason(&state, result, 0, fixed_now(), None);
+    match plan {
+        TurnPlan::Complete { stop_reason, error } => {
+            assert_eq!(stop_reason, TurnStopReason::Error);
+            assert_eq!(error.as_deref(), Some("Budget exhausted"));
+        }
+        other => panic!("expected Complete, got {other:?}"),
+    }
+    assert_eq!(effects.len(), 2);
+    match &effects[0] {
+        TurnLifecycleEffect::TurnFailedWithDisclosure { text, .. } => {
+            assert_eq!(text, "budget exhausted");
+        }
+        other => panic!("expected TurnFailedWithDisclosure, got {other:?}"),
+    }
+    assert!(matches!(
+        effects[1],
+        TurnLifecycleEffect::FireTurnEndHooks { success: false, .. }
+    ));
+}
+
+/// A blocked act (host-side cancellation / dependency block) ends the turn with
+/// no effects.
+#[test]
+fn act_blocked_completes_end_turn() {
+    let state = turn_state();
+    let (plan, effects) = plan_after_act(
+        &state,
+        ActOutcome {
+            blocked: true,
+            waiting_for_tool_results: false,
+        },
+        false,
+    );
+    assert!(effects.is_empty());
+    assert!(matches!(
+        plan,
+        TurnPlan::Complete {
+            stop_reason: TurnStopReason::EndTurn,
+            error: None,
+        }
+    ));
+}
+
+/// When the iteration budget is already spent, a reason that still wants tools
+/// surfaces `MaxTurnRequests` instead of scheduling another act.
+#[test]
+fn reason_at_max_iterations_surfaces_max_turn_requests() {
+    let state = turn_state(); // iteration = 1
+    let result = ReasonResult {
+        text: "still calling tools".into(),
+        tool_calls: vec![tool_call("call_x", "multiply")],
+        has_tool_calls: true,
+        max_iterations: 1, // reached
+        finish_reason: Some("tool_calls".into()),
+        ..reason_result()
+    };
+
+    assert!(!reason_schedules_act(&state, &result));
+    let (plan, effects) = plan_after_reason(&state, result, 0, fixed_now(), None);
+    assert!(matches!(
+        plan,
+        TurnPlan::Complete {
+            stop_reason: TurnStopReason::MaxTurnRequests,
+            error: None,
+        }
+    ));
+    // Terminal: completion + idle + turn-end-hook effects.
+    assert_eq!(effects.len(), 3);
+}
+
+/// An act awaiting tool results pauses only when the setup_connection hint is
+/// enabled, emitting the waiting effect and bumping the iteration.
+#[test]
+fn act_waiting_pauses_when_hint_enabled() {
+    let state = turn_state();
+    let (plan, effects) = plan_after_act(
+        &state,
+        ActOutcome {
+            blocked: false,
+            waiting_for_tool_results: true,
+        },
+        true,
+    );
+    match plan {
+        TurnPlan::WaitForToolResults { resume } => {
+            assert_eq!(resume.iteration, 2);
+            assert_eq!(resume.turn_id, state.turn_id);
+        }
+        other => panic!("expected WaitForToolResults, got {other:?}"),
+    }
+    assert_eq!(effects.len(), 1);
+    assert!(matches!(
+        effects[0],
+        TurnLifecycleEffect::WaitingForToolResults
+    ));
+}
+
+/// Without the hint, an act awaiting tool results continues to reason instead.
+#[test]
+fn act_waiting_continues_when_hint_absent() {
+    let state = turn_state();
+    let (plan, effects) = plan_after_act(
+        &state,
+        ActOutcome {
+            blocked: false,
+            waiting_for_tool_results: true,
+        },
+        false,
+    );
+    assert!(effects.is_empty());
+    match plan {
+        TurnPlan::ScheduleReason(next) => assert_eq!(next.iteration, 2),
+        other => panic!("expected ScheduleReason, got {other:?}"),
+    }
+}
+
+/// Serializing a `TurnState`, deserializing it, and planning from both must
+/// yield the same next plan for the same input — the durable-replay property in
+/// miniature.
+#[test]
+fn serialize_deserialize_plan_round_trip_is_equal() {
+    let mut state = turn_state();
+    state.started_at = Some(fixed_now() - chrono::Duration::milliseconds(500));
+    state.cumulative_usage = Some(TokenUsage::new(3, 1));
+    state.tool_call_count = 2;
+    state.llm_call_count = 1;
+
+    let serialized = serde_json::to_string(&state).expect("serialize");
+    let restored: TurnState = serde_json::from_str(&serialized).expect("deserialize");
+
+    let now = fixed_now();
+    let (plan_a, effects_a) = plan_after_reason(&state, reason_result(), 0, now, None);
+    let (plan_b, effects_b) = plan_after_reason(&restored, reason_result(), 0, now, None);
+
+    // Both terminal completions with identical stop reason + summarized fields.
+    let (sr_a, err_a) = match plan_a {
+        TurnPlan::Complete { stop_reason, error } => (stop_reason, error),
+        other => panic!("expected Complete, got {other:?}"),
+    };
+    let (sr_b, err_b) = match plan_b {
+        TurnPlan::Complete { stop_reason, error } => (stop_reason, error),
+        other => panic!("expected Complete, got {other:?}"),
+    };
+    assert_eq!(sr_a, sr_b);
+    assert_eq!(err_a, err_b);
+
+    let completed = |effects: &[TurnLifecycleEffect]| -> everruns_core::events::TurnCompletedData {
+        match &effects[0] {
+            TurnLifecycleEffect::TurnCompleted { data, .. } => data.clone(),
+            other => panic!("expected TurnCompleted, got {other:?}"),
+        }
+    };
+    let data_a = completed(&effects_a);
+    let data_b = completed(&effects_b);
+    assert_eq!(data_a.duration_ms, data_b.duration_ms);
+    assert_eq!(data_a.tool_call_count, data_b.tool_call_count);
+    assert_eq!(data_a.llm_call_count, data_b.llm_call_count);
+    assert_eq!(
+        serde_json::to_value(&data_a.usage).unwrap(),
+        serde_json::to_value(&data_b.usage).unwrap()
+    );
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -43,6 +43,7 @@ tracing.workspace = true
 uuid.workspace = true
 
 everruns-core.workspace = true
+everruns-engine.workspace = true
 everruns-mcp.workspace = true
 
 [dev-dependencies]

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -1,163 +1,33 @@
-// Shared turn-strategy planning for embedded, durable, and custom hosts.
-// Decision: everruns-runtime stays durable-agnostic and returns generic next-step plans.
+// Thin I/O wrapper over the pure turn planner in `everruns-engine`.
+//
+// Decision (EVE-840, Sans-IO Turn State epic): the authoritative turn-planning
+// brain lives in `everruns-engine` as pure, deterministic functions. This
+// module is the runtime host's I/O shell around it: it resolves the same facts
+// via the adapter *in exactly the same conditions as before* (fetch the session
+// only when scheduling an act; read the setup_connection hint only when the act
+// paused for tool results), supplies `Utc::now()`, calls the engine planner,
+// then performs any returned `TurnLifecycleEffect`s via `RuntimeSessionLifecycle`
+// (identical order to the pre-extraction code), and returns the plan. The
+// runtime carries no second copy of the planning brain.
 
 use crate::{RuntimeHostAdapter, RuntimeSessionLifecycle};
-use chrono::{DateTime, Utc};
-use everruns_core::atoms::{ActInput, AtomContext};
+use chrono::Utc;
+use everruns_core::Controls;
+use everruns_core::atoms::ReasonResult;
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::events::TokenUsage;
-use everruns_core::turn::TurnStopReason;
-use everruns_core::typed_id::{AgentId, ExecId, HarnessId, MessageId, SessionId, TurnId};
-use everruns_core::{
-    Controls, ReasonResult, UserFacingError, UserFacingErrorContext,
-    classify_runtime_error_message, user_facing_error_codes,
+use everruns_core::typed_id::{SessionId, TurnId};
+use everruns_engine::{
+    ActOutcome, ActSchedulingFacts, ActivityOutcome, HostFacts, TurnLifecycleEffect,
+    plan_next_turn, reason_schedules_act,
 };
-use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
 
-/// Host-owned state carried across turn phases.
-///
-/// Durable hosts can persist this between activities; in-memory hosts can hold
-/// it directly in memory. The type itself is runtime-level and has no durable
-/// engine coupling.
-///
-/// Hosts are expected to serialize this however they want. `everruns-runtime`
-/// only defines the fields required to resume the next semantic step.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RuntimeTurnState {
-    pub org_id: i64,
-    pub session_id: SessionId,
-    pub harness_id: HarnessId,
-    pub agent_id: Option<AgentId>,
-    pub input_message_id: MessageId,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<TurnId>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub previous_response_id: Option<String>,
-    #[serde(default = "default_iteration")]
-    pub iteration: u32,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub request_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub started_at: Option<DateTime<Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub cumulative_usage: Option<TokenUsage>,
-    #[serde(default)]
-    pub tool_call_count: u32,
-    #[serde(default)]
-    pub llm_call_count: u32,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub time_to_first_token_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub final_message_id: Option<MessageId>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub final_answer_preview: Option<String>,
-}
-
-fn default_iteration() -> u32 {
-    1
-}
-
-/// Runtime-owned act scheduling payload.
-///
-/// Hosts enqueue or execute this immediately using their own worker model.
-#[derive(Debug, Clone)]
-pub struct RuntimeActPlan {
-    pub input: ActInput,
-    pub previous_response_id: Option<String>,
-    pub iteration: u32,
-    pub request_id: Option<String>,
-    pub resume_state: Box<RuntimeTurnState>,
-}
-
-/// Generic next-step decision for a host turn.
-///
-/// This intentionally stops at the semantic boundary:
-/// - runtime decides what should happen next
-/// - the host decides how to persist, enqueue, retry, or resume it
-#[derive(Debug, Clone)]
-pub enum RuntimeTurnPlan {
-    ScheduleReason(RuntimeTurnState),
-    ScheduleAct(RuntimeActPlan),
-    Complete {
-        stop_reason: TurnStopReason,
-        error: Option<String>,
-    },
-    WaitForToolResults {
-        resume: RuntimeTurnState,
-    },
-}
-
-fn preview_final_answer(text: &str) -> Option<String> {
-    if text.is_empty() {
-        return None;
-    }
-
-    Some(text.chars().take(2000).collect())
-}
-
-fn add_usage(current: &mut Option<TokenUsage>, next: &TokenUsage) {
-    match current {
-        Some(current) => current.add(next),
-        None => *current = Some(next.clone()),
-    }
-}
-
-impl RuntimeTurnState {
-    fn with_reason_summary(&self, reason_result: &ReasonResult) -> Self {
-        let mut next = self.clone();
-        next.llm_call_count = next.llm_call_count.saturating_add(1);
-        next.tool_call_count = next
-            .tool_call_count
-            .saturating_add(reason_result.tool_calls.len() as u32);
-        if let Some(usage) = &reason_result.usage {
-            add_usage(&mut next.cumulative_usage, usage);
-        }
-        if next.time_to_first_token_ms.is_none() {
-            next.time_to_first_token_ms = reason_result.time_to_first_token_ms;
-        }
-        next.final_message_id = reason_result.output_message_id;
-        next.final_answer_preview = preview_final_answer(&reason_result.text);
-        next
-    }
-
-    fn duration_ms(&self) -> Option<u64> {
-        self.started_at
-            .map(|started_at| Utc::now().signed_duration_since(started_at))
-            .and_then(|duration| u64::try_from(duration.num_milliseconds()).ok())
-    }
-}
-
-fn classify_reason_failure(reason_result: &ReasonResult) -> UserFacingError {
-    // The reason atom already classified and disclosure-filtered the failure.
-    // Reuse it so the turn.failed event matches what the session message
-    // showed; re-classifying strings here could leak past a generic mode.
-    if let Some(user_error) = &reason_result.user_facing_error {
-        return user_error.clone();
-    }
-
-    let from_text =
-        classify_runtime_error_message(&reason_result.text, &UserFacingErrorContext::default());
-
-    let Some(error) = reason_result.error.as_deref() else {
-        return from_text;
-    };
-
-    let from_error = classify_runtime_error_message(error, &UserFacingErrorContext::default());
-
-    if from_error.code == user_facing_error_codes::PROCESSING_ERROR {
-        return from_text;
-    }
-
-    if from_error.code == from_text.code
-        && from_error.fields.is_empty()
-        && !from_text.fields.is_empty()
-    {
-        return from_text;
-    }
-
-    from_error
-}
+// Compat re-exports (EVE-840): existing callers keep importing the turn-planning
+// types from `everruns-runtime`. The types now live in `everruns-engine` and
+// dropped their `Runtime` prefix; these aliases preserve the old names so
+// pattern matches and signatures compile unchanged.
+pub use everruns_engine::{
+    ActPlan as RuntimeActPlan, TurnPlan as RuntimeTurnPlan, TurnState as RuntimeTurnState,
+};
 
 /// Determine the next host step after an activity finishes.
 ///
@@ -167,8 +37,8 @@ fn classify_reason_failure(reason_result: &ReasonResult) -> UserFacingError {
 /// - `output`: serialized activity output
 /// - `pending_user_message_count`: number of queued steering messages already consumed by the host
 ///
-/// Runtime owns the semantic decision. Hosts translate the returned plan into
-/// their own queueing / persistence model.
+/// The engine owns the semantic decision; this wrapper owns the I/O around it.
+/// Hosts translate the returned plan into their own queueing / persistence model.
 ///
 /// Typical host mapping:
 /// - `ScheduleReason` => enqueue or invoke a reason phase with the returned state
@@ -188,197 +58,156 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                 .get("turn_id")
                 .and_then(|value| value.as_str())
                 .and_then(|value| value.parse().ok());
-            let next = RuntimeTurnState {
-                turn_id,
-                previous_response_id: None,
-                iteration: 1,
-                started_at: state.started_at.or_else(|| Some(Utc::now())),
-                ..state.clone()
-            };
-            debug!(session_id = %state.session_id, turn_id = ?turn_id, "planned reason step");
-            Ok(RuntimeTurnPlan::ScheduleReason(next))
+            let (plan, effects) = plan_next_turn(
+                state,
+                ActivityOutcome::ProcessInput { turn_id },
+                pending_user_message_count,
+                Utc::now(),
+                HostFacts::default(),
+            );
+            perform_effects(adapter, state, effects).await;
+            Ok(plan)
         }
         "reason" => {
             let reason_result: ReasonResult = serde_json::from_value(output.clone())
                 .map_err(|error| AgentLoopError::Internal(error.into()))?;
-            let response_id = reason_result.response_id.clone();
-            let summarized_state = state.with_reason_summary(&reason_result);
-            let max_turn_requests_reached = state.iteration >= reason_result.max_iterations as u32;
 
-            if reason_result.has_tool_calls && reason_result.success && !max_turn_requests_reached {
+            // Fetch the session only when the reason outcome schedules an act —
+            // the exact condition the pre-extraction planner fetched under — to
+            // resolve the act's blueprint + workspace.
+            let act_scheduling = if reason_schedules_act(state, &reason_result) {
                 let session = adapter
                     .session_store(state.org_id)
                     .get_session(state.session_id)
                     .await?;
-                let session_blueprint_id = session.as_ref().and_then(|s| s.blueprint_id.clone());
-                // Attach the session's workspace so tool file I/O addresses the
-                // (possibly shared) workspace, not the session's own keyspace.
-                let workspace_id = session.as_ref().map(|s| s.workspace_id);
-                let plan = RuntimeActPlan {
-                    input: ActInput {
-                        org_id: Some(state.org_id),
-                        context: AtomContext {
-                            session_id: state.session_id,
-                            turn_id: state.turn_id.unwrap_or_default(),
-                            input_message_id: state.input_message_id,
-                            exec_id: ExecId::new(),
-                            workspace_id,
-                        },
-                        harness_id: state.harness_id,
-                        agent_id: state.agent_id,
-                        tool_calls: reason_result.tool_calls,
-                        tool_definitions: reason_result.tool_definitions,
-                        locale: reason_result.locale,
-                        blueprint_id: session_blueprint_id,
-                        network_access: reason_result.network_access,
-                        // Request-level parallel tool calling preference, carried
-                        // from agent config through the reason path (EVE-598).
-                        parallel_tool_calls: reason_result.parallel_tool_calls,
-                    },
-                    previous_response_id: response_id,
-                    iteration: state.iteration,
-                    request_id: state.request_id.clone(),
-                    resume_state: Box::new(summarized_state),
-                };
-                return Ok(RuntimeTurnPlan::ScheduleAct(plan));
-            }
-
-            if reason_result.success && pending_user_message_count > 0 && !max_turn_requests_reached
-            {
-                if pending_user_message_count > 1 {
-                    info!(
-                        session_id = %state.session_id,
-                        pending_user_message_count,
-                        "multiple steering messages arrived during turn"
-                    );
-                }
-
-                let next = RuntimeTurnState {
-                    previous_response_id: response_id,
-                    iteration: state.iteration.saturating_add(1),
-                    ..summarized_state
-                };
-                return Ok(RuntimeTurnPlan::ScheduleReason(next));
-            }
-
-            let lifecycle =
-                RuntimeSessionLifecycle::new(adapter.clone(), state.org_id, state.session_id);
-            let turn_id = state.turn_id.unwrap_or_default();
-
-            if reason_result.success {
-                lifecycle
-                    .emit_turn_completed(
-                        state.input_message_id,
-                        everruns_core::events::TurnCompletedData {
-                            turn_id,
-                            iterations: state.iteration,
-                            duration_ms: summarized_state.duration_ms(),
-                            usage: summarized_state.cumulative_usage.clone(),
-                            input_content: None,
-                            final_message_id: summarized_state.final_message_id,
-                            final_answer_preview: summarized_state.final_answer_preview.clone(),
-                            time_to_first_token_ms: summarized_state.time_to_first_token_ms,
-                            tool_call_count: Some(summarized_state.tool_call_count),
-                            llm_call_count: Some(summarized_state.llm_call_count),
-                            status: Some("completed".to_string()),
-                        },
-                    )
-                    .await;
-                lifecycle
-                    .emit_session_idled(
-                        turn_id,
-                        state.input_message_id,
-                        Some(state.iteration),
-                        summarized_state.cumulative_usage.clone(),
-                    )
-                    .await;
+                Some(ActSchedulingFacts {
+                    blueprint_id: session.as_ref().and_then(|s| s.blueprint_id.clone()),
+                    // Attach the session's workspace so tool file I/O addresses
+                    // the (possibly shared) workspace, not the session's own
+                    // keyspace.
+                    workspace_id: session.as_ref().map(|s| s.workspace_id),
+                })
             } else {
-                let user_error = classify_reason_failure(&reason_result);
-                lifecycle
-                    .turn_failed_with_disclosure(
-                        turn_id,
-                        state.input_message_id,
-                        &reason_result.text,
-                        Some(&user_error),
-                        reason_result.error_disclosure,
-                    )
-                    .await;
-            }
-
-            // turn_end lifecycle hooks (advisory). Fired once the turn reaches a
-            // terminal reason outcome on the durable/strategy path.
-            lifecycle
-                .fire_turn_end_hooks(
-                    state.harness_id,
-                    state.agent_id,
-                    turn_id,
-                    reason_result.success,
-                )
-                .await;
-
-            let stop_reason = if !reason_result.success {
-                match TurnStopReason::from_provider_finish_reason(
-                    reason_result.finish_reason.as_deref(),
-                ) {
-                    TurnStopReason::Refusal => TurnStopReason::Refusal,
-                    _ => TurnStopReason::Error,
-                }
-            } else if max_turn_requests_reached
-                && (reason_result.has_tool_calls || pending_user_message_count > 0)
-            {
-                TurnStopReason::MaxTurnRequests
-            } else {
-                TurnStopReason::from_provider_finish_reason(reason_result.finish_reason.as_deref())
+                None
             };
 
-            Ok(RuntimeTurnPlan::Complete {
-                stop_reason,
-                error: reason_result.error,
-            })
+            let (plan, effects) = plan_next_turn(
+                state,
+                ActivityOutcome::Reason(Box::new(reason_result)),
+                pending_user_message_count,
+                Utc::now(),
+                HostFacts {
+                    act_scheduling,
+                    ..HostFacts::default()
+                },
+            );
+            perform_effects(adapter, state, effects).await;
+            Ok(plan)
         }
         "act" => {
-            if output
-                .get("blocked")
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false)
-            {
-                return Ok(RuntimeTurnPlan::Complete {
-                    stop_reason: TurnStopReason::EndTurn,
-                    error: None,
-                });
-            }
-
-            let waiting_for_tool_results = output
-                .get("waiting_for_tool_results")
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false);
-            let should_pause_for_tool_results = waiting_for_tool_results
-                && setup_connection_hint_enabled(adapter, state.org_id, state.session_id).await;
-
-            let next = RuntimeTurnState {
-                iteration: state.iteration.saturating_add(1),
-                ..state.clone()
+            let outcome = ActOutcome {
+                blocked: output
+                    .get("blocked")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false),
+                waiting_for_tool_results: output
+                    .get("waiting_for_tool_results")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false),
             };
 
-            if should_pause_for_tool_results {
-                let lifecycle =
-                    RuntimeSessionLifecycle::new(adapter.clone(), state.org_id, state.session_id);
-                lifecycle.waiting_for_tool_results().await;
-                return Ok(RuntimeTurnPlan::WaitForToolResults { resume: next });
-            }
+            // Read the setup_connection hint only when the act actually paused
+            // for tool results — the same short-circuit the pre-extraction
+            // planner used. A blocked act returns before the hint is consulted,
+            // so gate on `!blocked` too to avoid any extra fetch.
+            let setup_connection_hint_enabled =
+                if !outcome.blocked && outcome.waiting_for_tool_results {
+                    setup_connection_hint_enabled(adapter, state.org_id, state.session_id).await
+                } else {
+                    false
+                };
 
-            if waiting_for_tool_results {
-                info!(
-                    session_id = %state.session_id,
-                    "setup_connection hint absent, continuing turn instead of pausing"
-                );
-            }
-
-            Ok(RuntimeTurnPlan::ScheduleReason(next))
+            let (plan, effects) = plan_next_turn(
+                state,
+                ActivityOutcome::Act(outcome),
+                pending_user_message_count,
+                Utc::now(),
+                HostFacts {
+                    setup_connection_hint_enabled,
+                    ..HostFacts::default()
+                },
+            );
+            perform_effects(adapter, state, effects).await;
+            Ok(plan)
         }
         other => Err(AgentLoopError::config(format!(
             "Unknown activity type completed: {other}"
         ))),
+    }
+}
+
+/// Perform the engine-returned lifecycle effects, in list order, via
+/// `RuntimeSessionLifecycle`. The engine never emits — it returns these — so
+/// this is the single place the runtime host translates a planning decision
+/// into event/status/hook I/O, preserving the exact stream and ordering.
+async fn perform_effects<A: RuntimeHostAdapter>(
+    adapter: &A,
+    state: &RuntimeTurnState,
+    effects: Vec<TurnLifecycleEffect>,
+) {
+    if effects.is_empty() {
+        return;
+    }
+    let lifecycle = RuntimeSessionLifecycle::new(adapter.clone(), state.org_id, state.session_id);
+    for effect in effects {
+        match effect {
+            TurnLifecycleEffect::TurnCompleted {
+                input_message_id,
+                data,
+            } => {
+                lifecycle.emit_turn_completed(input_message_id, data).await;
+            }
+            TurnLifecycleEffect::SessionIdled {
+                turn_id,
+                input_message_id,
+                iterations,
+                usage,
+            } => {
+                lifecycle
+                    .emit_session_idled(turn_id, input_message_id, iterations, usage)
+                    .await;
+            }
+            TurnLifecycleEffect::TurnFailedWithDisclosure {
+                turn_id,
+                input_message_id,
+                text,
+                user_error,
+                disclosure,
+            } => {
+                lifecycle
+                    .turn_failed_with_disclosure(
+                        turn_id,
+                        input_message_id,
+                        &text,
+                        user_error.as_ref(),
+                        disclosure,
+                    )
+                    .await;
+            }
+            TurnLifecycleEffect::FireTurnEndHooks {
+                harness_id,
+                agent_id,
+                turn_id,
+                success,
+            } => {
+                lifecycle
+                    .fire_turn_end_hooks(harness_id, agent_id, turn_id, success)
+                    .await;
+            }
+            TurnLifecycleEffect::WaitingForToolResults => {
+                lifecycle.waiting_for_tool_results().await;
+            }
+        }
     }
 }
 

--- a/knowledge/foundations/sans-io-turn-state.md
+++ b/knowledge/foundations/sans-io-turn-state.md
@@ -157,5 +157,8 @@ converge later.
 
 - `crates/core/src/turn.rs` — `TurnStateMachine`, `TurnPhase`, `TurnAction`, `TurnOutcome`
 - `crates/core/src/turn_state.rs` — the stage-1 value
-- `crates/runtime/src/turn_strategy.rs` — `RuntimeTurnState`, `plan_next_host_turn`
+- `crates/engine/src/turn.rs` — the pure, sans-IO turn planner (`TurnState`, `TurnPlan`,
+  `plan_next_turn`, `TurnLifecycleEffect`), extracted from the runtime in EVE-840
+- `crates/runtime/src/turn_strategy.rs` — `plan_next_host_turn`, the runtime host's thin
+  I/O wrapper over the engine planner (plus compat re-exports of the pre-EVE-840 names)
 - `knowledge/operations/durable-execution-engine.md` — the durable host this converges with


### PR DESCRIPTION
## What changed

The authoritative turn-planning brain now lives in a new `everruns-engine`
crate as pure, deterministic, sans-IO functions. Given the carried `TurnState`,
a parsed `ActivityOutcome`, host-resolved facts, and `now`, the engine returns
the next `TurnPlan` plus a `Vec<TurnLifecycleEffect>` that *describes* (never
performs) the events/hooks to run. It touches no store, socket, process, event
bus, or `Utc::now()`.

`crates/runtime/src/turn_strategy.rs` is reduced to a thin I/O wrapper around
the engine: it resolves the same facts under the same conditions as before
(session fetch only when scheduling an act; the setup_connection hint only when
the act paused for tool results), supplies `Utc::now()`, calls the engine, and
performs the returned effects in identical order. Compat re-exports keep the old
names — `RuntimeTurnState`/`RuntimeTurnPlan`/`RuntimeActPlan` and
`plan_next_host_turn` — so `everruns-worker` and `everruns-server` compile
unchanged through the runtime re-exports. The runtime carries no second copy of
the planning logic.

This is the "create the engine crate" step of the Sans-IO Turn State epic
(`knowledge/foundations/sans-io-turn-state.md`). Resolves EVE-840.

## Why

The turn loop is implemented twice and the two representations drift; every
turn-semantics change has to be made in both places. Extracting the planner into
a pure engine crate is the first structural step toward one shared, testable
implementation that an in-process host and a durable host can both drive without
either owning semantics. Pulling planning out of I/O also makes the loop
testable as table tests over values — no provider, database, or clock.

## Before / After

Pure refactor — no observable behavior change. The turn plans and the emitted
event/hook stream are identical before and after.

Evidence:
- `crates/runtime/tests/runtime_host_test.rs` is the behavior-preservation
  guard: it drives the wrapper with an adapter and asserts both the plans and
  the emitted lifecycle events. It is **unchanged** and stays green (28 passed).
- New engine unit tests (`crates/engine/tests/planner_test.rs`, 9 passed) cover
  schedule-act (incl. an unknown tool), a parallel tool batch, completion,
  failure, cancellation (blocked act), max-iteration, act pause/continue, and a
  serialize -> deserialize -> plan round-trip proving the same state+input yields
  an equal next plan.
- `crates/engine/tests/dependency_direction.rs` asserts the engine manifest has
  no edge to runtime/server/worker/platform/durable.

```
cargo test -p everruns-engine      -> 9 + 1 passed
cargo test -p everruns-runtime --test runtime_host_test -> 28 passed
cargo check -p everruns-worker -p everruns-server        -> clean (compile via re-exports)
just pre-push                       -> all checks passed (fmt, clippy -D warnings,
                                       lockfile, migrations, knowledge OKF, attribution)
```

## Risk

- Low
- The engine is behavior-preserving and covered by the unchanged runtime host
  test plus new engine unit tests. The only realistic breakage would be a
  changed plan or event stream, which the guard test would catch. No schema,
  migration, API, auth, or persistence surface is touched.

## Security

- Threat categories reviewed: none applicable — no security-relevant code
  changes. This is an internal refactor that moves pure planning logic between
  crates. No new external input is parsed (the runtime wrapper still performs the
  exact same `serde_json` deserialization it did before), and no auth, network,
  SQL, filesystem, or credential surface is added or changed.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. Migrating the runtime loop / durable worker onto the engine,
introducing the shared `TurnEffect` vocabulary, and folding the durable
bookkeeping onto `TurnState` are later stages of the epic and explicitly out of
scope for this step.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Htj4yG8ekxiyQvVCvh6ADP)_