### PR TITLE
refactor(runtime): drive InProcessRuntime turns through everruns-engine

### DIFF
--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -8,13 +8,15 @@ use crate::backends::{
 };
 use crate::builders::SingleSessionBuilder;
 use crate::host::{
-    RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle, execute_act_activity,
-    execute_input_activity, execute_reason_activity_with_prompt_messages,
+    RuntimeHostAdapter, RuntimeHostTurnContext, execute_act_activity, execute_input_activity,
+    execute_reason_activity_with_prompt_messages,
 };
 use crate::in_memory::{InMemorySessionFileStore, InMemorySessionFileSystemFactory};
+use crate::turn_strategy::{RuntimeTurnPlan, RuntimeTurnState};
 use async_trait::async_trait;
+use chrono::Utc;
 use everruns_core::agent::Agent;
-use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput, ReasonInput};
+use everruns_core::atoms::{AtomContext, InputAtomInput, ReasonInput};
 use everruns_core::capabilities::{
     Capability, CapabilityRegistry, CapabilityStatus, collect_capability_mcp_servers,
     resolve_capability_configs,
@@ -39,12 +41,13 @@ use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, ProviderStore, ResolvedModel, SessionMutator,
     SessionStorageStore, SessionStore, UserConnectionResolver,
 };
-use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine, TurnStopReason};
-use everruns_core::typed_id::{AgentId, HarnessId, MessageId, OrgId, SessionId};
+use everruns_core::turn::TurnStopReason;
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, OrgId, SessionId, TurnId};
 use everruns_core::{
     AgentCapabilityConfig, CapabilityId, InputMessage, MessageRetriever, SessionFileSystem,
     SessionFileSystemFactoryContext, plugin_capability_id, resolve_runtime_capabilities,
 };
+use everruns_engine::{ActOutcome, plan_after_act, plan_after_process_input, plan_after_reason};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 use std::sync::Arc;
@@ -139,65 +142,41 @@ pub struct CapabilityDelta {
     pub surfaces_dirty: bool,
 }
 
-impl TurnResult {
-    fn from_outcome(outcome: TurnOutcome, turn_id: everruns_core::typed_id::TurnId) -> Self {
-        let stop_reason = outcome.stop_reason();
-        match outcome {
-            TurnOutcome::Success {
-                response,
-                iterations,
-                tool_calls_count,
-                ..
-            } => Self {
-                response,
-                iterations,
-                tool_calls_count,
-                success: true,
-                error: None,
-                stop_reason,
-                turn_id,
-            },
-            TurnOutcome::Failed {
-                error, iterations, ..
-            } => Self {
-                response: String::new(),
-                iterations,
-                tool_calls_count: 0,
-                success: false,
-                error: Some(error),
-                stop_reason,
-                turn_id,
-            },
-            TurnOutcome::MaxIterationsReached {
-                response,
-                iterations,
-                tool_calls_count,
-            } => Self {
-                response,
-                iterations,
-                tool_calls_count,
-                success: true,
-                error: None,
-                stop_reason,
-                turn_id,
-            },
-            // A sealed turn was deliberately stopped (EVE-534) — distinct from a
-            // success. Report it as non-success carrying the seal reason.
-            TurnOutcome::Sealed {
-                reason,
-                response,
-                iterations,
-                tool_calls_count,
-            } => Self {
-                response,
-                iterations,
-                tool_calls_count,
-                success: false,
-                error: Some(format!("turn sealed: {reason}")),
-                stop_reason,
-                turn_id,
-            },
-        }
+/// Summarize a terminal engine plan into the public [`TurnResult`].
+///
+/// The engine reports the stop reason and the carried error; the host supplies
+/// the running summaries it accumulated while executing the planned steps. A
+/// carried error is the failure signal (it is exactly what the pre-engine state
+/// machine kept in `pending_error`), and a failed turn reports no response and
+/// no tool calls, matching the previous `TurnOutcome::Failed` mapping.
+fn finish_turn(
+    turn_id: everruns_core::typed_id::TurnId,
+    stop_reason: TurnStopReason,
+    error: Option<String>,
+    response: String,
+    iterations: usize,
+    tool_calls_count: usize,
+) -> TurnResult {
+    if error.is_some() {
+        return TurnResult {
+            response: String::new(),
+            iterations,
+            tool_calls_count: 0,
+            success: false,
+            error,
+            stop_reason,
+            turn_id,
+        };
+    }
+
+    TurnResult {
+        response,
+        iterations,
+        tool_calls_count,
+        success: true,
+        error: None,
+        stop_reason,
+        turn_id,
     }
 }
 
@@ -852,8 +831,9 @@ impl InProcessRuntime {
     /// Execute one turn for an existing session.
     ///
     /// The input message is stored in the runtime history, an `input.message`
-    /// event is emitted, and the turn then executes the shared core
-    /// `input -> reason -> act` state machine.
+    /// event is emitted, and the turn then runs `input -> reason -> act` as
+    /// planned step-by-step by [`everruns_engine`] — the same planner the
+    /// durable worker drives its turns with.
     pub async fn run_turn(
         &self,
         session_id: SessionId,
@@ -881,169 +861,164 @@ impl InProcessRuntime {
             ))
             .await?;
 
-        let assembled = self
-            .inspect_context_with_ids(session_id, session.harness_id, session.agent_id)
-            .await?;
-        let synthetic_agent_id = session
-            .agent_id
-            .unwrap_or_else(|| AgentId::from_uuid(session.id.uuid()));
         let org_id = in_process_internal_org_id(&session.organization_id);
-        let mut state_machine = TurnStateMachine::new(
-            TurnContext::new(session_id, input_message.id, synthetic_agent_id, org_id),
-            assembled.runtime_agent.max_iterations,
-        );
+        let turn_id = TurnId::new();
 
-        let mut previous_response_id: Option<String> = None;
-        let mut last_reason_result: Option<everruns_core::ReasonResult> = None;
+        // Engine-planned turn loop (EVE-842). Every reason-vs-act-vs-complete
+        // decision comes from `everruns-engine`; this loop only executes the
+        // host operation each plan names and performs the lifecycle effects the
+        // engine returns as data. There is no second copy of the planning brain
+        // in the runtime.
+        let mut state = RuntimeTurnState {
+            org_id,
+            session_id,
+            harness_id: session.harness_id,
+            agent_id: session.agent_id,
+            input_message_id: input_message.id,
+            turn_id: None,
+            previous_response_id: None,
+            iteration: 1,
+            request_id: None,
+            started_at: None,
+            cumulative_usage: None,
+            tool_call_count: 0,
+            llm_call_count: 0,
+            time_to_first_token_ms: None,
+            final_message_id: None,
+            final_answer_preview: None,
+        };
+
+        let base_context = |exec: bool| {
+            let context = AtomContext::new(session_id, turn_id, input_message.id)
+                .with_workspace_id(session.workspace_id);
+            if exec { context.next_exec() } else { context }
+        };
+
+        // `process_input` is the turn's fixed entry step: the durable host
+        // enqueues it before any planning, and it is what mints the turn id the
+        // planner then carries.
+        execute_input_activity(
+            self,
+            org_id,
+            InputAtomInput {
+                context: base_context(false),
+            },
+        )
+        .await?;
+        let mut plan = plan_after_process_input(&state, Some(turn_id), Utc::now());
+
+        // Host-side bookkeeping for the returned `TurnResult`. These are
+        // summaries of what the host executed, not inputs to any decision.
+        let mut iterations: usize = 0;
+        let mut tool_calls_count: usize = 0;
+        let mut last_response = String::new();
 
         loop {
-            match state_machine.next_action() {
-                TurnAction::ExecuteInput => {
-                    let ctx = state_machine.context();
-                    let base_context =
-                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
-                            .with_workspace_id(session.workspace_id);
-                    execute_input_activity(
-                        self,
-                        org_id,
-                        InputAtomInput {
-                            context: base_context,
-                        },
-                    )
-                    .await?;
-                    state_machine.on_input_completed();
-                }
-                TurnAction::ExecuteReason => {
-                    let ctx = state_machine.context();
-                    let session_id = ctx.session_id;
+            match plan {
+                RuntimeTurnPlan::ScheduleReason(next_state) => {
+                    state = next_state;
                     // Iteration boundary: drain queued task wakes and inject
                     // them before the LLM call so this reason reacts to them
                     // (EVE-681, part A). Draining here also delivers wakes that
                     // arrived while the session was idle, on the next turn's
                     // first iteration (between-turn fallback).
                     let wake_message_ids = self.drain_and_inject_wakes(session_id).await?;
-                    let base_context =
-                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
-                            .with_workspace_id(session.workspace_id);
                     let mut prompt_message_ids = wake_message_ids;
-                    if state_machine.current_iteration() == 0 {
-                        prompt_message_ids.insert(0, ctx.input_message_id);
+                    if state.iteration == 1 {
+                        prompt_message_ids.insert(0, input_message.id);
                     }
                     let reason_result = execute_reason_activity_with_prompt_messages(
                         self,
                         org_id,
                         ReasonInput {
-                            context: base_context.next_exec(),
+                            context: base_context(true),
                             harness_id: session.harness_id,
                             agent_id: session.agent_id,
                             org_id,
                             mcp_tool_definitions: vec![],
-                            previous_response_id: previous_response_id.take(),
-                            iteration: state_machine.current_iteration() as u32 + 1,
+                            previous_response_id: state.previous_response_id.clone(),
+                            iteration: state.iteration,
                         },
                         prompt_message_ids,
                     )
                     .await?;
-                    previous_response_id = reason_result.response_id.clone();
+
+                    iterations += 1;
+                    if !reason_result.text.is_empty() {
+                        last_response = reason_result.text.clone();
+                    }
+
                     // If a wake landed during this reason (e.g. a background
                     // task settling on another task), continue a would-idle turn
                     // so it is delivered on the very next iteration rather than
-                    // after the session idles.
-                    let has_pending_wakes = self
-                        .session_wake_queue
-                        .as_ref()
-                        .is_some_and(|q| q.has_pending(session_id));
-                    state_machine.on_reason_completed(
-                        reason_result.text.clone(),
-                        reason_result.tool_calls.len(),
-                        reason_result.success,
-                        reason_result.error.clone(),
-                        reason_result.finish_reason.clone(),
-                        has_pending_wakes,
+                    // after the session idles. The engine reads this as the
+                    // steering-message count the durable host reports.
+                    let pending_user_message_count = usize::from(
+                        self.session_wake_queue
+                            .as_ref()
+                            .is_some_and(|q| q.has_pending(session_id)),
                     );
-                    if reason_result.has_tool_calls {
-                        last_reason_result = Some(reason_result);
-                    }
-                }
-                TurnAction::ExecuteAct => {
-                    let reason_result = last_reason_result
-                        .take()
-                        .expect("ExecuteAct requires a prior ReasonResult");
-                    let ctx = state_machine.context();
-                    let base_context =
-                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
-                            .with_workspace_id(session.workspace_id);
-                    execute_act_activity(
-                        self,
-                        ActInput {
-                            org_id: Some(org_id),
-                            context: base_context.next_exec(),
-                            harness_id: session.harness_id,
-                            agent_id: session.agent_id,
-                            tool_calls: reason_result.tool_calls,
-                            tool_definitions: reason_result.tool_definitions,
-                            locale: reason_result.locale,
-                            blueprint_id: None,
-                            network_access: reason_result.network_access,
-                            // Request-level parallel tool calling preference,
-                            // carried from agent config through reason (EVE-598).
-                            parallel_tool_calls: reason_result.parallel_tool_calls,
-                        },
-                    )
-                    .await?;
-                    state_machine.on_act_completed();
-                }
-                TurnAction::Complete(outcome) => {
-                    let ctx = state_machine.context();
-                    let lifecycle =
-                        RuntimeSessionLifecycle::new(self.clone(), org_id, ctx.session_id);
-                    let turn_succeeded = matches!(
-                        &outcome,
-                        TurnOutcome::Success { .. } | TurnOutcome::MaxIterationsReached { .. }
+
+                    let act_scheduling =
+                        crate::turn_strategy::resolve_act_scheduling(self, &state, &reason_result)
+                            .await?;
+                    let (next, effects) = plan_after_reason(
+                        &state,
+                        reason_result,
+                        pending_user_message_count,
+                        Utc::now(),
+                        act_scheduling,
                     );
-                    match &outcome {
-                        TurnOutcome::Success { iterations, .. }
-                        | TurnOutcome::MaxIterationsReached { iterations, .. } => {
-                            lifecycle
-                                .turn_completed(
-                                    ctx.turn_id,
-                                    ctx.input_message_id,
-                                    *iterations as u32,
-                                    None,
-                                    None,
-                                )
-                                .await;
-                        }
-                        TurnOutcome::Failed { error, .. } => {
-                            lifecycle
-                                .turn_failed(ctx.turn_id, ctx.input_message_id, error, None)
-                                .await;
-                        }
-                        TurnOutcome::Sealed {
-                            reason, iterations, ..
-                        } => {
-                            lifecycle
-                                .turn_sealed(
-                                    ctx.turn_id,
-                                    ctx.input_message_id,
-                                    reason.as_str(),
-                                    *iterations as u32,
-                                    None,
-                                )
-                                .await;
-                        }
-                    }
-                    // turn_end lifecycle hooks (advisory). Fired after the
-                    // terminal turn event for both success and failure.
-                    lifecycle
-                        .fire_turn_end_hooks(
-                            session.harness_id,
-                            session.agent_id,
-                            ctx.turn_id,
-                            turn_succeeded,
+                    crate::turn_strategy::perform_effects(self, org_id, session_id, effects).await;
+                    plan = next;
+                }
+                RuntimeTurnPlan::ScheduleAct(act_plan) => {
+                    tool_calls_count += act_plan.input.tool_calls.len();
+                    // Same resume contract the durable host applies when it
+                    // dequeues the act task: the plan's response id / iteration
+                    // / request id override the carried state.
+                    state = *act_plan.resume_state;
+                    state.previous_response_id = act_plan.previous_response_id;
+                    state.iteration = act_plan.iteration;
+                    state.request_id = act_plan.request_id;
+
+                    let act_result = execute_act_activity(self, act_plan.input).await?;
+                    let outcome = ActOutcome {
+                        blocked: act_result.blocked,
+                        waiting_for_tool_results: act_result.waiting_for_tool_results,
+                    };
+                    let setup_connection_hint_enabled =
+                        crate::turn_strategy::resolve_setup_connection_hint(
+                            self, org_id, session_id, outcome,
                         )
                         .await;
-                    return Ok(TurnResult::from_outcome(outcome, ctx.turn_id));
+                    let (next, effects) =
+                        plan_after_act(&state, outcome, setup_connection_hint_enabled);
+                    crate::turn_strategy::perform_effects(self, org_id, session_id, effects).await;
+                    plan = next;
+                }
+                RuntimeTurnPlan::Complete { stop_reason, error } => {
+                    return Ok(finish_turn(
+                        turn_id,
+                        stop_reason,
+                        error,
+                        last_response,
+                        iterations,
+                        tool_calls_count,
+                    ));
+                }
+                // The in-process runtime has no external tool-result delivery
+                // path, so a pause resolves the turn here. The session has
+                // already been marked `waiting_for_tool_results` by the effect.
+                RuntimeTurnPlan::WaitForToolResults { .. } => {
+                    return Ok(finish_turn(
+                        turn_id,
+                        TurnStopReason::EndTurn,
+                        None,
+                        last_response,
+                        iterations,
+                        tool_calls_count,
+                    ));
                 }
             }
         }

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -65,31 +65,14 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                 Utc::now(),
                 HostFacts::default(),
             );
-            perform_effects(adapter, state, effects).await;
+            perform_effects(adapter, state.org_id, state.session_id, effects).await;
             Ok(plan)
         }
         "reason" => {
             let reason_result: ReasonResult = serde_json::from_value(output.clone())
                 .map_err(|error| AgentLoopError::Internal(error.into()))?;
 
-            // Fetch the session only when the reason outcome schedules an act —
-            // the exact condition the pre-extraction planner fetched under — to
-            // resolve the act's blueprint + workspace.
-            let act_scheduling = if reason_schedules_act(state, &reason_result) {
-                let session = adapter
-                    .session_store(state.org_id)
-                    .get_session(state.session_id)
-                    .await?;
-                Some(ActSchedulingFacts {
-                    blueprint_id: session.as_ref().and_then(|s| s.blueprint_id.clone()),
-                    // Attach the session's workspace so tool file I/O addresses
-                    // the (possibly shared) workspace, not the session's own
-                    // keyspace.
-                    workspace_id: session.as_ref().map(|s| s.workspace_id),
-                })
-            } else {
-                None
-            };
+            let act_scheduling = resolve_act_scheduling(adapter, state, &reason_result).await?;
 
             let (plan, effects) = plan_next_turn(
                 state,
@@ -101,7 +84,7 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     ..HostFacts::default()
                 },
             );
-            perform_effects(adapter, state, effects).await;
+            perform_effects(adapter, state.org_id, state.session_id, effects).await;
             Ok(plan)
         }
         "act" => {
@@ -116,16 +99,9 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     .unwrap_or(false),
             };
 
-            // Read the setup_connection hint only when the act actually paused
-            // for tool results — the same short-circuit the pre-extraction
-            // planner used. A blocked act returns before the hint is consulted,
-            // so gate on `!blocked` too to avoid any extra fetch.
             let setup_connection_hint_enabled =
-                if !outcome.blocked && outcome.waiting_for_tool_results {
-                    setup_connection_hint_enabled(adapter, state.org_id, state.session_id).await
-                } else {
-                    false
-                };
+                resolve_setup_connection_hint(adapter, state.org_id, state.session_id, outcome)
+                    .await;
 
             let (plan, effects) = plan_next_turn(
                 state,
@@ -137,7 +113,7 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     ..HostFacts::default()
                 },
             );
-            perform_effects(adapter, state, effects).await;
+            perform_effects(adapter, state.org_id, state.session_id, effects).await;
             Ok(plan)
         }
         other => Err(AgentLoopError::config(format!(
@@ -146,19 +122,63 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
     }
 }
 
+/// Resolve the act-scheduling session facts, fetching the session only when the
+/// reason outcome actually schedules an act — the exact condition the
+/// pre-extraction planner fetched under.
+///
+/// Shared by the JSON-shaped [`plan_next_host_turn`] wrapper and the in-process
+/// runtime loop (EVE-842) so both hosts do the same I/O under the same
+/// condition.
+pub(crate) async fn resolve_act_scheduling<A: RuntimeHostAdapter>(
+    adapter: &A,
+    state: &RuntimeTurnState,
+    reason_result: &ReasonResult,
+) -> Result<Option<ActSchedulingFacts>> {
+    if !reason_schedules_act(state, reason_result) {
+        return Ok(None);
+    }
+    let session = adapter
+        .session_store(state.org_id)
+        .get_session(state.session_id)
+        .await?;
+    Ok(Some(ActSchedulingFacts {
+        blueprint_id: session.as_ref().and_then(|s| s.blueprint_id.clone()),
+        // Attach the session's workspace so tool file I/O addresses the
+        // (possibly shared) workspace, not the session's own keyspace.
+        workspace_id: session.as_ref().map(|s| s.workspace_id),
+    }))
+}
+
+/// Resolve the `setup_connection` hint only when the act actually paused for
+/// tool results — the same short-circuit the pre-extraction planner used. A
+/// blocked act returns before the hint is consulted, so gate on `!blocked` too
+/// to avoid any extra fetch.
+pub(crate) async fn resolve_setup_connection_hint<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    session_id: SessionId,
+    outcome: ActOutcome,
+) -> bool {
+    if outcome.blocked || !outcome.waiting_for_tool_results {
+        return false;
+    }
+    setup_connection_hint_enabled(adapter, org_id, session_id).await
+}
+
 /// Perform the engine-returned lifecycle effects, in list order, via
 /// `RuntimeSessionLifecycle`. The engine never emits — it returns these — so
 /// this is the single place the runtime host translates a planning decision
 /// into event/status/hook I/O, preserving the exact stream and ordering.
-async fn perform_effects<A: RuntimeHostAdapter>(
+pub(crate) async fn perform_effects<A: RuntimeHostAdapter>(
     adapter: &A,
-    state: &RuntimeTurnState,
+    org_id: i64,
+    session_id: SessionId,
     effects: Vec<TurnLifecycleEffect>,
 ) {
     if effects.is_empty() {
         return;
     }
-    let lifecycle = RuntimeSessionLifecycle::new(adapter.clone(), state.org_id, state.session_id);
+    let lifecycle = RuntimeSessionLifecycle::new(adapter.clone(), org_id, session_id);
     for effect in effects {
         match effect {
             TurnLifecycleEffect::TurnCompleted {

--- a/crates/runtime/tests/engine_planned_turn_test.rs
+++ b/crates/runtime/tests/engine_planned_turn_test.rs
@@ -1,0 +1,451 @@
+//! Parity coverage for the engine-planned in-process turn loop (EVE-842).
+//!
+//! `InProcessRuntime::run_turn` no longer decides reason-vs-act-vs-complete on
+//! its own — every step comes from `everruns-engine`'s planner and the loop only
+//! executes the named host operation. These tests pin the observable contract
+//! that migration had to preserve: the `TurnResult` summary values and the
+//! turn-scoped event sequence, across single/parallel tools, tool errors,
+//! provider failure, and the max-iteration ceiling.
+//!
+//! The last test covers the durable property the engine buys us: the planner's
+//! carried state survives a serialize/reconstruct between every step, so a host
+//! that persists it between activities plans the identical turn.
+
+use everruns_core::capabilities::TestMathCapability;
+use everruns_core::driver_registry::DriverRegistry;
+use everruns_core::llmsim_driver::{LlmSimConfig, SimError, SimToolCall, SimTurn};
+use everruns_core::{
+    Agent, CapabilityRegistry, DriverId, Harness, PlatformDefinition, ResolvedModel, Session,
+};
+use everruns_engine::{
+    ActOutcome, TurnPlan, TurnState, plan_after_act, plan_after_process_input, plan_after_reason,
+};
+use everruns_runtime::{
+    AgentBuilder, HarnessBuilder, InProcessRuntime, InProcessRuntimeBuilder, SessionBuilder,
+    TurnStopReason,
+};
+use serde_json::json;
+
+fn math_platform() -> PlatformDefinition {
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(TestMathCapability);
+    PlatformDefinition::new(capabilities, DriverRegistry::new())
+}
+
+fn harness(harness_id: everruns_core::HarnessId) -> Harness {
+    HarnessBuilder::new("math", "You are a math assistant.")
+        .id(harness_id)
+        .display_name("Math")
+        .capability("test_math")
+        .build()
+}
+
+fn agent(agent_id: everruns_core::AgentId, max_iterations: usize) -> Agent {
+    AgentBuilder::new("math-agent", "Use tools when needed.")
+        .id(agent_id)
+        .display_name("Math Agent")
+        .max_iterations(max_iterations)
+        .build()
+}
+
+fn session(
+    session_id: everruns_core::SessionId,
+    harness_id: everruns_core::HarnessId,
+    agent_id: everruns_core::AgentId,
+) -> Session {
+    SessionBuilder::new(harness_id)
+        .id(session_id)
+        .agent(agent_id)
+        .title("Engine Planned Session")
+        .build()
+}
+
+fn add(id: &str, a: i64, b: i64) -> SimToolCall {
+    SimToolCall {
+        name: "add".to_string(),
+        arguments: json!({ "a": a, "b": b }),
+        id: Some(id.to_string()),
+    }
+}
+
+/// Build a runtime whose LLM turns follow `script`, seeded deterministically so
+/// concurrent tests never share ids.
+async fn runtime_running(
+    seed: u128,
+    max_iterations: usize,
+    script: Vec<SimTurn>,
+) -> (InProcessRuntime, everruns_core::SessionId) {
+    let harness_id = everruns_core::HarnessId::from_seed(seed);
+    let agent_id = everruns_core::AgentId::from_seed(seed);
+    let session_id = everruns_core::SessionId::from_seed(seed);
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(math_platform())
+        .harness(harness(harness_id))
+        .agent(agent(agent_id, max_iterations))
+        .session(session(session_id, harness_id, agent_id))
+        .llm_sim(LlmSimConfig::scripted(script))
+        .default_model(ResolvedModel {
+            model: "llmsim-model".into(),
+            provider_type: DriverId::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+            provider_metadata: None,
+        })
+        .build()
+        .await
+        .expect("runtime builds");
+
+    (runtime, session_id)
+}
+
+async fn event_types(runtime: &InProcessRuntime) -> Vec<String> {
+    runtime
+        .events()
+        .await
+        .expect("events")
+        .into_iter()
+        .map(|event| event.data.event_type().to_string())
+        .collect()
+}
+
+/// Turn-scoped lifecycle events, with the per-tool / per-message noise dropped
+/// so the assertion pins the sequence the planner is responsible for.
+fn lifecycle_sequence(event_types: &[String]) -> Vec<&str> {
+    event_types
+        .iter()
+        .map(String::as_str)
+        .filter(|event_type| {
+            matches!(
+                *event_type,
+                "input.message"
+                    | "session.activated"
+                    | "turn.started"
+                    | "turn.completed"
+                    | "turn.failed"
+                    | "session.idled"
+            )
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn single_tool_turn_reports_two_iterations_and_one_tool_call() {
+    let (runtime, session_id) = runtime_running(
+        901,
+        8,
+        vec![
+            SimTurn::ToolCalls(vec![add("call_1", 2, 2)]),
+            SimTurn::Assistant("The answer is 4.".to_string()),
+        ],
+    )
+    .await;
+
+    let result = runtime
+        .run_text_turn(session_id, "What is 2 + 2?")
+        .await
+        .expect("turn runs");
+
+    assert!(result.success, "expected success, got {result:?}");
+    assert_eq!(result.response, "The answer is 4.");
+    assert_eq!(result.iterations, 2);
+    assert_eq!(result.tool_calls_count, 1);
+    assert_eq!(result.error, None);
+    assert_eq!(result.stop_reason, TurnStopReason::EndTurn);
+
+    let types = event_types(&runtime).await;
+    assert_eq!(
+        lifecycle_sequence(&types),
+        vec![
+            "input.message",
+            "session.activated",
+            "turn.started",
+            "turn.completed",
+            "session.idled",
+        ],
+    );
+    assert!(
+        types
+            .iter()
+            .any(|event_type| event_type == "tool.completed"),
+        "expected the planned act to run a tool: {types:?}"
+    );
+}
+
+#[tokio::test]
+async fn parallel_tool_batch_runs_as_one_planned_act() {
+    let (runtime, session_id) = runtime_running(
+        902,
+        8,
+        vec![
+            SimTurn::ToolCalls(vec![add("call_1", 1, 1), add("call_2", 3, 4)]),
+            SimTurn::Assistant("2 and 7.".to_string()),
+        ],
+    )
+    .await;
+
+    let result = runtime
+        .run_text_turn(session_id, "Add these")
+        .await
+        .expect("turn runs");
+
+    assert!(result.success);
+    // Both calls land in a single act plan, so the turn still costs two reasons.
+    assert_eq!(result.iterations, 2);
+    assert_eq!(result.tool_calls_count, 2);
+
+    let types = event_types(&runtime).await;
+    let tool_completions = types
+        .iter()
+        .filter(|event_type| *event_type == "tool.completed")
+        .count();
+    assert_eq!(tool_completions, 2, "{types:?}");
+}
+
+#[tokio::test]
+async fn failing_tool_does_not_fail_the_turn() {
+    // `divide` by zero is a tool-level error: the act reports it as a result and
+    // the engine keeps planning, so the turn completes normally.
+    let (runtime, session_id) = runtime_running(
+        903,
+        8,
+        vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "divide".to_string(),
+                arguments: json!({ "a": 1, "b": 0 }),
+                id: Some("call_1".to_string()),
+            }]),
+            SimTurn::Assistant("That division is undefined.".to_string()),
+        ],
+    )
+    .await;
+
+    let result = runtime
+        .run_text_turn(session_id, "Divide 1 by 0")
+        .await
+        .expect("turn runs");
+
+    assert!(result.success, "tool errors are results, not turn failures");
+    assert_eq!(result.iterations, 2);
+    assert_eq!(result.tool_calls_count, 1);
+    assert_eq!(result.stop_reason, TurnStopReason::EndTurn);
+    assert_eq!(
+        lifecycle_sequence(&event_types(&runtime).await),
+        vec![
+            "input.message",
+            "session.activated",
+            "turn.started",
+            "turn.completed",
+            "session.idled",
+        ],
+    );
+}
+
+#[tokio::test]
+async fn provider_failure_completes_the_turn_as_failed() {
+    let (runtime, session_id) =
+        runtime_running(904, 8, vec![SimTurn::Error(SimError::Authentication)]).await;
+
+    let result = runtime
+        .run_text_turn(session_id, "hello")
+        .await
+        .expect("turn runs");
+
+    assert!(!result.success);
+    assert_eq!(result.iterations, 1);
+    assert_eq!(result.tool_calls_count, 0);
+    assert_eq!(result.response, "");
+    assert!(result.error.is_some(), "failure must carry the error text");
+    assert_eq!(result.stop_reason, TurnStopReason::Error);
+
+    assert_eq!(
+        lifecycle_sequence(&event_types(&runtime).await),
+        vec![
+            "input.message",
+            "session.activated",
+            "turn.started",
+            "turn.failed",
+            "session.idled",
+        ],
+    );
+}
+
+#[tokio::test]
+async fn tool_calls_at_the_iteration_ceiling_stop_with_max_turn_requests() {
+    // Every scripted turn asks for another tool call, so the ceiling is what
+    // ends the turn rather than the model.
+    let (runtime, session_id) = runtime_running(
+        905,
+        2,
+        vec![
+            SimTurn::ToolCalls(vec![add("call_1", 1, 1)]),
+            SimTurn::ToolCalls(vec![add("call_2", 2, 2)]),
+            SimTurn::ToolCalls(vec![add("call_3", 3, 3)]),
+        ],
+    )
+    .await;
+
+    let result = runtime
+        .run_text_turn(session_id, "keep going")
+        .await
+        .expect("turn runs");
+
+    assert!(result.success);
+    assert_eq!(result.iterations, 2);
+    // The second reason's batch is never acted on — the ceiling stops it first.
+    assert_eq!(result.tool_calls_count, 1);
+    assert_eq!(result.stop_reason, TurnStopReason::MaxTurnRequests);
+    assert_eq!(
+        lifecycle_sequence(&event_types(&runtime).await),
+        vec![
+            "input.message",
+            "session.activated",
+            "turn.started",
+            "turn.completed",
+            "session.idled",
+        ],
+    );
+}
+
+#[tokio::test]
+async fn cancelling_a_turn_leaves_the_runtime_usable() {
+    // The facade cancels by dropping the `run_turn` future. Nothing in the
+    // engine-planned loop holds a lock across an await point, so a later turn on
+    // the same session still runs to completion.
+    let (runtime, session_id) = runtime_running(
+        906,
+        8,
+        vec![
+            SimTurn::ToolCalls(vec![add("call_1", 2, 2)]),
+            SimTurn::Assistant("4".to_string()),
+            SimTurn::Assistant("still here".to_string()),
+        ],
+    )
+    .await;
+
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_nanos(1),
+        runtime.run_text_turn(session_id, "start something"),
+    )
+    .await;
+    assert!(cancelled.is_err(), "expected the turn future to be dropped");
+
+    let result = runtime
+        .run_text_turn(session_id, "and again")
+        .await
+        .expect("a later turn still runs");
+    assert!(result.success, "{result:?}");
+}
+
+/// Restart-between-steps: serialize the planner's carried state after every
+/// plan, reconstruct it, and continue from the reconstructed copy. A host that
+/// persists state between activities must plan the identical turn.
+#[test]
+fn planner_state_survives_a_restart_between_every_step() {
+    fn round_trip(state: &TurnState) -> TurnState {
+        let encoded = serde_json::to_value(state).expect("state serializes");
+        serde_json::from_value(encoded).expect("state deserializes")
+    }
+
+    let session_id = everruns_core::SessionId::from_seed(907);
+    let harness_id = everruns_core::HarnessId::from_seed(907);
+    let input_message_id = everruns_core::MessageId::from_seed(907);
+    let turn_id = everruns_core::TurnId::from_seed(907);
+    let now = chrono::Utc::now();
+
+    let initial = TurnState {
+        org_id: 1,
+        session_id,
+        harness_id,
+        agent_id: None,
+        input_message_id,
+        turn_id: None,
+        previous_response_id: None,
+        iteration: 1,
+        request_id: None,
+        started_at: None,
+        cumulative_usage: None,
+        tool_call_count: 0,
+        llm_call_count: 0,
+        time_to_first_token_ms: None,
+        final_message_id: None,
+        final_answer_preview: None,
+    };
+
+    // process_input -> reason
+    let TurnPlan::ScheduleReason(state) =
+        plan_after_process_input(&round_trip(&initial), Some(turn_id), now)
+    else {
+        panic!("process_input must schedule a reason");
+    };
+    assert_eq!(state.turn_id, Some(turn_id));
+    assert_eq!(state.iteration, 1);
+
+    // reason (with tool calls) -> act
+    let with_tools = everruns_core::ReasonResult {
+        success: true,
+        has_tool_calls: true,
+        max_iterations: 8,
+        text: "calling a tool".to_string(),
+        response_id: Some("resp_1".to_string()),
+        tool_calls: vec![everruns_core::ToolCall {
+            id: "call_1".to_string(),
+            name: "add".to_string(),
+            arguments: json!({ "a": 1, "b": 1 }),
+        }],
+        ..Default::default()
+    };
+
+    let (plan, effects) = plan_after_reason(
+        &round_trip(&state),
+        with_tools,
+        0,
+        now,
+        Some(Default::default()),
+    );
+    assert!(
+        effects.is_empty(),
+        "a continuing turn emits no lifecycle effects"
+    );
+    let TurnPlan::ScheduleAct(act_plan) = plan else {
+        panic!("a reason with tool calls must schedule an act");
+    };
+
+    // The host applies the plan's response id / iteration onto the resumed
+    // state, exactly as the durable worker does when it dequeues the act.
+    let mut resumed = round_trip(act_plan.resume_state.as_ref());
+    resumed.previous_response_id = act_plan.previous_response_id.clone();
+    resumed.iteration = act_plan.iteration;
+    assert_eq!(resumed.previous_response_id.as_deref(), Some("resp_1"));
+    assert_eq!(resumed.tool_call_count, 1);
+    assert_eq!(resumed.llm_call_count, 1);
+
+    // act -> reason
+    let (plan, effects) = plan_after_act(&round_trip(&resumed), ActOutcome::default(), false);
+    assert!(effects.is_empty());
+    let TurnPlan::ScheduleReason(state) = plan else {
+        panic!("a completed act must schedule the next reason");
+    };
+    assert_eq!(state.iteration, 2);
+    assert_eq!(state.previous_response_id.as_deref(), Some("resp_1"));
+
+    // reason (no tool calls) -> complete
+    let final_reason = everruns_core::ReasonResult {
+        success: true,
+        max_iterations: 8,
+        text: "done".to_string(),
+        ..Default::default()
+    };
+
+    let (plan, effects) = plan_after_reason(&round_trip(&state), final_reason, 0, now, None);
+    let TurnPlan::Complete { stop_reason, error } = plan else {
+        panic!("a reason with no tool calls must complete the turn");
+    };
+    assert_eq!(stop_reason, TurnStopReason::EndTurn);
+    assert_eq!(error, None);
+    assert_eq!(
+        effects.len(),
+        3,
+        "turn.completed + session.idled + turn_end hooks"
+    );
+}

--- a/knowledge/foundations/sans-io-turn-state.md
+++ b/knowledge/foundations/sans-io-turn-state.md
@@ -10,12 +10,17 @@ tags:
 
 ## Abstract
 
-The turn loop is implemented twice. `TurnStateMachine`
-(`crates/core/src/turn.rs`) is a mutable, in-memory machine driven by the
-in-process runtime; `RuntimeTurnState` + `plan_next_host_turn`
-(`crates/runtime/src/turn_strategy.rs`) is a serializable state plus a planner
-driven by the durable worker. They encode the same phases and the same
-transitions, in different shapes, and neither can be derived from the other.
+The turn loop was implemented twice. `TurnStateMachine`
+(`crates/core/src/turn.rs`) is a mutable, in-memory machine; `RuntimeTurnState` +
+`plan_next_host_turn` (`crates/runtime/src/turn_strategy.rs`) is a serializable
+state plus a planner driven by the durable worker. They encode the same phases
+and the same transitions, in different shapes, and neither can be derived from
+the other.
+
+Both real hosts now plan through the engine: the durable worker via
+`plan_next_host_turn`, and the in-process runtime since EVE-842. The mutable
+machine survives only behind core's `in_memory_loop`, which no shipped host
+drives.
 
 This spec proposes converging them on one **sans-IO** representation: a
 serializable `TurnState` whose transitions are pure functions, with all I/O —
@@ -24,8 +29,10 @@ loading messages, calling the model, running tools, emitting events, persisting
 host is an in-process host that persists between steps, rather than a second
 implementation of the same loop.
 
-Status: **stage 1 landed** (the value type and its equivalence proof). Later
-stages are proposals, not commitments.
+Status: **stage 1 landed** (the value type and its equivalence proof); the
+planner has since been extracted into `everruns-engine` (EVE-840) and the
+in-process runtime rewired onto it (EVE-842). Later stages are proposals, not
+commitments.
 
 ## Motivation
 
@@ -92,6 +99,15 @@ asserts the same actions and outcomes.
 
 Nothing is rewired. The deliverable is a representation both hosts *could*
 share, plus the evidence that it behaves identically.
+
+### Stage 1b — one planner, two hosts (landed)
+
+`crates/engine`: the planner moved out of the runtime into `everruns-engine`
+(EVE-840), then `InProcessRuntime::run_turn` was rewired onto it (EVE-842). The
+in-process loop no longer decides reason-vs-act-vs-complete; it executes the host
+operation each `TurnPlan` names and performs the returned `TurnLifecycleEffect`s.
+`crates/runtime/tests/engine_planned_turn_test.rs` carries the behavior-preserving
+evidence and the restart-between-steps property.
 
 ### Stage 2 — fold in the durable bookkeeping
 
@@ -160,5 +176,8 @@ converge later.
 - `crates/engine/src/turn.rs` — the pure, sans-IO turn planner (`TurnState`, `TurnPlan`,
   `plan_next_turn`, `TurnLifecycleEffect`), extracted from the runtime in EVE-840
 - `crates/runtime/src/turn_strategy.rs` — `plan_next_host_turn`, the runtime host's thin
-  I/O wrapper over the engine planner (plus compat re-exports of the pre-EVE-840 names)
+  I/O wrapper over the engine planner (plus compat re-exports of the pre-EVE-840 names),
+  and the host-fact resolvers / effect applier both runtime hosts share
+- `crates/runtime/src/runtime.rs` — `InProcessRuntime::run_turn`, the engine-planned
+  in-process loop (EVE-842)
 - `knowledge/operations/durable-execution-engine.md` — the durable host this converges with


### PR DESCRIPTION
## What changed

`InProcessRuntime::run_turn` no longer decides what a turn does next. Every
reason-vs-act-vs-complete decision now comes from `everruns-engine`'s planner —
the same planner the durable worker drives its turns with — and the in-process
loop only executes the host operation each `TurnPlan` names, then performs the
`TurnLifecycleEffect`s the engine returns as data. The mutable `TurnStateMachine`
copy of the planning brain is gone from the runtime.

Two deliberate alignments come with it, both matching what the durable host
already does:

- **Act resolves its blueprint and workspace from the session** (via the shared
  `resolve_act_scheduling` adapter) instead of passing `blueprint_id: None`. The
  reason path already validated the model-visible tool set against
  `session.blueprint_id`; act did not, so a blueprint-scoped session could
  execute a tool its blueprint excluded. Act now narrows to the same registry.
- **A blocked act ends the turn** rather than looping back into another reason.
  A dependency-blocked act has already emitted `turn.failed`; continuing to
  reason past it burned a model call for nothing.

`turn_strategy` now exposes the host-fact resolvers and the effect applier it
already owned, so both runtime hosts do the same I/O under the same conditions
instead of each carrying its own copy.

Public surface is unchanged: `run_turn`, `TurnResult`, mid-turn wake, capability
refresh, and cancellation all behave as before, and the `everruns`
`Agent`/`Session` facade needed no changes.

## Why

EVE-840 extracted the planner into `everruns-engine`, but the in-process runtime
kept planning with `TurnStateMachine` — so turn semantics lived in two places and
every change had to be made twice, with nothing detecting a change made in only
one. The two had already drifted: the iteration ceiling, the steering-message
continuation, and the failure classification were each expressed differently.
This removes the second copy. Fixes EVE-842.

## Before / After

**No observable behavior change.** The evidence is a golden parity suite run
against both implementations: `crates/runtime/tests/engine_planned_turn_test.rs`
pins the `TurnResult` values *and* the turn-scoped event sequence for six
scenarios, and it passes identically on `origin/main` (the pre-migration
`TurnStateMachine` loop) and on this branch (the engine-planned loop).

Against `origin/main`, with this PR's test file copied in:

```
     Running tests/engine_planned_turn_test.rs
running 7 tests
test planner_state_survives_a_restart_between_every_step ... ok
test cancelling_a_turn_leaves_the_runtime_usable ... ok
test failing_tool_does_not_fail_the_turn ... ok
test parallel_tool_batch_runs_as_one_planned_act ... ok
test provider_failure_completes_the_turn_as_failed ... ok
test single_tool_turn_reports_two_iterations_and_one_tool_call ... ok
test tool_calls_at_the_iteration_ceiling_stop_with_max_turn_requests ... ok

test result: ok. 7 passed; 0 failed
```

On this branch — same seven, same assertions:

```
     Running tests/engine_planned_turn_test.rs
running 7 tests
test planner_state_survives_a_restart_between_every_step ... ok
test cancelling_a_turn_leaves_the_runtime_usable ... ok
test parallel_tool_batch_runs_as_one_planned_act ... ok
test provider_failure_completes_the_turn_as_failed ... ok
test failing_tool_does_not_fail_the_turn ... ok
test single_tool_turn_reports_two_iterations_and_one_tool_call ... ok
test tool_calls_at_the_iteration_ceiling_stop_with_max_turn_requests ... ok

test result: ok. 7 passed; 0 failed
```

The pinned sequences are, for a single-tool turn:
`input.message → session.activated → turn.started → turn.completed → session.idled`,
and for a provider failure: `… → turn.failed → session.idled`. `turn.completed`
now carries the engine's richer summary (duration, usage, token timing, call
counts) where the runtime previously sent `None`; the event types and their order
are unchanged.

End-to-end smoke, `cargo run -p everruns-runtime --example in_process_runtime`:

```
success: true
iterations: 2
response: Let me calculate that.
```

Full validation:

- `cargo test -p everruns-runtime -p everruns` — all suites pass, including the
  pre-existing `in_process_runtime`, `mid_turn_wake`, `turn_recovery`,
  `usage_limit_auto_continue`, and `tool_scheduler_e2e` tests, unmodified.
- `cargo check --workspace --all-targets` — clean.
- `just pre-push` — all checks pass (fmt, clippy, lockfile, migrations, knowledge
  conformance).

## Risk

- **Low**
- The two intentional alignments are the only paths where behavior can differ.
  Blueprint scoping only bites a session with `blueprint_id` set, which no
  in-process builder does today; the blueprint registry drops pre/post tool
  hooks, so a custom-backend embedder seeding a blueprint session would lose
  those hooks in act — the same trade the durable host already makes. The
  blocked-act change only fires after a dependency blocker has already failed
  the turn.
- A pause for tool results (`WaitForToolResults`) resolves the turn in-process,
  since there is no external tool-result delivery path to resume from. Reachable
  only when the session carries the `setup_connection` hint; the pre-migration
  loop ignored the pause and continued reasoning.

## Security

- Threat categories reviewed: **TM-TOOL**, **TM-DOS**, **TM-LLM**, **TM-TENANT**.
- Findings and resolutions:
  - **TM-TOOL (improvement).** Act previously ignored `session.blueprint_id`
    while reason validated against it, so a blueprint-scoped session's act could
    execute tools outside the blueprint's registry. Act now resolves the same
    blueprint, narrowing the executable tool set to match what reason validated.
    Related to TM-TOOL-001 (only registered tools execute); no mitigation weakened.
  - **TM-DOS.** The `max_turn_requests` iteration ceiling is now enforced by the
    engine rather than the runtime's own counter.
    `tool_calls_at_the_iteration_ceiling_stop_with_max_turn_requests` pins that a
    model looping on tool calls still stops at the configured limit, and the
    blocked-act change removes a wasted model call.
  - **TM-LLM.** `previous_response_id` threading is unchanged in value and
    timing; no provider credential or prompt handling was touched.
  - **TM-TENANT.** `org_id` derivation (`in_process_internal_org_id`) and all
    per-org store scoping are untouched; the engine receives the same `org_id`
    the loop already resolved.
  - No `THREAT[...]` markers exist in or adjacent to the changed code, and the
    change introduces no new threat, so `knowledge/security/threat-model.md`
    needs no update.

## Follow-ups

- `crates/core/src/in_memory_loop.rs` is now the only remaining driver of
  `TurnStateMachine`. Migrating or removing it is explicitly out of scope for
  EVE-842 (which scopes `InProcessRuntime` only) and belongs to a later stage of
  the Sans-IO Turn State epic; `knowledge/foundations/sans-io-turn-state.md` is
  updated to record that no shipped host drives the mutable machine any more.
- Otherwise, no follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtEA4BhF3evJXmLPww8Jii)_