### PR TITLE
fix(ui): reorder agent detail tabs

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import { Suspense } from "react";
 import AgentDetailPage from "@/app/(main)/agents/[agentId]/page";
 import type { Session, Agent, ModelWithProvider } from "@/lib/api/types";
+
+let mockSearchParams = new URLSearchParams();
 
 // Mock next/navigation
 jest.mock("next/navigation", () => ({
@@ -10,7 +12,7 @@ jest.mock("next/navigation", () => ({
     replace: jest.fn(),
     back: jest.fn(),
   }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams,
 }));
 
 // Mock next/link
@@ -52,6 +54,14 @@ jest.mock("@/components/chat/streamdown-message", () => ({
 
 jest.mock("@/components/agents/agent-preview", () => ({
   AgentPreview: () => <div data-testid="agent-preview">agent preview</div>,
+}));
+
+jest.mock("@/components/agents/agent-credentials-panel", () => ({
+  AgentCredentialsPanel: () => <div>agent credentials</div>,
+}));
+
+jest.mock("@/components/agents/agent-triggers-panel", () => ({
+  AgentTriggersPanel: () => <div>agent triggers</div>,
 }));
 
 // Mock data
@@ -185,7 +195,7 @@ jest.mock("@/hooks/use-organizations", () => ({
 }));
 
 jest.mock("@/providers/feature-flags-provider", () => ({
-  useFeatureFlag: () => false,
+  useFeatureFlag: (flag: string) => flag === "agent_versions",
 }));
 
 // Helper to render with Suspense for React.use()
@@ -202,6 +212,66 @@ async function renderWithSuspense(params: { agentId: string }) {
     await paramsPromise;
   });
 }
+
+beforeEach(() => {
+  mockSearchParams = new URLSearchParams();
+});
+
+describe("AgentDetailPage - tab navigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockUseAgent.mockReturnValue({ data: mockAgent, isLoading: false });
+    mockUseSessions.mockReturnValue({ data: [], isLoading: false });
+    mockUseCreateSession.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseCapabilities.mockReturnValue({ data: [] });
+    mockUseModels.mockReturnValue({ data: mockModels });
+    mockUseExportAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseCopyAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseHarnesses.mockReturnValue({ data: [] });
+    mockUseOrganization.mockReturnValue({ data: null });
+    mockUseAgentStats.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  });
+
+  it("renders the agent detail tabs in workflow order", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Overview",
+      "Preview",
+      "Credentials",
+      "Triggers",
+      "Versions",
+      "Stats",
+      "Integrate",
+    ]);
+  });
+
+  it("selects the credentials tab from its deep link", async () => {
+    mockSearchParams = new URLSearchParams("tab=credentials");
+
+    await renderWithSuspense({ agentId: "agent-1" });
+
+    expect(screen.getByRole("tab", { name: "Credentials" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("agent credentials")).toBeInTheDocument();
+  });
+
+  it("keeps focus and active state aligned when selecting a tab", async () => {
+    await renderWithSuspense({ agentId: "agent-1" });
+    const triggersTab = screen.getByRole("tab", { name: "Triggers" });
+
+    triggersTab.focus();
+    expect(triggersTab).toHaveFocus();
+    fireEvent.click(triggersTab);
+
+    expect(triggersTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByText("agent triggers")).toBeInTheDocument();
+  });
+});
 
 describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
   beforeEach(() => {

--- a/apps/ui/src/__tests__/agent-tabs.test.tsx
+++ b/apps/ui/src/__tests__/agent-tabs.test.tsx
@@ -1,0 +1,34 @@
+import { agentEditTabItems, getAgentDetailTabItems } from "@/components/agents/agent-tabs";
+
+function labels(items: ReturnType<typeof getAgentDetailTabItems>): React.ReactNode[] {
+  return items.map((item) => item.label);
+}
+
+describe("agent tab definitions", () => {
+  it("keeps the detail workflow order when versions are enabled", () => {
+    expect(labels(getAgentDetailTabItems(true))).toEqual([
+      "Overview",
+      "Preview",
+      "Credentials",
+      "Triggers",
+      "Versions",
+      "Stats",
+      "Integrate",
+    ]);
+  });
+
+  it("removes only versions when its feature is disabled", () => {
+    expect(labels(getAgentDetailTabItems(false))).toEqual([
+      "Overview",
+      "Preview",
+      "Credentials",
+      "Triggers",
+      "Stats",
+      "Integrate",
+    ]);
+  });
+
+  it("reuses the shared preview definition in edit navigation", () => {
+    expect(agentEditTabItems.map((item) => item.label)).toEqual(["Edit", "Preview"]);
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -46,6 +46,7 @@ import {
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { normalizeCapabilityConfigs } from "@/components/agents/capability-config";
 import { AgentPreview } from "@/components/agents/agent-preview";
+import { agentEditTabItems } from "@/components/agents/agent-tabs";
 import { AgentChecks, applyByteSpanReplacement } from "@/components/agents/agent-checks";
 import { AgentHealthCheck } from "@/components/agents/agent-health-check";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
@@ -53,7 +54,7 @@ import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { NetworkAccessEditor, normalizeNetworkAccess } from "@/components/network-access-editor";
 import { ModelPicker } from "@/components/models/model-picker";
 import { HarnessSelect } from "@/components/harness/harness-select";
-import { Trash2, Eye, Edit2, Check, X, Loader2, Boxes, Pencil } from "lucide-react";
+import { Trash2, Check, X, Loader2, Boxes, Pencil } from "lucide-react";
 import {
   agentFormSchema,
   getFieldErrors,
@@ -310,10 +311,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
         <SectionTabs
           value={activeTab}
           onValueChange={setActiveTab}
-          items={[
-            { value: "edit", label: "Edit", icon: <Edit2 className="size-4" /> },
-            { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
-          ]}
+          items={agentEditTabItems}
           className="border-b-0"
         />
         {activeTab === "edit" && (

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -32,16 +32,9 @@ import {
   Download,
   Copy,
   Zap,
-  Eye,
-  LayoutDashboard,
-  BarChart3,
-  GitBranch,
   Rocket,
   Telescope,
-  Terminal,
   Boxes,
-  Clock3,
-  LockKeyhole,
   MoreHorizontal,
 } from "lucide-react";
 import { AgentTriggersPanel } from "@/components/agents/agent-triggers-panel";
@@ -58,8 +51,8 @@ import {
   PageRail,
   PageFooter,
   BackLink,
-  type SectionTabItem,
 } from "@/components/layout";
+import { getAgentDetailTabItems } from "@/components/agents/agent-tabs";
 import type { Capability, ModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
 import {
@@ -257,17 +250,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
 
   const defaultModelName = defaultModel?.display_name ?? defaultModel?.id;
 
-  const tabItems: SectionTabItem[] = [
-    { value: "overview", label: "Overview", icon: <LayoutDashboard className="size-4" /> },
-    { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
-    { value: "integrate", label: "Integrate", icon: <Terminal className="size-4" /> },
-    { value: "triggers", label: "Triggers", icon: <Clock3 className="size-4" /> },
-    { value: "credentials", label: "Credentials", icon: <LockKeyhole className="size-4" /> },
-    { value: "stats", label: "Stats", icon: <BarChart3 className="size-4" /> },
-    ...(agentVersionsEnabled
-      ? [{ value: "versions", label: "Versions", icon: <GitBranch className="size-4" /> }]
-      : []),
-  ];
+  const tabItems = getAgentDetailTabItems(agentVersionsEnabled);
 
   return (
     <PageContainer>

--- a/apps/ui/src/components/agents/agent-tabs.tsx
+++ b/apps/ui/src/components/agents/agent-tabs.tsx
@@ -1,0 +1,44 @@
+import {
+  BarChart3,
+  Clock3,
+  Edit2,
+  Eye,
+  GitBranch,
+  LayoutDashboard,
+  LockKeyhole,
+  Terminal,
+} from "lucide-react";
+import type { SectionTabItem } from "@/components/layout";
+
+const agentTabItems = {
+  overview: {
+    value: "overview",
+    label: "Overview",
+    icon: <LayoutDashboard className="size-4" />,
+  },
+  preview: { value: "preview", label: "Preview", icon: <Eye className="size-4" /> },
+  credentials: {
+    value: "credentials",
+    label: "Credentials",
+    icon: <LockKeyhole className="size-4" />,
+  },
+  triggers: { value: "triggers", label: "Triggers", icon: <Clock3 className="size-4" /> },
+  versions: { value: "versions", label: "Versions", icon: <GitBranch className="size-4" /> },
+  stats: { value: "stats", label: "Stats", icon: <BarChart3 className="size-4" /> },
+  integrate: { value: "integrate", label: "Integrate", icon: <Terminal className="size-4" /> },
+  edit: { value: "edit", label: "Edit", icon: <Edit2 className="size-4" /> },
+} satisfies Record<string, SectionTabItem>;
+
+export function getAgentDetailTabItems(versionsEnabled: boolean): SectionTabItem[] {
+  return [
+    agentTabItems.overview,
+    agentTabItems.preview,
+    agentTabItems.credentials,
+    agentTabItems.triggers,
+    ...(versionsEnabled ? [agentTabItems.versions] : []),
+    agentTabItems.stats,
+    agentTabItems.integrate,
+  ];
+}
+
+export const agentEditTabItems: SectionTabItem[] = [agentTabItems.edit, agentTabItems.preview];


### PR DESCRIPTION
## What changed

Agent detail tabs now follow the setup workflow: Overview, Preview, Credentials, Triggers,
Versions, Stats, Integrate. Versions remains feature-flagged. A shared agent-tab definition now
drives the detail navigation and the related edit-page Preview item.

Deep links and active-tab behavior are unchanged, including `?tab=credentials`.

## Why

Credentials are normally configured before triggered execution. Keeping one ordered definition
prevents the desktop and narrow horizontal-overflow navigation from drifting.

## Before / After

Before: `Overview → Preview → Integrate → Triggers → Credentials → Stats → Versions`

After: `Overview → Preview → Credentials → Triggers → Versions → Stats → Integrate`

Manual browser evidence on the canonical local stack:

- 1440 × 1000: all seven tabs rendered in the new order.
- 390 × 844: the same DOM order was preserved in the scrollable tab strip with no page-level
  horizontal overflow.
- `?tab=credentials` selected Credentials and rendered its panel.
- Tab moved focus through the narrow overflow strip; Enter activated Triggers and kept focus and
  `aria-selected` aligned.

Desktop and narrow screenshots were captured and visually inspected. The repository screenshot
uploader could not attach them because `CLOUDINARY_URL` is not configured; the images remain
uncommitted local artifacts.

## Risk

- Low
- Risk is limited to agent detail/edit navigation metadata and selection rendering. Deep-link
  values and content conditions are unchanged; focused tests cover order, feature-flag filtering,
  deep-link selection, focus, and active state.

## Security

- Threat categories reviewed: TM-WEB.
- Findings and resolutions: No findings. The change uses only trusted static React labels/icons and
  introduces no user-controlled markup or URL, API/auth boundary, mutation, credential handling,
  dependency, logging, or unbounded work. No threat-model update is needed.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
