### PR TITLE
fix(release): publish everruns-engine and everruns-macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,13 @@ jobs:
               - 'scripts/test-*.sh'
               - 'scripts/check_okf.py'
               - 'scripts/lib/**'
+              - 'scripts/sync-publish-pin-versions.py'
+              # scripts/test-publish-crates-order.sh reads the publish workflow
+              # and the workspace member manifests it publishes.
+              - '.github/workflows/publish-crates.yml'
+              - 'Cargo.toml'
+              - 'crates/*/Cargo.toml'
+              - 'integrations/*/Cargo.toml'
               - 'plugins/everruns-dev/**'
               - '.agents/plugins/**'
               - '.claude-plugin/**'

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -136,6 +136,9 @@ jobs:
                   "everruns-a2ui",
                   "everruns-provider",
               ],
+              "crates/engine/Cargo.toml": [
+                  "everruns-core",
+              ],
               "crates/platform/Cargo.toml": [
                   "everruns-core",
               ],
@@ -144,10 +147,12 @@ jobs:
               ],
               "crates/runtime/Cargo.toml": [
                   "everruns-core",
+                  "everruns-engine",
               ],
               "crates/everruns/Cargo.toml": [
                   "everruns-core",
                   "everruns-runtime",
+                  "everruns-macros",
               ],
               "crates/local/Cargo.toml": [
                   "everruns-core",
@@ -239,6 +244,9 @@ jobs:
             everruns-provider
             everruns-meta
             everruns-core
+            # The sans-IO turn planner sits between core and runtime: it depends
+            # on everruns-core, and everruns-runtime depends on it.
+            everruns-engine
             everruns-platform
             everruns-mcp
             everruns-openai
@@ -259,6 +267,9 @@ jobs:
             everruns-integrations-sprites
             everruns-runtime
             everruns-local
+            # `everruns` enables its `macros` feature by default, so the facade
+            # is only installable once everruns-macros is on crates.io.
+            everruns-macros
             everruns
           )
 

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -31,10 +31,11 @@ INNER_PINS: dict[str, list[str]] = {
         "everruns-openui",
         "everruns-a2ui",
     ],
+    "crates/engine/Cargo.toml": ["everruns-core"],
     "crates/platform/Cargo.toml": ["everruns-core"],
     "crates/mcp/Cargo.toml": ["everruns-core"],
-    "crates/runtime/Cargo.toml": ["everruns-core"],
-    "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime"],
+    "crates/runtime/Cargo.toml": ["everruns-core", "everruns-engine"],
+    "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime", "everruns-macros"],
     "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
     "crates/openai/Cargo.toml": ["everruns-provider"],
     "crates/anthropic/Cargo.toml": ["everruns-provider"],
@@ -56,7 +57,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard", "everruns"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-engine", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard", "everruns", "everruns-macros"]
 
 
 def workspace_version() -> str:

--- a/scripts/test-publish-crates-order.sh
+++ b/scripts/test-publish-crates-order.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Guards the crates.io release contract in .github/workflows/publish-crates.yml:
+# a crate can only publish once every workspace dependency it carries is already
+# on crates.io, so the workflow's CRATES list must be a topological order of the
+# workspace dependency graph, and every such dependency must carry a version.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+python3 - <<'PY'
+import pathlib
+import re
+import sys
+import tomllib
+
+REPO = pathlib.Path(".").resolve()
+WORKFLOW = REPO / ".github/workflows/publish-crates.yml"
+workflow_text = WORKFLOW.read_text()
+
+failures: list[str] = []
+
+
+def fail(message: str) -> None:
+    failures.append(message)
+
+
+def load(path: pathlib.Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+workspace = load(REPO / "Cargo.toml")
+workspace_dependencies = workspace["workspace"].get("dependencies", {})
+
+# Every workspace member manifest, keyed by package name.
+manifests: dict[str, pathlib.Path] = {}
+for member_glob in ("crates/*/Cargo.toml", "integrations/*/Cargo.toml"):
+    for manifest_path in REPO.glob(member_glob):
+        package = load(manifest_path).get("package")
+        if package and "name" in package:
+            manifests[package["name"]] = manifest_path
+
+# The bash CRATES=( ... ) array the publish loop iterates.
+match = re.search(r"^\s*CRATES=\(\n(.*?)^\s*\)\s*$", workflow_text, re.MULTILINE | re.DOTALL)
+if match is None:
+    raise SystemExit("could not find the CRATES=( ... ) list in publish-crates.yml")
+published = [
+    line.strip()
+    for line in match.group(1).splitlines()
+    if line.strip() and not line.strip().startswith("#")
+]
+
+order = {crate: index for index, crate in enumerate(published)}
+
+if len(order) != len(published):
+    fail("publish-crates.yml CRATES list contains duplicate entries")
+
+for crate in published:
+    if crate not in manifests:
+        fail(f"publish-crates.yml publishes unknown package {crate}")
+
+# Ordering + version pins: for each published crate, look at the workspace
+# dependencies it carries (including optional ones — they are still recorded in
+# the packaged manifest and must resolve on crates.io).
+for crate in published:
+    if crate not in manifests:
+        continue
+    manifest_path = manifests[crate]
+    manifest = load(manifest_path)
+    relative = manifest_path.relative_to(REPO)
+    for name, dependency in manifest.get("dependencies", {}).items():
+        if not name.startswith("everruns") or name not in manifests:
+            continue
+        if isinstance(dependency, dict) and dependency.get("workspace"):
+            resolved = workspace_dependencies.get(name, {})
+        else:
+            resolved = dependency
+        version = resolved.get("version") if isinstance(resolved, dict) else resolved
+        if not version:
+            fail(f"{relative}: dependency {name} has no crates.io version, so {crate} cannot publish")
+        if name not in order:
+            fail(f"{relative}: {crate} depends on {name}, which publish-crates.yml never publishes")
+        elif order[name] > order[crate]:
+            fail(f"publish-crates.yml publishes {crate} before its dependency {name}")
+
+# Spot-check the edges this contract exists for (EVE-846), so a refactor that
+# drops a crate from the list fails loudly rather than silently passing.
+for earlier, later in (
+    ("everruns-core", "everruns-engine"),
+    ("everruns-engine", "everruns-runtime"),
+    ("everruns-macros", "everruns"),
+):
+    if earlier not in order:
+        fail(f"publish-crates.yml does not publish {earlier}")
+    elif later not in order:
+        fail(f"publish-crates.yml does not publish {later}")
+    elif order[earlier] > order[later]:
+        fail(f"publish-crates.yml must publish {earlier} before {later}")
+
+# The workflow's own version verification must cover the same edges.
+for manifest_rel, dependency in (
+    ("crates/engine/Cargo.toml", "everruns-core"),
+    ("crates/everruns/Cargo.toml", "everruns-macros"),
+):
+    entry = re.search(
+        rf'"{re.escape(manifest_rel)}":\s*\[(.*?)\]', workflow_text, re.DOTALL
+    )
+    if entry is None or f'"{dependency}"' not in entry.group(1):
+        fail(
+            f"publish-crates.yml version verification does not cover "
+            f"{manifest_rel} dependency {dependency}"
+        )
+
+# The sync script keeps those pins at the workspace version between releases.
+sync_text = (REPO / "scripts/sync-publish-pin-versions.py").read_text()
+workspace_pins = re.search(r"WORKSPACE_PIN_DEPS:\s*list\[str\]\s*=\s*\[(.*?)\]", sync_text, re.DOTALL)
+if workspace_pins is None:
+    fail("could not find WORKSPACE_PIN_DEPS in scripts/sync-publish-pin-versions.py")
+else:
+    for dependency in ("everruns-engine", "everruns-macros"):
+        if f'"{dependency}"' not in workspace_pins.group(1):
+            fail(f"scripts/sync-publish-pin-versions.py does not sync the {dependency} workspace pin")
+
+if failures:
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"publish order verified for {len(published)} crate(s)")
+PY


### PR DESCRIPTION
## What changed

The crates.io release now publishes `everruns-engine` (between `everruns-core` and `everruns-runtime`) and `everruns-macros` (before the `everruns` facade). Both edges are covered by the workflow's version verification and by `scripts/sync-publish-pin-versions.py`, so their pins track the workspace version between releases.

A new repo shell test, `scripts/test-publish-crates-order.sh`, asserts the workflow's `CRATES` list is a topological order of the workspace dependency graph and that every workspace dependency of a published crate carries a crates.io version — so a future crate split cannot silently reintroduce this class of bug. The CI `shell` path filter now includes the publish workflow and the workspace manifests the test reads.

Fixes EVE-846.

## Why

`everruns` enables its `macros` feature by default and depends on `everruns-macros`, which the publish list omitted — the published facade would not install. The same list also omitted `everruns-engine`, which `everruns-runtime` has depended on since #3052, so the already-published `everruns-runtime` is affected too, not just the new facade.

## Before / After

The new test encodes the contract. Run against the pre-fix tree (test script present, fix not yet applied) it fails; on this branch it passes.

Before:

```
FAIL: crates/runtime/Cargo.toml: everruns-runtime depends on everruns-engine, which publish-crates.yml never publishes
FAIL: crates/everruns/Cargo.toml: everruns depends on everruns-macros, which publish-crates.yml never publishes
FAIL: publish-crates.yml does not publish everruns-engine
FAIL: publish-crates.yml does not publish everruns-macros
FAIL: publish-crates.yml version verification does not cover crates/engine/Cargo.toml dependency everruns-core
FAIL: publish-crates.yml version verification does not cover crates/everruns/Cargo.toml dependency everruns-macros
FAIL: scripts/sync-publish-pin-versions.py does not sync the everruns-engine workspace pin
FAIL: scripts/sync-publish-pin-versions.py does not sync the everruns-macros workspace pin
```

After:

```
$ bash scripts/run-shell-tests.sh scripts/test-publish-crates-order.sh
publish order verified for 28 crate(s)
PASS: scripts/test-publish-crates-order.sh

$ python3 scripts/sync-publish-pin-versions.py --check
all path-dep pins at 0.17.23
```

Packaging the three affected crates, and the resulting manifests carrying crates.io versions for every path dependency:

```
$ cargo package --locked --no-verify -p everruns-macros -p everruns-engine -p everruns
   Packaging everruns-macros v0.17.23 … Packaged 6 files, 17.1KiB
   Packaging everruns v0.17.23        … Packaged 34 files, 270.0KiB
   Packaging everruns-engine v0.17.23 … Packaged 9 files, 160.5KiB

# everruns-0.17.23/Cargo.toml
[dependencies.everruns-core]    version = "0.17.23"
[dependencies.everruns-macros]  version = "0.17.23"  optional = true
[dependencies.everruns-runtime] version = "0.17.23"
# everruns-engine-0.17.23/Cargo.toml
[dependencies.everruns-core]    version = "0.17.23"
```

No runtime behavior changes: the diff is release automation, a test, and a CI path filter.

## Risk

- Low
- The release job publishes two additional packages. `everruns-engine` and `everruns-macros` are not yet on crates.io, so the next tagged release claims both names; two new crates stay well inside the 5-new-crates/10-minute token limit, and the existing `publish_one` retry already covers that window. Every failure mode here is fail-closed — an unpublishable crate aborts the job rather than shipping a broken release.

## Security

- Threat categories reviewed: supply chain / release integrity (`publish-crates.yml` handles `CARGO_REGISTRY_TOKEN`), `TM-DOS` (release-job resource use).
- Findings and resolutions: none. The change only extends the crate list and the version-verification map; token handling is untouched — publishing stays upload-only (`--no-verify`) so build scripts cannot inherit the token, and the two new packages go through the same `initial_publish_status` / `verify_published_package` sha256 comparison and `wait_until_published` gate as every other crate. Publishing `everruns-macros` and `everruns-engine` widens the published surface, but both are already-public workspace members whose sources ship inside `everruns` and `everruns-runtime` today. No `THREAT` markers are near the diff and no threat-model update is warranted.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
