### PR TITLE
feat(ui): regroup the sidebar into Chats · Operational · Building · Registries · Quality

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -296,28 +296,43 @@ describe("Sidebar", () => {
   it("renders all navigation items", () => {
     render(<Sidebar />);
 
-    expect(screen.getByText("Chat")).toBeInTheDocument();
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Chats")).toBeInTheDocument();
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Reports")).toBeInTheDocument();
     expect(screen.getByText("Harnesses")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText("Identities")).toBeInTheDocument();
+    expect(screen.getByText("Knowledge indexes")).toBeInTheDocument();
     expect(screen.getByText("Memory")).toBeInTheDocument();
+    expect(screen.getByText("Apps")).toBeInTheDocument();
     expect(screen.getByText("Models")).toBeInTheDocument();
+    expect(screen.getByText("MCP servers")).toBeInTheDocument();
+    expect(screen.getByText("Skills")).toBeInTheDocument();
     expect(screen.getByText("Capabilities")).toBeInTheDocument();
+    expect(screen.getByText("Plugins")).toBeInTheDocument();
+    expect(screen.getByText("Evals")).toBeInTheDocument();
+    expect(screen.getByText("Observers")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
   it("renders correct navigation links", () => {
     render(<Sidebar />);
 
-    const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+    const chatsLink = screen.getByRole("link", { name: /chats/i });
     const harnessesLink = screen.getByRole("link", { name: "Harnesses" });
     const agentsLink = screen.getByRole("link", { name: "Agents" });
     const memoryLink = screen.getByRole("link", { name: "Memory" });
     const modelsLink = screen.getByRole("link", { name: "Models" });
     const capabilitiesLink = screen.getByRole("link", { name: "Capabilities" });
+    const identitiesLink = screen.getByRole("link", { name: "Identities" });
+    const knowledgeLink = screen.getByRole("link", { name: "Knowledge indexes" });
+    const mcpServersLink = screen.getByRole("link", { name: "MCP servers" });
     const settingsLink = screen.getByRole("link", { name: "Settings" });
 
-    expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+    expect(chatsLink).toHaveAttribute("href", "/chat");
+    expect(identitiesLink).toHaveAttribute("href", "/agent-identities");
+    expect(knowledgeLink).toHaveAttribute("href", "/knowledge-indexes");
+    expect(mcpServersLink).toHaveAttribute("href", "/mcp-servers");
     expect(harnessesLink).toHaveAttribute("href", "/harnesses");
     expect(agentsLink).toHaveAttribute("href", "/agents");
     expect(memoryLink).toHaveAttribute("href", "/memory");
@@ -363,6 +378,9 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     expect(screen.queryByText("Runs")).not.toBeInTheDocument();
+    expect(screen.queryByText("Building Blocks")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Work")).not.toBeInTheDocument();
   });
 
   it("highlights the active navigation item", () => {
@@ -410,11 +428,22 @@ describe("Sidebar", () => {
   // cosmetic refactors while asserting no behavior. Active-state/routing tests
   // that verify *which* item is highlighted are kept below.
 
-  it("renders section labels for Building Blocks and Durable Execution", () => {
+  it("renders the grouped section labels and Durable Execution", () => {
     render(<Sidebar />);
 
-    expect(screen.getByText("Building Blocks")).toBeInTheDocument();
+    expect(screen.getByText("Operational")).toBeInTheDocument();
+    expect(screen.getByText("Building")).toBeInTheDocument();
+    expect(screen.getByText("Registries")).toBeInTheDocument();
+    expect(screen.getByText("Quality")).toBeInTheDocument();
     expect(screen.getByText("Durable Execution")).toBeInTheDocument();
+  });
+
+  it("leads with Chats above the first labelled group", () => {
+    render(<Sidebar />);
+
+    const navigation = screen.getByRole("navigation");
+    const links = within(navigation).getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/chat");
   });
 
   it("hides Durable Execution navigation items by default (collapsed)", () => {
@@ -493,7 +522,7 @@ describe("Sidebar with config", () => {
     expect(screen.getByText("Custom")).toBeInTheDocument();
     expect(screen.getByText("Custom Page")).toBeInTheDocument();
     // Default items should not appear
-    expect(screen.queryByText("Building Blocks")).not.toBeInTheDocument();
+    expect(screen.queryByText("Building")).not.toBeInTheDocument();
     expect(screen.queryByText("Durable Execution")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Custom Page" })).toHaveAttribute(
       "data-prefetch",
@@ -512,8 +541,8 @@ describe("Sidebar with config", () => {
     render(<Sidebar config={{ extraSections: extra }} />);
 
     // Default items still present
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
-    expect(screen.getByText("Building Blocks")).toBeInTheDocument();
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Building")).toBeInTheDocument();
     // Extra section appended
     expect(screen.getByText("Billing")).toBeInTheDocument();
     expect(screen.getByText("Usage")).toBeInTheDocument();
@@ -536,7 +565,7 @@ describe("Sidebar with config", () => {
     expect(screen.getByText("Extra")).toBeInTheDocument();
     expect(screen.getByText("Extra Item")).toBeInTheDocument();
     // Default items replaced
-    expect(screen.queryByText("Dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sessions")).not.toBeInTheDocument();
   });
 
   it("does not render CreateOrganizationDialog when custom createOrg is provided", () => {

--- a/apps/ui/src/components/layout/index.ts
+++ b/apps/ui/src/components/layout/index.ts
@@ -2,8 +2,11 @@ export { Sidebar } from "./sidebar";
 export type { SidebarConfig, NavigationSection, NavigationItem } from "./sidebar";
 export {
   defaultNavigationSections,
-  defaultTopNavigation,
-  defaultBuildingBlocksNavigation,
+  defaultChatsNavigation,
+  defaultOperationalNavigation,
+  defaultBuildingNavigation,
+  defaultRegistriesNavigation,
+  defaultQualityNavigation,
   defaultBottomNavigation,
   defaultDurableNavigation,
   defaultDevNavigation,

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -27,7 +27,6 @@ import {
   ChartColumn,
   ClipboardCheck,
   FlaskConical,
-  LayoutDashboard,
   Library,
   ListTodo,
   MessageCircle,
@@ -40,7 +39,6 @@ import {
   Shield,
   Telescope,
   UserRound,
-  Waypoints,
   Workflow,
   Cog,
   Cpu,
@@ -94,26 +92,38 @@ export interface SidebarConfig {
   };
 }
 
-export const defaultTopNavigation: NavigationItem[] = [
-  { name: "Chat", href: "/chat", icon: MessageCircle, flag: "global_chat", experimental: true },
-  { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-  { name: "Reports", href: "/reports", icon: ChartColumn },
-  { name: "Sessions", href: "/sessions", icon: MessageSquare },
-  { name: "Work", href: "/work", icon: Waypoints },
+/**
+ * Navigation is grouped by what you do with a thing, not what it is. The placement
+ * rule and the dismissed alternatives live in `knowledge/ui/information-architecture.md`;
+ * consult it before adding an entity to a group.
+ */
+export const defaultChatsNavigation: NavigationItem[] = [
+  { name: "Chats", href: "/chat", icon: MessageCircle, flag: "global_chat", experimental: true },
 ];
 
-export const defaultBuildingBlocksNavigation: NavigationItem[] = [
-  { name: "Harnesses", href: "/harnesses", icon: Shield },
+export const defaultOperationalNavigation: NavigationItem[] = [
+  { name: "Sessions", href: "/sessions", icon: MessageSquare },
+  { name: "Reports", href: "/reports", icon: ChartColumn },
+];
+
+export const defaultBuildingNavigation: NavigationItem[] = [
   { name: "Agents", href: "/agents", icon: Boxes },
-  { name: "Agent Identities", href: "/agent-identities", icon: UserRound },
-  { name: "Skills", href: "/skills", icon: BookOpen },
+  { name: "Harnesses", href: "/harnesses", icon: Shield },
+  { name: "Identities", href: "/agent-identities", icon: UserRound },
+  { name: "Knowledge indexes", href: "/knowledge-indexes", icon: Library },
   { name: "Memory", href: "/memory", icon: Brain },
-  { name: "Knowledge Indexes", href: "/knowledge-indexes", icon: Library },
-  { name: "Models", href: "/models", icon: Cpu },
-  { name: "Capabilities", href: "/capabilities", icon: Puzzle },
-  { name: "MCP Servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },
-  { name: "Plugins", href: "/plugins", icon: Puzzle },
   { name: "Apps", href: "/apps", icon: Rocket },
+];
+
+export const defaultRegistriesNavigation: NavigationItem[] = [
+  { name: "Models", href: "/models", icon: Cpu },
+  { name: "MCP servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },
+  { name: "Skills", href: "/skills", icon: BookOpen },
+  { name: "Capabilities", href: "/capabilities", icon: Puzzle },
+  { name: "Plugins", href: "/plugins", icon: Puzzle },
+];
+
+export const defaultQualityNavigation: NavigationItem[] = [
   { name: "Evals", href: "/evals", icon: ClipboardCheck, flag: "evals", experimental: true },
   {
     name: "Observers",
@@ -147,8 +157,11 @@ export const defaultDevNavigation: NavigationItem[] = [
 ];
 
 export const defaultNavigationSections: NavigationSection[] = [
-  { items: defaultTopNavigation },
-  { label: "Building Blocks", items: defaultBuildingBlocksNavigation },
+  { items: defaultChatsNavigation },
+  { label: "Operational", items: defaultOperationalNavigation },
+  { label: "Building", items: defaultBuildingNavigation },
+  { label: "Registries", items: defaultRegistriesNavigation },
+  { label: "Quality", items: defaultQualityNavigation },
   { items: defaultBottomNavigation },
   { label: "Durable Execution", items: defaultDurableNavigation, defaultCollapsed: true },
   { label: "Dev", items: defaultDevNavigation, devOnly: true },

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-08
 
+* **Navigation information architecture**: Recorded the placement rule that groups the
+  shell by what you do with a thing (Chats, Operational, Building, Registries, Quality),
+  the worked hard cases, the surface contracts, and the three dismissed options.
+
 * **Agent MCP credentials**: Added durable write-only Agent bindings for MCP
   tool-parameter credentials, model-schema removal, runtime-only injection,
   secure setup affordances, and tenant/non-disclosure threat controls.

--- a/knowledge/ui/index.md
+++ b/knowledge/ui/index.md
@@ -5,6 +5,7 @@
 * [OpenUI — Generative UI Integration](openui.md) - OpenUI generative-UI capability.
 * [A2UI — Google Generative UI Integration](a2ui.md) - A2UI generative-UI capability.
 * [MCP Entity Cards](mcp-cards.md) - MCP Apps entity cards and sandboxed HTML resources.
+* [Navigation Information Architecture](information-architecture.md) - How navigation is grouped by what you do with a thing, and the dismissed alternatives.
 * [Brand Specification](brand.md) - Brand identity, colors, typography.
 * [Diagram Specification](diagrams.md) - Diagram specification.
 * [Documentation Site Specification](documentation.md) - Documentation site.

--- a/knowledge/ui/information-architecture.md
+++ b/knowledge/ui/information-architecture.md
@@ -1,0 +1,100 @@
+---
+type: Decision
+title: "Navigation Information Architecture"
+description: "How Everruns groups navigation by what you do with a thing, and which alternatives were dismissed."
+tags:
+  - everruns
+  - ui
+  - navigation
+---
+
+# Navigation Information Architecture
+
+## Abstract
+
+The shell groups navigation by **what you do with a thing**, not by what the thing is.
+Five groups carry every destination: Chats, Operational, Building, Registries, Quality,
+with Settings pinned below them. The data lives in
+[`apps/ui/src/components/layout/sidebar.tsx`](../../apps/ui/src/components/layout/sidebar.tsx)
+and renders through the generic section renderer in
+[`sidebar-navigation.tsx`](../../apps/ui/src/components/layout/sidebar-navigation.tsx).
+
+This concept exists so that a new entity is placed by a rule instead of by argument.
+
+## The organising principle
+
+A destination belongs to the group that matches the **verb the user brings to it**.
+Nothing is grouped by implementation layer, by owning crate, or by how the entity is
+stored.
+
+The placement test for a new entity is a single question:
+
+> What does the user do with it — talk to it, look at what it did, author it, register it
+> once and reference it by name, or check the quality of something else with it?
+
+The first answer that is true names the group. If two answers feel true, the earlier one
+in that list wins; a thing you author and also reference by name is Building, because
+authoring is the activity that brings the user to the page.
+
+## What each group asserts
+
+| Group | Assertion |
+|---|---|
+| **Chats** | Where you talk. First, no section header, and it carries the new-chat affordance. |
+| **Operational** | What ran. Recordings and views over them — read, not authored. |
+| **Building** | What you author. Editable definitions the user composes and owns. |
+| **Registries** | What you register once and reference by name. Mostly-write-once entries other things point at. |
+| **Quality** | How you check it. Instruments that judge or observe other entities. |
+
+Settings sits below the groups and is not one of them: it configures the workspace rather
+than being a thing the user works on. Durable Execution and Dev keep their existing
+policy and dev-mode gating and stay out of the five groups for the same reason.
+
+## The hard cases, worked
+
+* **A Skill is a Registry entry, not Knowledge.** You register a skill once and then
+  reference it by name from an agent. You do not sit and author a skill as part of
+  building a specific agent, and you do not read it back as a record of what ran.
+  Registering-and-referencing beats its surface resemblance to Knowledge indexes.
+* **Memory is Building, not Operational.** Memory looks like a recording, but the user
+  authors what goes into it and curates it deliberately. The verb is authoring, so it
+  sits with the things you compose.
+* **Reports is Operational, not Quality.** A report reads what ran. Quality is reserved
+  for instruments that judge — Evals and Observers.
+* **Identities is Building, not Registries.** An identity is authored per agent
+  deployment with credentials and scope decisions, not registered once and forgotten.
+
+## Surface contracts
+
+* **Chats is the landing route.** It is the first thing in the sidebar and the default
+  destination for a user with no other intent.
+* **A thread is bound to exactly one agent.** Switching agents starts a new thread rather
+  than re-pointing an existing one; the thread's transcript is only meaningful against
+  the agent that produced it.
+* **A session is a read-only recording.** Session detail inspects, it does not edit. The
+  inspector pattern lives inside session detail rather than in the shell.
+* **Reports is a saved view on Sessions, not a separate page concept.** It shares the
+  session model and adds persistence of a query.
+
+## Dismissed options
+
+These were considered and rejected. They are recorded so they are not re-proposed.
+
+* **Agent is the product** — four groups, Compute / Knowledge / Tools / Delivery, framed
+  around what an agent is made of. Dismissed because the grouping needed defending on
+  every new entity: each addition triggered a fresh argument about which of the four
+  substances it was made of, which is exactly the cost the placement rule exists to
+  remove.
+* **Use / Build modes** — a mode switch that shows either the operating surface or the
+  authoring surface. Dismissed because modes hide things, and the builder switches
+  between using and building too often for the hidden half to stay out of the way.
+  Search does not rescue a hidden item for a user who does not yet know its name.
+* **No navigation** — search and in-context links only. Dismissed because it kills
+  discovery for the first-time builder, who is the primary user. The idea survives in a
+  narrower form: the inspector pattern is kept inside session detail, where the user
+  already knows what they are looking at.
+
+## See also
+
+* [Brand Specification](brand.md) — visual language the shell renders in.
+* [Documentation Site Specification](documentation.md) — the public documentation surface.

--- a/test_cases/ui/evals/TC002_evals_hidden_without_flag.md
+++ b/test_cases/ui/evals/TC002_evals_hidden_without_flag.md
@@ -16,7 +16,7 @@ None.
 ## Steps
 
 1. Observe the sidebar navigation
-2. Look for "Evals" link in the Building Blocks section
+2. Look for "Evals" link in the Quality section
 
 ## Expected Result
 

--- a/test_cases/ui/mcp_servers/TC005_update_mcp_server.md
+++ b/test_cases/ui/mcp_servers/TC005_update_mcp_server.md
@@ -19,7 +19,7 @@ Verify that an existing MCP server's name, description, and URL can be edited fr
 
 ## Steps
 
-1. Navigate to Building blocks > MCP Servers
+1. Navigate to Registries > MCP servers
 2. Find the row for the server "test-mcp-server"
 3. Click the "Edit" button in that row
 4. In the "Edit MCP Server" dialog, update Name to: `updated-mcp-server`

--- a/test_cases/ui/mcp_servers/TC006_archive_mcp_server.md
+++ b/test_cases/ui/mcp_servers/TC006_archive_mcp_server.md
@@ -17,7 +17,7 @@ Verify that an MCP server can be archived and remains available in the archived 
 
 ## Steps
 
-1. Navigate to Building blocks > MCP Servers
+1. Navigate to Registries > MCP servers
 2. Find an active MCP server
 3. Open the server actions and click "Archive"
 4. Confirm the action

--- a/test_cases/ui/mcp_servers/TC008_validation_empty_name.md
+++ b/test_cases/ui/mcp_servers/TC008_validation_empty_name.md
@@ -17,7 +17,7 @@ Verify that the create action remains unavailable while the required name is emp
 
 ## Steps
 
-1. Navigate to Building blocks > MCP Servers
+1. Navigate to Registries > MCP servers
 2. Click "Add MCP Server" button
 3. Leave name field empty
 4. Enter URL: `https://mcp.example.com/v1/mcp`

--- a/test_cases/ui/mcp_servers/TC009_validation_empty_url.md
+++ b/test_cases/ui/mcp_servers/TC009_validation_empty_url.md
@@ -17,7 +17,7 @@ Verify that the create action remains unavailable while the required URL is empt
 
 ## Steps
 
-1. Navigate to Building blocks > MCP Servers
+1. Navigate to Registries > MCP servers
 2. Click "Add MCP Server" button
 3. Enter name: `test-server`
 4. Leave URL field empty


### PR DESCRIPTION
## What changed

The sidebar is now grouped by **what you do with a thing**, not what it is. The old
`Chat · Dashboard · Reports · Sessions · Work` top block and the flat "Building Blocks"
list are replaced by five groups, with Settings still pinned below them:

- **Chats** — first, no section header, carries the new-chat affordance.
- **Operational** — Sessions, Reports.
- **Building** — Agents, Harnesses, Identities, Knowledge indexes, Memory, Apps.
- **Registries** — Models, MCP servers, Skills, Capabilities, Plugins.
- **Quality** — Evals, Observers.

Naming moves to sentence case: "Agent Identities" → "Identities", "Knowledge Indexes" →
"Knowledge indexes", "MCP Servers" → "MCP servers". Skills moves out of Building into
Registries — the placement rule doing its first piece of work.

Nav data only. No page rewrites, no route deletions: Dashboard and Work leave the sidebar
but their routes stay reachable (the logo still links to `/dashboard`) until the cleanup
issue. Durable Execution and Dev keep their existing policy and dev-mode gating.

**Breaking for forks.** The exported navigation arrays are a `SidebarConfig` extension
point. `defaultTopNavigation` and `defaultBuildingBlocksNavigation` are gone, replaced by
`defaultChatsNavigation`, `defaultOperationalNavigation`, `defaultBuildingNavigation`,
`defaultRegistriesNavigation`, and `defaultQualityNavigation`. All five are re-exported
from the layout barrel. `SidebarConfig`, `NavigationSection`, `NavigationItem`,
`defaultNavigationSections`, `defaultBottomNavigation`, `defaultDurableNavigation`, and
`defaultDevNavigation` are unchanged, so a fork that overrides `navigation` wholesale is
unaffected; one that imports the two removed arrays must update the import.

Also adds `knowledge/ui/information-architecture.md` recording the decision, linked from
`knowledge/ui/index.md`: the organising principle and the placement test, what each group
asserts, the hard cases worked (a Skill is a Registry entry because you register it once
and reference it by name; Memory is Building because you author what goes into it), the
surface contracts (Chats is the landing route, a thread is bound to exactly one agent, a
session is a read-only recording, Reports is a saved view on Sessions), and the three
dismissed options — *Agent is the product*, *Use / Build modes*, *No navigation* — with
why each died.

## Why

Every new entity was re-litigating where it belonged, because the old grouping had no
stated rule. First of six tickets carrying the IA rethink (EVE-849). Writing the rule down
alongside the regrouping is what stops the next entity from re-opening the argument.

## Before / After

Rendered navigation tree (`SidebarNavigation` with `defaultNavigationSections`, all
feature flags on, Durable Execution collapsed as it is by default):

Before:

```
  - Chat [experimental]
  - Dashboard
  - Reports
  - Sessions
  - Work
BUILDING BLOCKS
  - Harnesses
  - Agents
  - Agent Identities
  - Skills
  - Memory
  - Knowledge Indexes
  - Models
  - Capabilities
  - MCP Servers
  - Plugins
  - Apps
  - Evals [experimental]
  - Observers [experimental]
  - Settings
DURABLE EXECUTION
```

After:

```
  - Chats [experimental]
OPERATIONAL
  - Sessions
  - Reports
BUILDING
  - Agents
  - Harnesses
  - Identities
  - Knowledge indexes
  - Memory
  - Apps
REGISTRIES
  - Models
  - MCP servers
  - Skills
  - Capabilities
  - Plugins
QUALITY
  - Evals [experimental]
  - Observers [experimental]
  - Settings
DURABLE EXECUTION
```

Behavior held constant, covered by tests:

- Active-state highlighting resolves for every item, including `/settings/*` via
  `activePrefix` and nested routes like `/agents/123/sessions/456`.
- `global_chat`, `evals`, and `observers` gating unchanged; the missing-provider warning
  badge still attaches to the `/chat` item.
- Prefetch discipline from EVE-780/EVE-794 not regressed: every nav link still renders
  `prefetch={false}`, hover/focus prefetches exactly one route, and Settings still
  prefetches neither.

Evidence:

```
$ pnpm test -- src/__tests__/sidebar.test.tsx
Tests:       45 passed, 45 total

$ pnpm test
Test Suites: 170 passed, 170 total
Tests:       1379 passed, 1379 total

$ pnpm typecheck && pnpm lint && pnpm format:check
(clean)

$ ./scripts/lib/pre-push.sh
✅ All pre-push checks passed.   # includes check-okf: OKF v0.2 conformant
```

No stack smoke test: the change touches no server, API, or database surface, and no page
component — it is navigation data plus a knowledge concept, and the rendered tree above is
taken from the real component render rather than from the source arrays.

## Risk

- Low
- A fork importing `defaultTopNavigation` or `defaultBuildingBlocksNavigation` breaks at
  build time — loud, not silent. In-repo, a user's muscle memory for Dashboard and Work
  breaks: both routes remain reachable by URL and via the logo (Dashboard), and the
  cleanup issue decides their fate.

## Security

- Threat categories reviewed: TM-WEB. No security-relevant code changes — the diff is
  static navigation data (labels, hrefs, icons, existing feature-flag keys), test updates,
  and Markdown. No new routes, no new user input, no auth, authorization, or tenancy
  surface; feature-flag and policy gating for Evals, Observers, `global_chat`, and Durable
  Execution is carried over unchanged.
- Findings and resolutions: none.

## Follow-ups

- No follow-ups for this ticket. The remaining IA work is already tracked as the other five
  tickets in the series: the Chats thread list, and the route cleanup that decides
  Dashboard and Work. The command palette and global search still use the old
  "Agent Identities" / "Knowledge Indexes" / "MCP Servers" labels; that is deliberate —
  they are entity-type labels, not sidebar nav data, and this ticket is scoped to nav.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7D1PwPJM8EzDVF9GrM8FT)_