### PR TITLE
refactor(platform): move identity family out of core

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -505,23 +505,25 @@ pub use model_discovery::{
     normalize_and_enrich, rank_discovered_models, search_provider_models,
 };
 pub use model_profiles::{get_model_profile, get_model_vendor};
-// EVE-837: `Organization` moved to the `everruns-platform` crate. The role,
-// membership, and multitenancy constants stay here — the permissions/auth layer
-// and runtime fixtures depend on them.
+// EVE-837/EVE-845: `Organization`, `OrgMembership`, the `ANONYMOUS_USER_*`
+// constants, and the public-id generation/validation helpers moved to the
+// `everruns-platform` crate. `OrgRole` (portable turn authorization via
+// `permissions`), the `DEFAULT_ORG_*` constants, and the internal<->public id
+// conversion helper stay here because core's permissions/auth layer and runtime
+// name them.
 pub use organization::{
-    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, generate_org_public_id,
-    org_public_id_from_internal, validate_org_public_id,
+    DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgRole, org_public_id_from_internal,
 };
 // EVE-838: the payment accounting records (`PaymentAccount`, `PaymentPolicy`,
 // `PaymentAttempt`, `PaymentOwnerType`, `PaymentStatus`) moved to the
 // `everruns-platform` crate. The capability-internal execution contract below
 // stays here — it is bound to the `PaymentAuthority` trait and `ToolContext`.
 pub use payment::{MachinePaymentRequest, MachinePaymentResponse, PaymentMethod, PaymentRail};
-// EVE-837: `Principal` moved to the `everruns-platform` crate. The value types
-// below stay here — they are embedded by `Session`/`App`/`SessionSchedule` and
-// the agent-identity lifecycle.
-pub use principal::{PrincipalKind, PrincipalStatus, PrincipalSummary};
+// EVE-837/EVE-845: `Principal` and the `PrincipalStatus` lifecycle enum moved to
+// the `everruns-platform` crate. `PrincipalSummary` and the `PrincipalKind` that
+// backs it stay here — they are embedded by `Session`/`SessionSchedule`/
+// `AgentIdentity`.
+pub use principal::{PrincipalKind, PrincipalSummary};
 pub use provider::{Provider, ProviderStatus, ProviderTraceConfig};
 pub use session::{
     Session, SessionParticipant, SessionParticipantKind, SessionParticipantRole, SessionSeedMode,

--- a/crates/core/src/organization.rs
+++ b/crates/core/src/organization.rs
@@ -7,31 +7,21 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
-use uuid::Uuid;
 
 // EVE-837: the `Organization` aggregate entity moved to the `everruns-platform`
-// crate. The role/membership value types and multitenancy constants below stay
-// in core because the permissions layer, auth-facing membership, and runtime
-// fixtures depend on them.
+// crate. EVE-845 moved the remaining auth-facing identity values that no core
+// code names — `OrgMembership`, the `ANONYMOUS_USER_*` constants, and the
+// public-id generation/validation helpers (`generate_org_public_id`,
+// `validate_org_public_id`) — to `everruns-platform` as well. What stays here
+// does so because core's permissions layer and runtime name it: `OrgRole`
+// (portable turn authorization), the `DEFAULT_ORG_*` constants, and the
+// internal<->public id conversion helpers.
 
 /// Default organization ID (internal, for DB queries)
 pub const DEFAULT_ORG_ID: i64 = 1;
 
 /// Default organization public ID (external, for API)
 pub const DEFAULT_ORG_PUBLIC_ID: &str = "org_00000000000000000000000000000001";
-
-/// Well-known anonymous user UUID for auth=none mode.
-/// This is a real database user seeded at startup, so all code paths
-/// (org membership, API keys, etc.) work without special-casing.
-pub const ANONYMOUS_USER_ID: Uuid = Uuid::from_bytes([
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-]);
-
-/// Anonymous user email
-pub const ANONYMOUS_USER_EMAIL: &str = "anonymous@local";
-
-/// Anonymous user display name
-pub const ANONYMOUS_USER_NAME: &str = "Anonymous";
 
 /// Organization-level role with hierarchical permissions.
 /// Owner > Admin > Member — checked via `has_permission()`.
@@ -88,22 +78,6 @@ impl FromStr for OrgRole {
     }
 }
 
-/// Organization membership info (for user context)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct OrgMembership {
-    /// Internal org_id for DB queries (not serialized to API)
-    #[serde(skip_serializing)]
-    pub org_id: i64,
-    /// External identifier
-    pub public_id: String,
-    /// Display name
-    pub name: String,
-    /// User's role in this organization
-    #[serde(default)]
-    pub role: OrgRole,
-}
-
 /// Derive a deterministic public_id from an internal org_id.
 ///
 /// For `DEFAULT_ORG_ID` this returns `DEFAULT_ORG_PUBLIC_ID`.
@@ -128,76 +102,9 @@ pub fn org_internal_id_from_public(org_id: crate::typed_id::OrgId) -> i64 {
     org_id.uuid().as_u128() as i64
 }
 
-/// Generate a new organization public ID
-/// Format: org_<32-hex-chars> (UUIDv4 lowercase hex, no dashes)
-pub fn generate_org_public_id() -> String {
-    let uuid = Uuid::new_v4();
-    format!("org_{}", uuid.simple())
-}
-
-/// Validate organization public ID format
-/// Pattern: ^org_[0-9a-f]{32}$
-pub fn validate_org_public_id(public_id: &str) -> bool {
-    if !public_id.starts_with("org_") {
-        return false;
-    }
-    let suffix = &public_id[4..];
-    suffix.len() == 32
-        && suffix
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_generate_org_public_id() {
-        let id = generate_org_public_id();
-        assert!(id.starts_with("org_"));
-        assert_eq!(id.len(), 36); // "org_" + 32 hex chars
-        assert!(validate_org_public_id(&id));
-    }
-
-    #[test]
-    fn test_validate_org_public_id() {
-        // Valid
-        assert!(validate_org_public_id(
-            "org_00000000000000000000000000000001"
-        ));
-        assert!(validate_org_public_id(
-            "org_2f3c1b3e6a9d4c6f8a1d4e9c9b7f21a0"
-        ));
-
-        // Invalid - wrong prefix
-        assert!(!validate_org_public_id(
-            "organization_12345678901234567890123456789012"
-        ));
-
-        // Invalid - too short
-        assert!(!validate_org_public_id("org_123"));
-
-        // Invalid - too long
-        assert!(!validate_org_public_id(
-            "org_123456789012345678901234567890123"
-        ));
-
-        // Invalid - uppercase
-        assert!(!validate_org_public_id(
-            "org_2F3C1B3E6A9D4C6F8A1D4E9C9B7F21A0"
-        ));
-
-        // Invalid - non-hex characters
-        assert!(!validate_org_public_id(
-            "org_ghijklmnopqrstuvwxyz1234567890"
-        ));
-    }
-
-    #[test]
-    fn test_default_org_public_id_valid() {
-        assert!(validate_org_public_id(DEFAULT_ORG_PUBLIC_ID));
-    }
 
     #[test]
     fn test_org_internal_id_round_trips() {

--- a/crates/core/src/principal.rs
+++ b/crates/core/src/principal.rs
@@ -8,9 +8,10 @@
 //
 // EVE-837: the `Principal` aggregate entity moved to the `everruns-platform`
 // crate. The value types below stay in core because they are embedded by core
-// domain models: `PrincipalSummary` is a field of `Session`/`App`/
-// `SessionSchedule`, `PrincipalKind` backs that summary, and `PrincipalStatus`
-// is shared with the agent-identity lifecycle.
+// domain models: `PrincipalSummary` is a field of `Session`/`SessionSchedule`/
+// `AgentIdentity`, and `PrincipalKind` backs that summary. EVE-845: the
+// `PrincipalStatus` lifecycle enum, which no core type embeds, moved to
+// `everruns-platform` alongside the `Principal` aggregate it describes.
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -48,35 +49,6 @@ impl From<&str> for PrincipalKind {
             "agent_identity" => Self::AgentIdentity,
             "system" => Self::System,
             _ => Self::User,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum PrincipalStatus {
-    Active,
-    Archived,
-    Deleted,
-}
-
-impl std::fmt::Display for PrincipalStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Active => write!(f, "active"),
-            Self::Archived => write!(f, "archived"),
-            Self::Deleted => write!(f, "deleted"),
-        }
-    }
-}
-
-impl From<&str> for PrincipalStatus {
-    fn from(value: &str) -> Self {
-        match value {
-            "archived" => Self::Archived,
-            "deleted" => Self::Deleted,
-            _ => Self::Active,
         }
     }
 }

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -3,12 +3,13 @@
 # Decision (EVE-837): the platform crate owns the durable backend identity
 # aggregates that were historically defined in `everruns-core` — starting with
 # the `Organization` and `Principal` entity structs. EVE-838 extended it with
-# the payment accounting, reporting, and audit records. Cross-cutting value
-# types that core's runtime, permissions, and domain models embed (OrgRole,
-# OrgMembership, PrincipalKind, PrincipalStatus, PrincipalSummary, the
-# multitenancy constants, and the payment execution contract PaymentRail/
-# PaymentMethod/MachinePaymentRequest/MachinePaymentResponse) remain in
-# `everruns-core` and are re-exported here for a unified consumer surface.
+# the payment accounting, reporting, and audit records. EVE-845 added the
+# auth-facing identity values no core code names (OrgMembership, ANONYMOUS_USER_*,
+# generate_org_public_id/validate_org_public_id, PrincipalStatus). Cross-cutting
+# value types that core's runtime, permissions, and domain models embed (OrgRole,
+# PrincipalKind, PrincipalSummary, the DEFAULT_ORG_* constants, and the payment
+# execution contract PaymentRail/PaymentMethod/MachinePaymentRequest/
+# MachinePaymentResponse) remain in `everruns-core` and are re-exported here.
 #
 # Dependency direction is strictly `platform -> core`. Core never depends on
 # platform (enforced by crates/core/tests/no_platform_dependency.rs).
@@ -44,10 +45,10 @@ embedded-platform-docs = ["dep:include_dir", "everruns-core/embedded-platform-do
 sqlx = ["everruns-core/sqlx"]
 
 [dependencies]
-# Cross-cutting value types (PrincipalKind/PrincipalStatus/PrincipalSummary,
-# Caller, the payment execution contract), typed IDs, domain aggregates
-# (Harness/Agent/Session), and multitenancy constants live in core; the platform
-# aggregates embed and re-export them. Direction is platform -> core.
+# Cross-cutting value types (OrgRole, PrincipalKind/PrincipalSummary, Caller, the
+# payment execution contract), typed IDs, domain aggregates
+# (Harness/Agent/Session), and the DEFAULT_ORG_* constants live in core; the
+# platform aggregates embed and re-export them. Direction is platform -> core.
 everruns-core = { workspace = true }
 
 serde.workspace = true

--- a/crates/platform/README.md
+++ b/crates/platform/README.md
@@ -9,10 +9,14 @@ defined in `everruns-core`:
 - `Organization`
 - `Principal`
 
-Cross-cutting identity value types that core's runtime and permissions layer
-embed (`OrgRole`, `OrgMembership`, `PrincipalKind`, `PrincipalStatus`,
-`PrincipalSummary`) and the multitenancy constants remain in `everruns-core` and
-are re-exported here for a unified consumer surface.
+It also owns the auth-facing identity values that no core code names
+(`OrgMembership`, the `ANONYMOUS_USER_*` seed constants, the org public-id
+generation/validation helpers, and the `PrincipalStatus` lifecycle enum).
+
+Cross-cutting value types that core's runtime and permissions layer embed
+(`OrgRole`, `PrincipalKind`, `PrincipalSummary`) and the `DEFAULT_ORG_*`
+multitenancy constants remain in `everruns-core` and are re-exported here for a
+unified consumer surface.
 
 The dependency direction is strictly `platform -> core`; `everruns-core` never
 depends on `everruns-platform`.

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -19,14 +19,22 @@
 //! models embed remain in `everruns-core` and are re-exported here so consumers
 //! can reach the whole surface through `everruns_platform`:
 //!
-//! - [`OrgRole`], [`OrgMembership`] and the multitenancy constants — used by
-//!   core's permissions/auth layer.
-//! - [`PrincipalKind`], [`PrincipalStatus`], [`PrincipalSummary`] — embedded in
-//!   `Session`/`App`/`SessionSchedule` and the agent-identity lifecycle.
+//! - [`OrgRole`] and the `DEFAULT_ORG_*` constants plus the internal<->public id
+//!   conversion helper — used by core's permissions/auth layer during a turn.
+//! - [`PrincipalKind`], [`PrincipalSummary`] — embedded in
+//!   `Session`/`SessionSchedule`/`AgentIdentity`.
 //! - The capability-internal payment execution contract (`PaymentRail`,
 //!   `PaymentMethod`, `MachinePaymentRequest`, `MachinePaymentResponse`) — bound
 //!   to core's `PaymentAuthority` trait and `ToolContext`. Re-exported from
 //!   [`payment`].
+//!
+//! # Identity values owned here (EVE-845)
+//!
+//! [`OrgMembership`], the `ANONYMOUS_USER_*` seed constants, the org public-id
+//! generation/validation helpers ([`generate_org_public_id`],
+//! [`validate_org_public_id`]), and the [`PrincipalStatus`] lifecycle enum are
+//! defined in this crate: no core code names them, so they moved out of the
+//! runtime-facing contract in `everruns-core`.
 
 pub mod audit;
 pub mod organization;
@@ -45,12 +53,15 @@ pub mod platform_store;
 pub mod agent_trigger;
 pub mod app;
 
-pub use organization::Organization;
+pub use organization::{
+    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, OrgMembership, Organization,
+    generate_org_public_id, validate_org_public_id,
+};
 pub use platform_store::{
     PlatformCreateSessionRequest, PlatformMessage, PlatformStore, PlatformStoreExt,
     PlatformStoreSubagentDelegate,
 };
-pub use principal::Principal;
+pub use principal::{Principal, PrincipalStatus};
 
 // Hosted control-plane orchestration records (EVE-841).
 pub use agent_trigger::{AgentTrigger, AgentTriggerType, ScheduleTriggerConfig};
@@ -77,7 +88,6 @@ pub use audit::{
 // Re-export the identity value types and multitenancy constants that remain in
 // `everruns-core`, so `everruns_platform` exposes the complete identity surface.
 pub use everruns_core::{
-    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, PrincipalKind, PrincipalStatus,
-    PrincipalSummary, generate_org_public_id, org_public_id_from_internal, validate_org_public_id,
+    DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgRole, PrincipalKind, PrincipalSummary,
+    org_public_id_from_internal,
 };

--- a/crates/platform/src/organization.rs
+++ b/crates/platform/src/organization.rs
@@ -1,14 +1,23 @@
 // Organization entity (platform domain aggregate).
 //
-// Moved out of `everruns-core` in EVE-837. The cross-cutting organization value
-// types and multitenancy constants (OrgRole, OrgMembership, DEFAULT_ORG_ID,
-// DEFAULT_ORG_PUBLIC_ID, ANONYMOUS_USER_*, and the org public-id helpers) remain
-// in `everruns-core` because core's permissions layer, auth-facing membership,
-// and runtime fixtures depend on them; they are re-exported from this crate's
-// root for a unified consumer surface.
+// Moved out of `everruns-core` in EVE-837. EVE-845 additionally moved the
+// auth-facing organization value types and helpers that no core code names into
+// this crate: `OrgMembership`, the `ANONYMOUS_USER_*` seed constants, and the
+// org public-id generation/validation helpers (`generate_org_public_id`,
+// `validate_org_public_id`). They are backend/API-surface concerns consumed by
+// the server's auth and organization layers, not during a turn.
+//
+// The role/permission and internal<->public conversion values that core's
+// permissions layer and runtime still need — `OrgRole`, `DEFAULT_ORG_ID`,
+// `DEFAULT_ORG_PUBLIC_ID`, `org_public_id_from_internal`,
+// `org_internal_id_from_public` — remain in `everruns-core` and are re-exported
+// from this crate's root for a unified consumer surface.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use everruns_core::OrgRole;
 
 /// Organization entity (domain type)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,4 +29,106 @@ pub struct Organization {
     pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Well-known anonymous user UUID for auth=none mode.
+/// This is a real database user seeded at startup, so all code paths
+/// (org membership, API keys, etc.) work without special-casing.
+pub const ANONYMOUS_USER_ID: Uuid = Uuid::from_bytes([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+]);
+
+/// Anonymous user email
+pub const ANONYMOUS_USER_EMAIL: &str = "anonymous@local";
+
+/// Anonymous user display name
+pub const ANONYMOUS_USER_NAME: &str = "Anonymous";
+
+/// Organization membership info (for user context)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OrgMembership {
+    /// Internal org_id for DB queries (not serialized to API)
+    #[serde(skip_serializing)]
+    pub org_id: i64,
+    /// External identifier
+    pub public_id: String,
+    /// Display name
+    pub name: String,
+    /// User's role in this organization
+    #[serde(default)]
+    pub role: OrgRole,
+}
+
+/// Generate a new organization public ID
+/// Format: org_<32-hex-chars> (UUIDv4 lowercase hex, no dashes)
+pub fn generate_org_public_id() -> String {
+    let uuid = Uuid::new_v4();
+    format!("org_{}", uuid.simple())
+}
+
+/// Validate organization public ID format
+/// Pattern: ^org_[0-9a-f]{32}$
+pub fn validate_org_public_id(public_id: &str) -> bool {
+    if !public_id.starts_with("org_") {
+        return false;
+    }
+    let suffix = &public_id[4..];
+    suffix.len() == 32
+        && suffix
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::DEFAULT_ORG_PUBLIC_ID;
+
+    #[test]
+    fn test_generate_org_public_id() {
+        let id = generate_org_public_id();
+        assert!(id.starts_with("org_"));
+        assert_eq!(id.len(), 36); // "org_" + 32 hex chars
+        assert!(validate_org_public_id(&id));
+    }
+
+    #[test]
+    fn test_validate_org_public_id() {
+        // Valid
+        assert!(validate_org_public_id(
+            "org_00000000000000000000000000000001"
+        ));
+        assert!(validate_org_public_id(
+            "org_2f3c1b3e6a9d4c6f8a1d4e9c9b7f21a0"
+        ));
+
+        // Invalid - wrong prefix
+        assert!(!validate_org_public_id(
+            "organization_12345678901234567890123456789012"
+        ));
+
+        // Invalid - too short
+        assert!(!validate_org_public_id("org_123"));
+
+        // Invalid - too long
+        assert!(!validate_org_public_id(
+            "org_123456789012345678901234567890123"
+        ));
+
+        // Invalid - uppercase
+        assert!(!validate_org_public_id(
+            "org_2F3C1B3E6A9D4C6F8A1D4E9C9B7F21A0"
+        ));
+
+        // Invalid - non-hex characters
+        assert!(!validate_org_public_id(
+            "org_ghijklmnopqrstuvwxyz1234567890"
+        ));
+    }
+
+    #[test]
+    fn test_default_org_public_id_valid() {
+        assert!(validate_org_public_id(DEFAULT_ORG_PUBLIC_ID));
+    }
 }

--- a/crates/platform/src/principal.rs
+++ b/crates/platform/src/principal.rs
@@ -1,21 +1,52 @@
 // Principal entity (platform domain aggregate).
 //
-// Moved out of `everruns-core` in EVE-837. The principal value types embedded by
-// core domain models remain in `everruns-core`: `PrincipalSummary` is a field of
-// `Session`/`App`/`SessionSchedule`, `PrincipalKind` backs that summary, and
-// `PrincipalStatus` is shared with the agent-identity lifecycle. This aggregate
-// depends on them (direction: platform -> core) and re-exports them from the
-// crate root.
+// Moved out of `everruns-core` in EVE-837. The compact embedded value types
+// remain in `everruns-core`: `PrincipalSummary` is a field of `Session`/
+// `SessionSchedule`/`AgentIdentity`, and `PrincipalKind` backs that summary.
+// EVE-845 moved the `PrincipalStatus` lifecycle enum here — no core type embeds
+// it; it describes this durable aggregate. This crate depends on the core value
+// types (direction: platform -> core) and re-exports the full principal surface
+// from the crate root.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use everruns_core::typed_id::PrincipalId;
-use everruns_core::{PrincipalKind, PrincipalStatus, PrincipalSummary};
+use everruns_core::{PrincipalKind, PrincipalSummary};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
+
+/// Principal lifecycle status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum PrincipalStatus {
+    Active,
+    Archived,
+    Deleted,
+}
+
+impl std::fmt::Display for PrincipalStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::Archived => write!(f, "archived"),
+            Self::Deleted => write!(f, "deleted"),
+        }
+    }
+}
+
+impl From<&str> for PrincipalStatus {
+    fn from(value: &str) -> Self {
+        match value {
+            "archived" => Self::Archived,
+            "deleted" => Self::Deleted,
+            _ => Self::Active,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -3371,7 +3371,8 @@ mod tests {
         use async_trait::async_trait;
         use axum::body::{Body, to_bytes};
         use axum::http::Request;
-        use everruns_core::{OrgMembership, OrgRole};
+        use everruns_core::OrgRole;
+        use everruns_platform::OrgMembership;
         use tower::ServiceExt;
 
         /// Mock auth backend returning user with configurable platform access.

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -52,8 +52,9 @@ use axum::{
 };
 use everruns_core::mcp_server::{McpErrorCode, McpExecuteError, classify_mcp_execute_error};
 use everruns_core::session_sqldb::SessionSqlDbStore;
-use everruns_core::{Caller, OrgRole, PlatformDefinition, validate_org_public_id};
+use everruns_core::{Caller, OrgRole, PlatformDefinition};
 use everruns_durable::WorkflowEventStore;
+use everruns_platform::validate_org_public_id;
 use everruns_worker::AgentRunner;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -1858,7 +1859,7 @@ pub(crate) fn domain_context(caller: Caller, state: &AppState) -> crate::domains
 #[cfg(test)]
 mod org_override_scope_tests {
     use super::*;
-    use everruns_core::OrgMembership;
+    use everruns_platform::OrgMembership;
     use uuid::Uuid;
 
     fn test_auth_user(auth_method: AuthMethod) -> AuthUser {

--- a/crates/server/src/api/org_feature_flags.rs
+++ b/crates/server/src/api/org_feature_flags.rs
@@ -11,7 +11,8 @@ use axum::{
     extract::{Path, State},
     routing::get,
 };
-use everruns_core::{FeatureFlagMap, FeatureFlags, validate_org_public_id};
+use everruns_core::{FeatureFlagMap, FeatureFlags};
+use everruns_platform::validate_org_public_id;
 
 use crate::auth::middleware::{AuthState, OrgAdmin};
 use crate::services::org_feature_flags::{

--- a/crates/server/src/api/org_invitations.rs
+++ b/crates/server/src/api/org_invitations.rs
@@ -768,7 +768,7 @@ mod tests {
     async fn seed_org(db: &StorageBackend) -> i64 {
         let org = db
             .create_organization(crate::storage::models::CreateOrganizationRow {
-                public_id: everruns_core::generate_org_public_id(),
+                public_id: everruns_platform::generate_org_public_id(),
                 name: "Acme".to_string(),
                 created_by: None,
             })

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -13,12 +13,11 @@ use axum::{
     http::{HeaderMap, StatusCode},
     routing::get,
 };
-use everruns_core::{
-    BuiltInHarnessDefinition, DEFAULT_ORG_ID, OrgRole, generate_org_public_id,
-    validate_org_public_id,
-};
+use everruns_core::{BuiltInHarnessDefinition, DEFAULT_ORG_ID, OrgRole};
 use everruns_durable::UpdateField;
-use everruns_platform::{AuditEvent, ManagementAction, Organization};
+use everruns_platform::{
+    AuditEvent, ManagementAction, Organization, generate_org_public_id, validate_org_public_id,
+};
 
 use super::common::{
     ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, impl_auth_state,
@@ -1156,7 +1155,7 @@ mod tests {
     use crate::auth::routes::AuthConfigResponse;
     use axum::body::Body;
     use axum::http::Request;
-    use everruns_core::OrgMembership;
+    use everruns_platform::OrgMembership;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
     use uuid::Uuid;

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -865,7 +865,8 @@ mod tests {
     use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::Request;
-    use everruns_core::{OrgMembership, OrgRole};
+    use everruns_core::OrgRole;
+    use everruns_platform::OrgMembership;
     use tower::ServiceExt;
 
     use crate::auth::config::{AuthConfig, AuthMode, JwtConfig};

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -12,8 +12,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{DateTime, Utc};
-use everruns_core::validate_org_public_id;
-use everruns_platform::{AuditEvent, ManagementAction};
+use everruns_platform::{AuditEvent, ManagementAction, validate_org_public_id};
 
 use super::common::{ListResponse, impl_auth_state};
 use serde::{Deserialize, Serialize};

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -7,7 +7,8 @@
 
 use async_trait::async_trait;
 use axum::Router;
-use everruns_core::{OrgMembership, OrgRole, PlatformDefinition};
+use everruns_core::{OrgRole, PlatformDefinition};
+use everruns_platform::OrgMembership;
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -1531,7 +1531,7 @@ mod tests {
             roles: vec!["admin".to_string()],
             is_platform_user: false,
             auth_method: crate::auth::middleware::AuthMethod::Jwt,
-            organizations: vec![everruns_core::OrgMembership {
+            organizations: vec![everruns_platform::OrgMembership {
                 org_id: 42,
                 public_id: "org_test".to_string(),
                 name: "User Personal".to_string(),

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -9,9 +9,12 @@ use axum::{
 };
 use axum_extra::extract::CookieJar;
 use everruns_core::{
-    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, Caller, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, FeatureFlags, OrgMembership, OrgRole,
-    PermissionResolver, validate_org_public_id,
+    Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, FeatureFlags,
+    OrgRole, PermissionResolver,
+};
+use everruns_platform::{
+    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, OrgMembership,
+    validate_org_public_id,
 };
 use serde::Serialize;
 use std::sync::Arc;

--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -11,7 +11,8 @@ use super::types::{
 use super::{AGENT_IDENTITY_DANGEROUS, AGENT_IDENTITY_MANAGE, AGENT_IDENTITY_VIEW};
 use crate::domains::common::*;
 use crate::services::PrincipalService;
-use everruns_core::{AgentIdentity, AgentIdentityId, Policy, PrincipalStatus};
+use everruns_core::{AgentIdentity, AgentIdentityId, Policy};
+use everruns_platform::PrincipalStatus;
 use serde::Deserialize;
 use utoipa::ToSchema;
 

--- a/crates/server/src/domains/agent_triggers/commands.rs
+++ b/crates/server/src/domains/agent_triggers/commands.rs
@@ -1002,7 +1002,7 @@ async fn ensure_identity_for_agent(
     // is harmless: the orphan is an unreferenced, archivable row on a rare race.
     let _ = db.delete_agent_identity(org_id, new_id).await;
     let _ = principals
-        .sync_agent_identity_status(org_id, new_id, everruns_core::PrincipalStatus::Archived)
+        .sync_agent_identity_status(org_id, new_id, everruns_platform::PrincipalStatus::Archived)
         .await;
     let winner_principal = principals
         .default_owner_principal(&caller, Some(winner))

--- a/crates/server/src/domains/organizations/commands.rs
+++ b/crates/server/src/domains/organizations/commands.rs
@@ -2,7 +2,7 @@ use super::queries as q;
 use super::types::{ListOrganizationsResponse, OrganizationResponse, ResolveOrgResponse};
 use crate::domains::common::*;
 use crate::domains::org_resolver;
-use everruns_core::validate_org_public_id;
+use everruns_platform::validate_org_public_id;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -185,7 +185,8 @@ mod tests {
         .await
         .expect("create agent");
 
-        let ctx = Ctx::minimal_for_test(seed_caller(everruns_core::ANONYMOUS_USER_ID), db, None);
+        let ctx =
+            Ctx::minimal_for_test(seed_caller(everruns_platform::ANONYMOUS_USER_ID), db, None);
 
         let json =
             crate::domains::common::dispatch("resolve_org", json!({ "id": agent_public_id }), &ctx)
@@ -249,7 +250,8 @@ mod tests {
     #[tokio::test]
     async fn resolve_org_returns_not_found_for_unknown_prefix() {
         let db = Arc::new(StorageBackend::in_memory());
-        let ctx = Ctx::minimal_for_test(seed_caller(everruns_core::ANONYMOUS_USER_ID), db, None);
+        let ctx =
+            Ctx::minimal_for_test(seed_caller(everruns_platform::ANONYMOUS_USER_ID), db, None);
 
         let err = crate::domains::common::dispatch(
             "resolve_org",
@@ -285,7 +287,7 @@ mod tests {
             Caller {
                 org_id: DEFAULT_ORG_ID,
                 org_public_id: "org_00000000000000000000000000000001".to_string(),
-                user_id: Some(everruns_core::ANONYMOUS_USER_ID),
+                user_id: Some(everruns_platform::ANONYMOUS_USER_ID),
                 role: OrgRole::Owner,
                 is_platform_user: false,
                 is_internal: false,

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -14,9 +14,10 @@ use everruns_core::model_profiles::get_model_profile;
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::{AgentId, MessageId, SessionParticipantId, TurnId};
 use everruns_core::{
-    ANONYMOUS_USER_ID, Message, Session, SessionContextReport, SessionParticipant,
-    SessionParticipantKind, SessionParticipantRole, session_title_updated_event,
+    Message, Session, SessionContextReport, SessionParticipant, SessionParticipantKind,
+    SessionParticipantRole, session_title_updated_event,
 };
+use everruns_platform::ANONYMOUS_USER_ID;
 use serde::Deserialize;
 use std::str::FromStr;
 use utoipa::ToSchema;

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -1433,7 +1433,7 @@ impl SessionService {
         let mut hydration = SessionListHydration::default();
         for row in principal_rows {
             let principal = row_to_principal(row);
-            if principal.status != everruns_core::PrincipalStatus::Deleted {
+            if principal.status != everruns_platform::PrincipalStatus::Deleted {
                 hydration.owners.insert(principal.id, principal.summary());
             }
             if principal.kind == everruns_core::PrincipalKind::User
@@ -2988,7 +2988,7 @@ mod tests {
             .list(
                 &caller,
                 None,
-                Some(everruns_core::ANONYMOUS_USER_ID),
+                Some(everruns_platform::ANONYMOUS_USER_ID),
                 None,
                 Pagination {
                     limit: 1,
@@ -3005,7 +3005,7 @@ mod tests {
             .list(
                 &caller,
                 None,
-                Some(everruns_core::ANONYMOUS_USER_ID),
+                Some(everruns_platform::ANONYMOUS_USER_ID),
                 None,
                 Pagination {
                     limit: 20,
@@ -3073,7 +3073,7 @@ mod tests {
             .collect();
         db.get_session_previews(&legacy_ids).await.unwrap();
         db.get_session_output_previews(&legacy_ids).await.unwrap();
-        db.list_pinned_session_ids(everruns_core::ANONYMOUS_USER_ID, DEFAULT_ORG_ID)
+        db.list_pinned_session_ids(everruns_platform::ANONYMOUS_USER_ID, DEFAULT_ORG_ID)
             .await
             .unwrap();
         let legacy_elapsed = legacy_started.elapsed();
@@ -3085,7 +3085,7 @@ mod tests {
             .list(
                 &caller,
                 None,
-                Some(everruns_core::ANONYMOUS_USER_ID),
+                Some(everruns_platform::ANONYMOUS_USER_ID),
                 None,
                 Pagination {
                     limit: 20,
@@ -3215,7 +3215,7 @@ mod tests {
             .unwrap();
         }
         db.pin_session(
-            everruns_core::ANONYMOUS_USER_ID,
+            everruns_platform::ANONYMOUS_USER_ID,
             agent_session.id,
             DEFAULT_ORG_ID,
         )
@@ -3272,7 +3272,7 @@ mod tests {
             .list(
                 &caller,
                 None,
-                Some(everruns_core::ANONYMOUS_USER_ID),
+                Some(everruns_platform::ANONYMOUS_USER_ID),
                 None,
                 Pagination {
                     limit: 20,
@@ -3339,7 +3339,7 @@ mod tests {
             .list(
                 &caller,
                 None,
-                Some(everruns_core::ANONYMOUS_USER_ID),
+                Some(everruns_platform::ANONYMOUS_USER_ID),
                 None,
                 Pagination {
                     limit: 20,

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -16,10 +16,8 @@ use crate::storage::{
     },
     password::hash_password,
 };
-use everruns_core::{
-    ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, DeploymentGrade, PlatformDefinition,
-};
+use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DeploymentGrade, PlatformDefinition};
+use everruns_platform::{ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/server/src/services/principal.rs
+++ b/crates/server/src/services/principal.rs
@@ -5,11 +5,11 @@
 
 use anyhow::{Result, anyhow};
 use everruns_core::{
-    ANONYMOUS_USER_ID, Caller, ExternalActor, PrincipalId, PrincipalKind, PrincipalStatus,
-    PrincipalSummary, org_public_id_from_internal,
+    Caller, ExternalActor, PrincipalId, PrincipalKind, PrincipalSummary,
+    org_public_id_from_internal,
 };
 use everruns_durable::UpdateField;
-use everruns_platform::Principal;
+use everruns_platform::{ANONYMOUS_USER_ID, Principal, PrincipalStatus};
 use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -373,10 +373,8 @@ pub fn row_to_principal(row: PrincipalRow) -> Principal {
 mod tests {
     use super::*;
     use crate::storage::{CreateAgentIdentityRow, CreateUserRow, StorageBackend};
-    use everruns_core::{
-        ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, AgentIdentityId,
-        DEFAULT_ORG_ID,
-    };
+    use everruns_core::{AgentIdentityId, DEFAULT_ORG_ID};
+    use everruns_platform::{ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME};
 
     async fn create_user_with_principal(
         db: &Arc<StorageBackend>,

--- a/crates/server/tests/org_creation_test.rs
+++ b/crates/server/tests/org_creation_test.rs
@@ -312,7 +312,7 @@ async fn test_delete_organization() {
 
 #[test]
 fn test_validate_org_public_id() {
-    use everruns_core::validate_org_public_id;
+    use everruns_platform::validate_org_public_id;
 
     assert!(validate_org_public_id(
         "org_00000000000000000000000000000001"
@@ -333,7 +333,7 @@ fn test_validate_org_public_id() {
 
 #[test]
 fn test_generate_org_public_id_format() {
-    use everruns_core::{generate_org_public_id, validate_org_public_id};
+    use everruns_platform::{generate_org_public_id, validate_org_public_id};
 
     for _ in 0..10 {
         let id = generate_org_public_id();

--- a/knowledge/security/authentication.md
+++ b/knowledge/security/authentication.md
@@ -473,7 +473,7 @@ See `crates/server/migrations/001_base_schema.sql` for `users`, `personal_access
 
 #### Anonymous User (seeded at startup)
 
-For `auth=none` mode, a well-known anonymous user is seeded via `crates/server/src/seed.rs`. Constants in `crates/core/src/organization.rs`: `ANONYMOUS_USER_ID`, `ANONYMOUS_USER_EMAIL`, `ANONYMOUS_USER_NAME`. The anonymous user has admin role and belongs to the default organization.
+For `auth=none` mode, a well-known anonymous user is seeded via `crates/server/src/seed.rs`. Constants in `crates/platform/src/organization.rs`: `ANONYMOUS_USER_ID`, `ANONYMOUS_USER_EMAIL`, `ANONYMOUS_USER_NAME`. The anonymous user has admin role and belongs to the default organization.
 
 #### Default-Org Membership (single-tenant only)
 


### PR DESCRIPTION
## What changed
Finishes the core→platform identity migration (EVE-837/839/841) by moving the
remaining auth-facing identity values out of the default `everruns-core` surface
and into `everruns-platform`, so they can no longer be imported from
`everruns_core`:

- `OrgMembership`, the `ANONYMOUS_USER_ID/NAME/EMAIL` seed constants, and the org
  public-id generation/validation helpers (`generate_org_public_id`,
  `validate_org_public_id`) → `everruns-platform`'s organization module.
- `PrincipalStatus` → `everruns-platform`'s principal module, alongside the
  `Principal` aggregate whose lifecycle it describes.

`everruns-platform` now defines and re-exports these; `everruns-core` no longer
defines or re-exports them. All consumers (server auth/api/domains/services/
seed/tests) import the moved symbols from `everruns_platform`.

Intentionally **kept in core** because core turn/permissions/runtime code names
or embeds them (documented near the code):

- `OrgRole` — `permissions.rs` `Caller.role` / `role_has_permission` /
  `Rule::UserHasRole`; portable tool authorization consumed during a turn.
- `DEFAULT_ORG_ID` / `DEFAULT_ORG_PUBLIC_ID` and the internal↔public id
  conversion helpers `org_public_id_from_internal` / `org_internal_id_from_public`
  — used by permissions and the `knowledge_index` capability during a turn.
- `PrincipalKind` + `PrincipalSummary` — embedded in `Session` /
  `SessionSchedule` / `AgentIdentity`; their serialized JSON and OpenAPI shapes
  must stay byte-identical.

## Why
EVE-845 is the final step of the active core→platform migration. Carving the
backend identity family out of the default `everruns-core` keeps the
runtime-facing contract lean and preserves the strict `platform -> core`
dependency direction. The values that genuinely participate in a turn
(authorization role, id conversion, embedded principal summary) stay in core per
the migration's own scoping rule.

## Before / After
Pure crate-boundary refactor — no observable runtime behavior change.

- `everruns_core::OrgMembership` / `::ANONYMOUS_USER_*` / `::generate_org_public_id`
  / `::validate_org_public_id` / `::PrincipalStatus` no longer resolve; the same
  symbols now resolve via `everruns_platform::…`.
- OpenAPI export is byte-identical: `./scripts/export-openapi.sh` then
  `git diff --quiet docs/api/openapi.json` exits 0 (moving the `ToSchema` types
  `OrgMembership`/`PrincipalStatus` between crates keeps their schema names, so
  the generated spec is unchanged).

Evidence gathered (all green):
- `cargo build -p everruns-core --no-default-features`
- `cargo check --workspace --tests`
- `cargo test -p everruns-core --test no_platform_dependency --test no_platform_store_symbol`
- `cargo test -p everruns-core -p everruns-platform`
- `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/sync-publish-pin-versions.py --check`
- `bash scripts/lib/pre-push.sh` (all 10 checks)

## Risk
- Low
- Compile-time-only reshuffle of where identity value types live. The only ways
  this could break are a missed import (caught by `cargo check --workspace
  --tests`), a reversed dependency edge (caught by `no_platform_dependency`), or
  a changed serialized/OpenAPI shape (caught by the byte-identical OpenAPI
  export) — all verified green.

## Security
- Threat categories reviewed: TM-AUTHZ (authorization), TM-TENANT (tenancy),
  TM-AUTH (auth). The moved values are auth/identity-adjacent (`OrgMembership`,
  anonymous-user seed constants, org public-id validation, principal status).
- Findings and resolutions: none. This is pure code motion — the type/enum/const
  definitions and all validation logic are unchanged (e.g. `validate_org_public_id`
  and the `ANONYMOUS_USER_ID` value are moved verbatim). No trust boundary, auth
  check, or serialized shape is altered. The `THREAT[TM-AUTHZ-002]` marker in
  `permissions.rs::Caller::internal` is untouched and still holds (`OrgRole` and
  `org_public_id_from_internal` stay in core). No new threat surface; threat model
  unchanged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (moved the org public-id helper tests with the code; guard tests `no_platform_dependency` / `no_platform_store_symbol` stay green)
- [x] Backward compatibility considered (internal crate boundary; no public HTTP/OpenAPI change — byte-identical export)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Htj4yG8ekxiyQvVCvh6ADP)_