### PR TITLE
fix(ui): distinguish registry navigation icons

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -356,6 +356,17 @@ describe("Sidebar", () => {
     expect(settingsLink).toHaveAttribute("href", "/settings/organization");
   });
 
+  it("renders distinct semantic icons for registry navigation", () => {
+    render(<Sidebar />);
+
+    const icon = (name: string) => screen.getByRole("link", { name }).querySelector("svg");
+
+    expect(icon("Skills")).toHaveClass("lucide-book-open");
+    expect(icon("Capabilities")).toHaveClass("lucide-blocks");
+    expect(icon("Plugins")).toHaveClass("lucide-plug");
+    expect(icon("MCP servers")).toHaveAttribute("viewBox", "0 0 186 186");
+  });
+
   it("disables automatic viewport prefetch for every sidebar navigation link", () => {
     render(<Sidebar />);
 

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
+import { Blocks, BookOpen, Plug } from "lucide-react";
 import { useGlobalSearch } from "@/hooks/use-global-search";
 import type { OrganizationMembership } from "@/lib/api/types";
 
@@ -195,6 +196,18 @@ describe("useGlobalSearch", () => {
 
     expect(result.current).toContainEqual(
       expect.objectContaining({ category: "navigation", href }),
+    );
+  });
+
+  it.each([
+    ["skills", "/skills", BookOpen],
+    ["capabilities", "/capabilities", Blocks],
+    ["plugins", "/plugins", Plug],
+  ])("uses the semantic %s icon in navigation search", (query, href, icon) => {
+    const { result } = renderHook(() => useGlobalSearch(query));
+
+    expect(result.current).toContainEqual(
+      expect.objectContaining({ category: "navigation", href, icon }),
     );
   });
 

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -13,11 +13,12 @@ import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
-import { CircleOff, Bot, Layers, Plus, Pencil, Puzzle } from "lucide-react";
+import { CircleOff, Bot, Layers, Plus, Pencil } from "lucide-react";
 import { EntityCard } from "@/components/ui/entity-card";
 import { EntityIdentity } from "@/components/ui/entity-identity";
 import type { Capability, CapabilityStatus, DeclarativeCapability } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
+import { registryDomainIcons } from "@/lib/registry-navigation";
 import {
   localizedCapabilityDescription,
   localizedCapabilityName,
@@ -43,6 +44,8 @@ import { cn } from "@/lib/utils";
 
 const UNCATEGORIZED = "Uncategorized";
 type StatusTab = "all" | CapabilityStatus;
+
+const CapabilitiesIcon = registryDomainIcons.capabilities;
 
 function getStatusLabel(status: CapabilityStatus): string {
   switch (status) {
@@ -258,7 +261,7 @@ export default function CapabilitiesPage() {
       <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Capabilities" }]} />
 
       <PageMasthead
-        icon={<Puzzle />}
+        icon={<CapabilitiesIcon />}
         title="Capabilities"
         badges={
           <Badge variant="outline" className="font-mono">

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -73,11 +73,11 @@ import {
   RailSection,
   PageFooter,
 } from "@/components/layout";
-import { capabilityIconMap } from "@/lib/capability-icons";
+import { registryDomainIcons } from "@/lib/registry-navigation";
 import { pluralize } from "@/lib/formatting";
 import { EntityIdentity } from "@/components/ui/entity-identity";
 
-const McpIcon = capabilityIconMap.mcp;
+const McpIcon = registryDomainIcons.mcpServers;
 
 /** Human-readable label for the protocol-era policy. Undefined means `auto`. */
 function protocolModeLabel(mode?: McpProtocolMode): string {

--- a/apps/ui/src/app/(main)/plugins/page.tsx
+++ b/apps/ui/src/app/(main)/plugins/page.tsx
@@ -57,7 +57,6 @@ import {
 import { usePageTitle } from "@/hooks";
 import {
   Plus,
-  Puzzle,
   Package,
   Store,
   RefreshCw,
@@ -68,6 +67,7 @@ import {
   ChevronRight,
   Ellipsis,
 } from "lucide-react";
+import { registryDomainIcons } from "@/lib/registry-navigation";
 import { pluralize } from "@/lib/formatting";
 import type {
   Marketplace,
@@ -79,6 +79,8 @@ import type {
 // ============================================
 // Helpers
 // ============================================
+
+const PluginsIcon = registryDomainIcons.plugins;
 
 function truncateSha(sha: string | null | undefined): string {
   if (!sha) return "";
@@ -782,7 +784,7 @@ export default function PluginsPage() {
       <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Plugins" }]} />
 
       <PageMasthead
-        icon={<Puzzle />}
+        icon={<PluginsIcon />}
         title="Plugins"
         badges={
           <Badge variant="outline" className="font-mono">

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -26,7 +26,8 @@ import {
   useUploadSkill,
 } from "@/hooks/use-skills";
 import { usePolicies } from "@/hooks/use-policies";
-import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box } from "lucide-react";
+import { Plus, Trash2, Upload, FileText, Archive, Box } from "lucide-react";
+import { registryDomainIcons } from "@/lib/registry-navigation";
 import type { Skill, SkillUsage } from "@/lib/api/types";
 import {
   getDisplayName,
@@ -53,6 +54,8 @@ import {
 import { SkillUsageRow } from "@/components/skills/skill-usage-row";
 
 type StatusTab = "all" | "active" | "archived";
+
+const SkillsIcon = registryDomainIcons.skills;
 
 function SkillRow({
   skill,
@@ -314,7 +317,7 @@ export default function SkillsPageClient() {
       <PageBreadcrumb items={[{ label: "Building blocks" }, { label: "Skills" }]} />
 
       <PageMasthead
-        icon={<BookOpen />}
+        icon={<SkillsIcon />}
         title="Skills"
         badges={
           <Badge variant="outline" className="font-mono">
@@ -374,7 +377,7 @@ export default function SkillsPageClient() {
             }
             emptyState={
               <EmptyState
-                icon={<BookOpen />}
+                icon={<SkillsIcon />}
                 title={
                   search.trim() || statusTab !== "active"
                     ? "No skills match your filters."

--- a/apps/ui/src/components/capabilities/declarative-capability-form.tsx
+++ b/apps/ui/src/components/capabilities/declarative-capability-form.tsx
@@ -15,7 +15,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Pencil, Plus, Puzzle, Settings, Wrench, BookOpen, FileText } from "lucide-react";
+import { Pencil, Plus, Settings, Wrench, BookOpen, FileText } from "lucide-react";
+import { registryDomainIcons } from "@/lib/registry-navigation";
 import type { DeclarativeCapabilityDefinition } from "@/lib/api/types";
 import { useCreateDeclarativeCapability, useUpdateDeclarativeCapability } from "@/hooks";
 import { McpServersEditor } from "./mcp-servers-editor";
@@ -41,6 +42,7 @@ import {
 } from "@/components/layout";
 
 const FORM_ID = "capability-edit-form";
+const CapabilitiesIcon = registryDomainIcons.capabilities;
 
 function TabCount({ count }: { count: number }) {
   if (count === 0) return null;
@@ -141,7 +143,7 @@ export function DeclarativeCapabilityForm({
       />
 
       <PageMasthead
-        icon={<Puzzle />}
+        icon={<CapabilitiesIcon />}
         title={title}
         badges={
           <Badge variant="accent">

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -21,7 +21,6 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 import {
   Boxes,
-  BookOpen,
   Brain,
   Calendar,
   ChartColumn,
@@ -31,7 +30,6 @@ import {
   ListTodo,
   MessageCircle,
   MessageSquare,
-  Puzzle,
   Rocket,
   Search,
   Server,
@@ -41,10 +39,10 @@ import {
   UserRound,
   Workflow,
   Cog,
-  Cpu,
   Menu,
 } from "lucide-react";
-import { capabilityIconMap } from "@/lib/capability-icons";
+import type { IconComponent } from "@/lib/capability-icons";
+import { registryNavigationItems } from "@/lib/registry-navigation";
 import { useCommandPalette } from "@/hooks/use-command-palette";
 import { useProviders } from "@/hooks/use-providers";
 import { usePolicies } from "@/hooks/use-policies";
@@ -65,7 +63,7 @@ const { version } = packageJson;
 export type NavigationItem = {
   name: string;
   href: string;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
   activePrefix?: string;
   /** Set false to disable the shared hover/focus prefetch in addition to automatic prefetch. */
   prefetch?: boolean;
@@ -118,13 +116,9 @@ export const defaultBuildingNavigation: NavigationItem[] = [
   { name: "Apps", href: "/apps", icon: Rocket },
 ];
 
-export const defaultRegistriesNavigation: NavigationItem[] = [
-  { name: "Models", href: "/models", icon: Cpu },
-  { name: "MCP servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },
-  { name: "Skills", href: "/skills", icon: BookOpen },
-  { name: "Capabilities", href: "/capabilities", icon: Puzzle },
-  { name: "Plugins", href: "/plugins", icon: Puzzle },
-];
+export const defaultRegistriesNavigation: NavigationItem[] = registryNavigationItems.map(
+  ({ name, href, icon }) => ({ name, href, icon }),
+);
 
 export const defaultQualityNavigation: NavigationItem[] = [
   { name: "Evals", href: "/evals", icon: ClipboardCheck, flag: "evals", experimental: true },

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -28,18 +28,15 @@ import {
   Shield,
   Boxes,
   UserRound,
-  BookOpen,
-  Puzzle,
   Rocket,
   Settings,
   Cog,
-  Server,
   Workflow,
   ListTodo,
   Calendar,
   MessageCircle,
   FlaskConical,
-  Cpu,
+  Server,
   HardDrive,
   Building2,
   ChartColumn,
@@ -48,7 +45,12 @@ import {
   WalletCards,
   CircuitBoard,
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import type { IconComponent } from "@/lib/capability-icons";
+import {
+  registryDomainIcons,
+  registryNavigationByHref,
+  type RegistryNavigationItem,
+} from "@/lib/registry-navigation";
 import { useAgents } from "@/hooks/use-agents";
 import { useSessions } from "@/hooks/use-sessions";
 import { useHarnesses } from "@/hooks/use-harnesses";
@@ -91,7 +93,7 @@ export type SearchResultCategory =
 export interface SearchResult {
   id: string;
   category: SearchResultCategory;
-  icon: LucideIcon;
+  icon: IconComponent;
   title: string;
   /** Breadcrumb-style subtitle, e.g. "Agents > Daytona Coder" */
   subtitle?: string;
@@ -102,8 +104,17 @@ export interface SearchResult {
 interface NavigationPage {
   title: string;
   href: string;
-  icon: LucideIcon;
+  icon: IconComponent;
   keywords?: string[];
+}
+
+function registryPage(item: RegistryNavigationItem): NavigationPage {
+  return {
+    title: item.name,
+    href: item.href,
+    icon: item.icon,
+    keywords: item.keywords,
+  };
 }
 
 const NAVIGATION_PAGES: NavigationPage[] = [
@@ -149,12 +160,7 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     icon: Shield,
     keywords: ["template", "config"],
   },
-  {
-    title: "Skills",
-    href: "/skills",
-    icon: BookOpen,
-    keywords: ["ability", "tool"],
-  },
+  registryPage(registryNavigationByHref["/skills"]),
   {
     title: "Memory",
     href: "/memory",
@@ -167,19 +173,9 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     icon: Library,
     keywords: ["knowledge", "index", "search", "retrieval"],
   },
-  {
-    title: "Models",
-    href: "/models",
-    icon: Cpu,
-    keywords: ["llm", "openai", "anthropic", "default model"],
-  },
-  { title: "Capabilities", href: "/capabilities", icon: Puzzle },
-  {
-    title: "Plugins",
-    href: "/plugins",
-    icon: Puzzle,
-    keywords: ["marketplace", "extension", "integration"],
-  },
+  registryPage(registryNavigationByHref["/models"]),
+  registryPage(registryNavigationByHref["/capabilities"]),
+  registryPage(registryNavigationByHref["/plugins"]),
   {
     title: "Apps",
     href: "/apps",
@@ -198,12 +194,7 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     icon: Telescope,
     keywords: ["monitor", "score", "production eval"],
   },
-  {
-    title: "MCP Servers",
-    href: "/mcp-servers",
-    icon: Server,
-    keywords: ["mcp", "tool", "integration"],
-  },
+  registryPage(registryNavigationByHref["/mcp-servers"]),
   {
     title: "Settings",
     href: "/settings",
@@ -571,7 +562,7 @@ export function useGlobalSearch(query: string) {
         results.push({
           id: `skill:${skill.id}`,
           category: "skill",
-          icon: BookOpen,
+          icon: registryDomainIcons.skills,
           title: skill.name,
           subtitle: `Skills > ${skill.name}`,
           href: `/skills/${skill.id}`,
@@ -588,7 +579,7 @@ export function useGlobalSearch(query: string) {
         results.push({
           id: `mcp:${server.id}`,
           category: "mcp_server",
-          icon: Server,
+          icon: registryDomainIcons.mcpServers,
           title: server.name,
           subtitle: `MCP Servers > ${server.name}`,
           href: `/mcp-servers`,
@@ -622,7 +613,7 @@ export function useGlobalSearch(query: string) {
         results.push({
           id: `capability:${capability.id}`,
           category: "capability",
-          icon: Puzzle,
+          icon: registryDomainIcons.capabilities,
           title: capabilityName,
           subtitle: `Capabilities > ${capabilityName}`,
           href: `/capabilities/${capability.id}`,
@@ -649,7 +640,7 @@ export function useGlobalSearch(query: string) {
         results.push({
           id: `declarative-capability:${capability.id}`,
           category: "capability",
-          icon: Puzzle,
+          icon: registryDomainIcons.capabilities,
           title,
           subtitle: `Capabilities > ${capability.capability_id}`,
           href: "/capabilities",
@@ -756,7 +747,7 @@ export function useGlobalSearch(query: string) {
         results.push({
           id: `plugin:${plugin.id}`,
           category: "plugin",
-          icon: Puzzle,
+          icon: registryDomainIcons.plugins,
           title,
           subtitle: `Plugins > ${title}`,
           href: "/plugins",

--- a/apps/ui/src/lib/capability-icons.tsx
+++ b/apps/ui/src/lib/capability-icons.tsx
@@ -33,7 +33,7 @@ import {
  * Icon component type that accepts both LucideIcon and custom SVG forwardRef components.
  * Avoids `as unknown as LucideIcon` double casts for custom icons.
  */
-type IconComponent =
+export type IconComponent =
   | LucideIcon
   | ForwardRefExoticComponent<SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>>;
 

--- a/apps/ui/src/lib/registry-navigation.ts
+++ b/apps/ui/src/lib/registry-navigation.ts
@@ -1,0 +1,51 @@
+import { Blocks, BookOpen, Cpu, Plug } from "lucide-react";
+import { capabilityIconMap, type IconComponent } from "@/lib/capability-icons";
+
+export interface RegistryNavigationItem {
+  name: string;
+  href: string;
+  icon: IconComponent;
+  keywords?: string[];
+}
+
+export const registryDomainIcons = {
+  models: Cpu,
+  mcpServers: capabilityIconMap.mcp,
+  skills: BookOpen,
+  capabilities: Blocks,
+  plugins: Plug,
+} satisfies Record<string, IconComponent>;
+
+export const registryNavigationByHref = {
+  "/models": {
+    name: "Models",
+    href: "/models",
+    icon: registryDomainIcons.models,
+    keywords: ["llm", "openai", "anthropic", "default model"],
+  },
+  "/mcp-servers": {
+    name: "MCP servers",
+    href: "/mcp-servers",
+    icon: registryDomainIcons.mcpServers,
+    keywords: ["mcp", "tool", "integration"],
+  },
+  "/skills": {
+    name: "Skills",
+    href: "/skills",
+    icon: registryDomainIcons.skills,
+    keywords: ["ability", "tool"],
+  },
+  "/capabilities": {
+    name: "Capabilities",
+    href: "/capabilities",
+    icon: registryDomainIcons.capabilities,
+  },
+  "/plugins": {
+    name: "Plugins",
+    href: "/plugins",
+    icon: registryDomainIcons.plugins,
+    keywords: ["marketplace", "extension", "integration"],
+  },
+} satisfies Record<string, RegistryNavigationItem>;
+
+export const registryNavigationItems = Object.values(registryNavigationByHref);

--- a/test_cases/ui/navigation_icons/TC001_registry_icon_mapping.md
+++ b/test_cases/ui/navigation_icons/TC001_registry_icon_mapping.md
@@ -1,0 +1,35 @@
+# TC001: Registry navigation icon mapping
+
+## Description
+
+Verify registry domains use distinct semantic icons consistently across desktop navigation, the
+responsive drawer, page mastheads, and command search.
+
+## Preconditions
+
+- Everruns is running on the full DB-backed stack with authentication disabled.
+
+## Test Data
+
+| Domain | Expected icon |
+|---|---|
+| Skills | Book |
+| Capabilities | Blocks |
+| Plugins | Plug |
+| MCP servers | MCP glyph |
+
+## Steps
+
+1. At a desktop viewport, open `/skills` and inspect the Registries section of the left navigation.
+2. Confirm Skills, Capabilities, Plugins, and MCP servers use the expected distinct icons.
+3. Open `/capabilities`, `/plugins`, and `/mcp-servers`; confirm each masthead matches its navigation icon.
+4. Open command search and query each registry domain; confirm page and entity results use the same icon.
+5. At a narrow viewport, open the navigation drawer and repeat the icon check.
+6. Close and reopen the drawer; confirm icon sizing, alignment, active state, accessible names, and drawer behavior are unchanged.
+
+## Expected Result
+
+- Skills uses the book icon, Capabilities uses blocks, Plugins uses a plug, and MCP servers retains
+  its custom MCP glyph everywhere the registry domains are represented.
+- All four entries remain visually distinct at desktop and narrow widths.
+- Navigation sizing, alignment, active states, accessible labels, and responsive behavior are unchanged.


### PR DESCRIPTION
## What changed

Registry domains now use distinct semantic icons everywhere they are represented: Skills keeps the book, Capabilities uses Blocks, Plugins uses Plug, and MCP servers retains its custom glyph. A shared registry mapping drives the desktop/sidebar drawer, command search, entity search results, and matching page mastheads so those surfaces cannot drift independently.

Focused unit coverage and a manual responsive test case protect the mapping.

## Why

Capabilities and Plugins both used the puzzle-piece icon in adjacent registry navigation entries, making them visually indistinguishable.

## Before / After

Before: Capabilities and Plugins both rendered the puzzle-piece glyph in the left navigation and command search.

After: Capabilities renders Blocks and Plugins renders Plug; Skills and MCP servers remain distinct. Desktop, command-search, and 375 × 900 responsive-drawer screenshots were captured during the manual smoke test and retained out-of-tree (not committed).

Manual smoke test: PASS on the canonical DB-backed stack (`PORT_PREFIX=492`, `AUTH_MODE=none`) across `/skills`, `/capabilities`, `/plugins`, `/mcp-servers`, command search, and the responsive drawer close/reopen cycle.

## Risk

- Low
- Limited to static icon component selection and shared navigation/search configuration. Navigation sizing, stroke weight, active states, accessible names, hrefs, and behavior are unchanged.

## Security

- Threat categories reviewed: TM-WEB
- Findings and resolutions: No findings. The change selects static existing icon components and does not alter user-controlled markup, URLs, authentication, authorization, storage, API calls, secrets, dependencies, or resource bounds. No threat-model update is required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
