### PR TITLE
fix(security): gate machine-payment custody surfaces

### DIFF
--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -14,15 +14,55 @@ jest.mock("next/link", () => ({
   ),
 }));
 
-// Mock next/navigation
 const mockPathname = jest.fn();
+const mockMachinePaymentsEnabled = jest.fn(() => true);
+jest.mock("@/providers/feature-flags-provider", () => ({
+  useFeatureFlagsState: () => ({
+    flags: { machine_payments: mockMachinePaymentsEnabled() },
+    isLoading: false,
+  }),
+}));
+
+const mockNotFound = jest.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
 jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname(),
+  notFound: () => mockNotFound(),
 }));
 
 describe("SettingsLayout", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/settings/providers");
+    mockMachinePaymentsEnabled.mockReturnValue(true);
+    mockNotFound.mockClear();
+  });
+
+  it("hides Payments navigation when machine payments are disabled", () => {
+    mockMachinePaymentsEnabled.mockReturnValue(false);
+
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    expect(screen.queryByRole("link", { name: /Payments/i })).not.toBeInTheDocument();
+  });
+
+  it("returns not found for the Payments page when machine payments are disabled", () => {
+    mockPathname.mockReturnValue("/settings/payments");
+    mockMachinePaymentsEnabled.mockReturnValue(false);
+
+    expect(() =>
+      render(
+        <SettingsLayout>
+          <div>Payment custody form</div>
+        </SettingsLayout>,
+      ),
+    ).toThrow("NEXT_NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+    expect(screen.queryByText("Payment custody form")).not.toBeInTheDocument();
   });
 
   it("renders the Settings header", () => {

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -103,6 +103,7 @@ const mockFeatureFlags = {
   knowledge: true,
   plugins: true,
   observers: true,
+  machine_payments: true,
 };
 jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => mockFeatureFlags,
@@ -148,6 +149,7 @@ describe("useGlobalSearch", () => {
       knowledge: true,
       plugins: true,
       observers: true,
+      machine_payments: true,
     });
   });
 
@@ -242,6 +244,14 @@ describe("useGlobalSearch", () => {
     expect(result.current).toContainEqual(
       expect.objectContaining({ category: "navigation", href }),
     );
+  });
+
+  it("hides Payments navigation when machine payments are disabled", () => {
+    mockFeatureFlags.machine_payments = false;
+
+    const { result } = renderHook(() => useGlobalSearch("payments"));
+
+    expect(result.current.some((item) => item.href === "/settings/payments")).toBe(false);
   });
 
   it.each([

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { notFound, usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { IconTile } from "@/components/layout/page-layout";
 import {
@@ -15,6 +15,7 @@ import {
   FlaskConical,
   Settings as SettingsIcon,
 } from "lucide-react";
+import { useFeatureFlagsState } from "@/providers/feature-flags-provider";
 
 interface NavItem {
   name: string;
@@ -95,6 +96,16 @@ interface SettingsLayoutProps {
 
 export default function SettingsLayout({ children }: SettingsLayoutProps) {
   const pathname = usePathname();
+  const { flags, isLoading: featureFlagsLoading } = useFeatureFlagsState();
+  const machinePaymentsEnabled = flags.machine_payments;
+
+  if (
+    !featureFlagsLoading &&
+    !machinePaymentsEnabled &&
+    pathname.startsWith("/settings/payments")
+  ) {
+    notFound();
+  }
 
   return (
     <div className="flex h-full flex-col">
@@ -117,27 +128,29 @@ export default function SettingsLayout({ children }: SettingsLayoutProps) {
                   {section.label}
                 </div>
                 <div className="grid gap-1 sm:grid-cols-2 lg:block lg:space-y-1">
-                  {section.items.map((item) => {
-                    const isActive = pathname === item.href;
-                    return (
-                      <Link
-                        key={item.name}
-                        href={item.href}
-                        prefetch={false}
-                        className={cn(
-                          "flex items-center gap-3 px-3 py-2 text-sm transition-colors border-l-2",
-                          isActive
-                            ? "bg-accent/10 text-accent-foreground border-accent"
-                            : "text-muted-foreground hover:bg-muted hover:text-foreground border-transparent",
-                        )}
-                      >
-                        <item.icon className="h-4 w-4" />
-                        <div>
-                          <div className="font-medium">{item.name}</div>
-                        </div>
-                      </Link>
-                    );
-                  })}
+                  {section.items
+                    .filter((item) => item.href !== "/settings/payments" || machinePaymentsEnabled)
+                    .map((item) => {
+                      const isActive = pathname === item.href;
+                      return (
+                        <Link
+                          key={item.name}
+                          href={item.href}
+                          prefetch={false}
+                          className={cn(
+                            "flex items-center gap-3 px-3 py-2 text-sm transition-colors border-l-2",
+                            isActive
+                              ? "bg-accent/10 text-accent-foreground border-accent"
+                              : "text-muted-foreground hover:bg-muted hover:text-foreground border-transparent",
+                          )}
+                        >
+                          <item.icon className="h-4 w-4" />
+                          <div>
+                            <div className="font-medium">{item.name}</div>
+                          </div>
+                        </Link>
+                      );
+                    })}
                 </div>
               </div>
             ))}

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -264,6 +264,7 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     href: "/settings/payments",
     icon: WalletCards,
     keywords: ["wallet", "spend", "billing"],
+    flag: "machine_payments",
   },
   {
     title: "Durable Execution",

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -812,6 +812,8 @@ export interface FeatureFlags {
   public_chat: boolean;
   /** Browser-native tools exposed by the authenticated Everruns UI. Experimental. */
   webmcp: boolean;
+  /** Machine-payment custody, policy, audit, and paid capability surfaces. */
+  machine_payments: boolean;
 }
 
 export interface OrgFeatureFlagSetting {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -27,6 +27,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   observers: false,
   public_chat: false,
   webmcp: false,
+  machine_payments: false,
 };
 
 export interface FeatureFlagsContextValue {
@@ -70,11 +71,15 @@ export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
 }
 
 export function useFeatureFlags(): FeatureFlags {
+  return useFeatureFlagsState().flags;
+}
+
+export function useFeatureFlagsState(): FeatureFlagsContextValue {
   const context = useContext(FeatureFlagsContext);
   if (context === undefined) {
-    throw new Error("useFeatureFlags must be used within a FeatureFlagsProvider");
+    throw new Error("feature flag hooks must be used within a FeatureFlagsProvider");
   }
-  return context.flags;
+  return context;
 }
 
 export function useFeatureFlag(flag: keyof FeatureFlags): boolean {

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -63,8 +63,8 @@ use std::sync::Arc;
 pub struct IntegrationPlugin {
     /// If true, only registered when `DeploymentGrade::experimental_features_enabled()` is true.
     pub experimental_only: bool,
-    /// If set, only registered when the named internal feature flag is enabled.
-    /// Checked via `InternalFeatureFlags::is_enabled()` at registry build time.
+    /// If set, only registered when the named deployment feature flag is enabled.
+    /// Both API-visible and internal flag catalogs are checked at registry build time.
     pub feature_flag: Option<&'static str>,
     /// Factory function that creates the capability instance.
     pub factory: fn() -> Box<dyn Capability>,
@@ -1558,6 +1558,7 @@ impl CapabilityRegistry {
 
         // External integration plugins (registered via inventory::submit! in integration crates)
         let internal_flags = crate::InternalFeatureFlags::from_env();
+        let feature_flags = crate::FeatureFlags::from_env(&grade);
         if internal_flags.session_sandbox {
             registry.register(SessionSandboxCapability);
         }
@@ -1575,7 +1576,7 @@ impl CapabilityRegistry {
             if (!plugin.experimental_only || grade.experimental_features_enabled())
                 && plugin
                     .feature_flag
-                    .is_none_or(|f| internal_flags.is_enabled(f))
+                    .is_none_or(|f| internal_flags.is_enabled(f) || feature_flags.is_enabled(f))
             {
                 registry.register_boxed((plugin.factory)());
             }

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -65,6 +65,10 @@ pub struct FeatureFlags {
     /// Experimental remote-control surface; requires deployment enablement and
     /// per-org opt-in. See `knowledge/ui/webmcp.md`.
     pub webmcp: bool,
+    /// Machine-payment custody, policy, audit, and paid capability surfaces.
+    /// Deployment-controlled and off by default on every grade because spend is
+    /// irreversible. Unlike experimental flags, this is not org-configurable.
+    pub machine_payments: bool,
 }
 
 /// Untyped API representation of feature flags: a generic `{ "<flag>": bool }` map.
@@ -103,7 +107,8 @@ pub struct FeatureFlagDefinition {
     pub experimental: bool,
 }
 
-/// All API-visible flags that organizations may opt into when the deployment allows them.
+/// API-visible flags that organizations may opt into when the deployment allows them.
+/// Deployment-only UI gates such as `machine_payments` intentionally stay out of this catalog.
 pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
     FeatureFlagDefinition {
         name: "global_chat",
@@ -205,7 +210,8 @@ pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
 ];
 
 impl FeatureFlags {
-    /// Effective flags for an organization: deployment/system gates AND explicit org opt-in.
+    /// Effective flags for an organization: org-configurable deployment/system gates AND
+    /// explicit org opt-in, plus deployment-only UI gates unchanged.
     ///
     /// Org overrides default to disabled; a flag is on only when the deployment allows it
     /// and the org has opted in (`enabled: true` in storage).
@@ -228,6 +234,7 @@ impl FeatureFlags {
             observers: opt_in("observers", system.observers),
             public_chat: opt_in("public_chat", system.public_chat),
             webmcp: opt_in("webmcp", system.webmcp),
+            machine_payments: system.machine_payments,
         }
     }
 
@@ -248,6 +255,7 @@ impl FeatureFlags {
             observers: experimental_flag("FEATURE_OBSERVERS", grade),
             public_chat: experimental_flag("FEATURE_PUBLIC_CHAT", grade),
             webmcp: experimental_flag("FEATURE_WEBMCP", grade),
+            machine_payments: standard_flag("FEATURE_MACHINE_PAYMENTS", false),
         }
     }
 
@@ -279,6 +287,7 @@ impl FeatureFlags {
             ("observers".to_string(), self.observers),
             ("public_chat".to_string(), self.public_chat),
             ("webmcp".to_string(), self.webmcp),
+            ("machine_payments".to_string(), self.machine_payments),
         ]))
     }
 
@@ -299,6 +308,7 @@ impl FeatureFlags {
             "observers" => self.observers,
             "public_chat" => self.public_chat,
             "webmcp" => self.webmcp,
+            "machine_payments" => self.machine_payments,
             _ => false,
         }
     }
@@ -321,6 +331,7 @@ impl FeatureFlags {
             observers: true,
             public_chat: true,
             webmcp: true,
+            machine_payments: true,
         }
     }
 }
@@ -342,11 +353,6 @@ pub struct InternalFeatureFlags {
     /// Managed session-owned sandbox capability and lifecycle orchestration.
     /// Experimental and disabled by default.
     pub session_sandbox: bool,
-    /// Machine-payment capabilities (e.g. the Parallel paid search/extract/task
-    /// capability). Gates registration of any capability that spends real money
-    /// through `PaymentAuthority`. Disabled by default on all envs, including dev,
-    /// because spend is irreversible. Enable via `FEATURE_MACHINE_PAYMENTS=true`.
-    pub machine_payments: bool,
     /// Experimental sandboxed Lua execution capability (`knowledge/execution/lua-execution.md`).
     /// Disabled by default; requires the `lua` cargo feature to be compiled in to
     /// actually run scripts. Enable via `FEATURE_LUA=true`.
@@ -362,7 +368,6 @@ impl InternalFeatureFlags {
             docker_capability,
             container_sandbox: standard_flag("FEATURE_CONTAINER_SANDBOX", docker_capability),
             session_sandbox: standard_flag("FEATURE_SESSION_SANDBOX", false),
-            machine_payments: standard_flag("FEATURE_MACHINE_PAYMENTS", false),
             lua: standard_flag("FEATURE_LUA", false),
         }
     }
@@ -373,7 +378,6 @@ impl InternalFeatureFlags {
             "docker_capability" => self.docker_capability,
             "container_sandbox" => self.container_sandbox,
             "session_sandbox" => self.session_sandbox,
-            "machine_payments" => self.machine_payments,
             "lua" => self.lua,
             _ => false,
         }
@@ -483,6 +487,7 @@ mod tests {
             observers: true,
             public_chat: true,
             webmcp: true,
+            machine_payments: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("notifications"));
@@ -502,6 +507,7 @@ mod tests {
             "MCP is a product surface, not a feature flag"
         );
         assert!(flags.is_enabled("webmcp"));
+        assert!(flags.is_enabled("machine_payments"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -522,6 +528,7 @@ mod tests {
             observers: true,
             public_chat: true,
             webmcp: true,
+            machine_payments: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
@@ -532,6 +539,7 @@ mod tests {
         assert!(json.contains("\"agent_delegation\":true"));
         assert!(json.contains("\"observers\":true"));
         assert!(json.contains("\"webmcp\":true"));
+        assert!(json.contains("\"machine_payments\":true"));
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
         assert_eq!(flags, parsed);
@@ -622,6 +630,7 @@ mod tests {
         let system = FeatureFlags {
             global_chat: true,
             evals: true,
+            machine_payments: true,
             ..FeatureFlags::default()
         };
         let mut org = std::collections::HashMap::new();
@@ -629,9 +638,11 @@ mod tests {
         let effective = FeatureFlags::for_org(&system, &org);
         assert!(effective.global_chat);
         assert!(!effective.evals);
+        assert!(effective.machine_payments);
 
         let effective_none = FeatureFlags::for_org(&system, &std::collections::HashMap::new());
         assert!(!effective_none.global_chat);
+        assert!(effective_none.machine_payments);
     }
 
     #[test]
@@ -684,6 +695,29 @@ mod tests {
         unsafe { std::env::remove_var("FEATURE_NOTIFICATIONS") };
     }
 
+    #[test]
+    fn test_machine_payments_disabled_by_default() {
+        let _lock = lock_env();
+        let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
+        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
+        assert!(
+            !flags.machine_payments,
+            "machine_payments should be disabled by default on all envs"
+        );
+        restore_env("FEATURE_MACHINE_PAYMENTS", prev);
+    }
+
+    #[test]
+    fn test_machine_payments_enabled_by_env_override() {
+        let _lock = lock_env();
+        let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
+        unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
+        assert!(flags.machine_payments);
+        restore_env("FEATURE_MACHINE_PAYMENTS", prev);
+    }
+
     // =========================================================================
     // InternalFeatureFlags tests
     // =========================================================================
@@ -694,7 +728,6 @@ mod tests {
         assert!(!flags.docker_capability);
         assert!(!flags.container_sandbox);
         assert!(!flags.session_sandbox);
-        assert!(!flags.machine_payments);
     }
 
     #[test]
@@ -743,38 +776,13 @@ mod tests {
             docker_capability: true,
             container_sandbox: true,
             session_sandbox: true,
-            machine_payments: true,
             lua: true,
         };
         assert!(flags.is_enabled("docker_capability"));
         assert!(flags.is_enabled("container_sandbox"));
         assert!(flags.is_enabled("session_sandbox"));
-        assert!(flags.is_enabled("machine_payments"));
         assert!(flags.is_enabled("lua"));
         assert!(!flags.is_enabled("nonexistent"));
-    }
-
-    #[test]
-    fn test_machine_payments_disabled_by_default() {
-        let _lock = lock_env();
-        let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
-        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
-        let flags = InternalFeatureFlags::from_env();
-        assert!(
-            !flags.machine_payments,
-            "machine_payments should be disabled by default on all envs"
-        );
-        restore_env("FEATURE_MACHINE_PAYMENTS", prev);
-    }
-
-    #[test]
-    fn test_machine_payments_enabled_by_env_override() {
-        let _lock = lock_env();
-        let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
-        unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
-        let flags = InternalFeatureFlags::from_env();
-        assert!(flags.machine_payments);
-        restore_env("FEATURE_MACHINE_PAYMENTS", prev);
     }
 
     #[test]

--- a/crates/server/src/api/payments.rs
+++ b/crates/server/src/api/payments.rs
@@ -59,7 +59,13 @@ impl AppState {
 
 impl_auth_state!(AppState);
 
-pub fn routes(state: AppState) -> Router {
+pub fn routes(state: AppState, machine_payments_enabled: bool) -> Router {
+    // THREAT[TM-CRYPTO-008]: Do not expose wallet-custody or spending-policy APIs when
+    // machine payments are disabled, even though their handlers remain compiled in.
+    if !machine_payments_enabled {
+        return Router::new();
+    }
+
     Router::new()
         .route(
             "/v1/payments/accounts",
@@ -371,16 +377,19 @@ mod tests {
     use serde_json::json;
     use tower::ServiceExt;
 
-    fn test_app() -> Router {
+    fn test_app(machine_payments_enabled: bool) -> Router {
         let db = Arc::new(StorageBackend::in_memory());
         let encryption =
             EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
                 .unwrap();
-        routes(AppState::new(
-            db.clone(),
-            Some(Arc::new(encryption)),
-            AuthState::builtin(AuthConfig::default(), db),
-        ))
+        routes(
+            AppState::new(
+                db.clone(),
+                Some(Arc::new(encryption)),
+                AuthState::builtin(AuthConfig::default(), db),
+            ),
+            machine_payments_enabled,
+        )
     }
 
     fn request(method: Method, uri: &str, body: serde_json::Value) -> Request<Body> {
@@ -419,7 +428,7 @@ mod tests {
 
     #[tokio::test]
     async fn account_routes_support_list_get_and_uuid_paths() {
-        let app = test_app();
+        let app = test_app(true);
         let account = create_test_account(app.clone()).await;
 
         let response = app
@@ -461,7 +470,7 @@ mod tests {
 
     #[tokio::test]
     async fn policy_routes_support_get_uuid_paths_and_missing_disable_404() {
-        let app = test_app();
+        let app = test_app(true);
         let account = create_test_account(app.clone()).await;
 
         let response = app
@@ -506,5 +515,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn payment_routes_are_not_mounted_when_machine_payments_are_disabled() {
+        let app = test_app(false);
+        let account_id = uuid::Uuid::now_v7();
+        let policy_id = uuid::Uuid::now_v7();
+        let routes = [
+            (Method::GET, "/v1/payments/accounts".to_string()),
+            (Method::POST, "/v1/payments/accounts".to_string()),
+            (Method::GET, format!("/v1/payments/accounts/{account_id}")),
+            (Method::PATCH, format!("/v1/payments/accounts/{account_id}")),
+            (
+                Method::DELETE,
+                format!("/v1/payments/accounts/{account_id}"),
+            ),
+            (Method::GET, "/v1/payments/policies".to_string()),
+            (Method::POST, "/v1/payments/policies".to_string()),
+            (Method::GET, format!("/v1/payments/policies/{policy_id}")),
+            (Method::PATCH, format!("/v1/payments/policies/{policy_id}")),
+            (Method::DELETE, format!("/v1/payments/policies/{policy_id}")),
+            (Method::GET, "/v1/payments/attempts".to_string()),
+        ];
+
+        for (method, uri) in routes {
+            let response = app
+                .clone()
+                .oneshot(request(method, &uri, serde_json::Value::Null))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{uri}");
+        }
     }
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1540,7 +1540,10 @@ impl ServerAppBuilder {
             .merge(api::memory_files::routes(memory_files_state))
             .merge(api::knowledge_bases::routes(knowledge_bases_state))
             .merge(api::knowledge_indexes::routes(knowledge_indexes_state))
-            .merge(api::payments::routes(payments_state))
+            .merge(api::payments::routes(
+                payments_state,
+                feature_flags.machine_payments,
+            ))
             .merge(api::reporting::routes(reporting_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::user_preferences::routes(

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -127,6 +127,7 @@ async fn test_feature_flags_endpoint() {
     assert!(body.get("global_chat").is_some());
     assert!(body.get("notifications").is_some());
     assert!(body.get("mcp_endpoint").is_none());
+    assert_eq!(body["machine_payments"], Value::Bool(false));
     // In test env (DEV_MODE=true), experimental flags are enabled
     assert!(body["global_chat"].is_boolean());
     assert_eq!(body["notifications"], Value::Bool(false));
@@ -172,6 +173,10 @@ async fn test_org_feature_flags_opt_in() {
         .json();
     assert_eq!(effective["notifications"], serde_json::Value::Bool(false));
     assert!(effective.get("mcp_endpoint").is_none());
+    assert_eq!(
+        effective["machine_payments"],
+        serde_json::Value::Bool(false)
+    );
 
     server
         .patch(

--- a/docs/integrations/parallel.md
+++ b/docs/integrations/parallel.md
@@ -25,3 +25,11 @@ To use Parallel's OAuth-compatible MCP endpoint, configure the capability with `
 | `mcp_parallel__web_fetch` | Fetch and extract focused content from known URLs. |
 
 Agents should reuse one stable `session_id` across Parallel tool calls in the same conversation.
+
+## Paid machine payments
+
+Operators can separately enable Parallel's paid search, extraction, and task tools with
+`FEATURE_MACHINE_PAYMENTS=true`. This deployment flag is off by default in every environment.
+When it is off, Everruns does not expose Settings > Payments or the payment account, policy, and
+attempt APIs, so the deployment does not ask organization owners to entrust wallet keys for a
+capability that cannot spend.

--- a/integrations/parallel/SPEC.md
+++ b/integrations/parallel/SPEC.md
@@ -6,7 +6,7 @@ This crate hosts two independent Parallel capabilities. They share only the vend
   server for web search/fetch. Experimental (dev-only).
 - `parallel` — **paid**, payment-backed. Implements in-process search/extract/task tools
   that spend real money through the core `PaymentAuthority`. Gated by the
-  `machine_payments` internal feature flag (off by default everywhere).
+  deployment-controlled `machine_payments` feature flag (off by default everywhere).
 
 The two have opposite trust models and share no code. Core owns the payment trust
 boundary (`PaymentAuthority`, payment DTOs, `ToolContext`); this crate owns only the
@@ -49,7 +49,7 @@ for the trust boundary and rails.
 The paid tools never sign or submit payments themselves: they build a typed
 `MachinePaymentRequest` and call `ToolContext.payment_authority`. With no authority wired
 (the default), they fail closed. The capability is registered only when the
-`machine_payments` internal feature flag is on (`FEATURE_MACHINE_PAYMENTS=true`), off by
+`machine_payments` feature flag is on (`FEATURE_MACHINE_PAYMENTS=true`), off by
 default on every grade including dev because spend is irreversible.
 
 ## Tests

--- a/integrations/parallel/src/lib.rs
+++ b/integrations/parallel/src/lib.rs
@@ -46,7 +46,7 @@ inventory::submit! {
 }
 
 // Paid Parallel tools route spend through the core `PaymentAuthority`. Gated by
-// the `machine_payments` internal feature flag (off by default on all envs,
+// the deployment-controlled `machine_payments` feature flag (off by default on all envs,
 // including dev, because spend is irreversible) rather than the experimental
 // grade gate, so it can be enabled deliberately in any environment.
 inventory::submit! {

--- a/knowledge/security/machine-payments.md
+++ b/knowledge/security/machine-payments.md
@@ -106,7 +106,7 @@ Unattended work must not silently spend a human user's wallet.
 The `parallel` capability is the first machine-payment consumer. Core owns only the
 trust-boundary primitive (`PaymentAuthority`, payment DTOs, `ToolContext`); the
 vendor-specific paid adapter lives in the `integrations/parallel` crate and is
-registered as an integration plugin gated by the `machine_payments` internal feature
+registered as an integration plugin gated by the deployment-controlled `machine_payments` feature
 flag. It contributes:
 - `parallel_search`
 - `parallel_extract`
@@ -144,17 +144,20 @@ Threat model entries:
 Current mitigations include no generic paid HTTP tool, capability and host
 allowlists, per-request caps, encrypted wallet custody, control-plane-only
 signing, no worker key exposure, and durable attempt records. Registration of any
-money-spending capability is itself gated by the `machine_payments` feature flag, so
-spend tools are never offered by default. Budget reservations, per-turn/day
+money-spending capability, wallet custody UI, and payment account/policy/attempt API is
+itself gated by the `machine_payments` feature flag. When disabled, the UI is hidden and
+the API routes are not mounted, so a deployment that cannot spend does not collect wallet
+keys. Budget reservations, per-turn/day
 enforcement, and idempotency-key settlement hardening remain follow-ups.
 
 ## Rollout
 
-Feature flag: `FEATURE_MACHINE_PAYMENTS` (the `machine_payments` `InternalFeatureFlags`
-field). It is a standard flag, off by default on every grade including dev because spend
-is irreversible; set `FEATURE_MACHINE_PAYMENTS=true` to deliberately enable. The flag
-gates registration of machine-payment capabilities (currently the `parallel` integration
-plugin).
+Feature flag: `FEATURE_MACHINE_PAYMENTS` (the deployment-only, API-visible
+`machine_payments` feature flag). It is off by default on every grade including dev because
+spend is irreversible; set `FEATURE_MACHINE_PAYMENTS=true` to deliberately enable. It is
+reported by the feature-flags API so the UI can remove the custody surface, but it is not an
+organization opt-in. The flag gates machine-payment capabilities (currently the `parallel`
+integration plugin), payment account/policy/attempt APIs, and Settings > Payments.
 
 Recommended sequence:
 1. Payment DTOs, account/policy/attempt APIs, and UI.

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -167,7 +167,7 @@ Display:   evr_pat_<first-8-chars>...      (prefix for identification)
 | TM-CRYPTO-005 | Stale encryption key | Medium | Key rotation supported (primary + previous KEK); key_id in payload | MITIGATED |
 | TM-CRYPTO-006 | Re-encryption job missing | Low | CLI tool `reencrypt_secrets` implemented with batch processing, dry-run mode, and key rotation detection | MITIGATED |
 | TM-CRYPTO-007 | Limited encryption scope | Medium | LLM API keys encrypted; system prompt encryption reverted (PII should not be in prompts) | **OPEN** |
-| TM-CRYPTO-008 | Machine-payment wallet key exposure | Critical | Wallet private keys are accepted only on payment account create/update, encrypted with the server envelope encryption service, never returned from API responses, decrypted only inside `ServerPaymentAuthority` immediately before native rail signing, and never sent to workers | MITIGATED |
+| TM-CRYPTO-008 | Machine-payment wallet key exposure | Critical | When machine payments are disabled, custody UI/navigation is hidden and payment account/policy/attempt routes return 404; when enabled, wallet private keys are accepted only on payment account create/update, encrypted with the server envelope encryption service, never returned from API responses, decrypted only inside `ServerPaymentAuthority` immediately before native rail signing, and never sent to workers | MITIGATED |
 
 ### Mitigation Details
 
@@ -195,7 +195,13 @@ Re-encryption CLI tool implemented at `crates/server/src/bin/reencrypt_secrets.r
 - Full UPDATE statements to write re-encrypted data back
 
 **TM-CRYPTO-008 — Machine-Payment Wallet Custody (MITIGATED):**
-Payment accounts store wallet signing material in `credential_encrypted`, protected by the same envelope encryption service used for other secrets. The public `PaymentAccount` model intentionally omits this field. Native x402 signing happens only in `ServerPaymentAuthority`; external workers call the control-plane `ExecuteMachinePayment` RPC and never receive private keys.
+`FEATURE_MACHINE_PAYMENTS` gates the entire custody surface. When it is false, the payment
+routes are not mounted and the UI removes Settings navigation, direct page access, and
+global-search discovery. When it is true, payment accounts store wallet signing material in
+`credential_encrypted`, protected by the same envelope encryption service used for other
+secrets. The public `PaymentAccount` model intentionally omits this field. Native x402 signing
+happens only in `ServerPaymentAuthority`; external workers call the control-plane
+`ExecuteMachinePayment` RPC and never receive private keys.
 
 ## 3. Tenant Isolation (TM-TENANT)
 
@@ -923,7 +929,8 @@ preference, and per-request maximum before creating any rail-specific signature.
 persisted with status, amount, target URL, and receipt/error. Registration of any money-spending
 capability is additionally gated by the `machine_payments` feature flag
 (`FEATURE_MACHINE_PAYMENTS`), off by default on every grade, so spend tools are never offered
-unless deliberately enabled.
+unless deliberately enabled. The same deployment gate removes wallet-management UI and leaves
+payment account, policy, and attempt API paths unmounted, preventing custody without spend.
 
 ## 14. Voice Sessions (TM-VOICE)
 

--- a/test_cases/api/machine_payments/TC001_disabled_surface_returns_404.md
+++ b/test_cases/api/machine_payments/TC001_disabled_surface_returns_404.md
@@ -1,0 +1,32 @@
+# TC001: Disabled machine-payment API surface
+
+## Description
+
+Verify that payment account, policy, and attempt APIs are unavailable when machine payments are disabled.
+
+## Preconditions
+
+- Canonical local stack running with `AUTH_MODE=none`
+- `FEATURE_MACHINE_PAYMENTS=false` (or unset)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Account ID | A valid, nonexistent UUID |
+| Policy ID | A valid, nonexistent UUID |
+
+## Steps
+
+1. Request `GET /v1/feature-flags` and record `machine_payments`.
+2. Call `GET` and `POST` on `/v1/payments/accounts`.
+3. Call `GET`, `PATCH`, and `DELETE` on `/v1/payments/accounts/{account_id}`.
+4. Call `GET` and `POST` on `/v1/payments/policies`.
+5. Call `GET`, `PATCH`, and `DELETE` on `/v1/payments/policies/{payment_policy_id}`.
+6. Call `GET /v1/payments/attempts`.
+
+## Expected Result
+
+- The feature-flags response contains `"machine_payments": false`.
+- Every payment endpoint returns HTTP 404, including syntactically valid create requests.
+- No payment account, policy, or attempt record is created.

--- a/test_cases/api/machine_payments/TC002_enabled_surface_works.md
+++ b/test_cases/api/machine_payments/TC002_enabled_surface_works.md
@@ -1,0 +1,36 @@
+# TC002: Enabled machine-payment API surface
+
+## Description
+
+Verify that payment account, policy, and attempt APIs retain their working behavior when machine payments are enabled.
+
+## Preconditions
+
+- Canonical local stack running with `AUTH_MODE=none`
+- `FEATURE_MACHINE_PAYMENTS=true`
+- Stable local-development encryption key configured by the startup contract
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Wallet key | Newly generated disposable local-only Base test key |
+| Wallet label | `Machine payment smoke test` |
+| Allowed host | `parallelmpp.dev` |
+| Per-request limit | `0.01` USD |
+
+## Steps
+
+1. Request `GET /v1/feature-flags` and record `machine_payments`.
+2. Create an organization-owned x402/Base payment account with the disposable key.
+3. List and fetch the account; verify no private key is returned.
+4. Create a policy for the account and list/fetch it.
+5. List payment attempts.
+6. Disable the policy and account.
+
+## Expected Result
+
+- The feature-flags response contains `"machine_payments": true`.
+- Account and policy create/list/get/disable operations return their documented success statuses.
+- Account responses never contain the submitted private key.
+- The attempts endpoint returns an array.

--- a/test_cases/ui/machine_payments/TC001_disabled_custody_surface_hidden.md
+++ b/test_cases/ui/machine_payments/TC001_disabled_custody_surface_hidden.md
@@ -1,0 +1,31 @@
+# TC001: Disabled machine-payment custody surface
+
+## Description
+
+Verify that a deployment with machine payments disabled does not advertise or render wallet custody controls.
+
+## Preconditions
+
+- Canonical local stack running with `AUTH_MODE=none`
+- `FEATURE_MACHINE_PAYMENTS=false` (or unset)
+- Browser session open as the local organization owner
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Open `/settings/organization`.
+2. Inspect the Settings navigation for Payments.
+3. Open global search and search for `payments` and `wallet`.
+4. Navigate directly to `/settings/payments`.
+5. Inspect browser network activity for `/v1/payments/` requests.
+
+## Expected Result
+
+- Settings navigation contains no Payments link.
+- Global search contains no `/settings/payments` result.
+- Direct navigation renders the application 404 state.
+- No wallet/private-key form is rendered.
+- No payment account, policy, or attempt request is sent.

--- a/test_cases/ui/machine_payments/TC002_enabled_custody_surface_works.md
+++ b/test_cases/ui/machine_payments/TC002_enabled_custody_surface_works.md
@@ -1,0 +1,35 @@
+# TC002: Enabled machine-payment custody surface
+
+## Description
+
+Verify that payment navigation and wallet/policy management remain available when machine payments are enabled.
+
+## Preconditions
+
+- Canonical local stack running with `AUTH_MODE=none`
+- `FEATURE_MACHINE_PAYMENTS=true`
+- Browser session open as the local organization owner
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Wallet key | Newly generated disposable local-only Base test key |
+| Wallet label | `Machine payment UI smoke test` |
+
+## Steps
+
+1. Open Settings and select Payments.
+2. Verify global search finds Settings > Payments.
+3. Create an organization-owned x402/Base payment account with the disposable key.
+4. Create a spend policy for that account.
+5. Refresh the page and inspect the account, policy, and attempts sections.
+6. Disable the policy and account.
+
+## Expected Result
+
+- The Payments link and page are visible.
+- Global search links to `/settings/payments`.
+- The account and policy can be created and disabled.
+- The private key is not displayed after submission or refresh.
+- The attempts section loads without a feature-disabled error.


### PR DESCRIPTION
## What changed

- Expose the deployment-level machine-payments flag to the UI while keeping it non-configurable by organizations.
- Hide the Payments settings navigation and search result, and return the settings 404 boundary for direct payment routes while disabled.
- Unmount payment account, policy, and attempt API routes while disabled so every method returns 404.
- Preserve the existing enabled behavior and add unit, integration, UI, manual, specification, and threat-model coverage.

## Why

Public-release finding 001 / EVE-858 identified that the disabled feature still invited organization owners to submit an x402/Base private key and exposed payment-management APIs. Removing that dormant custody surface avoids collecting sensitive wallet material when spending is unavailable.

## Before / After

Before: with FEATURE_MACHINE_PAYMENTS=false, the Payments UI, private-key form, search result, and payment APIs remained reachable.

After: the UI surface is absent and direct routes use the 404 boundary; all payment account, policy, and attempt endpoints return 404. With the flag enabled, the existing UI and API flows continue to work.

## Risk

Low to moderate. The change touches shared feature-flag plumbing and payment route composition. It is fail-closed, has no schema or migration changes, and can be rolled back by reverting this commit.

## Security

Addresses TM-CRYPTO-008 by eliminating unnecessary wallet-key custody exposure while machine payments are disabled. Existing authentication, tenant isolation, encryption-at-rest, and response key-redaction behavior are unchanged when enabled.

## Follow-ups

None. Repository policy does not require a separate versioned release for every merged fix.

## Checklist

- [x] Added tests that failed against the vulnerable behavior before the fix.
- [x] Ran just pre-push successfully.
- [x] Passed targeted UI, server, plugin, core flag, and database-backed API tests.
- [x] Passed documentation, OKF, and OpenAPI checks.
- [x] Manually verified UI and API behavior with the flag disabled and enabled.
- [x] Updated canonical specifications, threat model, security knowledge, and manual test cases.

Fixes EVE-858