### PR TITLE
chore(release): prepare v0.17.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.25] - 2026-08-09
+
+### What's Changed
+
+- fix(docker): install perl and make in the unified builder so git2's `vendored-openssl` build succeeds ([#3071](https://github.com/everruns/everruns/pull/3071)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.24] - 2026-08-09
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### What's Changed
 
 - fix(docker): install perl and make in the unified builder so git2's `vendored-openssl` build succeeds ([#3071](https://github.com/everruns/everruns/pull/3071)) by [@chaliy](https://github.com/chaliy)
+- fix(docker): copy `pnpm-workspace.yaml` into the UI image build so the frozen install finds the `overrides` config ([#3071](https://github.com/everruns/everruns/pull/3071)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.17.24] - 2026-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2412,11 +2412,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.24"
+version = "0.17.25"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3048,11 +3048,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.24"
+version = "0.17.25"
 
 [[package]]
 name = "everruns-platform"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.24"
+version = "0.17.25"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.24"
+version = "0.17.25"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -167,17 +167,17 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.24" }
-everruns-engine = { path = "crates/engine", version = "0.17.24" }
-everruns-platform = { path = "crates/platform", version = "0.17.24" }
-everruns-provider = { path = "crates/provider", version = "0.17.24" }
+everruns-core = { path = "crates/core", version = "0.17.25" }
+everruns-engine = { path = "crates/engine", version = "0.17.25" }
+everruns-platform = { path = "crates/platform", version = "0.17.25" }
+everruns-provider = { path = "crates/provider", version = "0.17.25" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.24" }
-everruns-ard = { path = "crates/ard", version = "0.17.24" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.25" }
+everruns-ard = { path = "crates/ard", version = "0.17.25" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.24" }
-everruns = { path = "crates/everruns", version = "0.17.24" }
-everruns-macros = { path = "crates/everruns-macros", version = "0.17.24" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.25" }
+everruns = { path = "crates/everruns", version = "0.17.25" }
+everruns-macros = { path = "crates/everruns-macros", version = "0.17.25" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -12,8 +12,10 @@ WORKDIR /app
 # Version pinned to match `packageManager` in apps/ui/package.json.
 RUN npm install -g pnpm@10.33.0
 
-# Install dependencies (fail if pnpm-lock.yaml is out of sync with package.json)
-COPY package.json pnpm-lock.yaml ./
+# Install dependencies (fail if pnpm-lock.yaml is out of sync with package.json).
+# pnpm-workspace.yaml carries `overrides`/`onlyBuiltDependencies` (moved here from
+# package.json); without it a frozen install fails with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.24",
+  "version": "0.17.25",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.24" }
+everruns-provider = { path = "../provider", version = "0.17.25" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.24" }
+everruns-provider = { path = "../provider", version = "0.17.25" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -136,10 +136,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.24", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.25", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.24", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.25", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.24" }
+everruns-provider = { path = "../provider", version = "0.17.25" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -21,7 +21,7 @@ async-trait.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-everruns-provider = { path = "../provider", version = "0.17.24" }
+everruns-provider = { path = "../provider", version = "0.17.25" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.24" }
+everruns-provider = { path = "../provider", version = "0.17.25" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.24" }
+everruns-provider = { path = "../provider", version = "0.17.25" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -22,12 +22,18 @@ COPY --from=tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd1
 
 ARG TARGETPLATFORM
 
+# perl + make are host build tools required by git2's `vendored-openssl` feature,
+# which compiles OpenSSL from source (openssl-src) during the build. The slim
+# rust base ships neither; without them the release image build fails at
+# OpenSSL's ./Configure. Runtime images stay distroless (no system libssl).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     clang \
     lld \
     curl \
     libssl-dev \
+    perl \
+    make \
     && xx-apt-get install -y --no-install-recommends \
     gcc \
     libc6-dev \


### PR DESCRIPTION
## What changed
Hotfix patch release **v0.17.25**. Fixes the Docker image publish that failed on the v0.17.24 release tag.

The v0.17.24 `Docker Publish` run failed building the unified image: `git2`'s `vendored-openssl` feature (added in v0.17.24) compiles OpenSSL from source via `openssl-src`, which needs `perl` and `make` at build time. The builder base (`rust:1.97.1-slim-bookworm`) ships neither, so the build aborted at OpenSSL's `./Configure`. This wasn't caught by PR CI because Docker builds only run on release tags (and path-filtered PRs).

Fix: install `perl` and `make` in the `Dockerfile.unified` builder stage. Runtime images stay distroless (rustls TLS, no system libssl). This PR touches `docker/**`, so PR CI runs the amd64 Docker build and validates the fix before merge.

Also bumps version to `0.17.25` across `Cargo.toml`, `apps/ui/package.json`, path-dependency publish pins, CHANGELOG, and lockfiles.

## Why
v0.17.24 has no published Docker images because the release-tag build failed. Docker tags are immutable and `docker-publish` only runs on a matching `v*` tag, so republishing requires a new release. This is the minimal forward fix.

## Before / After
- Before (v0.17.24 release): `Build Rust Images` → `error: failed to run custom build command for openssl-sys` → OpenSSL `./Configure` aborts (perl missing).
- After: builder installs `perl` + `make`; the amd64 Docker build in this PR's CI exercises the fixed path.
- Migration ordering: `migrations sequential (001..116)`. Pins: `all path-dep pins at 0.17.25`. `cargo fmt --check` clean.

## Risk
- Low
- Adds two build-only apt packages to the builder stage. No runtime image change, no code change.

## Security
- Threat categories reviewed: No security-relevant code changes (build tooling + version bump). Runtime images unchanged (still distroless, rustls).
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [ ] Tests added or updated (n/a — build/release)
- [x] Backward compatibility considered (patch bump)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR (Docker amd64 build runs on this PR)
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_018CH8wtqg1mDAnccXdvQ2dh)_