### PR TITLE
refactor(provider): separate providers from drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "everruns-macros",
  "everruns-openai",
  "everruns-runtime",
+ "futures",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -26,9 +26,9 @@ use everruns_provider::driver_helpers::{
     parse_data_url,
 };
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
-    LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent, fold_system_messages,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent, fold_system_messages,
 };
 use everruns_provider::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_provider::is_provider_quota_message;
@@ -39,9 +39,21 @@ use everruns_provider::llm_retry::{
 use everruns_provider::stream_reconnect::connect_sse_with_reconnect;
 use everruns_provider::tool_types::{DeferrablePolicy, ToolCall, ToolDefinition};
 
-const DEFAULT_API_URL: &str = "https://api.anthropic.com/v1/messages";
-const ANTHROPIC_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Ready-to-use Anthropic Messages provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> everruns_provider::Provider {
+    everruns_provider::Provider::new(id, AnthropicChatDriver::new())
+        .base_url(DEFAULT_BASE_URL)
+        .auth(everruns_provider::StaticHeaderAuth::new(
+            "x-api-key",
+            api_key,
+        ))
+}
 
 /// Message-level prompt-cache breakpoints per request. Anthropic allows four
 /// in total; the system prompt and the tool array take one each, leaving two
@@ -61,43 +73,31 @@ const MESSAGE_CACHE_BREAKPOINTS: usize = 2;
 /// ```ignore
 /// use everruns_anthropic::AnthropicChatDriver;
 ///
-/// let driver = AnthropicChatDriver::new("your-api-key");
-/// // or with custom endpoint
-/// let driver = AnthropicChatDriver::with_base_url("your-api-key", "https://api.example.com/v1/messages");
-/// // or with custom retry config
-/// let driver = AnthropicChatDriver::new("your-api-key")
+/// let driver = AnthropicChatDriver::new();
+/// // Endpoint and auth belong to the runtime Provider.
+/// let driver = AnthropicChatDriver::new()
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
 #[derive(Clone)]
 pub struct AnthropicChatDriver {
     client: Client,
-    api_key: String,
-    api_url: String,
-    /// Whether using a custom base URL (not Anthropic's API)
-    uses_custom_url: bool,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
 }
 
+#[derive(Clone, Copy)]
+struct SendMessagesOptions<'a> {
+    needs_interleaved_thinking: bool,
+    wants_million_context: bool,
+    max_tokens_from_profile: bool,
+    model: &'a str,
+}
+
 impl AnthropicChatDriver {
     /// Create a new provider with the given API key
-    pub fn new(api_key: impl Into<String>) -> Self {
+    pub fn new() -> Self {
         Self {
             client: driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            api_url: DEFAULT_API_URL.to_string(),
-            uses_custom_url: false,
-            retry_config: LlmRetryConfig::default(),
-        }
-    }
-
-    /// Create a new provider with a custom API URL
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        Self {
-            client: driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            api_url: api_url.into(),
-            uses_custom_url: true,
             retry_config: LlmRetryConfig::default(),
         }
     }
@@ -120,13 +120,17 @@ impl AnthropicChatDriver {
     /// exactly.
     async fn send_messages_request(
         &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
         request: Arc<Mutex<AnthropicRequest>>,
-        needs_interleaved_thinking: bool,
-        wants_million_context: bool,
-        max_tokens_from_profile: bool,
-        model: &str,
+        options: SendMessagesOptions<'_>,
         retries_consumed: u32,
     ) -> Result<(reqwest::Response, RetryMetadata)> {
+        let SendMessagesOptions {
+            needs_interleaved_thinking,
+            wants_million_context,
+            max_tokens_from_profile,
+            model,
+        } = options;
         let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let max_tokens_fallback_attempted = Arc::new(Mutex::new(false));
         let beta_logged = Arc::new(Mutex::new(false));
@@ -141,10 +145,12 @@ impl AnthropicChatDriver {
                 let beta_logged = Arc::clone(&beta_logged);
                 async move {
                     // Build request with headers (must rebuild each iteration).
+                    let url = endpoint.url("messages").ok_or_else(|| {
+                        SendOutcome::Fatal(AgentLoopError::config("Anthropic provider has no base URL"))
+                    })?;
                     let mut request_builder = self
                         .client
-                        .post(&self.api_url)
-                        .header("x-api-key", &self.api_key)
+                        .post(&url)
                         .header("anthropic-version", ANTHROPIC_VERSION)
                         .header("Content-Type", "application/json");
 
@@ -178,14 +184,18 @@ impl AnthropicChatDriver {
                     // Snapshot the (possibly fallback-mutated) request as JSON
                     // while holding the lock, then release it before awaiting the
                     // send so the guard never crosses an `.await` point.
-                    let body = serde_json::to_value(&*request.lock().unwrap())
+                    let body = serde_json::to_vec(&*request.lock().unwrap())
                         .map_err(|e| {
                             SendOutcome::Fatal(AgentLoopError::llm(format!(
                                 "Failed to serialize Anthropic request: {e}"
                             )))
                         })?;
+                    let resolved = endpoint.resolve("POST", url, &body).await.map_err(SendOutcome::Fatal)?;
+                    for (name, value) in resolved.headers {
+                        request_builder = request_builder.header(name, value);
+                    }
                     request_builder
-                        .json(&body)
+                        .body(body)
                         .send()
                         .await
                         .map_err(SendOutcome::Send)
@@ -301,11 +311,6 @@ impl AnthropicChatDriver {
             |e, attempts| AgentLoopError::llm(send_error_message(e, attempts)),
         )
         .await
-    }
-
-    /// Check if using a custom base URL
-    pub fn uses_custom_url(&self) -> bool {
-        self.uses_custom_url
     }
 
     fn convert_role(role: &LlmMessageRole) -> &'static str {
@@ -688,6 +693,7 @@ impl AnthropicChatDriver {
 impl ChatDriver for AnthropicChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
@@ -850,11 +856,14 @@ impl ChatDriver for AnthropicChatDriver {
         let (event_stream, retry_metadata) =
             connect_sse_with_reconnect(&self.retry_config, "AnthropicDriver", |attempts| {
                 self.send_messages_request(
+                    endpoint,
                     Arc::clone(&request),
-                    needs_interleaved_thinking,
-                    wants_million_context,
-                    max_tokens_from_profile,
-                    &config.model,
+                    SendMessagesOptions {
+                        needs_interleaved_thinking,
+                        wants_million_context,
+                        max_tokens_from_profile,
+                        model: &config.model,
+                    },
                     attempts,
                 )
             })
@@ -1107,17 +1116,27 @@ impl ChatDriver for AnthropicChatDriver {
         true
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
         // Skip discovery for custom URLs (proxies, self-hosted)
-        if self.uses_custom_url {
+        if endpoint.base_url() != Some(DEFAULT_BASE_URL) {
             return Ok(None);
         }
 
-        let response = self
+        let url = endpoint
+            .url("models")
+            .ok_or_else(|| AgentLoopError::config("Anthropic provider has no base URL"))?;
+        let resolved = endpoint.resolve("GET", url, &[]).await?;
+        let mut request = self
             .client
-            .get(ANTHROPIC_MODELS_URL)
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", ANTHROPIC_VERSION)
+            .get(&resolved.url)
+            .header("anthropic-version", ANTHROPIC_VERSION);
+        for (name, value) in resolved.headers {
+            request = request.header(name, value);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| AgentLoopError::llm(format!("Failed to fetch models: {}", e)))?;
@@ -1163,9 +1182,7 @@ impl ChatDriver for AnthropicChatDriver {
 impl std::fmt::Debug for AnthropicChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AnthropicChatDriver")
-            .field("api_url", &self.api_url)
-            .field("api_key", &"[REDACTED]")
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -1188,18 +1205,23 @@ impl std::fmt::Debug for AnthropicChatDriver {
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_descriptor(DriverDescriptor {
+        display_name: "Anthropic".into(),
         credential_schema: CredentialFormSchema::api_key(
             "Create an API key in the [Anthropic Console](https://console.anthropic.com/settings/keys).",
         ),
         ..DriverDescriptor::chat_only(DriverId::Anthropic, |config| {
-            let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => AnthropicChatDriver::with_base_url(api_key, url),
-                None => AnthropicChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            let provider = everruns_provider::Provider::new(config.provider.clone(), AnthropicChatDriver::new())
+                .base_url(config.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL))
+                .auth(everruns_provider::StaticHeaderAuth::new("x-api-key", config.api_key.as_deref().unwrap_or("")));
+            provider.into_boxed_driver()
         })
     });
+}
+
+impl Default for AnthropicChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ============================================================================
@@ -1998,7 +2020,7 @@ mod tests {
 
     #[test]
     fn supports_parallel_tool_calls_is_true() {
-        let driver = AnthropicChatDriver::new("test-key");
+        let driver = AnthropicChatDriver::new();
         assert!(driver.supports_parallel_tool_calls("claude-opus-4-8"));
     }
 

--- a/crates/anthropic/src/lib.rs
+++ b/crates/anthropic/src/lib.rs
@@ -11,15 +11,17 @@
 //! # Example
 //!
 //! ```
-//! use everruns_anthropic::{AnthropicChatDriver, register_driver};
+//! use everruns_anthropic::{AnthropicChatDriver, provider, register_driver};
 //! use everruns_provider::DriverRegistry;
 //!
-//! let driver = AnthropicChatDriver::new("your-api-key");
+//! let driver = AnthropicChatDriver::new();
+//! let service = provider("anthropic", "your-api-key");
 //!
 //! let mut registry = DriverRegistry::new();
 //! register_driver(&mut registry);
 //!
 //! assert!(format!("{driver:?}").contains("AnthropicChatDriver"));
+//! assert_eq!(service.id().as_str(), "anthropic");
 //! ```
 
 mod driver;
@@ -27,7 +29,7 @@ mod driver;
 #[cfg(test)]
 mod tests;
 
-pub use driver::{AnthropicChatDriver, register_driver};
+pub use driver::{AnthropicChatDriver, provider, register_driver};
 
 // Re-export core types for convenience
 pub use everruns_provider::driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -12,9 +12,10 @@
 
 use everruns_anthropic::AnthropicChatDriver;
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
-    LlmResponseStream, LlmStreamEvent,
+    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream,
+    LlmStreamEvent,
 };
+use everruns_provider::{Provider, StaticHeaderAuth};
 use futures::StreamExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -122,8 +123,10 @@ async fn mount_sse(server: &MockServer, body: String) {
         .await;
 }
 
-fn driver(server: &MockServer) -> AnthropicChatDriver {
-    AnthropicChatDriver::with_base_url("test-key", format!("{}/v1/messages", server.uri()))
+fn driver(server: &MockServer) -> Provider {
+    Provider::new("anthropic-test", AnthropicChatDriver::new())
+        .base_url(format!("{}/v1/messages", server.uri()))
+        .auth(StaticHeaderAuth::new("x-api-key", "test-key"))
 }
 
 /// Text streaming: `message_start` carries input/cache usage, two text deltas

--- a/crates/anthropic/tests/parallel_tool_calls_live.rs
+++ b/crates/anthropic/tests/parallel_tool_calls_live.rs
@@ -10,8 +10,8 @@
 //! Ignored by default (requires network + `ANTHROPIC_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-anthropic --test parallel_tool_calls_live -- --ignored --nocapture`
 
-use everruns_anthropic::AnthropicChatDriver;
-use everruns_core::driver_registry::{ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_anthropic::provider;
+use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
 use everruns_core::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
 };
@@ -64,7 +64,7 @@ fn config_with(parallel: Option<bool>) -> LlmCallConfig {
 }
 
 async fn tool_call_count(parallel: Option<bool>) -> usize {
-    let driver = AnthropicChatDriver::new(api_key());
+    let provider = provider("anthropic", api_key());
     let messages = vec![
         LlmMessage::text(
             LlmMessageRole::System,
@@ -75,7 +75,7 @@ async fn tool_call_count(parallel: Option<bool>) -> usize {
             "Get both the current weather and the current local time in Paris.",
         ),
     ];
-    let response = driver
+    let response = provider
         .chat_completion(messages, &config_with(parallel))
         .await
         .expect("Anthropic should accept the request");

--- a/crates/bedrock/src/credential.rs
+++ b/crates/bedrock/src/credential.rs
@@ -12,7 +12,7 @@ use everruns_provider::error::{AgentLoopError, Result};
 
 const DEFAULT_REGION: &str = "us-east-1";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BedrockCredential {
     pub access_key_id: String,
     pub secret_access_key: String,
@@ -20,7 +20,41 @@ pub struct BedrockCredential {
     pub region: String,
 }
 
+impl std::fmt::Debug for BedrockCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedrockCredential")
+            .field("access_key_id", &"[REDACTED]")
+            .field("secret_access_key", &"[REDACTED]")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("region", &self.region)
+            .finish()
+    }
+}
+
 impl BedrockCredential {
+    /// Construct credentials for a ready-made Bedrock provider.
+    pub fn new(
+        access_key_id: impl Into<String>,
+        secret_access_key: impl Into<String>,
+        region: impl Into<String>,
+    ) -> Self {
+        Self {
+            access_key_id: access_key_id.into(),
+            secret_access_key: secret_access_key.into(),
+            session_token: None,
+            region: region.into(),
+        }
+    }
+
+    /// Attach the session token used by temporary AWS credentials.
+    pub fn with_session_token(mut self, session_token: impl Into<String>) -> Self {
+        self.session_token = Some(session_token.into());
+        self
+    }
+
     /// Build a credential from the typed driver credential fields.
     ///
     /// `access_key_id` and `secret_access_key` are required; `region` defaults
@@ -59,6 +93,7 @@ mod tests {
 
     fn config_from_document(document: &str) -> DriverConfig {
         DriverConfig {
+            provider: everruns_provider::ProviderKey::new("bedrock"),
             provider_type: DriverId::Bedrock,
             credentials: parse_credential_document(Some(document)),
             api_key: Some(document.to_string()),
@@ -75,6 +110,10 @@ mod tests {
         assert_eq!(cred.secret_access_key, "SECRET");
         assert_eq!(cred.session_token.as_deref(), Some("TOKEN"));
         assert_eq!(cred.region, "eu-west-1");
+        let debug = format!("{cred:?}");
+        assert!(!debug.contains("AKID"));
+        assert!(!debug.contains("SECRET"));
+        assert!(!debug.contains("TOKEN"));
     }
 
     #[test]

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -37,26 +37,68 @@ const BEDROCK_STREAM_BUFFER_SIZE: usize = 64;
 
 use crate::credential::BedrockCredential;
 
-/// AWS Bedrock Runtime Chat Driver.
+/// Provider-owned Bedrock authentication and signing stack.
 ///
-/// Implements `ChatDriver` using the `ConverseStream` API.
-/// Credentials come from the driver's declared typed credential fields.
-#[derive(Clone, Debug)]
-pub struct BedrockChatDriver {
-    /// AWS Bedrock client built once at construction. `aws_sdk_bedrockruntime::Client`
-    /// is cheap to clone and reuses its connection pool and credentials provider,
-    /// so we build it here instead of rebuilding the whole SDK client (credential
-    /// chain + pool) on every `chat_completion_stream` call (EVE-635).
+/// The AWS SDK resolves credentials and signs every ConverseStream request;
+/// keeping its client here preserves SigV4/event-stream behavior while the
+/// protocol driver itself remains credential-free.
+#[derive(Clone)]
+pub struct BedrockAuth {
     client: Client,
 }
 
-impl BedrockChatDriver {
+impl BedrockAuth {
+    pub fn new(credential: BedrockCredential) -> Self {
+        Self {
+            client: build_client(&credential),
+        }
+    }
+
     pub fn from_config(config: &DriverConfig) -> Result<Self> {
         let credential = BedrockCredential::from_driver_config(config)?;
-        Ok(Self {
-            client: build_client(&credential),
-        })
+        Ok(Self::new(credential))
     }
+}
+
+impl std::fmt::Debug for BedrockAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedrockAuth")
+            .field("configured", &true)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl everruns_provider::ProviderAuth for BedrockAuth {
+    async fn headers(
+        &self,
+        _request: everruns_provider::ProviderAuthRequest<'_>,
+    ) -> Result<Vec<(String, String)>> {
+        Ok(Vec::new())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Credential-free Bedrock ConverseStream wire-protocol driver.
+#[derive(Clone, Debug, Default)]
+pub struct BedrockChatDriver;
+
+impl BedrockChatDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Ready-to-use AWS Bedrock provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    credential: BedrockCredential,
+) -> everruns_provider::Provider {
+    everruns_provider::Provider::new(id, BedrockChatDriver::new())
+        .auth(BedrockAuth::new(credential))
 }
 
 /// Build the AWS Bedrock runtime client from typed credentials. Called once per
@@ -84,6 +126,7 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     // `api_key`. The fields are assembled into the stored credential document
     // and parsed back into the typed `DriverConfig` credential map.
     registry.register_descriptor(DriverDescriptor {
+        display_name: "AWS Bedrock".into(),
         credential_schema: CredentialFormSchema {
             fields: vec![
                 FormField::password("access_key_id", "Access Key ID").required(),
@@ -102,8 +145,13 @@ pub fn register_driver(registry: &mut DriverRegistry) {
                     .to_string(),
         },
         ..DriverDescriptor::chat_only(DriverId::Bedrock, |config| {
-            match BedrockChatDriver::from_config(config) {
-                Ok(driver) => Box::new(driver) as BoxedChatDriver,
+            match BedrockAuth::from_config(config) {
+                Ok(auth) => everruns_provider::Provider::new(
+                    config.provider.clone(),
+                    BedrockChatDriver::new(),
+                )
+                .auth(auth)
+                .into_boxed_driver(),
                 Err(e) => Box::new(FailDriver(e.to_string())) as BoxedChatDriver,
             }
         })
@@ -117,6 +165,7 @@ struct FailDriver(String);
 impl ChatDriver for FailDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_provider::ProviderEndpoint,
         _messages: Vec<LlmMessage>,
         _config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
@@ -128,10 +177,15 @@ impl ChatDriver for FailDriver {
 impl ChatDriver for BedrockChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        let client = self.client.clone();
+        let client = endpoint
+            .auth::<BedrockAuth>()
+            .ok_or_else(|| AgentLoopError::config("Bedrock provider requires BedrockAuth"))?
+            .client
+            .clone();
         let model_id = config.model.clone();
 
         let (system_blocks, bedrock_messages) = build_messages(&messages)?;
@@ -298,7 +352,10 @@ impl ChatDriver for BedrockChatDriver {
         Ok(Box::pin(ReceiverStream::new(rx)))
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        _endpoint: &everruns_provider::ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
         // Converse-compatible model set is seeded statically; skip discovery.
         Ok(None)
     }

--- a/crates/bedrock/src/lib.rs
+++ b/crates/bedrock/src/lib.rs
@@ -22,6 +22,7 @@
 mod credential;
 mod driver;
 
-pub use driver::{BedrockChatDriver, register_driver};
+pub use credential::BedrockCredential;
+pub use driver::{BedrockAuth, BedrockChatDriver, provider, register_driver};
 
 pub use everruns_provider::driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -657,12 +657,15 @@ async fn try_apply_native_compaction(
     let (input, compact_previous_response_id) = (standalone_input, None);
 
     let compact_response = match chat_driver
-        .compact(CompactRequest {
-            model: model.to_string(),
-            input,
-            previous_response_id: compact_previous_response_id,
-            instructions: system_prompt.map(str::to_string),
-        })
+        .compact(
+            &crate::ProviderEndpoint::default(),
+            CompactRequest {
+                model: model.to_string(),
+                input,
+                previous_response_id: compact_previous_response_id,
+                instructions: system_prompt.map(str::to_string),
+            },
+        )
         .await
     {
         Ok(Some(response)) => response,
@@ -1647,7 +1650,7 @@ impl ReasonAtom {
             .collect();
 
         // 7. Create LLM driver using factory
-        let chat_driver = self.create_chat_driver(&model_with_provider)?;
+        let chat_driver = self.create_chat_driver(&model_with_provider).await?;
         let stateful_response_continuation =
             previous_response_id.is_some() && chat_driver.supports_stateful_responses();
         let mut restored_checkpoint: Option<crate::CompactionCheckpoint> = None;
@@ -2408,7 +2411,11 @@ impl ReasonAtom {
             {
                 match tokio::time::timeout(
                     remaining,
-                    chat_driver.chat_completion_stream(llm_messages_for_call.clone(), &llm_config),
+                    chat_driver.chat_completion_stream(
+                        &crate::ProviderEndpoint::default(),
+                        llm_messages_for_call.clone(),
+                        &llm_config,
+                    ),
                 )
                 .await
                 {
@@ -2427,7 +2434,11 @@ impl ReasonAtom {
                 }
             } else {
                 chat_driver
-                    .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
+                    .chat_completion_stream(
+                        &crate::ProviderEndpoint::default(),
+                        llm_messages_for_call.clone(),
+                        &llm_config,
+                    )
                     .await
             };
             let mut stream = match stream_result {
@@ -2646,7 +2657,11 @@ impl ReasonAtom {
                             };
 
                             match chat_driver
-                                .chat_completion(summary_messages, &summary_config)
+                                .chat_completion(
+                                    &crate::ProviderEndpoint::default(),
+                                    summary_messages,
+                                    &summary_config,
+                                )
                                 .await
                             {
                                 Ok(response) => {
@@ -2776,7 +2791,11 @@ impl ReasonAtom {
                     );
 
                     chat_driver
-                        .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
+                        .chat_completion_stream(
+                            &crate::ProviderEndpoint::default(),
+                            llm_messages_for_call.clone(),
+                            &llm_config,
+                        )
                         .await?
                 }
                 Err(e)
@@ -3810,12 +3829,17 @@ impl ReasonAtom {
 
     /// Resolve model using priority chain: controls > session > agent > harness > system default
     /// Create LLM driver using the driver registry
-    fn create_chat_driver(
+    async fn create_chat_driver(
         &self,
         model: &ResolvedModel,
     ) -> Result<crate::driver_registry::BoxedChatDriver> {
-        self.driver_registry
-            .create_chat_driver(&crate::llm_conversions::provider_config_from_resolved_model(model))
+        let (_, compatibility_config) = model.canonical_parts();
+        let config = self
+            .provider_store
+            .get_provider_config(&compatibility_config.provider)
+            .await?
+            .unwrap_or(compatibility_config);
+        self.driver_registry.create_chat_driver(&config)
     }
 
     /// Resolve image_file references to actual image data

--- a/crates/core/src/command_host.rs
+++ b/crates/core/src/command_host.rs
@@ -398,11 +398,19 @@ impl StoreCommandHost {
         }
         let llm_config = llm_config_builder.build();
 
+        let (_, compatibility_config) = model.canonical_parts();
+        let provider_config = self
+            .provider_store
+            .get_provider_config(&compatibility_config.provider)
+            .await
+            .map_err(|error| SessionCompletionError::Completion {
+                error: error.to_string(),
+                context: context.clone(),
+            })?
+            .unwrap_or(compatibility_config);
         let driver = self
             .driver_registry
-            .create_chat_driver(
-                &crate::llm_conversions::provider_config_from_resolved_model(&model),
-            )
+            .create_chat_driver(&provider_config)
             .map_err(|error| SessionCompletionError::Completion {
                 error: error.to_string(),
                 context: context.clone(),
@@ -452,7 +460,11 @@ impl CommandHost for StoreCommandHost {
 
         let response = prepared
             .driver
-            .chat_completion(prepared.llm_messages, &prepared.llm_config)
+            .chat_completion(
+                &crate::ProviderEndpoint::default(),
+                prepared.llm_messages,
+                &prepared.llm_config,
+            )
             .await
             .map_err(|error| completion_error(error.to_string()))?;
 
@@ -472,7 +484,11 @@ impl CommandHost for StoreCommandHost {
         let prepared = self.prepare_completion(request).await?;
         let events = prepared
             .driver
-            .chat_completion_stream(prepared.llm_messages, &prepared.llm_config)
+            .chat_completion_stream(
+                &crate::ProviderEndpoint::default(),
+                prepared.llm_messages,
+                &prepared.llm_config,
+            )
             .await
             .map_err(|error| SessionCompletionError::Completion {
                 error: error.to_string(),

--- a/crates/core/src/credential_provider.rs
+++ b/crates/core/src/credential_provider.rs
@@ -57,17 +57,9 @@ pub trait CredentialProvider: Send + Sync {
 /// org-scoped server execution paths — doing so would reopen the env fallback the
 /// Key Resolution Contract forbids.
 ///
-/// Recognized variables (per driver):
-///
-/// | Driver | API key | Base URL |
-/// |--------|---------|----------|
-/// | `openai`, `openai_completions` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
-/// | `openrouter` | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL` |
-/// | `anthropic` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
-/// | `gemini` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-///
-/// Other drivers (Azure OpenAI, Bedrock, MAI, external) return `None`; their
-/// dev/standalone credentials are supplied explicitly by the caller.
+/// Variables follow the open driver id: `<UPPERCASE_ID>_API_KEY` and
+/// `<UPPERCASE_ID>_BASE_URL`, with punctuation normalized to `_`.
+/// `openai_completions` also falls back to the historical `OPENAI_*` names.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct EnvCredentialProvider;
 
@@ -83,17 +75,27 @@ impl EnvCredentialProvider {
     where
         F: Fn(&str) -> Option<String>,
     {
-        let (key_var, url_var) = match driver {
-            DriverId::OpenAI | DriverId::OpenAICompletions => ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
-            DriverId::OpenRouter => ("OPENROUTER_API_KEY", "OPENROUTER_BASE_URL"),
-            DriverId::Anthropic => ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"),
-            DriverId::Gemini => ("GEMINI_API_KEY", "GEMINI_BASE_URL"),
-            _ => return None,
-        };
+        let stem = driver
+            .as_str()
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() {
+                    c.to_ascii_uppercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
+        let key_var = format!("{stem}_API_KEY");
+        let url_var = format!("{stem}_BASE_URL");
 
         let non_empty = |s: String| (!s.is_empty()).then_some(s);
-        let api_key = lookup(key_var).and_then(non_empty);
-        let base_url = lookup(url_var).and_then(non_empty);
+        let mut api_key = lookup(&key_var).and_then(non_empty);
+        let mut base_url = lookup(&url_var).and_then(non_empty);
+        if driver == &DriverId::OpenAICompletions {
+            api_key = api_key.or_else(|| lookup("OPENAI_API_KEY").and_then(non_empty));
+            base_url = base_url.or_else(|| lookup("OPENAI_BASE_URL").and_then(non_empty));
+        }
 
         let creds = ProviderCredentials { api_key, base_url };
         (!creds.is_empty()).then_some(creds)

--- a/crates/core/src/in_memory.rs
+++ b/crates/core/src/in_memory.rs
@@ -674,6 +674,7 @@ impl MockProvider {
 impl ChatDriver for MockProvider {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &crate::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         _config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -105,7 +105,9 @@ pub mod observer;
 pub mod organization;
 pub mod payment;
 pub mod principal;
+pub use everruns_provider::model_spec;
 pub use everruns_provider::provider;
+pub use everruns_provider::runtime_provider;
 pub mod session;
 pub mod session_file;
 pub mod session_path;
@@ -315,7 +317,7 @@ pub use driver_registry::{
     EmbedResponse, EmbeddingsDriver, EmbeddingsDriverError, EmbeddingsDriverFactory, LlmCallConfig,
     LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamError, LlmStreamEvent, ProviderConfig,
-    ProviderOpaqueContext, ServiceKind, fold_system_messages,
+    ProviderMetadata, ProviderOpaqueContext, ServiceKind, fold_system_messages,
 };
 
 // LLM retry types re-exports
@@ -323,10 +325,6 @@ pub use llm_retry::{LlmRetryConfig, RateLimitInfo, RateLimitType, RetryMetadata}
 
 // OpenAI Protocol driver (Chat Completions API for backward compatibility)
 pub use openai_protocol::OpenAIProtocolChatDriver;
-
-// Pluggable request authentication, shared by the Chat Completions and Open
-// Responses protocol drivers (e.g. static API key vs. refreshable OAuth bearer).
-pub use openai_protocol::AuthHeaderProvider;
 
 // Open Responses Protocol driver (https://www.openresponses.org/)
 // Vendor-neutral API standard, recommended for new projects
@@ -523,8 +521,14 @@ pub use payment::{MachinePaymentRequest, MachinePaymentResponse, PaymentMethod, 
 // the `everruns-platform` crate. `PrincipalSummary` and the `PrincipalKind` that
 // backs it stay here — they are embedded by `Session`/`SessionSchedule`/
 // `AgentIdentity`.
+pub use model_spec::{ModelSpec, UnknownProvider};
 pub use principal::{PrincipalKind, PrincipalSummary};
-pub use provider::{Provider, ProviderStatus, ProviderTraceConfig};
+pub use provider::{Provider as ProviderRecord, ProviderStatus, ProviderTraceConfig};
+pub use runtime_provider::{
+    BearerAuth, Provider, ProviderAuth, ProviderAuthRequest, ProviderEndpoint, ProviderKey,
+    ProviderRegistry, ResolvedProviderRequest, RuntimeProvider, RuntimeProviderRegistry,
+    StaticHeaderAuth,
+};
 pub use session::{
     Session, SessionParticipant, SessionParticipantKind, SessionParticipantRole, SessionSeedMode,
     SessionStatus, SubagentStatus,

--- a/crates/core/src/llm_conversions.rs
+++ b/crates/core/src/llm_conversions.rs
@@ -195,14 +195,11 @@ pub fn llm_call_config_builder_from_agent(runtime_agent: &RuntimeAgent) -> LlmCa
     LlmCallConfigBuilder::from_config(llm_call_config_from_agent(runtime_agent))
 }
 
-/// Build a [`ProviderConfig`] from a resolved model (credentials + endpoint).
+/// Build the default provider lookup config for an application-registered
+/// provider. Hosted stores override it with their independently resolved
+/// endpoint and authentication material.
 pub fn provider_config_from_resolved_model(model: &ResolvedModel) -> ProviderConfig {
-    ProviderConfig {
-        provider_type: model.provider_type.clone(),
-        api_key: model.api_key.clone(),
-        base_url: model.base_url.clone(),
-        metadata: model.provider_metadata.clone().unwrap_or_default(),
-    }
+    model.canonical_parts().1
 }
 
 #[cfg(test)]

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::driver_registry::{
-    BoxedChatDriver, ChatDriver, DriverId, DriverRegistry, LlmCallConfig, LlmCompletionMetadata,
-    LlmMessage, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    BoxedChatDriver, ChatDriver, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
 };
 use crate::error::{AgentLoopError, Result};
 use crate::tool_types::ToolCall;
@@ -662,6 +662,7 @@ impl LlmSimDriver {
 impl ChatDriver for LlmSimDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &crate::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
@@ -806,10 +807,12 @@ impl std::fmt::Debug for LlmSimDriver {
 /// register_driver(&mut registry);
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(DriverId::LlmSim, |_config| {
-        // Default driver - tests can create custom drivers directly
+    let mut descriptor = DriverDescriptor::chat_only(DriverId::LlmSim, |_config| {
+        // Default driver - tests can create custom drivers directly.
         Box::new(LlmSimDriver::default_driver()) as BoxedChatDriver
     });
+    descriptor.display_name = "LLM Simulator".into();
+    registry.register_descriptor_or_replace(descriptor);
 }
 
 /// Register the LlmSim driver with a custom configuration. Useful for
@@ -822,9 +825,11 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 /// shared across invocations.
 pub fn register_driver_with_config(registry: &mut DriverRegistry, config: LlmSimConfig) {
     let driver = LlmSimDriver::new(config);
-    registry.register(DriverId::LlmSim, move |_config| {
+    let mut descriptor = DriverDescriptor::chat_only(DriverId::LlmSim, move |_config| {
         Box::new(driver.clone()) as BoxedChatDriver
     });
+    descriptor.display_name = "LLM Simulator".into();
+    registry.register_descriptor_or_replace(descriptor);
 }
 
 /// Parse TTFT (time to first token) delay from model name if it contains "-ttft-{ms}" pattern.
@@ -1024,6 +1029,31 @@ pub fn monitor_demo_script() -> LlmSimConfig {
 mod tests {
     use super::*;
     use futures::StreamExt;
+
+    impl LlmSimDriver {
+        async fn chat_completion(
+            &self,
+            messages: Vec<LlmMessage>,
+            config: &LlmCallConfig,
+        ) -> Result<crate::driver_registry::LlmResponse> {
+            ChatDriver::chat_completion(self, &crate::ProviderEndpoint::default(), messages, config)
+                .await
+        }
+
+        async fn chat_completion_stream(
+            &self,
+            messages: Vec<LlmMessage>,
+            config: &LlmCallConfig,
+        ) -> Result<LlmResponseStream> {
+            ChatDriver::chat_completion_stream(
+                self,
+                &crate::ProviderEndpoint::default(),
+                messages,
+                config,
+            )
+            .await
+        }
+    }
 
     #[test]
     fn auditor_demo_script_calls_ec2_then_s3_then_summarises() {

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -230,26 +230,50 @@ impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
 // ProviderStore - For retrieving LLM provider configurations
 // ============================================================================
 
-/// Model information with provider details needed for LLM calls
+/// Legacy runtime model input retained for the 0.17.x compatibility surface.
+///
+/// Execution converts this value into a credential-free [`crate::ModelSpec`]
+/// plus a runtime provider configuration before selecting a driver. New
+/// application code should use `ModelSpec` and `Provider` directly.
 #[derive(Debug, Clone)]
 pub struct ResolvedModel {
-    /// The model ID string to pass to the LLM API (e.g., "gpt-4o", "claude-3-opus")
     pub model: String,
-    /// Provider type for factory selection
     pub provider_type: DriverId,
-    /// Decrypted API key (if configured)
     pub api_key: Option<String>,
-    /// Optional base URL override
     pub base_url: Option<String>,
-    /// Extra provider-specific metadata (OAuth tokens, account ids, etc.).
-    /// Used by embedder-defined providers that authenticate without an API key.
     pub provider_metadata: Option<crate::driver_registry::ProviderMetadata>,
 }
 
-/// Trait for retrieving LLM provider and model configurations
+impl ResolvedModel {
+    pub fn provider_key(&self) -> crate::ProviderKey {
+        self.provider_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.extra.as_ref())
+            .and_then(|extra| extra.get("provider_id"))
+            .and_then(serde_json::Value::as_str)
+            .map(crate::ProviderKey::new)
+            .unwrap_or_else(|| crate::ProviderKey::new(self.provider_type.as_str()))
+    }
+
+    pub fn canonical_parts(&self) -> (crate::ModelSpec, crate::ProviderConfig) {
+        let provider = self.provider_key();
+        let spec = crate::ModelSpec::on(provider.clone(), self.model.clone());
+        let config = crate::ProviderConfig {
+            provider,
+            provider_type: self.provider_type.clone(),
+            api_key: self.api_key.clone(),
+            base_url: self.base_url.clone(),
+            metadata: self.provider_metadata.clone().unwrap_or_default(),
+        };
+        (spec, config)
+    }
+}
+
+/// Trait for retrieving model identity and LLM provider configurations.
 ///
-/// This trait abstracts the database lookup and API key decryption needed
-/// to create LLM providers at runtime.
+/// Model lookup is credential-free. Provider configuration is resolved
+/// separately by provider identity before execution. The inline credential
+/// fields on [`ResolvedModel`] remain only for the 0.17.x compatibility input.
 ///
 /// Implementations can:
 /// - Load from a database with encrypted API keys
@@ -259,14 +283,26 @@ pub struct ResolvedModel {
 pub trait ProviderStore: Send + Sync {
     /// Get model with provider info by model ID
     ///
-    /// Returns the model string ID, provider type, decrypted API key, and base URL
-    /// needed to create an LLM provider via the factory.
+    /// Hosted implementations return model and provider identity only. Legacy
+    /// embedders may still return inline provider configuration during 0.17.x;
+    /// execution immediately converts it into the canonical provider path.
     async fn get_resolved_model(&self, model_id: ModelId) -> Result<Option<ResolvedModel>>;
 
     /// Get the default model with provider info
     ///
     /// Returns the system default model when an agent has no default_model_id set.
     async fn get_default_model(&self) -> Result<Option<ResolvedModel>>;
+
+    /// Resolve runtime service configuration independently from the model.
+    /// Application-supplied providers registered directly on the platform do
+    /// not need a stored config, so the default maps the open provider id to an
+    /// equally named integration kind without credentials.
+    async fn get_provider_config(
+        &self,
+        _provider: &crate::ProviderKey,
+    ) -> Result<Option<crate::ProviderConfig>> {
+        Ok(None)
+    }
 }
 
 #[async_trait]
@@ -277,6 +313,13 @@ impl<T: ProviderStore + ?Sized> ProviderStore for std::sync::Arc<T> {
 
     async fn get_default_model(&self) -> Result<Option<ResolvedModel>> {
         (**self).get_default_model().await
+    }
+
+    async fn get_provider_config(
+        &self,
+        provider: &crate::ProviderKey,
+    ) -> Result<Option<crate::ProviderConfig>> {
+        (**self).get_provider_config(provider).await
     }
 }
 

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -5,8 +5,8 @@
 //! the model fixed so call sites cannot turn it into a user-selectable model.
 
 use crate::{
-    AgentLoopError, ChatDriver, LlmCallConfig, LlmMessage, LlmResponse, LlmResponseStream,
-    OpenResponsesProtocolChatDriver, Result,
+    AgentLoopError, BearerAuth, LlmCallConfig, LlmMessage, LlmResponse, LlmResponseStream,
+    OpenResponsesProtocolChatDriver, Provider, Result,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -150,7 +150,7 @@ impl UtilityLlmService for DisabledUtilityLlmService {
 
 #[derive(Clone)]
 pub struct OpenAiUtilityLlmService {
-    driver: OpenResponsesProtocolChatDriver,
+    provider: Provider,
 }
 
 impl std::fmt::Debug for OpenAiUtilityLlmService {
@@ -167,7 +167,9 @@ impl OpenAiUtilityLlmService {
         // THREAT[TM-LLM-021]: Utility LLM credentials must not become agent- or
         // session-configurable. Keep the key inside this host service.
         Self {
-            driver: OpenResponsesProtocolChatDriver::new(api_key),
+            provider: Provider::new("utility-openai", OpenResponsesProtocolChatDriver::new())
+                .base_url("https://api.openai.com/v1")
+                .auth(BearerAuth::new(api_key)),
         }
     }
 }
@@ -180,7 +182,7 @@ impl UtilityLlmService for OpenAiUtilityLlmService {
 
     async fn chat_completion(&self, request: UtilityLlmRequest) -> Result<LlmResponse> {
         let (messages, config) = request.into_parts()?;
-        self.driver.chat_completion(messages, &config).await
+        self.provider.chat_completion(messages, &config).await
     }
 
     async fn chat_completion_stream(
@@ -188,7 +190,9 @@ impl UtilityLlmService for OpenAiUtilityLlmService {
         request: UtilityLlmRequest,
     ) -> Result<LlmResponseStream> {
         let (messages, config) = request.into_parts()?;
-        self.driver.chat_completion_stream(messages, &config).await
+        self.provider
+            .chat_completion_stream(messages, &config)
+            .await
     }
 
     fn name(&self) -> &'static str {

--- a/crates/core/tests/openai_protocol_wire.rs
+++ b/crates/core/tests/openai_protocol_wire.rs
@@ -11,9 +11,10 @@
 
 use everruns_core::OpenAIProtocolChatDriver;
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
-    LlmResponseStream, LlmStreamEvent,
+    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream,
+    LlmStreamEvent,
 };
+use everruns_core::{BearerAuth, Provider};
 use futures::StreamExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -109,11 +110,10 @@ async fn mount_sse(server: &MockServer, body: String) {
         .await;
 }
 
-fn driver(server: &MockServer) -> OpenAIProtocolChatDriver {
-    OpenAIProtocolChatDriver::with_base_url(
-        "test-key",
-        format!("{}/v1/chat/completions", server.uri()),
-    )
+fn driver(server: &MockServer) -> Provider {
+    Provider::new("openai-protocol-test", OpenAIProtocolChatDriver::new())
+        .base_url(format!("{}/v1/chat/completions", server.uri()))
+        .auth(BearerAuth::new("test-key"))
 }
 
 /// Text streaming: two content deltas, a `stop` finish chunk, then the usage

--- a/crates/core/tests/openai_reconnect_wire.rs
+++ b/crates/core/tests/openai_reconnect_wire.rs
@@ -14,9 +14,10 @@ use std::time::Duration;
 
 use everruns_core::OpenAIProtocolChatDriver;
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    LlmCallConfig, LlmMessage, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
 };
 use everruns_core::llm_retry::LlmRetryConfig;
+use everruns_core::{BearerAuth, Provider};
 use futures::StreamExt;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -141,8 +142,12 @@ async fn drain(mut stream: LlmResponseStream) -> (Vec<String>, bool) {
 #[tokio::test]
 async fn driver_reconnects_on_truncated_first_response() {
     let (url, count) = spawn_flaky_openai_server(1).await;
-    let driver =
-        OpenAIProtocolChatDriver::with_base_url("test-key", url).with_retry_config(fast_retry());
+    let driver = Provider::new(
+        "openai-reconnect-test",
+        OpenAIProtocolChatDriver::new().with_retry_config(fast_retry()),
+    )
+    .base_url(url)
+    .auth(BearerAuth::new("test-key"));
 
     let stream = driver
         .chat_completion_stream(
@@ -169,8 +174,12 @@ async fn driver_reconnects_on_truncated_first_response() {
 async fn driver_surfaces_error_after_exhausting_reconnects() {
     // Always truncate. With max_retries = 2 that is 1 + 2 = 3 attempts.
     let (url, count) = spawn_flaky_openai_server(u32::MAX).await;
-    let driver =
-        OpenAIProtocolChatDriver::with_base_url("test-key", url).with_retry_config(fast_retry());
+    let driver = Provider::new(
+        "openai-reconnect-test",
+        OpenAIProtocolChatDriver::new().with_retry_config(fast_retry()),
+    )
+    .base_url(url)
+    .auth(BearerAuth::new("test-key"));
 
     let result = driver
         .chat_completion_stream(

--- a/crates/core/tests/openresponses_protocol_wire.rs
+++ b/crates/core/tests/openresponses_protocol_wire.rs
@@ -13,10 +13,10 @@
 
 use everruns_core::OpenResponsesProtocolChatDriver;
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
-    LlmResponseStream, LlmStreamEvent, ProviderOpaqueContext,
+    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream,
+    LlmStreamEvent, ProviderOpaqueContext,
 };
-use everruns_core::{CompactContent, CompactOutputItem};
+use everruns_core::{BearerAuth, CompactContent, CompactOutputItem, Provider};
 use futures::StreamExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -110,11 +110,10 @@ async fn mount_sse(server: &MockServer, body: String) {
         .await;
 }
 
-fn driver(server: &MockServer) -> OpenResponsesProtocolChatDriver {
-    OpenResponsesProtocolChatDriver::with_base_url(
-        "test-key",
-        format!("{}/v1/responses", server.uri()),
-    )
+fn driver(server: &MockServer) -> Provider {
+    Provider::new("openresponses-test", OpenResponsesProtocolChatDriver::new())
+        .base_url(format!("{}/v1/responses", server.uri()))
+        .auth(BearerAuth::new("test-key"))
 }
 
 /// Text streaming: two output-text deltas then a `response.completed` carrying

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -229,6 +229,7 @@ struct ProactiveCompactDriver {
 impl everruns_core::ChatDriver for ProactiveCompactDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -259,6 +260,7 @@ impl everruns_core::ChatDriver for ProactiveCompactDriver {
 
     async fn compact(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         request: everruns_core::CompactRequest,
     ) -> everruns_core::Result<Option<everruns_core::CompactResponse>> {
         self.compact_attempts.fetch_add(1, Ordering::SeqCst);
@@ -513,6 +515,7 @@ impl everruns_core::CompactionCheckpointStore for FailingProactiveAttemptStore {
 impl everruns_core::ChatDriver for NativeCompactFailureDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         _config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -535,6 +538,7 @@ impl everruns_core::ChatDriver for NativeCompactFailureDriver {
 
     async fn compact(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _request: everruns_core::CompactRequest,
     ) -> everruns_core::Result<Option<everruns_core::CompactResponse>> {
         Err(everruns_core::AgentLoopError::llm("compact failed"))
@@ -545,6 +549,7 @@ impl everruns_core::ChatDriver for NativeCompactFailureDriver {
 impl everruns_core::ChatDriver for NativeCompactRetryDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -616,6 +621,7 @@ impl everruns_core::ChatDriver for NativeCompactRetryDriver {
 
     async fn compact(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         request: everruns_core::CompactRequest,
     ) -> everruns_core::Result<Option<everruns_core::CompactResponse>> {
         *self.compact_request.lock().await = Some(request);
@@ -646,6 +652,7 @@ impl everruns_core::ChatDriver for NativeCompactRetryDriver {
 impl everruns_core::ChatDriver for FlakyStreamDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -696,6 +703,7 @@ struct StallingStreamDriver {
 impl everruns_core::ChatDriver for StallingStreamDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -737,6 +745,7 @@ struct ThinkingLeakDriver {
 impl everruns_core::ChatDriver for ThinkingLeakDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -770,6 +779,7 @@ struct SpeedCapturingDriver {
 impl everruns_core::ChatDriver for SpeedCapturingDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -2875,7 +2885,11 @@ async fn test_driver_registry_integration() {
     };
 
     let response = driver
-        .chat_completion(messages, &call_config)
+        .chat_completion(
+            &everruns_core::ProviderEndpoint::default(),
+            messages,
+            &call_config,
+        )
         .await
         .expect("Chat completion should succeed");
 
@@ -3210,6 +3224,7 @@ struct ToolCallsThenErrorDriver;
 impl everruns_core::ChatDriver for ToolCallsThenErrorDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         _config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -3303,6 +3318,7 @@ struct TextThenErrorDriver;
 impl everruns_core::ChatDriver for TextThenErrorDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         _config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -3393,6 +3409,7 @@ struct PureErrorDriver {
 impl everruns_core::ChatDriver for PureErrorDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         _messages: Vec<everruns_core::LlmMessage>,
         _config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -3770,6 +3787,7 @@ struct SystemPromptCapturingDriver {
 impl everruns_core::ChatDriver for SystemPromptCapturingDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
@@ -3806,6 +3824,7 @@ struct ConversationCapturingDriver {
 impl everruns_core::ChatDriver for ConversationCapturingDriver {
     async fn chat_completion_stream(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         messages: Vec<everruns_core::LlmMessage>,
         config: &everruns_core::LlmCallConfig,
     ) -> everruns_core::Result<everruns_core::LlmResponseStream> {

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -369,7 +369,8 @@ impl ProactiveTestRig {
             usage,
         };
         let mut driver_registry = DriverRegistry::new();
-        driver_registry.register(provider_type.clone(), move |_| Box::new(driver.clone()));
+        driver_registry
+            .register_external(provider_type.as_str(), move |_| Box::new(driver.clone()));
         let mut capability_registry = CapabilityRegistry::new();
         capability_registry.register(CompactionCapability);
 

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -73,6 +73,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
+futures.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 serde = { workspace = true }
 trybuild = { workspace = true }

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -5,39 +5,24 @@ The application-facing entrypoint to the [Everruns](https://everruns.com) agenti
 `everruns` is a thin, publishable facade over the in-process runtime. Add a single dependency and
 run an agent turn — without wiring up `everruns-core` or `everruns-runtime` directly.
 
-This first release is a **compatibility facade**: it moves no engine code and re-exports the
-minimum needed to construct and run an in-process session. Default features stay offline — no
-provider, MCP, filesystem, SQLx, server, or worker integrations are activated by default. APIs not
-yet promoted onto the facade remain reachable through the escape-hatch `everruns::core` and
-`everruns::runtime` modules.
+The high-level API uses an open, credential-free `ModelSpec` plus runtime
+`Provider` contract. Default features stay offline. Custom providers and wire
+protocols can be supplied through `everruns` alone; applications do not need to
+import `everruns-core` or `everruns-runtime`.
 
 ## Example
 
 ```rust
-use everruns::{DriverId, InProcessRuntimeBuilder, InputMessage, LlmSimConfig, ResolvedModel};
+use everruns::{Agent, Model};
 
 #[tokio::main]
-async fn main() -> Result<(), everruns::AgentLoopError> {
-    let runtime = InProcessRuntimeBuilder::new()
-        .single_session(|s| {
-            s.harness("assistant", "You are a helpful assistant.")
-                .agent("assistant-agent", "Answer the user.")
-        })
-        .llm_sim(LlmSimConfig::fixed("4"))
-        .default_model(ResolvedModel {
-            model: "llmsim-model".into(),
-            provider_type: DriverId::LlmSim,
-            api_key: Some("fake-key".into()),
-            base_url: None,
-            provider_metadata: None,
-        })
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let agent = Agent::builder()
+        .instructions("You are a helpful assistant.")
+        .model(Model::simulated("4"))
         .build()
-        .await?;
-
-    let session_id = runtime.default_session_id().expect("single_session id");
-    let result = runtime
-        .run_turn(session_id, InputMessage::user("What is 2 + 2?"))
-        .await?;
+        .expect("valid agent");
+    let result = agent.session().run("What is 2 + 2?").await?;
 
     assert_eq!(result.response, "4");
     Ok(())

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -14,8 +14,8 @@ use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
-use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::{AgentCapabilityConfig, DriverId, InitialFile, ResolvedModel, SessionId};
+use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
+use everruns_core::{AgentCapabilityConfig, InitialFile, ModelSpec, Provider, SessionId};
 use everruns_runtime::{
     AgentBuilder as RuntimeAgentBuilder, EventBus, HarnessBuilder, InProcessRuntime,
     InProcessRuntimeBuilder, RuntimeBackends, RuntimeMessageStore, SessionBuilder,
@@ -25,17 +25,13 @@ use crate::tool::{FunctionTool, IntoTool, Tool, validate_tool_name, validate_too
 
 /// How an [`Agent`] talks to a model.
 ///
-/// A `Model` carries the driver selection and model configuration behind a
-/// value-first surface, so the public builder never exposes `ResolvedModel`,
-/// `DriverId`, or the simulator config. [`Model::simulated`] backs an offline
-/// simulator; with the `openai` feature, an
-/// [`OpenAI`](crate::providers::openai::OpenAI) configuration converts into a
-/// `Model` that targets the real provider.
+/// A `Model` carries a credential-free specification and may bundle a ready-made
+/// provider assembly. [`Model::simulated`] uses the same provider path as every
+/// network-backed model.
 #[derive(Clone)]
 pub struct Model {
-    resolved: ResolvedModel,
-    /// Present when the model is backed by the in-process LLM simulator.
-    sim: Option<LlmSimConfig>,
+    spec: ModelSpec,
+    bundled_provider: Option<Provider>,
 }
 
 impl Model {
@@ -44,43 +40,41 @@ impl Model {
     /// Backed by the `llmsim` driver, so an agent using it runs entirely
     /// offline — no credentials, no network.
     pub fn simulated(response: impl Into<String>) -> Self {
-        Self {
-            resolved: ResolvedModel {
-                model: "llmsim-model".to_string(),
-                provider_type: DriverId::LlmSim,
-                api_key: Some("fake-key".to_string()),
-                base_url: None,
-                provider_metadata: None,
-            },
-            sim: Some(LlmSimConfig::fixed(response)),
-        }
+        Self::with_provider(
+            ModelSpec::on("llmsim", "llmsim-model"),
+            Provider::new("llmsim", LlmSimDriver::new(LlmSimConfig::fixed(response))),
+        )
     }
 
     /// Build a `Model` that targets OpenAI's Responses API.
     ///
-    /// Keeps `ResolvedModel`/`DriverId` off the public surface: the
-    /// [`OpenAI`](crate::providers::openai::OpenAI) config is the value-first
-    /// entry point, and `build_runtime` registers the OpenAI driver only for a
-    /// model produced here.
+    /// The convenience produces the same public model/provider pair callers can
+    /// assemble directly with [`ModelSpec`] and [`Provider`].
     #[cfg(feature = "openai")]
     pub(crate) fn openai(config: crate::providers::openai::OpenAI) -> Self {
         let (model, api_key, base_url) = config.into_parts();
-        Self {
-            resolved: ResolvedModel {
-                model,
-                provider_type: DriverId::OpenAI,
-                api_key: Some(api_key),
-                base_url,
-                provider_metadata: None,
-            },
-            sim: None,
+        let mut provider = everruns_openai::provider("openai", api_key);
+        if let Some(base_url) = base_url {
+            provider = provider.base_url(base_url);
         }
+        Self::with_provider(ModelSpec::on("openai", model), provider)
     }
 
-    /// Whether this model needs the OpenAI driver registered on the runtime.
-    #[cfg(feature = "openai")]
-    fn is_openai(&self) -> bool {
-        self.resolved.provider_type == DriverId::OpenAI
+    /// Pair a model specification with a ready-to-use provider assembly.
+    pub fn with_provider(spec: ModelSpec, provider: Provider) -> Self {
+        Self {
+            spec,
+            bundled_provider: Some(provider),
+        }
+    }
+}
+
+impl From<ModelSpec> for Model {
+    fn from(spec: ModelSpec) -> Self {
+        Self {
+            spec,
+            bundled_provider: None,
+        }
     }
 }
 
@@ -95,16 +89,10 @@ impl Model {
     ) -> Self {
         let mut sim = LlmSimConfig::fixed(response);
         sim.message_capture = Some(capture);
-        Self {
-            resolved: ResolvedModel {
-                model: "llmsim-model".to_string(),
-                provider_type: DriverId::LlmSim,
-                api_key: Some("fake-key".to_string()),
-                base_url: None,
-                provider_metadata: None,
-            },
-            sim: Some(sim),
-        }
+        Self::with_provider(
+            ModelSpec::on("llmsim", "llmsim-model"),
+            Provider::new("llmsim", LlmSimDriver::new(sim)),
+        )
     }
 
     /// Test-only: a simulated model that waits `delay` (a TTFT delay) before
@@ -115,16 +103,10 @@ impl Model {
         delay: std::time::Duration,
     ) -> Self {
         let sim = LlmSimConfig::fixed(response).with_response_delay(delay);
-        Self {
-            resolved: ResolvedModel {
-                model: "llmsim-model".to_string(),
-                provider_type: DriverId::LlmSim,
-                api_key: Some("fake-key".to_string()),
-                base_url: None,
-                provider_metadata: None,
-            },
-            sim: Some(sim),
-        }
+        Self::with_provider(
+            ModelSpec::on("llmsim", "llmsim-model"),
+            Provider::new("llmsim", LlmSimDriver::new(sim)),
+        )
     }
 
     /// Test-only: a simulated model that emits the given per-turn tool-call
@@ -135,26 +117,18 @@ impl Model {
         tool_call_sequence: Vec<Vec<everruns_core::ToolCall>>,
     ) -> Self {
         let sim = LlmSimConfig::fixed(response).with_tool_call_sequence(tool_call_sequence);
-        Self {
-            resolved: ResolvedModel {
-                model: "llmsim-model".to_string(),
-                provider_type: DriverId::LlmSim,
-                api_key: Some("fake-key".to_string()),
-                base_url: None,
-                provider_metadata: None,
-            },
-            sim: Some(sim),
-        }
+        Self::with_provider(
+            ModelSpec::on("llmsim", "llmsim-model"),
+            Provider::new("llmsim", LlmSimDriver::new(sim)),
+        )
     }
 }
 
 impl fmt::Debug for Model {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Redact the resolved model's api key; report only the shape.
         f.debug_struct("Model")
-            .field("model", &self.resolved.model)
-            .field("provider_type", &self.resolved.provider_type)
-            .field("simulated", &self.sim.is_some())
+            .field("spec", &self.spec)
+            .field("bundled_provider", &self.bundled_provider)
             .finish()
     }
 }
@@ -188,6 +162,13 @@ pub enum BuildError {
         /// The colliding tool name.
         name: String,
     },
+    /// Two providers used the same normalized identity.
+    DuplicateProvider { id: String },
+    /// The selected model names a provider that was not registered.
+    UnknownProvider {
+        requested: String,
+        registered: Vec<String>,
+    },
 }
 
 impl fmt::Display for BuildError {
@@ -206,6 +187,15 @@ impl fmt::Display for BuildError {
             BuildError::DuplicateTool { name } => {
                 write!(f, "duplicate tool name {name:?}")
             }
+            BuildError::DuplicateProvider { id } => write!(f, "duplicate provider {id:?}"),
+            BuildError::UnknownProvider {
+                requested,
+                registered,
+            } => write!(
+                f,
+                "provider {requested:?} is not registered; registered providers: [{}]",
+                registered.join(", ")
+            ),
         }
     }
 }
@@ -223,6 +213,7 @@ pub struct Agent {
     name: String,
     instructions: String,
     model: Model,
+    providers: Vec<Provider>,
     capabilities: Vec<AgentCapabilityConfig>,
     function_tools: Vec<FunctionTool>,
     initial_files: Vec<InitialFile>,
@@ -355,7 +346,7 @@ impl Agent {
             .harness(harness)
             .agent(agent)
             .session(session)
-            .default_model(self.model.resolved.clone());
+            .model_spec(self.model.spec.clone());
         // Route the runtime's raw event bus through the facade sink, and swap in
         // a persisting message store when one was supplied (EVE-836). Any store
         // not overridden stays on the default in-memory backend.
@@ -375,17 +366,8 @@ impl Agent {
         for tool in &self.function_tools {
             builder = builder.capability(tool.clone().into_capability());
         }
-        if let Some(sim) = &self.model.sim {
-            builder = builder.llm_sim(sim.clone());
-        }
-        // A real OpenAI model needs its driver registered so a turn can reach the
-        // provider; setting `default_model` alone is not enough. Register only for
-        // an OpenAI model, so a simulated-model agent needs no provider wiring.
-        #[cfg(feature = "openai")]
-        if self.model.is_openai() {
-            let mut registry = everruns_core::DriverRegistry::new();
-            everruns_openai::register_driver(&mut registry);
-            builder = builder.driver_registry(registry);
+        for provider in &self.providers {
+            builder = builder.provider(provider.clone());
         }
         builder.build().await
     }
@@ -401,6 +383,7 @@ pub struct AgentBuilder {
     name: Option<String>,
     instructions: Option<String>,
     model: Option<Model>,
+    providers: Vec<Provider>,
     capabilities: Vec<AgentCapabilityConfig>,
     tools: Vec<Tool>,
     initial_files: Vec<InitialFile>,
@@ -421,6 +404,12 @@ impl AgentBuilder {
     /// under the `openai` feature.
     pub fn model(mut self, model: impl Into<Model>) -> Self {
         self.model = Some(model.into());
+        self
+    }
+
+    /// Register a service provider selected by the model specification.
+    pub fn provider(mut self, provider: Provider) -> Self {
+        self.providers.push(provider);
         self
     }
 
@@ -499,6 +488,29 @@ impl AgentBuilder {
             return Err(BuildError::BlankInstructions);
         }
         let model = self.model.ok_or(BuildError::MissingModel)?;
+        let mut providers = self.providers;
+        if let Some(provider) = model.bundled_provider.clone() {
+            providers.push(provider);
+        }
+        let mut provider_ids = HashSet::new();
+        for provider in &providers {
+            if !provider_ids.insert(provider.id().clone()) {
+                return Err(BuildError::DuplicateProvider {
+                    id: provider.id().to_string(),
+                });
+            }
+        }
+        if !provider_ids.contains(&model.spec.provider) {
+            let mut registered = provider_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            registered.sort();
+            return Err(BuildError::UnknownProvider {
+                requested: model.spec.provider.to_string(),
+                registered,
+            });
+        }
         let name = self.name.unwrap_or_else(|| "agent".to_string());
 
         // Validate tools and split them into capability refs (attached to the
@@ -537,6 +549,7 @@ impl AgentBuilder {
             name,
             instructions,
             model,
+            providers,
             capabilities,
             function_tools,
             initial_files: self.initial_files,
@@ -742,9 +755,11 @@ mod tests {
         use crate::providers::openai::OpenAI;
 
         let model = Model::openai(OpenAI::new("gpt-5-mini", "sk-super-secret"));
-        assert!(model.is_openai());
-        assert_eq!(model.resolved.model, "gpt-5-mini");
-        assert!(model.sim.is_none(), "an OpenAI model uses no simulator");
+        assert_eq!(model.spec, ModelSpec::on("openai", "gpt-5-mini"));
+        assert_eq!(
+            model.bundled_provider.as_ref().unwrap().id().as_str(),
+            "openai"
+        );
         // The value-first `Debug` reports shape only, never the key.
         let rendered = format!("{model:?}");
         assert!(!rendered.contains("sk-super-secret"), "got {rendered}");

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -19,36 +19,15 @@
 //!
 //! ```
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), everruns::AgentLoopError> {
-//! use everruns::{
-//!     DriverId, InProcessRuntimeBuilder, InputMessage, LlmSimConfig, ResolvedModel,
-//! };
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use everruns::{Agent, Model};
 //!
-//! let runtime = InProcessRuntimeBuilder::new()
-//!     .single_session(|s| {
-//!         s.harness("assistant", "You are a helpful assistant.")
-//!             .harness_display_name("Assistant")
-//!             .agent("assistant-agent", "Answer the user.")
-//!             .agent_display_name("Assistant Agent")
-//!             .agent_max_iterations(4)
-//!             .session_title("Facade Smoke")
-//!     })
-//!     .llm_sim(LlmSimConfig::fixed("4"))
-//!     .default_model(ResolvedModel {
-//!         model: "llmsim-model".into(),
-//!         provider_type: DriverId::LlmSim,
-//!         api_key: Some("fake-key".into()),
-//!         base_url: None,
-//!         provider_metadata: None,
-//!     })
+//! let agent = Agent::builder()
+//!     .instructions("You are a helpful assistant.")
+//!     .model(Model::simulated("4"))
 //!     .build()
-//!     .await?;
-//!
-//! let session_id = runtime.default_session_id().expect("single_session id");
-//! let result = runtime
-//!     .run_turn(session_id, InputMessage::user("What is 2 + 2?"))
-//!     .await?;
-//!
+//!     .expect("valid agent");
+//! let result = agent.session().run("What is 2 + 2?").await?;
 //! assert!(result.success);
 //! assert_eq!(result.response, "4");
 //! # Ok(())
@@ -139,8 +118,10 @@ pub use everruns_runtime::{
 // --- Portable message, model, and platform types ------------------------
 pub use everruns_core::turn::TurnStopReason;
 pub use everruns_core::{
-    AgentLoopError, CapabilityRegistry, ContentPart, DriverId, DriverRegistry, InputMessage,
-    MessageRole, PlatformDefinition, ResolvedModel,
+    AgentLoopError, BearerAuth, CapabilityRegistry, ChatDriver, ContentPart, InputMessage,
+    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmResponseStream, LlmStreamEvent,
+    MessageRole, ModelSpec, PlatformDefinition, Provider, ProviderAuth, ProviderAuthRequest,
+    ProviderEndpoint, ProviderKey, ProviderRegistry, StaticHeaderAuth,
 };
 
 // --- Deterministic in-process LLM simulator -----------------------------

--- a/crates/everruns/tests/custom_provider.rs
+++ b/crates/everruns/tests/custom_provider.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use everruns::{
+    Agent, AgentLoopError, ChatDriver, LlmCallConfig, LlmMessage, LlmResponseStream,
+    LlmStreamEvent, ModelSpec, Provider, ProviderEndpoint,
+};
+
+#[derive(Clone)]
+struct DownstreamProtocol;
+
+#[async_trait]
+impl ChatDriver for DownstreamProtocol {
+    async fn chat_completion_stream(
+        &self,
+        _endpoint: &ProviderEndpoint,
+        _messages: Vec<LlmMessage>,
+        _config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream, AgentLoopError> {
+        Ok(Box::pin(futures::stream::iter([
+            Ok(LlmStreamEvent::TextDelta("downstream works".to_string())),
+            Ok(LlmStreamEvent::Done(Box::default())),
+        ])))
+    }
+}
+
+#[tokio::test]
+async fn downstream_provider_needs_only_the_everruns_api() {
+    let agent = Agent::builder()
+        .instructions("Reply through the configured provider.")
+        .model(ModelSpec::on("my-gateway", "custom-model"))
+        .provider(
+            Provider::new("my-gateway", DownstreamProtocol)
+                .base_url("https://gateway.example/v1")
+                .header("x-tenant", "tenant-a"),
+        )
+        .build()
+        .unwrap();
+
+    let turn = agent.session().run("hello").await.unwrap();
+    assert_eq!(turn.response, "downstream works");
+}
+
+#[test]
+fn fixture_has_no_private_runtime_imports() {
+    let source = include_str!("custom_provider.rs");
+    assert!(!source.contains(concat!("everruns_", "core")));
+    assert!(!source.contains(concat!("everruns_", "runtime")));
+    assert!(!source.contains(concat!("is_", "openai")));
+}
+
+#[test]
+fn facade_has_no_builtin_provider_dispatch() {
+    let source = include_str!("../src/agent.rs");
+    assert!(!source.contains("DriverId"));
+    assert!(!source.contains(concat!("is_", "openai")));
+    assert!(!source.contains("provider_type =="));
+}

--- a/crates/everruns/tests/facade_smoke.rs
+++ b/crates/everruns/tests/facade_smoke.rs
@@ -2,37 +2,19 @@
 //! must be able to build one session and run one turn without importing
 //! `everruns-core` or `everruns-runtime`.
 
-use everruns::{DriverId, InProcessRuntimeBuilder, InputMessage, LlmSimConfig, ResolvedModel};
+use everruns::{Agent, Model};
 
 #[tokio::test]
 async fn facade_runs_one_simulated_turn() {
-    let runtime = InProcessRuntimeBuilder::new()
-        .single_session(|s| {
-            s.harness("assistant", "You are a helpful assistant.")
-                .harness_display_name("Assistant")
-                .agent("assistant-agent", "Answer the user.")
-                .agent_display_name("Assistant Agent")
-                .agent_max_iterations(4)
-                .session_title("Facade Smoke")
-        })
-        .llm_sim(LlmSimConfig::fixed("4"))
-        .default_model(ResolvedModel {
-            model: "llmsim-model".into(),
-            provider_type: DriverId::LlmSim,
-            api_key: Some("fake-key".into()),
-            base_url: None,
-            provider_metadata: None,
-        })
+    let agent = Agent::builder()
+        .instructions("You are a helpful assistant.")
+        .model(Model::simulated("4"))
         .build()
-        .await
-        .expect("runtime builds");
+        .expect("agent builds");
 
-    let session_id = runtime
-        .default_session_id()
-        .expect("single_session yields a default session id");
-
-    let result = runtime
-        .run_turn(session_id, InputMessage::user("What is 2 + 2?"))
+    let result = agent
+        .session()
+        .run("What is 2 + 2?")
         .await
         .expect("turn runs");
 

--- a/crates/fireworks/src/driver.rs
+++ b/crates/fireworks/src/driver.rs
@@ -15,19 +15,28 @@ use everruns_provider::OpenAIProtocolChatDriver;
 use everruns_provider::credential_schema::{CredentialFormSchema, FormField};
 use everruns_provider::driver_helpers::fetch_models;
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverConfig, DriverDescriptor, DriverId,
-    DriverRegistry, LlmCallConfig, LlmMessage, LlmResponseStream,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmMessage, LlmResponseStream,
 };
 use everruns_provider::error::Result;
 use everruns_provider::model::{Modality, ModelLimits, ModelModalities, ModelProfile};
-use everruns_provider::openai_protocol::{
-    apply_models_api_auth, models_url_for_api_url, normalize_api_url, url_host_eq,
-};
+use everruns_provider::openai_protocol::{models_url_for_api_url, url_host_eq};
+use everruns_provider::{BearerAuth, Provider, ProviderEndpoint};
 
 /// Fireworks AI serverless inference endpoint (OpenAI-compatible Chat
 /// Completions). The chat URL is the normalized `…/chat/completions` form.
 pub const FIREWORKS_DEFAULT_API_URL: &str =
     "https://api.fireworks.ai/inference/v1/chat/completions";
+
+/// Ready-to-use Fireworks provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> Provider {
+    Provider::new(id, FireworksChatDriver::new())
+        .base_url("https://api.fireworks.ai/inference/v1")
+        .auth(BearerAuth::new(api_key))
+}
 
 /// Canonical Fireworks API host. Discovery only runs against this host.
 const FIREWORKS_HOST: &str = "api.fireworks.ai";
@@ -46,65 +55,30 @@ pub fn is_fireworks_api_url(api_url: &str) -> bool {
 /// Fireworks AI chat driver.
 ///
 /// Construct directly for programmatic use, or let [`register_driver`] build
-/// instances from a [`DriverConfig`].
+/// instances from the transitional descriptor catalog.
 ///
 /// # Example
 ///
 /// ```
-/// use everruns_fireworks::FireworksChatDriver;
+/// use everruns_fireworks::provider;
 ///
-/// let driver = FireworksChatDriver::new("fw-key");
+/// let service = provider("fireworks", "fw-key");
 /// assert_eq!(
-///     driver.api_url(),
+///     service.endpoint().url("chat/completions").unwrap(),
 ///     "https://api.fireworks.ai/inference/v1/chat/completions",
 /// );
 /// ```
 #[derive(Clone)]
 pub struct FireworksChatDriver {
     inner: OpenAIProtocolChatDriver,
-    api_url: String,
-    /// Whether constructed with an explicit base URL override via
-    /// [`with_base_url`]. Discovery is skipped for custom (non-Fireworks) hosts.
-    uses_custom_url: bool,
 }
 
 impl FireworksChatDriver {
-    /// Create a driver with the default Fireworks serverless endpoint.
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create the Fireworks-compatible Chat Completions wire driver.
+    pub fn new() -> Self {
         Self {
-            inner: OpenAIProtocolChatDriver::with_base_url(api_key, FIREWORKS_DEFAULT_API_URL),
-            api_url: FIREWORKS_DEFAULT_API_URL.to_string(),
-            uses_custom_url: false,
+            inner: OpenAIProtocolChatDriver::new(),
         }
-    }
-
-    /// Create a driver with an explicit API URL override (self-hosted proxy or a
-    /// custom Fireworks endpoint). The URL is normalized to a
-    /// `…/chat/completions` endpoint.
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        let api_url = normalize_api_url(&api_url.into(), "/chat/completions");
-        Self {
-            inner: OpenAIProtocolChatDriver::with_base_url(api_key, &api_url),
-            api_url,
-            uses_custom_url: true,
-        }
-    }
-
-    /// Build a driver from a registry [`DriverConfig`]. The API key is required
-    /// (enforced by the registry); `base_url` overrides the default endpoint.
-    fn from_driver_config(config: &DriverConfig) -> Self {
-        // The registry guarantees an api_key for Fireworks before calling the
-        // factory; default to empty so the infallible factory contract holds.
-        let api_key = config.api_key.clone().unwrap_or_default();
-        match config.base_url.as_deref().filter(|u| !u.is_empty()) {
-            Some(base_url) => Self::with_base_url(api_key, base_url),
-            None => Self::new(api_key),
-        }
-    }
-
-    /// The resolved chat-completions API URL.
-    pub fn api_url(&self) -> &str {
-        &self.api_url
     }
 }
 
@@ -112,35 +86,42 @@ impl FireworksChatDriver {
 impl ChatDriver for FireworksChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        self.inner.chat_completion_stream(messages, config).await
+        self.inner
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
     fn supports_parallel_tool_calls(&self, model: &str) -> bool {
         self.inner.supports_parallel_tool_calls(model)
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        let Some(api_url) = endpoint.url("chat/completions") else {
+            return Ok(None);
+        };
         // Discovery only runs against Fireworks' own host. A custom proxy URL may
         // resolve to private infrastructure at request time (mirrors the
         // OpenRouter/MAI host gating).
-        if self.uses_custom_url && !is_fireworks_api_url(&self.api_url) {
+        if !is_fireworks_api_url(&api_url) {
             return Ok(None);
         }
 
-        let models_url = models_url_for_api_url(&self.api_url);
-        list_fireworks_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        let models_url = models_url_for_api_url(&api_url);
+        list_fireworks_models(self.inner.client(), endpoint, &models_url).await
     }
 }
 
 impl std::fmt::Debug for FireworksChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FireworksChatDriver")
-            .field("api_url", &self.api_url)
             .field("api", &"Fireworks AI (Chat Completions)")
-            .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
@@ -155,11 +136,16 @@ impl std::fmt::Debug for FireworksChatDriver {
 /// `supports_image_input`, `context_length`).
 async fn list_fireworks_models(
     client: &reqwest::Client,
-    api_key: &str,
+    endpoint: &ProviderEndpoint,
     models_url: &str,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
+    let resolved = endpoint.resolve("GET", models_url, &[]).await?;
+    let mut request = client.get(&resolved.url);
+    for (name, value) in resolved.headers {
+        request = request.header(name, value);
+    }
     fetch_models::<FireworksModelsResponse, _>(
-        apply_models_api_auth(client.get(models_url), models_url, api_key),
+        request,
         "Failed to fetch Fireworks models",
         "Failed to parse Fireworks models response",
         &[],
@@ -343,11 +329,26 @@ fn fireworks_credential_schema() -> CredentialFormSchema {
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_descriptor(DriverDescriptor {
+        display_name: "Fireworks AI".into(),
         credential_schema: fireworks_credential_schema(),
         ..DriverDescriptor::chat_only(DriverId::Fireworks, |config| {
-            Box::new(FireworksChatDriver::from_driver_config(config)) as BoxedChatDriver
+            Provider::new(config.provider.clone(), FireworksChatDriver::new())
+                .base_url(
+                    config
+                        .base_url
+                        .as_deref()
+                        .unwrap_or("https://api.fireworks.ai/inference/v1"),
+                )
+                .auth(BearerAuth::new(config.api_key.clone().unwrap_or_default()))
+                .into_boxed_driver()
         })
     });
+}
+
+impl Default for FireworksChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]
@@ -359,23 +360,30 @@ mod tests {
 
     #[test]
     fn default_driver_uses_fireworks_endpoint() {
-        let driver = FireworksChatDriver::new("fw-key");
-        assert_eq!(driver.api_url(), FIREWORKS_DEFAULT_API_URL);
-        assert!(!driver.uses_custom_url);
+        let service = provider("fireworks", "fw-key");
+        assert_eq!(
+            service.endpoint().url("chat/completions").as_deref(),
+            Some(FIREWORKS_DEFAULT_API_URL)
+        );
     }
 
     #[test]
     fn with_base_url_normalizes_to_chat_completions() {
-        let driver =
-            FireworksChatDriver::with_base_url("fw-key", "https://api.fireworks.ai/inference/v1");
-        assert_eq!(driver.api_url(), FIREWORKS_DEFAULT_API_URL);
-        assert!(driver.uses_custom_url);
+        let service =
+            provider("fireworks", "fw-key").base_url("https://api.fireworks.ai/inference/v1");
+        assert_eq!(
+            service.endpoint().url("chat/completions").as_deref(),
+            Some(FIREWORKS_DEFAULT_API_URL)
+        );
     }
 
     #[test]
     fn with_base_url_preserves_full_chat_completions_url() {
-        let driver = FireworksChatDriver::with_base_url("fw-key", FIREWORKS_DEFAULT_API_URL);
-        assert_eq!(driver.api_url(), FIREWORKS_DEFAULT_API_URL);
+        let service = provider("fireworks", "fw-key").base_url(FIREWORKS_DEFAULT_API_URL);
+        assert_eq!(
+            service.endpoint().url("chat/completions").as_deref(),
+            Some(FIREWORKS_DEFAULT_API_URL)
+        );
     }
 
     #[test]
@@ -465,8 +473,16 @@ mod tests {
 
     #[tokio::test]
     async fn list_models_skips_custom_non_fireworks_host() {
-        let driver = FireworksChatDriver::with_base_url("fw-key", "https://proxy.example.com/v1");
-        assert!(driver.list_models().await.unwrap().is_none());
+        let service = Provider::new("proxy", FireworksChatDriver::new())
+            .base_url("https://proxy.example.com/v1");
+        let driver = FireworksChatDriver::new();
+        assert!(
+            driver
+                .list_models(service.endpoint())
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -502,10 +518,14 @@ mod tests {
             .await;
 
         let models_url = format!("{}/inference/v1/models", server.uri());
-        let discovered = list_fireworks_models(&reqwest::Client::new(), "fw-secret", &models_url)
-            .await
-            .expect("discovery request should succeed")
-            .expect("discovery should return a model list");
+        let service = Provider::new("fireworks-test", FireworksChatDriver::new())
+            .base_url(format!("{}/inference/v1", server.uri()))
+            .auth(BearerAuth::new("fw-secret"));
+        let discovered =
+            list_fireworks_models(&reqwest::Client::new(), service.endpoint(), &models_url)
+                .await
+                .expect("discovery request should succeed")
+                .expect("discovery should return a model list");
 
         // Image model filtered out; chat model retained with a discovered profile.
         assert_eq!(discovered.len(), 1);

--- a/crates/fireworks/src/lib.rs
+++ b/crates/fireworks/src/lib.rs
@@ -31,7 +31,7 @@
 mod driver;
 
 pub use driver::{
-    FIREWORKS_DEFAULT_API_URL, FireworksChatDriver, is_fireworks_api_url, register_driver,
+    FIREWORKS_DEFAULT_API_URL, FireworksChatDriver, is_fireworks_api_url, provider, register_driver,
 };
 
 // Re-export core types for convenience.

--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -8,10 +8,8 @@
 //! Ignored by default (requires network + `FIREWORKS_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-fireworks --test chat_live -- --ignored --nocapture`
 
-use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent,
-};
-use everruns_fireworks::FireworksChatDriver;
+use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent};
+use everruns_fireworks::provider;
 use futures::StreamExt;
 
 const LIVE_MODEL: &str = "accounts/fireworks/models/gpt-oss-120b";
@@ -24,7 +22,7 @@ fn api_key() -> String {
 #[tokio::test]
 #[ignore = "live network + FIREWORKS_API_KEY"]
 async fn fireworks_chat_streams_response() {
-    let driver = FireworksChatDriver::new(api_key());
+    let provider = provider("fireworks", api_key());
 
     let config = LlmCallConfig {
         speed: None,
@@ -51,7 +49,7 @@ async fn fireworks_chat_streams_response() {
         "Reply with exactly one word: pong",
     )];
 
-    let mut stream = driver
+    let mut stream = provider
         .chat_completion_stream(messages, &config)
         .await
         .expect("Fireworks should accept the chat request");
@@ -93,9 +91,9 @@ async fn fireworks_chat_streams_response() {
 #[tokio::test]
 #[ignore = "live network + FIREWORKS_API_KEY"]
 async fn fireworks_discovery_returns_chat_models_with_profiles() {
-    let driver = FireworksChatDriver::new(api_key());
+    let provider = provider("fireworks", api_key());
 
-    let models = driver
+    let models = provider
         .list_models()
         .await
         .expect("discovery request should succeed")

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -9,7 +9,7 @@
 // exponential backoff. Retry metadata is included in the response for observability.
 
 use async_trait::async_trait;
-use futures::{FutureExt, StreamExt};
+use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -22,10 +22,9 @@ use everruns_provider::driver_helpers::{
     parse_data_url,
 };
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
-    LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent, disjoint_prompt_tokens,
-    fold_system_messages,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent, disjoint_prompt_tokens, fold_system_messages,
 };
 use everruns_provider::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_provider::is_provider_quota_message;
@@ -38,6 +37,19 @@ use everruns_provider::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 
+/// Ready-to-use Gemini provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> everruns_provider::Provider {
+    everruns_provider::Provider::new(id, GeminiChatDriver::new())
+        .base_url(DEFAULT_BASE_URL)
+        .auth(everruns_provider::StaticHeaderAuth::new(
+            "x-goog-api-key",
+            api_key,
+        ))
+}
+
 /// Google Gemini Chat Driver
 ///
 /// Implements `ChatDriver` for Google's Gemini API.
@@ -45,31 +57,14 @@ const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta
 #[derive(Clone)]
 pub struct GeminiChatDriver {
     client: Client,
-    api_key: String,
-    base_url: String,
-    uses_custom_url: bool,
     retry_config: LlmRetryConfig,
 }
 
 impl GeminiChatDriver {
     /// Create a new driver with the given API key
-    pub fn new(api_key: impl Into<String>) -> Self {
+    pub fn new() -> Self {
         Self {
             client: everruns_provider::driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            base_url: DEFAULT_BASE_URL.to_string(),
-            uses_custom_url: false,
-            retry_config: LlmRetryConfig::default(),
-        }
-    }
-
-    /// Create a new driver with a custom base URL
-    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
-        Self {
-            client: everruns_provider::driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            base_url: base_url.into(),
-            uses_custom_url: true,
             retry_config: LlmRetryConfig::default(),
         }
     }
@@ -282,18 +277,11 @@ impl GeminiChatDriver {
     }
 
     /// Build the streaming URL for a model
-    fn stream_url(&self, model: &str) -> String {
-        format!(
-            "{}/models/{}:streamGenerateContent?alt=sse",
-            self.base_url, model
-        )
+    fn stream_path(model: &str) -> String {
+        format!("models/{model}:streamGenerateContent?alt=sse")
     }
 
     /// Build the models list URL
-    fn models_url(&self) -> String {
-        format!("{}/models", self.base_url)
-    }
-
     /// Send one streaming `streamGenerateContent` request, applying the shared
     /// header-phase retry loop (transient send failures, 429, and 5xx), and
     /// return the raw response plus its retry metadata.
@@ -304,6 +292,7 @@ impl GeminiChatDriver {
     /// exactly.
     async fn send_generate_content_request(
         &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
         request: &GeminiRequest,
         url: &str,
         model: &str,
@@ -313,14 +302,24 @@ impl GeminiChatDriver {
         retry_request(
             &self.retry_config,
             "GeminiDriver",
-            || {
-                self.client
-                    .post(url)
-                    .header("Content-Type", "application/json")
-                    .header("x-goog-api-key", &self.api_key)
-                    .json(request)
-                    .send()
-                    .map(|r| r.map_err(SendOutcome::Send))
+            || async {
+                let body = serde_json::to_vec(request).map_err(|error| {
+                    SendOutcome::Fatal(AgentLoopError::llm(format!(
+                        "Failed to serialize Gemini request: {error}"
+                    )))
+                })?;
+                let resolved = endpoint
+                    .resolve("POST", url, &body)
+                    .await
+                    .map_err(SendOutcome::Fatal)?;
+                let mut builder = self
+                    .client
+                    .post(&resolved.url)
+                    .header("Content-Type", "application/json");
+                for (name, value) in resolved.headers {
+                    builder = builder.header(name, value);
+                }
+                builder.body(body).send().await.map_err(SendOutcome::Send)
             },
             |response, attempts, can_retry| {
                 let model = model.to_string();
@@ -391,6 +390,7 @@ impl GeminiChatDriver {
 impl ChatDriver for GeminiChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
@@ -438,10 +438,12 @@ impl ChatDriver for GeminiChatDriver {
         // response body" flake). Header-phase retries (429/5xx and transient
         // send failures) are handled inside the per-attempt send. Gemini parses
         // SSE by hand, so this uses the raw byte-stream reconnect variant.
-        let url = self.stream_url(&config.model);
+        let url = endpoint
+            .url(&Self::stream_path(&config.model))
+            .ok_or_else(|| AgentLoopError::config("Gemini provider has no base URL"))?;
         let (byte_stream, retry_metadata) =
             connect_bytes_with_reconnect(&self.retry_config, "GeminiDriver", |_attempt| {
-                self.send_generate_content_request(&request, &url, &config.model)
+                self.send_generate_content_request(endpoint, &request, &url, &config.model)
             })
             .await?;
 
@@ -778,15 +780,23 @@ impl ChatDriver for GeminiChatDriver {
         Ok(converted_stream)
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        if self.uses_custom_url {
+    async fn list_models(
+        &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        if endpoint.base_url() != Some(DEFAULT_BASE_URL) {
             return Ok(None);
         }
 
-        let response = self
-            .client
-            .get(self.models_url())
-            .header("x-goog-api-key", &self.api_key)
+        let url = endpoint
+            .url("models")
+            .ok_or_else(|| AgentLoopError::config("Gemini provider has no base URL"))?;
+        let resolved = endpoint.resolve("GET", url, &[]).await?;
+        let mut request = self.client.get(&resolved.url);
+        for (name, value) in resolved.headers {
+            request = request.header(name, value);
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| AgentLoopError::llm(format!("Failed to fetch models: {}", e)))?;
@@ -839,10 +849,7 @@ impl ChatDriver for GeminiChatDriver {
 
 impl std::fmt::Debug for GeminiChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GeminiChatDriver")
-            .field("base_url", &self.base_url)
-            .field("api_key", &"[REDACTED]")
-            .finish()
+        f.debug_struct("GeminiChatDriver").finish_non_exhaustive()
     }
 }
 
@@ -853,18 +860,27 @@ impl std::fmt::Debug for GeminiChatDriver {
 /// Register the Gemini driver with the driver registry
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_descriptor(DriverDescriptor {
+        display_name: "Google Gemini".into(),
         credential_schema: CredentialFormSchema::api_key(
             "Create an API key in [Google AI Studio](https://aistudio.google.com/apikey).",
         ),
         ..DriverDescriptor::chat_only(DriverId::Gemini, |config| {
-            let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => GeminiChatDriver::with_base_url(api_key, url),
-                None => GeminiChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            let provider =
+                everruns_provider::Provider::new(config.provider.clone(), GeminiChatDriver::new())
+                    .base_url(config.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL))
+                    .auth(everruns_provider::StaticHeaderAuth::new(
+                        "x-goog-api-key",
+                        config.api_key.as_deref().unwrap_or(""),
+                    ));
+            provider.into_boxed_driver()
         })
     });
+}
+
+impl Default for GeminiChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ============================================================================
@@ -1104,7 +1120,7 @@ mod tests {
     fn supports_parallel_tool_calls_is_false() {
         // Gemini has no request control; the preference is honored only by the
         // local tool scheduler.
-        let driver = GeminiChatDriver::new("test-key");
+        let driver = GeminiChatDriver::new();
         assert!(!driver.supports_parallel_tool_calls("gemini-2.5-pro"));
     }
 
@@ -1423,15 +1439,6 @@ mod tests {
         let mut buffer = "data: {\"cand".to_string();
         let event = extract_sse_event(&mut buffer);
         assert!(event.is_none());
-    }
-
-    #[test]
-    fn test_stream_url() {
-        let driver = GeminiChatDriver::new("test-key");
-        let url = driver.stream_url("gemini-2.5-pro");
-        assert!(url.contains("gemini-2.5-pro:streamGenerateContent"));
-        assert!(url.contains("alt=sse"));
-        assert!(!url.contains("key="));
     }
 
     #[test]

--- a/crates/gemini/src/lib.rs
+++ b/crates/gemini/src/lib.rs
@@ -20,7 +20,7 @@
 
 mod driver;
 
-pub use driver::{GeminiChatDriver, register_driver};
+pub use driver::{GeminiChatDriver, provider, register_driver};
 
 // Re-export core types for convenience
 pub use everruns_provider::driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -12,10 +12,11 @@
 // finish handling collapses into a single terminal `Done` event.
 
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole,
-    LlmResponseStream, LlmStreamEvent,
+    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream,
+    LlmStreamEvent,
 };
 use everruns_gemini::GeminiChatDriver;
+use everruns_provider::{Provider, StaticHeaderAuth};
 use futures::StreamExt;
 use wiremock::matchers::{method, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -38,6 +39,12 @@ fn config(model: &str) -> LlmCallConfig {
         parallel_tool_calls: None,
         volatile_suffix_len: 0,
     }
+}
+
+fn provider(server: &MockServer) -> Provider {
+    Provider::new("gemini-test", GeminiChatDriver::new())
+        .base_url(server.uri())
+        .auth(StaticHeaderAuth::new("x-goog-api-key", "test-key"))
 }
 
 /// Normalized, comparable form of an `LlmStreamEvent` for golden assertions.
@@ -136,7 +143,7 @@ async fn text_stream_golden_events() {
     .join("\n");
     mount_sse(&server, body).await;
 
-    let driver = GeminiChatDriver::with_base_url("test-key", server.uri());
+    let driver = provider(&server);
     let stream = driver
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "hi")],
@@ -181,7 +188,7 @@ async fn function_call_stream_golden_events() {
     .join("\n");
     mount_sse(&server, body).await;
 
-    let driver = GeminiChatDriver::with_base_url("test-key", server.uri());
+    let driver = provider(&server);
     let stream = driver
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "weather?")],
@@ -223,7 +230,7 @@ async fn eos_without_finish_reason_emits_done() {
     .join("\n");
     mount_sse(&server, body).await;
 
-    let driver = GeminiChatDriver::with_base_url("test-key", server.uri());
+    let driver = provider(&server);
     let stream = driver
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "hi")],

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -640,9 +640,9 @@ message CommitExecResponse {
 
 message ResolvedModel {
     string model = 1;
-    string provider_type = 2;
-    optional string api_key = 3;  // Decrypted by control plane
-    optional string base_url = 4;
+    string provider_id = 2;
+    reserved 3, 4;
+    string provider_type = 5;
 }
 
 message GetResolvedModelRequest {
@@ -1149,12 +1149,16 @@ message GetImageArtifactInfoResponse {
 message GetDefaultProviderCredentialsRequest {
     int64 org_id = 1;
     string provider_type = 2;
+    // Exact provider identity for model execution. Empty preserves the legacy
+    // tool-side lookup by provider type.
+    string provider_id = 3;
 }
 
 message GetDefaultProviderCredentialsResponse {
     bool found = 1;
     string api_key = 2;
     string base_url = 3;
+    string provider_type = 4;
 }
 
 

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -188,7 +188,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
     // - Anthropic: cryptographic signature (always present with thinking)
     // - OpenAI o-series: encrypted_content (present when model uses encrypted reasoning)
     // - OpenAI GPT-5.x: not used (reasoning summary is readable, not encrypted)
-    if matches!(config.provider_type, DriverId::Anthropic) {
+    if config.provider_type == DriverId::Anthropic {
         assert!(
             assistant_msg.thinking_signature.is_some(),
             "Anthropic should have thinking_signature for multi-turn"

--- a/crates/mai/README.md
+++ b/crates/mai/README.md
@@ -19,25 +19,19 @@ Two schemes are supported:
   metadata. Bearer tokens are minted with the client-credentials grant and
   cached, refreshed before expiry.
 
-The auth layer is built on the pluggable `AuthHeaderProvider` hook in
-`everruns-provider`, so additional schemes (managed identity, workload identity
-federation, ...) can be added by implementing the trait without changing the
-driver.
+The provider owns authentication through the pluggable `ProviderAuth` contract
+in `everruns-provider`. Additional schemes (managed identity, workload identity
+federation, ...) can be added without changing the Chat Completions wire driver.
 
 ## Usage
 
 ```rust
-use everruns_provider::DriverRegistry;
-use everruns_mai::{register_driver, MaiAuth, MaiChatDriver};
+use everruns_mai::{provider, MaiAuth};
 
-// Register into a driver registry (the usual integration path):
-let mut registry = DriverRegistry::new();
-register_driver(&mut registry);
-
-// Or construct a driver directly:
-let driver = MaiChatDriver::new(
+let provider = provider(
+    "mai-prod",
+    "https://my-resource.services.ai.azure.com/openai/v1",
     MaiAuth::ApiKey("foundry-key".into()),
-    "https://my-resource.services.ai.azure.com",
 );
 ```
 

--- a/crates/mai/src/auth.rs
+++ b/crates/mai/src/auth.rs
@@ -8,10 +8,10 @@
 //      client-credentials grant and are short-lived, so they are cached and
 //      refreshed before expiry.
 //
-// Both schemes are exposed through the generic [`AuthHeaderProvider`] hook on
-// the core Chat Completions driver, so the protocol driver never has to know
+// Both schemes implement the runtime provider's generic [`ProviderAuth`]
+// contract, so the protocol driver never has to know
 // which scheme is in use. New schemes (managed identity, workload identity
-// federation, ...) can be added by implementing [`AuthHeaderProvider`] without
+// federation, ...) can be added by implementing [`ProviderAuth`] without
 // touching the driver.
 
 use std::sync::Arc;
@@ -20,8 +20,8 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use everruns_provider::driver_registry::DriverConfig;
 use everruns_provider::error::{AgentLoopError, Result};
-use everruns_provider::openai_protocol::AuthHeaderProvider;
 use everruns_provider::validate_safe_url;
+use everruns_provider::{ProviderAuth, ProviderAuthRequest};
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
@@ -105,12 +105,44 @@ impl MaiAuth {
         }
     }
 
-    /// Build the [`AuthHeaderProvider`] this strategy resolves to.
-    pub fn into_provider(self) -> Arc<dyn AuthHeaderProvider> {
+    /// Build the refreshable provider-auth implementation for this strategy.
+    pub fn into_provider(self) -> Arc<dyn ProviderAuth> {
         match self {
             MaiAuth::ApiKey(key) => Arc::new(ApiKeyAuth { key }),
             MaiAuth::EntraOAuth(config) => Arc::new(EntraOAuthProvider::new(config)),
         }
+    }
+}
+
+/// Preserve a configuration failure inside the provider-owned auth layer.
+///
+/// Transitional descriptor factories cannot return a construction error, so
+/// malformed credentials become an auth implementation that fails closed
+/// before the protocol sends a request.
+pub(crate) fn failing_provider(error: AgentLoopError) -> Arc<dyn ProviderAuth> {
+    Arc::new(FailingAuth {
+        message: error.to_string(),
+    })
+}
+
+struct FailingAuth {
+    message: String,
+}
+
+impl std::fmt::Debug for FailingAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FailingAuth").finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl ProviderAuth for FailingAuth {
+    async fn headers(&self, _request: ProviderAuthRequest<'_>) -> Result<Vec<(String, String)>> {
+        Err(AgentLoopError::llm(self.message.clone()))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -128,9 +160,12 @@ impl std::fmt::Debug for ApiKeyAuth {
 }
 
 #[async_trait]
-impl AuthHeaderProvider for ApiKeyAuth {
-    async fn auth_header(&self) -> Result<(String, String)> {
-        Ok(("api-key".to_string(), self.key.clone()))
+impl ProviderAuth for ApiKeyAuth {
+    async fn headers(&self, _request: ProviderAuthRequest<'_>) -> Result<Vec<(String, String)>> {
+        Ok(vec![("api-key".to_string(), self.key.clone())])
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -295,7 +330,7 @@ struct EntraTokenResponse {
     expires_in: i64,
 }
 
-/// [`AuthHeaderProvider`] that mints and caches Entra ID bearer tokens via the
+/// [`ProviderAuth`] implementation that mints and caches Entra ID bearer tokens via the
 /// client-credentials grant.
 pub struct EntraOAuthProvider {
     config: EntraOAuthConfig,
@@ -373,10 +408,16 @@ impl EntraOAuthProvider {
 }
 
 #[async_trait]
-impl AuthHeaderProvider for EntraOAuthProvider {
-    async fn auth_header(&self) -> Result<(String, String)> {
+impl ProviderAuth for EntraOAuthProvider {
+    async fn headers(&self, _request: ProviderAuthRequest<'_>) -> Result<Vec<(String, String)>> {
         let token = self.bearer_token().await?;
-        Ok(("Authorization".to_string(), format!("Bearer {token}")))
+        Ok(vec![(
+            "authorization".to_string(),
+            format!("Bearer {token}"),
+        )])
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -390,6 +431,7 @@ mod tests {
     /// `DriverConfig::from_provider_config`.
     fn driver_config(api_key: Option<&str>, extra: Option<serde_json::Value>) -> DriverConfig {
         DriverConfig {
+            provider: everruns_provider::ProviderKey::new("mai"),
             provider_type: DriverId::Mai,
             credentials: everruns_provider::credential_schema::parse_credential_document(api_key),
             api_key: api_key.map(str::to_string),
@@ -583,7 +625,16 @@ mod tests {
     #[tokio::test]
     async fn api_key_provider_emits_api_key_header() {
         let provider = MaiAuth::ApiKey("secret-key".to_string()).into_provider();
-        let (name, value) = provider.auth_header().await.unwrap();
+        let headers = provider
+            .headers(ProviderAuthRequest {
+                method: "POST",
+                url: "https://example.services.ai.azure.com/openai/v1/chat/completions",
+                headers: &[],
+                body: b"{}",
+            })
+            .await
+            .unwrap();
+        let (name, value) = &headers[0];
         assert_eq!(name, "api-key");
         assert_eq!(value, "secret-key");
     }

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -2,13 +2,8 @@
 //
 // Microsoft MAI models (e.g. MAI-Code-1-Flash) are served via Azure AI Foundry
 // behind an OpenAI-compatible Chat Completions API. This driver wraps the core
-// `OpenAIProtocolChatDriver` and supplies a pluggable, OAuth-capable auth layer
-// (see `auth.rs`) through the driver's `AuthHeaderProvider` hook.
-//
-// Because authentication is handled by the auth provider, the underlying
-// protocol driver's own `api_key` field is unused (constructed empty).
-
-use std::sync::Arc;
+// `OpenAIProtocolChatDriver`; the runtime provider owns the OAuth-capable auth
+// layer from `auth.rs`.
 
 use async_trait::async_trait;
 use chrono::TimeZone;
@@ -18,105 +13,64 @@ use everruns_provider::OpenAIProtocolChatDriver;
 use everruns_provider::credential_schema::{CredentialFormSchema, FormField};
 use everruns_provider::driver_helpers::fetch_models;
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverConfig, DriverDescriptor, DriverId,
-    DriverRegistry, LlmCallConfig, LlmMessage, LlmResponseStream,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmMessage, LlmResponseStream,
 };
-use everruns_provider::error::{AgentLoopError, Result};
-use everruns_provider::openai_protocol::{
-    AuthHeaderProvider, is_azure_openai_api_url, models_url_for_api_url,
-};
+use everruns_provider::error::Result;
+use everruns_provider::openai_protocol::{is_azure_openai_api_url, models_url_for_api_url};
+use everruns_provider::{Provider, ProviderEndpoint};
 
-use crate::auth::{DEFAULT_ENTRA_AUTHORITY, DEFAULT_ENTRA_SCOPE, MaiAuth};
+use crate::auth::{DEFAULT_ENTRA_AUTHORITY, DEFAULT_ENTRA_SCOPE, MaiAuth, failing_provider};
+
+/// Ready-to-use Microsoft MAI provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    base_url: impl Into<String>,
+    auth: MaiAuth,
+) -> Provider {
+    Provider::new(id, MaiChatDriver::new())
+        .base_url(mai_api_base_url(base_url.into()))
+        .auth_arc(auth.into_provider())
+}
+
+fn mai_api_base_url(base_url: String) -> String {
+    let base_url = base_url.trim_end_matches('/');
+    if base_url.ends_with("/openai/v1") {
+        base_url.to_string()
+    } else {
+        format!("{base_url}/openai/v1")
+    }
+}
 
 /// Microsoft MAI chat driver (Azure AI Foundry, OpenAI-compatible).
 ///
 /// Construct directly for programmatic use, or let [`register_driver`] build
-/// instances from a [`DriverConfig`].
+/// instances from the transitional descriptor catalog.
 ///
 /// # Example
 ///
 /// ```
-/// use everruns_mai::{MaiAuth, MaiChatDriver};
+/// use everruns_mai::{MaiAuth, provider};
 ///
-/// let driver = MaiChatDriver::new(
+/// let service = provider(
+///     "mai-prod",
+///     "https://my-resource.services.ai.azure.com/openai/v1",
 ///     MaiAuth::ApiKey("foundry-key".into()),
-///     "https://my-resource.services.ai.azure.com",
 /// );
 /// assert_eq!(
-///     driver.api_url(),
+///     service.endpoint().url("chat/completions").unwrap(),
 ///     "https://my-resource.services.ai.azure.com/openai/v1/chat/completions",
 /// );
 /// ```
 pub struct MaiChatDriver {
-    /// Ready driver, or a captured configuration error surfaced at call time.
-    state: DriverState,
-}
-
-enum DriverState {
-    Ready {
-        inner: OpenAIProtocolChatDriver,
-        api_url: String,
-        /// Retained so model discovery can authenticate the `/models` request
-        /// with the same scheme (api-key or OAuth bearer) as chat requests.
-        auth: Arc<dyn AuthHeaderProvider>,
-    },
-    Misconfigured(String),
+    inner: OpenAIProtocolChatDriver,
 }
 
 impl MaiChatDriver {
-    /// Create a driver from an explicit auth strategy and Azure AI Foundry
-    /// endpoint. The endpoint is normalized to the chat-completions URL.
-    pub fn new(auth: MaiAuth, endpoint: impl Into<String>) -> Self {
-        let api_url = normalize_mai_url(&endpoint.into());
-        let auth = auth.into_provider();
-        let inner =
-            OpenAIProtocolChatDriver::with_base_url("", &api_url).with_auth_provider(auth.clone());
+    /// Create an Azure AI Foundry Chat Completions wire driver.
+    pub fn new() -> Self {
         Self {
-            state: DriverState::Ready {
-                inner,
-                api_url,
-                auth,
-            },
-        }
-    }
-
-    /// Build a driver from a registry [`DriverConfig`], resolving auth from the
-    /// api key / OAuth metadata and the endpoint from `base_url`.
-    ///
-    /// Configuration errors (no endpoint, no auth) are captured and surfaced
-    /// when the driver is first called, so the infallible factory contract is
-    /// preserved while still producing a clear error.
-    fn from_driver_config(config: &DriverConfig) -> Self {
-        let Some(endpoint) = config.base_url.as_deref().filter(|u| !u.is_empty()) else {
-            return Self {
-                state: DriverState::Misconfigured(
-                    "Microsoft MAI provider requires a base URL: set it to your Azure AI \
-                     Foundry resource endpoint (e.g. https://<resource>.services.ai.azure.com)."
-                        .to_string(),
-                ),
-            };
-        };
-
-        match MaiAuth::from_driver_config(config) {
-            Ok(auth) => Self::new(auth, endpoint),
-            Err(err) => Self {
-                state: DriverState::Misconfigured(err.to_string()),
-            },
-        }
-    }
-
-    /// The resolved chat-completions API URL, or `None` when misconfigured.
-    pub fn api_url(&self) -> &str {
-        match &self.state {
-            DriverState::Ready { api_url, .. } => api_url,
-            DriverState::Misconfigured(_) => "",
-        }
-    }
-
-    fn ready(&self) -> Result<&OpenAIProtocolChatDriver> {
-        match &self.state {
-            DriverState::Ready { inner, .. } => Ok(inner),
-            DriverState::Misconfigured(err) => Err(AgentLoopError::llm(err.clone())),
+            inner: OpenAIProtocolChatDriver::new(),
         }
     }
 }
@@ -125,43 +79,40 @@ impl MaiChatDriver {
 impl ChatDriver for MaiChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        self.ready()?.chat_completion_stream(messages, config).await
+        self.inner
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
     fn supports_parallel_tool_calls(&self, model: &str) -> bool {
         // MAI is OpenAI-compatible Chat Completions; the inner protocol driver
         // maps the preference onto the wire when the provider is configured.
-        match self.ready() {
-            Ok(inner) => inner.supports_parallel_tool_calls(model),
-            Err(_) => false,
-        }
+        self.inner.supports_parallel_tool_calls(model)
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        let DriverState::Ready {
-            inner,
-            api_url,
-            auth,
-        } = &self.state
-        else {
-            // Misconfigured providers have nothing to discover.
+    async fn list_models(
+        &self,
+        endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        let Some(api_url) = endpoint.url("chat/completions") else {
             return Ok(None);
         };
 
         // Only run discovery against recognized Azure AI Foundry hosts. Custom
         // proxy URLs may resolve to private infrastructure, so they are skipped
         // (mirrors the OpenAI/Azure OpenAI driver gating).
-        if !is_azure_openai_api_url(api_url) {
+        if !is_azure_openai_api_url(&api_url) {
             return Ok(None);
         }
 
         list_foundry_models(
-            inner.client(),
-            auth.as_ref(),
-            &models_url_for_api_url(api_url),
+            self.inner.client(),
+            endpoint,
+            &models_url_for_api_url(&api_url),
         )
         .await
     }
@@ -177,14 +128,18 @@ impl ChatDriver for MaiChatDriver {
 /// not match a known profile falls back to a minimal profile — the same caveat
 /// as Azure OpenAI.)
 ///
-/// The request is authenticated with the same `AuthHeaderProvider` used for chat
+/// The request is authenticated with the same runtime `ProviderAuth` used for chat
 /// (`api-key` or an Entra ID OAuth bearer), so discovery works for both schemes.
 async fn list_foundry_models(
     client: &reqwest::Client,
-    auth: &dyn AuthHeaderProvider,
+    endpoint: &ProviderEndpoint,
     models_url: &str,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
-    let (header_name, header_value) = auth.auth_header().await?;
+    let resolved = endpoint.resolve("GET", models_url, &[]).await?;
+    let mut request = client.get(&resolved.url);
+    for (name, value) in resolved.headers {
+        request = request.header(name, value);
+    }
     // Project-scoped Azure AI Foundry endpoints expose chat completions but not a
     // `/models` catalog: such an endpoint returns 404 for `/openai/v1/models`
     // while `/openai/v1/chat/completions` works. Treat a missing/unimplemented
@@ -192,7 +147,7 @@ async fn list_foundry_models(
     // error, so model sync degrades gracefully instead of reporting a spurious
     // failure. (Verified live against a project endpoint.)
     fetch_models::<FoundryModelsResponse, _>(
-        client.get(models_url).header(header_name, header_value),
+        request,
         "Failed to fetch MAI models",
         "Failed to parse MAI models response",
         &[
@@ -260,29 +215,8 @@ impl FoundryModelInfo {
 impl std::fmt::Debug for MaiChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MaiChatDriver")
-            .field("api_url", &self.api_url())
             .field("api", &"Azure AI Foundry (Chat Completions)")
             .finish()
-    }
-}
-
-/// Normalize an Azure AI Foundry endpoint to its chat-completions URL.
-///
-/// Accepts a bare resource host, a `/openai/v1` or `/models` base, or a full
-/// `/chat/completions` URL, and always returns a `/chat/completions` endpoint.
-/// A bare host gets Foundry's v1 OpenAI-compatible path appended.
-fn normalize_mai_url(endpoint: &str) -> String {
-    let trimmed = endpoint.trim_end_matches('/');
-    if trimmed.ends_with("/chat/completions") {
-        trimmed.to_string()
-    } else if let Some(base) = trimmed.strip_suffix("/models") {
-        // A models-listing URL was pasted as the endpoint; derive the sibling
-        // chat endpoint by replacing `/models` rather than appending to it.
-        format!("{base}/chat/completions")
-    } else if trimmed.ends_with("/v1") || trimmed.ends_with("/openai/v1") {
-        format!("{trimmed}/chat/completions")
-    } else {
-        format!("{trimmed}/openai/v1/chat/completions")
     }
 }
 
@@ -347,11 +281,26 @@ fn mai_credential_schema() -> CredentialFormSchema {
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_descriptor(DriverDescriptor {
+        display_name: "Microsoft MAI".into(),
         credential_schema: mai_credential_schema(),
         ..DriverDescriptor::chat_only(DriverId::Mai, |config| {
-            Box::new(MaiChatDriver::from_driver_config(config)) as BoxedChatDriver
+            let provider = Provider::new(config.provider.clone(), MaiChatDriver::new()).base_url(
+                mai_api_base_url(config.base_url.clone().unwrap_or_default()),
+            );
+            match MaiAuth::from_driver_config(config) {
+                Ok(auth) => provider.auth_arc(auth.into_provider()).into_boxed_driver(),
+                Err(error) => provider
+                    .auth_arc(failing_provider(error))
+                    .into_boxed_driver(),
+            }
         })
     });
+}
+
+impl Default for MaiChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]
@@ -381,8 +330,19 @@ mod tests {
     #[tokio::test]
     async fn list_models_skips_non_azure_hosts() {
         // A custom/proxy (non-Foundry) host must not be probed for discovery.
-        let driver = MaiChatDriver::new(MaiAuth::ApiKey("k".into()), "https://proxy.example.com");
-        assert!(driver.list_models().await.unwrap().is_none());
+        let service = provider(
+            "proxy",
+            "https://proxy.example.com",
+            MaiAuth::ApiKey("k".into()),
+        );
+        let driver = MaiChatDriver::new();
+        assert!(
+            driver
+                .list_models(service.endpoint())
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -403,12 +363,17 @@ mod tests {
             .mount(&server)
             .await;
 
-        let auth = MaiAuth::ApiKey("foundry-secret".into()).into_provider();
+        let service = provider(
+            "mai-test",
+            format!("{}/openai/v1", server.uri()),
+            MaiAuth::ApiKey("foundry-secret".into()),
+        );
         let models_url = format!("{}/openai/v1/models", server.uri());
-        let discovered = list_foundry_models(&reqwest::Client::new(), auth.as_ref(), &models_url)
-            .await
-            .expect("discovery request should succeed")
-            .expect("discovery should return a model list");
+        let discovered =
+            list_foundry_models(&reqwest::Client::new(), service.endpoint(), &models_url)
+                .await
+                .expect("discovery request should succeed")
+                .expect("discovery should return a model list");
 
         // Embedding model filtered out; chat model retained with bare metadata
         // (no discovered_profile — profiles come from the registry by id).
@@ -431,9 +396,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let auth = MaiAuth::ApiKey("k".into()).into_provider();
+        let service = provider(
+            "mai-test",
+            format!("{}/openai/v1", server.uri()),
+            MaiAuth::ApiKey("k".into()),
+        );
         let models_url = format!("{}/openai/v1/models", server.uri());
-        let result = list_foundry_models(&reqwest::Client::new(), auth.as_ref(), &models_url)
+        let result = list_foundry_models(&reqwest::Client::new(), service.endpoint(), &models_url)
             .await
             .expect("404 on /models should not be a hard error");
         assert!(
@@ -443,85 +412,16 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_bare_foundry_host() {
-        assert_eq!(
-            normalize_mai_url("https://res.services.ai.azure.com"),
-            "https://res.services.ai.azure.com/openai/v1/chat/completions"
-        );
-    }
-
-    #[test]
-    fn normalizes_trailing_slash_and_v1() {
-        assert_eq!(
-            normalize_mai_url("https://res.services.ai.azure.com/openai/v1/"),
-            "https://res.services.ai.azure.com/openai/v1/chat/completions"
-        );
-    }
-
-    #[test]
-    fn preserves_full_chat_completions_url() {
-        let url = "https://res.services.ai.azure.com/openai/v1/chat/completions";
-        assert_eq!(normalize_mai_url(url), url);
-    }
-
-    #[test]
-    fn models_url_is_rewritten_to_chat_completions() {
-        // A pasted models-listing URL must derive the sibling chat endpoint,
-        // not append to `/models`.
-        assert_eq!(
-            normalize_mai_url("https://res.services.ai.azure.com/openai/v1/models"),
-            "https://res.services.ai.azure.com/openai/v1/chat/completions"
-        );
-        assert_eq!(
-            normalize_mai_url("https://res.services.ai.azure.com/api/projects/p/openai/v1/models/"),
-            "https://res.services.ai.azure.com/api/projects/p/openai/v1/chat/completions"
-        );
-    }
-
-    #[test]
-    fn ready_driver_exposes_normalized_url() {
-        let driver = MaiChatDriver::new(
+    fn ready_provider_exposes_protocol_url() {
+        let service = provider(
+            "mai",
+            "https://res.services.ai.azure.com/openai/v1",
             MaiAuth::ApiKey("k".into()),
-            "https://res.services.ai.azure.com",
         );
         assert_eq!(
-            driver.api_url(),
-            "https://res.services.ai.azure.com/openai/v1/chat/completions"
+            service.endpoint().url("chat/completions").as_deref(),
+            Some("https://res.services.ai.azure.com/openai/v1/chat/completions")
         );
-    }
-
-    #[tokio::test]
-    async fn misconfigured_without_base_url_errors_at_call_time() {
-        let config = DriverConfig {
-            provider_type: DriverId::Mai,
-            credentials: [("api_key".to_string(), "k".to_string())].into(),
-            api_key: Some("k".into()),
-            base_url: None,
-            metadata: ProviderMetadata::default(),
-        };
-        let driver = MaiChatDriver::from_driver_config(&config);
-        let err = match driver.chat_completion_stream(vec![], &dummy_config()).await {
-            Ok(_) => panic!("expected configuration error"),
-            Err(e) => e,
-        };
-        assert!(err.to_string().contains("requires a base URL"));
-    }
-
-    #[tokio::test]
-    async fn misconfigured_without_auth_errors_at_call_time() {
-        let config = DriverConfig {
-            provider_type: DriverId::Mai,
-            credentials: Default::default(),
-            api_key: None,
-            base_url: Some("https://res.services.ai.azure.com".into()),
-            metadata: ProviderMetadata::default(),
-        };
-        let driver = MaiChatDriver::from_driver_config(&config);
-        let err = match driver.chat_completion_stream(vec![], &dummy_config()).await {
-            Ok(_) => panic!("expected configuration error"),
-            Err(e) => e,
-        };
-        assert!(err.to_string().contains("not authenticated"));
     }
 
     #[test]
@@ -561,25 +461,5 @@ mod tests {
             });
         // No api_key, but OAuth metadata present — must construct successfully.
         assert!(registry.create_chat_driver(&config).is_ok());
-    }
-
-    fn dummy_config() -> LlmCallConfig {
-        LlmCallConfig {
-            speed: None,
-            verbosity: None,
-            model: "mai-code-1-flash".into(),
-            temperature: None,
-            max_tokens: None,
-            tools: vec![],
-            reasoning_effort: None,
-            metadata: Default::default(),
-            previous_response_id: None,
-            provider_opaque_context: None,
-            tool_search: None,
-            prompt_cache: None,
-            openrouter_routing: None,
-            parallel_tool_calls: None,
-            volatile_suffix_len: 0,
-        }
     }
 }

--- a/crates/mai/src/lib.rs
+++ b/crates/mai/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! Microsoft MAI models are served via [Azure AI Foundry](https://ai.azure.com)
 //! behind an OpenAI-compatible Chat Completions API, so [`MaiChatDriver`] wraps
-//! `everruns_provider::OpenAIProtocolChatDriver` and supplies authentication through
-//! the driver's pluggable [`AuthHeaderProvider`] hook.
+//! `everruns_provider::OpenAIProtocolChatDriver`; its runtime provider owns
+//! authentication through [`ProviderAuth`].
 //!
 //! # Authentication
 //!
@@ -19,7 +19,7 @@
 //!   metadata. Bearer tokens are minted and cached, refreshed before expiry.
 //!
 //! Additional schemes (managed identity, workload identity federation, ...) can
-//! be added by implementing [`AuthHeaderProvider`] without changing the driver.
+//! be added by implementing [`ProviderAuth`] without changing the driver.
 //!
 //! # Registering the Driver
 //!
@@ -31,7 +31,7 @@
 //! register_driver(&mut registry);
 //! ```
 //!
-//! [`AuthHeaderProvider`]: everruns_provider::openai_protocol::AuthHeaderProvider
+//! [`ProviderAuth`]: everruns_provider::ProviderAuth
 
 mod auth;
 mod driver;
@@ -39,7 +39,7 @@ mod driver;
 pub use auth::{
     DEFAULT_ENTRA_AUTHORITY, DEFAULT_ENTRA_SCOPE, EntraOAuthConfig, EntraOAuthProvider, MaiAuth,
 };
-pub use driver::{MaiChatDriver, register_driver};
+pub use driver::{MaiChatDriver, provider, register_driver};
 
 // Re-export core types for convenience.
 pub use everruns_provider::driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -15,7 +15,8 @@ use everruns_core::DriverRegistry;
 use everruns_core::driver_registry::{
     ChatDriver, DriverId, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, ProviderConfig,
 };
-use everruns_mai::{EntraOAuthConfig, MaiAuth, MaiChatDriver, register_driver};
+use everruns_mai::{EntraOAuthConfig, MaiAuth, provider, register_driver};
+use everruns_provider::ProviderEndpoint;
 use futures::StreamExt;
 use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -78,9 +79,13 @@ async fn api_key_auth_sends_api_key_header_and_streams() {
         .mount(&server)
         .await;
 
-    let driver = MaiChatDriver::new(MaiAuth::ApiKey("foundry-secret".into()), server.uri());
+    let provider = provider(
+        "mai-test",
+        server.uri(),
+        MaiAuth::ApiKey("foundry-secret".into()),
+    );
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
-    let stream = driver
+    let stream = provider
         .chat_completion_stream(messages, &config("mai-code-1-flash"))
         .await
         .expect("MAI should accept the api-key authed request");
@@ -124,9 +129,9 @@ async fn entra_oauth_mints_token_and_sends_bearer() {
         authority: server.uri(),
     });
 
-    let driver = MaiChatDriver::new(auth, server.uri());
+    let provider = provider("mai-test", server.uri(), auth);
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
-    let stream = driver
+    let stream = provider
         .chat_completion_stream(messages, &config("mai-code-1-flash"))
         .await
         .expect("MAI should accept the OAuth bearer authed request");
@@ -163,7 +168,11 @@ async fn registry_built_driver_rejects_unsafe_oauth_json_authority() {
 
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
     let result = driver
-        .chat_completion_stream(messages, &config("mai-code-1-flash"))
+        .chat_completion_stream(
+            &ProviderEndpoint::default(),
+            messages,
+            &config("mai-code-1-flash"),
+        )
         .await;
     let Err(err) = result else {
         panic!("unsafe OAuth authority should be rejected before token minting");

--- a/crates/meta/src/driver.rs
+++ b/crates/meta/src/driver.rs
@@ -12,53 +12,41 @@ use everruns_provider::OpenResponsesProtocolChatDriver;
 use everruns_provider::credential_schema::CredentialFormSchema;
 use everruns_provider::driver_helpers::fetch_models;
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
-    LlmCallConfig, LlmMessage, LlmResponseStream,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmMessage, LlmResponseStream,
 };
 use everruns_provider::error::Result;
-use everruns_provider::openai_protocol::{
-    apply_models_api_auth, models_url_for_api_url, normalize_api_url, url_host_eq,
-};
+use everruns_provider::openai_protocol::{models_url_for_api_url, url_host_eq};
+use everruns_provider::{BearerAuth, Provider, ProviderEndpoint};
 
 /// Meta Model API Responses endpoint.
 pub const META_DEFAULT_API_URL: &str = "https://api.meta.ai/v1/responses";
 const META_API_HOST: &str = "api.meta.ai";
 
+/// Ready-to-use Meta Model API provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> Provider {
+    Provider::new(id, MetaChatDriver::new())
+        .base_url("https://api.meta.ai/v1")
+        .auth(BearerAuth::new(api_key))
+}
+
 /// Meta Model API driver using the OpenAI-compatible Responses API.
 #[derive(Clone)]
 pub struct MetaChatDriver {
     inner: OpenResponsesProtocolChatDriver,
-    uses_custom_url: bool,
 }
 
 impl MetaChatDriver {
-    /// Create a driver targeting Meta's hosted Model API.
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create the Meta-compatible Responses wire driver.
+    pub fn new() -> Self {
         Self {
-            inner: OpenResponsesProtocolChatDriver::with_base_url(api_key, META_DEFAULT_API_URL)
-                .with_provider_type(DriverId::Meta),
-            uses_custom_url: false,
+            inner: OpenResponsesProtocolChatDriver::new()
+                .with_native_features(true, true)
+                .with_stateful_responses(true),
         }
-    }
-
-    /// Create a driver with an explicit Responses API endpoint override.
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        let api_url = normalize_api_url(&api_url.into(), "/responses");
-        Self {
-            inner: OpenResponsesProtocolChatDriver::with_base_url(api_key, api_url)
-                .with_provider_type(DriverId::Meta),
-            uses_custom_url: true,
-        }
-    }
-
-    /// The resolved Responses API URL.
-    pub fn api_url(&self) -> &str {
-        self.inner.api_url()
-    }
-
-    /// The provider id used for model-profile lookup.
-    pub fn provider_type(&self) -> &DriverId {
-        self.inner.provider_type()
     }
 }
 
@@ -66,10 +54,13 @@ impl MetaChatDriver {
 impl ChatDriver for MetaChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        self.inner.chat_completion_stream(messages, config).await
+        self.inner
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
     fn supports_stateful_responses(&self) -> bool {
@@ -80,22 +71,26 @@ impl ChatDriver for MetaChatDriver {
         self.inner.supports_parallel_tool_calls(model)
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        if self.uses_custom_url && !url_host_eq(self.api_url(), META_API_HOST) {
+    async fn list_models(
+        &self,
+        endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        let Some(api_url) = endpoint.url("responses") else {
+            return Ok(None);
+        };
+        if !url_host_eq(&api_url, META_API_HOST) {
             return Ok(None);
         }
 
-        let models_url = models_url_for_api_url(self.api_url());
-        list_meta_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        let models_url = models_url_for_api_url(&api_url);
+        list_meta_models(self.inner.client(), endpoint, &models_url).await
     }
 }
 
 impl std::fmt::Debug for MetaChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MetaChatDriver")
-            .field("api_url", &self.api_url())
             .field("api", &"Meta Model API Responses")
-            .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
@@ -116,11 +111,16 @@ struct MetaModelInfo {
 
 async fn list_meta_models(
     client: &reqwest::Client,
-    api_key: &str,
+    endpoint: &ProviderEndpoint,
     models_url: &str,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
+    let resolved = endpoint.resolve("GET", models_url, &[]).await?;
+    let mut request = client.get(&resolved.url);
+    for (name, value) in resolved.headers {
+        request = request.header(name, value);
+    }
     fetch_models::<MetaModelsResponse, _>(
-        apply_models_api_auth(client.get(models_url), models_url, api_key),
+        request,
         "Failed to fetch Meta models",
         "Failed to parse Meta models response",
         &[],
@@ -147,18 +147,28 @@ async fn list_meta_models(
 /// Register Meta Model API as a chat provider.
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_descriptor(DriverDescriptor {
+        display_name: "Meta Model API".into(),
         credential_schema: CredentialFormSchema::api_key(
             "Create an API key in the [Meta Model API dashboard](https://dev.meta.ai/).",
         ),
         ..DriverDescriptor::chat_only(DriverId::Meta, |config| {
-            let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => MetaChatDriver::with_base_url(api_key, url),
-                None => MetaChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            Provider::new(config.provider.clone(), MetaChatDriver::new())
+                .base_url(
+                    config
+                        .base_url
+                        .as_deref()
+                        .unwrap_or("https://api.meta.ai/v1"),
+                )
+                .auth(BearerAuth::new(config.api_key.clone().unwrap_or_default()))
+                .into_boxed_driver()
         })
     });
+}
+
+impl Default for MetaChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]
@@ -170,23 +180,37 @@ mod tests {
 
     #[test]
     fn defaults_to_meta_responses_api() {
-        let driver = MetaChatDriver::new("test-key");
-        assert_eq!(driver.api_url(), META_DEFAULT_API_URL);
-        assert_eq!(driver.provider_type(), &DriverId::Meta);
+        let provider = provider("meta", "test-key");
+        let driver = MetaChatDriver::new();
+        assert_eq!(
+            provider.endpoint().url("responses").unwrap(),
+            META_DEFAULT_API_URL
+        );
         assert!(driver.supports_stateful_responses());
         assert!(driver.supports_parallel_tool_calls("muse-spark-1.2"));
     }
 
     #[test]
     fn base_url_is_normalized_to_responses() {
-        let driver = MetaChatDriver::with_base_url("test-key", "https://api.meta.ai/v1");
-        assert_eq!(driver.api_url(), META_DEFAULT_API_URL);
+        let provider = provider("meta", "test-key");
+        assert_eq!(
+            provider.endpoint().url("responses").unwrap(),
+            META_DEFAULT_API_URL
+        );
     }
 
     #[tokio::test]
     async fn custom_non_meta_host_skips_discovery() {
-        let driver = MetaChatDriver::with_base_url("test-key", "https://proxy.example.com/v1");
-        assert!(driver.list_models().await.unwrap().is_none());
+        let provider =
+            Provider::new("proxy", MetaChatDriver::new()).base_url("https://proxy.example.com/v1");
+        let driver = MetaChatDriver::new();
+        assert!(
+            driver
+                .list_models(provider.endpoint())
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -207,9 +231,12 @@ mod tests {
             .mount(&server)
             .await;
 
+        let provider = Provider::new("meta-test", MetaChatDriver::new())
+            .base_url(format!("{}/v1", server.uri()))
+            .auth(BearerAuth::new("meta-secret"));
         let models = list_meta_models(
             &reqwest::Client::new(),
-            "meta-secret",
+            provider.endpoint(),
             &format!("{}/v1/models", server.uri()),
         )
         .await

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -6,5 +6,5 @@
 
 mod driver;
 
-pub use driver::{META_DEFAULT_API_URL, MetaChatDriver, register_driver};
+pub use driver::{META_DEFAULT_API_URL, MetaChatDriver, provider, register_driver};
 pub use everruns_provider::driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/meta/tests/model_api_live.rs
+++ b/crates/meta/tests/model_api_live.rs
@@ -4,8 +4,8 @@
 //! ignored by default and require `MODEL_API_KEY`:
 //!   `doppler run -- cargo test -p everruns-meta --test model_api_live -- --ignored --nocapture`
 
-use everruns_meta::MetaChatDriver;
-use everruns_provider::driver_registry::{ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_meta::provider;
+use everruns_provider::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
 use everruns_provider::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
 };
@@ -60,13 +60,13 @@ fn config(tools: Vec<ToolDefinition>, parallel_tool_calls: Option<bool>) -> LlmC
 #[tokio::test]
 #[ignore = "live network + MODEL_API_KEY"]
 async fn contributor_completes_text_response() {
-    let driver = MetaChatDriver::new(api_key());
+    let provider = provider("meta", api_key());
     let messages = vec![LlmMessage::text(
         LlmMessageRole::User,
         "Reply with exactly: muse-live-ok",
     )];
 
-    let response = driver
+    let response = provider
         .chat_completion(messages, &config(vec![], None))
         .await
         .expect("Meta Model API should complete a text response");
@@ -82,7 +82,7 @@ async fn contributor_completes_text_response() {
 #[tokio::test]
 #[ignore = "live network + MODEL_API_KEY"]
 async fn contributor_accepts_parallel_tool_calls() {
-    let driver = MetaChatDriver::new(api_key());
+    let provider = provider("meta", api_key());
     let messages = vec![
         LlmMessage::text(
             LlmMessageRole::System,
@@ -98,7 +98,7 @@ async fn contributor_accepts_parallel_tool_calls() {
         tool("get_local_time", "Get the current local time for a city."),
     ];
 
-    let response = driver
+    let response = provider
         .chat_completion(messages, &config(tools, Some(true)))
         .await
         .expect("Meta Model API should accept parallel tool calls");

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -15,18 +15,49 @@ use everruns_provider::OpenAIProtocolChatDriver;
 use everruns_provider::OpenResponsesProtocolChatDriver;
 use everruns_provider::credential_schema::CredentialFormSchema;
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, BoxedEmbeddingsDriver, ChatDriver, DiscoveredModel, DriverDescriptor,
-    DriverId, DriverRegistry, EmbeddingsDriverFactory, LlmCallConfig, LlmMessage,
-    LlmResponseStream, ServiceKind,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
+    EmbeddingsDriverFactory, LlmCallConfig, LlmMessage, LlmResponseStream, ServiceKind,
 };
 use everruns_provider::error::{AgentLoopError, Result};
 use everruns_provider::openai_protocol::{
-    apply_models_api_auth, is_azure_openai_api_url, is_openai_api_url, models_api_status_error,
-    models_url_for_api_url, normalize_api_url,
+    is_azure_openai_api_url, is_openai_api_url, models_api_status_error, models_url_for_api_url,
 };
-use everruns_provider::{CompactRequest, CompactResponse};
+use everruns_provider::{
+    BearerAuth, CompactRequest, CompactResponse, Provider, ProviderEndpoint, StaticHeaderAuth,
+};
 
 use crate::types::OpenAiModelsResponse;
+
+/// Ready-to-use OpenAI Responses provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> Provider {
+    Provider::new(id, OpenAIChatDriver::new())
+        .base_url("https://api.openai.com/v1")
+        .auth(BearerAuth::new(api_key))
+}
+
+/// Ready-to-use Azure OpenAI Responses provider assembly.
+pub fn azure_provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    base_url: impl Into<String>,
+    api_key: impl Into<String>,
+) -> Provider {
+    Provider::new(id, OpenAIChatDriver::new())
+        .base_url(base_url)
+        .auth(StaticHeaderAuth::new("api-key", api_key))
+}
+
+/// Ready-to-use OpenAI Chat Completions provider assembly.
+pub fn completions_provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> Provider {
+    Provider::new(id, OpenAICompletionsChatDriver::new())
+        .base_url("https://api.openai.com/v1")
+        .auth(BearerAuth::new(api_key))
+}
 
 // ============================================================================
 // OpenAI Chat Driver (Open Responses API)
@@ -50,47 +81,22 @@ use crate::types::OpenAiModelsResponse;
 /// ```ignore
 /// use everruns_openai::OpenAIChatDriver;
 ///
-/// let driver = OpenAIChatDriver::new("your-api-key");
-///
-/// // With custom endpoint
-/// let driver = OpenAIChatDriver::with_base_url(
-///     "your-api-key",
-///     "https://api.example.com/v1/responses",
-/// );
+/// let driver = OpenAIChatDriver::new();
+/// // Bind it to a runtime Provider for endpoint and authentication.
 /// ```
 #[derive(Clone)]
 pub struct OpenAIChatDriver {
     inner: OpenResponsesProtocolChatDriver,
-    /// Whether using a custom base URL (not OpenAI's API)
-    uses_custom_url: bool,
 }
 
 impl OpenAIChatDriver {
-    /// Create a new driver with the given API key
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create an Open Responses wire-protocol driver.
+    pub fn new() -> Self {
         Self {
-            inner: OpenResponsesProtocolChatDriver::new(api_key),
-            uses_custom_url: false,
+            inner: OpenResponsesProtocolChatDriver::new()
+                .with_stateful_responses(true)
+                .with_native_features(true, true),
         }
-    }
-
-    /// Create a new driver with a custom API URL
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        let api_url = normalize_api_url(&api_url.into(), "/responses");
-        Self {
-            inner: OpenResponsesProtocolChatDriver::with_base_url(api_key, api_url),
-            uses_custom_url: true,
-        }
-    }
-
-    /// Get the API URL
-    pub fn api_url(&self) -> &str {
-        self.inner.api_url()
-    }
-
-    /// Check if using a custom base URL
-    pub fn uses_custom_url(&self) -> bool {
-        self.uses_custom_url
     }
 
     /// Compact a conversation to reduce context size
@@ -107,8 +113,12 @@ impl OpenAIChatDriver {
     ///
     /// Returns a `CompactResponse` containing the compacted output items.
     /// The output can be used directly as input for the next /v1/responses call.
-    pub async fn compact_conversation(&self, request: CompactRequest) -> Result<CompactResponse> {
-        self.inner.compact(request).await
+    pub async fn compact_conversation(
+        &self,
+        endpoint: &ProviderEndpoint,
+        request: CompactRequest,
+    ) -> Result<CompactResponse> {
+        self.inner.compact(endpoint, request).await
     }
 
     /// Check if this driver supports the compact endpoint
@@ -124,20 +134,29 @@ impl OpenAIChatDriver {
 impl ChatDriver for OpenAIChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        self.inner.chat_completion_stream(messages, config).await
+        self.inner
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        let Some(api_url) = endpoint.url("responses") else {
+            return Ok(None);
+        };
         // Skip discovery for non-standard custom URLs (proxies, self-hosted)
-        if self.uses_custom_url && !supports_model_listing(self.api_url()) {
+        if !supports_model_listing(&api_url) {
             return Ok(None);
         }
 
-        let models_url = models_url_for_api_url(self.api_url());
-        list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        let models_url = models_url_for_api_url(&api_url);
+        list_openai_models(self.inner.client(), endpoint, &models_url).await
     }
 
     fn supports_compact(&self) -> bool {
@@ -148,17 +167,19 @@ impl ChatDriver for OpenAIChatDriver {
         self.inner.supports_parallel_tool_calls(model)
     }
 
-    async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
-        Ok(Some(self.inner.compact(request).await?))
+    async fn compact(
+        &self,
+        endpoint: &ProviderEndpoint,
+        request: CompactRequest,
+    ) -> Result<Option<CompactResponse>> {
+        Ok(Some(self.inner.compact(endpoint, request).await?))
     }
 }
 
 impl std::fmt::Debug for OpenAIChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenAIChatDriver")
-            .field("api_url", &self.api_url())
             .field("api", &"Open Responses")
-            .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
@@ -181,47 +202,20 @@ impl std::fmt::Debug for OpenAIChatDriver {
 /// ```ignore
 /// use everruns_openai::OpenAICompletionsChatDriver;
 ///
-/// let driver = OpenAICompletionsChatDriver::new("your-api-key");
-///
-/// // With custom endpoint
-/// let driver = OpenAICompletionsChatDriver::with_base_url(
-///     "your-api-key",
-///     "https://api.example.com/v1/chat/completions",
-/// );
+/// let driver = OpenAICompletionsChatDriver::new();
+/// // Bind it to a runtime Provider for endpoint and authentication.
 /// ```
 #[derive(Clone)]
 pub struct OpenAICompletionsChatDriver {
     inner: OpenAIProtocolChatDriver,
-    /// Whether using a custom base URL (not OpenAI's API)
-    uses_custom_url: bool,
 }
 
 impl OpenAICompletionsChatDriver {
-    /// Create a new driver with the given API key
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create a Chat Completions wire-protocol driver.
+    pub fn new() -> Self {
         Self {
-            inner: OpenAIProtocolChatDriver::new(api_key),
-            uses_custom_url: false,
+            inner: OpenAIProtocolChatDriver::new(),
         }
-    }
-
-    /// Create a new driver with a custom API URL
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        let api_url = normalize_api_url(&api_url.into(), "/chat/completions");
-        Self {
-            inner: OpenAIProtocolChatDriver::with_base_url(api_key, api_url),
-            uses_custom_url: true,
-        }
-    }
-
-    /// Get the API URL
-    pub fn api_url(&self) -> &str {
-        self.inner.api_url()
-    }
-
-    /// Check if using a custom base URL
-    pub fn uses_custom_url(&self) -> bool {
-        self.uses_custom_url
     }
 }
 
@@ -229,20 +223,29 @@ impl OpenAICompletionsChatDriver {
 impl ChatDriver for OpenAICompletionsChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        self.inner.chat_completion_stream(messages, config).await
+        self.inner
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        let Some(api_url) = endpoint.url("chat/completions") else {
+            return Ok(None);
+        };
         // Skip discovery for non-standard custom URLs (proxies, self-hosted)
-        if self.uses_custom_url && !supports_model_listing(self.api_url()) {
+        if !supports_model_listing(&api_url) {
             return Ok(None);
         }
 
-        let models_url = models_url_for_api_url(self.api_url());
-        list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        let models_url = models_url_for_api_url(&api_url);
+        list_openai_models(self.inner.client(), endpoint, &models_url).await
     }
 
     fn supports_parallel_tool_calls(&self, model: &str) -> bool {
@@ -253,9 +256,7 @@ impl ChatDriver for OpenAICompletionsChatDriver {
 impl std::fmt::Debug for OpenAICompletionsChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenAICompletionsChatDriver")
-            .field("api_url", &self.api_url())
             .field("api", &"Chat Completions")
-            .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
@@ -267,10 +268,15 @@ impl std::fmt::Debug for OpenAICompletionsChatDriver {
 /// Fetch and filter OpenAI models (shared between both OpenAI drivers)
 async fn list_openai_models(
     client: &reqwest::Client,
-    api_key: &str,
+    endpoint: &ProviderEndpoint,
     models_url: &str,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
-    let response = apply_models_api_auth(client.get(models_url), models_url, api_key)
+    let resolved = endpoint.resolve("GET", models_url, &[]).await?;
+    let mut request = client.get(&resolved.url);
+    for (name, value) in resolved.headers {
+        request = request.header(name, value);
+    }
+    let response = request
         .send()
         .await
         .map_err(|e| AgentLoopError::llm(format!("Failed to fetch models: {}", e)))?;
@@ -345,14 +351,18 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     // (knowledge/foundations/providers.md phase 6), so the descriptor declares those services
     // alongside Chat.
     let openai_embeddings_factory: EmbeddingsDriverFactory = std::sync::Arc::new(|config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => crate::embeddings::OpenAIEmbeddingsDriver::with_base_url(api_key, url),
-            None => crate::embeddings::OpenAIEmbeddingsDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedEmbeddingsDriver
+        Provider::new(config.provider.clone(), OpenAIChatDriver::new())
+            .base_url(
+                config
+                    .base_url
+                    .as_deref()
+                    .unwrap_or("https://api.openai.com/v1"),
+            )
+            .auth(BearerAuth::new(config.api_key.clone().unwrap_or_default()))
+            .bind_embeddings(Box::new(crate::embeddings::OpenAIEmbeddingsDriver::new()))
     });
     registry.register_descriptor(DriverDescriptor {
+        display_name: "OpenAI".into(),
         services: vec![ServiceKind::Chat, ServiceKind::Realtime, ServiceKind::Embeddings],
         credential_schema: CredentialFormSchema::api_key(
             "Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys).",
@@ -360,42 +370,56 @@ pub fn register_driver(registry: &mut DriverRegistry) {
         embeddings: Some(openai_embeddings_factory),
         ..DriverDescriptor::chat_only(DriverId::OpenAI, |config| {
             let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
-                None => OpenAIChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            Provider::new(config.provider.clone(), OpenAIChatDriver::new())
+                .base_url(config.base_url.as_deref().unwrap_or("https://api.openai.com/v1"))
+                .auth(BearerAuth::new(api_key))
+                .into_boxed_driver()
         })
     });
 
     registry.register_descriptor(DriverDescriptor {
+        display_name: "Azure OpenAI".into(),
         credential_schema: CredentialFormSchema::api_key(
             "Use an API key for your Azure OpenAI resource and set the resource endpoint as the base URL.",
         ),
         ..DriverDescriptor::chat_only(DriverId::AzureOpenAI, |config| {
             let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
-                None => OpenAIChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            Provider::new(config.provider.clone(), OpenAIChatDriver::new())
+                .base_url(config.base_url.as_deref().unwrap_or("https://api.openai.com/v1"))
+                .auth(StaticHeaderAuth::new("api-key", api_key))
+                .into_boxed_driver()
         })
     });
 
     // Register OpenAI Completions with Chat Completions API
     registry.register_descriptor(DriverDescriptor {
+        display_name: "OpenAI (Chat Completions)".into(),
         credential_schema: CredentialFormSchema::api_key(
             "Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys).",
         ),
         ..DriverDescriptor::chat_only(DriverId::OpenAICompletions, |config| {
             let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => OpenAICompletionsChatDriver::with_base_url(api_key, url),
-                None => OpenAICompletionsChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            Provider::new(
+                config.provider.clone(),
+                OpenAICompletionsChatDriver::new(),
+            )
+            .base_url(config.base_url.as_deref().unwrap_or("https://api.openai.com/v1"))
+            .auth(BearerAuth::new(api_key))
+            .into_boxed_driver()
         })
     });
+}
+
+impl Default for OpenAIChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Default for OpenAICompletionsChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]

--- a/crates/openai/src/embeddings.rs
+++ b/crates/openai/src/embeddings.rs
@@ -6,24 +6,12 @@ use serde::{Deserialize, Serialize};
 
 /// Embeddings driver for OpenAI's `/v1/embeddings` endpoint.
 pub struct OpenAIEmbeddingsDriver {
-    api_key: String,
-    base_url: String,
     client: reqwest::Client,
 }
 
 impl OpenAIEmbeddingsDriver {
-    pub fn new(api_key: impl Into<String>) -> Self {
+    pub fn new() -> Self {
         Self {
-            api_key: api_key.into(),
-            base_url: "https://api.openai.com/v1".to_string(),
-            client: shared_request_http_client(),
-        }
-    }
-
-    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
-        Self {
-            api_key: api_key.into(),
-            base_url: base_url.into().trim_end_matches('/').to_string(),
             client: shared_request_http_client(),
         }
     }
@@ -55,8 +43,14 @@ struct EmbeddingsUsage {
 
 #[async_trait]
 impl EmbeddingsDriver for OpenAIEmbeddingsDriver {
-    async fn embed(&self, request: EmbedRequest) -> Result<EmbedResponse, EmbeddingsDriverError> {
-        let url = format!("{}/embeddings", self.base_url);
+    async fn embed(
+        &self,
+        endpoint: &everruns_provider::ProviderEndpoint,
+        request: EmbedRequest,
+    ) -> Result<EmbedResponse, EmbeddingsDriverError> {
+        let url = endpoint
+            .url("embeddings")
+            .ok_or_else(|| EmbeddingsDriverError::Provider("provider has no base URL".into()))?;
         let body = EmbeddingsApiRequest {
             input: request.texts,
             model: request.model,
@@ -68,13 +62,20 @@ impl EmbeddingsDriver for OpenAIEmbeddingsDriver {
         let retry = LlmRetryConfig::default();
         let mut attempt: u32 = 0;
         loop {
-            let send_result = self
+            let bytes = serde_json::to_vec(&body)
+                .map_err(|error| EmbeddingsDriverError::Transport(error.to_string()))?;
+            let resolved = endpoint
+                .resolve("POST", &url, &bytes)
+                .await
+                .map_err(|error| EmbeddingsDriverError::Provider(error.to_string()))?;
+            let mut builder = self
                 .client
-                .post(&url)
-                .bearer_auth(&self.api_key)
-                .json(&body)
-                .send()
-                .await;
+                .post(&resolved.url)
+                .header("content-type", "application/json");
+            for (name, value) in resolved.headers {
+                builder = builder.header(name, value);
+            }
+            let send_result = builder.body(bytes).send().await;
 
             let transient_err: EmbeddingsDriverError = match send_result {
                 Ok(response) => {
@@ -117,5 +118,11 @@ impl EmbeddingsDriver for OpenAIEmbeddingsDriver {
             tokio::time::sleep(backoff).await;
             attempt += 1;
         }
+    }
+}
+
+impl Default for OpenAIEmbeddingsDriver {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -68,7 +68,10 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub use driver::{OpenAIChatDriver, OpenAICompletionsChatDriver, register_driver};
+pub use driver::{
+    OpenAIChatDriver, OpenAICompletionsChatDriver, azure_provider, completions_provider, provider,
+    register_driver,
+};
 pub use embeddings::OpenAIEmbeddingsDriver;
 pub use types::{
     ChatMessage, ChatRequest, CompletionMetadata, LlmConfig, LlmStreamEvent, MessageRole,

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -2,67 +2,76 @@
 
 #[cfg(test)]
 mod driver_tests {
-    use crate::{DriverRegistry, OpenAIChatDriver, OpenAICompletionsChatDriver, register_driver};
+    use crate::{
+        DriverRegistry, OpenAIChatDriver, OpenAICompletionsChatDriver, azure_provider,
+        completions_provider, provider, register_driver,
+    };
     use everruns_provider::driver_registry::{DriverId, ProviderConfig};
 
     #[test]
-    fn test_driver_with_api_key() {
-        let driver = OpenAIChatDriver::new("test-key");
+    fn test_responses_driver_is_wire_only() {
+        let driver = OpenAIChatDriver::new();
         // Just verify it can be created
         assert!(format!("{:?}", driver).contains("OpenAIChatDriver"));
         assert!(format!("{:?}", driver).contains("Open Responses"));
-        // URL should be for Open Responses API
-        assert!(driver.api_url().contains("responses"));
+        let service = provider("openai", "test-key");
+        assert_eq!(
+            service.endpoint().url("responses").as_deref(),
+            Some("https://api.openai.com/v1/responses")
+        );
     }
 
     #[test]
-    fn test_driver_with_base_url() {
-        let driver =
-            OpenAIChatDriver::with_base_url("test-key", "https://custom.api.com/v1/responses");
-        assert!(format!("{:?}", driver).contains("OpenAIChatDriver"));
-        assert_eq!(driver.api_url(), "https://custom.api.com/v1/responses");
-        assert!(driver.uses_custom_url());
+    fn test_provider_accepts_custom_base_url() {
+        let service = provider("custom", "test-key").base_url("https://custom.api.com/v1");
+        assert_eq!(
+            service.endpoint().url("responses").as_deref(),
+            Some("https://custom.api.com/v1/responses")
+        );
     }
 
     #[test]
     fn test_driver_normalizes_v1_base_url() {
-        let driver = OpenAIChatDriver::with_base_url("test-key", "https://api.openai.com/v1");
-        assert_eq!(driver.api_url(), "https://api.openai.com/v1/responses");
+        let service = provider("openai", "test-key");
+        assert_eq!(
+            service.endpoint().url("responses").as_deref(),
+            Some("https://api.openai.com/v1/responses")
+        );
     }
 
     #[test]
     fn test_driver_normalizes_azure_v1_base_url() {
-        let driver = OpenAIChatDriver::with_base_url(
-            "test-key",
+        let service = azure_provider(
+            "azure",
             "https://resource.openai.azure.com/openai/v1/",
+            "test-key",
         );
         assert_eq!(
-            driver.api_url(),
-            "https://resource.openai.azure.com/openai/v1/responses"
+            service.endpoint().url("responses").as_deref(),
+            Some("https://resource.openai.azure.com/openai/v1/responses")
         );
     }
 
     #[test]
     fn test_completions_driver_with_api_key() {
-        let driver = OpenAICompletionsChatDriver::new("test-key");
+        let driver = OpenAICompletionsChatDriver::new();
         assert!(format!("{:?}", driver).contains("OpenAICompletionsChatDriver"));
         assert!(format!("{:?}", driver).contains("Chat Completions"));
-        // URL should be for Chat Completions API
-        assert!(driver.api_url().contains("chat/completions"));
+        let service = completions_provider("openai-completions", "test-key");
+        assert_eq!(
+            service.endpoint().url("chat/completions").as_deref(),
+            Some("https://api.openai.com/v1/chat/completions")
+        );
     }
 
     #[test]
     fn test_completions_driver_with_base_url() {
-        let driver = OpenAICompletionsChatDriver::with_base_url(
-            "test-key",
-            "https://custom.api.com/v1/chat/completions",
-        );
-        assert!(format!("{:?}", driver).contains("OpenAICompletionsChatDriver"));
+        let service = completions_provider("custom", "test-key")
+            .base_url("https://custom.api.com/v1/chat/completions");
         assert_eq!(
-            driver.api_url(),
-            "https://custom.api.com/v1/chat/completions"
+            service.endpoint().url("chat/completions").as_deref(),
+            Some("https://custom.api.com/v1/chat/completions")
         );
-        assert!(driver.uses_custom_url());
     }
 
     #[test]

--- a/crates/openai/tests/parallel_tool_calls_live.rs
+++ b/crates/openai/tests/parallel_tool_calls_live.rs
@@ -9,11 +9,11 @@
 //! Ignored by default (requires network + `OPENAI_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-openai --test parallel_tool_calls_live -- --ignored --nocapture`
 
-use everruns_core::driver_registry::{ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
 use everruns_core::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
 };
-use everruns_openai::OpenAIChatDriver;
+use everruns_openai::provider;
 
 const LIVE_MODEL: &str = "gpt-4o-mini";
 
@@ -63,7 +63,7 @@ fn config_with(parallel: Option<bool>) -> LlmCallConfig {
 }
 
 async fn tool_call_count(parallel: Option<bool>) -> usize {
-    let driver = OpenAIChatDriver::new(api_key());
+    let provider = provider("openai", api_key());
     let messages = vec![
         LlmMessage::text(
             LlmMessageRole::System,
@@ -74,7 +74,7 @@ async fn tool_call_count(parallel: Option<bool>) -> usize {
             "Get both the current weather and the current local time in Paris.",
         ),
     ];
-    let response = driver
+    let response = provider
         .chat_completion(messages, &config_with(parallel))
         .await
         .expect("OpenAI should accept the request");

--- a/crates/openrouter/src/driver.rs
+++ b/crates/openrouter/src/driver.rs
@@ -15,18 +15,25 @@ use everruns_provider::OpenResponsesProtocolChatDriver;
 use everruns_provider::credential_schema::CredentialFormSchema;
 use everruns_provider::driver_helpers::fetch_models;
 use everruns_provider::driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
-    LlmCallConfig, LlmMessage, LlmResponseStream,
+    ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry, LlmCallConfig,
+    LlmMessage, LlmResponseStream,
 };
 use everruns_provider::error::Result;
-use everruns_provider::openai_protocol::{
-    apply_models_api_auth, models_url_for_api_url, normalize_api_url, url_host_eq,
-};
+use everruns_provider::openai_protocol::{models_url_for_api_url, url_host_eq};
+use everruns_provider::{BearerAuth, Provider, ProviderEndpoint};
 
 use crate::request_ext::OpenRouterRequestExtension;
 use crate::types::OpenRouterModelsResponse;
 
-const OPENROUTER_RESPONSES_URL: &str = "https://openrouter.ai/api/v1/responses";
+/// Ready-to-use OpenRouter provider assembly.
+pub fn provider(
+    id: impl Into<everruns_provider::ProviderKey>,
+    api_key: impl Into<String>,
+) -> Provider {
+    Provider::new(id, OpenRouterChatDriver::new())
+        .base_url("https://openrouter.ai/api/v1")
+        .auth(BearerAuth::new(api_key))
+}
 
 // ============================================================================
 // OpenRouter Chat Driver (OpenAI-compatible Responses API)
@@ -36,48 +43,15 @@ const OPENROUTER_RESPONSES_URL: &str = "https://openrouter.ai/api/v1/responses";
 #[derive(Clone)]
 pub struct OpenRouterChatDriver {
     inner: OpenResponsesProtocolChatDriver,
-    /// Whether constructed with an explicit base URL override via [`with_base_url`].
-    uses_custom_url: bool,
 }
 
 impl OpenRouterChatDriver {
-    /// Create a new OpenRouter driver with the default Responses API endpoint.
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create the OpenRouter Responses wire driver.
+    pub fn new() -> Self {
         Self {
-            inner: OpenResponsesProtocolChatDriver::with_base_url(
-                api_key,
-                OPENROUTER_RESPONSES_URL,
-            )
-            .with_provider_type(DriverId::OpenRouter)
-            .with_request_extension(Arc::new(OpenRouterRequestExtension)),
-            uses_custom_url: false,
-        }
-    }
-
-    /// Create a new OpenRouter driver with an explicit API URL override.
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        let api_url = normalize_api_url(&api_url.into(), "/responses");
-        Self {
-            inner: OpenResponsesProtocolChatDriver::with_base_url(api_key, api_url)
-                .with_provider_type(DriverId::OpenRouter)
+            inner: OpenResponsesProtocolChatDriver::new()
                 .with_request_extension(Arc::new(OpenRouterRequestExtension)),
-            uses_custom_url: true,
         }
-    }
-
-    /// Get the API URL.
-    pub fn api_url(&self) -> &str {
-        self.inner.api_url()
-    }
-
-    /// Get the provider type used for model profile lookup.
-    pub fn provider_type(&self) -> &DriverId {
-        self.inner.provider_type()
-    }
-
-    /// Check if using a custom base URL.
-    pub fn uses_custom_url(&self) -> bool {
-        self.uses_custom_url
     }
 }
 
@@ -85,34 +59,41 @@ impl OpenRouterChatDriver {
 impl ChatDriver for OpenRouterChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        self.inner.chat_completion_stream(messages, config).await
+        self.inner
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
     fn supports_parallel_tool_calls(&self, model: &str) -> bool {
         self.inner.supports_parallel_tool_calls(model)
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        let Some(api_url) = endpoint.url("responses") else {
+            return Ok(None);
+        };
         // OpenRouter discovery is only safe against OpenRouter's own host.
         // Custom proxy URLs may resolve to private infrastructure at request time.
-        if self.uses_custom_url && !is_openrouter_api_url(self.api_url()) {
+        if !is_openrouter_api_url(&api_url) {
             return Ok(None);
         }
 
-        let models_url = models_url_for_api_url(self.api_url());
-        list_openrouter_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        let models_url = models_url_for_api_url(&api_url);
+        list_openrouter_models(self.inner.client(), endpoint, &models_url).await
     }
 }
 
 impl std::fmt::Debug for OpenRouterChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenRouterChatDriver")
-            .field("api_url", &self.api_url())
             .field("api", &"OpenRouter Responses")
-            .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
@@ -125,11 +106,16 @@ impl std::fmt::Debug for OpenRouterChatDriver {
 /// `supported_parameters` metadata OpenRouter advertises.
 async fn list_openrouter_models(
     client: &reqwest::Client,
-    api_key: &str,
+    endpoint: &ProviderEndpoint,
     models_url: &str,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
+    let resolved = endpoint.resolve("GET", models_url, &[]).await?;
+    let mut request = client.get(&resolved.url);
+    for (name, value) in resolved.headers {
+        request = request.header(name, value);
+    }
     fetch_models::<OpenRouterModelsResponse, _>(
-        apply_models_api_auth(client.get(models_url), models_url, api_key),
+        request,
         "Failed to fetch models",
         "Failed to parse models response",
         &[],
@@ -182,6 +168,7 @@ fn is_openrouter_api_url(api_url: &str) -> bool {
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register_descriptor(DriverDescriptor {
+        display_name: "OpenRouter".into(),
         credential_schema: CredentialFormSchema::api_key(
             "Create an API key at [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys), \
              or use \"Connect with OpenRouter\" to authorize one without leaving the app.",
@@ -191,14 +178,18 @@ pub fn register_driver(registry: &mut DriverRegistry) {
         // pasting a key manually. The key is stored like any other credential.
         oauth: Some(everruns_provider::DriverOAuthConfig::openrouter()),
         ..DriverDescriptor::chat_only(DriverId::OpenRouter, |config| {
-            let api_key = config.api_key.as_deref().unwrap_or("");
-            let driver = match config.base_url.as_deref() {
-                Some(url) => OpenRouterChatDriver::with_base_url(api_key, url),
-                None => OpenRouterChatDriver::new(api_key),
-            };
-            Box::new(driver) as BoxedChatDriver
+            Provider::new(config.provider.clone(), OpenRouterChatDriver::new())
+                .base_url(config.base_url.as_deref().unwrap_or("https://openrouter.ai/api/v1"))
+                .auth(BearerAuth::new(config.api_key.clone().unwrap_or_default()))
+                .into_boxed_driver()
         })
     });
+}
+
+impl Default for OpenRouterChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]
@@ -208,31 +199,33 @@ mod tests {
 
     #[test]
     fn test_openrouter_driver_defaults_to_responses_api() {
-        let driver = OpenRouterChatDriver::new("test-key");
+        let driver = OpenRouterChatDriver::new();
+        let service = provider("openrouter", "test-key");
         assert!(format!("{:?}", driver).contains("OpenRouterChatDriver"));
-        assert_eq!(driver.api_url(), "https://openrouter.ai/api/v1/responses");
-        assert_eq!(driver.provider_type(), &DriverId::OpenRouter);
+        assert_eq!(
+            service.endpoint().url("responses").as_deref(),
+            Some("https://openrouter.ai/api/v1/responses")
+        );
     }
 
     #[test]
     fn test_openrouter_driver_with_base_url_marks_custom_url() {
-        let driver = OpenRouterChatDriver::with_base_url(
-            "test-key",
-            "https://openrouter.ai/api/v1/responses",
+        let service =
+            provider("openrouter", "test-key").base_url("https://openrouter.ai/api/v1/responses");
+        assert_eq!(
+            service.endpoint().url("responses").as_deref(),
+            Some("https://openrouter.ai/api/v1/responses")
         );
-        assert_eq!(driver.api_url(), "https://openrouter.ai/api/v1/responses");
-        assert!(driver.uses_custom_url());
     }
 
     #[tokio::test]
     async fn test_openrouter_custom_non_openrouter_host_skips_model_listing() {
-        let driver = OpenRouterChatDriver::with_base_url(
-            "test-key",
-            "https://custom.api.example/v1/responses",
-        );
+        let service = Provider::new("custom", OpenRouterChatDriver::new())
+            .base_url("https://custom.api.example/v1");
+        let driver = OpenRouterChatDriver::new();
 
         let discovered = driver
-            .list_models()
+            .list_models(service.endpoint())
             .await
             .expect("custom non-OpenRouter discovery should be skipped");
 

--- a/crates/openrouter/src/lib.rs
+++ b/crates/openrouter/src/lib.rs
@@ -24,7 +24,7 @@ mod driver;
 mod request_ext;
 mod types;
 
-pub use driver::{OpenRouterChatDriver, register_driver};
+pub use driver::{OpenRouterChatDriver, provider, register_driver};
 pub use request_ext::OpenRouterRequestExtension;
 pub use types::{
     OpenRouterArchitecture, OpenRouterModelInfo, OpenRouterModelsResponse, OpenRouterPricing,

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -10,10 +10,10 @@
 //!   `doppler run -- cargo test -p everruns-openrouter --test chat_live -- --ignored --nocapture`
 
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, OpenRouterRoute,
+    LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, OpenRouterRoute,
     OpenRouterRoutingConfig,
 };
-use everruns_openrouter::OpenRouterChatDriver;
+use everruns_openrouter::provider;
 use futures::StreamExt;
 
 #[tokio::test]
@@ -22,7 +22,7 @@ async fn openrouter_chat_with_session_id_and_routing_succeeds() {
     let api_key = std::env::var("OPENROUTER_API_KEY")
         .expect("OPENROUTER_API_KEY must be set for the live smoke test");
 
-    let driver = OpenRouterChatDriver::new(api_key);
+    let provider = provider("openrouter", api_key);
 
     let mut metadata = std::collections::HashMap::new();
     metadata.insert("session_id".to_string(), "session_live_smoke".to_string());
@@ -58,7 +58,7 @@ async fn openrouter_chat_with_session_id_and_routing_succeeds() {
         "Reply with exactly one word: pong",
     )];
 
-    let mut stream = driver
+    let mut stream = provider
         .chat_completion_stream(messages, &config)
         .await
         .expect("OpenRouter should accept the decorated chat request");

--- a/crates/openrouter/tests/openrouter_discovery_live.rs
+++ b/crates/openrouter/tests/openrouter_discovery_live.rs
@@ -7,8 +7,7 @@
 //! Ignored by default (requires network + `OPENROUTER_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-openrouter --test openrouter_discovery_live -- --ignored --nocapture`
 
-use everruns_core::driver_registry::ChatDriver;
-use everruns_openrouter::OpenRouterChatDriver;
+use everruns_openrouter::provider;
 
 #[tokio::test]
 #[ignore = "live network + OPENROUTER_API_KEY"]
@@ -16,9 +15,9 @@ async fn openrouter_discovers_nemotron_reasoning_profile() {
     let api_key = std::env::var("OPENROUTER_API_KEY")
         .expect("OPENROUTER_API_KEY must be set for the live smoke test");
 
-    let driver = OpenRouterChatDriver::with_base_url(api_key, "https://openrouter.ai/api/v1");
+    let provider = provider("openrouter", api_key);
 
-    let models = driver
+    let models = provider
         .list_models()
         .await
         .expect("list_models should succeed")

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -7,13 +7,14 @@
 // assert the exact JSON sent.
 
 use everruns_core::driver_registry::{
-    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, OpenRouterDataCollection,
-    OpenRouterMaxPrice, OpenRouterPluginConfig, OpenRouterProviderRouting, OpenRouterProviderSort,
+    LlmCallConfig, LlmMessage, LlmMessageRole, OpenRouterDataCollection, OpenRouterMaxPrice,
+    OpenRouterPluginConfig, OpenRouterProviderRouting, OpenRouterProviderSort,
     OpenRouterProviderSortBy, OpenRouterProviderSortOptions, OpenRouterRoute,
     OpenRouterRoutingConfig, OpenRouterServerTool, OpenRouterServerToolKind,
     OpenRouterSortPartition, OpenRouterWebSearchPlugin,
 };
 use everruns_openrouter::OpenRouterChatDriver;
+use everruns_provider::{BearerAuth, Provider};
 use serde_json::json;
 use wiremock::matchers::method;
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -38,6 +39,12 @@ fn base_config(model: &str) -> LlmCallConfig {
     }
 }
 
+fn provider(api_url: String) -> Provider {
+    Provider::new("openrouter-test", OpenRouterChatDriver::new())
+        .base_url(api_url)
+        .auth(BearerAuth::new("test-key"))
+}
+
 async fn capture_request_body(config: &LlmCallConfig) -> serde_json::Value {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
@@ -46,7 +53,7 @@ async fn capture_request_body(config: &LlmCallConfig) -> serde_json::Value {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
 
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
     let _ = driver.chat_completion_stream(messages, config).await;
@@ -68,7 +75,7 @@ async fn sends_routing_controls_and_session_id() {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
 
     let mut config = base_config("openai/gpt-5-mini");
     config
@@ -142,7 +149,7 @@ async fn sends_openrouter_attribution_headers_from_metadata() {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
 
     let mut config = base_config("openai/gpt-5-mini");
     config.metadata.insert(
@@ -199,7 +206,7 @@ async fn skips_blank_openrouter_attribution_metadata() {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
 
     let mut config = base_config("openai/gpt-5-mini");
     config
@@ -332,7 +339,7 @@ async fn retries_after_openrouter_rate_limit_reset() {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
     let mut stream = driver
         .chat_completion_stream(messages, &base_config("openai/gpt-4o-mini"))
@@ -369,7 +376,7 @@ async fn rejects_invalid_routing_before_dispatch() {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
 
     // Primary model absent from the fallback list.
     let mut mismatch = base_config("openai/gpt-5-mini");
@@ -428,7 +435,7 @@ async fn includes_plugins_in_request() {
         .await;
 
     let api_url = format!("{}/v1/responses", server.uri());
-    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let driver = provider(api_url);
 
     let mut config = base_config("openai/gpt-5-mini");
     config.openrouter_routing = Some(OpenRouterRoutingConfig {

--- a/crates/provider/src/driver_helpers.rs
+++ b/crates/provider/src/driver_helpers.rs
@@ -319,9 +319,8 @@ pub const GEMINI_NOT_FOUND_PATTERNS: &[&str] = &["not_found", "model"];
 /// Error message prefixes are passed in so each provider keeps its exact
 /// user-facing wording.
 ///
-/// Note: callers attach auth on `request` themselves (via
-/// [`crate::openai_protocol::apply_models_api_auth`] or an awaited
-/// `AuthHeaderProvider`), so this stays agnostic to the auth scheme.
+/// Note: callers resolve the request through their runtime
+/// `ProviderEndpoint` first, so this stays agnostic to the auth scheme.
 pub async fn fetch_models<T, F>(
     request: reqwest::RequestBuilder,
     fetch_err_prefix: &str,

--- a/crates/provider/src/driver_registry.rs
+++ b/crates/provider/src/driver_registry.rs
@@ -290,6 +290,7 @@ pub trait ChatDriver: Send + Sync {
     /// Call the LLM with streaming response
     async fn chat_completion_stream(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream>;
@@ -297,12 +298,15 @@ pub trait ChatDriver: Send + Sync {
     /// Call the LLM without streaming (convenience method)
     async fn chat_completion(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponse> {
         use futures::StreamExt;
 
-        let mut stream = self.chat_completion_stream(messages, config).await?;
+        let mut stream = self
+            .chat_completion_stream(endpoint, messages, config)
+            .await?;
         let mut text = String::new();
         let mut thinking = String::new();
         let mut thinking_signature: Option<String> = None;
@@ -359,7 +363,10 @@ pub trait ChatDriver: Send + Sync {
     ///
     /// Implementations should filter to chat/completion models only,
     /// excluding embedding models, TTS, whisper, etc.
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+    async fn list_models(
+        &self,
+        _endpoint: &crate::runtime_provider::ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
         // Default: not supported. Providers override if they support listing.
         Ok(None)
     }
@@ -428,7 +435,11 @@ pub trait ChatDriver: Send + Sync {
     ///
     /// The response contains the compacted output items which can be used
     /// directly as input for the next chat completion call.
-    async fn compact(&self, _request: CompactRequest) -> Result<Option<CompactResponse>> {
+    async fn compact(
+        &self,
+        _endpoint: &crate::runtime_provider::ProviderEndpoint,
+        _request: CompactRequest,
+    ) -> Result<Option<CompactResponse>> {
         // Default: not supported
         Ok(None)
     }
@@ -439,22 +450,29 @@ pub trait ChatDriver: Send + Sync {
 impl ChatDriver for Box<dyn ChatDriver> {
     async fn chat_completion_stream(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        (**self).chat_completion_stream(messages, config).await
+        (**self)
+            .chat_completion_stream(endpoint, messages, config)
+            .await
     }
 
     async fn chat_completion(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponse> {
-        (**self).chat_completion(messages, config).await
+        (**self).chat_completion(endpoint, messages, config).await
     }
 
-    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        (**self).list_models().await
+    async fn list_models(
+        &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
+    ) -> Result<Option<Vec<DiscoveredModel>>> {
+        (**self).list_models(endpoint).await
     }
 
     fn supports_compact(&self) -> bool {
@@ -473,8 +491,12 @@ impl ChatDriver for Box<dyn ChatDriver> {
         (**self).supports_parallel_tool_calls(model)
     }
 
-    async fn compact(&self, request: CompactRequest) -> Result<Option<CompactResponse>> {
-        (**self).compact(request).await
+    async fn compact(
+        &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
+        request: CompactRequest,
+    ) -> Result<Option<CompactResponse>> {
+        (**self).compact(endpoint, request).await
     }
 }
 
@@ -1534,7 +1556,7 @@ pub use crate::provider::DriverId;
 /// Built-in providers ignore this; embedder-defined ([`DriverId::External`])
 /// providers use it to carry OAuth tokens, account ids, or arbitrary extras
 /// their driver factory needs.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct ProviderMetadata {
     /// OAuth refresh token, when the provider authenticates via OAuth.
     pub refresh_token: Option<String>,
@@ -1544,9 +1566,24 @@ pub struct ProviderMetadata {
     pub extra: Option<serde_json::Value>,
 }
 
+impl std::fmt::Debug for ProviderMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderMetadata")
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "<configured>"),
+            )
+            .field("account_id", &self.account_id)
+            .field("extra", &self.extra.as_ref().map(|_| "<configured>"))
+            .finish()
+    }
+}
+
 /// Configuration for creating an LLM provider
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ProviderConfig {
+    /// Runtime service identity selected by the model.
+    pub provider: crate::runtime_provider::ProviderKey,
     /// Type of provider
     pub provider_type: DriverId,
     /// API key for authentication
@@ -1560,7 +1597,24 @@ pub struct ProviderConfig {
 impl ProviderConfig {
     /// Create a new provider config
     pub fn new(provider_type: DriverId) -> Self {
+        let provider = crate::runtime_provider::ProviderKey::new(provider_type.as_str());
         Self {
+            provider,
+            provider_type,
+            api_key: None,
+            base_url: None,
+            metadata: ProviderMetadata::default(),
+        }
+    }
+
+    /// Configure a runtime provider id independently from its hosted
+    /// integration kind.
+    pub fn for_provider(
+        provider: impl Into<crate::runtime_provider::ProviderKey>,
+        provider_type: DriverId,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
             provider_type,
             api_key: None,
             base_url: None,
@@ -1587,13 +1641,30 @@ impl ProviderConfig {
     }
 }
 
+impl std::fmt::Debug for ProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderConfig")
+            .field("provider", &self.provider)
+            .field("provider_type", &self.provider_type)
+            .field("auth", &self.api_key.as_ref().map(|_| "<configured>"))
+            .field("base_url", &self.base_url.as_ref().map(|_| "<configured>"))
+            .field(
+                "metadata",
+                &self.metadata.extra.as_ref().map(|_| "<configured>"),
+            )
+            .finish()
+    }
+}
+
 /// Everything a [`DriverFactory`] receives to build a driver instance.
 ///
 /// Replaces the old `(api_key, base_url)` factory arguments so that
 /// embedder-defined providers can receive richer auth via [`ProviderMetadata`]
 /// without changing the factory signature again.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DriverConfig {
+    /// Runtime service identity.
+    pub provider: crate::runtime_provider::ProviderKey,
     /// Provider type being created.
     pub provider_type: DriverId,
     /// Raw credential document, when one is configured. `None` for keyless
@@ -1622,6 +1693,7 @@ impl DriverConfig {
     /// gets the same typed view.
     pub fn from_provider_config(config: &ProviderConfig) -> Self {
         Self {
+            provider: config.provider.clone(),
             provider_type: config.provider_type.clone(),
             credentials: crate::credential_schema::parse_credential_document(
                 config.api_key.as_deref(),
@@ -1638,6 +1710,21 @@ impl DriverConfig {
             .get(name)
             .map(String::as_str)
             .filter(|s| !s.is_empty())
+    }
+}
+
+impl std::fmt::Debug for DriverConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DriverConfig")
+            .field("provider", &self.provider)
+            .field("provider_type", &self.provider_type)
+            .field("auth", &self.api_key.as_ref().map(|_| "<configured>"))
+            .field(
+                "credential_fields",
+                &self.credentials.keys().collect::<Vec<_>>(),
+            )
+            .field("base_url", &self.base_url.as_ref().map(|_| "<configured>"))
+            .finish()
     }
 }
 
@@ -1689,8 +1776,20 @@ pub trait EmbeddingsDriver: Send + Sync {
     /// Embed a batch of texts and return one vector per input.
     async fn embed(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         request: EmbedRequest,
     ) -> std::result::Result<EmbedResponse, EmbeddingsDriverError>;
+}
+
+#[async_trait]
+impl EmbeddingsDriver for Box<dyn EmbeddingsDriver> {
+    async fn embed(
+        &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
+        request: EmbedRequest,
+    ) -> std::result::Result<EmbedResponse, EmbeddingsDriverError> {
+        (**self).embed(endpoint, request).await
+    }
 }
 
 /// Boxed embeddings driver for dynamic dispatch.
@@ -1858,27 +1957,14 @@ impl std::fmt::Debug for DriverDescriptor {
 }
 
 fn default_display_name(id: &DriverId) -> String {
-    match id {
-        DriverId::OpenAI => "OpenAI".to_string(),
-        DriverId::OpenRouter => "OpenRouter".to_string(),
-        DriverId::AzureOpenAI => "Azure OpenAI".to_string(),
-        DriverId::OpenAICompletions => "OpenAI (Chat Completions)".to_string(),
-        DriverId::Anthropic => "Anthropic".to_string(),
-        DriverId::Gemini => "Google Gemini".to_string(),
-        DriverId::Bedrock => "AWS Bedrock".to_string(),
-        DriverId::Mai => "Microsoft MAI".to_string(),
-        DriverId::Fireworks => "Fireworks AI".to_string(),
-        DriverId::Meta => "Meta Model API".to_string(),
-        DriverId::LlmSim => "LLM Simulator".to_string(),
-        DriverId::External(id) => id.to_string(),
-    }
+    id.as_str().replace(['_', '-'], " ")
 }
 
 fn default_credential_schema(id: &DriverId) -> CredentialFormSchema {
-    match id {
-        // Keyless: simulator always; external drivers may auth via metadata.
-        DriverId::LlmSim | DriverId::External(_) => CredentialFormSchema::empty(),
-        _ => CredentialFormSchema::api_key(String::new()),
+    if id == &DriverId::LlmSim {
+        CredentialFormSchema::empty()
+    } else {
+        CredentialFormSchema::api_key(String::new())
     }
 }
 
@@ -1904,6 +1990,7 @@ fn default_credential_schema(id: &DriverId) -> CredentialFormSchema {
 #[derive(Clone, Default)]
 pub struct DriverRegistry {
     descriptors: HashMap<DriverId, DriverDescriptor>,
+    providers: crate::runtime_provider::RuntimeProviderRegistry,
 }
 
 impl DriverRegistry {
@@ -1911,7 +1998,32 @@ impl DriverRegistry {
     pub fn new() -> Self {
         Self {
             descriptors: HashMap::new(),
+            providers: crate::runtime_provider::RuntimeProviderRegistry::new(),
         }
+    }
+
+    /// Register an application-supplied runtime provider directly.
+    pub fn register_provider(
+        &mut self,
+        provider: crate::runtime_provider::RuntimeProvider,
+    ) -> Result<()> {
+        self.providers.register(provider)
+    }
+
+    /// Explicitly replace an application-supplied runtime provider.
+    pub fn replace_provider(
+        &mut self,
+        provider: crate::runtime_provider::RuntimeProvider,
+    ) -> Option<Arc<crate::runtime_provider::RuntimeProvider>> {
+        self.providers.replace(provider)
+    }
+
+    /// Look up a directly registered runtime provider by service identity.
+    pub fn provider(
+        &self,
+        id: &crate::runtime_provider::ProviderKey,
+    ) -> Option<Arc<crate::runtime_provider::RuntimeProvider>> {
+        self.providers.get(id)
     }
 
     /// Register a full driver descriptor.
@@ -1962,11 +2074,13 @@ impl DriverRegistry {
     /// keyed by its canonical id. The id is normalized to lowercase (via
     /// [`DriverId::external`]) so it matches parsed lookups regardless of
     /// the casing stored in the database or sent on the wire.
-    pub fn register_external<F>(&mut self, id: impl Into<Arc<str>>, factory: F)
+    pub fn register_external<F>(&mut self, id: impl AsRef<str>, factory: F)
     where
         F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
     {
-        self.register(DriverId::external(id), factory);
+        let mut descriptor = DriverDescriptor::chat_only(DriverId::external(id), factory);
+        descriptor.credential_schema = CredentialFormSchema::empty();
+        self.register_descriptor(descriptor);
     }
 
     /// Create an LLM driver based on configuration
@@ -1978,13 +2092,17 @@ impl DriverRegistry {
     ///
     /// Returns `DriverNotRegistered` error if no driver is registered for the provider type.
     pub fn create_chat_driver(&self, config: &ProviderConfig) -> Result<BoxedChatDriver> {
-        // API key is required for real built-in providers, but not for LlmSim
-        // (testing), External providers, or Mai (which may all authenticate via
-        // metadata-based auth — Mai supports Entra ID OAuth without an api_key).
-        let requires_api_key = !matches!(
-            config.provider_type,
-            DriverId::LlmSim | DriverId::External(_) | DriverId::Mai
-        );
+        if let Some(provider) = self.providers.get(&config.provider) {
+            return Ok((*provider).clone().into_boxed_driver());
+        }
+        let descriptor = self.descriptors.get(&config.provider_type).ok_or_else(|| {
+            AgentLoopError::driver_not_registered(config.provider_type.to_string())
+        })?;
+        let requires_api_key = descriptor
+            .credential_schema
+            .fields
+            .iter()
+            .any(|field| field.name == "api_key" && field.required && field.group.is_none());
         if requires_api_key && config.api_key.is_none() {
             return Err(AgentLoopError::llm(
                 "API key is required. Configure the API key in provider settings.",
@@ -1992,9 +2110,6 @@ impl DriverRegistry {
         }
 
         // Look up the descriptor and its chat factory for this provider type
-        let descriptor = self.descriptors.get(&config.provider_type).ok_or_else(|| {
-            AgentLoopError::driver_not_registered(config.provider_type.to_string())
-        })?;
         let factory = descriptor.chat.as_ref().ok_or_else(|| {
             AgentLoopError::llm(format!(
                 "Provider driver '{}' does not implement the chat service.",
@@ -2038,6 +2153,11 @@ impl DriverRegistry {
         self.descriptors.keys().cloned().collect()
     }
 
+    /// Runtime provider ids registered directly by an application.
+    pub fn registered_provider_ids(&self) -> Vec<String> {
+        self.providers.ids()
+    }
+
     /// Create an embeddings driver based on configuration.
     ///
     /// API keys must be provided in the config for real providers. Exception:
@@ -2049,10 +2169,7 @@ impl DriverRegistry {
         &self,
         config: &ProviderConfig,
     ) -> std::result::Result<BoxedEmbeddingsDriver, EmbeddingsDriverError> {
-        let requires_api_key = !matches!(
-            config.provider_type,
-            DriverId::LlmSim | DriverId::External(_)
-        );
+        let requires_api_key = config.provider_type != DriverId::LlmSim;
         if requires_api_key && config.api_key.is_none() {
             return Err(EmbeddingsDriverError::Provider(
                 "API key is required. Configure the API key in provider settings.".to_string(),
@@ -2105,6 +2222,7 @@ pub fn truncate_tool_result(text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime_provider::ProviderEndpoint;
 
     #[test]
     fn test_disjoint_prompt_tokens_subtracts_cached_subset() {
@@ -2126,6 +2244,7 @@ mod tests {
         impl ChatDriver for DefaultDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {
@@ -2140,6 +2259,7 @@ mod tests {
         impl ChatDriver for StatefulDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {
@@ -2373,6 +2493,28 @@ mod tests {
     }
 
     #[test]
+    fn provider_config_debug_redacts_runtime_values() {
+        let config = ProviderConfig::new(DriverId::OpenAI)
+            .with_api_key("secret-key")
+            .with_base_url("https://user:password@example.test/v1?token=secret")
+            .with_metadata(ProviderMetadata {
+                refresh_token: Some("refresh-secret".into()),
+                account_id: Some("account-1".into()),
+                extra: Some(serde_json::json!({ "client_secret": "metadata-secret" })),
+            });
+        let debug = format!("{config:?}");
+        for secret in [
+            "secret-key",
+            "password",
+            "token=secret",
+            "refresh-secret",
+            "metadata-secret",
+        ] {
+            assert!(!debug.contains(secret), "debug output exposed {secret}");
+        }
+    }
+
+    #[test]
     fn test_driver_registry_requires_api_key() {
         // Register a mock factory
         let mut registry = DriverRegistry::new();
@@ -2383,6 +2525,7 @@ mod tests {
             impl ChatDriver for MockDriver {
                 async fn chat_completion_stream(
                     &self,
+                    _endpoint: &ProviderEndpoint,
                     _messages: Vec<LlmMessage>,
                     _config: &LlmCallConfig,
                 ) -> Result<LlmResponseStream> {
@@ -2431,6 +2574,7 @@ mod tests {
             impl ChatDriver for MockDriver {
                 async fn chat_completion_stream(
                     &self,
+                    _endpoint: &ProviderEndpoint,
                     _messages: Vec<LlmMessage>,
                     _config: &LlmCallConfig,
                 ) -> Result<LlmResponseStream> {
@@ -2451,6 +2595,7 @@ mod tests {
         impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {
@@ -2484,6 +2629,7 @@ mod tests {
         impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {
@@ -2495,7 +2641,7 @@ mod tests {
         registry.register(DriverId::Anthropic, |_config| Box::new(MockDriver));
 
         let descriptor = registry.descriptor(&DriverId::Anthropic).unwrap();
-        assert_eq!(descriptor.display_name, "Anthropic");
+        assert_eq!(descriptor.display_name, "anthropic");
         assert_eq!(descriptor.services, vec![ServiceKind::Chat]);
         assert!(descriptor.chat.is_some());
         // Default credential shape is a single required api_key field.
@@ -2516,6 +2662,7 @@ mod tests {
         impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {
@@ -2575,6 +2722,7 @@ mod tests {
         impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {
@@ -2595,6 +2743,7 @@ mod tests {
         impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
+                _endpoint: &ProviderEndpoint,
                 _messages: Vec<LlmMessage>,
                 _config: &LlmCallConfig,
             ) -> Result<LlmResponseStream> {

--- a/crates/provider/src/error.rs
+++ b/crates/provider/src/error.rs
@@ -207,6 +207,25 @@ pub enum AgentLoopError {
 }
 
 impl AgentLoopError {
+    /// Prefix a provider-bound error without discarding its semantic variant.
+    pub fn with_provider(mut self, provider: &str) -> Self {
+        let prefix = format!("provider '{provider}': ");
+        match &mut self {
+            AgentLoopError::Llm(error) if !error.message.starts_with(&prefix) => {
+                error.message.insert_str(0, &prefix)
+            }
+            AgentLoopError::RequestTooLarge(message)
+            | AgentLoopError::ModelNotAvailable(message)
+            | AgentLoopError::Configuration(message)
+                if !message.starts_with(&prefix) =>
+            {
+                message.insert_str(0, &prefix)
+            }
+            _ => {}
+        }
+        self
+    }
+
     /// Create an LLM error with no semantic kind (falls back to string
     /// classification downstream).
     pub fn llm(msg: impl Into<String>) -> Self {

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -25,10 +25,12 @@ pub mod llm_retry;
 pub mod model;
 pub mod model_discovery;
 pub mod model_profiles;
+pub mod model_spec;
 pub mod openai_protocol;
 pub mod openresponses_protocol;
 pub mod openresponses_types;
 pub mod provider;
+pub mod runtime_provider;
 pub mod stream_accumulator;
 pub mod stream_reconnect;
 pub mod tool_schema_compat;
@@ -54,7 +56,7 @@ pub use driver_registry::{
     EmbedResponse, EmbeddingsDriver, EmbeddingsDriverError, EmbeddingsDriverFactory, LlmCallConfig,
     LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamError, LlmStreamEvent, ProviderConfig,
-    ProviderOpaqueContext, ServiceKind, fold_system_messages,
+    ProviderMetadata, ProviderOpaqueContext, ServiceKind, fold_system_messages,
 };
 pub use error::{
     AgentLoopError, FileSystemError, FileSystemErrorClass, LlmError, LlmErrorKind, Result,
@@ -72,13 +74,19 @@ pub use model_discovery::{
     normalize_and_enrich, rank_discovered_models, search_provider_models,
 };
 pub use model_profiles::{get_model_profile, get_model_vendor};
-pub use openai_protocol::{AuthHeaderProvider, OpenAIProtocolChatDriver};
+pub use model_spec::{ModelSpec, UnknownProvider};
+pub use openai_protocol::OpenAIProtocolChatDriver;
 pub use openresponses_protocol::{
     CompactContent, CompactContentPart, CompactInputItem, CompactOutputItem, CompactRequest,
     CompactResponse, CompactUsage, OpenResponsesProtocolChatDriver, OpenResponsesRequestExtension,
     messages_to_compact_input,
 };
-pub use provider::{Provider, ProviderStatus, ProviderTraceConfig};
+pub use provider::{Provider as ProviderRecord, ProviderStatus, ProviderTraceConfig};
+pub use runtime_provider::{
+    BearerAuth, Provider, ProviderAuth, ProviderAuthRequest, ProviderEndpoint, ProviderKey,
+    ProviderRegistry, ResolvedProviderRequest, RuntimeProvider, RuntimeProviderRegistry,
+    StaticHeaderAuth,
+};
 pub use tool_types::{
     BuiltinTool, ClientSideTool, DeferrablePolicy, SideEffectClass, ToolCall, ToolDefinition,
     ToolHints, ToolPolicy, ToolResult, ToolResultImage,

--- a/crates/provider/src/llm_retry.rs
+++ b/crates/provider/src/llm_retry.rs
@@ -533,7 +533,7 @@ pub enum SendOutcome {
     /// [`is_transient_send_error`] for retry.
     Send(reqwest::Error),
     /// A non-transport error that must abort the loop immediately (e.g. an
-    /// `AuthHeaderProvider` failure resolved per attempt).
+    /// `ProviderAuth` failure resolved per attempt).
     Fatal(AgentLoopError),
 }
 

--- a/crates/provider/src/model.rs
+++ b/crates/provider/src/model.rs
@@ -473,75 +473,63 @@ mod tests {
     #[test]
     fn test_provider_type_deserialization() {
         // Verify all provider types deserialize correctly
-        assert!(matches!(
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"openai\"").unwrap(),
             DriverId::OpenAI
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"openrouter\"").unwrap(),
             DriverId::OpenRouter
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"openai_completions\"").unwrap(),
             DriverId::OpenAICompletions
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"azure_openai\"").unwrap(),
             DriverId::AzureOpenAI
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"anthropic\"").unwrap(),
             DriverId::Anthropic
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"gemini\"").unwrap(),
             DriverId::Gemini
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"llmsim\"").unwrap(),
             DriverId::LlmSim
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             serde_json::from_str::<DriverId>("\"meta\"").unwrap(),
             DriverId::Meta
-        ));
+        );
     }
 
     #[test]
     fn test_provider_type_from_str() {
         // Verify FromStr works correctly
-        assert!(matches!(
-            "openai".parse::<DriverId>().unwrap(),
-            DriverId::OpenAI
-        ));
-        assert!(matches!(
+        assert_eq!("openai".parse::<DriverId>().unwrap(), DriverId::OpenAI);
+        assert_eq!(
             "openrouter".parse::<DriverId>().unwrap(),
             DriverId::OpenRouter
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             "openai_completions".parse::<DriverId>().unwrap(),
             DriverId::OpenAICompletions
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             "azure_openai".parse::<DriverId>().unwrap(),
             DriverId::AzureOpenAI
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             "anthropic".parse::<DriverId>().unwrap(),
             DriverId::Anthropic
-        ));
-        assert!(matches!(
-            "gemini".parse::<DriverId>().unwrap(),
-            DriverId::Gemini
-        ));
-        assert!(matches!(
-            "llmsim".parse::<DriverId>().unwrap(),
-            DriverId::LlmSim
-        ));
-        assert!(matches!(
-            "meta".parse::<DriverId>().unwrap(),
-            DriverId::Meta
-        ));
+        );
+        assert_eq!("gemini".parse::<DriverId>().unwrap(), DriverId::Gemini);
+        assert_eq!("llmsim".parse::<DriverId>().unwrap(), DriverId::LlmSim);
+        assert_eq!("meta".parse::<DriverId>().unwrap(), DriverId::Meta);
     }
 
     #[test]

--- a/crates/provider/src/model_discovery.rs
+++ b/crates/provider/src/model_discovery.rs
@@ -35,30 +35,15 @@ pub struct DiscoveredProviderModel {
 /// support model listing; callers should fall back to curated suggestions in
 /// that case rather than treating it as an error.
 ///
-/// Drivers that decline listing for an unrecognized OpenAI-compatible endpoint
-/// (Ollama, Gemini's OpenAI surface, proxies) are retried against
-/// [`list_openai_compatible_models`] when the config carries a base URL.
 pub async fn discover_provider_models(
     registry: &DriverRegistry,
     config: &ProviderConfig,
 ) -> Result<Option<Vec<DiscoveredProviderModel>>> {
-    // Neither of these has a catalog: the simulator has no API, and Bedrock
-    // model access is an account-level IAM concern rather than a listable one.
-    if matches!(config.provider_type, DriverId::LlmSim | DriverId::Bedrock) {
-        return Ok(None);
-    }
-
     let driver = registry.create_chat_driver(config)?;
-    let models = match driver.list_models().await? {
-        Some(models) => Some(models),
-        None => match &config.base_url {
-            Some(base_url) => {
-                list_openai_compatible_models(base_url, config.api_key.as_deref()).await?
-            }
-            None => None,
-        },
-    };
-    let Some(models) = models else {
+    let Some(models) = driver
+        .list_models(&crate::runtime_provider::ProviderEndpoint::default())
+        .await?
+    else {
         return Ok(None);
     };
 
@@ -142,39 +127,40 @@ struct OpenAiCompatibleModel {
 /// Discovery fallback for OpenAI-compatible endpoints no driver recognizes:
 /// `GET <base>/models` with bearer auth.
 pub async fn list_openai_compatible_models(
-    base_url: &str,
-    api_key: Option<&str>,
+    endpoint: &crate::runtime_provider::ProviderEndpoint,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
+    let url = endpoint
+        .url("models")
+        .ok_or_else(|| AgentLoopError::config("provider endpoint is not configured"))?;
+    let resolved = endpoint.resolve("GET", url, &[]).await?;
     // THREAT[TM-API-013]: Provider base URLs are org-configurable. Use the
     // shared client so redirects, private DNS results, and hung responses are
     // rejected at request time.
-    list_openai_compatible_models_with_client(&shared_request_http_client(), base_url, api_key)
-        .await
+    list_openai_compatible_models_with_client(&shared_request_http_client(), &resolved).await
 }
 
 async fn list_openai_compatible_models_with_client(
     client: &reqwest::Client,
-    base_url: &str,
-    api_key: Option<&str>,
+    resolved: &crate::runtime_provider::ResolvedProviderRequest,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
-    let url = format!("{}/models", base_url.trim_end_matches('/'));
-    let mut request = client.get(&url);
-    if let Some(key) = api_key {
-        request = request.bearer_auth(key);
+    let mut request = client.get(&resolved.url);
+    for (name, value) in &resolved.headers {
+        request = request.header(name, value);
     }
     let response = request
         .send()
         .await
-        .map_err(|error| AgentLoopError::llm(format!("fetch models from {url}: {error}")))?;
+        .map_err(|error| AgentLoopError::llm(format!("fetch models: {error}")))?;
     if !response.status().is_success() {
         return Err(AgentLoopError::llm(format!(
-            "models API at {url} returned {}",
+            "models API returned {}",
             response.status()
         )));
     }
-    let parsed: OpenAiCompatibleModelsResponse = response.json().await.map_err(|error| {
-        AgentLoopError::llm(format!("parse models response from {url}: {error}"))
-    })?;
+    let parsed: OpenAiCompatibleModelsResponse = response
+        .json()
+        .await
+        .map_err(|error| AgentLoopError::llm(format!("parse models response: {error}")))?;
     let models = parsed
         .data
         .into_iter()
@@ -222,7 +208,7 @@ pub fn rank_discovered_models(
     current_model: Option<&str>,
     curated: &[&str],
 ) -> RankedDiscoveredModels {
-    if matches!(provider_type, DriverId::OpenRouter) {
+    if provider_type == &DriverId::OpenRouter {
         rank_aggregator_models(provider_type, models, current_model, curated)
     } else {
         RankedDiscoveredModels {
@@ -411,6 +397,20 @@ pub async fn search_provider_models(
 mod tests {
     use super::*;
 
+    struct NoCatalog;
+
+    #[async_trait::async_trait]
+    impl crate::ChatDriver for NoCatalog {
+        async fn chat_completion_stream(
+            &self,
+            _endpoint: &crate::ProviderEndpoint,
+            _messages: Vec<crate::LlmMessage>,
+            _config: &crate::LlmCallConfig,
+        ) -> crate::Result<crate::LlmResponseStream> {
+            unreachable!()
+        }
+    }
+
     fn bare_discovered(model_id: &str) -> DiscoveredModel {
         DiscoveredModel {
             capabilities: vec!["chat".to_string()],
@@ -434,7 +434,8 @@ mod tests {
     async fn discovery_is_unsupported_for_llmsim() {
         // The offline simulator has no models API; discovery must signal
         // "unsupported" rather than erroring, so callers keep curated lists.
-        let registry = DriverRegistry::new();
+        let mut registry = DriverRegistry::new();
+        registry.register(DriverId::LlmSim, |_| Box::new(NoCatalog));
         let result = discover_provider_models(&registry, &ProviderConfig::new(DriverId::LlmSim))
             .await
             .expect("llmsim discovery should not error");
@@ -554,9 +555,8 @@ mod tests {
         );
     }
 
-    /// Drivers decline listing for unrecognized custom endpoints (here a
-    /// localhost "Ollama"); discovery must then query the OpenAI-compatible
-    /// `GET <base>/models` itself.
+    /// The explicit OpenAI-compatible discovery helper uses provider-resolved
+    /// request metadata rather than inferring auth from the endpoint host.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn openai_compatible_fallback_lists_models() {
         use std::io::{Read, Write};
@@ -585,8 +585,10 @@ mod tests {
                 .no_proxy()
                 .build()
                 .expect("build mock HTTP client"),
-            &format!("http://{addr}/v1"),
-            None,
+            &crate::ResolvedProviderRequest {
+                url: format!("http://{addr}/v1/models"),
+                headers: Vec::new(),
+            },
         )
         .await
         .expect("fallback discovery should succeed")
@@ -602,9 +604,15 @@ mod tests {
 
     #[tokio::test]
     async fn openai_compatible_fallback_blocks_internal_addresses() {
-        list_openai_compatible_models("http://127.0.0.1:9/v1", None)
-            .await
-            .expect_err("model discovery must use the provider SSRF guard");
+        list_openai_compatible_models_with_client(
+            &shared_request_http_client(),
+            &crate::ResolvedProviderRequest {
+                url: "http://127.0.0.1:9/v1/models".into(),
+                headers: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("model discovery must use the provider SSRF guard");
     }
 
     fn presented(id: &str, display_name: Option<&str>) -> DiscoveredProviderModel {
@@ -643,7 +651,8 @@ mod tests {
 
     #[tokio::test]
     async fn search_skips_catalog_less_providers_and_records_failures() {
-        let registry = DriverRegistry::new();
+        let mut registry = DriverRegistry::new();
+        registry.register(DriverId::LlmSim, |_| Box::new(NoCatalog));
         let providers = vec![
             // No catalog to offer: skipped, not an error.
             ("sim".to_string(), ProviderConfig::new(DriverId::LlmSim)),

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -527,7 +527,7 @@ pub fn get_model_profile(provider_type: &DriverId, model_id: &str) -> Option<Mod
     // Native execution phases are implemented by the first-party OpenAI and
     // Meta Responses surfaces. Gateways keep the base model profile while
     // masking provider-native request options.
-    if !matches!(provider_type, DriverId::OpenAI | DriverId::Meta) {
+    if provider_type != &DriverId::OpenAI && provider_type != &DriverId::Meta {
         profile.supports_phases = false;
     }
     // Hosted tool_search is rendered by the OpenAI Responses driver and the
@@ -539,22 +539,22 @@ pub fn get_model_profile(provider_type: &DriverId, model_id: &str) -> Option<Mod
     //     only on the InvokeModel API, which this driver does not use.
     //   - OpenAI Completions / Gemini: no hosted tool_search at all.
     // So mask the flag except on the first-party surfaces that implement it.
-    if !matches!(
-        provider_type,
-        DriverId::OpenAI | DriverId::Anthropic | DriverId::Meta
-    ) {
+    if provider_type != &DriverId::OpenAI
+        && provider_type != &DriverId::Anthropic
+        && provider_type != &DriverId::Meta
+    {
         profile.tool_search = false;
     }
     // Speed (service tier) is an OpenAI-platform billing feature. Azure has
     // its own capacity model and gateways (OpenRouter) do their own routing,
     // so only the first-party OpenAI surface keeps the selector.
-    if !matches!(provider_type, DriverId::OpenAI) {
+    if provider_type != &DriverId::OpenAI {
         profile.speed = None;
     }
     // Verbosity (`text.verbosity` / `verbosity`) is an OpenAI-specific request
     // parameter. Gateways that proxy these models may reject the unknown field,
     // so only the first-party OpenAI surface keeps the selector.
-    if !matches!(provider_type, DriverId::OpenAI) {
+    if provider_type != &DriverId::OpenAI {
         profile.verbosity = None;
     }
     Some(profile)

--- a/crates/provider/src/model_spec.rs
+++ b/crates/provider/src/model_spec.rs
@@ -1,0 +1,105 @@
+//! Credential-free model selection.
+
+use serde::{Deserialize, Serialize};
+
+use crate::runtime_provider::{ProviderKey, RuntimeProviderRegistry};
+
+/// A model name paired with the runtime provider that serves it.
+///
+/// This is ordinary serializable configuration: credentials, endpoints, and
+/// service authentication live exclusively on the runtime provider.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ModelSpec {
+    pub provider: ProviderKey,
+    pub model: String,
+}
+
+impl ModelSpec {
+    pub fn on(provider: impl Into<ProviderKey>, model: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            model: model.into(),
+        }
+    }
+
+    pub fn resolve_provider(
+        &self,
+        registry: &RuntimeProviderRegistry,
+    ) -> Result<std::sync::Arc<crate::RuntimeProvider>, UnknownProvider> {
+        registry.get(&self.provider).ok_or_else(|| UnknownProvider {
+            requested: self.provider.clone(),
+            registered: registry.ids(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownProvider {
+    pub requested: ProviderKey,
+    pub registered: Vec<String>,
+}
+
+impl std::fmt::Display for UnknownProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "provider '{}' is not registered; registered providers: [{}]",
+            self.requested,
+            self.registered.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for UnknownProvider {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Noop;
+
+    #[async_trait::async_trait]
+    impl crate::ChatDriver for Noop {
+        async fn chat_completion_stream(
+            &self,
+            _endpoint: &crate::ProviderEndpoint,
+            _messages: Vec<crate::LlmMessage>,
+            _config: &crate::LlmCallConfig,
+        ) -> crate::Result<crate::LlmResponseStream> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn model_spec_is_credential_and_endpoint_free() {
+        let spec = ModelSpec::on("openai-prod", "gpt-5");
+        let json = serde_json::to_string(&spec).unwrap();
+        let debug = format!("{spec:?}");
+        assert_eq!(json, r#"{"provider":"openai-prod","model":"gpt-5"}"#);
+        assert!(!debug.contains("api_key"));
+        assert!(!debug.contains("base_url"));
+    }
+
+    #[test]
+    fn two_models_select_distinct_providers_over_one_protocol() {
+        let driver: std::sync::Arc<dyn crate::ChatDriver> = std::sync::Arc::new(Noop);
+        let mut registry = RuntimeProviderRegistry::new();
+        registry
+            .register(crate::Provider::from_driver("east", driver.clone()))
+            .unwrap();
+        registry
+            .register(crate::Provider::from_driver("west", driver))
+            .unwrap();
+
+        let east = ModelSpec::on("east", "shared-model")
+            .resolve_provider(&registry)
+            .unwrap();
+        let west = ModelSpec::on("west", "shared-model")
+            .resolve_provider(&registry)
+            .unwrap();
+        assert_eq!(east.id().as_str(), "east");
+        assert_eq!(west.id().as_str(), "west");
+        assert!(std::sync::Arc::ptr_eq(east.driver(), west.driver()));
+    }
+}

--- a/crates/provider/src/openai_protocol.rs
+++ b/crates/provider/src/openai_protocol.rs
@@ -16,10 +16,9 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use reqwest::{Client, RequestBuilder, Url};
+use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 use crate::driver_registry::{
@@ -31,60 +30,11 @@ use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryDecision, RetryMetadata, SendOutcome, is_rate_limit_status,
     retry_request, send_error_message,
 };
+use crate::runtime_provider::ProviderEndpoint;
 use crate::stream_accumulator::StreamToolCallAccumulator;
 use crate::stream_reconnect::connect_sse_with_reconnect;
 use crate::tool_types::ToolDefinition;
 use crate::user_facing_error::is_provider_quota_message;
-
-const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
-
-/// Compute the default OpenAI/Azure auth header `(name, value)` for `api_url`:
-/// Azure OpenAI uses `api-key`, everything else uses `Authorization: Bearer`.
-///
-/// Shared by the Chat Completions and Open Responses drivers so the default
-/// static-key behavior stays identical to a pluggable [`AuthHeaderProvider`]
-/// path (see [`AuthHeaderProvider`]). The Azure `api-key` branch borrows the
-/// key (no per-request allocation); only the bearer branch allocates.
-pub(crate) fn openai_auth_header_pair<'a>(
-    api_url: &str,
-    api_key: &'a str,
-) -> (&'static str, Cow<'a, str>) {
-    if is_azure_openai_api_url(api_url) {
-        ("api-key", Cow::Borrowed(api_key))
-    } else {
-        ("Authorization", Cow::Owned(format!("Bearer {}", api_key)))
-    }
-}
-
-pub(crate) fn apply_openai_api_auth(
-    request: RequestBuilder,
-    api_url: &str,
-    api_key: &str,
-) -> RequestBuilder {
-    let (name, value) = openai_auth_header_pair(api_url, api_key);
-    request.header(name, value.as_ref())
-}
-
-/// Pluggable authentication-header provider for OpenAI-compatible drivers.
-///
-/// When set on an [`OpenAIProtocolChatDriver`] via
-/// [`OpenAIProtocolChatDriver::with_auth_provider`], the driver calls
-/// [`AuthHeaderProvider::auth_header`] before each request and applies the
-/// returned `(name, value)` header instead of the default `api-key` / bearer
-/// logic keyed on the host.
-///
-/// This lets a driver authenticate with short-lived, refreshable tokens —
-/// e.g. Microsoft Entra ID (OAuth) bearer tokens for Azure AI Foundry — without
-/// the generic protocol driver having to know the auth scheme. The provider is
-/// responsible for caching and refreshing tokens; `auth_header` is awaited once
-/// per HTTP attempt, so it should be cheap on the cached path.
-#[async_trait]
-pub trait AuthHeaderProvider: Send + Sync {
-    /// Return the `(header_name, header_value)` pair to apply for
-    /// authentication, refreshing any cached credential as needed. Returning
-    /// `Err` aborts the request before it is sent.
-    async fn auth_header(&self) -> Result<(String, String)>;
-}
 
 pub fn is_azure_openai_api_url(api_url: &str) -> bool {
     Url::parse(api_url)
@@ -155,20 +105,6 @@ pub fn models_url_for_api_url(api_url: &str) -> String {
     OPENAI_MODELS_URL.to_string()
 }
 
-/// Apply the appropriate auth header for a `/models` discovery request: Azure
-/// OpenAI uses `api-key`, everything else uses bearer auth.
-pub fn apply_models_api_auth(
-    request: RequestBuilder,
-    api_url: &str,
-    api_key: &str,
-) -> RequestBuilder {
-    if is_azure_openai_api_url(api_url) {
-        request.header("api-key", api_key)
-    } else {
-        request.bearer_auth(api_key)
-    }
-}
-
 /// Build the error returned when the `/models` endpoint responds with a
 /// non-success status.
 pub fn models_api_status_error(status: reqwest::StatusCode) -> AgentLoopError {
@@ -191,45 +127,25 @@ pub fn models_api_status_error(status: reqwest::StatusCode) -> AgentLoopError {
 /// ```ignore
 /// use everruns_core::OpenAIProtocolChatDriver;
 ///
-/// let driver = OpenAIProtocolChatDriver::new("your-api-key");
-/// // or with custom endpoint
-/// let driver = OpenAIProtocolChatDriver::with_base_url("your-api-key", "https://api.example.com/v1/chat/completions");
-/// // or with custom retry config
-/// let driver = OpenAIProtocolChatDriver::new("your-api-key")
+/// let driver = OpenAIProtocolChatDriver::new();
+/// // Endpoint and authentication are configured on a runtime Provider.
+/// // Retry policy remains a wire-protocol concern.
+/// let driver = OpenAIProtocolChatDriver::new()
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
 #[derive(Clone)]
 pub struct OpenAIProtocolChatDriver {
     client: Client,
-    api_key: String,
-    api_url: String,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
-    /// Optional pluggable auth-header provider. When set, it overrides the
-    /// default `api-key` / bearer auth (used for OAuth bearer tokens).
-    auth_provider: Option<Arc<dyn AuthHeaderProvider>>,
 }
 
 impl OpenAIProtocolChatDriver {
-    /// Create a new driver with the given API key
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create a wire-only OpenAI Chat Completions protocol driver.
+    pub fn new() -> Self {
         Self {
             client: crate::driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            api_url: DEFAULT_API_URL.to_string(),
             retry_config: LlmRetryConfig::default(),
-            auth_provider: None,
-        }
-    }
-
-    /// Create a new driver with a custom API URL (for OpenAI-compatible APIs)
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        Self {
-            client: crate::driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            api_url: api_url.into(),
-            retry_config: LlmRetryConfig::default(),
-            auth_provider: None,
         }
     }
 
@@ -237,23 +153,6 @@ impl OpenAIProtocolChatDriver {
     pub fn with_retry_config(mut self, config: LlmRetryConfig) -> Self {
         self.retry_config = config;
         self
-    }
-
-    /// Set a pluggable [`AuthHeaderProvider`] that overrides the default
-    /// `api-key` / bearer auth. Used for OAuth bearer tokens (e.g. Entra ID).
-    pub fn with_auth_provider(mut self, provider: Arc<dyn AuthHeaderProvider>) -> Self {
-        self.auth_provider = Some(provider);
-        self
-    }
-
-    /// Get the API URL
-    pub fn api_url(&self) -> &str {
-        &self.api_url
-    }
-
-    /// Get the API key (for subclass access)
-    pub fn api_key(&self) -> &str {
-        &self.api_key
     }
 
     /// Get the HTTP client (for subclass access)
@@ -271,6 +170,8 @@ impl OpenAIProtocolChatDriver {
     /// and error messages exactly.
     async fn send_chat_completion_request(
         &self,
+        endpoint: &ProviderEndpoint,
+        api_url: &str,
         request: &OpenAiRequest,
         model: &str,
         retries_consumed: u32,
@@ -279,25 +180,23 @@ impl OpenAIProtocolChatDriver {
         let mut retry_config = self.retry_config.clone();
         retry_config.max_retries = retry_config.max_retries.saturating_sub(retries_consumed);
 
+        let body = serde_json::to_vec(request)
+            .map_err(|e| AgentLoopError::llm(format!("failed to serialize request: {e}")))?;
         retry_request(
             &retry_config,
             "OpenAIProtocolDriver",
             || async {
-                // Apply auth: a pluggable provider (e.g. OAuth bearer token)
-                // takes precedence over the default host-keyed `api-key` /
-                // bearer logic. An auth-provider failure is fatal (no retry).
-                let request_builder = self.client.post(&self.api_url);
-                let request_builder = match &self.auth_provider {
-                    Some(provider) => {
-                        let (name, value) =
-                            provider.auth_header().await.map_err(SendOutcome::Fatal)?;
-                        request_builder.header(name, value)
-                    }
-                    None => apply_openai_api_auth(request_builder, &self.api_url, &self.api_key),
-                };
+                let resolved = endpoint
+                    .resolve("POST", api_url, &body)
+                    .await
+                    .map_err(SendOutcome::Fatal)?;
+                let mut request_builder = self.client.post(&resolved.url);
+                for (name, value) in resolved.headers {
+                    request_builder = request_builder.header(name, value);
+                }
                 request_builder
                     .header("Content-Type", "application/json")
-                    .json(request)
+                    .body(body.clone())
                     .send()
                     .await
                     .map_err(SendOutcome::Send)
@@ -467,6 +366,12 @@ impl OpenAIProtocolChatDriver {
     }
 }
 
+impl Default for OpenAIProtocolChatDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Drop Tool-role messages whose tool_call_id has no matching assistant tool call in the
 /// visible window. Chat Completions rejects payloads where a `tool`-role message references
 /// a call that is absent from the conversation.
@@ -507,6 +412,7 @@ fn drop_orphaned_tool_messages(messages: &[LlmMessage]) -> Vec<LlmMessage> {
 impl ChatDriver for OpenAIProtocolChatDriver {
     async fn chat_completion_stream(
         &self,
+        endpoint: &ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
@@ -558,9 +464,20 @@ impl ChatDriver for OpenAIProtocolChatDriver {
         // decoding response body" flake). Header-phase retries (429/5xx and
         // transient send failures) are handled inside the per-attempt send;
         // this adds the body-phase reconnect the official SDKs get for free.
+        let api_url = endpoint.url("chat/completions").ok_or_else(|| {
+            AgentLoopError::Configuration(
+                "OpenAI Chat Completions provider has no base URL".to_string(),
+            )
+        })?;
         let (event_stream, retry_metadata) =
             connect_sse_with_reconnect(&self.retry_config, "OpenAIProtocolDriver", |attempts| {
-                self.send_chat_completion_request(&request, &config.model, attempts)
+                self.send_chat_completion_request(
+                    endpoint,
+                    &api_url,
+                    &request,
+                    &config.model,
+                    attempts,
+                )
             })
             .await?;
 
@@ -729,8 +646,7 @@ impl ChatDriver for OpenAIProtocolChatDriver {
 impl std::fmt::Debug for OpenAIProtocolChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenAIProtocolChatDriver")
-            .field("api_url", &self.api_url)
-            .field("api_key", &"[REDACTED]")
+            .field("protocol", &"openai_chat_completions")
             .finish()
     }
 }
@@ -1116,19 +1032,9 @@ mod tests {
     }
 
     #[test]
-    fn test_driver_with_api_key() {
-        let driver = OpenAIProtocolChatDriver::new("test-key");
+    fn test_driver_is_wire_only() {
+        let driver = OpenAIProtocolChatDriver::new();
         assert!(format!("{:?}", driver).contains("OpenAIProtocolChatDriver"));
-    }
-
-    #[test]
-    fn test_driver_with_base_url() {
-        let driver = OpenAIProtocolChatDriver::with_base_url(
-            "test-key",
-            "https://custom.api.com/v1/completions",
-        );
-        assert!(format!("{:?}", driver).contains("OpenAIProtocolChatDriver"));
-        assert_eq!(driver.api_url(), "https://custom.api.com/v1/completions");
     }
 
     #[test]

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -21,10 +21,7 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use reqwest::{
-    Client,
-    header::{HeaderMap, HeaderName, HeaderValue},
-};
+use reqwest::{Client, header::HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -41,17 +38,12 @@ use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryDecision, RetryMetadata, SendOutcome, is_rate_limit_status,
     retry_request, send_error_message,
 };
-use crate::openai_protocol::{
-    AuthHeaderProvider, is_openai_model_not_found, is_openai_request_too_large,
-    openai_auth_header_pair,
-};
+use crate::openai_protocol::{is_openai_model_not_found, is_openai_request_too_large};
 use crate::openresponses_types::{self as types, StreamingEvent};
-use crate::provider::DriverId;
 use crate::stream_reconnect::connect_sse_with_reconnect;
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::user_facing_error::is_provider_quota_message;
 
-const DEFAULT_API_URL: &str = "https://api.openai.com/v1/responses";
 const OPENAI_PROMPT_CACHE_KEY_MAX_LEN: usize = 64;
 const PROMPT_CACHE_KEY_PREFIX: &str = "everruns:";
 
@@ -74,11 +66,9 @@ const PROMPT_CACHE_KEY_PREFIX: &str = "everruns:";
 /// ```ignore
 /// use everruns_core::OpenResponsesProtocolChatDriver;
 ///
-/// let driver = OpenResponsesProtocolChatDriver::new("your-api-key");
-/// // or with custom endpoint
-/// let driver = OpenResponsesProtocolChatDriver::with_base_url("your-api-key", "https://api.example.com/v1/responses");
-/// // or with custom retry config
-/// let driver = OpenResponsesProtocolChatDriver::new("your-api-key")
+/// let driver = OpenResponsesProtocolChatDriver::new();
+/// // Endpoint and authentication are configured on a runtime Provider.
+/// let driver = OpenResponsesProtocolChatDriver::new()
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
 /// Hook for provider-specific augmentation of an Open Responses request.
@@ -95,11 +85,9 @@ pub trait OpenResponsesRequestExtension: Send + Sync {
     /// Add provider-specific **non-auth** request headers (routing, attribution,
     /// `session_id`, `OpenAI-Beta`, `originator`, account ids, …).
     ///
-    /// Authentication is a separate seam ([`AuthHeaderProvider`], set via
-    /// [`OpenResponsesProtocolChatDriver::with_auth_provider`]). The driver
-    /// applies these decoration headers first, then applies the resolved auth
-    /// header, so **the auth header always wins on a name conflict**. Do not set
-    /// `Authorization` / `api-key` here; use an auth provider instead.
+    /// Authentication is owned by the runtime provider. The driver applies
+    /// these decoration headers first, then the provider-resolved auth headers,
+    /// so authentication wins on a name conflict. Do not set auth here.
     fn decorate_headers(&self, _headers: &mut HeaderMap, _config: &LlmCallConfig) -> Result<()> {
         Ok(())
     }
@@ -117,60 +105,38 @@ pub trait OpenResponsesRequestExtension: Send + Sync {
 #[derive(Clone)]
 pub struct OpenResponsesProtocolChatDriver {
     client: Client,
-    api_key: String,
-    api_url: String,
-    provider_type: DriverId,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
     /// Optional provider-specific request-body decorator (see
     /// [`OpenResponsesRequestExtension`]). `None` for vanilla OpenAI/Azure.
     request_extension: Option<Arc<dyn OpenResponsesRequestExtension>>,
-    /// Optional pluggable auth-header provider (see [`AuthHeaderProvider`]). When
-    /// set it overrides the default host-keyed `api-key` / bearer auth and is
-    /// awaited once per HTTP attempt so refreshable (OAuth) providers can mint or
-    /// refresh tokens per retry. `None` falls back to the static `api_key`.
-    auth_provider: Option<Arc<dyn AuthHeaderProvider>>,
-    /// Explicit stateful-continuation support for compatible custom endpoints.
-    /// `None` uses the conservative host allowlist.
+    /// Explicit stateful-continuation support supplied by the service provider.
     stateful_responses: Option<bool>,
+    native_phases: bool,
+    hosted_tool_search: bool,
 }
 
 impl OpenResponsesProtocolChatDriver {
-    /// Create a new driver with the given API key
-    pub fn new(api_key: impl Into<String>) -> Self {
+    /// Create a wire-only Open Responses protocol driver.
+    pub fn new() -> Self {
         Self {
             // SSRF-hardened shared client (redirects disabled + DNS-pinned
             // resolver). The api_url is org-configurable, so a bare
             // `Client::new()` would leave this provider open to DNS-rebind /
             // redirect SSRF (TM-API-013, EVE-623).
             client: crate::driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            api_url: DEFAULT_API_URL.to_string(),
-            provider_type: DriverId::OpenAI,
             retry_config: LlmRetryConfig::default(),
             request_extension: None,
-            auth_provider: None,
             stateful_responses: None,
+            native_phases: false,
+            hosted_tool_search: false,
         }
     }
 
-    /// Create a new driver with a custom API URL
-    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
-        Self {
-            client: crate::driver_helpers::shared_streaming_http_client(),
-            api_key: api_key.into(),
-            api_url: api_url.into(),
-            provider_type: DriverId::OpenAI,
-            retry_config: LlmRetryConfig::default(),
-            request_extension: None,
-            auth_provider: None,
-            stateful_responses: None,
-        }
-    }
-
-    /// Set the model provider used for provider-specific request features.
-    pub fn with_provider_type(mut self, provider_type: DriverId) -> Self {
-        self.provider_type = provider_type;
+    /// Enable optional protocol extensions implemented by this endpoint.
+    pub fn with_native_features(mut self, phases: bool, hosted_tool_search: bool) -> Self {
+        self.native_phases = phases;
+        self.hosted_tool_search = hosted_tool_search;
         self
     }
 
@@ -185,48 +151,10 @@ impl OpenResponsesProtocolChatDriver {
         self
     }
 
-    /// Set a pluggable [`AuthHeaderProvider`] that overrides the default
-    /// host-keyed `api-key` / bearer auth. The provider is awaited once per HTTP
-    /// attempt (including retries), so refreshable OAuth providers (ChatGPT/Codex,
-    /// Entra ID, workload identity, …) can mint or refresh tokens per request
-    /// without the driver knowing the scheme. The resolved auth header takes
-    /// precedence over any header set by an
-    /// [`OpenResponsesRequestExtension::decorate_headers`].
-    pub fn with_auth_provider(mut self, provider: Arc<dyn AuthHeaderProvider>) -> Self {
-        self.auth_provider = Some(provider);
-        self
-    }
-
     /// Override whether this endpoint persists Responses continuation state.
     pub fn with_stateful_responses(mut self, supported: bool) -> Self {
         self.stateful_responses = Some(supported);
         self
-    }
-
-    fn persists_responses(&self) -> bool {
-        self.stateful_responses
-            .unwrap_or_else(|| endpoint_persists_responses(&self.api_url))
-    }
-
-    /// Resolve the auth header `(name, value)` for one HTTP attempt against
-    /// `url`. Uses the pluggable [`AuthHeaderProvider`] when set (awaited each
-    /// attempt so tokens can refresh), otherwise the default static-key behavior
-    /// shared with the Chat Completions driver.
-    async fn resolve_auth_header(&self, url: &str) -> Result<(HeaderName, HeaderValue)> {
-        let (name, value) = match &self.auth_provider {
-            Some(provider) => provider.auth_header().await?,
-            None => {
-                let (name, value) = openai_auth_header_pair(url, &self.api_key);
-                (name.to_string(), value.into_owned())
-            }
-        };
-        let name = HeaderName::from_bytes(name.as_bytes())
-            .map_err(|e| AgentLoopError::llm(format!("invalid auth header name {name:?}: {e}")))?;
-        let mut value = HeaderValue::from_str(&value)
-            .map_err(|e| AgentLoopError::llm(format!("invalid auth header value: {e}")))?;
-        // Auth material must never leak into debug logs of the request builder.
-        value.set_sensitive(true);
-        Ok((name, value))
     }
 
     /// Configure retry behavior for rate limit errors
@@ -245,6 +173,8 @@ impl OpenResponsesProtocolChatDriver {
     /// classification and error messages exactly.
     async fn send_responses_request(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
+        api_url: &str,
         request_body: &Value,
         extension_headers: &HeaderMap,
         model: &str,
@@ -254,6 +184,8 @@ impl OpenResponsesProtocolChatDriver {
         let mut retry_config = self.retry_config.clone();
         retry_config.max_retries = retry_config.max_retries.saturating_sub(retries_consumed);
 
+        let body = serde_json::to_vec(request_body)
+            .map_err(|e| AgentLoopError::llm(format!("failed to serialize request: {e}")))?;
         retry_request(
             &retry_config,
             "OpenResponsesProtocolDriver",
@@ -264,17 +196,41 @@ impl OpenResponsesProtocolChatDriver {
                 // decoration header, so auth always wins on conflict. An auth
                 // failure is fatal (no retry).
                 let mut headers = extension_headers.clone();
-                let (auth_name, auth_value) = self
-                    .resolve_auth_header(&self.api_url)
+                let service_headers = headers
+                    .iter()
+                    .filter_map(|(name, value)| {
+                        value
+                            .to_str()
+                            .ok()
+                            .map(|value| (name.to_string(), value.to_string()))
+                    })
+                    .collect::<Vec<_>>();
+                let resolved = endpoint
+                    .resolve("POST", api_url, &body)
                     .await
                     .map_err(SendOutcome::Fatal)?;
-                headers.insert(auth_name, auth_value);
+                for (name, value) in service_headers.into_iter().chain(resolved.headers) {
+                    let name =
+                        reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                            SendOutcome::Fatal(AgentLoopError::llm(format!(
+                                "invalid header name: {e}"
+                            )))
+                        })?;
+                    let mut value =
+                        reqwest::header::HeaderValue::from_str(&value).map_err(|e| {
+                            SendOutcome::Fatal(AgentLoopError::llm(format!(
+                                "invalid header value: {e}"
+                            )))
+                        })?;
+                    value.set_sensitive(true);
+                    headers.insert(name, value);
+                }
 
                 self.client
-                    .post(&self.api_url)
+                    .post(&resolved.url)
                     .headers(headers)
                     .header("Content-Type", "application/json")
-                    .json(request_body)
+                    .body(body.clone())
                     .send()
                     .await
                     .map_err(SendOutcome::Send)
@@ -364,24 +320,9 @@ impl OpenResponsesProtocolChatDriver {
         .await
     }
 
-    /// Get the API URL
-    pub fn api_url(&self) -> &str {
-        &self.api_url
-    }
-
-    /// Get the API key (for subclass access)
-    pub fn api_key(&self) -> &str {
-        &self.api_key
-    }
-
     /// Get the HTTP client (for subclass access)
     pub fn client(&self) -> &Client {
         &self.client
-    }
-
-    /// Get the provider type used for model profile lookup.
-    pub fn provider_type(&self) -> &DriverId {
-        &self.provider_type
     }
 
     fn convert_role(role: &LlmMessageRole) -> &'static str {
@@ -619,7 +560,7 @@ impl OpenResponsesProtocolChatDriver {
     /// ```ignore
     /// use everruns_core::{OpenResponsesProtocolChatDriver, CompactRequest, CompactInputItem, CompactContent};
     ///
-    /// let driver = OpenResponsesProtocolChatDriver::new("your-api-key");
+    /// let driver = OpenResponsesProtocolChatDriver::new();
     ///
     /// let request = CompactRequest {
     ///     model: "gpt-4o".to_string(),
@@ -636,17 +577,27 @@ impl OpenResponsesProtocolChatDriver {
     /// let response = driver.compact(request).await?;
     /// // Use response.output as input for the next /v1/responses call
     /// ```
-    pub async fn compact(&self, request: CompactRequest) -> Result<CompactResponse> {
+    pub async fn compact(
+        &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
+        request: CompactRequest,
+    ) -> Result<CompactResponse> {
         // Build the compact endpoint URL
         // Replace /v1/responses with /v1/responses/compact
-        let compact_url = if self.api_url.ends_with("/responses") {
-            format!("{}/compact", self.api_url)
-        } else if self.api_url.ends_with("/responses/") {
-            format!("{}compact", self.api_url)
+        let responses_url = endpoint.url("responses").ok_or_else(|| {
+            AgentLoopError::Configuration("Open Responses provider has no base URL".to_string())
+        })?;
+        let compact_url = if responses_url.ends_with("/responses") {
+            format!("{responses_url}/compact")
+        } else if responses_url.ends_with("/responses/") {
+            format!("{responses_url}compact")
         } else {
             // Custom URL - just append /compact
-            format!("{}/compact", self.api_url.trim_end_matches('/'))
+            format!("{}/compact", responses_url.trim_end_matches('/'))
         };
+        let body = serde_json::to_vec(&request).map_err(|e| {
+            AgentLoopError::llm(format!("failed to serialize compact request: {e}"))
+        })?;
 
         // Retry loop for rate limit (429) and transient errors. Shared executor
         // owns the loop/backoff/send-error retry/exhaustion logging; the
@@ -660,15 +611,17 @@ impl OpenResponsesProtocolChatDriver {
             || async {
                 // Auth is resolved per attempt so refreshable providers can
                 // rotate tokens across retries (same seam as the streaming path).
-                let (auth_name, auth_value) = self
-                    .resolve_auth_header(&compact_url)
+                let resolved = endpoint
+                    .resolve("POST", &compact_url, &body)
                     .await
                     .map_err(SendOutcome::Fatal)?;
-                self.client
-                    .post(&compact_url)
-                    .header(auth_name, auth_value)
+                let mut builder = self.client.post(&resolved.url);
+                for (name, value) in resolved.headers {
+                    builder = builder.header(name, value);
+                }
+                builder
                     .header("Content-Type", "application/json")
-                    .json(&request)
+                    .body(body.clone())
                     .send()
                     .await
                     .map_err(SendOutcome::Send)
@@ -765,9 +718,7 @@ impl OpenResponsesProtocolChatDriver {
     /// Returns true for OpenAI's Responses API. Custom endpoints may or may not
     /// support compaction.
     pub fn supports_compact(&self) -> bool {
-        // We assume compact is supported for the default OpenAI endpoint
-        // For custom endpoints, callers should try and handle errors gracefully
-        self.api_url.starts_with("https://api.openai.com/")
+        true
     }
 
     /// Build input items from messages, extracting system/developer instructions
@@ -846,6 +797,12 @@ impl OpenResponsesProtocolChatDriver {
         }
 
         (instructions, input_items)
+    }
+}
+
+impl Default for OpenResponsesProtocolChatDriver {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -996,44 +953,27 @@ fn is_missing_tool_output_continuation_error(error: &AgentLoopError) -> bool {
         || message.contains("no tool call found for function call output")
 }
 
-/// Whether the endpoint at `api_url` persists responses server-side and honors
-/// `previous_response_id` for stateful continuation.
-///
-/// Only OpenAI's hosted API and Azure OpenAI are known to store responses.
-/// OpenAI-compatible gateways that expose a stateless `/responses` shim — e.g.
-/// OpenRouter and Google Gemini's compat endpoint — *accept* `previous_response_id`
-/// but silently ignore it (`store: false`). Chaining against those drops the
-/// conversation from turn 2 onward, so they must get the full transcript replayed
-/// in `input` each turn instead (EVE-523).
-fn endpoint_persists_responses(api_url: &str) -> bool {
-    crate::openai_protocol::is_openai_api_url(api_url)
-        || crate::openai_protocol::is_azure_openai_api_url(api_url)
-        || crate::openai_protocol::url_host_eq(api_url, "api.meta.ai")
-}
-
 #[async_trait]
 impl ChatDriver for OpenResponsesProtocolChatDriver {
     fn supports_stateful_responses(&self) -> bool {
-        self.persists_responses()
+        self.stateful_responses.unwrap_or(false)
     }
 
     async fn chat_completion_stream(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
+        let api_url = endpoint.url("responses").ok_or_else(|| {
+            AgentLoopError::Configuration("Open Responses provider has no base URL".to_string())
+        })?;
         // Check the provider-specific model profile before sending native
         // Responses features. OpenAI-compatible gateways may share base model
         // metadata without supporting OpenAI-only extensions such as phases or
         // hosted tool_search.
-        let model_profile =
-            crate::model_profiles::get_model_profile(&self.provider_type, &config.model);
-        let supports_phases = model_profile
-            .as_ref()
-            .is_some_and(|profile| profile.supports_phases);
-        let supports_tool_search = model_profile
-            .as_ref()
-            .is_some_and(|profile| profile.tool_search);
+        let supports_phases = self.native_phases;
+        let supports_tool_search = self.hosted_tool_search;
 
         let (instructions, transcript_input_items) = Self::build_input(&messages, supports_phases);
         let full_replay_input_items = transcript_input_items.clone();
@@ -1043,7 +983,7 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
         // Gemini compat, …) accept the field but ignore it, so chaining there drops
         // the conversation from turn 2 onward (EVE-523). For those we send no
         // continuation handle and replay the full transcript in `input` below.
-        let mut previous_response_id = if self.persists_responses() {
+        let mut previous_response_id = if self.stateful_responses.unwrap_or(false) {
             config.previous_response_id.clone()
         } else {
             None
@@ -1135,7 +1075,7 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                 has_instructions = has_instructions,
                 has_reasoning = has_reasoning,
                 has_previous_response = has_previous_response,
-                api_url = %self.api_url,
+                api_url = %api_url,
                 "OpenResponsesDriver: sending request"
             );
         }
@@ -1161,6 +1101,8 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             "OpenResponsesProtocolDriver",
             |attempts| {
                 self.send_responses_request(
+                    endpoint,
+                    &api_url,
                     &request_body,
                     &extension_headers,
                     &config.model,
@@ -1204,6 +1146,8 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                     "OpenResponsesProtocolDriver",
                     |attempts| {
                         self.send_responses_request(
+                            endpoint,
+                            &api_url,
                             &request_body,
                             &extension_headers,
                             &config.model,
@@ -1579,11 +1523,12 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
 
     async fn compact(
         &self,
+        endpoint: &crate::runtime_provider::ProviderEndpoint,
         request: crate::openresponses_protocol::CompactRequest,
     ) -> Result<Option<crate::openresponses_protocol::CompactResponse>> {
         // Delegate to the inherent method and wrap in Some
         Ok(Some(
-            OpenResponsesProtocolChatDriver::compact(self, request).await?,
+            OpenResponsesProtocolChatDriver::compact(self, endpoint, request).await?,
         ))
     }
 }
@@ -1591,10 +1536,10 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
 impl std::fmt::Debug for OpenResponsesProtocolChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenResponsesProtocolChatDriver")
-            .field("api_url", &self.api_url)
-            .field("provider_type", &self.provider_type)
-            .field("api_key", &"[REDACTED]")
-            .finish()
+            .field("stateful_responses", &self.stateful_responses)
+            .field("native_phases", &self.native_phases)
+            .field("hosted_tool_search", &self.hosted_tool_search)
+            .finish_non_exhaustive()
     }
 }
 
@@ -2304,19 +2249,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_driver_with_api_key() {
-        let driver = OpenResponsesProtocolChatDriver::new("test-key");
+    fn test_driver_is_wire_only() {
+        let driver = OpenResponsesProtocolChatDriver::new();
         assert!(format!("{:?}", driver).contains("OpenResponsesProtocolChatDriver"));
-    }
-
-    #[test]
-    fn test_driver_with_base_url() {
-        let driver = OpenResponsesProtocolChatDriver::with_base_url(
-            "test-key",
-            "https://custom.api.com/v1/responses",
-        );
-        assert!(format!("{:?}", driver).contains("OpenResponsesProtocolChatDriver"));
-        assert_eq!(driver.api_url(), "https://custom.api.com/v1/responses");
     }
 
     #[test]
@@ -3413,50 +3348,21 @@ mod tests {
     }
 
     // ========================================================================
-    // Stateless-gateway detection (EVE-523)
+    // Provider-declared statefulness (EVE-523)
     // ========================================================================
 
     #[test]
-    fn endpoint_persists_responses_for_openai_and_azure() {
-        // OpenAI hosted API — stateful.
-        assert!(endpoint_persists_responses(
-            "https://api.openai.com/v1/responses"
-        ));
-        assert!(endpoint_persists_responses(
-            "https://api.openai.com:443/v1/responses"
-        ));
-        // Azure OpenAI — stateful.
-        assert!(endpoint_persists_responses(
-            "https://my-resource.openai.azure.com/openai/v1/responses"
-        ));
-        assert!(endpoint_persists_responses(
-            "https://my-resource.services.ai.azure.com/openai/v1/responses"
-        ));
-        assert!(OpenResponsesProtocolChatDriver::new("test").supports_stateful_responses());
+    fn provider_can_enable_stateful_responses() {
+        assert!(
+            OpenResponsesProtocolChatDriver::new()
+                .with_stateful_responses(true)
+                .supports_stateful_responses()
+        );
     }
 
     #[test]
-    fn endpoint_does_not_persist_for_stateless_gateways() {
-        // OpenRouter and Gemini's compat shim accept `previous_response_id` but
-        // ignore it — they must be treated as stateless so we replay the full
-        // transcript each turn (EVE-523).
-        assert!(!endpoint_persists_responses(
-            "https://openrouter.ai/api/v1/responses"
-        ));
-        assert!(!endpoint_persists_responses(
-            "https://generativelanguage.googleapis.com/v1beta/openai/responses"
-        ));
-        // A host that merely contains "openai" in its name must not be trusted.
-        assert!(!endpoint_persists_responses(
-            "https://api.openai.example.com/v1/responses"
-        ));
-        assert!(
-            !OpenResponsesProtocolChatDriver::with_base_url(
-                "test",
-                "https://openrouter.ai/api/v1/responses"
-            )
-            .supports_stateful_responses()
-        );
+    fn wire_protocol_defaults_to_stateless() {
+        assert!(!OpenResponsesProtocolChatDriver::new().supports_stateful_responses());
     }
 
     /// End-to-end shape of the call path: against a stateless gateway, a request
@@ -3465,11 +3371,10 @@ mod tests {
     /// the prior response. This is the core EVE-523 regression guard.
     #[test]
     fn stateless_gateway_replays_full_transcript_despite_previous_response_id() {
-        let api_url = "https://openrouter.ai/api/v1/responses";
         let prev_id: Option<String> = Some("gen-turn-1".to_string());
 
-        // Mirror the gating the call path performs.
-        let effective_prev_id = if endpoint_persists_responses(api_url) {
+        let driver = OpenResponsesProtocolChatDriver::new();
+        let effective_prev_id = if driver.supports_stateful_responses() {
             prev_id.clone()
         } else {
             None
@@ -3494,10 +3399,10 @@ mod tests {
     /// for genuinely stateful endpoints.
     #[test]
     fn stateful_endpoint_still_trims_and_chains() {
-        let api_url = "https://api.openai.com/v1/responses";
         let prev_id: Option<String> = Some("resp_turn_1".to_string());
 
-        let effective_prev_id = if endpoint_persists_responses(api_url) {
+        let driver = OpenResponsesProtocolChatDriver::new().with_stateful_responses(true);
+        let effective_prev_id = if driver.supports_stateful_responses() {
             prev_id.clone()
         } else {
             None
@@ -3531,10 +3436,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        // server.uri() is a 127.0.0.1 host — not OpenAI/Azure — so it is treated
-        // as a stateless gateway.
-        let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "stateless-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth(crate::runtime_provider::BearerAuth::new("test-key"));
+        let driver = OpenResponsesProtocolChatDriver::new();
 
         let messages = vec![
             LlmMessage::text(LlmMessageRole::System, "You are helpful"),
@@ -3584,7 +3492,9 @@ mod tests {
         };
 
         // Fire the request. The stream body is irrelevant for this assertion.
-        let _ = driver.chat_completion_stream(messages, &config).await;
+        let _ = driver
+            .chat_completion_stream(endpoint.endpoint(), messages, &config)
+            .await;
 
         let requests = server
             .received_requests()
@@ -3659,12 +3569,15 @@ mod tests {
             .mount(&server)
             .await;
 
-        let driver = OpenResponsesProtocolChatDriver::with_base_url(
-            "test-key",
-            format!("{}/v1/responses", server.uri()),
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "stateful-test",
+            OpenResponsesProtocolChatDriver::new(),
         )
-        .with_stateful_responses(true)
-        .with_retry_config(LlmRetryConfig::no_retry());
+        .base_url(format!("{}/v1", server.uri()))
+        .auth(crate::runtime_provider::BearerAuth::new("test-key"));
+        let driver = OpenResponsesProtocolChatDriver::new()
+            .with_stateful_responses(true)
+            .with_retry_config(LlmRetryConfig::no_retry());
         let messages = vec![
             LlmMessage::text(LlmMessageRole::User, "inspect the project"),
             LlmMessage {
@@ -3709,7 +3622,7 @@ mod tests {
         };
 
         let mut stream = driver
-            .chat_completion_stream(messages, &config)
+            .chat_completion_stream(endpoint.endpoint(), messages, &config)
             .await
             .expect("continuation should recover");
         while let Some(event) = stream.next().await {
@@ -3744,9 +3657,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url)
-            .with_provider_type(DriverId::OpenRouter);
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "openrouter-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth(crate::runtime_provider::BearerAuth::new("test-key"));
+        let driver = OpenResponsesProtocolChatDriver::new();
 
         let tools: Vec<ToolDefinition> = (0..16)
             .map(|i| {
@@ -3780,7 +3697,9 @@ mod tests {
         };
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
-        let _ = driver.chat_completion_stream(messages, &config).await;
+        let _ = driver
+            .chat_completion_stream(endpoint.endpoint(), messages, &config)
+            .await;
 
         let requests = server
             .received_requests()
@@ -3816,8 +3735,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "openai-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth(crate::runtime_provider::BearerAuth::new("test-key"));
+        let driver = OpenResponsesProtocolChatDriver::new();
 
         let mut metadata = std::collections::HashMap::new();
         metadata.insert("session_id".to_string(), "session_abc123".to_string());
@@ -3845,7 +3769,9 @@ mod tests {
         };
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
-        let _ = driver.chat_completion_stream(messages, &config).await;
+        let _ = driver
+            .chat_completion_stream(endpoint.endpoint(), messages, &config)
+            .await;
 
         let requests = server
             .received_requests()
@@ -3887,8 +3813,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "stream-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth(crate::runtime_provider::BearerAuth::new("test-key"));
+        let driver = OpenResponsesProtocolChatDriver::new();
         let config = LlmCallConfig {
             speed: None,
             verbosity: None,
@@ -3908,7 +3839,11 @@ mod tests {
         };
 
         let stream = driver
-            .chat_completion_stream(vec![LlmMessage::text(LlmMessageRole::User, "hi")], &config)
+            .chat_completion_stream(
+                endpoint.endpoint(),
+                vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+                &config,
+            )
             .await
             .expect("stream should start");
         let events: Vec<_> = stream.collect().await;
@@ -4073,20 +4008,9 @@ mod tests {
     }
 
     #[test]
-    fn test_supports_compact_default_url() {
-        let driver = OpenResponsesProtocolChatDriver::new("test-key");
-        // Default URL is OpenAI, should support compact
+    fn test_wire_protocol_supports_compact() {
+        let driver = OpenResponsesProtocolChatDriver::new();
         assert!(driver.supports_compact());
-    }
-
-    #[test]
-    fn test_supports_compact_custom_url() {
-        let driver = OpenResponsesProtocolChatDriver::with_base_url(
-            "test-key",
-            "https://custom.api.com/v1/responses",
-        );
-        // Custom URL, compact support unknown
-        assert!(!driver.supports_compact());
     }
 
     // ========================================================================
@@ -5293,7 +5217,7 @@ mod tests {
     }
 
     // ========================================================================
-    // Pluggable request auth (EVE-618)
+    // Provider-owned request auth (EVE-618 / EVE-856)
     // ========================================================================
 
     /// Minimal `LlmCallConfig` for wire tests.
@@ -5325,10 +5249,17 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl AuthHeaderProvider for CountingAuth {
-        async fn auth_header(&self) -> Result<(String, String)> {
+    impl crate::runtime_provider::ProviderAuth for CountingAuth {
+        async fn headers(
+            &self,
+            _request: crate::runtime_provider::ProviderAuthRequest<'_>,
+        ) -> Result<Vec<(String, String)>> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(self.header.clone())
+            Ok(vec![self.header.clone()])
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 
@@ -5342,57 +5273,88 @@ mod tests {
         }
 
         fn decorate_headers(&self, headers: &mut HeaderMap, _config: &LlmCallConfig) -> Result<()> {
-            headers.insert("x-openrouter-route", HeaderValue::from_static("fallback"));
+            headers.insert(
+                "x-openrouter-route",
+                reqwest::header::HeaderValue::from_static("fallback"),
+            );
             // Decoration must never override auth — the driver applies auth last.
             headers.insert(
                 "authorization",
-                HeaderValue::from_static("Bearer decoration"),
+                reqwest::header::HeaderValue::from_static("Bearer decoration"),
             );
             Ok(())
         }
     }
 
     #[tokio::test]
-    async fn resolve_auth_header_defaults_to_bearer_on_non_azure() {
-        let driver = OpenResponsesProtocolChatDriver::new("secret-key");
-        let (name, value) = driver
-            .resolve_auth_header("https://api.openai.com/v1/responses")
+    async fn provider_resolves_bearer_auth() {
+        let provider = crate::runtime_provider::RuntimeProvider::new(
+            "openai-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url("https://api.openai.com/v1")
+        .auth(crate::runtime_provider::BearerAuth::new("secret-key"));
+        let resolved = provider
+            .endpoint()
+            .resolve("POST", "https://api.openai.com/v1/responses", b"{}")
             .await
             .expect("auth resolves");
-        assert_eq!(name.as_str(), "authorization");
-        assert_eq!(value.to_str().unwrap(), "Bearer secret-key");
-    }
-
-    #[tokio::test]
-    async fn resolve_auth_header_uses_api_key_header_on_azure() {
-        let driver = OpenResponsesProtocolChatDriver::new("secret-key");
-        let (name, value) = driver
-            .resolve_auth_header("https://my-resource.openai.azure.com/openai/v1/responses")
-            .await
-            .expect("auth resolves");
-        assert_eq!(name.as_str(), "api-key");
-        assert_eq!(value.to_str().unwrap(), "secret-key");
-    }
-
-    #[tokio::test]
-    async fn resolve_auth_header_prefers_provider_over_static_key() {
-        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let driver = OpenResponsesProtocolChatDriver::new("ignored-key").with_auth_provider(
-            std::sync::Arc::new(CountingAuth {
-                header: (
-                    "Authorization".to_string(),
-                    "Bearer minted-token".to_string(),
-                ),
-                calls: calls.clone(),
-            }),
+        assert_eq!(
+            resolved.headers,
+            vec![("authorization".into(), "Bearer secret-key".into())]
         );
-        // Azure URL: the static path would emit `api-key`, but the provider wins.
-        let (name, value) = driver
-            .resolve_auth_header("https://my-resource.openai.azure.com/openai/v1/responses")
+    }
+
+    #[tokio::test]
+    async fn provider_selects_auth_independently_of_host() {
+        let provider = crate::runtime_provider::RuntimeProvider::new(
+            "azure-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url("https://my-resource.openai.azure.com/openai/v1")
+        .auth(crate::runtime_provider::StaticHeaderAuth::new(
+            "api-key",
+            "secret-key",
+        ));
+        let resolved = provider
+            .endpoint()
+            .resolve(
+                "POST",
+                "https://my-resource.openai.azure.com/openai/v1/responses",
+                b"{}",
+            )
             .await
             .expect("auth resolves");
-        assert_eq!(name.as_str(), "authorization");
-        assert_eq!(value.to_str().unwrap(), "Bearer minted-token");
+        assert_eq!(
+            resolved.headers,
+            vec![("api-key".into(), "secret-key".into())]
+        );
+    }
+
+    #[tokio::test]
+    async fn refreshable_provider_auth_is_resolved() {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let provider = crate::runtime_provider::RuntimeProvider::new(
+            "refreshable-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url("https://service.example/v1")
+        .auth_arc(std::sync::Arc::new(CountingAuth {
+            header: (
+                "Authorization".to_string(),
+                "Bearer minted-token".to_string(),
+            ),
+            calls: calls.clone(),
+        }));
+        let resolved = provider
+            .endpoint()
+            .resolve("POST", "https://service.example/v1/responses", b"{}")
+            .await
+            .expect("auth resolves");
+        assert_eq!(
+            resolved.headers,
+            vec![("authorization".into(), "Bearer minted-token".into())]
+        );
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
@@ -5408,11 +5370,16 @@ mod tests {
             .mount(&server)
             .await;
 
-        let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("wire-key", api_url);
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "wire-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth(crate::runtime_provider::BearerAuth::new("wire-key"));
+        let driver = OpenResponsesProtocolChatDriver::new();
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hi")];
         let _ = driver
-            .chat_completion_stream(messages, &auth_test_config())
+            .chat_completion_stream(endpoint.endpoint(), messages, &auth_test_config())
             .await;
 
         let requests = server.received_requests().await.unwrap();
@@ -5439,20 +5406,24 @@ mod tests {
             .await;
 
         let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("ignored", api_url)
-            .with_request_extension(std::sync::Arc::new(HeaderInjectingExtension))
-            .with_auth_provider(std::sync::Arc::new(CountingAuth {
-                header: (
-                    "Authorization".to_string(),
-                    "Bearer minted-token".to_string(),
-                ),
-                calls: calls.clone(),
-            }));
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "auth-wins-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth_arc(std::sync::Arc::new(CountingAuth {
+            header: (
+                "Authorization".to_string(),
+                "Bearer minted-token".to_string(),
+            ),
+            calls: calls.clone(),
+        }));
+        let driver = OpenResponsesProtocolChatDriver::new()
+            .with_request_extension(std::sync::Arc::new(HeaderInjectingExtension));
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hi")];
         let _ = driver
-            .chat_completion_stream(messages, &auth_test_config())
+            .chat_completion_stream(endpoint.endpoint(), messages, &auth_test_config())
             .await;
 
         let requests = server.received_requests().await.unwrap();
@@ -5478,7 +5449,6 @@ mod tests {
             .await;
 
         let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let api_url = format!("{}/v1/responses", server.uri());
         let fast_retry = LlmRetryConfig {
             max_retries: 1,
             initial_backoff: std::time::Duration::from_millis(1),
@@ -5487,19 +5457,23 @@ mod tests {
             jitter_factor: 0.0,
             ..Default::default()
         };
-        let driver = OpenResponsesProtocolChatDriver::with_base_url("ignored", api_url)
-            .with_retry_config(fast_retry)
-            .with_auth_provider(std::sync::Arc::new(CountingAuth {
-                header: (
-                    "Authorization".to_string(),
-                    "Bearer minted-token".to_string(),
-                ),
-                calls: calls.clone(),
-            }));
+        let endpoint = crate::runtime_provider::RuntimeProvider::new(
+            "retry-auth-test",
+            OpenResponsesProtocolChatDriver::new(),
+        )
+        .base_url(format!("{}/v1", server.uri()))
+        .auth_arc(std::sync::Arc::new(CountingAuth {
+            header: (
+                "Authorization".to_string(),
+                "Bearer minted-token".to_string(),
+            ),
+            calls: calls.clone(),
+        }));
+        let driver = OpenResponsesProtocolChatDriver::new().with_retry_config(fast_retry);
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hi")];
         let _ = driver
-            .chat_completion_stream(messages, &auth_test_config())
+            .chat_completion_stream(endpoint.endpoint(), messages, &auth_test_config())
             .await;
 
         // Initial attempt + one retry = two auth resolutions.

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -12,43 +12,13 @@ use crate::typed_id::ProviderId;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-/// LLM provider type identifier.
+/// Open string identifier retained as the 0.17.x integration-kind name.
 ///
-/// Built-in variants cover providers shipped with everruns. Any string that
-/// does not match a built-in id becomes `External(id)`, so embedders can store
-/// and use custom provider ids without schema migrations.
-///
-/// Serializes to/from a plain string (e.g. `"anthropic"`, `"openai-codex"`).
+/// Despite the legacy type name, this is not a built-in-provider enum: any
+/// normalized string is valid. The associated constants keep source
+/// compatibility for the 0.17.x runtime adapter and persisted HTTP shapes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum DriverId {
-    /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
-    OpenAI,
-    /// OpenRouter using the OpenAI-compatible Responses API
-    OpenRouter,
-    /// Azure OpenAI using the Azure-hosted OpenAI v1 API
-    AzureOpenAI,
-    /// OpenAI using Chat Completions API (for backward compatibility)
-    OpenAICompletions,
-    Anthropic,
-    /// Google Gemini API
-    Gemini,
-    /// LLM simulator for testing
-    LlmSim,
-    /// AWS Bedrock Runtime (ConverseStream API)
-    Bedrock,
-    /// Microsoft MAI models (e.g. MAI-Code-1-Flash) served via Azure AI Foundry.
-    /// Uses an OpenAI-compatible Chat Completions API and supports either an
-    /// Azure AI Foundry API key or Microsoft Entra ID (OAuth) authentication.
-    Mai,
-    /// Fireworks AI — open-model inference (Llama, Qwen, DeepSeek, GLM, ...)
-    /// served via an OpenAI-compatible Chat Completions API.
-    Fireworks,
-    /// Meta Model API — Muse models served via an OpenAI-compatible Responses API.
-    Meta,
-    /// Embedder-defined provider not compiled into everruns-core. The inner id
-    /// is the canonical wire string (e.g. `"openai-codex"`).
-    External(std::sync::Arc<str>),
-}
+pub struct DriverId(std::borrow::Cow<'static, str>);
 
 impl std::fmt::Display for DriverId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -57,36 +27,42 @@ impl std::fmt::Display for DriverId {
 }
 
 impl DriverId {
+    #[allow(non_upper_case_globals)]
+    pub const OpenAI: Self = Self(std::borrow::Cow::Borrowed("openai"));
+    #[allow(non_upper_case_globals)]
+    pub const OpenRouter: Self = Self(std::borrow::Cow::Borrowed("openrouter"));
+    #[allow(non_upper_case_globals)]
+    pub const AzureOpenAI: Self = Self(std::borrow::Cow::Borrowed("azure_openai"));
+    #[allow(non_upper_case_globals)]
+    pub const OpenAICompletions: Self = Self(std::borrow::Cow::Borrowed("openai_completions"));
+    #[allow(non_upper_case_globals)]
+    pub const Anthropic: Self = Self(std::borrow::Cow::Borrowed("anthropic"));
+    #[allow(non_upper_case_globals)]
+    pub const Gemini: Self = Self(std::borrow::Cow::Borrowed("gemini"));
+    #[allow(non_upper_case_globals)]
+    pub const LlmSim: Self = Self(std::borrow::Cow::Borrowed("llmsim"));
+    #[allow(non_upper_case_globals)]
+    pub const Bedrock: Self = Self(std::borrow::Cow::Borrowed("bedrock"));
+    #[allow(non_upper_case_globals)]
+    pub const Mai: Self = Self(std::borrow::Cow::Borrowed("mai"));
+    #[allow(non_upper_case_globals)]
+    pub const Fireworks: Self = Self(std::borrow::Cow::Borrowed("fireworks"));
+    #[allow(non_upper_case_globals)]
+    pub const Meta: Self = Self(std::borrow::Cow::Borrowed("meta"));
+
     /// Construct an external driver id from its canonical wire id.
     ///
     /// The id is normalized to lowercase so registration and lookup match
     /// case-insensitively, consistent with built-in parsing.
-    pub fn external(id: impl Into<std::sync::Arc<str>>) -> Self {
-        let id: std::sync::Arc<str> = id.into();
-        // Avoid reallocating when the id is already lowercase.
-        if id.bytes().any(|b| b.is_ascii_uppercase()) {
-            DriverId::External(std::sync::Arc::from(id.to_lowercase().as_str()))
-        } else {
-            DriverId::External(id)
-        }
+    pub fn external(id: impl AsRef<str>) -> Self {
+        Self(std::borrow::Cow::Owned(
+            id.as_ref().trim().to_ascii_lowercase(),
+        ))
     }
 
     /// Return the canonical string identifier for this provider.
     pub fn as_str(&self) -> &str {
-        match self {
-            DriverId::OpenAI => "openai",
-            DriverId::OpenRouter => "openrouter",
-            DriverId::AzureOpenAI => "azure_openai",
-            DriverId::OpenAICompletions => "openai_completions",
-            DriverId::Anthropic => "anthropic",
-            DriverId::Gemini => "gemini",
-            DriverId::LlmSim => "llmsim",
-            DriverId::Bedrock => "bedrock",
-            DriverId::Mai => "mai",
-            DriverId::Fireworks => "fireworks",
-            DriverId::Meta => "meta",
-            DriverId::External(id) => id.as_ref(),
-        }
+        self.0.as_ref()
     }
 
     /// Default trace-link URL templates for this driver, as
@@ -106,12 +82,13 @@ impl DriverId {
     /// passes the id best-effort; worst case it lands on the Logs page where the
     /// generation can be found by recency.
     pub fn default_trace_templates(&self) -> (Option<String>, Option<String>) {
-        match self {
-            DriverId::OpenRouter => (
+        if self == &DriverId::OpenRouter {
+            (
                 Some("https://openrouter.ai/logs?id={response_id}".to_string()),
                 Some("https://openrouter.ai/logs".to_string()),
-            ),
-            _ => (None, None),
+            )
+        } else {
+            (None, None)
         }
     }
 }
@@ -123,21 +100,7 @@ impl std::str::FromStr for DriverId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Normalize once so built-in matching and the External id share the
         // same lowercased form; casing variance never yields duplicate ids.
-        let lower = s.to_lowercase();
-        Ok(match lower.as_str() {
-            "openai" => DriverId::OpenAI,
-            "openrouter" => DriverId::OpenRouter,
-            "azure_openai" => DriverId::AzureOpenAI,
-            "openai_completions" => DriverId::OpenAICompletions,
-            "anthropic" => DriverId::Anthropic,
-            "gemini" => DriverId::Gemini,
-            "llmsim" => DriverId::LlmSim,
-            "bedrock" => DriverId::Bedrock,
-            "mai" => DriverId::Mai,
-            "fireworks" => DriverId::Fireworks,
-            "meta" => DriverId::Meta,
-            _ => DriverId::External(std::sync::Arc::from(lower.as_str())),
-        })
+        Ok(DriverId::external(s))
     }
 }
 
@@ -150,8 +113,37 @@ impl Serialize for DriverId {
 impl<'de> Deserialize<'de> for DriverId {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let s = String::deserialize(d)?;
+        if s.trim().is_empty() {
+            return Err(serde::de::Error::custom("provider type cannot be empty"));
+        }
+        if s != s.trim() {
+            return Err(serde::de::Error::custom(
+                "provider type cannot have leading or trailing whitespace",
+            ));
+        }
         // FromStr is infallible (unknown ids become External).
         Ok(s.parse().unwrap_or_else(|_| unreachable!()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DriverId;
+
+    #[test]
+    fn wire_ids_reject_empty_and_padded_values() {
+        assert!(serde_json::from_str::<DriverId>(r#"""#).is_err());
+        assert!(serde_json::from_str::<DriverId>(r#"" openai ""#).is_err());
+    }
+
+    #[test]
+    fn wire_ids_normalize_case_and_accept_extensions() {
+        assert_eq!(
+            serde_json::from_str::<DriverId>(r#""Custom-Driver""#)
+                .unwrap()
+                .as_str(),
+            "custom-driver"
+        );
     }
 }
 

--- a/crates/provider/src/runtime_provider.rs
+++ b/crates/provider/src/runtime_provider.rs
@@ -1,0 +1,701 @@
+//! Runtime providers: service identity, endpoint, authentication, and wire driver.
+//!
+//! A [`ChatDriver`](crate::driver_registry::ChatDriver) implements a wire
+//! protocol. A `Provider` is a configured service that speaks that protocol.
+//! Keeping credentials and endpoints here lets one driver serve any number of
+//! services without adding vendor branches to the runtime.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use crate::driver_registry::{BoxedChatDriver, ChatDriver};
+use crate::error::Result;
+
+/// Open, normalized identity used by model specifications to select a provider.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProviderKey(String);
+
+impl ProviderKey {
+    pub fn new(id: impl AsRef<str>) -> Self {
+        Self(id.as_ref().trim().to_ascii_lowercase())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ProviderKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for ProviderKey {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for ProviderKey {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Serialize for ProviderKey {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderKey {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        String::deserialize(deserializer).map(Self::new)
+    }
+}
+
+/// Immutable request material available to an authentication implementation.
+///
+/// `body` is the exact serialized payload. This makes the contract suitable
+/// for request signatures such as AWS SigV4 as well as ordinary header auth.
+pub struct ProviderAuthRequest<'a> {
+    pub method: &'a str,
+    pub url: &'a str,
+    pub headers: &'a [(String, String)],
+    pub body: &'a [u8],
+}
+
+/// Resolves authentication for each outbound provider request.
+#[async_trait]
+pub trait ProviderAuth: Send + Sync {
+    async fn headers(&self, request: ProviderAuthRequest<'_>) -> Result<Vec<(String, String)>>;
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+/// Static `Authorization: Bearer …` authentication.
+pub struct BearerAuth {
+    key: String,
+}
+
+impl BearerAuth {
+    pub fn new(key: impl Into<String>) -> Self {
+        Self { key: key.into() }
+    }
+}
+
+#[async_trait]
+impl ProviderAuth for BearerAuth {
+    async fn headers(&self, _request: ProviderAuthRequest<'_>) -> Result<Vec<(String, String)>> {
+        Ok(vec![(
+            "authorization".to_string(),
+            format!("Bearer {}", self.key),
+        )])
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Static authentication carried in one named header.
+pub struct StaticHeaderAuth {
+    name: String,
+    value: String,
+}
+
+impl StaticHeaderAuth {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into().to_ascii_lowercase(),
+            value: value.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ProviderAuth for StaticHeaderAuth {
+    async fn headers(&self, _request: ProviderAuthRequest<'_>) -> Result<Vec<(String, String)>> {
+        Ok(vec![(self.name.clone(), self.value.clone())])
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Endpoint and authentication policy handed to a wire driver.
+///
+/// This runtime value is intentionally not serializable. Its `Debug` output
+/// exposes only header names and whether authentication is configured.
+#[derive(Clone, Default)]
+pub struct ProviderEndpoint {
+    base_url: Option<String>,
+    headers: Vec<(String, String)>,
+    auth: Option<Arc<dyn ProviderAuth>>,
+}
+
+impl ProviderEndpoint {
+    pub fn base_url(&self) -> Option<&str> {
+        self.base_url.as_deref()
+    }
+
+    pub fn url(&self, path: &str) -> Option<String> {
+        self.base_url.as_ref().map(|base| {
+            let base = base.trim_end_matches('/');
+            if path.is_empty() || base.ends_with(path) {
+                base.to_string()
+            } else {
+                format!("{base}/{}", path.trim_start_matches('/'))
+            }
+        })
+    }
+
+    pub async fn resolve(
+        &self,
+        method: &str,
+        url: impl Into<String>,
+        body: &[u8],
+    ) -> Result<ResolvedProviderRequest> {
+        let url = url.into();
+        let mut headers = self.headers.clone();
+        if let Some(auth) = &self.auth {
+            let auth_headers = auth
+                .headers(ProviderAuthRequest {
+                    method,
+                    url: &url,
+                    headers: &headers,
+                    body,
+                })
+                .await?;
+            for (name, value) in auth_headers {
+                headers.retain(|(existing, _)| !existing.eq_ignore_ascii_case(&name));
+                headers.push((name.to_ascii_lowercase(), value));
+            }
+        }
+        Ok(ResolvedProviderRequest { url, headers })
+    }
+
+    /// Access a provider-owned authentication implementation needed by a
+    /// protocol whose signing stack cannot be represented as header strings.
+    pub fn auth<T: ProviderAuth + 'static>(&self) -> Option<&T> {
+        self.auth.as_deref()?.as_any().downcast_ref()
+    }
+}
+
+impl fmt::Debug for ProviderEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProviderEndpoint")
+            .field("base_url", &self.base_url.as_ref().map(|_| "<configured>"))
+            .field("auth", &self.auth.as_ref().map(|_| "<configured>"))
+            .field(
+                "headers",
+                &self
+                    .headers
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+/// Fully resolved outbound request metadata.
+#[derive(Clone)]
+pub struct ResolvedProviderRequest {
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+}
+
+impl fmt::Debug for ResolvedProviderRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedProviderRequest")
+            .field("url", &redacted_url(&self.url))
+            .field(
+                "headers",
+                &self
+                    .headers
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+fn redacted_url(value: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(value) else {
+        return "<configured>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
+/// Runtime service assembly over one reusable wire-protocol driver.
+#[derive(Clone)]
+pub struct RuntimeProvider {
+    id: ProviderKey,
+    driver: Arc<dyn ChatDriver>,
+    endpoint: ProviderEndpoint,
+}
+
+/// Public application-facing name for a runtime provider.
+pub type Provider = RuntimeProvider;
+
+impl RuntimeProvider {
+    pub fn new(id: impl Into<ProviderKey>, driver: impl ChatDriver + 'static) -> Self {
+        Self::from_driver(id, Arc::new(driver))
+    }
+
+    pub fn from_driver(id: impl Into<ProviderKey>, driver: Arc<dyn ChatDriver>) -> Self {
+        Self {
+            id: id.into(),
+            driver,
+            endpoint: ProviderEndpoint::default(),
+        }
+    }
+
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.endpoint.base_url = Some(url.into().trim_end_matches('/').to_string());
+        self
+    }
+
+    pub fn auth(mut self, auth: impl ProviderAuth + 'static) -> Self {
+        self.endpoint.auth = Some(Arc::new(auth));
+        self
+    }
+
+    pub fn auth_arc(mut self, auth: Arc<dyn ProviderAuth>) -> Self {
+        self.endpoint.auth = Some(auth);
+        self
+    }
+
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.endpoint
+            .headers
+            .push((name.into().to_ascii_lowercase(), value.into()));
+        self
+    }
+
+    pub fn id(&self) -> &ProviderKey {
+        &self.id
+    }
+
+    pub fn driver(&self) -> &Arc<dyn ChatDriver> {
+        &self.driver
+    }
+
+    pub fn endpoint(&self) -> &ProviderEndpoint {
+        &self.endpoint
+    }
+
+    pub async fn chat_completion_stream(
+        &self,
+        messages: Vec<crate::driver_registry::LlmMessage>,
+        config: &crate::driver_registry::LlmCallConfig,
+    ) -> Result<crate::driver_registry::LlmResponseStream> {
+        let id = self.id.to_string();
+        let stream = self
+            .driver
+            .chat_completion_stream(&self.endpoint, messages, config)
+            .await
+            .map_err(|error| error.with_provider(&id))?;
+        Ok(Box::pin(stream.map(move |result| {
+            result.map_err(|error| error.with_provider(&id))
+        })))
+    }
+
+    pub async fn chat_completion(
+        &self,
+        messages: Vec<crate::driver_registry::LlmMessage>,
+        config: &crate::driver_registry::LlmCallConfig,
+    ) -> Result<crate::driver_registry::LlmResponse> {
+        self.driver
+            .chat_completion(&self.endpoint, messages, config)
+            .await
+            .map_err(|error| error.with_provider(self.id.as_str()))
+    }
+
+    pub async fn list_models(
+        &self,
+    ) -> Result<Option<Vec<crate::driver_registry::DiscoveredModel>>> {
+        self.driver
+            .list_models(&self.endpoint)
+            .await
+            .map_err(|error| error.with_provider(self.id.as_str()))
+    }
+
+    pub fn into_boxed_driver(self) -> BoxedChatDriver {
+        Box::new(ProviderBoundDriver(self))
+    }
+
+    pub fn bind_embeddings(
+        self,
+        driver: crate::driver_registry::BoxedEmbeddingsDriver,
+    ) -> crate::driver_registry::BoxedEmbeddingsDriver {
+        Box::new(ProviderBoundEmbeddingsDriver {
+            id: self.id,
+            endpoint: self.endpoint,
+            driver,
+        })
+    }
+}
+
+impl fmt::Debug for RuntimeProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Provider")
+            .field("id", &self.id)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+struct ProviderBoundDriver(RuntimeProvider);
+
+struct ProviderBoundEmbeddingsDriver {
+    id: ProviderKey,
+    endpoint: ProviderEndpoint,
+    driver: crate::driver_registry::BoxedEmbeddingsDriver,
+}
+
+#[async_trait]
+impl crate::driver_registry::EmbeddingsDriver for ProviderBoundEmbeddingsDriver {
+    async fn embed(
+        &self,
+        _endpoint: &ProviderEndpoint,
+        request: crate::driver_registry::EmbedRequest,
+    ) -> std::result::Result<
+        crate::driver_registry::EmbedResponse,
+        crate::driver_registry::EmbeddingsDriverError,
+    > {
+        self.driver
+            .embed(&self.endpoint, request)
+            .await
+            .map_err(|error| {
+                crate::driver_registry::EmbeddingsDriverError::Provider(format!(
+                    "provider '{}': {error}",
+                    self.id
+                ))
+            })
+    }
+}
+
+#[async_trait]
+impl ChatDriver for ProviderBoundDriver {
+    async fn chat_completion_stream(
+        &self,
+        _endpoint: &ProviderEndpoint,
+        messages: Vec<crate::driver_registry::LlmMessage>,
+        config: &crate::driver_registry::LlmCallConfig,
+    ) -> Result<crate::driver_registry::LlmResponseStream> {
+        self.0.chat_completion_stream(messages, config).await
+    }
+
+    async fn list_models(
+        &self,
+        _endpoint: &ProviderEndpoint,
+    ) -> Result<Option<Vec<crate::driver_registry::DiscoveredModel>>> {
+        self.0.list_models().await
+    }
+
+    fn supports_compact(&self) -> bool {
+        self.0.driver.supports_compact()
+    }
+
+    fn supports_stateful_responses(&self) -> bool {
+        self.0.driver.supports_stateful_responses()
+    }
+
+    fn effective_context_window(&self, model: &str) -> Option<usize> {
+        self.0.driver.effective_context_window(model)
+    }
+
+    fn supports_parallel_tool_calls(&self, model: &str) -> bool {
+        self.0.driver.supports_parallel_tool_calls(model)
+    }
+
+    async fn compact(
+        &self,
+        _endpoint: &ProviderEndpoint,
+        request: crate::openresponses_protocol::CompactRequest,
+    ) -> Result<Option<crate::openresponses_protocol::CompactResponse>> {
+        self.0
+            .driver
+            .compact(self.0.endpoint(), request)
+            .await
+            .map_err(|error| error.with_provider(self.0.id.as_str()))
+    }
+}
+
+/// Runtime provider instances keyed by their open service identity.
+#[derive(Clone, Default)]
+pub struct RuntimeProviderRegistry {
+    providers: HashMap<ProviderKey, Arc<RuntimeProvider>>,
+}
+
+/// Public registry name for runtime provider instances.
+pub type ProviderRegistry = RuntimeProviderRegistry;
+
+impl RuntimeProviderRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, provider: RuntimeProvider) -> Result<()> {
+        if self.providers.contains_key(provider.id()) {
+            return Err(crate::error::AgentLoopError::Configuration(format!(
+                "provider '{}' is already registered; use replace() to overwrite intentionally",
+                provider.id()
+            )));
+        }
+        self.providers
+            .insert(provider.id.clone(), Arc::new(provider));
+        Ok(())
+    }
+
+    pub fn replace(&mut self, provider: RuntimeProvider) -> Option<Arc<RuntimeProvider>> {
+        self.providers
+            .insert(provider.id.clone(), Arc::new(provider))
+    }
+
+    pub fn get(&self, id: &ProviderKey) -> Option<Arc<RuntimeProvider>> {
+        self.providers.get(id).cloned()
+    }
+
+    pub fn ids(&self) -> Vec<String> {
+        let mut ids = self
+            .providers
+            .keys()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+}
+
+impl fmt::Debug for RuntimeProviderRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProviderRegistry")
+            .field("providers", &self.ids())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_key_deserialization_is_canonical() {
+        let key: ProviderKey = serde_json::from_str(r#"" Gateway-PROD ""#).unwrap();
+        assert_eq!(key.as_str(), "gateway-prod");
+        assert_eq!(serde_json::to_string(&key).unwrap(), r#""gateway-prod""#);
+    }
+
+    #[test]
+    fn debug_redacts_auth_and_header_values() {
+        struct Noop;
+        #[async_trait]
+        impl ChatDriver for Noop {
+            async fn chat_completion_stream(
+                &self,
+                _endpoint: &ProviderEndpoint,
+                _messages: Vec<crate::driver_registry::LlmMessage>,
+                _config: &crate::driver_registry::LlmCallConfig,
+            ) -> Result<crate::driver_registry::LlmResponseStream> {
+                unreachable!()
+            }
+        }
+
+        let provider = RuntimeProvider::new("Gateway", Noop)
+            .base_url("https://example.test/")
+            .header("x-secret", "hidden-service-value")
+            .auth(BearerAuth::new("hidden-key"));
+        let debug = format!("{provider:?}");
+        assert!(debug.contains("gateway"));
+        assert!(debug.contains("x-secret"));
+        assert!(!debug.contains("hidden-service-value"));
+        assert!(!debug.contains("hidden-key"));
+    }
+
+    #[test]
+    fn duplicate_registration_is_explicit() {
+        struct Noop;
+        #[async_trait]
+        impl ChatDriver for Noop {
+            async fn chat_completion_stream(
+                &self,
+                _endpoint: &ProviderEndpoint,
+                _messages: Vec<crate::driver_registry::LlmMessage>,
+                _config: &crate::driver_registry::LlmCallConfig,
+            ) -> Result<crate::driver_registry::LlmResponseStream> {
+                unreachable!()
+            }
+        }
+        let mut registry = RuntimeProviderRegistry::new();
+        registry.register(RuntimeProvider::new("a", Noop)).unwrap();
+        assert!(registry.register(RuntimeProvider::new("A", Noop)).is_err());
+        assert_eq!(registry.ids(), vec!["a"]);
+    }
+
+    #[tokio::test]
+    async fn one_protocol_serves_distinct_provider_identities() {
+        struct Noop;
+        #[async_trait]
+        impl ChatDriver for Noop {
+            async fn chat_completion_stream(
+                &self,
+                _endpoint: &ProviderEndpoint,
+                _messages: Vec<crate::driver_registry::LlmMessage>,
+                _config: &crate::driver_registry::LlmCallConfig,
+            ) -> Result<crate::driver_registry::LlmResponseStream> {
+                unreachable!()
+            }
+        }
+
+        let protocol: Arc<dyn ChatDriver> = Arc::new(Noop);
+        let first = Provider::from_driver("first", protocol.clone())
+            .base_url("https://first.example/v1")
+            .header("x-service", "first")
+            .auth(BearerAuth::new("first-key"));
+        let second = Provider::from_driver("second", protocol.clone())
+            .base_url("https://second.example/v1")
+            .header("x-service", "second")
+            .auth(BearerAuth::new("second-key"));
+
+        assert!(Arc::ptr_eq(first.driver(), second.driver()));
+        let first_request = first
+            .endpoint()
+            .resolve("POST", first.endpoint().url("chat").unwrap(), b"{}")
+            .await
+            .unwrap();
+        let second_request = second
+            .endpoint()
+            .resolve("POST", second.endpoint().url("chat").unwrap(), b"{}")
+            .await
+            .unwrap();
+        assert_ne!(first_request.url, second_request.url);
+        assert_ne!(first_request.headers, second_request.headers);
+    }
+
+    #[tokio::test]
+    async fn refreshable_auth_is_resolved_for_each_request() {
+        struct Rotating(std::sync::atomic::AtomicUsize);
+        #[async_trait]
+        impl ProviderAuth for Rotating {
+            async fn headers(
+                &self,
+                request: ProviderAuthRequest<'_>,
+            ) -> Result<Vec<(String, String)>> {
+                let token = self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                Ok(vec![
+                    ("authorization".into(), format!("Bearer token-{token}")),
+                    (
+                        "x-signed-body".into(),
+                        String::from_utf8_lossy(request.body).into_owned(),
+                    ),
+                ])
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        let endpoint = ProviderEndpoint {
+            base_url: Some("https://service.example".into()),
+            headers: Vec::new(),
+            auth: Some(Arc::new(Rotating(std::sync::atomic::AtomicUsize::new(0)))),
+        };
+        let first = endpoint
+            .resolve("POST", "https://service.example/chat", b"one")
+            .await
+            .unwrap();
+        let second = endpoint
+            .resolve("POST", "https://service.example/chat", b"two")
+            .await
+            .unwrap();
+        assert_eq!(first.headers[0].1, "Bearer token-1");
+        assert_eq!(second.headers[0].1, "Bearer token-2");
+        assert_eq!(first.headers[1].1, "one");
+        assert_eq!(second.headers[1].1, "two");
+    }
+
+    #[tokio::test]
+    async fn provider_identity_prefixes_start_and_stream_errors() {
+        struct Failing {
+            fail_to_start: bool,
+        }
+        #[async_trait]
+        impl ChatDriver for Failing {
+            async fn chat_completion_stream(
+                &self,
+                _endpoint: &ProviderEndpoint,
+                _messages: Vec<crate::LlmMessage>,
+                _config: &crate::LlmCallConfig,
+            ) -> Result<crate::LlmResponseStream> {
+                if self.fail_to_start {
+                    return Err(crate::AgentLoopError::llm("request failed"));
+                }
+                Ok(Box::pin(futures::stream::once(async {
+                    Err(crate::AgentLoopError::llm("stream failed"))
+                })))
+            }
+        }
+
+        let config = crate::LlmCallConfig {
+            model: "model".into(),
+            temperature: None,
+            max_tokens: None,
+            tools: Vec::new(),
+            reasoning_effort: None,
+            speed: None,
+            verbosity: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            provider_opaque_context: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: None,
+            parallel_tool_calls: None,
+            volatile_suffix_len: 0,
+        };
+        let start = Provider::new(
+            "customer-gateway",
+            Failing {
+                fail_to_start: true,
+            },
+        );
+        let error = match start.chat_completion_stream(Vec::new(), &config).await {
+            Ok(_) => panic!("the test driver should fail before returning a stream"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("provider 'customer-gateway'"));
+
+        let stream = Provider::new(
+            "customer-gateway",
+            Failing {
+                fail_to_start: false,
+            },
+        );
+        let error = stream
+            .chat_completion_stream(Vec::new(), &config)
+            .await
+            .unwrap()
+            .next()
+            .await
+            .unwrap()
+            .unwrap_err();
+        assert!(error.to_string().contains("provider 'customer-gateway'"));
+    }
+}

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -192,7 +192,9 @@ fn finish_turn(
 pub struct InProcessRuntimeBuilder {
     platform_definition: PlatformDefinition,
     llm_sim_config: Option<LlmSimConfig>,
-    default_model: Option<ResolvedModel>,
+    providers: Vec<everruns_core::Provider>,
+    model_spec: Option<everruns_core::ModelSpec>,
+    legacy_provider_config: Option<everruns_core::ProviderConfig>,
     backends: Option<RuntimeBackends>,
     session_file_system_factory_context: SessionFileSystemFactoryContext,
     harnesses: Vec<Harness>,
@@ -235,7 +237,9 @@ impl InProcessRuntimeBuilder {
                 .session_file_system_factory(Arc::new(InMemorySessionFileSystemFactory))
                 .build(),
             llm_sim_config: None,
-            default_model: None,
+            providers: Vec::new(),
+            model_spec: None,
+            legacy_provider_config: None,
             backends: None,
             session_file_system_factory_context: SessionFileSystemFactoryContext::new(),
             harnesses: Vec::new(),
@@ -279,6 +283,12 @@ impl InProcessRuntimeBuilder {
         self
     }
 
+    /// Register a canonical runtime provider selected by [`ModelSpec`](everruns_core::ModelSpec).
+    pub fn provider(mut self, provider: everruns_core::Provider) -> Self {
+        self.providers.push(provider);
+        self
+    }
+
     /// Register the built-in `llmsim` driver for deterministic local execution.
     pub fn llm_sim(mut self, config: LlmSimConfig) -> Self {
         self.llm_sim_config = Some(config);
@@ -287,7 +297,16 @@ impl InProcessRuntimeBuilder {
 
     /// Set the runtime default model used when sessions/agents do not override it.
     pub fn default_model(mut self, model: ResolvedModel) -> Self {
-        self.default_model = Some(model);
+        let (spec, provider_config) = model.canonical_parts();
+        self.model_spec = Some(spec);
+        self.legacy_provider_config = Some(provider_config);
+        self
+    }
+
+    /// Select a credential-free model served by a provider registered on this builder.
+    pub fn model_spec(mut self, model: everruns_core::ModelSpec) -> Self {
+        self.model_spec = Some(model);
+        self.legacy_provider_config = None;
         self
     }
 
@@ -488,30 +507,74 @@ impl InProcessRuntimeBuilder {
 
         if let Some(config) = self.llm_sim_config.take() {
             let driver = LlmSimDriver::new(config);
-            // Replace intentionally: the platform may already register a
-            // built-in LlmSim driver, and the builder's config takes precedence.
+            // This legacy convenience adapts into the canonical provider path.
             self.platform_definition
                 .driver_registry_mut()
-                .register_or_replace(DriverId::LlmSim, move |_config| Box::new(driver.clone()));
+                .replace_provider(everruns_core::Provider::new("llmsim", driver));
 
-            if self.default_model.is_none() {
-                self.default_model = Some(ResolvedModel {
-                    model: "llmsim-model".to_string(),
-                    provider_type: DriverId::LlmSim,
-                    api_key: Some("fake-key".to_string()),
-                    base_url: None,
-                    provider_metadata: None,
-                });
+            if self.model_spec.is_none() {
+                self.model_spec = Some(everruns_core::ModelSpec::on("llmsim", "llmsim-model"));
             }
         }
 
-        let default_model = self.default_model.ok_or_else(|| {
+        for provider in self.providers {
+            self.platform_definition
+                .driver_registry_mut()
+                .register_provider(provider)?;
+        }
+
+        let model_spec = self.model_spec.ok_or_else(|| {
             AgentLoopError::config(
                 "in-process runtime requires a default model; call \
                  InProcessRuntimeBuilder::default_model(...) or \
                  InProcessRuntimeBuilder::llm_sim(...)",
             )
         })?;
+
+        // `ResolvedModel` is a 0.17 compatibility input. Adapt it once into a
+        // canonical registered provider; no credential-bearing model state is
+        // retained by the runtime execution path.
+        let legacy_config = self.legacy_provider_config.take();
+        let provider_type = legacy_config
+            .as_ref()
+            .map(|config| config.provider_type.clone())
+            .unwrap_or_else(|| DriverId::external(model_spec.provider.as_str()));
+        if let Some(config) = legacy_config
+            && self
+                .platform_definition
+                .driver_registry()
+                .provider(&model_spec.provider)
+                .is_none()
+        {
+            let driver = self
+                .platform_definition
+                .driver_registry()
+                .create_chat_driver(&config)?;
+            self.platform_definition
+                .driver_registry_mut()
+                .register_provider(everruns_core::Provider::new(
+                    model_spec.provider.clone(),
+                    driver,
+                ))?;
+        }
+
+        let provider_metadata = if provider_type.as_str() == model_spec.provider.as_str() {
+            None
+        } else {
+            Some(everruns_core::ProviderMetadata {
+                extra: Some(serde_json::json!({
+                    "provider_id": model_spec.provider.as_str(),
+                })),
+                ..Default::default()
+            })
+        };
+        let default_model = ResolvedModel {
+            model: model_spec.model,
+            provider_type,
+            api_key: None,
+            base_url: None,
+            provider_metadata,
+        };
 
         backends
             .provider_store

--- a/crates/runtime/tests/provider_compatibility.rs
+++ b/crates/runtime/tests/provider_compatibility.rs
@@ -1,0 +1,62 @@
+use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
+use everruns_core::{DriverId, DriverRegistry, InputMessage, ModelSpec, Provider, ResolvedModel};
+use everruns_runtime::InProcessRuntimeBuilder;
+
+fn registry(response: &str) -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    registry
+        .register_provider(Provider::new(
+            "llmsim",
+            LlmSimDriver::new(LlmSimConfig::fixed(response)),
+        ))
+        .unwrap();
+    registry
+}
+
+fn builder(registry: DriverRegistry) -> InProcessRuntimeBuilder {
+    InProcessRuntimeBuilder::new()
+        .driver_registry(registry)
+        .single_session(|session| {
+            session
+                .harness("assistant", "Be concise.")
+                .agent("assistant-agent", "Answer.")
+        })
+}
+
+#[tokio::test]
+async fn legacy_and_canonical_setup_share_provider_execution() {
+    let legacy = builder(registry("same-path"))
+        .default_model(ResolvedModel {
+            model: "llmsim-model".into(),
+            provider_type: DriverId::LlmSim,
+            api_key: None,
+            base_url: None,
+            provider_metadata: None,
+        })
+        .build()
+        .await
+        .unwrap();
+    let canonical = builder(registry("same-path"))
+        .model_spec(ModelSpec::on("llmsim", "llmsim-model"))
+        .build()
+        .await
+        .unwrap();
+
+    let legacy_result = legacy
+        .run_turn(
+            legacy.default_session_id().unwrap(),
+            InputMessage::user("hello"),
+        )
+        .await
+        .unwrap();
+    let canonical_result = canonical
+        .run_turn(
+            canonical.default_session_id().unwrap(),
+            InputMessage::user("hello"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(legacy_result.response, canonical_result.response);
+    assert_eq!(legacy_result.response, "same-path");
+}

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -758,9 +758,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
         Ok(resolved.map(|r| ResolvedModel {
             model: r.model_id,
             provider_type: string_to_provider_type(&r.provider_type),
-            api_key: r.api_key,
-            base_url: r.base_url,
-            provider_metadata: None,
+            api_key: None,
+            base_url: None,
+            provider_metadata: Some(everruns_core::ProviderMetadata {
+                extra: Some(serde_json::json!({ "provider_id": r.provider_id })),
+                ..Default::default()
+            }),
         }))
     }
 
@@ -777,9 +780,34 @@ impl WorkerAdapters for DirectWorkerAdapters {
         Ok(resolved.map(|r| ResolvedModel {
             model: r.model_id,
             provider_type: string_to_provider_type(&r.provider_type),
-            api_key: r.api_key,
-            base_url: r.base_url,
-            provider_metadata: None,
+            api_key: None,
+            base_url: None,
+            provider_metadata: Some(everruns_core::ProviderMetadata {
+                extra: Some(serde_json::json!({ "provider_id": r.provider_id })),
+                ..Default::default()
+            }),
+        }))
+    }
+
+    async fn get_provider_config(
+        &self,
+        org_id: i64,
+        provider: &everruns_core::ProviderKey,
+    ) -> Result<Option<everruns_core::ProviderConfig>> {
+        let resolved = self
+            .provider_resolver
+            .resolve_runtime_provider(org_id, provider.as_str())
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, "Failed to resolve provider");
+                store_error("Failed to resolve provider")
+            })?;
+        Ok(resolved.map(|value| everruns_core::ProviderConfig {
+            provider: provider.clone(),
+            provider_type: string_to_provider_type(&value.provider_type),
+            api_key: Some(value.credentials.api_key),
+            base_url: value.credentials.base_url,
+            metadata: everruns_core::ProviderMetadata::default(),
         }))
     }
 

--- a/crates/server/src/domains/knowledge_indexes/embedding.rs
+++ b/crates/server/src/domains/knowledge_indexes/embedding.rs
@@ -54,6 +54,7 @@ pub async fn build_embeddings_driver(
         .parse()
         .expect("DriverId::from_str is infallible");
     let provider_config = ProviderConfig {
+        provider: everruns_core::ProviderKey::new(provider.id.to_string()),
         provider_type,
         api_key: Some(resolved.credentials.api_key),
         base_url: resolved.credentials.base_url,

--- a/crates/server/src/domains/knowledge_indexes/search.rs
+++ b/crates/server/src/domains/knowledge_indexes/search.rs
@@ -75,10 +75,13 @@ impl KnowledgeIndexSearchService {
         .await?;
         let response = embedder
             .driver
-            .embed(EmbedRequest {
-                texts: vec![query.to_string()],
-                model: embedder.model_id,
-            })
+            .embed(
+                &everruns_core::ProviderEndpoint::default(),
+                EmbedRequest {
+                    texts: vec![query.to_string()],
+                    model: embedder.model_id,
+                },
+            )
             .await
             .map_err(|e| anyhow::anyhow!("embedding request failed: {e}"))?;
         let embedding = response

--- a/crates/server/src/domains/knowledge_indexes/search/tests.rs
+++ b/crates/server/src/domains/knowledge_indexes/search/tests.rs
@@ -34,6 +34,7 @@ struct DeterministicEmbeddingsDriver;
 impl EmbeddingsDriver for DeterministicEmbeddingsDriver {
     async fn embed(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         request: EmbedRequest,
     ) -> std::result::Result<EmbedResponse, EmbeddingsDriverError> {
         let embeddings = request

--- a/crates/server/src/domains/knowledge_indexes/source_sync.rs
+++ b/crates/server/src/domains/knowledge_indexes/source_sync.rs
@@ -303,7 +303,10 @@ impl KnowledgeIndexSyncService {
                     async move {
                         let expected = texts.len();
                         let response = driver
-                            .embed(EmbedRequest { texts, model })
+                            .embed(
+                                &everruns_core::ProviderEndpoint::default(),
+                                EmbedRequest { texts, model },
+                            )
                             .await
                             .map_err(|e| anyhow!("embedding request failed: {e}"))?;
                         if response.embeddings.len() != expected {

--- a/crates/server/src/domains/knowledge_indexes/source_sync/tests.rs
+++ b/crates/server/src/domains/knowledge_indexes/source_sync/tests.rs
@@ -340,6 +340,7 @@ struct DeterministicEmbeddingsDriver;
 impl EmbeddingsDriver for DeterministicEmbeddingsDriver {
     async fn embed(
         &self,
+        _endpoint: &everruns_core::ProviderEndpoint,
         request: EmbedRequest,
     ) -> std::result::Result<EmbedResponse, EmbeddingsDriverError> {
         let embeddings = request

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -191,13 +191,20 @@ impl JudgeClient for LlmJudgeClient {
 
         // DriverId::from_str is infallible (unknown ids become External).
         let driver_id: DriverId = resolved.provider_type.parse().unwrap();
-        let mut provider_config = ProviderConfig::new(driver_id);
-        if let Some(key) = resolved.api_key {
-            provider_config = provider_config.with_api_key(key);
-        }
-        if let Some(base) = resolved.base_url {
-            provider_config = provider_config.with_base_url(base);
-        }
+        let Some(runtime_provider) = self
+            .provider_resolver
+            .resolve_runtime_provider(org_id, &resolved.provider_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let provider_config = ProviderConfig {
+            provider: everruns_core::ProviderKey::new(&resolved.provider_id),
+            provider_type: driver_id,
+            api_key: Some(runtime_provider.credentials.api_key),
+            base_url: runtime_provider.credentials.base_url,
+            metadata: Default::default(),
+        };
         let driver = self.driver_registry.create_chat_driver(&provider_config)?;
 
         let (system, user) = build_judge_messages(rubric, evidence);
@@ -226,7 +233,13 @@ impl JudgeClient for LlmJudgeClient {
             volatile_suffix_len: 0,
         };
 
-        let response = driver.chat_completion(messages, &config).await?;
+        let response = driver
+            .chat_completion(
+                &everruns_core::ProviderEndpoint::default(),
+                messages,
+                &config,
+            )
+            .await?;
         let parsed = parse_judge_output(&response.text)?;
         let meta = response.metadata;
         Ok(Some(JudgeResult {

--- a/crates/server/src/domains/providers/service.rs
+++ b/crates/server/src/domains/providers/service.rs
@@ -368,10 +368,9 @@ fn validate_provider_type(provider_type: &DriverId) -> Result<()> {
     if raw.trim().is_empty() {
         return Err(BadRequestError::new("Provider type cannot be empty").into());
     }
-    // `DriverId::external` preserves the string verbatim, so a padded id like
-    // " openai " is non-empty here but later fails driver-registry lookup and
-    // persists as a corrupt row. Reject surrounding whitespace outright rather
-    // than silently normalizing it.
+    // Keep this defense for already-constructed values. HTTP deserialization
+    // rejects padding before normalization, so malformed wire ids cannot reach
+    // persistence as canonical-but-unintended names.
     if raw != raw.trim() {
         return Err(BadRequestError::new(
             "Provider type cannot have leading or trailing whitespace",
@@ -551,14 +550,8 @@ mod tests {
 
     #[test]
     fn provider_type_rejects_padded_external_id() {
-        // Non-empty but whitespace-padded: would persist verbatim and fail
-        // driver-registry lookup later, so it must be rejected at write time.
-        let err = validate_provider_type(&DriverId::external(" openai ")).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Provider type cannot have leading or trailing whitespace")
-        );
-        assert!(err.downcast_ref::<BadRequestError>().is_some());
+        let result = serde_json::from_str::<DriverId>(r#"" openai ""#);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -866,9 +866,8 @@ impl WorkerServiceImpl {
     fn resolved_model_to_proto(resolved: crate::services::ResolvedModel) -> proto::ResolvedModel {
         proto::ResolvedModel {
             model: resolved.model_id,
+            provider_id: resolved.provider_id,
             provider_type: resolved.provider_type,
-            api_key: resolved.api_key,
-            base_url: resolved.base_url,
         }
     }
 

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -894,13 +894,6 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let model_id = parse_uuid(req.model_id.as_ref())?;
 
-        // Check if encryption service is available
-        if !self.provider_resolver_service.has_encryption() {
-            return Err(Status::unavailable(
-                "Encryption service not configured - cannot decrypt API keys",
-            ));
-        }
-
         // Resolve model via ProviderResolverService
         let resolved = self
             .provider_resolver_service
@@ -921,14 +914,6 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<GetDefaultModelRequest>,
     ) -> Result<Response<GetDefaultModelResponse>, Status> {
         let req = request.into_inner();
-        // Check if encryption service is available
-        if !self.provider_resolver_service.has_encryption() {
-            tracing::error!("gRPC get_default_model: encryption service not available");
-            return Err(Status::unavailable(
-                "Encryption service not configured - cannot decrypt API keys",
-            ));
-        }
-
         // Resolve default model via ProviderResolverService
         let resolved = self
             .provider_resolver_service
@@ -939,12 +924,12 @@ impl WorkerService for WorkerServiceImpl {
                 Status::internal("Failed to resolve default model")
             })?;
 
-        // Log model resolution result (omit api_key length for security)
+        // Model resolution is credential-free; provider config resolves later.
         if let Some(ref model) = resolved {
             tracing::debug!(
                 model_id = %model.model_id,
                 provider_type = %model.provider_type,
-                has_api_key = model.api_key.is_some(),
+                provider_id = %model.provider_id,
                 "gRPC get_default_model: resolved model"
             );
         } else {
@@ -2345,29 +2330,38 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<GetDefaultProviderCredentialsRequest>,
     ) -> Result<Response<GetDefaultProviderCredentialsResponse>, Status> {
         let req = request.into_inner();
-        let resolved = self
-            .provider_resolver_service
-            .resolve_provider_credentials(req.org_id, &req.provider_type)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    provider_type = %req.provider_type,
-                    error = %e,
-                    "Failed to resolve provider credentials"
-                );
-                Status::internal("Failed to resolve provider credentials")
-            })?;
+        let resolved = if req.provider_id.is_empty() {
+            self.provider_resolver_service
+                .resolve_provider_credentials(req.org_id, &req.provider_type)
+                .await
+                .map(|value| value.map(|credentials| (req.provider_type.clone(), credentials)))
+        } else {
+            self.provider_resolver_service
+                .resolve_runtime_provider(req.org_id, &req.provider_id)
+                .await
+                .map(|value| value.map(|provider| (provider.provider_type, provider.credentials)))
+        }
+        .map_err(|e| {
+            tracing::error!(
+                provider_type = %req.provider_type,
+                error = %e,
+                "Failed to resolve provider credentials"
+            );
+            Status::internal("Failed to resolve provider credentials")
+        })?;
 
         Ok(Response::new(match resolved {
-            Some(credentials) => GetDefaultProviderCredentialsResponse {
+            Some((provider_type, credentials)) => GetDefaultProviderCredentialsResponse {
                 found: true,
                 api_key: credentials.api_key,
                 base_url: credentials.base_url.unwrap_or_default(),
+                provider_type,
             },
             None => GetDefaultProviderCredentialsResponse {
                 found: false,
                 api_key: String::new(),
                 base_url: String::new(),
+                provider_type: String::new(),
             },
         }))
     }

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -74,16 +74,6 @@ impl ModelSyncService {
             .parse()
             .map_err(|e| anyhow::anyhow!("Invalid provider type: {}", e))?;
 
-        // Skip sync for providers with custom base URLs unless the provider
-        // needs a tenant-specific endpoint for discovery.
-        if provider_row.base_url.is_some() && !supports_sync_with_base_url(&provider_type) {
-            tracing::debug!(
-                provider_id = %provider_id,
-                "Skipping sync for provider with custom base URL"
-            );
-            return Ok(SyncResult::NotSupported);
-        }
-
         // Get API key from DB (fail closed — no env fallback in tenant path).
         let api_key = self.resolve_api_key(&provider_row)?;
         let Some(api_key) = api_key else {
@@ -101,6 +91,7 @@ impl ModelSyncService {
         }
 
         let config = ProviderConfig {
+            provider: everruns_core::ProviderKey::new(provider_id.to_string()),
             provider_type: driver_type,
             api_key: Some(api_key),
             base_url: provider_row.base_url.clone(),
@@ -113,7 +104,10 @@ impl ModelSyncService {
             .map_err(|e| anyhow::anyhow!("Failed to create driver: {}", e))?;
 
         // Call list_models on the driver
-        let discovered = match driver.list_models().await {
+        let discovered = match driver
+            .list_models(&everruns_core::ProviderEndpoint::default())
+            .await
+        {
             Ok(Some(models)) => models,
             Ok(None) => {
                 tracing::debug!(
@@ -183,7 +177,10 @@ impl ModelSyncService {
         let mut updated = 0;
 
         // Parse provider type for profile lookup
-        let provider_type: DriverId = provider.provider_type.parse().unwrap_or(DriverId::OpenAI);
+        let provider_type: DriverId = provider
+            .provider_type
+            .parse()
+            .unwrap_or_else(|_| unreachable!());
 
         // Get existing models for this provider
         let existing = self
@@ -268,26 +265,6 @@ impl ModelSyncService {
     }
 }
 
-fn supports_sync_with_base_url(provider_type: &DriverId) -> bool {
-    matches!(
-        provider_type,
-        DriverId::OpenAI
-            | DriverId::OpenRouter
-            | DriverId::AzureOpenAI
-            | DriverId::OpenAICompletions
-            // MAI providers always carry a base URL (the Azure AI Foundry
-            // resource endpoint); the driver gates discovery to recognized
-            // Foundry hosts internally.
-            | DriverId::Mai
-            // Fireworks providers may carry a custom base URL (proxy); the
-            // driver gates discovery to the recognized Fireworks host internally.
-            | DriverId::Fireworks
-            // External providers are custom by nature: a configured base URL is
-            // the embedder's endpoint, so do not skip discovery for them.
-            | DriverId::External(_)
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,16 +308,6 @@ mod tests {
 
         let deserialized: SyncResult = serde_json::from_str(&json).unwrap();
         assert!(matches!(deserialized, SyncResult::NotSupported));
-    }
-
-    #[test]
-    fn test_azure_openai_supports_sync_with_base_url() {
-        assert!(supports_sync_with_base_url(&DriverId::AzureOpenAI));
-        assert!(supports_sync_with_base_url(&DriverId::OpenAI));
-        assert!(supports_sync_with_base_url(&DriverId::OpenRouter));
-        assert!(supports_sync_with_base_url(&DriverId::OpenAICompletions));
-        assert!(supports_sync_with_base_url(&DriverId::Mai));
-        assert!(!supports_sync_with_base_url(&DriverId::Anthropic));
     }
 
     #[test]

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -1,7 +1,8 @@
-// LLM Resolver service for resolving models with decrypted provider credentials
+// Model and provider resolver service.
 //
-// This service handles the resolution of LLM models with their provider credentials,
-// including API key decryption. Used by gRPC service for worker communication.
+// Model resolution returns credential-free identity. Provider configuration,
+// including decrypted credentials, is resolved independently by exact public
+// provider id for worker communication and non-chat services.
 //
 // Decision: In-process moka cache keyed on (org_id, model_id) with 1-hour TTL.
 // Providers/models change rarely but resolution is called per LLM request.
@@ -119,20 +120,15 @@ pub fn resolve_provider_api_key(
     Ok(None)
 }
 
-/// Resolved model with provider credentials (decrypted API key)
-///
-/// This is the service-layer representation of a model with its provider details.
-/// Used for internal communication (gRPC) where decrypted credentials are needed.
+/// Credential-free resolved model identity.
 #[derive(Debug, Clone)]
 pub struct ResolvedModel {
     /// The model identifier (e.g., "gpt-4", "claude-3-opus")
     pub model_id: String,
     /// Provider type (e.g., "openai", "anthropic")
     pub provider_type: String,
-    /// Decrypted API key (if available)
-    pub api_key: Option<String>,
-    /// Provider base URL override (if set)
-    pub base_url: Option<String>,
+    /// Public persisted provider identity; credentials resolve independently.
+    pub provider_id: String,
 }
 
 /// Resolved provider credentials for tool-side API clients.
@@ -189,7 +185,7 @@ impl ProviderResolverService {
         self
     }
 
-    /// Resolve a model by ID with decrypted provider credentials.
+    /// Resolve a model by ID without provider credentials or endpoint details.
     /// Results are cached per (org_id, model_id) with 1-hour TTL.
     pub async fn resolve_model(
         &self,
@@ -207,7 +203,7 @@ impl ProviderResolverService {
         Ok(result)
     }
 
-    /// Resolve the default model with decrypted provider credentials.
+    /// Resolve the default model without provider credentials or endpoint details.
     /// Cached under sentinel key (org_id, nil UUID).
     pub async fn resolve_default_model(&self, org_id: i64) -> Result<Option<ResolvedModel>> {
         let key = (org_id, DEFAULT_MODEL_SENTINEL);
@@ -427,13 +423,10 @@ impl ProviderResolverService {
             None => return Ok(None),
         };
 
-        let api_key = self.resolve_api_key(&provider_row)?;
-
         Ok(Some(ResolvedModel {
             model_id: model_row.model_id,
             provider_type: provider_row.provider_type.clone(),
-            api_key,
-            base_url: provider_row.base_url.clone(),
+            provider_id: provider_row.id.to_string(),
         }))
     }
 
@@ -456,13 +449,35 @@ impl ProviderResolverService {
             None => return Ok(None),
         };
 
-        let api_key = self.resolve_api_key(&provider_row)?;
-
         Ok(Some(ResolvedModel {
             model_id: model_row.model_id,
             provider_type: provider_row.provider_type.clone(),
-            api_key,
-            base_url: provider_row.base_url.clone(),
+            provider_id: provider_row.id.to_string(),
+        }))
+    }
+
+    /// Resolve one exact persisted provider for model execution.
+    pub async fn resolve_runtime_provider(
+        &self,
+        org_id: i64,
+        provider_id: &str,
+    ) -> Result<Option<ResolvedServiceProvider>> {
+        let id: ProviderId = provider_id
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid provider id"))?;
+        let Some(provider) = self.db.get_provider(org_id, id.uuid()).await? else {
+            return Ok(None);
+        };
+        let Some(api_key) = self.resolve_api_key(&provider)? else {
+            return Ok(None);
+        };
+        Ok(Some(ResolvedServiceProvider {
+            provider_type: provider.provider_type,
+            provider_id: provider.id.to_string(),
+            credentials: ResolvedProviderCredentials {
+                api_key,
+                base_url: provider.base_url,
+            },
         }))
     }
 
@@ -1171,6 +1186,29 @@ mod tests {
         .await
         .unwrap()
         .id
+    }
+
+    #[tokio::test]
+    async fn exact_runtime_provider_resolution_is_org_scoped() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        let provider = seed_active_provider(&db, &encryption, "openai").await;
+        let resolver = ProviderResolverService::new(db, Some(encryption));
+
+        let own = resolver
+            .resolve_runtime_provider(DEFAULT_ORG_ID, &provider.to_string())
+            .await
+            .unwrap();
+        assert!(own.is_some());
+
+        let cross_org = resolver
+            .resolve_runtime_provider(999, &provider.to_string())
+            .await
+            .unwrap();
+        assert!(
+            cross_org.is_none(),
+            "provider must not cross org boundaries"
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/storage/provider_store.rs
+++ b/crates/server/src/storage/provider_store.rs
@@ -69,21 +69,18 @@ impl ProviderStore for DbProviderStore {
             None => return Ok(None),
         };
 
-        // Decrypt the API key
-        let provider_with_key = self
-            .db
-            .get_provider_with_api_key(&provider_row, &self.encryption)
-            .store_err()?;
-
         // Parse provider type
-        let provider_type = parse_provider_type(&provider_with_key.provider_type)?;
+        let provider_type = parse_provider_type(&provider_row.provider_type)?;
 
         Ok(Some(ResolvedModel {
             model: model_row.model_id,
             provider_type,
-            api_key: provider_with_key.api_key,
-            base_url: provider_with_key.base_url,
-            provider_metadata: None,
+            api_key: None,
+            base_url: None,
+            provider_metadata: Some(everruns_core::ProviderMetadata {
+                extra: Some(serde_json::json!({ "provider_id": provider_row.id.to_string() })),
+                ..Default::default()
+            }),
         }))
     }
 
@@ -108,21 +105,46 @@ impl ProviderStore for DbProviderStore {
             None => return Ok(None),
         };
 
-        // Decrypt the API key
-        let provider_with_key = self
-            .db
-            .get_provider_with_api_key(&provider_row, &self.encryption)
-            .store_err()?;
-
         // Parse provider type
-        let provider_type = parse_provider_type(&provider_with_key.provider_type)?;
+        let provider_type = parse_provider_type(&provider_row.provider_type)?;
 
         Ok(Some(ResolvedModel {
             model: model_row.model_id,
             provider_type,
-            api_key: provider_with_key.api_key,
-            base_url: provider_with_key.base_url,
-            provider_metadata: None,
+            api_key: None,
+            base_url: None,
+            provider_metadata: Some(everruns_core::ProviderMetadata {
+                extra: Some(serde_json::json!({ "provider_id": provider_row.id.to_string() })),
+                ..Default::default()
+            }),
+        }))
+    }
+
+    async fn get_provider_config(
+        &self,
+        provider: &everruns_core::ProviderKey,
+    ) -> Result<Option<everruns_core::ProviderConfig>> {
+        let id: everruns_core::ProviderId = provider.as_str().parse().map_err(|_| {
+            AgentLoopError::Configuration(format!("invalid persisted provider id '{}'", provider))
+        })?;
+        let Some(row) = self
+            .db
+            .get_provider(self.org_id, id.uuid())
+            .await
+            .store_err()?
+        else {
+            return Ok(None);
+        };
+        let with_key = self
+            .db
+            .get_provider_with_api_key(&row, &self.encryption)
+            .store_err()?;
+        Ok(Some(everruns_core::ProviderConfig {
+            provider: provider.clone(),
+            provider_type: parse_provider_type(&with_key.provider_type)?,
+            api_key: with_key.api_key,
+            base_url: with_key.base_url,
+            metadata: everruns_core::ProviderMetadata::default(),
         }))
     }
 }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -326,6 +326,7 @@ impl GrpcClient {
         let request = proto::GetDefaultProviderCredentialsRequest {
             org_id,
             provider_type: provider_type.to_string(),
+            provider_id: String::new(),
         };
 
         let mut client = self.inner.lock().await;
@@ -342,6 +343,38 @@ impl GrpcClient {
         Ok(Some(ProviderCredentials {
             api_key: response.api_key,
             base_url: non_empty_string(response.base_url),
+        }))
+    }
+
+    pub async fn get_provider_config(
+        &self,
+        org_id: i64,
+        provider_id: &str,
+    ) -> Result<Option<everruns_core::ProviderConfig>> {
+        let request = proto::GetDefaultProviderCredentialsRequest {
+            org_id,
+            provider_type: String::new(),
+            provider_id: provider_id.to_string(),
+        };
+        let mut client = self.inner.lock().await;
+        let response = client
+            .get_default_provider_credentials(request)
+            .await
+            .map_err(grpc_status_to_error)?
+            .into_inner();
+        if !response.found {
+            return Ok(None);
+        }
+        let provider_type = response
+            .provider_type
+            .parse()
+            .unwrap_or_else(|_| unreachable!());
+        Ok(Some(everruns_core::ProviderConfig {
+            provider: everruns_core::ProviderKey::new(provider_id),
+            provider_type,
+            api_key: non_empty_string(response.api_key),
+            base_url: non_empty_string(response.base_url),
+            metadata: everruns_core::ProviderMetadata::default(),
         }))
     }
 
@@ -1683,6 +1716,15 @@ impl ProviderStore for GrpcOrgAdapter {
             None => Ok(None),
         }
     }
+
+    async fn get_provider_config(
+        &self,
+        provider: &everruns_core::ProviderKey,
+    ) -> Result<Option<everruns_core::ProviderConfig>> {
+        self.client
+            .get_provider_config(self.org_id, provider.as_str())
+            .await
+    }
 }
 
 #[async_trait]
@@ -1735,9 +1777,12 @@ fn proto_model_with_provider_to_model(proto: proto::ResolvedModel) -> Result<Res
     Ok(ResolvedModel {
         model: proto.model,
         provider_type,
-        api_key: proto.api_key.filter(|s| !s.is_empty()),
-        base_url: proto.base_url.filter(|s| !s.is_empty()),
-        provider_metadata: None,
+        api_key: None,
+        base_url: None,
+        provider_metadata: Some(everruns_core::ProviderMetadata {
+            extra: Some(serde_json::json!({ "provider_id": proto.provider_id })),
+            ..Default::default()
+        }),
     })
 }
 
@@ -4363,6 +4408,21 @@ impl everruns_core::session_task::SessionTaskRegistry for GrpcAdapter {
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    #[test]
+    fn resolved_model_proto_conversion_is_credential_free() {
+        let resolved = proto_model_with_provider_to_model(proto::ResolvedModel {
+            model: "custom-model".into(),
+            provider_id: "provider-123".into(),
+            provider_type: "custom-protocol".into(),
+        })
+        .unwrap();
+
+        assert_eq!(resolved.model, "custom-model");
+        assert_eq!(resolved.provider_key().as_str(), "provider-123");
+        assert!(resolved.api_key.is_none());
+        assert!(resolved.base_url.is_none());
+    }
 
     #[test]
     fn test_proto_harness_to_harness_preserves_metadata() {

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -214,6 +214,16 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         everruns_core::traits::ProviderStore::get_default_model(&store).await
     }
 
+    async fn get_provider_config(
+        &self,
+        org_id: i64,
+        provider: &everruns_core::ProviderKey,
+    ) -> Result<Option<everruns_core::ProviderConfig>> {
+        self.client
+            .get_provider_config(org_id, provider.as_str())
+            .await
+    }
+
     // =========================================================================
     // Image Resolution Operations
     // =========================================================================

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -2040,6 +2040,13 @@ mod tests {
             ) -> CoreResult<Option<everruns_core::traits::ResolvedModel>> {
                 unimplemented!()
             }
+            async fn get_provider_config(
+                &self,
+                _org_id: i64,
+                _provider: &everruns_core::ProviderKey,
+            ) -> CoreResult<Option<everruns_core::ProviderConfig>> {
+                unimplemented!()
+            }
             async fn resolve_image(
                 &self,
                 _org_id: i64,

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -116,6 +116,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     /// Get default model configuration
     async fn get_default_model(&self, org_id: i64) -> Result<Option<ResolvedModel>>;
 
+    async fn get_provider_config(
+        &self,
+        org_id: i64,
+        provider: &everruns_core::ProviderKey,
+    ) -> Result<Option<everruns_core::ProviderConfig>>;
+
     // =========================================================================
     // Image Resolution Operations
     // =========================================================================
@@ -610,6 +616,15 @@ impl<A: WorkerAdapters> everruns_core::traits::ProviderStore for OrgAdapter<A> {
 
     async fn get_default_model(&self) -> Result<Option<ResolvedModel>> {
         self.adapters.get_default_model(self.org_id).await
+    }
+
+    async fn get_provider_config(
+        &self,
+        provider: &everruns_core::ProviderKey,
+    ) -> Result<Option<everruns_core::ProviderConfig>> {
+        self.adapters
+            .get_provider_config(self.org_id, provider)
+            .await
     }
 }
 

--- a/knowledge/foundations/llm-drivers.md
+++ b/knowledge/foundations/llm-drivers.md
@@ -10,15 +10,16 @@ tags:
 
 > **Domain model note:** the canonical provider domain model (drivers, services,
 > providers, models, model profiles) is [providers.md](providers.md). That
-> refactor is in progress: the driver trait is now `ChatDriver` (it implements
-> the chat service of a provider). As later phases land, the entity/resolution
-> content will move out of this document, leaving this spec as the chat-service
-> wire contract (streaming, error types, retries, thinking, prompt cache,
-> compaction).
+> `ChatDriver` is the chat wire-protocol contract. Service identity, endpoint,
+> headers, and authentication belong to runtime providers as specified in
+> [providers.md](providers.md).
 
 ## Abstract
 
-LLM drivers provide a provider-agnostic interface for interacting with Large Language Model APIs. The driver abstraction enables dependency inversion - provider implementations (OpenAI, Anthropic) register their drivers at startup, while core business logic operates against the trait interface.
+LLM drivers implement reusable wire protocols. Runtime providers bind those
+drivers to concrete services. Core business logic resolves a credential-free
+model specification and runtime provider independently, then passes the
+provider-owned endpoint into the protocol driver.
 
 ## Architecture
 
@@ -26,7 +27,7 @@ LLM drivers provide a provider-agnostic interface for interacting with Large Lan
 graph TD
     subgraph Provider [everruns-provider]
         ChatDriver[ChatDriver Trait]
-        Registry[DriverRegistry]
+        Registry[ProviderRegistry]
         Errors[AgentLoopError]
     end
 
@@ -44,13 +45,13 @@ graph TD
         ReasonAtom[ReasonAtom]
     end
 
-    OpenAI -->|implements| ChatDriver
-    Anthropic -->|implements| ChatDriver
-    Gemini -->|implements| ChatDriver
-    OpenAI -->|registers| Registry
-    Anthropic -->|registers| Registry
-    Gemini -->|registers| Registry
-    ReasonAtom -->|uses| Registry
+    OpenAI -->|assembles provider over| ChatDriver
+    Anthropic -->|assembles provider over| ChatDriver
+    Gemini -->|assembles provider over| ChatDriver
+    OpenAI -->|registers provider| Registry
+    Anthropic -->|registers provider| Registry
+    Gemini -->|registers provider| Registry
+    ReasonAtom -->|resolves provider from| Registry
     OpenAI -->|outbound HTTP| Egress
     Anthropic -->|outbound HTTP| Egress
     Gemini -->|outbound HTTP| Egress
@@ -65,7 +66,9 @@ graph TD
 
 2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error). In-band provider failures use `LlmStreamError` so stable provider code and HTTP status survive the driver boundary.
 
-3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `Bedrock` (AWS Bedrock ConverseStream), `Mai` (Microsoft MAI via Azure AI Foundry, OpenAI-compatible Chat Completions), `Fireworks` (Fireworks AI open models, OpenAI-compatible Chat Completions), `Meta` (Muse models via Meta Model API, OpenAI-compatible Responses), `LlmSim` (testing).
+3. **Provider independence**: the trait contains no service/vendor identity,
+   default hostname, or credential. The same driver instance may serve multiple
+   provider keys with different endpoints, headers, and auth.
 
 ### Error Types (Contract)
 
@@ -87,23 +90,27 @@ Each driver MUST implement provider-specific error detection to classify context
 - `crates/anthropic/src/` — Anthropic error detection
 - `crates/gemini/src/` — Gemini error detection
 
-### Driver Registry
+### Provider registry and 0.17 compatibility catalog
 
-Provider crates register a `DriverDescriptor` at startup: driver id, display
-name, declared `ServiceKind`s (see `knowledge/foundations/providers.md`), a credential form
-schema, and per-service factories (chat today). Chat drivers are created
-on-demand from `ProviderConfig`. All real built-in providers require API keys;
-`LlmSim` and `External` drivers are exempted (external drivers may authenticate
-via `ProviderMetadata`). See `crates/provider/src/driver_registry.rs` for
-`DriverRegistry` and `DriverDescriptor`.
+Applications register concrete runtime providers in `ProviderRegistry`, keyed
+by open `ProviderKey`. Official integration crates expose ready-made provider
+assemblies; downstream code may construct the same public `Provider` directly.
+
+`DriverDescriptor`/`DriverRegistry` remain in `0.17.x` as the hosted
+provider-management catalog and the compatibility surface for
+`everruns-runtime`. Descriptor factories compose runtime providers and route
+into the same registry/execution path; they are not a second driver semantics
+layer.
 
 ### Host-Owned Transport
 
-Provider drivers and model discovery use direct provider HTTP clients. They are
+Protocol drivers and model discovery use direct provider HTTP clients. They are
 host-owned platform services: provider endpoints and credentials come from
 deployment/org provider configuration, not from agent-authored URLs or
-tenant/agent egress policy. Drivers still own provider-specific request
-construction, streaming parse logic, retry classification, and error mapping.
+tenant/agent egress policy. Runtime providers own endpoint, auth, and service
+headers. Drivers own protocol request construction, streaming parse logic,
+retry classification, and error mapping. Shared clients disable redirects and
+pin DNS only after private-range validation.
 
 ### Message Types
 
@@ -396,7 +403,7 @@ capabilities by matching the id at sync time (the OpenAI/Azure OpenAI pattern).
 Rich capability metadata lives only in the separate Foundry model *catalog* API
 (different host/auth, reflects the catalog not the deployment) and cost is never
 provider-reported, so neither is used for profiling. The discovery request is
-authenticated with the same `AuthHeaderProvider` as chat (so it works for both
+authenticated with the same runtime `ProviderAuth` as chat (so it works for both
 api-key and OAuth) and is gated to recognized Foundry hosts
 (`*.services.ai.azure.com` / `*.openai.azure.com`); custom proxy URLs return
 `None`. Project-scoped Foundry endpoints (`.../api/projects/<project>`) expose
@@ -423,22 +430,17 @@ preserved (a stored credential is still required; nothing falls back to env).
 Existing rows that stored OAuth as a JSON document keep resolving, since that
 document parses into the same typed fields.
 
-### Pluggable Authentication (`AuthHeaderProvider`)
+### Provider-owned authentication
 
-Authentication is the reason MAI gets its own crate rather than reusing the
-Azure OpenAI driver: MAI deployments accept either an Azure AI Foundry **API
-key** (`api-key` header) or a Microsoft **Entra ID (OAuth)** bearer token. Both
-the Chat Completions and Open Responses protocol drivers expose the same
-generic, async `AuthHeaderProvider` hook
-(`OpenAIProtocolChatDriver::with_auth_provider` and
-`OpenResponsesProtocolChatDriver::with_auth_provider`); the trait is exported
-from one stable place (`everruns_core::AuthHeaderProvider`, defined in
-`crates/provider/src/openai_protocol.rs`). When set, it overrides the default
-host-keyed `api-key`/bearer logic and is awaited once per HTTP attempt — for the
-Open Responses driver this includes the streaming `/responses` call, every retry
-attempt, and the `/responses/compact` call — so providers can refresh short-lived
-tokens transparently. When unset, both drivers fall back to the identical static
-`api_key` behavior (Azure → `api-key`, otherwise `Authorization: Bearer`).
+MAI deployments accept either an Azure AI Foundry **API key** (`api-key`
+header) or a Microsoft **Entra ID (OAuth)** bearer token. Both are runtime
+`ProviderAuth` implementations attached to a provider over the reusable Chat
+Completions protocol. `ProviderAuth::headers` is async and receives the method,
+URL, service headers, and exact serialized body on every HTTP attempt. This
+supports refreshable OAuth and body-aware signing without teaching a protocol
+driver about service identity. Bedrock keeps the AWS SDK client in
+provider-owned `BedrockAuth`, preserving SDK SigV4 signing and event-stream
+framing.
 
 The four request seams are deliberately separate and compose as follows:
 
@@ -446,8 +448,8 @@ The four request seams are deliberately separate and compose as follows:
   `crates/core/src/credential_provider.rs`) resolves a *static*
   `ProviderCredentials` (`api_key`, `base_url`) **before** the driver is built.
   It cannot mint or refresh request-time tokens.
-- **Request auth** (`AuthHeaderProvider`) runs **per HTTP attempt** and owns the
-  single authentication header. This is the seam for refreshable OAuth.
+- **Request auth** (`ProviderAuth`) runs **per HTTP attempt** and may return
+  multiple headers. This is the seam for static, refreshable, and signed auth.
 - **Request decoration** (`OpenResponsesRequestExtension`, Open Responses only)
   layers provider-specific *non-auth* body fields and headers (routing,
   attribution, `session_id`, `OpenAI-Beta`, `originator`, account ids). It must
@@ -469,7 +471,7 @@ The MAI crate ships two providers built on that hook:
 present is a fail-closed configuration error. Because OAuth needs no `api_key`,
 `DriverId::Mai` is exempt from the registry's mandatory-api-key check (like
 `External`). New schemes (managed identity, workload identity federation) are
-additive: implement `AuthHeaderProvider` without touching the driver.
+additive: implement `ProviderAuth` without touching the protocol driver.
 
 ### Model Discovery and Capability Profiles
 
@@ -609,11 +611,16 @@ Invariant: **a request with `previous_response_id` only carries delta items in `
 
 `OpenResponsesProtocolChatDriver` enforces this by trimming `input` via `compute_delta_input_items` whenever `previous_response_id` is `Some(_)` (see `crates/provider/src/openresponses_protocol.rs`).
 
-### Stateless Gateways
+### Provider-declared statefulness
 
 Server-side continuation only works where the endpoint actually stores responses. OpenAI-compatible gateways that expose a stateless `/responses` shim — e.g. OpenRouter and Google Gemini's compat endpoint — *accept* `previous_response_id` but silently ignore it (`store: false`). Chaining against them drops the conversation from turn 2 onward (only the latest tool output reaches the model), so the agent loses the task and loops on exploration.
 
-The driver therefore gates continuation on the endpoint: only `api.openai.com` and Azure OpenAI hosts (`endpoint_persists_responses`) are treated as stateful. For any other base URL the driver drops `previous_response_id` and replays the **full** transcript in `input` each turn. The full transcript is always available because the runtime reconstructs it from stored messages on every turn; delta trimming is purely a token-saving optimization for genuinely stateful endpoints.
+Statefulness is service semantics, not a hostname property. The provider
+assembly explicitly enables it for OpenAI, Azure OpenAI, and Meta. Stateless
+assemblies such as OpenRouter leave it disabled, so the driver drops
+`previous_response_id` and replays the **full** transcript. Custom services opt
+in only when their endpoint actually persists Responses state. No protocol
+driver contains a host-based service dispatch.
 
 ## Automatic Retry for Transient Errors
 
@@ -755,7 +762,7 @@ useful headroom instead of accepting any merely smaller response.
 ## Key Resolution Contract (Fail-Closed)
 
 This section is the single source of truth for **where provider credentials may
-come from**. Read it before touching any driver constructor, `DriverConfig`
+come from**. Read it before touching any provider assembly, `DriverConfig`
 builder, provider store, or resolver. Violating it can silently fund tenant
 execution from platform credentials — a cost-runaway and trust boundary
 incident, not a cosmetic bug.
@@ -767,7 +774,8 @@ incident, not a cosmetic bug.
 > in any `crates/openai`, `crates/anthropic`, `crates/gemini`,
 > `crates/openrouter`, `crates/bedrock`, `crates/mai`, or the protocol drivers in
 > `crates/core` (`openai_protocol.rs`, `openresponses_protocol.rs`). Credentials
-> only ever arrive through a constructor argument or a `DriverConfig`.
+> only ever arrive through a runtime provider assembly or a `DriverConfig`
+> compatibility/catalog adapter.
 >
 > Scope: this bans reading *credentials* from env, not all environment access. A
 > driver may still read a non-credential tuning knob from env (e.g.
@@ -790,7 +798,7 @@ path must be one of them; there is no third option and no fallback between them.
    resolve_provider_api_key()                  caller injects a CredentialProvider
    (encrypted DB, fail-closed)                 (EnvCredentialProvider for env vars)
               │                                           │
-        DriverConfig ─────────────► driver constructor ◄──────── DriverConfig
+        DriverConfig ─────────────► runtime Provider ◄──────── Provider assembly
               (no env reads anywhere on either path)
 ```
 
@@ -855,8 +863,8 @@ into the DB, never read by a driver.
 
 **Do**
 
-- Pass credentials into a driver via its constructor (`new`, `with_base_url`) or a
-  `DriverConfig`.
+- Attach credentials/auth and the endpoint to a runtime `Provider`; protocol
+  driver constructors remain credential-free.
 - In a standalone/dev/CLI entrypoint, construct `EnvCredentialProvider` (or any
   other `CredentialProvider`) and inject it.
 - Add a new env var mapping for an existing driver in `EnvCredentialProvider` —

--- a/knowledge/foundations/models.md
+++ b/knowledge/foundations/models.md
@@ -267,6 +267,20 @@ Key design points:
 - Organization default model: stored in `organization_settings.default_model_id` (not on the model itself). Auto-elects a new default from enabled models if the current default is disabled or deleted.
 - Stale model detection: `last_seen_at < provider.last_synced_at` means model no longer returned by provider API. Stale models kept (not deleted) to preserve customizations.
 
+### Execution Model Specification
+
+`ModelSpec` is the canonical execution-facing model configuration. It contains
+an open normalized provider key, the provider-visible model name, and optional
+non-secret metadata. It never contains credentials, a base URL, authentication
+metadata, or a protocol/vendor enum, so it is safe to serialize, persist, emit,
+and print with derived `Debug`.
+
+Persisted model rows resolve to a `ModelSpec`; the exact provider record resolves
+independently into a non-serializable runtime `Provider`. For the `0.17.x`
+patch, the public `everruns-runtime::ResolvedModel` input remains available as a
+transitional adapter and is converted immediately into these canonical parts.
+The high-level `everruns` facade accepts only `ModelSpec` plus runtime providers.
+
 ### LLM Model Profile
 
 Read-only metadata describing model capabilities, costs, and limits. Computed at runtime (not stored in database).

--- a/knowledge/foundations/providers.md
+++ b/knowledge/foundations/providers.md
@@ -10,9 +10,13 @@ tags:
 
 ## Abstract
 
-Providers are org-scoped accounts on AI service vendors (OpenAI, Anthropic, AWS Bedrock, OpenRouter, Azure OpenAI). A provider is configured once with credentials and connection settings, then powers one or more **services**: chat completion today; embeddings, realtime voice, images, and reranking as they land.
+Providers are configured AI services. The control plane persists org-scoped
+provider records; execution composes each record into a non-serializable runtime
+`Provider` containing its open identity, endpoint, headers, authentication, and
+wire-protocol driver. Models name that provider through a credential-free
+`ModelSpec`.
 
-This spec replaces the "LLM providers" framing. The old name was wrong in a specific way: the database row was already a generic vendor account, but the code layer hard-wired it to exactly one service (chat completion), so every non-chat consumer grew a bypass. This is the canonical **target** domain model; implementation lands in the phases below. **There is no backward compatibility requirement**: old names (`llm_providers`, `llm_models`, `LlmProvider`, `provider_type`, `/v1/llm-providers`) will be removed everywhere — schema, code, API, UI, docs, and tests — as the refactor phases land, per the inventory below.
+This spec replaces the "LLM providers" framing. The old name was wrong in a specific way: the database row was already a generic vendor account, but the code layer hard-wired it to exactly one service (chat completion), so every non-chat consumer grew a bypass. The runtime provider model is canonical in `0.17.x`; persisted HTTP shapes and the published `everruns-runtime` model/driver setup remain compatible at the boundary and adapt into it. Removing that compatibility surface or preparing a `0.18.0` cutover is outside this contract.
 
 ## Motivation
 
@@ -29,37 +33,64 @@ Evidence the old model was straining:
 
 ```mermaid
 graph LR
-    Driver["Driver (code)"] -->|instantiated as| Provider["Provider (org instance)"]
-    Provider -->|serves| Model["Model (model via provider)"]
-    Profile["Model Profile (identity)"] -->|describes| Model
-    Driver -->|declares| Service["Services: chat, embeddings, realtime, ..."]
-
-    Binding["Session / Agent / Router candidate"] -->|references| Model
+    Record["Provider record (org configuration)"] -->|composed at host boundary| Provider["Runtime Provider"]
+    Driver["Protocol driver (wire only)"] --> Provider
+    Provider -->|selected by open provider key| Spec["ModelSpec"]
+    Spec -->|model name| Model["Provider model"]
+    Profile["Model Profile (capabilities)"] -->|describes| Model
+    Provider -->|offers| Service["Services: chat, embeddings, realtime, ..."]
 
     classDef code fill:#ffd6a5,stroke:#e07b39,color:#5a3000
     classDef org fill:#c7f0db,stroke:#2d6a4f,color:#1b4332
     classDef catalog fill:#bde0fe,stroke:#3a86a8,color:#023047
 
     class Driver,Service code
-    class Provider,Model,Binding org
+    class Record,Model org
+    class Provider,Spec code
     class Profile catalog
 ```
 
 | Entity | Scope | Meaning |
 |---|---|---|
-| **Driver** | Code | Technical implementation of a vendor API shape. Declares a credential schema, the set of services it supports, per-service client factories, and model discovery. Registered in `DriverRegistry`. |
+| **Protocol driver** | Code | Reusable wire implementation: request shape, endpoint path, mandated protocol headers, response/stream decoding, retries, and error classification. It has no service identity, hostname, or credentials. |
 | **Service** | Code | A typed capability a driver exposes: `chat`, `embeddings`, `realtime`, `images`, `rerank`, ... Only `chat` is implemented today; the set is additive. |
-| **Provider** | Org | A configured instance of a driver: name, credentials, endpoint/zone, settings, status. Many providers may use the same driver (e.g. Azure OpenAI in two regions). |
+| **Provider record** | Org | Persisted management entity: name, integration kind, encrypted credentials, endpoint/zone, settings, and status. Public HTTP/serde shapes stay stable. |
+| **Runtime Provider** | Process | Open provider identity plus endpoint, service headers, async auth, and a protocol driver. Never serializable; debug output redacts values. Many instances may reuse one driver. |
+| **ModelSpec** | Configuration | Credential-free provider key + model name. Safe to persist, serialize, include in events, and debug. |
 | **Model** | Org | A specific model via a specific provider: provider FK + wire model id + operational flags. The unit that bindings reference. |
 | **Model Profile** | Global | The model's identity and metadata: stable key, vendor, service kind, capabilities, limits, pricing. One profile describes N models (one per provider serving it). |
 
 Connectors are the user-scoped sibling concept (see "Providers vs Connections" below): **Connector (code) → Connection (user instance)** mirrors **Driver (code) → Provider (org instance)**.
 
-### Driver
+### Protocol driver and runtime provider
 
-A driver is a code unit registered in `DriverRegistry`, keyed by a **driver id** (`openai`, `azure_openai`, `openai_completions`, `openrouter`, `anthropic`, `gemini`, `bedrock`, `mai`, `fireworks`, `meta`, `llmsim`). Ids are open, not a closed set: built-in drivers are compiled-in enum variants, and embedder-defined drivers register arbitrary ids via `ProviderType::External` (`register_external`, landed in EVE-561) through `PlatformDefinition` — an embedder adds a vendor without patching core. The database stores the id as a plain string; unknown ids parse to `External` rather than erroring.
+`ChatDriver` is a wire protocol. Each request receives a `ProviderEndpoint`; the
+driver appends its protocol path, serializes the exact body, asks the provider
+to resolve headers/auth for that attempt, and decodes the wire response. It does
+not select a vendor, own a default host, store credentials, or infer service
+semantics from a hostname.
 
-The `mai` driver (`everruns-mai`) is a publishable example of a first-party built-in driver layered on a generic protocol: Microsoft MAI models (e.g. `mai-code-1-flash`) are served via Azure AI Foundry behind an OpenAI-compatible Chat Completions API, so the driver wraps `OpenAIProtocolChatDriver` and supplies authentication through the generic `AuthHeaderProvider` hook (see [llm-drivers.md](llm-drivers.md)). It is the only built-in driver besides `llmsim`/`External` that does not require an `api_key` at the registry layer, because it can authenticate via Microsoft Entra ID (OAuth) credentials supplied as first-class credential fields (or, on the embedder path, carried in `ProviderMetadata`).
+`ProviderKey` is an open normalized string. `ProviderRegistry` maps those keys
+to runtime providers. Duplicate registration is an error; tests and host
+overrides use the explicit replace operation. `ModelSpec::on(provider, model)`
+resolves the provider independently and reports the requested key plus sorted
+registered keys when missing. Thus two service identities can share one
+protocol driver while differing in endpoint, auth, and headers, and downstream
+code adds either a service or a new protocol without a central enum edit.
+
+`DriverId`, `DriverDescriptor`, and `DriverRegistry` remain in `0.17.x` for the
+published `everruns-runtime` and hosted provider-management integration. They
+are a compatibility/catalog adapter: descriptor factories compose the same
+runtime `Provider`, and execution checks direct runtime providers first. They
+must not acquire an independent resolution or execution algorithm. The
+high-level `everruns` facade accepts only `ModelSpec` and runtime `Provider`.
+
+The `mai` integration is a first-party example layered on a generic protocol:
+Microsoft MAI uses the OpenAI-compatible Chat Completions driver while its
+runtime provider owns either static `api-key` auth or refreshable Microsoft
+Entra auth. Bedrock uses the same provider boundary while retaining the AWS SDK
+client in provider-owned auth so ConverseStream framing and SigV4 signing remain
+unchanged.
 
 The `meta` driver (`everruns-meta`) wraps `OpenResponsesProtocolChatDriver` for Meta Model API at `api.meta.ai`. It uses Meta's stateful Responses API, bearer API-key authentication, and host-gated `/models` discovery. Muse profiles keep the Standard and Contributor data-use/pricing tiers distinct.
 
@@ -185,7 +216,21 @@ Profile matching heuristics (version normalization, slug mapping) run at **sync/
 
 ### Model-bound resolution (chat)
 
-Unchanged in shape: binding → model row → provider row → decrypt credentials → driver chat factory. The **fail-closed key resolution contract** in [llm-drivers.md](llm-drivers.md) (database-only in tenant paths, no env fallback, startup materialization rules, the `resolve_provider_api_key_env_key_set_does_not_leak` invariant) carries over verbatim with `credentials_encrypted` in place of `api_key_encrypted`. The resolver service is renamed `LlmResolverService` → `ProviderResolverService`.
+Resolution has two independent results:
+
+1. binding → persisted model row → credential-free `ModelSpec` (provider public
+   identity + wire model name);
+2. exact org/provider identity → provider record → decrypt credentials → compose
+   runtime `Provider` with the registered protocol implementation.
+
+The worker model DTO carries only the model and provider identities. It fetches
+provider configuration through the authenticated internal provider RPC, scoped
+by the turn's org and exact provider id, then executes through the same runtime
+provider registry used in-process. Credentials never ride in model DTOs.
+
+The **fail-closed key resolution contract** in
+[llm-drivers.md](llm-drivers.md) remains unchanged: tenant paths use database
+credentials only and never fall through to environment values.
 
 ### Service-bound resolution (non-chat)
 
@@ -304,25 +349,31 @@ PR-sized slices, each leaving the tree green and self-consistent (code + specs +
 
 | Question | Decision | Rationale |
 |---|---|---|
-| Rename registry to ProviderRegistry? | No — stays `DriverRegistry` | A driver is the technical implementation; a provider is an instance using it. Many providers per driver (Azure zones). |
-| Registry key: enum or string? | Open driver ids: built-in enum variants + `External(Arc<str>)` for embedder ids (EVE-561) | Embedder-extensible via `PlatformDefinition`; DB stores the id as a plain string; unknown ids parse to `External`. |
+| Runtime registry? | `ProviderRegistry` | Execution selects configured service instances; the `DriverRegistry` name remains only on the `0.17.x` compatibility/catalog adapter. |
+| Registry key: enum or string? | Open normalized string | Provider and driver ids accept downstream values without a central enum edit; built-in associated constants are conveniences only. |
 | Where do services live? | Declared by the driver in code | DB storage would drift from what the code can actually do. |
 | Separate join entity between model and provider? | No | A model *is* "a specific model via a specific provider" — the join. `(provider_id, model_id)` is unique; "model X via provider Y" needs no third noun. |
 | What do bindings reference? | Concrete models | Explicit and predictable; no hidden provider selection per call. Cross-provider failover is a Model Router concern (candidates sharing a profile). |
 | Model identity layer? | Promote Model Profile | It already existed as a runtime-computed shadow; promotion (stable public key, stored assignment) beats inventing a new entity. |
 | Merge providers and connections? | No | Different scope, trust model, and resolution path; share only the credential descriptor plumbing. |
 | Utility LLM through providers? | No | Deliberate system-owned exception (`knowledge/operations/utility-llm.md` non-goals). |
-| Backward compatibility? | None | Pre-1.0 internal domain; renames are clean cuts. Migrations preserve data, not names. |
+| `0.17.x` runtime compatibility? | Adapter only | Existing `ResolvedModel`/descriptor inputs remain public, but convert before execution into the same `ModelSpec` and runtime-provider registry path. No independent legacy semantics remain. |
 
 ## Source Index
 
 The refactor has landed; current implementations live at:
 
 - `crates/provider/src/provider.rs` — `Provider` entity + `DriverId`
+- `crates/provider/src/runtime_provider.rs` — runtime `Provider`, open
+  `ProviderKey`, async/body-aware auth, endpoint redaction, and
+  `ProviderRegistry`
+- `crates/provider/src/model_spec.rs` — credential-free execution model
+  selection
 - `crates/provider/src/model.rs` — `Model` / `ModelWithProvider` entity types
 - `crates/provider/src/model_profiles.rs` — built-in profile data
 - `crates/provider/src/model_discovery.rs` — host-side catalog presentation: driver `list_models` plus the OpenAI-compatible `GET <base>/models` fallback for endpoints the drivers decline, profile enrichment, and picker ranking (ported from yolop, which had reimplemented all of it), plus `search_provider_models` — a substring search across several providers' catalogs at once, returning provider-qualified exact ids. Partial results are the contract: a provider with no catalog is skipped, one that errors is reported in `provider_errors`, and the rest still return matches
-- `crates/provider/src/driver_registry.rs` — `ChatDriver` trait + `DriverRegistry` (string-keyed driver ids, credential schema + service factories); `DriverConfig` typed `credentials` map
+- `crates/provider/src/driver_registry.rs` — wire-only `ChatDriver`; transitional
+  `0.17.x` descriptor/catalog adapter and typed credential configuration
 - `crates/provider/src/credential_schema.rs` — declared credential form schema (typed fields, groups, validation) + credential-document assemble/parse
 - `crates/core/src/traits.rs` — `ProviderStore` + `ResolvedModel`
 - `crates/server/src/services/provider_resolver.rs` — fail-closed resolution (`resolve_service`)

--- a/knowledge/foundations/runtime.md
+++ b/knowledge/foundations/runtime.md
@@ -59,10 +59,10 @@ The builder must allow an embedder to:
 
 - Replace the `PlatformDefinition`
 - Register extra capabilities
-- Register or replace LLM drivers
+- Register or replace runtime providers over protocol drivers
 - Seed harnesses, agents, and sessions
 - Seed workspace files
-- Configure a default model
+- Configure a credential-free default `ModelSpec`
 - Optionally register `llmsim` for deterministic local examples and tests
 - Swap the default in-memory stores for custom backends via `RuntimeBackends`
 
@@ -384,10 +384,26 @@ backends.
 
 ## Model Resolution
 
-The runtime requires a default model. It may come from:
+The runtime requires a default model and resolves it through the canonical
+`ModelSpec` + runtime `Provider` path. New embedders use:
+
+- `InProcessRuntimeBuilder::provider(...)`
+- `InProcessRuntimeBuilder::model_spec(...)`
+
+Provider identity is an open string. The provider owns endpoint, headers,
+async authentication, and its protocol driver; the model remains
+credential-free.
+
+For the next `0.17.x` patch, these existing entry points remain compatibility
+inputs:
 
 - explicit `InProcessRuntimeBuilder::default_model(...)`
 - helper configuration like `InProcessRuntimeBuilder::llm_sim(...)`
+
+They convert into the same direct provider registry and execution path before a
+turn runs. They do not retain a separate provider resolution algorithm or
+driver semantics. This compatibility surface is transitional; removing
+`everruns-runtime` or preparing the `0.18.0` cutover is outside this contract.
 
 If no default model is available at build time, `build()` must fail with a
 configuration error.

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -614,7 +614,7 @@ never treated as permission to bypass the egress boundary.
 | TM-LLM-001 | API key at rest exposure | Critical | Encrypted via envelope encryption (AES-256-GCM); stored in `llm_providers.api_key_encrypted` | MITIGATED |
 | TM-LLM-002 | API key in logs | High | Never logged; tracing filters sensitive fields; generic error messages only | MITIGATED |
 | TM-LLM-003 | API key in error messages | High | Provider errors are sanitized before returning to users; full errors remain server-side. Agent Analyze responses and persisted health-check terminal errors use the shared user-facing provider taxonomy, which preserves actionable failure categories without copying raw provider bodies. Invalid tool-schema rejections expose only a stable category and bounded schema path in standard mode; raw provider text remains restricted to operator-enabled detailed disclosure. | MITIGATED |
-| TM-LLM-004 | API key lifetime in memory | Medium | Decrypted per-request; key dropped after LLM call completes | MITIGATED |
+| TM-LLM-004 | API key lifetime in memory | Medium | Decrypted only at the org-scoped provider composition boundary and held in a non-serializable runtime provider for its bounded execution lifetime; model DTOs/events never carry it; provider/request `Debug` redacts values | MITIGATED |
 | TM-LLM-005 | Provider failure retry amplifies cost or hides permanent account errors | Medium | Provider-boundary semantic classification separates transient transport/stall/overload/rate-limit/server failures from credentials, billing quota, unavailable models, invalid requests, and long-horizon usage limits. Automatic recovery is allowed only before assistant output commits, uses jittered exponential backoff, and is bounded by shared attempt and elapsed-time budgets; lower layers report consumed retries so nested loops cannot multiply attempts. Permanent classes fail fast. | MITIGATED |
 | TM-LLM-006 | Provider MITM | High | HTTPS required for all LLM provider communication | MITIGATED |
 | TM-LLM-007 | Indirect prompt injection | High | Tool results and user messages are role-separated; no complete mitigation exists for LLM-level prompt injection | **ACCEPTED** |
@@ -636,17 +636,19 @@ never treated as permission to bypass the egress boundary.
 
 **TM-LLM-001 — Key Retrieval Flow:**
 ```
-Worker needs LLM key
-    → gRPC GetTurnContext (no key material in worker config)
-    → Control plane fetches llm_providers row
-    → EncryptionService.decrypt(api_key_encrypted)
-    → Key returned in gRPC response (in-memory only)
-    → Worker creates ChatDriver with key
+Worker resolves model and provider
+    → gRPC GetTurnContext returns credential-free model + provider identity
+    → authenticated provider RPC resolves that exact provider under the turn org
+    → control plane decrypts the provider credential
+    → worker composes non-serializable runtime Provider over protocol driver
+    → ProviderAuth resolves headers/signing per request attempt
     → LLM API call over HTTPS
-    → Key dropped when driver goes out of scope
+    → provider dropped with the bounded execution context
 ```
 
-Workers never have direct database access or encryption keys. Key material exists in worker memory only during the LLM call.
+Workers never have direct database access or encryption keys. Credentials do
+not enter model records, internal model DTOs, events, logs, or serializable
+runtime values.
 
 **TM-LLM-007 — Prompt Injection (ACCEPTED):**
 Indirect prompt injection via tool results or user messages is an inherent LLM limitation. Mitigations:


### PR DESCRIPTION
## What changed
Introduces the canonical credential-free ModelSpec and Provider architecture for model execution. Models name a provider and model; providers own service identity, endpoint, headers, refreshable or signed authentication, and protocol drivers; drivers now implement wire protocols only.

All bundled providers use the same registry and resolution path, including Azure, Anthropic, Gemini, OpenRouter, Fireworks, Meta, MAI, OpenAI, and Bedrock. Bedrock signing and the hosted control-plane provider lookup remain intact. everruns-runtime remains available for the 0.17.x line as a compatibility adapter that immediately converts legacy ResolvedModel configuration into the canonical provider path, without independent execution semantics.

A downstream custom protocol/provider integration test imports only everruns and executes without any central Everruns source edit.

## Why
EVE-856 identified that service-provider concerns were coupled to wire-protocol drivers and that model configuration carried credentials. This prevented open provider identities and downstream protocols, duplicated dispatch semantics, and made credential ownership unclear.

The shape follows the provider/model separation established by agentyk PR #46.

Fixes EVE-856.

## Before / After
Before: model resolution returned provider credentials and driver selection relied on centrally known provider types and OpenAI-style branches.

After: credential-free ModelSpec resolves a named Provider from an open registry. The Provider resolves request-specific auth from the exact method, URL, headers, and serialized body before each attempt, then delegates only wire behavior to its driver. Hosted workers receive credential-free model metadata and separately load the exact org-scoped provider record.

Evidence:
- Custom downstream provider test uses only the public everruns crate.
- Two providers can share one protocol-driver instance with different endpoints and auth.
- Rotating and body-aware auth are resolved per request.
- Hosted stack smoke: health 200, worker running, UI proxy 307.

## Risk
- High
- This changes the execution boundary used by every LLM provider, hosted model resolution, embeddings, retries, and the 0.17.x runtime compatibility surface.
- Mitigations: all bundled wire suites passed; provider, core, runtime, server, and worker suites passed; Bedrock signing and MAI static/Entra auth have focused coverage; the legacy API is tested as an adapter into the same registry.

## Security
- Threat categories reviewed: TM-LLM, TM-API, TM-TENANT, TM-AUTHZ, TM-DURABLE, TM-OBS, TM-CRYPTO.
- Trust boundaries reviewed: application-supplied provider configuration, org-scoped encrypted database records, authenticated worker control plane, and outbound provider endpoints.
- Data flow reviewed: credential-free model -> exact org/provider lookup -> decrypt provider config -> non-serializable Provider -> per-attempt auth -> wire protocol.
- Findings and resolutions:
  - Provider endpoints, auth, provider records, refresh metadata, and Bedrock credentials have redacted Debug implementations; credentials are absent from model/protobuf serialization.
  - Worker model protobuf fields formerly carrying credentials are reserved, preventing accidental field-number reuse.
  - Exact org plus provider-id lookup is covered against cross-org resolution.
  - Auth receives the exact serialized request body and overrides duplicate service headers case-insensitively.
  - Existing safe URL/client behavior, redirect policy, and Bedrock signing are preserved.
  - External DriverId input rejects empty or padded identifiers while retaining normalized open extension identifiers.
  - No new production dependencies or unsafe code were introduced.
- Accepted residual risk: custom base URLs are trusted application/provider configuration; legacy provider-type credential lookup remains only for non-model runtime tools during the 0.17.x compatibility window.

## Follow-ups
No follow-ups. Removing everruns-runtime and preparing the 0.18 cutover are explicitly outside this 0.17.x issue.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- TMPDIR=/private/tmp just pre-push
- cargo check --workspace --all-targets --all-features after rebasing onto v0.17.24
- Full provider/core/runtime/server/worker suites and bundled provider wire suites
- Workspace clippy with all targets/features and warnings denied
- just check-okf
- Publish packaging dry-runs for the affected public publish set
- Full just pre-pr passed formatting, clippy, UI checks/build, OpenAPI freshness, migrations, docs build/link checks, and all non-live Rust tests. Its only failure was the intentionally fail-closed Turbopuffer live test because TURBOPUFFER_API_KEY is not present in the development Doppler configuration.
