### PR TITLE
fix(security): resolve open Dependabot advisories in ui and docs

### DIFF
--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   fast-uri: 3.1.5
   form-data: 4.0.6
   lodash: 4.17.23
+  nanoid: 3.3.17
   postcss: 8.5.23
   yaml: 2.8.4
 
@@ -2031,8 +2032,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5119,7 +5120,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   neotraverse@1.0.1: {}
 
@@ -5229,7 +5230,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/apps/docs/pnpm-workspace.yaml
+++ b/apps/docs/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ overrides:
   fast-uri: 3.1.5
   form-data: 4.0.6
   lodash: 4.17.23
+  nanoid: 3.3.17
   postcss: 8.5.23
   yaml: 2.8.4
 onlyBuiltDependencies:
@@ -17,10 +18,13 @@ minimumReleaseAgeStrict: true
 # Security patches adopted before the maturity window (Dependabot GHSA fixes):
 # form-data 4.0.6 (GHSA-hmw2-7cc7-3qxx), esbuild 0.28.1 (GHSA-g7r4-m6w7-qqqr),
 # fast-uri 3.1.5 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6; only
-# patched release, still inside the 7-day window). Exact-pinned via overrides.
+# patched release, still inside the 7-day window), nanoid 3.3.17 (custom
+# generators loop indefinitely at size 0; reached via postcss, still inside the
+# window). Exact-pinned via overrides.
 minimumReleaseAgeExclude:
   - form-data
   - esbuild
   - fast-uri
+  - nanoid
 allowBuilds:
   esbuild: true

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -8,9 +8,11 @@ overrides:
   '@babel/core': 7.29.6
   brace-expansion@1: 1.1.18
   brace-expansion@2: 2.1.4
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   fast-uri: 3.1.5
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
+  mermaid: 11.16.1
+  nanoid: 3.3.17
   postcss: 8.5.23
   prismjs: 1.30.0
   sharp: 0.35.3
@@ -730,8 +732,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@mermaid-js/parser@1.1.1':
-    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -2665,8 +2667,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3158,8 +3160,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -3430,8 +3432,8 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3570,8 +3572,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4913,7 +4915,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -5126,7 +5128,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mermaid-js/parser@1.1.1':
+  '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
 
@@ -5874,7 +5876,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -5981,7 +5983,7 @@ snapshots:
 
   '@streamdown/mermaid@1.0.2(react@19.2.7)':
     dependencies:
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.7
 
   '@swc/helpers@0.5.15':
@@ -6908,7 +6910,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7634,7 +7636,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7990,11 +7992,11 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  mermaid@11.15.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.3
-      '@mermaid-js/parser': 1.1.1
+      '@mermaid-js/parser': 1.2.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.4
@@ -8004,7 +8006,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0
@@ -8315,7 +8317,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8529,7 +8531,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8956,7 +8958,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.6
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       rehype-harden: 1.1.8

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -3,9 +3,11 @@ overrides:
   '@babel/core': 7.29.6
   brace-expansion@1: 1.1.18
   brace-expansion@2: 2.1.4
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   fast-uri: 3.1.5
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
+  mermaid: 11.16.1
+  nanoid: 3.3.17
   postcss: 8.5.23
   prismjs: 1.30.0
   sharp: 0.35.3
@@ -19,18 +21,29 @@ onlyBuiltDependencies:
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 # Security fixes for GHSA advisories, pinned to exact patched versions via the
-# overrides above: dompurify 3.4.12 (GHSA-c2j3-45gr-mqc4), postcss 8.5.23
-# (GHSA-r28c-9q8g-f849), sharp 0.35.3 — all matured past the 7-day window.
+# overrides above: postcss 8.5.23 (GHSA-r28c-9q8g-f849), sharp 0.35.3, js-yaml
+# 4.3.1 (CVE-2026-59870 — quadratic CPU in !!omap resolution, transitive dev-dep
+# via jest) — all matured past the 7-day window.
 # fast-uri 3.1.5 (GHSA-v2hh-gcrm-f6hx — host confusion via literal IPv6) is the
 # only patched release for that advisory and is still inside the 7-day window,
 # so it needs an exemption. brace-expansion 1.1.18 / 2.1.4 (GHSA-mh99-v99m-4gvg
 # — DoS via unbounded expansion, transitive dev-dep via jest/openapi-typescript)
 # are the patched releases and are likewise still inside the maturity window.
+# Same for the current advisory batch, all reached transitively and all still
+# inside the window: dompurify 3.4.13 (IN_PLACE hook removal leaves a detached
+# executable subtree — XSS, via @streamdown/mermaid > mermaid), mermaid 11.16.1
+# (prototype pollution in the config APIs and in architecture diagrams, CSS
+# injection into sibling elements, and XY-chart/radar DoS — one release fixes
+# all five), and nanoid 3.3.17 (custom generators loop indefinitely at size 0,
+# via @tailwindcss/postcss > postcss).
 # All exact-pinned via the overrides above, so an exemption cannot pull any other
 # freshly published version; it only lets the security fix land before maturity.
 minimumReleaseAgeExclude:
   - fast-uri
   - brace-expansion
+  - dompurify
+  - mermaid
+  - nanoid
 allowBuilds:
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
## What changed

Clears all nine open Dependabot advisories on the default branch (3 high, 5 moderate, 1 low). Every one is a transitive dependency, so the fix is four exact pins in the `pnpm` overrides plus regenerated lockfiles — no source changes, no API surface change.

| Package | To | Reached via | Advisory |
|---|---|---|---|
| `mermaid` | 11.16.1 | `@streamdown/mermaid` (ui) | prototype pollution in config APIs and architecture diagrams; CSS injection into sibling elements; XY-chart and radar infinite-loop DoS — one release fixes all five |
| `dompurify` | 3.4.13 | `mermaid` (ui) | `IN_PLACE` hook removal leaves a detached executable subtree → XSS |
| `js-yaml` | 4.3.1 | `jest` (ui, dev) | CVE-2026-59870 — quadratic CPU in `!!omap` resolution, not backported to 4.x |
| `nanoid` | 3.3.17 | `postcss` (ui **and** docs) | custom generators loop indefinitely when size is zero |

`mermaid`, `dompurify` and `nanoid` are still inside the repo's 7-day `minimumReleaseAge` window, so they get `minimumReleaseAgeExclude` entries with the rationale recorded in the comment block, following the convention already in both files. `js-yaml` 4.3.1 published 2026-07-31 and has matured, so it needs no exemption. Everything is exact-pinned, so an exemption cannot pull any other freshly published version — it only lets the security fix land early.

## Why

The nine advisories are reported on every push to the repository. `dompurify` and `js-yaml` were already pinned in the ui overrides at versions that have since become vulnerable, so they needed bumping rather than adding; `mermaid` and `nanoid` were unpinned and resolving to vulnerable ranges.

## Before / After

```
# apps/ui — before
8 vulnerabilities found
Severity: 1 low | 5 moderate | 2 high

# apps/docs — before
1 vulnerabilities found
Severity: 1 high

# apps/ui and apps/docs — after
No known vulnerabilities found
```

Resolved versions confirmed in both lockfiles: `dompurify: 3.4.13`, `js-yaml: 4.3.1`, `mermaid: 11.16.1`, `nanoid: 3.3.17`.

No observable behavior change — these are patch-level bumps within the same major lines.

## Risk

- **Low**
- `mermaid` moves 11.x → 11.16.1, the largest jump here and the only one on a runtime rendering path (`src/components/chat/streamdown-message.tsx`). A regression would show up as broken diagram rendering in chat messages. Covered by build plus the streamdown test suite; the remaining exposure is visual, in diagram output specifically.
- `js-yaml` is dev-only (jest). `nanoid` and `dompurify` are patch bumps.

## Security

- Threat categories reviewed: dependency supply chain. The `IN_PLACE`/XSS (`dompurify`) and prototype-pollution (`mermaid`) advisories are the ones with real reach here, since both sit under the chat message renderer that displays model-generated markdown — untrusted content by construction. The DoS advisories (`nanoid`, `js-yaml`, mermaid XY/radar) are lower reach: `js-yaml` is dev-only and `nanoid` is used for build-time IDs.
- Findings and resolutions: no new findings. Each pin is the minimum patched release named by its advisory, not a speculative upgrade. Exemptions are scoped per-package and paired with exact pins so the maturity bypass cannot widen to other versions.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — no new tests; existing `src/__tests__/streamdown-message.test.tsx` (27 tests) covers the mermaid render path and passes
- [x] Backward compatibility considered — patch-level bumps within the same majors, no source or API change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Local evidence: `pnpm audit` clean in both apps; `pnpm run build`, `pnpm run lint`, `pnpm run format:check` and `pnpm exec jest src/__tests__/streamdown-message.test.tsx` (27 passed) green in `apps/ui`; `pnpm run check` (0 errors, 0 warnings) and `pnpm run build` (472 pages) green in `apps/docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUJUzL3MUFDC9cQ2px42p8)_