### PR TITLE
feat(ui): rebuild Sessions as the operational list

### DIFF
--- a/apps/ui/src/__tests__/session-filters.test.ts
+++ b/apps/ui/src/__tests__/session-filters.test.ts
@@ -1,0 +1,139 @@
+// The sessions page keeps its whole filter set in the URL (EVE-853). These
+// tests pin the two properties that rests on: a filter set survives a round
+// trip through a link, and any change to what is counted resets the page.
+
+import {
+  EMPTY_SESSION_FILTERS,
+  hasActiveFilters,
+  parseSessionFilters,
+  serializeSessionFilters,
+  toQueryParams,
+  toggleAgentFilter,
+  toggleFilterValue,
+  windowStart,
+  withFilterChange,
+  type SessionFilters,
+} from "@/lib/session-filters";
+import { isViewActive, parseSavedViews } from "@/lib/session-views";
+
+const filters = (overrides: Partial<SessionFilters> = {}): SessionFilters => ({
+  ...EMPTY_SESSION_FILTERS,
+  ...overrides,
+});
+
+describe("session filter URL round trip", () => {
+  it("omits defaults so a pristine list has a clean URL", () => {
+    expect(serializeSessionFilters(EMPTY_SESSION_FILTERS)).toBe("");
+  });
+
+  it("round-trips a full filter set", () => {
+    const original = filters({
+      search: "churn by plan",
+      status: ["failed", "running"],
+      source: ["slack"],
+      agent: "agent_123",
+      window: "7d",
+      mine: true,
+      page: 3,
+    });
+    const restored = parseSessionFilters(new URLSearchParams(serializeSessionFilters(original)));
+    expect(restored).toEqual(original);
+  });
+
+  it("falls back on unknown values instead of filtering on nonsense", () => {
+    const parsed = parseSessionFilters(new URLSearchParams("window=forever&page=-2&mine=maybe"));
+    expect(parsed.window).toBe("all");
+    expect(parsed.page).toBe(0);
+    expect(parsed.mine).toBe(false);
+  });
+
+  it("deduplicates repeated facet values", () => {
+    expect(parseSessionFilters(new URLSearchParams("status=failed,failed")).status).toEqual([
+      "failed",
+    ]);
+  });
+});
+
+describe("pagination consistency", () => {
+  it("resets to page 1 when a facet is toggled", () => {
+    const next = toggleFilterValue(filters({ page: 4 }), "source", "slack");
+    expect(next.source).toEqual(["slack"]);
+    expect(next.page).toBe(0);
+  });
+
+  it("resets to page 1 when an agent is selected, and clears on re-click", () => {
+    const selected = toggleAgentFilter(filters({ page: 2 }), "agent_1");
+    expect(selected).toMatchObject({ agent: "agent_1", page: 0 });
+    expect(toggleAgentFilter(selected, "agent_1").agent).toBeNull();
+  });
+
+  it("keeps the page when the page itself is what changed", () => {
+    expect(withFilterChange(filters({ status: ["failed"] }), { page: 2 }).page).toBe(2);
+  });
+
+  it("resets the page for every other change", () => {
+    expect(withFilterChange(filters({ page: 5 }), { search: "x" }).page).toBe(0);
+  });
+});
+
+describe("API parameters", () => {
+  it("sends nothing for an unfiltered list", () => {
+    expect(toQueryParams(EMPTY_SESSION_FILTERS)).toEqual({
+      search: undefined,
+      status: undefined,
+      source: undefined,
+      agentId: undefined,
+      mine: undefined,
+      createdAfter: undefined,
+    });
+  });
+
+  it("joins multi-select dimensions the way the server parses them", () => {
+    const params = toQueryParams(filters({ status: ["running", "failed"], source: ["slack"] }));
+    expect(params.status).toBe("running,failed");
+    expect(params.source).toBe("slack");
+  });
+
+  it("quantizes the window bound so the query key is stable between renders", () => {
+    const base = Date.parse("2026-08-09T12:34:56.789Z");
+    expect(windowStart("24h", base)).toBe(windowStart("24h", base + 1_000));
+    expect(windowStart("24h", base)).toBe("2026-08-08T12:34:00.000Z");
+    expect(windowStart("all", base)).toBeUndefined();
+  });
+});
+
+describe("active filter detection", () => {
+  it("ignores pagination", () => {
+    expect(hasActiveFilters(filters({ page: 3 }))).toBe(false);
+  });
+
+  it("notices every dimension", () => {
+    expect(hasActiveFilters(filters({ mine: true }))).toBe(true);
+    expect(hasActiveFilters(filters({ window: "24h" }))).toBe(true);
+    expect(hasActiveFilters(filters({ agent: "agent_1" }))).toBe(true);
+  });
+});
+
+describe("saved views", () => {
+  it("drops malformed stored entries rather than rendering junk", () => {
+    expect(
+      parseSavedViews([
+        { id: "a", name: "Failures", query: "status=failed" },
+        { id: "b", name: 7 },
+        "nope",
+        null,
+      ]),
+    ).toEqual([{ id: "a", name: "Failures", query: "status=failed" }]);
+  });
+
+  it("treats a view as active regardless of the page being read", () => {
+    const view = { id: "a", name: "Failures", query: "status=failed&window=7d" };
+    expect(isViewActive(view, filters({ status: ["failed"], window: "7d", page: 2 }))).toBe(true);
+    expect(isViewActive(view, filters({ status: ["failed"] }))).toBe(false);
+  });
+
+  it("matches views whose stored query is not in canonical form", () => {
+    const view = { id: "a", name: "Failures", query: "?page=0&status=failed&mine=false" };
+    expect(isViewActive(view, filters({ status: ["failed"] }))).toBe(true);
+  });
+});

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -15,15 +15,24 @@ import {
   serverGetList,
   serverGetPaginated,
 } from "@/lib/server-query";
-import type { Agent, Harness, ModelWithProvider, Organization, Session } from "@/lib/api/types";
+import type { Agent, Organization, Session, SessionFacetsResponse } from "@/lib/api/types";
+import { SESSIONS_PAGE_SIZE } from "@/lib/session-filters";
 import SessionsPageClient from "./sessions-page-client";
 
-const PAGE_SIZE = 20;
-
-export default async function SessionsPage() {
+/**
+ * Seeding is deliberately limited to the unfiltered first page: that is the
+ * only filter set whose cache key the server can know without duplicating the
+ * client's URL parsing. Any other filter set simply fetches on the client.
+ */
+export default async function SessionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const queryClient = createServerQueryClient();
   const requestContext = await getServerRequestContext();
   const { currentOrgId } = await prefetchAuthBootstrap(queryClient, requestContext);
+  const isDefaultView = Object.keys(await searchParams).length === 0;
 
   if (currentOrgId) {
     await Promise.all([
@@ -33,18 +42,22 @@ export default async function SessionsPage() {
       seedQueryData(queryClient, queryKeys.organizations.detail(currentOrgId), () =>
         serverGet<Organization>(requestContext, `/v1/orgs/${currentOrgId}`),
       ),
-      seedQueryData(queryClient, [...queryKeys.harnesses.list(false), currentOrgId], () =>
-        serverGetList<Harness>(requestContext, "/v1/harnesses"),
-      ),
-      seedQueryData(
-        queryClient,
-        queryKeys.sessions.list(currentOrgId, undefined, 0, PAGE_SIZE),
-        () =>
-          serverGetPaginated<Session>(requestContext, `/v1/sessions?offset=0&limit=${PAGE_SIZE}`),
-      ),
-      seedQueryData(queryClient, [...queryKeys.models.list(), currentOrgId], () =>
-        serverGetList<ModelWithProvider>(requestContext, "/v1/models"),
-      ),
+      ...(isDefaultView
+        ? [
+            seedQueryData(
+              queryClient,
+              queryKeys.sessions.filtered(currentOrgId, "", 0, SESSIONS_PAGE_SIZE),
+              () =>
+                serverGetPaginated<Session>(
+                  requestContext,
+                  `/v1/sessions?offset=0&limit=${SESSIONS_PAGE_SIZE}`,
+                ),
+            ),
+            seedQueryData(queryClient, queryKeys.sessions.facets(currentOrgId, ""), () =>
+              serverGet<SessionFacetsResponse>(requestContext, "/v1/sessions/facets"),
+            ),
+          ]
+        : []),
     ]);
   }
 

--- a/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
+++ b/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
@@ -1,41 +1,34 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import {
-  useAgents,
-  useHarnesses,
-  useSessions,
-  useCreateSession,
-  useModels,
-  usePinSession,
-  useUnpinSession,
-} from "@/hooks";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
+/**
+ * Sessions — the operational list (EVE-853).
+ *
+ * This page answers "what ran". It is read-only on purpose: authoring a run
+ * belongs where the run is composed (`/chats/new` for an interactive thread,
+ * the agent page for an agent run), not on the surface you open when something
+ * has gone wrong. The old "New session" dialog moved out for that reason; both
+ * entry points already existed, so nothing was lost.
+ *
+ * The whole filter set lives in the URL. That is what makes a saved view just a
+ * link, and it keeps three things — the rows, the facet counts, and the address
+ * bar — describing one population. Counts come from `GET /v1/sessions/facets`,
+ * never from the rows on screen.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Activity, ChevronLeft, ChevronRight, Download, MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { SearchInput } from "@/components/ui/search-input";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { SessionCard } from "@/components/session/session-card";
-import { AgentSelect } from "@/components/agent/agent-select";
-import { HarnessSelect } from "@/components/harness/harness-select";
-import { AgentFilterMenu } from "@/components/agent/agent-filter-menu";
-import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
-import { Label } from "@/components/ui/label";
-import { Plus, ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
-import { downloadSessionExport } from "@/lib/session-export";
-import { useOptionalNotificationsContext } from "@/providers/notifications-provider";
-import { useLocale } from "@/providers/locale-provider";
-import type { SessionExportFormat } from "@/lib/api/sessions";
-import type { ModelWithProvider, Agent } from "@/lib/api/types";
-import { getDisplayName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
-import { useOrganization } from "@/hooks/use-organizations";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   PageContainer,
   PageBreadcrumb,
@@ -43,118 +36,149 @@ import {
   PageControlStrip,
   PageColumns,
   PageMain,
+  PageRail,
   PageFooter,
+  SectionTabs,
+  EmptyState,
 } from "@/components/layout";
-import { pluralize } from "@/lib/formatting";
+import { SessionRow } from "@/components/session/session-row";
+import { SessionFacetRail } from "@/components/session/session-facet-rail";
+import { useAgents, useFilteredSessions, useSessionFacets, usePageTitle } from "@/hooks";
+import { useSessionViews } from "@/hooks/use-session-views";
+import { useOptionalNotificationsContext } from "@/providers/notifications-provider";
+import { downloadSessionsCsv } from "@/lib/session-list-export";
+import { formatDurationCompact, formatTokens, pluralize } from "@/lib/formatting";
+import { getDisplayName } from "@/lib/entity-lifecycle";
+import { shortenId } from "@/lib/utils";
+import {
+  EMPTY_SESSION_FILTERS,
+  SESSIONS_PAGE_SIZE,
+  TIME_WINDOWS,
+  TIME_WINDOW_LABELS,
+  hasActiveFilters,
+  parseSessionFilters,
+  serializeSessionFilters,
+  toQueryParams,
+  toggleAgentFilter,
+  toggleFilterValue,
+  withFilterChange,
+  type SessionFilters,
+  type SessionTimeWindow,
+} from "@/lib/session-filters";
+import type { SavedSessionView } from "@/lib/session-views";
 
-const PAGE_SIZE = 20;
+/**
+ * The segmented control is a shortcut into the same `status` facet, not a
+ * separate filter. "All" clears the dimension; anything else selects exactly
+ * one value, so the control can always show a single active segment.
+ */
+const STATUS_SEGMENTS = [
+  { value: "all", label: "All" },
+  { value: "running", label: "Running" },
+  { value: "failed", label: "Failed" },
+  { value: "completed", label: "Completed" },
+];
+
+function segmentFor(filters: SessionFilters): string {
+  return filters.status.length === 1 ? filters.status[0] : "all";
+}
 
 export default function SessionsPageClient() {
+  usePageTitle("Sessions");
   const router = useRouter();
-  const { locale } = useLocale();
+  const searchParams = useSearchParams();
   const notificationsContext = useOptionalNotificationsContext();
-  const [page, setPage] = useState(0);
-  const [selectedAgentId, setSelectedAgentId] = useState<string>("");
-  const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
-  const [newSessionHarnessId, setNewSessionHarnessId] = useState<string>("");
-  const [newSessionAgentId, setNewSessionAgentId] = useState<string>("");
-  const [newSessionAgentIdentityId, setNewSessionAgentIdentityId] = useState<string>("");
-  const offset = page * PAGE_SIZE;
 
-  const { data: agents, isLoading: agentsLoading } = useAgents({
-    includeArchived: true,
-  });
-  const { data: organization } = useOrganization();
-  const { data: harnesses } = useHarnesses();
-  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
-    selectedAgentId || undefined,
-    { offset, limit: PAGE_SIZE },
+  const filters = useMemo(
+    () => parseSessionFilters(new URLSearchParams(searchParams.toString())),
+    [searchParams],
   );
-  const { data: models } = useModels();
-  const createSession = useCreateSession();
-  const pinSessionMutation = usePinSession();
-  const unpinSessionMutation = useUnpinSession();
 
-  const sessions = useMemo(() => {
-    const data = sessionsResponse?.data ?? [];
-    return [...data].sort((a, b) => {
-      const aPinned = a.is_pinned === true ? 1 : 0;
-      const bPinned = b.is_pinned === true ? 1 : 0;
-      return bPinned - aPinned;
-    });
-  }, [sessionsResponse?.data]);
-  const totalSessions = sessionsResponse?.total ?? 0;
-  const totalPages = Math.ceil(totalSessions / PAGE_SIZE);
+  // Search is typed locally and committed to the URL on submit. Pushing every
+  // keystroke into history would make Back walk letter by letter.
+  const [searchDraft, setSearchDraft] = useState(filters.search);
+  const [exporting, setExporting] = useState(false);
 
-  const modelMap = useMemo(() => {
-    if (!models) return new Map<string, ModelWithProvider>();
-    return new Map(models.map((m) => [m.id, m]));
-  }, [models]);
+  const applyFilters = useCallback(
+    (next: SessionFilters) => {
+      const query = serializeSessionFilters(next);
+      router.replace(query ? `/sessions?${query}` : "/sessions", { scroll: false });
+    },
+    [router],
+  );
 
-  const agentMap = useMemo(() => {
-    if (!agents) return new Map<string, Agent>();
-    return new Map(agents.map((a) => [a.id, a]));
+  const { data: agents } = useAgents({ includeArchived: true });
+  const {
+    data: sessionsResponse,
+    isLoading: sessionsLoading,
+    error: sessionsError,
+  } = useFilteredSessions(filters);
+  const { data: facets, error: facetsError } = useSessionFacets(filters);
+  const views = useSessionViews();
+
+  const agentNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const agent of agents ?? []) {
+      map.set(agent.id, getDisplayName(agent) || shortenId(agent.id));
+    }
+    return map;
   }, [agents]);
 
-  const handleOpenNewSessionDialog = () => {
-    const defaultHarnessId = organization?.default_harness_id;
-    const genericHarness = harnesses?.find((h) => h.name === "Generic");
-    setNewSessionHarnessId(defaultHarnessId || genericHarness?.id || harnesses?.[0]?.id || "");
-    setNewSessionAgentId(selectedAgentId || "");
-    setNewSessionDialogOpen(true);
-  };
+  const agentLabel = useCallback(
+    (agentId: string) => agentNames.get(agentId) ?? shortenId(agentId),
+    [agentNames],
+  );
 
-  const handleCreateSession = async () => {
-    // Agent-first: when an agent is chosen, the server derives the harness from
-    // it, so the harness picker is hidden and no harness is sent. A no-agent
-    // session still requires an explicit harness.
-    if (!newSessionAgentId && !newSessionHarnessId) {
-      console.error("No harness selected");
-      return;
-    }
+  const sessions = sessionsResponse?.data ?? [];
+  // The list total is the filtered total; the facet total is the same number
+  // computed independently. Prefer the list's own, so pagination arithmetic can
+  // never disagree with the rows it is describing.
+  const total = sessionsResponse?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / SESSIONS_PAGE_SIZE));
+  const offset = filters.page * SESSIONS_PAGE_SIZE;
+  const filtered = hasActiveFilters(filters);
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
     try {
-      const session = await createSession.mutateAsync({
-        request: {
-          harness_id: newSessionAgentId ? undefined : newSessionHarnessId,
-          agent_id: newSessionAgentId || undefined,
-          agent_identity_id: newSessionAgentIdentityId || undefined,
-        },
+      const result = await downloadSessionsCsv(toQueryParams(filters), agentLabel);
+      notificationsContext?.notify?.({
+        title: "Sessions exported",
+        body: result.truncated
+          ? `${result.rowsExported} rows exported (capped). Narrow the filters to export the rest.`
+          : `${result.rowsExported} ${pluralize(result.rowsExported, "row")} exported.`,
       });
-      setNewSessionDialogOpen(false);
-      router.push(`/sessions/${session.id}`);
     } catch (error) {
-      console.error("Failed to create session:", error);
+      console.error("Failed to export sessions:", error);
+      notificationsContext?.notify?.({
+        title: "Export failed",
+        body: "Could not export the filtered sessions. Try again.",
+      });
+    } finally {
+      setExporting(false);
     }
-  };
+  }, [agentLabel, filters, notificationsContext]);
 
-  const handlePreviousPage = () => {
-    setPage((p) => Math.max(0, p - 1));
-  };
+  const handleSelectView = useCallback(
+    (view: SavedSessionView) => {
+      applyFilters(parseSessionFilters(new URLSearchParams(view.query)));
+    },
+    [applyFilters],
+  );
 
-  const handleNextPage = () => {
-    setPage((p) => Math.min(totalPages - 1, p + 1));
-  };
+  const handleSaveView = useCallback(
+    (name: string) => {
+      void views.saveView(name, serializeSessionFilters({ ...filters, page: 0 }));
+    },
+    [filters, views],
+  );
 
-  const handleAgentFilterChange = (agentId: string) => {
-    setSelectedAgentId(agentId);
-    setPage(0);
-  };
-
-  const handleTogglePin = (sessionId: string, pinned: boolean) => {
-    if (pinned) {
-      pinSessionMutation.mutate({ sessionId });
-    } else {
-      unpinSessionMutation.mutate({ sessionId });
-    }
-  };
-
-  const handleExport = (sessionId: string, format: SessionExportFormat) => {
-    void downloadSessionExport(sessionId, format, locale, notificationsContext?.notify);
-  };
-
-  const filterLabel = selectedAgentId
-    ? getDisplayName(agentMap.get(selectedAgentId)) || "Agent"
-    : "All agents";
+  const metrics = facets && [
+    { label: "Active now", value: String(facets.active_now) },
+    { label: "Failed today", value: String(facets.failed_today) },
+    { label: "p95 duration", value: formatDurationCompact(facets.p95_duration_ms) },
+    { label: "Tokens today", value: formatTokens(facets.tokens_today) },
+  ];
 
   return (
     <PageContainer>
@@ -164,155 +188,199 @@ export default function SessionsPageClient() {
         icon={<MessageSquare />}
         title="Sessions"
         badges={
-          <Badge variant="outline" className="font-mono">
-            {totalSessions}
-          </Badge>
+          <>
+            <Badge variant="outline" className="font-mono">
+              {total}
+            </Badge>
+            <Badge variant="secondary">read-only</Badge>
+          </>
         }
-        description="Conversations and background runs across your agents."
+        description="Every run across your agents — chats, schedules, channels and API calls."
         meta={
-          <span>
-            Showing <span className="text-foreground">{filterLabel}</span>
-          </span>
+          metrics ? (
+            <>
+              {metrics.map((metric) => (
+                <span key={metric.label}>
+                  {metric.label} <span className="text-foreground">{metric.value}</span>
+                </span>
+              ))}
+            </>
+          ) : (
+            <span>Loading counters…</span>
+          )
         }
         actions={
-          <Button
-            variant="accent"
-            onClick={handleOpenNewSessionDialog}
-            disabled={!harnesses?.length}
-          >
-            <Plus className="size-4" />
-            New session
+          <Button variant="outline" onClick={handleExport} disabled={exporting || total === 0}>
+            <Download className="size-4" />
+            {exporting ? "Exporting…" : "Export"}
           </Button>
         }
       />
 
-      <PageControlStrip className="flex items-center justify-between gap-3">
-        <span className="text-[13px] text-muted-foreground">
-          {totalSessions} {pluralize(totalSessions, "session")}
-        </span>
-        <AgentFilterMenu value={selectedAgentId} onValueChange={handleAgentFilterChange} />
+      <PageControlStrip className="flex flex-wrap items-center gap-3">
+        <form
+          className="min-w-[12rem] flex-[1_1_16rem]"
+          onSubmit={(event) => {
+            event.preventDefault();
+            applyFilters(withFilterChange(filters, { search: searchDraft.trim() }));
+          }}
+        >
+          <SearchInput
+            value={searchDraft}
+            placeholder="Search runs by title"
+            aria-label="Search runs"
+            onChange={(event) => setSearchDraft(event.target.value)}
+            onBlur={() => {
+              if (searchDraft.trim() !== filters.search) {
+                applyFilters(withFilterChange(filters, { search: searchDraft.trim() }));
+              }
+            }}
+          />
+        </form>
+
+        <SectionTabs
+          className="flex-none border-b-0"
+          value={segmentFor(filters)}
+          items={STATUS_SEGMENTS}
+          onValueChange={(value) =>
+            applyFilters(withFilterChange(filters, { status: value === "all" ? [] : [value] }))
+          }
+        />
+
+        <Select
+          value={filters.window}
+          onValueChange={(value) =>
+            applyFilters(withFilterChange(filters, { window: value as SessionTimeWindow }))
+          }
+        >
+          <SelectTrigger className="w-40 flex-none" aria-label="Time window">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TIME_WINDOWS.map((window) => (
+              <SelectItem key={window} value={window}>
+                {TIME_WINDOW_LABELS[window]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {filtered && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="flex-none"
+            onClick={() => {
+              setSearchDraft("");
+              applyFilters(EMPTY_SESSION_FILTERS);
+            }}
+          >
+            Clear filters
+          </Button>
+        )}
       </PageControlStrip>
 
-      <PageColumns className="lg:grid-cols-1">
+      <PageColumns>
         <PageMain>
-          {sessionsLoading || agentsLoading ? (
+          {sessionsLoading ? (
             <div className="space-y-2">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <Skeleton key={i} className="h-16 w-full" />
+              {Array.from({ length: 6 }).map((_, index) => (
+                <Skeleton key={index} className="h-16 w-full" />
               ))}
             </div>
+          ) : sessionsError ? (
+            <EmptyState
+              icon={<Activity />}
+              title="Could not load runs"
+              description="The sessions list failed to load. Check your connection and try again."
+              action={<Button onClick={() => router.refresh()}>Retry</Button>}
+            />
           ) : sessions.length === 0 ? (
-            <div className="border border-dashed py-12 text-center text-muted-foreground">
-              No sessions yet. Start a new session to begin chatting.
-            </div>
+            <EmptyState
+              icon={<MessageSquare />}
+              title={filtered ? "No runs match these filters" : "No runs yet"}
+              description={
+                filtered
+                  ? "Every filter narrows the same set. Clear one to widen it."
+                  : "Runs appear here as soon as an agent is started — from a chat, a schedule, a channel or the API."
+              }
+              action={
+                filtered ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setSearchDraft("");
+                      applyFilters(EMPTY_SESSION_FILTERS);
+                    }}
+                  >
+                    Clear filters
+                  </Button>
+                ) : undefined
+              }
+            />
           ) : (
-            <div className="space-y-2">
-              {sessions.map((session) => {
-                const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
-                return (
-                  <SessionCard
-                    key={session.id}
-                    session={session}
-                    agentName={
-                      session.agent_id
-                        ? getEntityReferenceLabel({
-                            kind: "Agent",
-                            name: getDisplayName(agent),
-                            status: agent?.status ?? "deleted",
-                          })
-                        : undefined
-                    }
-                    agentStatus={session.agent_id ? (agent?.status ?? "deleted") : undefined}
-                    model={session.model_id ? modelMap.get(session.model_id) : undefined}
-                    onTogglePin={handleTogglePin}
-                    onExport={handleExport}
-                  />
-                );
-              })}
+            <div className="flex flex-col gap-2">
+              {sessions.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  agentName={session.agent_id ? agentLabel(session.agent_id) : undefined}
+                />
+              ))}
             </div>
           )}
         </PageMain>
+
+        <PageRail>
+          <SessionFacetRail
+            filters={filters}
+            facets={facets}
+            error={facetsError as Error | null}
+            agentLabel={agentLabel}
+            onToggleStatus={(value) => applyFilters(toggleFilterValue(filters, "status", value))}
+            onToggleSource={(value) => applyFilters(toggleFilterValue(filters, "source", value))}
+            onToggleAgent={(agentId) => applyFilters(toggleAgentFilter(filters, agentId))}
+            views={views.views}
+            viewsAreSaved={views.viewsAreSaved}
+            canSaveView={filtered && !views.isSaving}
+            onSelectView={handleSelectView}
+            onSaveView={handleSaveView}
+            onRemoveView={(id) => void views.removeView(id)}
+          />
+        </PageRail>
       </PageColumns>
 
       <PageFooter>
         <span>
-          Showing {totalSessions === 0 ? 0 : offset + 1}-
-          {Math.min(offset + PAGE_SIZE, totalSessions)} of {totalSessions}{" "}
-          {pluralize(totalSessions, "session")}
+          Showing {total === 0 ? 0 : offset + 1}-{Math.min(offset + SESSIONS_PAGE_SIZE, total)} of{" "}
+          {total} {pluralize(total, "run")}
         </span>
         {totalPages > 1 && (
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={handlePreviousPage} disabled={page === 0}>
-              <ChevronLeft className="h-4 w-4" />
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={filters.page === 0}
+              onClick={() => applyFilters({ ...filters, page: filters.page - 1 })}
+            >
+              <ChevronLeft className="size-4" />
               Previous
             </Button>
             <span>
-              Page {page + 1} of {totalPages}
+              Page {filters.page + 1} of {totalPages}
             </span>
             <Button
               variant="outline"
               size="sm"
-              onClick={handleNextPage}
-              disabled={page >= totalPages - 1}
+              disabled={filters.page >= totalPages - 1}
+              onClick={() => applyFilters({ ...filters, page: filters.page + 1 })}
             >
               Next
-              <ChevronRight className="h-4 w-4" />
+              <ChevronRight className="size-4" />
             </Button>
           </div>
         )}
       </PageFooter>
-
-      <Dialog open={newSessionDialogOpen} onOpenChange={setNewSessionDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>New Session</DialogTitle>
-            <DialogDescription>
-              Pick an agent to run on its harness, or choose a harness directly for a no-agent
-              session.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-4 space-y-4">
-            <div className="space-y-2">
-              <Label>Agent (optional)</Label>
-              <AgentSelect
-                value={newSessionAgentId}
-                onValueChange={setNewSessionAgentId}
-                placeholder="Select an agent"
-                includeAll
-                allLabel="No agent"
-              />
-            </div>
-            {!newSessionAgentId && (
-              <div className="space-y-2">
-                <Label>Harness (required)</Label>
-                <HarnessSelect
-                  value={newSessionHarnessId}
-                  onValueChange={setNewSessionHarnessId}
-                  placeholder="Select a harness"
-                />
-              </div>
-            )}
-            <div className="space-y-2">
-              <Label>Agent identity (background runs)</Label>
-              <AgentIdentitySelect
-                value={newSessionAgentIdentityId}
-                onValueChange={setNewSessionAgentIdentityId}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setNewSessionDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleCreateSession}
-              disabled={(!newSessionAgentId && !newSessionHarnessId) || createSession.isPending}
-            >
-              {createSession.isPending ? "Creating..." : "Create Session"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
+++ b/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
@@ -94,10 +94,19 @@ export default function SessionsPageClient() {
     [searchParams],
   );
 
-  // Search is typed locally and committed to the URL on submit. Pushing every
-  // keystroke into history would make Back walk letter by letter.
+  // Search is typed locally and committed to the URL on submit or blur. Pushing
+  // every keystroke into the URL would make Back walk letter by letter.
   const [searchDraft, setSearchDraft] = useState(filters.search);
+  const [committedSearch, setCommittedSearch] = useState(filters.search);
   const [exporting, setExporting] = useState(false);
+
+  // The URL can change without the field being touched — selecting a saved view,
+  // or clearing filters. Re-sync the draft when it does, so the box never shows
+  // a term the list is not filtered by.
+  if (filters.search !== committedSearch) {
+    setCommittedSearch(filters.search);
+    setSearchDraft(filters.search);
+  }
 
   const applyFilters = useCallback(
     (next: SessionFilters) => {
@@ -112,6 +121,7 @@ export default function SessionsPageClient() {
     data: sessionsResponse,
     isLoading: sessionsLoading,
     error: sessionsError,
+    refetch: refetchSessions,
   } = useFilteredSessions(filters);
   const { data: facets, error: facetsError } = useSessionFacets(filters);
   const views = useSessionViews();
@@ -293,7 +303,7 @@ export default function SessionsPageClient() {
               icon={<Activity />}
               title="Could not load runs"
               description="The sessions list failed to load. Check your connection and try again."
-              action={<Button onClick={() => router.refresh()}>Retry</Button>}
+              action={<Button onClick={() => void refetchSessions()}>Retry</Button>}
             />
           ) : sessions.length === 0 ? (
             <EmptyState

--- a/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
+++ b/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
@@ -215,6 +215,10 @@ export default function SessionsPageClient() {
                 </span>
               ))}
             </>
+          ) : facetsError ? (
+            // Say so rather than claim a permanent "Loading…" the counters will
+            // never resolve out of.
+            <span>Counters unavailable</span>
           ) : (
             <span>Loading counters…</span>
           )

--- a/apps/ui/src/components/session/session-facet-rail.tsx
+++ b/apps/ui/src/components/session/session-facet-rail.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+// Facet rail for the operational Sessions list (EVE-853).
+//
+// Every count comes from `GET /v1/sessions/facets`, aggregated server-side over
+// the same predicate as the list. Nothing here is derived from the rows on
+// screen — a page of 20 cannot know how many failures exist in 4,000 runs.
+//
+// Each dimension is counted with the other filters applied but its own
+// selection excluded, which is what makes multi-select usable: picking `failed`
+// does not zero out every other status in the Status facet.
+
+import { useState } from "react";
+import { Check, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { RailSection } from "@/components/layout";
+import { cn } from "@/lib/utils";
+import { activityLabel, sourceLabel, type SessionFilters } from "@/lib/session-filters";
+import { isViewActive, type SavedSessionView } from "@/lib/session-views";
+import type { SessionFacetCount } from "@/lib/api/types";
+
+interface FacetListProps {
+  label: string;
+  counts: SessionFacetCount[];
+  selected: string[];
+  labelFor: (value: string) => string;
+  onToggle: (value: string) => void;
+  /** Shown in place of the list when the filtered set has nothing in this dimension. */
+  emptyHint: string;
+}
+
+function FacetList({ label, counts, selected, labelFor, onToggle, emptyHint }: FacetListProps) {
+  // A selected value must stay clickable even when the current filter set
+  // leaves it with no rows — otherwise the only way to undo it is the URL.
+  const missingSelected = selected
+    .filter((value) => !counts.some((count) => count.value === value))
+    .map((value) => ({ value, count: 0 }));
+  const entries = [...counts, ...missingSelected];
+
+  return (
+    <RailSection label={label}>
+      {entries.length === 0 ? (
+        <p className="text-[13px] text-muted-foreground">{emptyHint}</p>
+      ) : (
+        <div className="flex flex-col gap-1.5 text-[13px]">
+          {entries.map((entry) => {
+            const isSelected = selected.includes(entry.value);
+            return (
+              <button
+                key={entry.value}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => onToggle(entry.value)}
+                className={cn(
+                  "flex items-center justify-between gap-2 text-left transition-colors hover:text-foreground",
+                  isSelected ? "text-foreground" : "text-muted-foreground",
+                )}
+              >
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <Check
+                    className={cn("size-3.5 flex-none", isSelected ? "opacity-100" : "opacity-0")}
+                  />
+                  <span className="truncate">{labelFor(entry.value)}</span>
+                </span>
+                <span className="flex-none font-mono text-muted-foreground">{entry.count}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </RailSection>
+  );
+}
+
+export interface SessionFacetRailProps {
+  filters: SessionFilters;
+  /** Facet buckets, or undefined while loading / after an error. */
+  facets?: {
+    by_activity: SessionFacetCount[];
+    by_source: SessionFacetCount[];
+    by_agent: SessionFacetCount[];
+  };
+  /** Failure loading the facets; the rail says so rather than showing zeros. */
+  error?: Error | null;
+  /** Resolve an agent's public id to a display name. */
+  agentLabel: (agentId: string) => string;
+  onToggleStatus: (value: string) => void;
+  onToggleSource: (value: string) => void;
+  onToggleAgent: (agentId: string) => void;
+  views: SavedSessionView[];
+  onSelectView: (view: SavedSessionView) => void;
+  onSaveView: (name: string) => void;
+  onRemoveView: (id: string) => void;
+  /** False for the suggested defaults, which nobody owns and nobody can delete. */
+  viewsAreSaved: boolean;
+  canSaveView: boolean;
+}
+
+export function SessionFacetRail({
+  filters,
+  facets,
+  error,
+  agentLabel,
+  onToggleStatus,
+  onToggleSource,
+  onToggleAgent,
+  views,
+  onSelectView,
+  onSaveView,
+  onRemoveView,
+  viewsAreSaved,
+  canSaveView,
+}: SessionFacetRailProps) {
+  const [naming, setNaming] = useState(false);
+  const [draftName, setDraftName] = useState("");
+
+  const submitName = () => {
+    const name = draftName.trim();
+    if (!name) return;
+    onSaveView(name);
+    setDraftName("");
+    setNaming(false);
+  };
+
+  return (
+    <>
+      <RailSection label="Saved views">
+        <div className="flex flex-col gap-1.5 text-[13px]">
+          {views.map((view) => {
+            const active = isViewActive(view, filters);
+            return (
+              <div key={view.id} className="group flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  onClick={() => onSelectView(view)}
+                  className={cn(
+                    "min-w-0 truncate text-left transition-colors hover:text-foreground",
+                    active ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  {view.name}
+                </button>
+                {viewsAreSaved && (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${view.name}`}
+                    onClick={() => onRemoveView(view.id)}
+                    className="flex-none text-muted-foreground/40 opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+
+          {naming ? (
+            <div className="mt-1.5 flex items-center gap-1.5">
+              <Input
+                // Focused on mount: the field only exists because the user just
+                // asked to name a view, so typing should land in it.
+                ref={(node) => node?.focus()}
+                value={draftName}
+                placeholder="View name"
+                onChange={(event) => setDraftName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") submitName();
+                  if (event.key === "Escape") setNaming(false);
+                }}
+                className="h-7 text-[13px]"
+              />
+              <Button size="sm" variant="outline" onClick={submitName} disabled={!draftName.trim()}>
+                Save
+              </Button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setNaming(true)}
+              disabled={!canSaveView}
+              className="mt-1.5 inline-flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Plus className="size-3.5" />
+              Save current filters
+            </button>
+          )}
+        </div>
+      </RailSection>
+
+      {error ? (
+        <RailSection label="Facets">
+          <p className="text-[13px] text-destructive">
+            Counts unavailable. The list below is still accurate.
+          </p>
+        </RailSection>
+      ) : (
+        <>
+          <FacetList
+            label="Status"
+            counts={facets?.by_activity ?? []}
+            selected={filters.status}
+            labelFor={activityLabel}
+            onToggle={onToggleStatus}
+            emptyHint="No runs match these filters."
+          />
+          <FacetList
+            label="Source"
+            counts={facets?.by_source ?? []}
+            selected={filters.source}
+            labelFor={sourceLabel}
+            onToggle={onToggleSource}
+            emptyHint="No runs match these filters."
+          />
+          <FacetList
+            label="Agent"
+            counts={facets?.by_agent ?? []}
+            selected={filters.agent ? [filters.agent] : []}
+            labelFor={agentLabel}
+            onToggle={onToggleAgent}
+            emptyHint="No agent-backed runs match these filters."
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/ui/src/components/session/session-facet-rail.tsx
+++ b/apps/ui/src/components/session/session-facet-rail.tsx
@@ -190,9 +190,7 @@ export function SessionFacetRail({
 
       {error ? (
         <RailSection label="Facets">
-          <p className="text-[13px] text-destructive">
-            Counts unavailable. The list below is still accurate.
-          </p>
+          <p className="text-[13px] text-destructive">Counts unavailable.</p>
         </RailSection>
       ) : (
         <>

--- a/apps/ui/src/components/session/session-row.tsx
+++ b/apps/ui/src/components/session/session-row.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+// One run in the operational Sessions list (EVE-853).
+//
+// The row answers "what ran, on whose behalf, and how did it go" in a single
+// scan: a status dot, source-and-subject as the primary line, the agent
+// underneath, then the outcome column, duration and when. The outcome column is
+// the one that earns its place — on a failed run it replaces the work summary,
+// because on a failing run nothing else on the row matters.
+
+import Link from "next/link";
+import { cn, shortenId } from "@/lib/utils";
+import { formatDurationCompact, formatRelativeTime, formatTokens } from "@/lib/formatting";
+import { activityLabel, sourceLabel } from "@/lib/session-filters";
+import type { Session, SessionActivity } from "@/lib/api/types";
+
+/** Dot colour per derived activity. Running also pulses so live runs stand out. */
+const ACTIVITY_DOT: Record<SessionActivity, string> = {
+  running: "bg-primary animate-pulse",
+  failed: "bg-destructive",
+  completed: "bg-emerald-500",
+  paused: "bg-amber-500",
+  idle: "bg-muted-foreground/40",
+};
+
+/**
+ * Wall-clock duration of the run, or undefined when the session has not started
+ * or is still going (an in-flight run has no duration yet, and inventing one
+ * from `now` would make the column tick while nothing changed).
+ */
+function runDuration(session: Session): string | undefined {
+  if (!session.started_at || !session.finished_at) return undefined;
+  const ms = new Date(session.finished_at).getTime() - new Date(session.started_at).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return undefined;
+  return formatDurationCompact(ms);
+}
+
+/** Total tokens across the run, when any were consumed. */
+function totalTokens(session: Session): number | undefined {
+  const usage = session.usage;
+  if (!usage) return undefined;
+  const total = usage.input_tokens + usage.output_tokens;
+  return total > 0 ? total : undefined;
+}
+
+export interface SessionRowProps {
+  session: Session;
+  /** Resolved agent display name, when the session names an agent. */
+  agentName?: string;
+}
+
+export function SessionRow({ session, agentName }: SessionRowProps) {
+  const activity = session.activity ?? "idle";
+  const failed = activity === "failed";
+  const subject = session.title?.trim() || session.preview?.trim() || shortenId(session.id);
+  const duration = runDuration(session);
+  const tokens = totalTokens(session);
+
+  return (
+    <Link
+      href={`/sessions/${session.id}`}
+      className="flex items-start gap-3 border bg-card px-4 py-3 transition-colors hover:border-foreground/20 hover:bg-accent/10"
+    >
+      <span
+        aria-hidden
+        className={cn("mt-1.5 size-2 flex-none rounded-full", ACTIVITY_DOT[activity])}
+      />
+
+      <div className="flex min-w-0 flex-[1_1_18rem] flex-col gap-0.5">
+        <div className="flex min-w-0 items-baseline gap-1.5 text-sm">
+          <span className="flex-none font-medium text-foreground">
+            {sourceLabel(session.source ?? "unknown")}
+          </span>
+          <span aria-hidden className="flex-none text-muted-foreground/50">
+            ·
+          </span>
+          <span className="truncate text-foreground/80">{subject}</span>
+        </div>
+        <span className="truncate text-[13px] text-muted-foreground">
+          {agentName ?? "No agent"}
+        </span>
+      </div>
+
+      {/* Outcome: the failure replaces the work summary, never sits beside it. */}
+      <div className="hidden min-w-0 flex-[1_1_12rem] text-[13px] @2xl/page-main:block">
+        {failed ? (
+          <span
+            className="truncate font-medium text-destructive"
+            title={session.output_preview ?? undefined}
+          >
+            {session.output_preview?.trim() || activityLabel(activity)}
+          </span>
+        ) : (
+          <span className="truncate text-muted-foreground">
+            {tokens !== undefined ? `${formatTokens(tokens)} tokens` : "No work recorded"}
+          </span>
+        )}
+      </div>
+
+      <span className="hidden w-16 flex-none text-right font-mono text-[13px] text-muted-foreground @xl/page-main:block">
+        {duration ?? "—"}
+      </span>
+      <span className="w-24 flex-none text-right text-[13px] text-muted-foreground">
+        {formatRelativeTime(session.created_at)}
+      </span>
+    </Link>
+  );
+}

--- a/apps/ui/src/components/session/session-row.tsx
+++ b/apps/ui/src/components/session/session-row.tsx
@@ -81,8 +81,12 @@ export function SessionRow({ session, agentName }: SessionRowProps) {
         </span>
       </div>
 
-      {/* Outcome: the failure replaces the work summary, never sits beside it. */}
-      <div className="hidden min-w-0 flex-[1_1_12rem] text-[13px] @2xl/page-main:block">
+      {/*
+        Outcome: the failure replaces the work summary, never sits beside it.
+        This is the column that earns its place, so it survives down to a narrow
+        main column — the rail alone keeps the page under the wider breakpoints.
+      */}
+      <div className="hidden min-w-0 flex-[1_1_10rem] text-[13px] @lg/page-main:block">
         {failed ? (
           <span
             className="truncate font-medium text-destructive"
@@ -97,7 +101,7 @@ export function SessionRow({ session, agentName }: SessionRowProps) {
         )}
       </div>
 
-      <span className="hidden w-16 flex-none text-right font-mono text-[13px] text-muted-foreground @xl/page-main:block">
+      <span className="hidden w-16 flex-none text-right font-mono text-[13px] text-muted-foreground @md/page-main:block">
         {duration ?? "—"}
       </span>
       <span className="w-24 flex-none text-right text-[13px] text-muted-foreground">

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -16,6 +16,7 @@ export * from "./use-session-resources";
 export * from "./use-session-participants";
 export * from "./use-session-tasks";
 export * from "./use-session-schedules";
+export * from "./use-session-views";
 export * from "./use-commands";
 export * from "./use-notifications";
 export * from "./use-mount-effect";

--- a/apps/ui/src/hooks/use-session-views.ts
+++ b/apps/ui/src/hooks/use-session-views.ts
@@ -1,0 +1,80 @@
+"use client";
+
+// Saved sessions views, persisted per user (EVE-853).
+//
+// Backed by the existing user-preference store rather than a new API: a view is
+// only a name and a query string, and preferences already give us per-user,
+// cross-device persistence with cache invalidation.
+
+import { useCallback, useMemo } from "react";
+import { useSetUserPreference, useUserPreference } from "./use-user-preferences";
+import {
+  DEFAULT_SESSION_VIEWS,
+  SESSION_VIEWS_PREFERENCE_KEY,
+  parseSavedViews,
+  type SavedSessionView,
+} from "@/lib/session-views";
+
+export interface UseSessionViewsResult {
+  /** The user's saved views, or the suggested defaults when they have none. */
+  views: SavedSessionView[];
+  /** False while `views` holds the suggested defaults, which nobody owns. */
+  viewsAreSaved: boolean;
+  /** True while the stored preference is still loading. */
+  isLoading: boolean;
+  /** True while a save or removal is in flight. */
+  isSaving: boolean;
+  /** Save the given query string under a name. Replaces a view of the same name. */
+  saveView: (name: string, query: string) => Promise<void>;
+  /** Remove a saved view. Built-in suggestions cannot be removed. */
+  removeView: (id: string) => Promise<void>;
+}
+
+export function useSessionViews(): UseSessionViewsResult {
+  const preference = useUserPreference(SESSION_VIEWS_PREFERENCE_KEY);
+  const setPreference = useSetUserPreference();
+
+  const saved = useMemo(() => parseSavedViews(preference.data?.value), [preference.data?.value]);
+  // Suggestions stand in only until the user has views of their own; mixing the
+  // two would make a "delete" that silently fails on half the list.
+  const views = saved.length > 0 ? saved : DEFAULT_SESSION_VIEWS;
+
+  const persist = useCallback(
+    async (next: SavedSessionView[]) => {
+      await setPreference.mutateAsync({ key: SESSION_VIEWS_PREFERENCE_KEY, value: next });
+    },
+    [setPreference],
+  );
+
+  const saveView = useCallback(
+    async (name: string, query: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const withoutDuplicate = saved.filter(
+        (view) => view.name.toLowerCase() !== trimmed.toLowerCase(),
+      );
+      await persist([
+        ...withoutDuplicate,
+        { id: `view:${trimmed.toLowerCase()}:${query}`, name: trimmed, query },
+      ]);
+    },
+    [persist, saved],
+  );
+
+  const removeView = useCallback(
+    async (id: string) => {
+      if (!saved.some((view) => view.id === id)) return;
+      await persist(saved.filter((view) => view.id !== id));
+    },
+    [persist, saved],
+  );
+
+  return {
+    views,
+    viewsAreSaved: saved.length > 0,
+    isLoading: preference.isLoading,
+    isSaving: setPreference.isPending,
+    saveView,
+    removeView,
+  };
+}

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -10,6 +10,7 @@ import {
   getSession,
   getSessionResolvedModel,
   getSessionContextReport,
+  getSessionFacets,
   getSessionStats,
   listSessions,
   updateSession,
@@ -27,6 +28,12 @@ import type {
   Event,
   PaginationParams,
 } from "@/lib/api/types";
+import {
+  SESSIONS_PAGE_SIZE,
+  serializeSessionFilters,
+  toQueryParams,
+  type SessionFilters,
+} from "@/lib/session-filters";
 import { useOrg } from "@/providers/org-provider";
 import { useLocale } from "@/providers/locale-provider";
 import { createReconnectTracker } from "@/lib/sse-reconnect";
@@ -53,6 +60,56 @@ export function useSessions(
   });
 
   // Include org loading state so pages show skeleton while org initializes
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+/**
+ * The filtered sessions list behind the operational Sessions page (EVE-853).
+ *
+ * Pairs with {@link useSessionFacets}: both take the same `SessionFilters`, so
+ * the rows and the counts beside them are always the same population.
+ */
+export function useFilteredSessions(filters: SessionFilters, options: { enabled?: boolean } = {}) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+  const serialized = serializeSessionFilters(filters);
+  const params = toQueryParams(filters);
+  const offset = filters.page * SESSIONS_PAGE_SIZE;
+
+  const query = useQuery({
+    queryKey: queryKeys.sessions.filtered(org, serialized, offset, SESSIONS_PAGE_SIZE),
+    queryFn: () => listSessions({ ...params, offset, limit: SESSIONS_PAGE_SIZE }),
+    enabled: !!org && (options.enabled ?? true),
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+/**
+ * Facet counts and masthead metrics for a filter set.
+ *
+ * Deliberately keyed on the filters minus pagination: paging through a result
+ * set does not change what is counted, so turning the page must not refetch or
+ * flicker the rail.
+ */
+export function useSessionFacets(filters: SessionFilters, options: { enabled?: boolean } = {}) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+  const serialized = serializeSessionFilters({ ...filters, page: 0 });
+  const params = toQueryParams(filters);
+
+  const query = useQuery({
+    queryKey: queryKeys.sessions.facets(org, serialized),
+    queryFn: () => getSessionFacets(params),
+    enabled: !!org && (options.enabled ?? true),
+  });
+
   return {
     ...query,
     isLoading: orgLoading || query.isLoading,

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -1,4 +1,9 @@
 // From legacy agent-identity-types.ts; retained as UI compatibility over generated OpenAPI schemas.
+
+// Enums that stay generated (closed sets the server owns) while the entity they
+// annotate is still hand-maintained here.
+import type { SessionActivity, SessionSource } from "./schema-types";
+
 // Agent Identity types
 export type AgentIdentityStatus = "active" | "archived" | "deleted";
 
@@ -3883,6 +3888,18 @@ export interface Session {
   /** Tool definitions (including client-side tools), defaults to [] */
   tools?: ToolDefinition[];
   status: SessionStatus;
+  /**
+   * How the session was started (EVE-852). Server-owned for every ingress
+   * except `chat`/`api`, which is what makes the Sessions source facet
+   * trustworthy. Optional here so responses from an older server still parse.
+   */
+  source?: SessionSource;
+  /**
+   * Outcome-oriented view of the session, derived server-side from its status
+   * and the outcome of its most recent turn. `status` alone has no notion of
+   * failure, which is why the list and the facet rail read this instead.
+   */
+  activity?: SessionActivity;
   created_at: string;
   updated_at: string;
   started_at: string | null;

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -10,6 +10,7 @@ import type {
   UpdateSessionRequest,
   SessionContextReport,
   SessionResolvedModelResponse,
+  SessionFacetsResponse,
   PaginatedResponse,
   PaginationParams,
 } from "./types";
@@ -32,19 +33,49 @@ export async function createSession(request: CreateSessionRequest): Promise<Sess
 }
 
 /**
+ * Filters `GET /v1/sessions` and `GET /v1/sessions/facets` share. Both
+ * endpoints resolve them into the same predicate server-side, which is what
+ * lets the facet counts annotate the very rows the list returns.
+ */
+export interface SessionListFilters {
+  /** Filter by agent public id. */
+  agentId?: string;
+  /** Case-insensitive title substring match. */
+  search?: string;
+  /** Comma-separated sources (`chat`, `slack`, `schedule`, …). */
+  source?: string;
+  /** Comma-separated derived activities (`running`, `failed`, …). */
+  status?: string;
+  /** Restrict to sessions owned by the calling user. */
+  mine?: boolean;
+  /** Inclusive lower bound on creation time (RFC 3339). */
+  createdAfter?: string;
+  /** Exclusive upper bound on creation time (RFC 3339). */
+  createdBefore?: string;
+  /** `created_at` (default) or `last_activity`. */
+  order?: "created_at" | "last_activity";
+}
+
+function sessionFilterParams(filters?: SessionListFilters): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  if (filters?.agentId) searchParams.set("agent_id", filters.agentId);
+  if (filters?.search) searchParams.set("search", filters.search);
+  if (filters?.source) searchParams.set("source", filters.source);
+  if (filters?.status) searchParams.set("status", filters.status);
+  if (filters?.mine) searchParams.set("mine", "true");
+  if (filters?.createdAfter) searchParams.set("created_after", filters.createdAfter);
+  if (filters?.createdBefore) searchParams.set("created_before", filters.createdBefore);
+  if (filters?.order) searchParams.set("order", filters.order);
+  return searchParams;
+}
+
+/**
  * List sessions for an organization.
- * @param agentId - Optional filter by agent ID
  */
 export async function listSessions(
-  params?: PaginationParams & { agentId?: string; search?: string },
+  params?: PaginationParams & SessionListFilters,
 ): Promise<PaginatedResponse<Session>> {
-  const searchParams = new URLSearchParams();
-  if (params?.agentId) {
-    searchParams.set("agent_id", params.agentId);
-  }
-  if (params?.search) {
-    searchParams.set("search", params.search);
-  }
+  const searchParams = sessionFilterParams(params);
   if (params?.offset !== undefined) {
     searchParams.set("offset", String(params.offset));
   }
@@ -54,6 +85,21 @@ export async function listSessions(
   const query = searchParams.toString();
   const url = `/v1/sessions${query ? `?${query}` : ""}`;
   const response = await api.get<PaginatedResponse<Session>>(url);
+  return response.data;
+}
+
+/**
+ * Facet-rail counts and masthead metrics over the same filter predicate as
+ * {@link listSessions}. Counts are aggregated server-side — the page never
+ * derives them by walking pages, so they stay correct beyond the first 20 rows.
+ */
+export async function getSessionFacets(
+  filters?: SessionListFilters,
+): Promise<SessionFacetsResponse> {
+  const query = sessionFilterParams(filters).toString();
+  const response = await api.get<SessionFacetsResponse>(
+    `/v1/sessions/facets${query ? `?${query}` : ""}`,
+  );
   return response.data;
 }
 

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -57,6 +57,15 @@ export const queryKeys = {
     list: (org?: string, agentId?: string, offset?: number, limit?: number) =>
       ["sessions", org, agentId ?? "all", offset ?? 0, limit ?? 20] as const,
     byAgent: (agentId: string) => ["sessions", "agent", agentId] as const,
+    /**
+     * The filtered operational list (EVE-853). `filters` is the serialized
+     * filter set, so it stays under `["sessions"]` and a create/update
+     * invalidation refreshes every filtered view at once.
+     */
+    filtered: (org?: string, filters?: string, offset?: number, limit?: number) =>
+      ["sessions", "filtered", org, filters ?? "", offset ?? 0, limit ?? 20] as const,
+    /** Facet counts and masthead metrics for a filter set. */
+    facets: (org?: string, filters?: string) => ["sessions", "facets", org, filters ?? ""] as const,
     detail: (org?: string, sessionId?: string) => ["session", org, sessionId] as const,
     contextReport: (org?: string, sessionId?: string) =>
       ["session", org, sessionId, "context-report"] as const,

--- a/apps/ui/src/lib/session-filters.ts
+++ b/apps/ui/src/lib/session-filters.ts
@@ -1,0 +1,229 @@
+// Sessions list filter state (EVE-853).
+//
+// The filter set lives in the URL, not in component state: a saved view is then
+// just a link, and the page, the facet counts and a shared URL can never
+// describe different populations. This module is the single translator between
+// the URL, the component props, and the query string the API expects — so the
+// list request and the facets request are always built from one value.
+
+import type { SessionActivity, SessionSource } from "@/lib/api/types";
+
+/** Page size for the operational list. */
+export const SESSIONS_PAGE_SIZE = 20;
+
+/**
+ * Time windows offered by the filter strip. Bounds are applied to session
+ * creation time, matching the `created_after` predicate the API filters on.
+ */
+export const TIME_WINDOWS = ["all", "24h", "7d", "30d"] as const;
+export type SessionTimeWindow = (typeof TIME_WINDOWS)[number];
+
+export const TIME_WINDOW_LABELS: Record<SessionTimeWindow, string> = {
+  all: "Any time",
+  "24h": "Last 24h",
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+};
+
+const WINDOW_DURATION_MS: Record<Exclude<SessionTimeWindow, "all">, number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+export const ACTIVITY_LABELS: Record<SessionActivity, string> = {
+  running: "Running",
+  failed: "Failed",
+  completed: "Completed",
+  paused: "Paused",
+  idle: "Idle",
+};
+
+export const SOURCE_LABELS: Record<SessionSource, string> = {
+  chat: "Chat",
+  api: "API",
+  slack: "Slack",
+  ag_ui: "AG-UI",
+  fcp: "FCP",
+  schedule: "Schedule",
+  webhook: "Webhook",
+  a2a: "A2A",
+  eval: "Eval",
+  subagent: "Subagent",
+  unknown: "Unknown",
+};
+
+/** Human label for a source value, tolerating values a newer server may add. */
+export function sourceLabel(value: string): string {
+  return SOURCE_LABELS[value as SessionSource] ?? value;
+}
+
+/** Human label for an activity value, tolerating values a newer server may add. */
+export function activityLabel(value: string): string {
+  return ACTIVITY_LABELS[value as SessionActivity] ?? value;
+}
+
+/**
+ * The complete filter state of the sessions page. Everything here round-trips
+ * through the URL; nothing about what is on screen lives only in memory.
+ */
+export interface SessionFilters {
+  /** Case-insensitive title search. */
+  search: string;
+  /** Selected derived activities. Empty means "every activity". */
+  status: string[];
+  /** Selected sources. Empty means "every source". */
+  source: string[];
+  /**
+   * Selected agent public id, or null for every agent. Single-valued because
+   * `GET /v1/sessions` takes one `agent_id`; the rail must not offer a
+   * selection the server cannot honour.
+   */
+  agent: string | null;
+  /** Creation-time window. */
+  window: SessionTimeWindow;
+  /** Restrict to sessions owned by the signed-in user. */
+  mine: boolean;
+  /** Zero-based page index. */
+  page: number;
+}
+
+export const EMPTY_SESSION_FILTERS: SessionFilters = {
+  search: "",
+  status: [],
+  source: [],
+  agent: null,
+  window: "all",
+  mine: false,
+  page: 0,
+};
+
+function parseList(raw: string | null): string[] {
+  if (!raw) return [];
+  return [
+    ...new Set(
+      raw
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function parseWindow(raw: string | null): SessionTimeWindow {
+  return TIME_WINDOWS.includes(raw as SessionTimeWindow) ? (raw as SessionTimeWindow) : "all";
+}
+
+/** Read the filter state out of a URL query string. Unknown values fall back. */
+export function parseSessionFilters(params: URLSearchParams): SessionFilters {
+  const page = Number.parseInt(params.get("page") ?? "", 10);
+  return {
+    search: params.get("q") ?? "",
+    status: parseList(params.get("status")),
+    source: parseList(params.get("source")),
+    agent: params.get("agent") || null,
+    window: parseWindow(params.get("window")),
+    mine: params.get("mine") === "true",
+    page: Number.isFinite(page) && page > 0 ? page : 0,
+  };
+}
+
+/**
+ * Serialize filters back to a query string. Defaults are omitted so a pristine
+ * list has a clean URL and two equivalent filter sets share one cache key.
+ */
+export function serializeSessionFilters(filters: SessionFilters): string {
+  const params = new URLSearchParams();
+  if (filters.search) params.set("q", filters.search);
+  if (filters.status.length) params.set("status", filters.status.join(","));
+  if (filters.source.length) params.set("source", filters.source.join(","));
+  if (filters.agent) params.set("agent", filters.agent);
+  if (filters.window !== "all") params.set("window", filters.window);
+  if (filters.mine) params.set("mine", "true");
+  if (filters.page > 0) params.set("page", String(filters.page));
+  return params.toString();
+}
+
+/** Whether any filter narrows the list (page position aside). */
+export function hasActiveFilters(filters: SessionFilters): boolean {
+  return (
+    filters.search !== "" ||
+    filters.status.length > 0 ||
+    filters.source.length > 0 ||
+    filters.agent !== null ||
+    filters.window !== "all" ||
+    filters.mine
+  );
+}
+
+/**
+ * Toggle one value of a multi-select facet, resetting to the first page.
+ * Changing what is counted must never leave the reader on a page that the new
+ * result set no longer has.
+ */
+export function toggleFilterValue(
+  filters: SessionFilters,
+  dimension: "status" | "source",
+  value: string,
+): SessionFilters {
+  const current = filters[dimension];
+  const next = current.includes(value)
+    ? current.filter((entry) => entry !== value)
+    : [...current, value];
+  return { ...filters, [dimension]: next, page: 0 };
+}
+
+/** Select an agent, or clear the selection by toggling the active one. */
+export function toggleAgentFilter(filters: SessionFilters, agentId: string): SessionFilters {
+  return { ...filters, agent: filters.agent === agentId ? null : agentId, page: 0 };
+}
+
+/** Apply a partial change, resetting pagination unless the page itself moved. */
+export function withFilterChange(
+  filters: SessionFilters,
+  change: Partial<SessionFilters>,
+): SessionFilters {
+  const next = { ...filters, ...change };
+  return "page" in change ? next : { ...next, page: 0 };
+}
+
+/**
+ * Lower bound on `created_at` for a window, as an RFC 3339 string.
+ *
+ * Floored to the start of the minute so the value is stable across renders —
+ * an unquantized `Date.now()` would mint a new query key (and a new request)
+ * on every keystroke.
+ */
+export function windowStart(
+  window: SessionTimeWindow,
+  now: number = Date.now(),
+): string | undefined {
+  if (window === "all") return undefined;
+  const anchor = Math.floor(now / 60_000) * 60_000;
+  return new Date(anchor - WINDOW_DURATION_MS[window]).toISOString();
+}
+
+/** Query parameters shared by the list request and the facets request. */
+export interface SessionQueryParams {
+  search?: string;
+  status?: string;
+  source?: string;
+  agentId?: string;
+  mine?: boolean;
+  createdAfter?: string;
+}
+
+/** Translate filters into the parameters both API calls take. */
+export function toQueryParams(
+  filters: SessionFilters,
+  now: number = Date.now(),
+): SessionQueryParams {
+  return {
+    search: filters.search || undefined,
+    status: filters.status.length ? filters.status.join(",") : undefined,
+    source: filters.source.length ? filters.source.join(",") : undefined,
+    agentId: filters.agent ?? undefined,
+    mine: filters.mine || undefined,
+    createdAfter: windowStart(filters.window, now),
+  };
+}

--- a/apps/ui/src/lib/session-list-export.ts
+++ b/apps/ui/src/lib/session-list-export.ts
@@ -1,0 +1,117 @@
+// CSV export of the filtered sessions list (EVE-853).
+//
+// The masthead Export exports what the filters describe, not what happens to be
+// on the current page — otherwise the button would quietly mean "export 20
+// rows". Rows are pulled from the same endpoint the list renders, so an export
+// and the screen can never disagree.
+
+import { listSessions, type SessionListFilters } from "@/lib/api/sessions";
+import type { Session } from "@/lib/api/types";
+
+/** Server maximum for `limit` on `GET /v1/sessions`. */
+const EXPORT_PAGE_SIZE = 100;
+
+/**
+ * Ceiling on exported rows. An unbounded export of an org's whole history is a
+ * request nobody means to make from a list page; the caller is told when the
+ * result was cut so the number is never silently wrong.
+ */
+export const EXPORT_ROW_LIMIT = 2_000;
+
+export interface SessionsCsvResult {
+  rowsExported: number;
+  /** True when the filtered set was larger than {@link EXPORT_ROW_LIMIT}. */
+  truncated: boolean;
+}
+
+function csvCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+const HEADER = [
+  "id",
+  "source",
+  "status",
+  "agent",
+  "title",
+  "created_at",
+  "started_at",
+  "finished_at",
+  "duration_ms",
+  "input_tokens",
+  "output_tokens",
+  "cost_usd",
+];
+
+function durationMs(session: Session): number | undefined {
+  if (!session.started_at || !session.finished_at) return undefined;
+  const ms = new Date(session.finished_at).getTime() - new Date(session.started_at).getTime();
+  return Number.isFinite(ms) && ms >= 0 ? ms : undefined;
+}
+
+function toRow(session: Session, agentName: (agentId: string) => string): string {
+  return [
+    session.id,
+    session.source,
+    session.activity,
+    session.agent_id ? agentName(session.agent_id) : "",
+    session.title ?? "",
+    session.created_at,
+    session.started_at ?? "",
+    session.finished_at ?? "",
+    durationMs(session) ?? "",
+    session.usage?.input_tokens ?? "",
+    session.usage?.output_tokens ?? "",
+    session.usage?.effective_cost_usd ?? session.usage?.actual_cost_usd ?? "",
+  ]
+    .map(csvCell)
+    .join(",");
+}
+
+/** Fetch every session matching `filters`, up to {@link EXPORT_ROW_LIMIT}. */
+async function fetchFilteredSessions(
+  filters: SessionListFilters,
+): Promise<{ sessions: Session[]; truncated: boolean }> {
+  const sessions: Session[] = [];
+  let offset = 0;
+  let total = Infinity;
+
+  while (sessions.length < Math.min(total, EXPORT_ROW_LIMIT)) {
+    const page = await listSessions({ ...filters, offset, limit: EXPORT_PAGE_SIZE });
+    total = page.total;
+    if (page.data.length === 0) break;
+    sessions.push(...page.data);
+    offset += page.data.length;
+  }
+
+  return {
+    sessions: sessions.slice(0, EXPORT_ROW_LIMIT),
+    truncated: total > EXPORT_ROW_LIMIT,
+  };
+}
+
+/**
+ * Build a CSV of the filtered sessions and trigger a browser download.
+ * Returns how many rows were written so the caller can report it.
+ */
+export async function downloadSessionsCsv(
+  filters: SessionListFilters,
+  agentName: (agentId: string) => string,
+): Promise<SessionsCsvResult> {
+  const { sessions, truncated } = await fetchFilteredSessions(filters);
+  const csv = [HEADER.join(","), ...sessions.map((session) => toRow(session, agentName))].join(
+    "\n",
+  );
+
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "sessions.csv";
+  anchor.click();
+  URL.revokeObjectURL(url);
+
+  return { rowsExported: sessions.length, truncated };
+}

--- a/apps/ui/src/lib/session-views.ts
+++ b/apps/ui/src/lib/session-views.ts
@@ -1,0 +1,68 @@
+// Saved sessions views (EVE-853).
+//
+// A view is a name plus the filter query string — nothing more. Because the
+// sessions page keeps its whole filter set in the URL, a saved view is just a
+// link: shareable by copy-paste, and reproducible for anyone who opens it.
+// Persistence is the per-user preference store, so views follow a user across
+// devices without needing a new API surface.
+
+import {
+  parseSessionFilters,
+  serializeSessionFilters,
+  type SessionFilters,
+} from "@/lib/session-filters";
+
+/** Preference key holding this user's saved sessions views. */
+export const SESSION_VIEWS_PREFERENCE_KEY = "sessions.saved_views";
+
+export interface SavedSessionView {
+  /** Stable id used as the React key and for removal. */
+  id: string;
+  /** User-supplied name shown on the rail. */
+  name: string;
+  /** Serialized filter set (the sessions page query string). */
+  query: string;
+}
+
+/**
+ * Views offered before a user has saved any of their own. They are ordinary
+ * views — selecting one only sets the URL — so the rail behaves identically
+ * whether a view was suggested or saved.
+ */
+export const DEFAULT_SESSION_VIEWS: SavedSessionView[] = [
+  { id: "builtin:failures-7d", name: "Failures, last 7 days", query: "status=failed&window=7d" },
+  { id: "builtin:running", name: "Running now", query: "status=running" },
+  {
+    id: "builtin:scheduled-24h",
+    name: "Scheduled runs, last 24h",
+    query: "source=schedule&window=24h",
+  },
+];
+
+/** Parse the stored preference value, tolerating anything unexpected. */
+export function parseSavedViews(value: unknown): SavedSessionView[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (typeof entry !== "object" || entry === null) return [];
+    const { id, name, query } = entry as Record<string, unknown>;
+    if (typeof id !== "string" || typeof name !== "string" || typeof query !== "string") return [];
+    return [{ id, name, query }];
+  });
+}
+
+/**
+ * Whether a view describes the filters currently on screen. Compared on the
+ * canonical serialization with pagination dropped, so "page 2 of Failures" is
+ * still recognizably the Failures view.
+ */
+export function isViewActive(view: SavedSessionView, filters: SessionFilters): boolean {
+  return normalizeViewQuery(view.query) === serializeSessionFilters({ ...filters, page: 0 });
+}
+
+/**
+ * Round-trip a stored query string through the filter parser so views saved by
+ * an older build (or hand-edited) compare against today's canonical form.
+ */
+export function normalizeViewQuery(query: string): string {
+  return serializeSessionFilters({ ...parseSessionFilters(new URLSearchParams(query)), page: 0 });
+}


### PR DESCRIPTION
## What changed

Sessions becomes the one surface that answers "what ran". It consumes the filters and facet counts merged in #3073, which until now nothing called.

- **Read-only masthead** — total, a `read-only` badge, and four live counters (active now, failed today, p95 duration, tokens today) served by `GET /v1/sessions/facets`. Export sits on the right and exports *the filtered set*, not the visible page: it walks the same endpoint at 100/page, capped at 2,000 rows, and reports when the cap truncated the result.
- **Filter strip** — title search, an All/Running/Failed/Completed segmented control, and a creation-time window.
- **Row** — status dot, `Source · subject` as the primary line, agent underneath, outcome, duration, relative time. On a failed run the outcome column carries the failure instead of the work summary.
- **Facet rail** — Status, Source and Agent with server-side counts. Status and Source are multi-select (the API takes CSV); Agent is single-select because `GET /v1/sessions` takes one `agent_id`, and the rail should not offer a selection the server cannot honour. A value you have selected stays clickable even when the current filter set leaves it at zero — otherwise the only way to undo it is editing the URL.
- **Saved views** — a name plus a query string, persisted per user in the existing preference store. Suggested views stand in until you save your own.

The whole filter set lives in the URL. That is what makes a saved view just a link, and it keeps the rows, the counts and the address bar describing one population. No count is derived from the rows on screen, so a page of 20 never misreports a set of 4,000, and every change to what is counted resets to page 1.

**"New session" is gone from this page.** Sessions is read-only; authoring a run belongs where the run is composed. Both entry points already existed — `/chats/new` for an interactive thread, the agent page for an agent run — so the dialog was removed rather than relocated.

`source` and `activity` join the hand-maintained UI `Session` type so the row and the rail can read them.

## Why

EVE-853. The backend for this shipped in #3073 and had no consumer — the page was still an unfiltered list of 20 with an agent dropdown.

## Before / After

**Before:** one flat list, a single agent dropdown, no counts, no notion of failure, filter state invisible to a link.

**After**, verified against a live stack (`just start-dev`, `AUTH_MODE=none`, 30 seeded sessions across `chat` and `api`):

| State | Result |
|---|---|
| Default view | 30 total, counters rendered, Status `Idle 30`, Source `API 7` / `Chat 23` |
| `?source=api` | 7 rows; Status narrows to `Idle 7`; Source still shows `Chat 23` — each dimension counted with its own selection excluded, which is what makes multi-select usable |
| `?status=failed` | empty state with a Clear action; `Failed 0` still listed and still clickable |
| `?page=1` | rows 21–30, Previous/Next bounded correctly |
| Save view → full reload → select | persisted server-side, suggested defaults replaced, selecting it restored `?source=chat&window=7d` and the Time window control |
| `?status=bogus` | API 400 → error state with Retry, `Counts unavailable.` on the rail |

Screenshots were captured for each state during the manual pass and deliberately not committed, per the shipping spec.

The manual pass earned its keep: it caught the outcome column hidden behind a container breakpoint the page never actually reaches once the rail is present, plus a masthead stuck on "Loading counters…" after a failed facets request and rail copy claiming the list was fine when the list had also failed. All three are fixed in the third commit.

## Risk

- **Low.** UI-only; no server, schema, or migration changes (verified neither side touched `crates/server/migrations/` since the merge base).
- What can break: the page's React Query cache keys changed, so the server-side prefetch only seeds the unfiltered first page — any other filter set fetches on the client. `SessionCard` is untouched and still used by the agent pages and dev routes.

**Rebased onto `00afdbb`.** This PR originally also regenerated the stale UI API types; #3077 landed the same regeneration (byte-identical) plus the actual root cause — the CI path filter did not watch `docs/api/openapi.json`, so a spec-only change skipped the UI job. The rebase collapsed those hunks, and the branch was revalidated locally against the Dependabot bump in #3076: install, `api-types:check`, typecheck, lint, 1450 tests, and a production build all clean.

## Security

- Threat categories reviewed: **TM-WEB**, **TM-API**, **TM-TENANT**, **TM-DOS**.
- Findings and resolutions:
  - *TM-WEB* — no `dangerouslySetInnerHTML`, `innerHTML`, or `eval` introduced. Session titles and previews render as React text. Navigation always builds a fixed `/sessions` path plus a serialized query string, so a crafted URL cannot redirect elsewhere. No `THREAT` marker in the diff's blast radius was invalidated.
  - *TM-TENANT* — every new query key includes the org public id, so a filtered list or facet response cannot be served across an org switch.
  - *TM-DOS* — the CSV export is the only new loop. It is bounded at 2,000 rows (≤20 requests) and advances by rows actually returned, so it terminates even if the server reports a larger total.
  - *TM-API* — no new server surface; the client calls existing endpoints. Unknown filter values are rejected by the server with 400 rather than silently widening the result set, and the page renders its error state.

## Follow-ups

Filed as findings on EVE-853 rather than silently dropped:

1. **The row's work summary and failure reason are not in the API.** The spec asks for `6 tool calls · 1 subagent`, and `channel_not_found` in its place on failure. `sessions.turn_count`/`tool_call_count` exist in the database (migration 102) but are not on the `Session` DTO; there is no subagent count; and no failure reason is stored anywhere — migration 118's `last_turn_status` only separates `failed` from `cancelled`. Shipped from what is truthfully available (tokens, or the last output preview on a failure). Adding fields to `Session` means touching ~56 literal construction sites, which is why it is not folded into a UI PR.
2. **`/reports` cannot fold into saved views.** Checked before assuming: it is a general query builder over six reporting datasets with grouped measures, aggregate CSV export, org-scoped saved reports, and projector diagnostics. A sessions saved view is a filter over session rows and can express none of that. Retiring the route in the cleanup ticket would drop real capability. Nothing was deleted here.
3. **The Chats sidebar still filters client-side** (`src/lib/chat-threads.ts`), which #3073 explicitly replaces with `source=chat&mine=true&order=last_activity`. Left alone to keep this PR to one surface.

## Checklist
- [x] Tests added or updated — 16 unit tests covering URL round-trip, pagination reset, API parameter mapping, and saved-view matching
- [x] Backward compatibility considered — `source`/`activity` are optional on the UI `Session` type so an older server still parses
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — green on the rebased head
- [x] All review comments addressed — no reviews or review comments were left on this PR