### PR TITLE
feat(everruns): close application runtime API gaps

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -152,6 +152,7 @@ jobs:
               "crates/everruns/Cargo.toml": [
                   "everruns-core",
                   "everruns-runtime",
+                  "everruns-local",
                   "everruns-macros",
               ],
               "crates/local/Cargo.toml": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,6 +2398,7 @@ version = "0.17.25"
 dependencies = [
  "async-trait",
  "everruns-core",
+ "everruns-local",
  "everruns-macros",
  "everruns-openai",
  "everruns-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ everruns-mcp = { path = "crates/mcp", version = "0.17.25" }
 everruns-ard = { path = "crates/ard", version = "0.17.25" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
 everruns-runtime = { path = "crates/runtime", version = "0.17.25" }
+everruns-local = { path = "crates/local", version = "0.17.25" }
 everruns = { path = "crates/everruns", version = "0.17.25" }
 everruns-macros = { path = "crates/macros", version = "0.17.25" }
 

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -44,6 +44,10 @@ jsonl = []
 lua = ["everruns-runtime/lua"]
 # Enable local-process (stdio) MCP servers, mirroring `everruns-runtime/mcp-stdio`.
 mcp-stdio = ["everruns-runtime/mcp-stdio"]
+# Enable SQLite-backed local task/schedule state and real workspaces through
+# `LocalConfig`. Conversation history is derived from canonical events rather
+# than selecting a writable message store here.
+local = ["dep:everruns-local"]
 # Configure real OpenAI-backed models via `everruns::providers::openai`. Off by
 # default so the standard facade build pulls in no provider or Reqwest edge; the
 # `OpenAI` config type and its driver wiring compile only with this feature.
@@ -52,6 +56,7 @@ openai = ["dep:everruns-openai"]
 [dependencies]
 everruns-core.workspace = true
 everruns-runtime.workspace = true
+everruns-local = { workspace = true, optional = true }
 # Optional real-provider edge, activated by the `openai` feature. Referenced via
 # workspace inheritance; the workspace pin is a compatible lower bound, so this
 # is intentionally absent from the publish version-sync lists (unlike

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
@@ -169,6 +170,10 @@ pub enum BuildError {
         requested: String,
         registered: Vec<String>,
     },
+    /// MCP server configuration was invalid or duplicated.
+    InvalidMcpServer { reason: String },
+    /// Context compaction configuration was invalid.
+    InvalidCompaction { reason: String },
 }
 
 impl fmt::Display for BuildError {
@@ -196,6 +201,12 @@ impl fmt::Display for BuildError {
                 "provider {requested:?} is not registered; registered providers: [{}]",
                 registered.join(", ")
             ),
+            BuildError::InvalidMcpServer { reason } => {
+                write!(f, "invalid MCP server configuration: {reason}")
+            }
+            BuildError::InvalidCompaction { reason } => {
+                write!(f, "invalid compaction configuration: {reason}")
+            }
         }
     }
 }
@@ -218,6 +229,11 @@ pub struct Agent {
     function_tools: Vec<FunctionTool>,
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
+    workspace_root: Option<PathBuf>,
+    mcp_servers: everruns_core::ScopedMcpServers,
+    plugin_warnings: Vec<String>,
+    #[cfg(feature = "local")]
+    local: Option<crate::LocalConfig>,
 }
 
 impl Agent {
@@ -304,6 +320,10 @@ impl Agent {
             .await
     }
 
+    pub(crate) fn plugin_warnings(&self) -> Vec<String> {
+        self.plugin_warnings.clone()
+    }
+
     async fn build_runtime_with_backends(
         &self,
         session_id: SessionId,
@@ -333,7 +353,8 @@ impl Agent {
         let mut session = SessionBuilder::new(harness_id)
             .id(session_id)
             .agent(agent_id)
-            .capabilities(self.capabilities.clone());
+            .capabilities(self.capabilities.clone())
+            .mcp_servers(self.mcp_servers.clone());
         if let Some(parallel) = self.parallel_tool_calls {
             session = session.parallel_tool_calls(parallel);
         }
@@ -347,18 +368,64 @@ impl Agent {
             .agent(agent)
             .session(session)
             .model_spec(self.model.spec.clone());
-        // Route the runtime's raw event bus through the facade sink, and swap in
-        // a persisting message store when one was supplied (EVE-836). Any store
-        // not overridden stays on the default in-memory backend.
-        if event_bus.is_some() || message_store.is_some() {
-            let mut backends = RuntimeBackends::in_memory();
-            if let Some(event_bus) = event_bus {
-                backends = backends.with_event_bus(event_bus);
+
+        let mut backends = RuntimeBackends::in_memory();
+        if let Some(event_bus) = event_bus {
+            backends = backends.with_event_bus(event_bus);
+        }
+        #[cfg(feature = "local")]
+        if let Some(config) = &self.local {
+            config
+                .profile()
+                .ensure_dirs()
+                .map_err(|error| everruns_core::AgentLoopError::config(error.to_string()))?;
+        }
+        if let Some(message_store) = message_store {
+            backends = backends.with_message_store(message_store);
+        }
+
+        #[cfg(feature = "local")]
+        if let Some(config) = &self.local {
+            let local = everruns_local::LocalBackends::new(config.profile(), backends)?;
+            backends = local.runtime_backends;
+        }
+        builder = builder.backends(backends);
+
+        let workspace_root = self.workspace_root.as_ref().or_else(|| {
+            #[cfg(feature = "local")]
+            {
+                self.local.as_ref().map(|config| &config.workspace_root)
             }
-            if let Some(message_store) = message_store {
-                backends = backends.with_message_store(message_store);
+            #[cfg(not(feature = "local"))]
+            {
+                None
             }
-            builder = builder.backends(backends);
+        });
+        if let Some(root) = workspace_root {
+            // THREAT[TM-BASH-001] / THREAT[TM-FS-013]: reuse the canonical
+            // real-disk factory so every operation retains containment and
+            // symlink rejection; the facade does not implement a second path
+            // mapper.
+            let registry = {
+                #[cfg(feature = "local")]
+                if self.local.is_some() {
+                    everruns_core::CapabilityRegistry::with_builtins()
+                } else {
+                    everruns_core::CapabilityRegistry::runtime_builtins()
+                }
+                #[cfg(not(feature = "local"))]
+                {
+                    everruns_core::CapabilityRegistry::runtime_builtins()
+                }
+            };
+            let platform = everruns_core::PlatformDefinition::builder()
+                .capability_registry(registry)
+                .driver_registry(everruns_core::DriverRegistry::new())
+                .session_file_system_factory(Arc::new(
+                    everruns_runtime::RealDiskSessionFileSystemFactory::new(root),
+                ))
+                .build();
+            builder = builder.platform_definition(platform);
         }
         // Register each function tool as a closure-backed, single-tool
         // capability so the runtime can execute the model's calls; the matching
@@ -388,6 +455,12 @@ pub struct AgentBuilder {
     tools: Vec<Tool>,
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
+    workspace_root: Option<PathBuf>,
+    mcp_servers: Vec<crate::McpServer>,
+    plugin_warnings: Vec<String>,
+    compaction: Option<crate::CompactionConfig>,
+    #[cfg(feature = "local")]
+    local: Option<crate::LocalConfig>,
 }
 
 impl AgentBuilder {
@@ -470,6 +543,91 @@ impl AgentBuilder {
         self
     }
 
+    /// Seed an editable UTF-8 text file into the initial workspace.
+    pub fn file(mut self, path: impl Into<String>, content: impl Into<String>) -> Self {
+        self.initial_files.push(InitialFile {
+            path: path.into(),
+            content: content.into(),
+            encoding: "text".to_string(),
+            is_readonly: false,
+        });
+        self
+    }
+
+    /// Seed a read-only UTF-8 text file into the initial workspace.
+    pub fn readonly_file(mut self, path: impl Into<String>, content: impl Into<String>) -> Self {
+        self.initial_files.push(InitialFile {
+            path: path.into(),
+            content: content.into(),
+            encoding: "text".to_string(),
+            is_readonly: true,
+        });
+        self
+    }
+
+    /// Use a real host directory as this agent's `/workspace`.
+    ///
+    /// The runtime rejects traversal and symlink escapes at every filesystem
+    /// operation. The directory must exist before the session is first used and
+    /// must be selected by trusted application configuration, not model input.
+    pub fn workspace(mut self, root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = Some(root.into());
+        if !self
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id() == "session_file_system")
+        {
+            self.capabilities
+                .push(AgentCapabilityConfig::new("session_file_system"));
+        }
+        self
+    }
+
+    /// Add a scoped MCP server to this agent.
+    pub fn mcp_server(mut self, server: crate::McpServer) -> Self {
+        self.mcp_servers.push(server);
+        self
+    }
+
+    /// Load and enable a local plugin directory.
+    ///
+    /// Reading and compilation happen immediately so invalid or unsafe plugin
+    /// input fails before the agent is built. Non-fatal warnings are available
+    /// from [`Session::inspect`](crate::Session::inspect). Plugins contribute
+    /// instructions and capabilities, so select the directory from trusted
+    /// application configuration rather than model or request input.
+    pub fn plugin(mut self, path: impl AsRef<Path>) -> Result<Self, crate::PluginError> {
+        let loaded = crate::plugin::load(path.as_ref())?;
+        self.capabilities.push(loaded.capability);
+        self.plugin_warnings.extend(loaded.warnings);
+        Ok(self)
+    }
+
+    /// Configure automatic context compaction for long-running sessions.
+    pub fn compaction(mut self, config: crate::CompactionConfig) -> Self {
+        self.compaction = Some(config);
+        self
+    }
+
+    /// Enable local task/schedule state and a real workspace.
+    ///
+    /// Task and schedule state is stored in SQLite. Conversation persistence is
+    /// event-derived and is not selected by this profile. Requires the `local`
+    /// feature.
+    #[cfg(feature = "local")]
+    pub fn local(mut self, config: crate::LocalConfig) -> Self {
+        self.local = Some(config);
+        if !self
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id() == "session_file_system")
+        {
+            self.capabilities
+                .push(AgentCapabilityConfig::new("session_file_system"));
+        }
+        self
+    }
+
     /// Validate the description and produce an [`Agent`].
     ///
     /// # Errors
@@ -482,6 +640,10 @@ impl AgentBuilder {
     /// - [`BuildError::InvalidToolSchema`] if a function tool's JSON schema is
     ///   not a valid arguments schema.
     /// - [`BuildError::DuplicateTool`] if two `.tool(..)` calls share a name.
+    /// - [`BuildError::InvalidMcpServer`] if an MCP server is unnamed,
+    ///   incomplete, or duplicates another server name.
+    /// - [`BuildError::InvalidCompaction`] if the proactive context budget is
+    ///   outside the supported range.
     pub fn build(self) -> Result<Agent, BuildError> {
         let instructions = self.instructions.unwrap_or_default();
         if instructions.trim().is_empty() {
@@ -545,6 +707,20 @@ impl AgentBuilder {
             }
         }
 
+        let mcp_servers = crate::mcp::into_scoped(self.mcp_servers)
+            .map_err(|reason| BuildError::InvalidMcpServer { reason })?;
+        if let Some(compaction) = self.compaction {
+            if !(compaction.budget_percent.is_finite()
+                && 0.1 <= compaction.budget_percent
+                && compaction.budget_percent <= 1.0)
+            {
+                return Err(BuildError::InvalidCompaction {
+                    reason: "budget_percent must be at least 0.1 and at most 1".to_string(),
+                });
+            }
+            capabilities.push(compaction.capability_config());
+        }
+
         Ok(Agent {
             name,
             instructions,
@@ -554,6 +730,11 @@ impl AgentBuilder {
             function_tools,
             initial_files: self.initial_files,
             parallel_tool_calls: self.parallel_tool_calls,
+            workspace_root: self.workspace_root,
+            mcp_servers,
+            plugin_warnings: self.plugin_warnings,
+            #[cfg(feature = "local")]
+            local: self.local,
         })
     }
 }

--- a/crates/everruns/src/compaction.rs
+++ b/crates/everruns/src/compaction.rs
@@ -1,0 +1,89 @@
+//! High-level context-compaction configuration.
+
+/// Strategy used when a conversation outgrows the model context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum CompactionStrategy {
+    /// Cascade through masking, provider-native compaction, and summarization.
+    #[default]
+    Auto,
+    /// Use the provider's native compaction operation.
+    Native,
+    /// Replace older tool outputs with compact summaries.
+    ObservationMasking,
+    /// Ask the configured model to summarize older turns.
+    Summarization,
+}
+
+impl CompactionStrategy {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Native => "native",
+            Self::ObservationMasking => "observation_masking",
+            Self::Summarization => "summarization",
+        }
+    }
+}
+
+/// Application-facing context-compaction policy.
+///
+/// The default proactively compacts at 85% of the model's context budget and
+/// lets the runtime select the best available strategy. Durable checkpoint
+/// storage remains a host concern; applications configure behavior without
+/// supplying a checkpoint store.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CompactionConfig {
+    pub(crate) strategy: CompactionStrategy,
+    pub(crate) proactive: bool,
+    pub(crate) budget_percent: f32,
+}
+
+impl CompactionConfig {
+    /// Start with the safe automatic policy.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Choose the compaction strategy.
+    pub fn strategy(mut self, strategy: CompactionStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    /// Enable or disable compaction before a provider rejects an oversized request.
+    pub fn proactive(mut self, enabled: bool) -> Self {
+        self.proactive = enabled;
+        self
+    }
+
+    /// Set the proactive trigger as a fraction of the model context budget.
+    ///
+    /// Values must be at least 0.1 and at most one. Validation happens in
+    /// [`AgentBuilder::build`](crate::AgentBuilder::build).
+    pub fn budget_percent(mut self, budget_percent: f32) -> Self {
+        self.budget_percent = budget_percent;
+        self
+    }
+
+    pub(crate) fn capability_config(self) -> everruns_core::AgentCapabilityConfig {
+        everruns_core::AgentCapabilityConfig::with_config(
+            "compaction",
+            serde_json::json!({
+                "strategy": self.strategy.as_str(),
+                "proactive": self.proactive,
+                "budget_percent": self.budget_percent,
+            }),
+        )
+    }
+}
+
+impl Default for CompactionConfig {
+    fn default() -> Self {
+        Self {
+            strategy: CompactionStrategy::Auto,
+            proactive: true,
+            budget_percent: 0.85,
+        }
+    }
+}

--- a/crates/everruns/src/context.rs
+++ b/crates/everruns/src/context.rs
@@ -1,0 +1,82 @@
+//! Curated, application-facing session context inspection.
+
+use everruns_core::AssembledTurnContext;
+
+use crate::{ContentPart, MessageRole, ModelSpec};
+
+/// The effective context a session will send to its model on the next turn.
+///
+/// This intentionally exposes values useful to applications while keeping
+/// stored harness/session records and backend-specific context internals out of
+/// the Framework API.
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    /// Credential-free provider and model selection.
+    pub model: ModelSpec,
+    /// Filtered conversation history visible to the next model call.
+    pub messages: Vec<ContextMessage>,
+    /// Model-visible tools after capability, plugin, and MCP resolution.
+    pub tools: Vec<ToolInfo>,
+    /// Effective system instructions after all configured contributions.
+    pub instructions: String,
+    /// Effective locale, when one was configured.
+    pub locale: Option<String>,
+    /// Non-fatal warnings produced while loading local plugins.
+    pub plugin_warnings: Vec<String>,
+}
+
+/// One message in an inspected session context.
+#[derive(Debug, Clone)]
+pub struct ContextMessage {
+    /// The message's conversational role.
+    pub role: MessageRole,
+    /// Structured text, image, tool-call, and tool-result content.
+    pub content: Vec<ContentPart>,
+}
+
+/// A model-visible tool in an inspected session context.
+#[derive(Debug, Clone)]
+pub struct ToolInfo {
+    /// Model-facing tool name.
+    pub name: String,
+    /// Model-facing description.
+    pub description: String,
+    /// JSON Schema for the tool arguments.
+    pub parameters: serde_json::Value,
+}
+
+impl SessionContext {
+    pub(crate) fn from_runtime(
+        context: AssembledTurnContext,
+        plugin_warnings: Vec<String>,
+    ) -> Self {
+        let model = context.model_with_provider.canonical_parts().0;
+        let messages = context
+            .messages
+            .into_iter()
+            .map(|message| ContextMessage {
+                role: message.role,
+                content: message.content,
+            })
+            .collect();
+        let tools = context
+            .runtime_agent
+            .tools
+            .iter()
+            .map(|tool| ToolInfo {
+                name: tool.name().to_string(),
+                description: tool.description().to_string(),
+                parameters: tool.parameters().clone(),
+            })
+            .collect();
+
+        Self {
+            model,
+            messages,
+            tools,
+            instructions: context.runtime_agent.system_prompt,
+            locale: context.resolved_locale,
+            plugin_warnings,
+        }
+    }
+}

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -40,13 +40,26 @@ extern crate self as everruns;
 
 // --- Value-first agent description and execution -------------------------
 mod agent;
+mod compaction;
+mod context;
 mod events;
+mod mcp;
+mod plugin;
 mod session;
 mod tool;
 pub use agent::{Agent, AgentBuilder, BuildError, Model};
+pub use compaction::{CompactionConfig, CompactionStrategy};
+pub use context::{ContextMessage, SessionContext, ToolInfo};
 pub use events::{CancellationToken, EventStream, RunOptions, SessionEvent, SessionEventKind};
+pub use mcp::McpServer;
+pub use plugin::PluginError;
 pub use session::{RunError, Session, Turn};
 pub use tool::{FunctionTool, IntoTool, IntoToolResult, Tool, ToolResponse};
+
+#[cfg(feature = "local")]
+mod local;
+#[cfg(feature = "local")]
+pub use local::LocalConfig;
 
 #[cfg(all(test, feature = "macros"))]
 mod tool_macro_tests;
@@ -118,10 +131,10 @@ pub use everruns_runtime::{
 // --- Portable message, model, and platform types ------------------------
 pub use everruns_core::turn::TurnStopReason;
 pub use everruns_core::{
-    AgentLoopError, BearerAuth, CapabilityRegistry, ChatDriver, ContentPart, InputMessage,
-    LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmResponseStream, LlmStreamEvent,
-    MessageRole, ModelSpec, PlatformDefinition, Provider, ProviderAuth, ProviderAuthRequest,
-    ProviderEndpoint, ProviderKey, ProviderRegistry, StaticHeaderAuth,
+    AgentLoopError, BearerAuth, CapabilityRegistry, ChatDriver, ContentPart, InitialFile,
+    InputMessage, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmResponseStream,
+    LlmStreamEvent, MessageRole, ModelSpec, PlatformDefinition, Provider, ProviderAuth,
+    ProviderAuthRequest, ProviderEndpoint, ProviderKey, ProviderRegistry, StaticHeaderAuth,
 };
 
 // --- Deterministic in-process LLM simulator -----------------------------
@@ -149,12 +162,15 @@ pub use everruns_runtime as runtime;
 /// assert!(agent.is_ok());
 /// ```
 pub mod prelude {
+    #[cfg(feature = "local")]
+    pub use crate::LocalConfig;
     #[cfg(feature = "macros")]
     pub use crate::tool;
     pub use crate::{
-        Agent, AgentBuilder, BuildError, CancellationToken, EventStream, FunctionTool, IntoTool,
-        IntoToolResult, Model, RunError, RunOptions, Session, SessionEvent, SessionEventKind, Tool,
-        ToolResponse, Turn,
+        Agent, AgentBuilder, BuildError, CancellationToken, CompactionConfig, CompactionStrategy,
+        EventStream, FunctionTool, InitialFile, IntoTool, IntoToolResult, McpServer, Model,
+        PluginError, RunError, RunOptions, Session, SessionContext, SessionEvent, SessionEventKind,
+        Tool, ToolInfo, ToolResponse, Turn,
     };
     #[cfg(feature = "openai")]
     pub use crate::{ModelError, OpenAI};

--- a/crates/everruns/src/local.rs
+++ b/crates/everruns/src/local.rs
@@ -1,0 +1,50 @@
+//! Local Framework configuration.
+
+use std::path::{Path, PathBuf};
+
+/// Local application data and workspace locations.
+///
+/// Enabling this profile gives sessions a real-disk workspace and
+/// SQLite-backed task/schedule state. Conversation persistence is intentionally
+/// not configured here: canonical events are the durable record and history is
+/// a rebuildable projection. Requires the `local` feature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalConfig {
+    pub(crate) data_dir: PathBuf,
+    pub(crate) workspace_root: PathBuf,
+}
+
+impl LocalConfig {
+    /// Store local state under `data_dir`; workspace files default to
+    /// `data_dir/workspace`. Select this directory from trusted application
+    /// configuration rather than model or request input.
+    pub fn new(data_dir: impl Into<PathBuf>) -> Self {
+        let data_dir = data_dir.into();
+        let workspace_root = data_dir.join("workspace");
+        Self {
+            data_dir,
+            workspace_root,
+        }
+    }
+
+    /// Override the real-disk workspace root.
+    pub fn workspace(mut self, root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = root.into();
+        self
+    }
+
+    /// Directory containing local state.
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    /// Root exposed to the agent as `/workspace`.
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    pub(crate) fn profile(&self) -> everruns_local::LocalProfile {
+        everruns_local::LocalProfile::new(self.data_dir.clone())
+            .with_workspace_root(self.workspace_root.clone())
+    }
+}

--- a/crates/everruns/src/mcp.rs
+++ b/crates/everruns/src/mcp.rs
@@ -1,0 +1,165 @@
+//! Application-facing MCP server configuration.
+
+use std::fmt;
+
+use everruns_core::{McpServerTransportType, ScopedMcpServer};
+
+/// A scoped MCP server available to an agent.
+///
+/// Use [`McpServer::stdio`] for a local child process (requires the
+/// `mcp-stdio` feature), or [`McpServer::http`] for a remote Streamable HTTP
+/// endpoint. Header and environment values are redacted from `Debug`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct McpServer {
+    pub(crate) name: String,
+    pub(crate) inner: ScopedMcpServer,
+}
+
+impl McpServer {
+    /// Configure a remote Streamable HTTP MCP server.
+    pub fn http(name: impl Into<String>, url: impl Into<String>) -> Self {
+        // THREAT[TM-TOOL-018]: request-time MCP transport performs DNS-pinned
+        // SSRF validation; this value-only builder does not create a bypass.
+        Self {
+            name: name.into(),
+            inner: ScopedMcpServer {
+                transport_type: McpServerTransportType::Http,
+                url: url.into(),
+                ..ScopedMcpServer::default()
+            },
+        }
+    }
+
+    /// Configure a local MCP server launched as a child process over stdio.
+    ///
+    /// The command, arguments, and environment must come from trusted host
+    /// configuration, never model output or untrusted request input.
+    #[cfg(feature = "mcp-stdio")]
+    pub fn stdio(name: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            inner: ScopedMcpServer {
+                transport_type: McpServerTransportType::Stdio,
+                command: Some(command.into()),
+                ..ScopedMcpServer::default()
+            },
+        }
+    }
+
+    /// Append one command-line argument for a stdio server.
+    #[cfg(feature = "mcp-stdio")]
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.inner.args.push(arg.into());
+        self
+    }
+
+    /// Append command-line arguments for a stdio server.
+    #[cfg(feature = "mcp-stdio")]
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.inner.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set one child-process environment variable for a stdio server.
+    #[cfg(feature = "mcp-stdio")]
+    pub fn env(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.inner.env.insert(name.into(), value.into());
+        self
+    }
+
+    /// Set one literal HTTP header for a remote server.
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.inner.headers.insert(name.into(), value.into());
+        self
+    }
+
+    /// Disable live tool discovery for this server.
+    pub fn tool_discovery(mut self, enabled: bool) -> Self {
+        self.inner.tool_discovery = enabled;
+        self
+    }
+
+    /// Server name used as the MCP tool namespace.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Debug for McpServer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // THREAT[TM-TOOL-007]: header/environment values and executable
+        // details may carry credentials, so Debug reports shape only.
+        let header_names = self.inner.headers.keys().cloned().collect::<Vec<_>>();
+        let env_names = self.inner.env.keys().cloned().collect::<Vec<_>>();
+        f.debug_struct("McpServer")
+            .field("name", &self.name)
+            .field("transport", &self.inner.transport_type)
+            .field("url_configured", &!self.inner.url.is_empty())
+            .field("command_configured", &self.inner.command.is_some())
+            .field("arg_count", &self.inner.args.len())
+            .field("header_names", &header_names)
+            .field("env_names", &env_names)
+            .field("tool_discovery", &self.inner.tool_discovery)
+            .finish()
+    }
+}
+
+pub(crate) fn into_scoped(
+    servers: Vec<McpServer>,
+) -> Result<everruns_core::ScopedMcpServers, String> {
+    let mut scoped = everruns_core::ScopedMcpServers::new();
+    for server in servers {
+        let name = server.name.trim();
+        if name.is_empty() {
+            return Err("MCP server name must not be blank".to_string());
+        }
+        match server.inner.transport_type {
+            McpServerTransportType::Http if server.inner.url.trim().is_empty() => {
+                return Err(format!("HTTP MCP server {name:?} requires a URL"));
+            }
+            McpServerTransportType::Stdio
+                if server
+                    .inner
+                    .command
+                    .as_deref()
+                    .is_none_or(|command| command.trim().is_empty()) =>
+            {
+                return Err(format!("stdio MCP server {name:?} requires a command"));
+            }
+            _ => {}
+        }
+        if scoped.insert(name.to_string(), server.inner).is_some() {
+            return Err(format!("duplicate MCP server {name:?}"));
+        }
+    }
+    Ok(scoped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_http_credentials_and_endpoint() {
+        let server = McpServer::http("remote", "https://secret.example/token")
+            .header("Authorization", "Bearer top-secret");
+
+        let debug = format!("{server:?}");
+        assert!(debug.contains("Authorization"));
+        assert!(!debug.contains("top-secret"));
+        assert!(!debug.contains("secret.example"));
+    }
+
+    #[cfg(feature = "mcp-stdio")]
+    #[test]
+    fn debug_redacts_stdio_command_arguments_and_environment_values() {
+        let server = McpServer::stdio("local", "/private/bin/server")
+            .arg("--api-key=top-secret")
+            .env("API_KEY", "top-secret");
+
+        let debug = format!("{server:?}");
+        assert!(debug.contains("API_KEY"));
+        assert!(!debug.contains("top-secret"));
+        assert!(!debug.contains("/private/bin/server"));
+    }
+}

--- a/crates/everruns/src/plugin.rs
+++ b/crates/everruns/src/plugin.rs
@@ -1,0 +1,57 @@
+//! Local plugin loading through the Framework API.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use everruns_core::plugins::{PluginFileSet, compile_plugin};
+use everruns_core::{AgentCapabilityConfig, plugin_capability_id};
+
+/// Failure while reading or compiling a local plugin directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginError {
+    path: PathBuf,
+    message: String,
+}
+
+impl PluginError {
+    /// Plugin directory that failed to load.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl fmt::Display for PluginError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "plugin {}: {}", self.path.display(), self.message)
+    }
+}
+
+impl std::error::Error for PluginError {}
+
+pub(crate) struct LoadedPlugin {
+    pub capability: AgentCapabilityConfig,
+    pub warnings: Vec<String>,
+}
+
+pub(crate) fn load(path: &Path) -> Result<LoadedPlugin, PluginError> {
+    // THREAT[TM-PLUGIN-004] / THREAT[TM-PLUGIN-005]: the shared loader rejects
+    // traversal and symlinks, enforces file/byte limits, and compiles data-only
+    // content.
+    let files = PluginFileSet::from_dir(path).map_err(|message| PluginError {
+        path: path.to_path_buf(),
+        message,
+    })?;
+    let compiled = compile_plugin(&files).map_err(|message| PluginError {
+        path: path.to_path_buf(),
+        message,
+    })?;
+    let capability_id = plugin_capability_id(&compiled.definition.name);
+    let config = serde_json::to_value(&compiled.definition).map_err(|error| PluginError {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    Ok(LoadedPlugin {
+        capability: AgentCapabilityConfig::with_config(capability_id, config),
+        warnings: compiled.warnings,
+    })
+}

--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -140,17 +140,7 @@ impl Session {
         input: impl Into<InputMessage>,
         options: RunOptions,
     ) -> Result<Turn, RunError> {
-        if self.runtime.is_none() {
-            self.runtime = Some(
-                self.agent
-                    .build_runtime_with_event_bus(
-                        self.session_id,
-                        self.event_bus.clone(),
-                        self.message_store.clone(),
-                    )
-                    .await?,
-            );
-        }
+        self.ensure_runtime().await?;
         let runtime = self.runtime.as_ref().expect("runtime built above");
 
         match options.cancel {
@@ -171,6 +161,40 @@ impl Session {
                 }
             }
         }
+    }
+
+    /// Inspect the exact application-facing context for the next model call.
+    ///
+    /// This is valid before the first turn and after any later turn. MCP tool
+    /// discovery, plugin prompt contributions, message filters, and model
+    /// selection use the same runtime assembly path as execution.
+    pub async fn inspect(&mut self) -> Result<crate::SessionContext, RunError> {
+        self.ensure_runtime().await?;
+        let context = self
+            .runtime
+            .as_ref()
+            .expect("runtime built above")
+            .load_context(self.session_id)
+            .await?;
+        Ok(crate::SessionContext::from_runtime(
+            context,
+            self.agent.plugin_warnings(),
+        ))
+    }
+
+    async fn ensure_runtime(&mut self) -> Result<(), RunError> {
+        if self.runtime.is_none() {
+            self.runtime = Some(
+                self.agent
+                    .build_runtime_with_event_bus(
+                        self.session_id,
+                        self.event_bus.clone(),
+                        self.message_store.clone(),
+                    )
+                    .await?,
+            );
+        }
+        Ok(())
     }
 }
 

--- a/crates/everruns/tests/agent_builder.rs
+++ b/crates/everruns/tests/agent_builder.rs
@@ -26,3 +26,32 @@ fn missing_model_is_a_typed_error() {
         .unwrap_err();
     assert_eq!(err, BuildError::MissingModel);
 }
+
+#[test]
+fn invalid_compaction_budget_is_a_typed_error() {
+    use everruns::{BuildError, CompactionConfig};
+
+    for invalid in [0.05, 1.5, f32::NAN] {
+        let err = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .compaction(CompactionConfig::new().budget_percent(invalid))
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, BuildError::InvalidCompaction { .. }));
+    }
+}
+
+#[test]
+fn duplicate_mcp_names_are_a_typed_error() {
+    use everruns::{BuildError, McpServer};
+
+    let err = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("ok"))
+        .mcp_server(McpServer::http("docs", "https://one.invalid/mcp"))
+        .mcp_server(McpServer::http("docs", "https://two.invalid/mcp"))
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, BuildError::InvalidMcpServer { .. }));
+}

--- a/crates/everruns/tests/application_parity.rs
+++ b/crates/everruns/tests/application_parity.rs
@@ -1,0 +1,158 @@
+//! Downstream-style acceptance fixtures for promoted Framework scenarios.
+//!
+//! This integration crate imports only `everruns`; it uses temporary files and
+//! local simulation, never credentials or the network.
+
+use std::fs;
+
+use everruns::{Agent, Model};
+
+#[tokio::test]
+async fn compaction_is_configured_without_checkpoint_store_types() {
+    use everruns::{CompactionConfig, CompactionStrategy};
+
+    let agent = Agent::builder()
+        .instructions("Keep long conversations useful.")
+        .model(Model::simulated("ok"))
+        .compaction(
+            CompactionConfig::new()
+                .strategy(CompactionStrategy::ObservationMasking)
+                .budget_percent(0.75),
+        )
+        .build()
+        .expect("agent builds");
+    agent
+        .session()
+        .run("offline turn")
+        .await
+        .expect("turn runs");
+}
+
+#[tokio::test]
+async fn real_workspace_seeding_and_context_inspection_use_framework_types() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let agent = Agent::builder()
+        .instructions("Inspect the workspace when asked.")
+        .model(Model::simulated("ready"))
+        .workspace(workspace.path())
+        .file("/workspace/notes.txt", "facade workspace")
+        .build()
+        .expect("agent builds");
+
+    let mut session = agent.session();
+    let before = session.inspect().await.expect("context before first turn");
+    assert!(before.messages.is_empty());
+    assert_eq!(before.model.model.as_str(), "llmsim-model");
+    assert!(before.tools.iter().any(|tool| tool.name == "read_file"));
+    assert_eq!(
+        fs::read_to_string(workspace.path().join("notes.txt")).expect("seeded file"),
+        "facade workspace"
+    );
+
+    session.run("hello").await.expect("offline turn");
+    let after = session.inspect().await.expect("context after turn");
+    assert!(!after.messages.is_empty());
+}
+
+#[tokio::test]
+async fn local_plugin_contributes_to_the_same_inspected_context() {
+    let plugin = tempfile::tempdir().expect("plugin dir");
+    fs::create_dir_all(plugin.path().join(".claude-plugin")).expect("manifest dir");
+    fs::create_dir_all(plugin.path().join("agents")).expect("agents dir");
+    fs::write(
+        plugin.path().join(".claude-plugin/plugin.json"),
+        r#"{
+          "name": "offline-helper",
+          "version": "0.1.0",
+          "description": "Offline fixture",
+          "agents": "./agents/"
+        }"#,
+    )
+    .expect("manifest");
+    fs::write(
+        plugin.path().join("agents/helper.md"),
+        "---\nname: helper\ndescription: Offline helper\n---\nPLUGIN_CONTEXT_SENTINEL\n",
+    )
+    .expect("agent contribution");
+
+    let agent = Agent::builder()
+        .instructions("Use configured plugins.")
+        .model(Model::simulated("ok"))
+        .plugin(plugin.path())
+        .expect("plugin compiles")
+        .build()
+        .expect("agent builds");
+    let mut session = agent.session();
+    let context = session.inspect().await.expect("plugin context");
+    assert!(context.instructions.contains("PLUGIN_CONTEXT_SENTINEL"));
+}
+
+#[cfg(feature = "mcp-stdio")]
+#[tokio::test]
+async fn stdio_mcp_is_discovered_through_the_framework() {
+    use everruns::McpServer;
+
+    let server =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mcp_stdio_server.py");
+    let agent = Agent::builder()
+        .instructions("Use the echo MCP server.")
+        .model(Model::simulated("ok"))
+        .mcp_server(McpServer::stdio("echo", "python3").arg(server.to_string_lossy()))
+        .build()
+        .expect("agent builds");
+    let mut session = agent.session();
+    let context = session.inspect().await.expect("MCP discovery");
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "mcp_echo__echo"),
+        "discovered tools: {:?}",
+        context
+            .tools
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[cfg(feature = "local")]
+#[tokio::test]
+async fn local_profile_exposes_workspace_and_schedule_tools() {
+    use everruns::LocalConfig;
+
+    let root = tempfile::tempdir().expect("local root");
+    let workspace = root.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    let agent = Agent::builder()
+        .instructions("Use the local workspace and schedule state.")
+        .model(Model::simulated("configured"))
+        .local(LocalConfig::new(root.path()).workspace(&workspace))
+        .capability("session_schedule")
+        .build()
+        .expect("agent builds");
+
+    let mut session = agent.session();
+    let context = session.inspect().await.expect("local context");
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "create_schedule")
+    );
+    session.run("continue").await.expect("local turn");
+}
+
+#[test]
+fn fixture_sources_import_only_the_framework() {
+    let source = include_str!("application_parity.rs");
+    for forbidden in [
+        ["everruns", "core"].join("_"),
+        ["everruns", "runtime"].join("_"),
+    ] {
+        assert!(
+            !source.contains(&forbidden),
+            "fixture must not import {forbidden}"
+        );
+    }
+}

--- a/crates/everruns/tests/fixtures/mcp_stdio_server.py
+++ b/crates/everruns/tests/fixtures/mcp_stdio_server.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Minimal offline MCP stdio fixture for the facade acceptance test."""
+
+import json
+import sys
+
+
+for line in sys.stdin:
+    try:
+        request = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    method = request.get("method", "")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "framework-fixture", "version": "0"},
+        }
+    elif method == "tools/list":
+        result = {
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "Echo a message",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"],
+                    },
+                }
+            ],
+            "nextCursor": None,
+        }
+    elif method == "notifications/initialized":
+        continue
+    else:
+        result = {"tools": []}
+    if request_id is not None:
+        print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -1157,8 +1157,29 @@ impl InProcessRuntime {
             .get_session(session_id)
             .await?
             .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
-        self.inspect_context_with_ids(session_id, session.harness_id, session.agent_id)
+        let agent = match session.agent_id {
+            Some(agent_id) => self.agent_store.get_agent(agent_id).await?,
+            None => None,
+        };
+        let scoped_servers = self.session_mcp_servers(&session, agent.as_ref()).await;
+        let mcp_tool_definitions = if scoped_servers.is_empty() {
+            vec![]
+        } else {
+            crate::mcp::discover_tool_definitions(
+                &self.mcp_discovery_cache,
+                self.mcp_client(),
+                session_id.uuid(),
+                &scoped_servers,
+            )
             .await
+        };
+        self.inspect_context_with_ids(
+            session_id,
+            session.harness_id,
+            session.agent_id,
+            &mcp_tool_definitions,
+        )
+        .await
     }
 
     /// Return all collected events from the runtime event bus.
@@ -1251,6 +1272,7 @@ impl InProcessRuntime {
         session_id: SessionId,
         harness_id: everruns_core::HarnessId,
         agent_id: Option<AgentId>,
+        mcp_tool_definitions: &[everruns_core::ToolDefinition],
     ) -> Result<AssembledTurnContext> {
         inspect_turn_context(
             self.harness_store.as_ref(),
@@ -1262,7 +1284,7 @@ impl InProcessRuntime {
             session_id,
             harness_id,
             agent_id,
-            &[],
+            mcp_tool_definitions,
             Some(self.file_store.clone()),
         )
         .await

--- a/crates/runtime/tests/mcp_runtime_test.rs
+++ b/crates/runtime/tests/mcp_runtime_test.rs
@@ -278,6 +278,19 @@ async fn runtime_discovers_and_executes_scoped_mcp_tool() {
         .await
         .expect("runtime builds");
 
+    let context = runtime
+        .load_context(session_id)
+        .await
+        .expect("context inspection discovers MCP tools");
+    assert!(
+        context
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "mcp_docs__echo"),
+        "load_context must use the same MCP discovery path as execution"
+    );
+
     let result = runtime
         .run_text_turn(session_id, "Use the docs MCP echo tool.")
         .await

--- a/examples/coding-cli/Cargo.toml
+++ b/examples/coding-cli/Cargo.toml
@@ -28,4 +28,7 @@ serde_json = "1.0"
 tokio = { version = "1.50", features = ["macros", "rt-multi-thread", "fs", "io-std", "io-util"] }
 
 [dev-dependencies]
+# Exercise opt-in application profiles without pulling SQLite or local-process
+# MCP support into the shipped coding CLI binary.
+everruns = { path = "../../crates/everruns", features = ["local", "mcp-stdio"] }
 tempfile = "3"

--- a/examples/coding-cli/tests/application_parity.rs
+++ b/examples/coding-cli/tests/application_parity.rs
@@ -1,0 +1,139 @@
+//! External-crate acceptance tests for promoted Framework application APIs.
+//!
+//! This package has exactly one Everruns dependency: the public `everruns`
+//! crate. Every fixture is offline and uses temporary files.
+
+use std::fs;
+use std::path::Path;
+
+use everruns::{Agent, CompactionConfig, CompactionStrategy, LocalConfig, McpServer, Model};
+
+#[tokio::test]
+async fn compaction_policy_runs_without_host_checkpoint_types() {
+    let agent = Agent::builder()
+        .instructions("Keep long conversations useful.")
+        .model(Model::simulated("ok"))
+        .compaction(
+            CompactionConfig::new()
+                .strategy(CompactionStrategy::ObservationMasking)
+                .budget_percent(0.75),
+        )
+        .build()
+        .expect("agent builds");
+    agent
+        .session()
+        .run("offline turn")
+        .await
+        .expect("turn runs");
+}
+
+#[tokio::test]
+async fn workspace_files_and_context_are_application_values() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let agent = Agent::builder()
+        .instructions("Inspect files when asked.")
+        .model(Model::simulated("ready"))
+        .workspace(workspace.path())
+        .file("/workspace/editable.txt", "editable")
+        .readonly_file("/workspace/reference.txt", "reference")
+        .build()
+        .expect("agent builds");
+
+    let mut session = agent.session();
+    let before = session.inspect().await.expect("context before a turn");
+    assert!(before.messages.is_empty());
+    assert_eq!(before.model.model.as_str(), "llmsim-model");
+    assert!(before.tools.iter().any(|tool| tool.name == "read_file"));
+    assert_eq!(
+        fs::read_to_string(workspace.path().join("editable.txt")).expect("seeded file"),
+        "editable"
+    );
+
+    session.run("hello").await.expect("offline turn");
+    assert!(
+        !session
+            .inspect()
+            .await
+            .expect("context after turn")
+            .messages
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn local_plugin_and_http_mcp_config_use_the_framework() {
+    let plugin = tempfile::tempdir().expect("plugin dir");
+    fs::create_dir_all(plugin.path().join(".claude-plugin")).expect("manifest dir");
+    fs::create_dir_all(plugin.path().join("agents")).expect("agents dir");
+    fs::write(
+        plugin.path().join(".claude-plugin/plugin.json"),
+        r#"{
+          "name": "offline-helper",
+          "version": "0.1.0",
+          "description": "Offline fixture",
+          "agents": "./agents/"
+        }"#,
+    )
+    .expect("manifest");
+    fs::write(
+        plugin.path().join("agents/helper.md"),
+        "---\nname: helper\ndescription: Offline helper\n---\nPLUGIN_CONTEXT_SENTINEL\n",
+    )
+    .expect("agent contribution");
+
+    let agent = Agent::builder()
+        .instructions("Use configured integrations.")
+        .model(Model::simulated("ok"))
+        .plugin(plugin.path())
+        .expect("plugin compiles")
+        // Discovery is disabled so this fixture proves HTTP configuration
+        // without making a network request.
+        .mcp_server(McpServer::http("remote", "https://mcp.invalid/example").tool_discovery(false))
+        .build()
+        .expect("agent builds");
+    let mut session = agent.session();
+    let context = session.inspect().await.expect("plugin context");
+    assert!(context.instructions.contains("PLUGIN_CONTEXT_SENTINEL"));
+}
+
+#[tokio::test]
+async fn stdio_mcp_discovers_a_local_tool() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mcp_stdio_server.py");
+    let agent = Agent::builder()
+        .instructions("Use the echo MCP server.")
+        .model(Model::simulated("ok"))
+        .mcp_server(McpServer::stdio("echo", "python3").arg(fixture.to_string_lossy()))
+        .build()
+        .expect("agent builds");
+    let context = agent.session().inspect().await.expect("MCP discovery");
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "mcp_echo__echo")
+    );
+}
+
+#[tokio::test]
+async fn local_profile_supplies_workspace_and_schedule_state() {
+    let root = tempfile::tempdir().expect("local root");
+    let workspace = root.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    let agent = Agent::builder()
+        .instructions("Use local task and workspace state.")
+        .model(Model::simulated("configured"))
+        .local(LocalConfig::new(root.path()).workspace(&workspace))
+        .capability("session_schedule")
+        .build()
+        .expect("agent builds");
+
+    let mut session = agent.session();
+    let context = session.inspect().await.expect("local context");
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "create_schedule")
+    );
+    session.run("continue").await.expect("local turn");
+}

--- a/examples/coding-cli/tests/fixtures/mcp_stdio_server.py
+++ b/examples/coding-cli/tests/fixtures/mcp_stdio_server.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Minimal offline MCP stdio fixture for Framework acceptance tests."""
+
+import json
+import sys
+
+
+for line in sys.stdin:
+    try:
+        request = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    method = request.get("method", "")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "framework-fixture", "version": "0"},
+        }
+    elif method == "tools/list":
+        result = {
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "Echo a message",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"],
+                    },
+                }
+            ],
+            "nextCursor": None,
+        }
+    elif method == "notifications/initialized":
+        continue
+    else:
+        result = {"tools": [], "nextCursor": None}
+    if request_id is not None:
+        print(
+            json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}),
+            flush=True,
+        )

--- a/knowledge/framework/application-api.md
+++ b/knowledge/framework/application-api.md
@@ -1,0 +1,190 @@
+---
+type: Specification
+title: "Framework Application API Boundaries"
+description: "Application-facing composition, low-level host boundaries, and runtime compatibility policy."
+tags:
+  - everruns
+  - framework
+  - rust
+  - compatibility
+---
+
+# Framework Application API Boundaries
+
+## Intent
+
+The Everruns Framework is the application-facing Rust library exposed by the
+`everruns` crate. An application should be able to describe an agent, connect
+providers and tools, configure its workspace and integrations, run sessions,
+and inspect effective context without importing execution-host or storage
+implementation crates. Session history and resume are application concerns,
+but their durable source is the canonical event log rather than a writable
+message store.
+
+`everruns-runtime` remains a supported `0.17.x` compatibility API. It is also
+the temporary owner of reusable host implementation, but that ownership does
+not make its backend entities part of the Framework application model.
+
+## Promoted application concerns
+
+The Framework owns value-first configuration for:
+
+- agent instructions, models, providers, tools, and capability references;
+- editable and read-only initial files plus an optional real-disk workspace;
+- scoped HTTP or local-process MCP servers;
+- local plugin directory loading and non-fatal compile warnings;
+- multi-turn execution, events, cancellation, context inspection, and
+  credential-free model identity;
+- canonical, lossless session events and lifecycle hooks through curated
+  application values rather than engine or worker phase records;
+- high-level context-compaction behavior without checkpoint-store plumbing;
+- high-level task, background-message, wake, and workspace-policy behavior
+  without route-claiming or filesystem-backend plumbing;
+- an advanced capability-author SPI with typed schemas, narrow call context,
+  progress, cancellation, and structured errors;
+- an opt-in local profile that combines real workspace files with local
+  task/schedule state;
+- event-derived session history and resume, without promoting writable message
+  stores or their file format into the application API.
+
+These APIs adapt into the same in-process host, provider registry, model
+selection, plugin compiler, MCP client, and engine execution used by the
+compatibility crate. The implementation and downstream acceptance fixtures are
+linked from the [source index](#source-index).
+
+## Supported dependency paths
+
+An ordinary application targets `everruns` alone for agent configuration and
+execution. The facade-only acceptance fixture enforces that boundary and is
+intentionally stricter than the requirement for a complete execution host.
+
+An advanced system integrator may combine `everruns` with focused host, MCP,
+provider, and integration crates. That modular composition is healthy: success
+means the host no longer imports `everruns-runtime`, not that every transport,
+backend, or integration is re-exported by one facade. During the `0.17.x`
+transition, host-only contracts remain available through the compatibility
+crate until their neutral host owner lands atomically.
+
+## Audited application and host surfaces
+
+The inventory covers the public [repository README](../../README.md),
+[runtime README](../../crates/runtime/README.md),
+[runtime skill](../../skills/everruns-runtime/SKILL.md),
+[runtime guide](../../docs/features/runtime.mdx), and
+[embedding guide](../../docs/advanced/embedding-everruns.md). It also includes
+the in-process, provider, inspection, real-disk, plugin, mount, and Lua examples
+under [the runtime examples](../../crates/runtime/examples/in_process_runtime.rs)
+and the provider-facing [OpenAI README](../../crates/openai/README.md).
+
+Repository consumers were audited separately because they exercise topologies
+that examples do not: the offline
+[weekend concierge](../../examples/weekend-concierge-host/src/lib.rs), the
+[generic evaluation runner](../../evals/generic/src/subject.rs), the
+[Lua-versus-bash research harness](../../research/lua-vs-bash/src/main.rs), the
+[worker host](../../crates/worker/src/unified_worker.rs), the
+[local host builder](../../crates/local/src/runtime_builder.rs), and the
+[live subagent host test](../../crates/llm-tests/tests/subagent_live_test.rs).
+The classification below is the durable decision for each family; individual
+implementation tests inside `crates/runtime` remain compatibility coverage, not
+additional application entrypoints.
+
+## Deliberately low-level host concerns
+
+The following stay on the host side rather than being mirrored into ordinary
+application configuration:
+
+- replacing individual harness, agent, session, message, provider, event,
+  checkpoint, storage, task, schedule, or platform stores;
+- constructing stored harness/agent/session records with stable internal ids;
+- replacing the complete platform definition, capability registry, filesystem
+  factory, connector registry, egress service, or utility services;
+- direct mount/filesystem primitives and mutable worktree routing;
+- raw assembled context records and live capability overlays;
+- host phase adapters, durable planning state, lifecycle effects, and worker
+  orchestration;
+- attaching a custom local platform runner or starting a schedule-delivery
+  daemon whose routing and lifecycle are owned by the embedding host.
+
+These are valid extension points for server, worker, evaluation, research, or
+specialized embedding hosts. Re-exporting their backend-oriented entities from
+the Framework would recreate the coupling the application API is intended to
+remove. Host implementations may continue using the compatibility crate in
+`0.17.x`; migration of internal consumers and implementation ownership is a
+separate atomic step.
+
+## Classification of existing public use cases
+
+| Audited use case | Classification | Why / Framework mapping |
+|---|---|---|
+| Runtime README, skill, and documentation quickstarts | Promote | Ordinary agent/model/session execution is the Framework's primary path. |
+| Built-in simulation and real or custom model providers | Promote | Applications select a credential-free model and attach provider configuration or a custom protocol driver without constructing a platform registry. |
+| Application-defined function tools and initial files | Promote | These are agent behavior and workspace inputs, not host entities. |
+| In-process and OpenAI runtime examples | Promote | They map to normal agent construction and one or more Framework sessions. |
+| Context-inspection example and evaluation assertions | Promote | Applications receive a curated next-turn context rather than stored records or backend assembly types. |
+| Real-disk filesystem and agent-instruction examples | Promote | A single owned workspace root plus editable/read-only seed files is an application concern and retains the runtime filesystem boundary. |
+| Plugin-directory example | Promote | Local plugin compilation configures an agent; non-fatal warnings stay inspectable. |
+| Scoped HTTP and stdio MCP configuration | Promote | MCP servers are application integrations; stdio remains an opt-in single-tenant feature. |
+| Weekend-concierge offline host | Promote | Its seeded harness/agent/session shape is ordinary Framework agent, tool, file, and session composition. |
+| Generic evaluation runner | Promote | A custom provider/model, fresh session per sample, workspace seeding/reads, events, and context assertions all have Framework equivalents. |
+| Event-derived local history and resume | Promote | Conversation identity and restart continuation are application behavior; canonical events are the durable truth and history is a rebuildable projection. |
+| Explicit JSONL message-store APIs | Keep for `0.17.x` compatibility | They remain source-compatible for existing callers but are legacy dual-write machinery, not the durable Framework ownership model. |
+| Context compaction policy | Promote | Applications choose high-level strategy and proactive budget; durable checkpoint storage remains host-owned. |
+| Local task/schedule state used by an agent | Promote | The local profile supplies the state behind activated Framework capabilities. |
+| Canonical events, post-turn sinks, and typed lifecycle hooks | Promote | Applications observe lossless values and register behavior; engine buses, worker phases, and durable event-store topology remain host-owned. |
+| High-level tasks, background messages, wake, and workspace policy | Promote | Applications configure behavior and resume work without taking ownership of route claims, delivery daemons, or filesystem implementations. |
+| Advanced capability authoring | Promote under a curated module | Capability authors need typed schemas, narrow context, progress, cancellation, and structured errors; backend registries and platform records stay hidden. |
+| Wake routing and schedule delivery lifecycle | Host-only | Route ownership, claiming, delivery retries, and daemon shutdown require a host runner. |
+| Raw custom backend/store examples | Host-only | Store topology and identity scope are host implementation choices. |
+| Standalone mount/multi-root/worktree example | Host-only | It demonstrates filesystem implementation and routing rather than application agent composition. |
+| Lua code-mode and Lua-versus-bash research harness | Host-only | These intentionally replace the platform/capability topology to compare execution hosts. |
+| Worker, durable recovery, and phase-adapter tests | Host-only | They verify execution-host contracts below the application boundary. |
+| Local subagent tests with a custom platform store/task registry/session runner | Host-only | The public local profile does not claim to own that specialized topology or its runner lifecycle. |
+
+No audited use case is removed as obsolete in this compatibility unit. The
+classification changes the recommended entrypoint, not the availability of the
+runtime API.
+
+## Compatibility constraints
+
+- The runtime compatibility surface remains published and usable throughout
+  `0.17.x`.
+- Old and new setup paths must converge before provider resolution and engine
+  execution; no parallel provider or turn semantics are allowed.
+- Canonical events are the sole durable conversation record. Message/context
+  history is a read projection; new Framework profiles must not select or own a
+  writable message store.
+- Promoting an application concern must not expose credentials, tenant records,
+  backend stores, or host lifecycle entities.
+- Local-process MCP stays opt-in and must not enter hosted builds by default.
+- Real workspaces keep the runtime filesystem's traversal and symlink-escape
+  protections.
+- Local task/schedule state is opt-in. Schedule delivery remains an explicitly
+  managed host lifecycle with at-least-once semantics.
+- Removal or compiler deprecation of `everruns-runtime`, and any post-`0.18`
+  cutover work, are outside this contract.
+
+## Success bar
+
+Every application surface promoted in an atomic unit has a downstream-style
+compile/run fixture that imports only `everruns`, uses offline simulation and
+temporary files, and does not require credentials or network access. The same
+bar applies when the event/history, hooks, task/wake, workspace-policy, and
+capability-SPI units land. Compatibility tests continue to exercise the old
+runtime path. Product worker/server and local host behavior must remain
+unchanged. Facade-only dependency guards apply to ordinary application
+fixtures; advanced host fixtures instead forbid the transitional runtime
+dependency while allowing focused host and sibling crates.
+
+## Source index
+
+- `crates/everruns/src/agent.rs`
+- `crates/everruns/src/compaction.rs`
+- `crates/everruns/src/session.rs`
+- `crates/everruns/src/context.rs`
+- `crates/everruns/src/mcp.rs`
+- `crates/everruns/src/plugin.rs`
+- `crates/everruns/src/local.rs`
+- `crates/everruns/tests/application_parity.rs`
+- `examples/coding-cli/tests/application_parity.rs`
+- `crates/runtime/src/runtime.rs`
+- `crates/local/`

--- a/knowledge/framework/index.md
+++ b/knowledge/framework/index.md
@@ -1,0 +1,3 @@
+# Framework
+
+* [Application API Boundaries](application-api.md) - Application-facing composition, low-level host boundaries, and runtime compatibility policy.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -9,6 +9,7 @@ okf_version: "0.2"
 
 # Domains
 
+* [framework/](framework/) - Application-facing Framework purpose, boundaries, and compatibility decisions.
 * [foundations/](foundations/) - Core entities, architecture, runtime, providers, and developer conventions.
 * [execution/](execution/) - API contracts, capability behavior, tool execution, and streaming.
 * [runtime-resources/](runtime-resources/) - Agents, sessions, workspaces, knowledge, memory, and runtime-owned resources.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,13 @@
 # Everruns Knowledge Update Log
 
+## 2026-08-09
+
+* **Framework application boundary**: Established the Framework knowledge
+  collection and classified workspace, MCP, plugins, context inspection,
+  event-derived history/resume, and schedules as application concerns while
+  retaining writable message stores, backend topology, mount primitives, and
+  host orchestration as low-level `0.17.x` compatibility surfaces.
+
 ## 2026-08-08
 
 * **Navigation information architecture**: Recorded the placement rule that groups the

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -35,7 +35,7 @@ INNER_PINS: dict[str, list[str]] = {
     "crates/platform/Cargo.toml": ["everruns-core"],
     "crates/mcp/Cargo.toml": ["everruns-core"],
     "crates/runtime/Cargo.toml": ["everruns-core", "everruns-engine"],
-    "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime", "everruns-macros"],
+    "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime", "everruns-local", "everruns-macros"],
     "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
     "crates/openai/Cargo.toml": ["everruns-provider"],
     "crates/anthropic/Cargo.toml": ["everruns-provider"],
@@ -57,7 +57,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-engine", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-ard", "everruns", "everruns-macros"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-engine", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-local", "everruns-ard", "everruns", "everruns-macros"]
 
 
 def workspace_version() -> str:


### PR DESCRIPTION
## What changed

- Adds curated Framework APIs for editable/read-only seed files, a containment-preserving real workspace, scoped HTTP and feature-gated stdio MCP servers, local plugin loading, high-level compaction policy, and `Session::inspect` context projection.
- Adds feature-gated `LocalConfig` for backend-neutral data/workspace configuration plus SQLite task/schedule state. It does not select a writable message store: canonical events remain the durable truth and history/resume remains an event-derived projection.
- Keeps the facade adapter on the existing in-process runtime/provider/model/engine path. `InProcessRuntime::load_context` now performs the same MCP discovery as turn execution.
- Adds facade-only offline downstream fixtures and the atomic `knowledge/framework/` inventory/classification scaffold.

## Why

Supported applications and embedders still had to import `everruns-runtime` for filesystem workspaces, MCP stdio, plugins, context inspection, local task/schedule configuration, and context compaction. These are application concerns, but promoting raw stores, platform records, transport negotiation, or host lifecycle entities would recreate the coupling the Framework is intended to remove.

## Before / After

Before: the public runtime README/examples and repository consumers constructed `InProcessRuntimeBuilder` or reached through `everruns::runtime::*` for these scenarios.

After: `examples/coding-cli/tests/application_parity.rs` is an external package with one Everruns dependency (`everruns`) and runs workspace, plugin, HTTP/stdio MCP, compaction, context inspection, and local schedule-state scenarios offline:

- `cargo test --manifest-path examples/coding-cli/Cargo.toml --test application_parity` — 5 passed
- `cargo test -p everruns --all-features --test agent_builder --test application_parity` — 10 passed
- `cargo test -p everruns-runtime --test mcp_runtime_test runtime_discovers_and_executes_scoped_mcp_tool` — 1 passed
- `cargo test -p everruns-local` — all unit/integration tests passed
- `cargo test -p everruns-worker --lib` — 96 passed
- `just pre-push` — all 11 gates passed on rebased commit `5fd41eee9`

## Risk

- Medium
- Application configuration now reaches real filesystem, local-process MCP, plugin compilation, and SQLite-backed local stores. Incorrect adapter wiring could change tool/context discovery or provider execution; focused facade/runtime fixtures and existing local/worker suites cover those boundaries.
- The `local` and `mcp-stdio` features remain opt-in; the facade default stays offline/no-DB, and the shipped coding CLI keeps them in dev-dependencies only.

## Security

- Threat categories reviewed: TM-TOOL/MCP, TM-PLUGIN, TM-FS, TM-BASH, credential disclosure, input validation, and resource exhaustion.
- Findings and resolutions:
  - Removed low-level MCP protocol/auth/OAuth controls from the facade root; advanced transport/credential ownership stays in focused host/MCP crates.
  - MCP HTTP execution continues through DNS-pinned SSRF validation (TM-TOOL-018); stdio is feature-gated and documented as trusted host configuration only.
  - MCP `Debug` omits URLs, commands, arguments, and header/environment values; redaction tests cover HTTP and stdio secrets (TM-TOOL-007).
  - Plugin loading reuses bounded, symlink/traversal-rejecting, data-only compilation (TM-PLUGIN-004/005) and is documented as trusted local configuration.
  - Real workspaces reuse the canonical containment/symlink-rejecting factory (TM-BASH-001/TM-FS-013); no second path resolver was added.
  - No threat-model mitigation changed; source markers document which existing mitigations the new entrypoints preserve.

## Follow-ups

- Coordinated atomic units already in progress will add canonical/lossless event APIs plus event-derived history/resume, typed lifecycle hooks, high-level task/wake behavior, workspace policy, and advanced capability SPI after this prerequisite is main-green. They are separate to keep every merged PR independently useful and avoid partial APIs.
- The Framework docs owner will port primary README/docs examples only after these exact names are main-green.
- Host ownership/migration remains a separate 0.17.x compatibility step; this PR does not remove or deprecate `everruns-runtime`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


