### PR TITLE
feat(framework): expose typed session identity

### DIFF
--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -391,7 +391,7 @@ impl Agent {
         }
         builder = builder.backends(backends);
 
-        let workspace_root = self.workspace_root.as_ref().or_else(|| {
+        let workspace_root = self.workspace_root.as_ref().or({
             #[cfg(feature = "local")]
             {
                 self.local.as_ref().map(|config| &config.workspace_root)

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -134,7 +134,8 @@ pub use everruns_core::{
     AgentLoopError, BearerAuth, CapabilityRegistry, ChatDriver, ContentPart, InitialFile,
     InputMessage, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmResponseStream,
     LlmStreamEvent, MessageRole, ModelSpec, PlatformDefinition, Provider, ProviderAuth,
-    ProviderAuthRequest, ProviderEndpoint, ProviderKey, ProviderRegistry, StaticHeaderAuth,
+    ProviderAuthRequest, ProviderEndpoint, ProviderKey, ProviderRegistry, SessionId,
+    StaticHeaderAuth,
 };
 
 // --- Deterministic in-process LLM simulator -----------------------------
@@ -170,7 +171,7 @@ pub mod prelude {
         Agent, AgentBuilder, BuildError, CancellationToken, CompactionConfig, CompactionStrategy,
         EventStream, FunctionTool, InitialFile, IntoTool, IntoToolResult, McpServer, Model,
         PluginError, RunError, RunOptions, Session, SessionContext, SessionEvent, SessionEventKind,
-        Tool, ToolInfo, ToolResponse, Turn,
+        SessionId, Tool, ToolInfo, ToolResponse, Turn,
     };
     #[cfg(feature = "openai")]
     pub use crate::{ModelError, OpenAI};

--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -92,6 +92,14 @@ impl Session {
         self.session_id.to_string()
     }
 
+    /// The typed Framework identity for this session.
+    ///
+    /// Use this value with typed session-resumption APIs. [`id`](Self::id)
+    /// remains available when a string is needed for display or serialization.
+    pub fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
     /// Subscribe to this session's live [`SessionEvent`](crate::SessionEvent)
     /// feed.
     ///

--- a/crates/everruns/tests/session_identity.rs
+++ b/crates/everruns/tests/session_identity.rs
@@ -1,0 +1,29 @@
+//! Public Framework acceptance tests for typed session identity.
+
+use everruns::{Agent, Model, SessionId};
+
+fn simulated_agent() -> Agent {
+    Agent::builder()
+        .instructions("Reply briefly.")
+        .model(Model::simulated("ack"))
+        .build()
+        .expect("valid agent")
+}
+
+#[test]
+fn session_exposes_a_typed_round_trippable_identity() {
+    let session = simulated_agent().session();
+
+    let typed = session.session_id();
+    let parsed: SessionId = session.id().parse().expect("valid session id");
+
+    assert_eq!(typed, parsed);
+    assert_eq!(typed.to_string(), session.id());
+}
+
+#[test]
+fn independent_sessions_have_distinct_typed_identities() {
+    let agent = simulated_agent();
+
+    assert_ne!(agent.session().session_id(), agent.session().session_id());
+}


### PR DESCRIPTION
## What changed
Framework applications can now use `SessionId` directly from `everruns` or its prelude and obtain it from `Session::session_id()`. The existing string-returning `Session::id()` remains unchanged.

Minimal-feature Clippy coverage also exposed and fixes an equivalent eager `Option` selection in the just-landed local workspace path.

## Why
Typed session resumption needs a curated Framework identity without making applications import `everruns-core` or pass an untyped string as the primary API. Landing this small prerequisite first lets the canonical-event host migration preserve the final identity contract atomically.

## Before / After
Before:
```rust
let id: String = session.id();
```

After:
```rust
use everruns::SessionId;

let id: SessionId = session.session_id();
assert_eq!(id.to_string(), session.id());
```

Focused tests pass with default and `--no-default-features`; all 11 `just pre-push` gates pass.

## Risk
- Low
- Adds a re-export and copy accessor; the existing string API is unchanged. The lint fix preserves side-effect-free option selection semantics.

## Security
- Threat categories reviewed: No security-relevant code changes. This exposes an existing immutable typed identifier and does not alter authentication, authorization, persistence, networking, filesystem access, or secret handling.
- Findings and resolutions: No findings.

## Follow-ups
The active session-history/resumption unit will add bounded event-derived history and typed `Agent::resume(SessionId)` after the canonical EventLog host seam is main-green.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)