### PR TITLE
refactor(host): extract shared orchestration

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -145,9 +145,14 @@ jobs:
               "crates/mcp/Cargo.toml": [
                   "everruns-core",
               ],
+              "crates/host/Cargo.toml": [
+                  "everruns-core",
+                  "everruns-mcp",
+              ],
               "crates/runtime/Cargo.toml": [
                   "everruns-core",
                   "everruns-engine",
+                  "everruns-host",
               ],
               "crates/everruns/Cargo.toml": [
                   "everruns-core",
@@ -250,6 +255,7 @@ jobs:
             everruns-engine
             everruns-platform
             everruns-mcp
+            everruns-host
             everruns-openai
             everruns-anthropic
             everruns-openrouter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,6 +2661,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-host"
+version = "0.17.25"
+dependencies = [
+ "async-trait",
+ "everruns-core",
+ "everruns-mcp",
+ "everruns-platform",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "everruns-integrations-brave-search"
 version = "0.17.25"
 dependencies = [
@@ -3106,6 +3118,7 @@ dependencies = [
  "chrono",
  "everruns-core",
  "everruns-engine",
+ "everruns-host",
  "everruns-mcp",
  "everruns-openai",
  "everruns-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/macros",
     "crates/core",
     "crates/engine",
+    "crates/host",
     "crates/platform",
     "crates/provider",
     "crates/bedrock",
@@ -169,6 +170,7 @@ futures-util = "0.3"
 everruns-sdk = "0.2.0"
 everruns-core = { path = "crates/core", version = "0.17.25" }
 everruns-engine = { path = "crates/engine", version = "0.17.25" }
+everruns-host = { path = "crates/host", version = "0.17.25" }
 everruns-platform = { path = "crates/platform", version = "0.17.25" }
 everruns-provider = { path = "crates/provider", version = "0.17.25" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }

--- a/crates/engine/tests/dependency_direction.rs
+++ b/crates/engine/tests/dependency_direction.rs
@@ -17,6 +17,7 @@ fn engine_manifest_has_no_edge_to_hosts_or_backends() {
 
     for forbidden in [
         "everruns-runtime",
+        "everruns-host",
         "everruns-server",
         "everruns-worker",
         "everruns-platform",

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -1,0 +1,29 @@
+# Shared effectful host orchestration below the application-facing facade.
+#
+# This crate is published because published facades and compatibility adapters
+# depend on it. It is not an application entrypoint: ordinary embedders use
+# `everruns`, while worker/local and advanced hosts may use this boundary.
+
+[package]
+name = "everruns-host"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-host"
+description = "Shared host orchestration for Everruns execution adapters"
+readme = "README.md"
+keywords = ["agent", "agentic", "llm", "ai", "runtime"]
+categories = ["development-tools", "asynchronous"]
+
+[dependencies]
+async-trait.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+
+everruns-core.workspace = true
+everruns-mcp.workspace = true
+everruns-platform.workspace = true

--- a/crates/host/README.md
+++ b/crates/host/README.md
@@ -1,0 +1,46 @@
+# everruns-host
+
+> Shared effectful orchestration for Everruns execution hosts.
+
+[![Crates.io](https://img.shields.io/crates/v/everruns-host.svg)](https://crates.io/crates/everruns-host)
+[![Documentation](https://docs.rs/everruns-host/badge.svg)](https://docs.rs/everruns-host)
+[![License](https://img.shields.io/crates/l/everruns-host.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
+
+Shared effectful host orchestration used by the Everruns application facade,
+local adapters, workers, and advanced custom hosts.
+
+This crate is a published implementation boundary so those crates can share a
+single execution path. It is not the ordinary application entrypoint; most
+applications in the [Everruns](https://everruns.com) ecosystem should use
+[`everruns`](https://crates.io/crates/everruns) and the
+[Framework guide](https://docs.everruns.com/framework/).
+
+The pure, sans-I/O turn planner remains in
+[`everruns-engine`](https://crates.io/crates/everruns-engine).
+
+## Quick Example
+
+```rust
+use everruns_host::{RuntimeHostAdapter, RuntimeHostTurnContext};
+
+fn accepts_host<A: RuntimeHostAdapter>() {}
+fn accepts_context(_: RuntimeHostTurnContext) {}
+# let _ = accepts_context;
+```
+
+## What It Provides
+
+- Shared input, reason, and act phase execution
+- Session and turn lifecycle application
+- Host adapter contracts for worker, local, and advanced integrations
+- One effectful boundary beneath the application facade
+
+## Documentation
+
+- [Framework custom backends](https://docs.everruns.com/framework/custom-backends/)
+- [Runtime compatibility](https://docs.everruns.com/framework/runtime-compatibility/)
+- [API reference](https://docs.rs/everruns-host)
+
+## License
+
+Licensed under the [MIT License](https://github.com/everruns/everruns/blob/main/LICENSE).

--- a/crates/host/src/host.rs
+++ b/crates/host/src/host.rs
@@ -1,6 +1,7 @@
 // Shared host orchestration for embedded and durable execution hosts.
-// Decision: everruns-runtime owns worker-facing turn phase execution so
-// durable/server-backed hosts reuse the same input/reason/act wiring.
+// Decision: everruns-host owns worker-facing turn phase execution so
+// durable/server-backed hosts reuse the same input/reason/act wiring without
+// depending on the application facade or the runtime compatibility crate.
 
 use async_trait::async_trait;
 use everruns_core::atoms::{

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -1,0 +1,28 @@
+//! Shared effectful host orchestration for Everruns execution adapters.
+//!
+//! `everruns-host` sits between the pure `everruns-engine` planner and the
+//! application, worker, and local adapters that apply its effects. It is a
+//! transitive implementation boundary, not the ordinary application
+//! entrypoint; applications in the [Everruns](https://everruns.com) ecosystem
+//! should normally depend on `everruns`.
+//!
+//! The deprecated `everruns-runtime` package re-exports this implementation so
+//! its 0.17 public paths continue to use the same canonical code.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_host::{RuntimeHostAdapter, RuntimeHostTurnContext};
+//!
+//! fn accepts_host<A: RuntimeHostAdapter>() {}
+//! fn accepts_context(_: RuntimeHostTurnContext) {}
+//! # let _ = accepts_context;
+//! ```
+
+mod host;
+
+pub use host::{
+    RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle, detect_dependency_blocker,
+    execute_act_activity, execute_input_activity, execute_reason_activity,
+    execute_reason_activity_with_prompt_messages,
+};

--- a/crates/host/tests/dependency_direction.rs
+++ b/crates/host/tests/dependency_direction.rs
@@ -1,0 +1,23 @@
+//! Dependency-direction guard for the neutral host implementation boundary.
+
+use std::path::Path;
+
+#[test]
+fn host_manifest_has_no_edge_to_facades_or_adapters() {
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", manifest_path.display()));
+
+    for forbidden in [
+        "everruns-runtime",
+        "everruns-local",
+        "everruns-worker",
+        "everruns-server",
+        "everruns-durable",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "everruns-host must not depend on {forbidden}; adapters and facades depend on host"
+        );
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -42,6 +42,7 @@ tracing.workspace = true
 uuid.workspace = true
 
 everruns-core.workspace = true
+everruns-host.workspace = true
 everruns-platform.workspace = true
 everruns-engine.workspace = true
 everruns-mcp.workspace = true

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -62,7 +62,15 @@ mod backends;
 mod builders;
 mod file_store_decorators;
 mod grep_limits;
-mod host;
+mod host {
+    // 0.17 compatibility: the implementation lives in `everruns-host`, while
+    // runtime-internal imports and old public paths keep resolving here.
+    pub use everruns_host::{
+        RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle,
+        detect_dependency_blocker, execute_act_activity, execute_input_activity,
+        execute_reason_activity, execute_reason_activity_with_prompt_messages,
+    };
+}
 mod in_memory;
 mod mcp;
 mod mcp_cache;

--- a/crates/runtime/tests/host_compatibility.rs
+++ b/crates/runtime/tests/host_compatibility.rs
@@ -1,0 +1,40 @@
+//! Compile-time proof that the 0.17 runtime host paths are aliases for the
+//! canonical implementation in `everruns-host`, not a parallel contract.
+
+use everruns_core::traits::SessionStore;
+
+fn requires_canonical_host<T: everruns_host::RuntimeHostAdapter>() {}
+
+fn runtime_bound_implies_canonical_bound<T: everruns_runtime::RuntimeHostAdapter>() {
+    requires_canonical_host::<T>();
+}
+
+fn context_round_trip(
+    context: everruns_runtime::RuntimeHostTurnContext,
+) -> everruns_host::RuntimeHostTurnContext {
+    context
+}
+
+#[test]
+fn runtime_host_paths_are_canonical_host_reexports() {
+    let _ = runtime_bound_implies_canonical_bound::<everruns_runtime::InProcessRuntime>;
+    let _ = context_round_trip;
+
+    fn session_store_type_checks<T: SessionStore + ?Sized>() {}
+    let _ = session_store_type_checks::<dyn SessionStore>;
+}
+
+#[test]
+fn runtime_has_no_host_implementation_file() {
+    let runtime_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    assert!(
+        !runtime_src.join("host.rs").exists(),
+        "host implementation must live in everruns-host"
+    );
+
+    let lib = std::fs::read_to_string(runtime_src.join("lib.rs")).expect("read runtime lib.rs");
+    assert!(
+        lib.contains("pub use everruns_host"),
+        "runtime must preserve its host paths by re-exporting everruns-host"
+    );
+}

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -34,7 +34,8 @@ INNER_PINS: dict[str, list[str]] = {
     "crates/engine/Cargo.toml": ["everruns-core"],
     "crates/platform/Cargo.toml": ["everruns-core"],
     "crates/mcp/Cargo.toml": ["everruns-core"],
-    "crates/runtime/Cargo.toml": ["everruns-core", "everruns-engine"],
+    "crates/host/Cargo.toml": ["everruns-core", "everruns-mcp"],
+    "crates/runtime/Cargo.toml": ["everruns-core", "everruns-engine", "everruns-host"],
     "crates/everruns/Cargo.toml": ["everruns-core", "everruns-runtime", "everruns-local", "everruns-macros"],
     "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
     "crates/openai/Cargo.toml": ["everruns-provider"],
@@ -57,7 +58,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-engine", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-local", "everruns-ard", "everruns", "everruns-macros"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-engine", "everruns-host", "everruns-platform", "everruns-provider", "everruns-mcp", "everruns-runtime", "everruns-local", "everruns-ard", "everruns", "everruns-macros"]
 
 
 def workspace_version() -> str:

--- a/scripts/test-publish-crates-order.sh
+++ b/scripts/test-publish-crates-order.sh
@@ -108,6 +108,9 @@ for crate in published:
 # drops a crate from the list fails loudly rather than silently passing.
 for earlier, later in (
     ("everruns-core", "everruns-engine"),
+    ("everruns-core", "everruns-host"),
+    ("everruns-mcp", "everruns-host"),
+    ("everruns-host", "everruns-runtime"),
     ("everruns-engine", "everruns-runtime"),
     ("everruns-macros", "everruns"),
 ):
@@ -121,6 +124,9 @@ for earlier, later in (
 # The workflow's own version verification must cover the same edges.
 for manifest_rel, dependency in (
     ("crates/engine/Cargo.toml", "everruns-core"),
+    ("crates/host/Cargo.toml", "everruns-core"),
+    ("crates/host/Cargo.toml", "everruns-mcp"),
+    ("crates/runtime/Cargo.toml", "everruns-host"),
     ("crates/everruns/Cargo.toml", "everruns-macros"),
 ):
     entry = re.search(


### PR DESCRIPTION
## What changed
Introduces the published, non-application-facing everruns-host boundary and moves the shared input/reason/act phase and lifecycle implementation into it. everruns-runtime keeps every existing 0.17 host path as an exact re-export, so runtime, worker, local, durable, and custom-host callers continue using the same implementation.

Adds dependency-direction, source-ownership, publication-order, and version-pin guards. Ordinary applications still use everruns; advanced host integrations may depend on everruns-host.

Atomic invariant and dependency order: this PR is independently green and useful. It introduces the owner and compatibility re-export in one checkpoint with no duplicate algorithm. Later Step 3 units will move in-process/event ownership and then reduce runtime to compatibility glue; Step 4 alone will migrate worker/local direct dependencies.

## Why
Shared effectful host orchestration cannot remain owned by the deprecated runtime compatibility crate, and it cannot move into the pure sans-I/O engine or the application facade. The neutral boundary prevents dependency cycles while preserving 0.17 compatibility.

## Before / After
Before: everruns-runtime owned the shared host phase/lifecycle algorithm; engine depended only on core.

After: everruns-host owns that algorithm; everruns-runtime depends on and re-exports host; engine still depends only on core. Public behavior is unchanged. Compile-time compatibility tests prove old and canonical paths are the same types, while a source guard proves runtime no longer contains the host implementation file.

## Risk
- Low
- Packaging or dependency-order mistakes could make a published runtime release unresolved; package, pin, and publish-order checks cover those edges.
- A missed re-export could break an existing worker/custom-host import; the runtime, worker, local, durable, and all-feature matrices compile and test the paths.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL, TM-LLM, TM-DOS; no security-relevant behavior changes.
- Findings and resolutions: no findings. This is a byte-for-byte implementation move plus compatibility and release wiring. It adds no trust boundary, unsafe code, credential handling, I/O, network path, or third-party dependency.

## Follow-ups
- Step 3 unit 2: move low-level in-process and event-authoritative host persistence into everruns-host, then switch everruns to host.
- Step 3 unit 3: reduce everruns-runtime to compatibility-only source and add final structural/equivalence guards.
- Step 4: migrate worker/local and remaining consumers away from runtime after the host API is main-green.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- just pre-push: all 11 gates passed
- cargo test -p everruns-runtime --tests: all affected host/runtime suites passed except one pre-existing macOS /var alias assertion; reproduced identically on untouched e7730ed1
- cargo test -p everruns-worker --lib --tests
- cargo test -p everruns-local --lib --tests
- cargo test -p everruns-durable --lib --tests
- cargo check -p everruns-runtime --all-features
- cargo check -p everruns --all-features
- cargo package -p everruns-host --allow-dirty --no-verify
- scripts/test-publish-crates-order.sh
- scripts/sync-publish-pin-versions.py --check