### PR TITLE
feat(framework): add advanced capability authoring API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ deterministic simulator; opt-in providers, typed tools, multi-turn sessions, eve
 cancellation, files, MCP, and context inspection all stay on the same public facade. Start with
 the [Framework quickstart](https://docs.everruns.com/framework/quickstart/).
 
+Reusable capability packages can use the curated
+[`everruns::capability`](https://docs.everruns.com/framework/advanced-capabilities/) authoring API.
+
 `everruns-runtime` remains available for existing 0.17.x applications and low-level execution
 hosts. See [Runtime compatibility](https://docs.everruns.com/framework/runtime-compatibility/)
 before choosing it for new code.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -182,6 +182,7 @@ export default defineConfig({
                 {
                   label: "Extend",
                   items: [
+                    { label: "Advanced Capabilities", slug: "framework/advanced-capabilities" },
                     { label: "Custom Providers", slug: "framework/custom-providers" },
                     { label: "Custom Backends", slug: "framework/custom-backends" },
                     { label: "Testing and Simulation", slug: "framework/testing-and-simulation" },

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -27,13 +27,17 @@ categories = ["development-tools", "asynchronous"]
 [features]
 # Default features stay offline: the facade activates no provider, MCP,
 # filesystem, SQLx, server, or worker integrations. The `macros` surface is the
-# one default beyond the bare re-exports — it pulls in no network or I/O edge,
-# only the proc-macro and schema-generation toolchain.
-default = ["macros"]
+# default surfaces beyond the bare re-exports — macros and typed capabilities —
+# pull in no network or I/O edge, only async adaptation and schema generation.
+default = ["macros", "capabilities"]
 # Re-export `#[everruns::tool]` (EVE-829) and the hidden `__macro_support`
 # runtime helpers it expands into. Pulls in `everruns-macros`, `schemars` (JSON
 # Schema generation), and `serde` (derive). Kept out of `everruns-core`.
 macros = ["dep:everruns-macros", "dep:schemars", "dep:serde"]
+# Curated service-provider interface for code-defined capabilities. This shares
+# serde/schemars with `macros` but remains independently gateable so the bare
+# facade still compiles with `--no-default-features`.
+capabilities = ["dep:schemars", "dep:serde"]
 # Persist and resume a session's conversation as an append-only JSONL file
 # (EVE-836). Off by default; adds no new dependencies (only `std::fs` and the
 # already-present `serde_json`), so the standard build gains no filesystem edge.
@@ -71,8 +75,9 @@ tokio = { workspace = true, features = ["sync", "macros"] }
 # leaking the tokio-util type onto the public surface. Matches the pin used by
 # everruns-core.
 tokio-util = { version = "0.7", default-features = false }
-# Activated by the `macros` feature. `everruns-macros` provides the
-# `#[everruns::tool]` attribute; `schemars` and `serde` back the code it emits.
+# Activated by `macros` and/or `capabilities`. `everruns-macros` provides the
+# `#[everruns::tool]` attribute; `schemars` and `serde` back generated and
+# advanced typed protocol schemas.
 everruns-macros = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -104,3 +109,7 @@ required-features = ["openai"]
 [[example]]
 name = "subagents"
 required-features = ["openai"]
+
+[[example]]
+name = "advanced_capability"
+required-features = ["capabilities", "openai"]

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -170,6 +170,16 @@ Examples are compiled in CI and import only `everruns`.
 - [Events and cancellation](https://docs.everruns.com/framework/events-and-cancellation/)
 - [API reference](https://docs.rs/everruns)
 
+## Extend agents
+
+Use `#[everruns::tool]` for an ordinary typed async function. Reusable packages
+that need multiple typed tools, capability metadata, execution context,
+progress, or call-scoped cancellation use the curated `everruns::capability`
+SPI and `AgentBuilder::advanced_capability`.
+
+See the [Framework capability-authoring guide](../../docs/framework/advanced-capabilities.md)
+and the [runnable advanced example](examples/advanced_capability.rs).
+
 ## License
 
 Licensed under the [MIT License](https://github.com/everruns/everruns/blob/main/LICENSE).

--- a/crates/everruns/examples/README.md
+++ b/crates/everruns/examples/README.md
@@ -10,6 +10,7 @@ These examples use the application-facing [`everruns`](../README.md) crate and
 | [`github_monitor.rs`](github_monitor.rs) | Host-owned background work that wakes an agent when it finishes | `cargo run -p everruns --features openai --example github_monitor -- --simulate` |
 | [`subagents.rs`](subagents.rs) | Concurrent child agents managed by an application-owned task registry | `cargo run -p everruns --features openai --example subagents` |
 | [`observe_and_cancel.rs`](observe_and_cancel.rs) | Live event streaming and cooperative cancellation | `cargo run -p everruns --features openai --example observe_and_cancel` |
+| [`advanced_capability.rs`](advanced_capability.rs) | Curated capability SPI with typed protocol, metadata, progress, and structured errors | `cargo run -p everruns --features openai --example advanced_capability` |
 
 The GitHub monitor's default `--simulate` mode skips GitHub access but still
 uses the configured model. Its explicit live mode requires an authenticated

--- a/crates/everruns/examples/advanced_capability.rs
+++ b/crates/everruns/examples/advanced_capability.rs
@@ -1,0 +1,110 @@
+//! A reusable typed capability with metadata, structured errors, execution
+//! context, progress, and a non-string result.
+//!
+//! ```text
+//! OPENAI_API_KEY=sk-... cargo run -p everruns --features openai --example advanced_capability
+//! ```
+
+use everruns::{Agent, OpenAI, SessionEventKind, capability};
+
+#[derive(capability::Deserialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct LookupInput {
+    sku: String,
+}
+
+#[derive(capability::Serialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct Product {
+    sku: String,
+    name: String,
+    price_cents: u64,
+    tags: Vec<String>,
+}
+
+struct ProductLookup;
+
+#[capability::async_trait]
+impl capability::Handler for ProductLookup {
+    type Input = LookupInput;
+    type Output = Product;
+    type Error = capability::Error;
+
+    fn name(&self) -> &str {
+        "lookup_product"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Look up product")
+    }
+
+    fn description(&self) -> &str {
+        "Look up one product by its exact SKU."
+    }
+
+    fn hints(&self) -> capability::Hints {
+        capability::Hints::default()
+            .readonly(true)
+            .idempotent(true)
+            .metadata(capability::serde_json::json!({ "domain": "catalog" }))
+    }
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        context: capability::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        context.progress("Searching the product catalog").await;
+        if input.sku != "EVR-42" {
+            return Err(
+                capability::Error::user("product_not_found", "No product has that SKU")
+                    .details(capability::serde_json::json!({ "sku": input.sku })),
+            );
+        }
+        Ok(Product {
+            sku: input.sku,
+            name: "Everruns Field Guide".into(),
+            price_cents: 4200,
+            tags: vec!["agents".into(), "rust".into()],
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let catalog = capability::Definition::new(
+        "product_catalog",
+        "Product catalog",
+        "Application-owned product data.",
+    )
+    .instructions("Use exact SKUs. Never invent catalog entries.")
+    .metadata(capability::serde_json::json!({ "owner": "commerce" }))
+    .tool(ProductLookup);
+
+    let agent = Agent::builder()
+        .name("catalog-assistant")
+        .instructions("Answer questions using the product catalog capability.")
+        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .advanced_capability(catalog)
+        .build()?;
+
+    let mut session = agent.session();
+    let mut events = session.events();
+    let observer = tokio::spawn(async move {
+        while let Some(event) = events.recv().await {
+            if let SessionEventKind::ToolProgress { message, .. } = &event.kind {
+                eprintln!("progress: {message}");
+            }
+            if matches!(event.kind, SessionEventKind::TurnCompleted) {
+                break;
+            }
+        }
+    });
+
+    let turn = session.run("What is product EVR-42?").await?;
+    println!("{}", turn.response);
+    observer.await?;
+    Ok(())
+}

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -163,6 +163,18 @@ pub enum BuildError {
         /// The colliding tool name.
         name: String,
     },
+    /// An advanced capability's public descriptor is invalid.
+    InvalidCapability {
+        /// The rejected capability id.
+        id: String,
+        /// Why the descriptor was rejected.
+        reason: String,
+    },
+    /// Two advanced capability registrations used the same stable id.
+    DuplicateCapability {
+        /// The colliding capability id.
+        id: String,
+    },
     /// Two providers used the same normalized identity.
     DuplicateProvider { id: String },
     /// The selected model names a provider that was not registered.
@@ -191,6 +203,12 @@ impl fmt::Display for BuildError {
             }
             BuildError::DuplicateTool { name } => {
                 write!(f, "duplicate tool name {name:?}")
+            }
+            BuildError::InvalidCapability { id, reason } => {
+                write!(f, "invalid advanced capability {id:?}: {reason}")
+            }
+            BuildError::DuplicateCapability { id } => {
+                write!(f, "duplicate advanced capability id {id:?}")
             }
             BuildError::DuplicateProvider { id } => write!(f, "duplicate provider {id:?}"),
             BuildError::UnknownProvider {
@@ -227,6 +245,8 @@ pub struct Agent {
     providers: Vec<Provider>,
     capabilities: Vec<AgentCapabilityConfig>,
     function_tools: Vec<FunctionTool>,
+    #[cfg(feature = "capabilities")]
+    advanced_capabilities: Vec<crate::capability::Definition>,
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
     workspace_root: Option<PathBuf>,
@@ -433,6 +453,10 @@ impl Agent {
         for tool in &self.function_tools {
             builder = builder.capability(tool.clone().into_capability());
         }
+        #[cfg(feature = "capabilities")]
+        for capability in &self.advanced_capabilities {
+            builder = builder.capability(capability.runtime_adapter());
+        }
         for provider in &self.providers {
             builder = builder.provider(provider.clone());
         }
@@ -453,6 +477,8 @@ pub struct AgentBuilder {
     providers: Vec<Provider>,
     capabilities: Vec<AgentCapabilityConfig>,
     tools: Vec<Tool>,
+    #[cfg(feature = "capabilities")]
+    advanced_capabilities: Vec<crate::capability::Definition>,
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
     workspace_root: Option<PathBuf>,
@@ -528,6 +554,19 @@ impl AgentBuilder {
     /// Add a capability the agent can use.
     pub fn capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
         self.capabilities.push(capability.into());
+        self
+    }
+
+    /// Register a code-defined capability through the curated advanced SPI.
+    ///
+    /// This both installs the implementation on the private in-process runtime
+    /// and activates its stable id on the agent. Use [`#[everruns::tool]`](crate::tool)
+    /// for ordinary single-function tools; use this method when a reusable
+    /// capability needs typed protocol descriptors, context, progress, or
+    /// call-scoped cancellation.
+    #[cfg(feature = "capabilities")]
+    pub fn advanced_capability(mut self, capability: crate::capability::Definition) -> Self {
+        self.advanced_capabilities.push(capability);
         self
     }
 
@@ -644,6 +683,9 @@ impl AgentBuilder {
     ///   incomplete, or duplicates another server name.
     /// - [`BuildError::InvalidCompaction`] if the proactive context budget is
     ///   outside the supported range.
+    /// - [`BuildError::InvalidCapability`] if an advanced capability descriptor
+    ///   is invalid.
+    /// - [`BuildError::DuplicateCapability`] if advanced capabilities share an id.
     pub fn build(self) -> Result<Agent, BuildError> {
         let instructions = self.instructions.unwrap_or_default();
         if instructions.trim().is_empty() {
@@ -721,6 +763,49 @@ impl AgentBuilder {
             capabilities.push(compaction.capability_config());
         }
 
+        #[cfg(feature = "capabilities")]
+        let advanced_capabilities = {
+            let mut seen_capability_ids: HashSet<String> = capabilities
+                .iter()
+                .map(|config| config.capability_id().to_string())
+                .collect();
+            for capability in &self.advanced_capabilities {
+                capability
+                    .validate()
+                    .map_err(|reason| BuildError::InvalidCapability {
+                        id: capability.id().to_string(),
+                        reason,
+                    })?;
+                if !seen_capability_ids.insert(capability.id().to_string()) {
+                    return Err(BuildError::DuplicateCapability {
+                        id: capability.id().to_string(),
+                    });
+                }
+                for tool in capability.tools() {
+                    let spec = tool.spec();
+                    validate_tool_name(spec.name()).map_err(|reason| {
+                        BuildError::InvalidToolName {
+                            name: spec.name().to_string(),
+                            reason,
+                        }
+                    })?;
+                    validate_tool_schema(spec.input_schema()).map_err(|reason| {
+                        BuildError::InvalidToolSchema {
+                            name: spec.name().to_string(),
+                            reason,
+                        }
+                    })?;
+                    if !seen_tool_names.insert(spec.name().to_string()) {
+                        return Err(BuildError::DuplicateTool {
+                            name: spec.name().to_string(),
+                        });
+                    }
+                }
+                capabilities.push(AgentCapabilityConfig::new(capability.id()));
+            }
+            self.advanced_capabilities
+        };
+
         Ok(Agent {
             name,
             instructions,
@@ -728,6 +813,8 @@ impl AgentBuilder {
             providers,
             capabilities,
             function_tools,
+            #[cfg(feature = "capabilities")]
+            advanced_capabilities,
             initial_files: self.initial_files,
             parallel_tool_calls: self.parallel_tool_calls,
             workspace_root: self.workspace_root,

--- a/crates/everruns/src/capability.rs
+++ b/crates/everruns/src/capability.rs
@@ -1,0 +1,1149 @@
+//! Stable service-provider interface for advanced, code-defined capabilities.
+//!
+//! Most application tools should use [`#[everruns::tool]`](macro@crate::tool).
+//! This module is for reusable capability packages that need several typed
+//! tools, capability-level instructions and metadata, execution context,
+//! progress events, or call-scoped cancellation. It deliberately projects the
+//! engine contracts needed by capability authors without exposing registries,
+//! stores, tenancy, or host implementation types.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns::{Agent, Model, capability};
+//!
+//! #[derive(capability::Deserialize, capability::JsonSchema)]
+//! #[serde(crate = "everruns::capability::serde")]
+//! #[schemars(crate = "everruns::capability::schemars")]
+//! struct LookupInput {
+//!     city: String,
+//! }
+//!
+//! #[derive(capability::Serialize, capability::JsonSchema)]
+//! #[serde(crate = "everruns::capability::serde")]
+//! #[schemars(crate = "everruns::capability::schemars")]
+//! struct LookupOutput {
+//!     city: String,
+//!     forecast: String,
+//! }
+//!
+//! struct Lookup;
+//!
+//! #[capability::async_trait]
+//! impl capability::Handler for Lookup {
+//!     type Input = LookupInput;
+//!     type Output = LookupOutput;
+//!     type Error = capability::Error;
+//!
+//!     fn name(&self) -> &str { "lookup_weather" }
+//!     fn description(&self) -> &str { "Look up the weather for a city." }
+//!
+//!     async fn execute(
+//!         &self,
+//!         input: Self::Input,
+//!         context: capability::Context,
+//!     ) -> Result<Self::Output, Self::Error> {
+//!         context.progress("Looking up the forecast").await;
+//!         Ok(LookupOutput {
+//!             city: input.city,
+//!             forecast: "sunny".into(),
+//!         })
+//!     }
+//! }
+//!
+//! let weather = capability::Definition::new(
+//!     "weather",
+//!     "Weather",
+//!     "Typed weather lookup tools.",
+//! )
+//! .instructions("Use weather data only when a user asks about a location.")
+//! .tool(Lookup);
+//!
+//! let agent = Agent::builder()
+//!     .instructions("You are a concise assistant.")
+//!     .model(Model::simulated("done"))
+//!     .advanced_capability(weather)
+//!     .build()?;
+//! # let _ = agent;
+//! # Ok::<(), everruns::BuildError>(())
+//! ```
+
+#![deny(missing_docs)]
+
+use std::fmt;
+use std::sync::Arc;
+
+use everruns_core::capabilities::Capability as CoreCapability;
+use everruns_core::tools::{Tool as CoreTool, ToolExecutionResult};
+use everruns_core::{ToolContext, ToolHints};
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+
+pub use async_trait::async_trait;
+pub use schemars::{self, JsonSchema};
+pub use serde::{self, Deserialize, Serialize};
+pub use serde_json;
+
+/// A reusable code-defined capability.
+///
+/// A definition is an immutable value: clone it to install the same capability
+/// on several agents. The runtime registers it privately when the agent's
+/// session starts; capability authors never manipulate an engine registry.
+#[derive(Clone)]
+pub struct Definition {
+    id: String,
+    name: String,
+    description: String,
+    instructions: Option<String>,
+    metadata: Option<Value>,
+    tools: Vec<Tool>,
+}
+
+impl Definition {
+    /// Start a capability definition.
+    ///
+    /// `id` is the stable persisted identifier. `name` and `description` are
+    /// human-facing catalog text. These values, tool names, and tool input
+    /// schemas are validated by [`AgentBuilder::build`](crate::AgentBuilder::build).
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            description: description.into(),
+            instructions: None,
+            metadata: None,
+            tools: Vec::new(),
+        }
+    }
+
+    /// Add capability-level behavioral guidance to the agent's system prompt.
+    ///
+    /// Do not repeat facts already expressed by tool names, descriptions, or
+    /// schemas. Use this for cross-tool ordering, constraints, and semantics.
+    pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
+        self.instructions = Some(instructions.into());
+        self
+    }
+
+    /// Attach host-owned, JSON metadata for catalogs and embedding hosts.
+    ///
+    /// The engine does not interpret this value. It may be persisted or shown
+    /// to clients, so it must never contain credentials or sensitive payloads.
+    pub fn metadata(mut self, metadata: impl Into<Value>) -> Self {
+        self.metadata = Some(metadata.into());
+        self
+    }
+
+    /// Add one typed tool handler.
+    pub fn tool<H>(mut self, handler: H) -> Self
+    where
+        H: Handler,
+    {
+        self.tools.push(Tool::new(handler));
+        self
+    }
+
+    /// The stable capability identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The human-readable capability name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The capability description.
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Capability-level instructions, when configured.
+    pub fn instructions_text(&self) -> Option<&str> {
+        self.instructions.as_deref()
+    }
+
+    /// Host-owned capability metadata, when configured.
+    pub fn metadata_value(&self) -> Option<&Value> {
+        self.metadata.as_ref()
+    }
+
+    /// Typed tool descriptors in registration order.
+    pub fn tools(&self) -> &[Tool] {
+        &self.tools
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        validate_identifier(&self.id, "capability")?;
+        if self.name.trim().is_empty() {
+            return Err("capability name must not be blank".to_string());
+        }
+        if self.description.trim().is_empty() {
+            return Err("capability description must not be blank".to_string());
+        }
+        if self
+            .instructions
+            .as_ref()
+            .is_some_and(|text| text.trim().is_empty())
+        {
+            return Err("capability instructions must not be blank".to_string());
+        }
+        if self.tools.is_empty() {
+            return Err("capability must define at least one tool".to_string());
+        }
+        if let Some(tool) = self
+            .tools
+            .iter()
+            .find(|tool| tool.spec.description.trim().is_empty())
+        {
+            return Err(format!(
+                "tool {:?} description must not be blank",
+                tool.spec.name
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn runtime_adapter(&self) -> RuntimeDefinition {
+        RuntimeDefinition(self.clone())
+    }
+}
+
+fn validate_identifier(value: &str, noun: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("{noun} id must not be empty"));
+    }
+    if value.len() > 64 {
+        return Err(format!("{noun} id must be at most 64 characters"));
+    }
+    let mut chars = value.chars();
+    let first = chars.next().expect("non-empty checked above");
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(format!("{noun} id must start with a letter or underscore"));
+    }
+    if value
+        .chars()
+        .any(|ch| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
+    {
+        return Err(format!(
+            "{noun} id may only contain letters, digits, '_' or '-'"
+        ));
+    }
+    Ok(())
+}
+
+impl fmt::Debug for Definition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Definition")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("instructions", &self.instructions)
+            .field("metadata", &self.metadata)
+            .field("tools", &self.tools)
+            .finish()
+    }
+}
+
+pub(crate) struct RuntimeDefinition(Definition);
+
+#[async_trait]
+impl CoreCapability for RuntimeDefinition {
+    fn id(&self) -> &str {
+        &self.0.id
+    }
+
+    fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    fn description(&self) -> &str {
+        &self.0.description
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        self.0.instructions.as_deref()
+    }
+
+    fn metadata(&self) -> Option<Value> {
+        self.0.metadata.clone()
+    }
+
+    fn tools(&self) -> Vec<Box<dyn CoreTool>> {
+        self.0
+            .tools
+            .iter()
+            .cloned()
+            .map(|tool| Box::new(tool) as Box<dyn CoreTool>)
+            .collect()
+    }
+}
+
+/// Implemented by one typed tool inside an advanced capability.
+///
+/// Input values are deserialized after the model calls the tool. Output values
+/// are serialized as JSON without a `String` intermediary. Both types also
+/// provide schemas, allowing hosts and documentation to inspect the full
+/// protocol even though the current model protocol consumes only the input
+/// schema.
+#[async_trait]
+pub trait Handler: Send + Sync + 'static {
+    /// Typed tool arguments.
+    type Input: DeserializeOwned + JsonSchema + Send + 'static;
+    /// Typed, JSON-serializable tool result.
+    type Output: Serialize + JsonSchema + Send + 'static;
+    /// Structured handler error. Custom error enums can implement `Into<Error>`.
+    type Error: Into<Error> + Send + 'static;
+
+    /// Stable model-facing tool name.
+    fn name(&self) -> &str;
+    /// Model-facing description of when and how to use the tool.
+    fn description(&self) -> &str;
+
+    /// Optional human-readable display name for clients.
+    fn display_name(&self) -> Option<&str> {
+        None
+    }
+
+    /// Semantic and host-owned tool metadata.
+    fn hints(&self) -> Hints {
+        Hints::default()
+    }
+
+    /// Execute one call.
+    ///
+    /// Awaited work is cancelled by dropping this future when the turn stops.
+    /// Use [`Context::cancellation`] for child tasks or resources that can
+    /// outlive this future, and [`Context::progress`] for correlated status.
+    async fn execute(
+        &self,
+        input: Self::Input,
+        context: Context,
+    ) -> Result<Self::Output, Self::Error>;
+}
+
+/// A type-erased typed tool plus its stable protocol descriptor.
+///
+/// Constructed through [`Definition::tool`] in normal use. The public accessor
+/// exists so capability packages can test and document their exported schema.
+#[derive(Clone)]
+pub struct Tool {
+    spec: ToolSpec,
+    handler: Arc<dyn ErasedHandler>,
+}
+
+impl Tool {
+    fn new<H: Handler>(handler: H) -> Self {
+        let spec = ToolSpec {
+            name: handler.name().to_string(),
+            display_name: handler.display_name().map(str::to_string),
+            description: handler.description().to_string(),
+            input_schema: schema_for::<H::Input>(),
+            output_schema: schema_for::<H::Output>(),
+            hints: handler.hints(),
+        };
+        Self {
+            spec,
+            handler: Arc::new(HandlerAdapter(handler)),
+        }
+    }
+
+    /// The stable tool protocol descriptor.
+    pub fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+}
+
+impl fmt::Debug for Tool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tool").field("spec", &self.spec).finish()
+    }
+}
+
+#[async_trait]
+impl CoreTool for Tool {
+    fn name(&self) -> &str {
+        &self.spec.name
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        self.spec.display_name.as_deref()
+    }
+
+    fn description(&self) -> &str {
+        &self.spec.description
+    }
+
+    fn parameters_schema(&self) -> Value {
+        self.spec.input_schema.clone()
+    }
+
+    fn hints(&self) -> ToolHints {
+        self.spec.hints.to_core()
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::internal_error_msg(
+            "advanced capability tool execution requires runtime context",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let context = Context::from_core(self.spec.name.clone(), context.clone());
+        self.handler.call(arguments, context).await
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[async_trait]
+trait ErasedHandler: Send + Sync {
+    async fn call(&self, input: Value, context: Context) -> ToolExecutionResult;
+}
+
+struct HandlerAdapter<H>(H);
+
+#[async_trait]
+impl<H: Handler> ErasedHandler for HandlerAdapter<H> {
+    async fn call(&self, input: Value, context: Context) -> ToolExecutionResult {
+        let input = match serde_json::from_value::<H::Input>(input) {
+            Ok(input) => input,
+            Err(error) => {
+                return Error::user(
+                    "invalid_arguments",
+                    format!("tool arguments did not match the declared schema: {error}"),
+                )
+                .into_execution_result();
+            }
+        };
+        match self.0.execute(input, context).await {
+            Ok(output) => match serde_json::to_value(output) {
+                Ok(output) => ToolExecutionResult::success(output),
+                Err(error) => Error::internal(
+                    "result_serialization",
+                    format!("failed to serialize capability result: {error}"),
+                )
+                .into_execution_result(),
+            },
+            Err(error) => error.into().into_execution_result(),
+        }
+    }
+}
+
+fn schema_for<T: JsonSchema>() -> Value {
+    serde_json::to_value(schemars::schema_for!(T)).unwrap_or(Value::Null)
+}
+
+/// Stable metadata and JSON schemas for one capability tool.
+#[derive(Clone, Debug)]
+pub struct ToolSpec {
+    name: String,
+    display_name: Option<String>,
+    description: String,
+    input_schema: Value,
+    output_schema: Value,
+    hints: Hints,
+}
+
+impl ToolSpec {
+    /// Stable model-facing name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    /// Optional human-readable display name.
+    pub fn display_name(&self) -> Option<&str> {
+        self.display_name.as_deref()
+    }
+    /// Model-facing tool description.
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+    /// Generated JSON Schema for [`Handler::Input`].
+    pub fn input_schema(&self) -> &Value {
+        &self.input_schema
+    }
+    /// Generated JSON Schema for [`Handler::Output`].
+    pub fn output_schema(&self) -> &Value {
+        &self.output_schema
+    }
+    /// Semantic and host-owned annotations.
+    pub fn hints(&self) -> &Hints {
+        &self.hints
+    }
+}
+
+/// Semantic and host-owned annotations for a capability tool.
+///
+/// Boolean values are `Option<bool>` so unspecified remains distinct from
+/// false. Hints inform scheduling and clients; they do not grant authority.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Hints {
+    /// The tool does not modify state.
+    pub readonly: Option<bool>,
+    /// The tool may irreversibly delete or destroy state.
+    pub destructive: Option<bool>,
+    /// Repeating a call with the same arguments is safe.
+    pub idempotent: Option<bool>,
+    /// The tool interacts with systems outside the local process.
+    pub open_world: Option<bool>,
+    /// The tool may commonly take more than a few seconds.
+    pub long_running: Option<bool>,
+    /// Calls sharing this non-empty key execute sequentially.
+    pub concurrency_class: Option<String>,
+    /// Host-owned annotations. Never include credentials or sensitive data.
+    pub metadata: Option<Value>,
+}
+
+impl Hints {
+    /// Mark whether the tool is read-only.
+    pub fn readonly(mut self, value: bool) -> Self {
+        self.readonly = Some(value);
+        self
+    }
+    /// Mark whether the tool can destroy state.
+    pub fn destructive(mut self, value: bool) -> Self {
+        self.destructive = Some(value);
+        self
+    }
+    /// Mark whether identical calls are safe to repeat.
+    pub fn idempotent(mut self, value: bool) -> Self {
+        self.idempotent = Some(value);
+        self
+    }
+    /// Mark whether the tool reaches external systems.
+    pub fn open_world(mut self, value: bool) -> Self {
+        self.open_world = Some(value);
+        self
+    }
+    /// Mark whether the tool is commonly long-running.
+    pub fn long_running(mut self, value: bool) -> Self {
+        self.long_running = Some(value);
+        self
+    }
+    /// Serialize calls that share this scheduling class.
+    pub fn concurrency_class(mut self, value: impl Into<String>) -> Self {
+        self.concurrency_class = Some(value.into());
+        self
+    }
+    /// Attach host-owned JSON annotations.
+    pub fn metadata(mut self, value: impl Into<Value>) -> Self {
+        self.metadata = Some(value.into());
+        self
+    }
+
+    fn to_core(&self) -> ToolHints {
+        ToolHints {
+            readonly: self.readonly,
+            destructive: self.destructive,
+            idempotent: self.idempotent,
+            open_world: self.open_world,
+            long_running: self.long_running,
+            concurrency_class: self.concurrency_class.clone(),
+            metadata: self.metadata.clone(),
+            ..ToolHints::default()
+        }
+    }
+}
+
+/// Runtime context available to an advanced capability tool.
+///
+/// This is a narrow projection: identity, locale, progress, and cancellation.
+/// Backend stores, credentials, tenant objects, registries, and host extensions
+/// intentionally remain private implementation details.
+#[derive(Clone)]
+pub struct Context {
+    tool_name: String,
+    session_id: String,
+    workspace_id: String,
+    locale: Option<String>,
+    cancellation: CallCancellation,
+    inner: ToolContext,
+}
+
+impl Context {
+    fn from_core(tool_name: String, inner: ToolContext) -> Self {
+        Self {
+            tool_name,
+            session_id: inner.session_id.to_string(),
+            workspace_id: inner.workspace_id.to_string(),
+            locale: inner.locale.clone(),
+            cancellation: CallCancellation {
+                inner: inner.cancellation.clone().unwrap_or_default(),
+            },
+            inner,
+        }
+    }
+
+    /// Opaque session identifier for correlation and application-side scoping.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Opaque identifier of the workspace attached to this session.
+    pub fn workspace_id(&self) -> &str {
+        &self.workspace_id
+    }
+
+    /// Resolved BCP 47 locale, when the host supplied one.
+    pub fn locale(&self) -> Option<&str> {
+        self.locale.as_deref()
+    }
+
+    /// Call-scoped cancellation signal for work that may outlive `execute`.
+    pub fn cancellation(&self) -> &CallCancellation {
+        &self.cancellation
+    }
+
+    /// Emit a best-effort, correlated `tool.progress` event.
+    ///
+    /// Delivery failure never fails the tool. Subscribe with
+    /// [`Session::events`](crate::Session::events) and match
+    /// [`SessionEventKind::ToolProgress`](crate::SessionEventKind::ToolProgress).
+    pub async fn progress(&self, message: impl AsRef<str>) {
+        self.inner
+            .emit_progress(&self.tool_name, message.as_ref())
+            .await;
+    }
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("tool_name", &self.tool_name)
+            .field("session_id", &self.session_id)
+            .field("workspace_id", &self.workspace_id)
+            .field("locale", &self.locale)
+            .field("cancelled", &self.cancellation.is_cancelled())
+            .finish()
+    }
+}
+
+/// Cancellation signal tied to one tool call's lifetime.
+///
+/// The engine cancels it when the call returns, fails, or is dropped because
+/// the turn was cancelled. Ordinary awaited work needs no special handling:
+/// its future is dropped with the call. Clone this signal into child tasks,
+/// processes, or watchers that could otherwise outlive `execute`.
+#[derive(Clone)]
+pub struct CallCancellation {
+    inner: tokio_util::sync::CancellationToken,
+}
+
+impl CallCancellation {
+    /// Whether the tool call has ended or been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Resolve when the tool call ends or is cancelled.
+    pub async fn cancelled(&self) {
+        self.inner.cancelled().await;
+    }
+}
+
+impl fmt::Debug for CallCancellation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CallCancellation")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+/// Whether a capability error is safe to show to the model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorVisibility {
+    /// Expected domain failure; code, message, and details are model-visible.
+    User,
+    /// Unexpected implementation failure; details are hidden from the model.
+    Internal,
+}
+
+/// A structured capability error with stable code, message, and JSON details.
+///
+/// Use [`Error::user`] for expected failures the model can act on and
+/// [`Error::internal`] for diagnostic details that are unsafe to show to the
+/// model. Internal messages are logged by the engine and replaced with a
+/// generic model-visible error, so they must not contain credentials or other
+/// secrets.
+#[derive(Debug)]
+pub struct Error {
+    visibility: ErrorVisibility,
+    code: String,
+    message: String,
+    details: Option<Value>,
+}
+
+impl Error {
+    /// Create an expected, model-visible domain error.
+    pub fn user(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            visibility: ErrorVisibility::User,
+            code: code.into(),
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Create an internal error whose details must not reach the model.
+    pub fn internal(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            visibility: ErrorVisibility::Internal,
+            code: code.into(),
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    /// Attach structured JSON details.
+    pub fn details(mut self, details: impl Into<Value>) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+
+    /// Stable machine-readable error code.
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    /// Human-readable error message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Structured details, when present.
+    pub fn details_value(&self) -> Option<&Value> {
+        self.details.as_ref()
+    }
+
+    /// Whether the error is model-visible or internal.
+    pub fn visibility(&self) -> ErrorVisibility {
+        self.visibility
+    }
+
+    fn into_execution_result(self) -> ToolExecutionResult {
+        match self.visibility {
+            ErrorVisibility::User => {
+                let payload = json!({
+                    "code": self.code,
+                    "message": self.message,
+                    "details": self.details,
+                });
+                ToolExecutionResult::tool_error(payload.to_string())
+            }
+            ErrorVisibility::Internal => ToolExecutionResult::internal_error_msg(format!(
+                "capability error [{}]: {}{}",
+                self.code,
+                self.message,
+                self.details
+                    .map(|details| format!("; details={details}"))
+                    .unwrap_or_default()
+            )),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
+    use everruns_core::tools::Tool as _;
+    use everruns_core::{ModelSpec, Provider, SessionId, ToolCall, ToolContext};
+    use serde_json::{Value, json};
+    use tokio::sync::Notify;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::{Agent, CancellationToken, Model, RunOptions, SessionEventKind, TurnStopReason};
+
+    #[derive(Deserialize, JsonSchema)]
+    struct LookupInput {
+        city: String,
+    }
+
+    #[derive(Debug, Serialize, JsonSchema)]
+    struct LookupOutput {
+        city: String,
+        temperatures: Vec<i32>,
+    }
+
+    struct Lookup;
+
+    #[async_trait]
+    impl Handler for Lookup {
+        type Input = LookupInput;
+        type Output = LookupOutput;
+        type Error = Error;
+
+        fn name(&self) -> &str {
+            "lookup_weather"
+        }
+
+        fn description(&self) -> &str {
+            "Look up a typed weather forecast."
+        }
+
+        fn hints(&self) -> Hints {
+            Hints::default().readonly(true).idempotent(true)
+        }
+
+        async fn execute(
+            &self,
+            input: Self::Input,
+            context: Context,
+        ) -> Result<Self::Output, Self::Error> {
+            context.progress("forecast ready").await;
+            Ok(LookupOutput {
+                city: input.city,
+                temperatures: vec![18, 21],
+            })
+        }
+    }
+
+    fn lookup_capability() -> Definition {
+        Definition::new("weather", "Weather", "Typed weather tools.")
+            .metadata(json!({ "owner": "example" }))
+            .tool(Lookup)
+    }
+
+    fn scripted_model(calls: Vec<Vec<ToolCall>>) -> Model {
+        let sim = LlmSimConfig::fixed("done").with_tool_call_sequence(calls);
+        Model::with_provider(
+            ModelSpec::on("llmsim", "llmsim-model"),
+            Provider::new("llmsim", LlmSimDriver::new(sim)),
+        )
+    }
+
+    #[test]
+    fn exposes_input_output_schemas_and_hints() {
+        let capability = lookup_capability();
+        let spec = capability.tools()[0].spec();
+
+        assert_eq!(spec.name(), "lookup_weather");
+        assert_eq!(spec.input_schema()["type"], "object");
+        assert_eq!(spec.output_schema()["type"], "object");
+        assert_eq!(
+            spec.output_schema()["properties"]["temperatures"]["type"],
+            "array"
+        );
+        assert_eq!(spec.hints().readonly, Some(true));
+        assert_eq!(spec.hints().idempotent, Some(true));
+        assert_eq!(
+            capability.metadata_value(),
+            Some(&json!({ "owner": "example" }))
+        );
+    }
+
+    #[tokio::test]
+    async fn typed_non_string_result_serializes_as_json() {
+        let tool = lookup_capability().tools()[0].clone();
+        let context = ToolContext::new(SessionId::new())
+            .with_cancellation(tokio_util::sync::CancellationToken::new());
+        let result = tool
+            .execute_with_context(json!({ "city": "Kyiv" }), &context)
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        assert_eq!(value, json!({ "city": "Kyiv", "temperatures": [18, 21] }));
+    }
+
+    struct Failing;
+
+    #[async_trait]
+    impl Handler for Failing {
+        type Input = LookupInput;
+        type Output = LookupOutput;
+        type Error = Error;
+
+        fn name(&self) -> &str {
+            "failing_lookup"
+        }
+
+        fn description(&self) -> &str {
+            "Return a structured not-found error."
+        }
+
+        async fn execute(
+            &self,
+            input: Self::Input,
+            _context: Context,
+        ) -> Result<Self::Output, Self::Error> {
+            Err(Error::user("city_not_found", "No forecast exists")
+                .details(json!({ "city": input.city })))
+        }
+    }
+
+    #[tokio::test]
+    async fn structured_user_error_keeps_code_message_and_details() {
+        let capability = Definition::new("failures", "Failures", "Error test.").tool(Failing);
+        let context = ToolContext::new(SessionId::new());
+        let result = capability.tools()[0]
+            .execute_with_context(json!({ "city": "Atlantis" }), &context)
+            .await;
+
+        let ToolExecutionResult::ToolError(payload) = result else {
+            panic!("expected tool error, got {result:?}");
+        };
+        let payload: Value = serde_json::from_str(&payload).expect("structured JSON error");
+        assert_eq!(payload["code"], "city_not_found");
+        assert_eq!(payload["message"], "No forecast exists");
+        assert_eq!(payload["details"]["city"], "Atlantis");
+    }
+
+    #[test]
+    fn internal_error_details_do_not_cross_the_model_boundary() {
+        let result = Error::internal("upstream_failed", "private endpoint returned token=secret")
+            .details(json!({ "trace": "private-trace" }))
+            .into_execution_result()
+            .into_tool_result("call_private", "private_tool");
+
+        let visible = result.error.expect("generic model-visible error");
+        assert_eq!(
+            visible,
+            "An internal error occurred while executing the tool"
+        );
+        assert!(!visible.contains("secret"));
+        assert!(!visible.contains("private-trace"));
+    }
+
+    #[tokio::test]
+    async fn capability_runs_end_to_end_and_emits_progress() {
+        let model = scripted_model(vec![
+            vec![ToolCall {
+                id: "call_weather".into(),
+                name: "lookup_weather".into(),
+                arguments: json!({ "city": "Kyiv" }),
+            }],
+            vec![],
+        ]);
+        let agent = Agent::builder()
+            .instructions("Use the weather capability.")
+            .model(model)
+            .advanced_capability(lookup_capability())
+            .build()
+            .expect("valid agent");
+        let mut session = agent.session();
+        let mut events = session.events();
+
+        let turn = session.run("Weather?").await.expect("turn runs");
+        assert!(turn.success, "turn should recover: {:?}", turn.error);
+        assert_eq!(turn.tool_calls, 1);
+
+        let mut saw_progress = false;
+        while let Ok(Some(event)) = timeout(Duration::from_millis(50), events.recv()).await {
+            if matches!(
+                event.kind,
+                SessionEventKind::ToolProgress {
+                    ref tool_name,
+                    ref message,
+                    ..
+                } if tool_name == "lookup_weather" && message == "forecast ready"
+            ) {
+                saw_progress = true;
+                break;
+            }
+        }
+        assert!(saw_progress, "advanced context emitted correlated progress");
+    }
+
+    #[tokio::test]
+    async fn user_error_is_a_recoverable_runtime_tool_error() {
+        let model = scripted_model(vec![
+            vec![ToolCall {
+                id: "call_failure".into(),
+                name: "failing_lookup".into(),
+                arguments: json!({ "city": "Atlantis" }),
+            }],
+            vec![],
+        ]);
+        let capability = Definition::new("failures", "Failures", "Error test.").tool(Failing);
+        let agent = Agent::builder()
+            .instructions("Try the lookup and handle errors.")
+            .model(model)
+            .advanced_capability(capability)
+            .build()
+            .expect("valid agent");
+
+        let turn = agent
+            .session()
+            .run("Find Atlantis")
+            .await
+            .expect("turn runs");
+        assert!(turn.success, "model should recover from a tool error");
+        assert_eq!(turn.tool_calls, 1);
+    }
+
+    struct Completing {
+        child_cancelled: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Handler for Completing {
+        type Input = LookupInput;
+        type Output = LookupOutput;
+        type Error = Error;
+
+        fn name(&self) -> &str {
+            "completing_lookup"
+        }
+
+        fn description(&self) -> &str {
+            "Return successfully after starting call-scoped child work."
+        }
+
+        async fn execute(
+            &self,
+            input: Self::Input,
+            context: Context,
+        ) -> Result<Self::Output, Self::Error> {
+            let cancellation = context.cancellation().clone();
+            let child_cancelled = self.child_cancelled.clone();
+            tokio::spawn(async move {
+                cancellation.cancelled().await;
+                child_cancelled.notify_one();
+            });
+            Ok(LookupOutput {
+                city: input.city,
+                temperatures: vec![],
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_call_completion_notifies_child_work() {
+        let child_cancelled = Arc::new(Notify::new());
+        let capability =
+            Definition::new("completing", "Completing", "Completion test.").tool(Completing {
+                child_cancelled: child_cancelled.clone(),
+            });
+        let model = scripted_model(vec![
+            vec![ToolCall {
+                id: "call_completing".into(),
+                name: "completing_lookup".into(),
+                arguments: json!({ "city": "Kyiv" }),
+            }],
+            vec![],
+        ]);
+        let agent = Agent::builder()
+            .instructions("Run the completing lookup.")
+            .model(model)
+            .advanced_capability(capability)
+            .build()
+            .expect("valid agent");
+
+        let turn = agent.session().run("start").await.expect("turn runs");
+        assert!(turn.success);
+        timeout(Duration::from_secs(2), child_cancelled.notified())
+            .await
+            .expect("child observed successful call completion");
+    }
+
+    struct Hanging {
+        started: Arc<Notify>,
+        child_cancelled: Arc<Notify>,
+        cancellation_seen: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Handler for Hanging {
+        type Input = LookupInput;
+        type Output = LookupOutput;
+        type Error = Error;
+
+        fn name(&self) -> &str {
+            "hanging_lookup"
+        }
+
+        fn description(&self) -> &str {
+            "Wait until the enclosing turn is cancelled."
+        }
+
+        async fn execute(
+            &self,
+            _input: Self::Input,
+            context: Context,
+        ) -> Result<Self::Output, Self::Error> {
+            let cancellation = context.cancellation().clone();
+            let seen = self.cancellation_seen.clone();
+            let child_cancelled = self.child_cancelled.clone();
+            tokio::spawn(async move {
+                cancellation.cancelled().await;
+                seen.store(true, Ordering::SeqCst);
+                child_cancelled.notify_one();
+            });
+            self.started.notify_one();
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_cancellation_stops_tool_and_notifies_child_work() {
+        let started = Arc::new(Notify::new());
+        let child_cancelled = Arc::new(Notify::new());
+        let cancellation_seen = Arc::new(AtomicBool::new(false));
+        let capability =
+            Definition::new("hanging", "Hanging", "Cancellation test.").tool(Hanging {
+                started: started.clone(),
+                child_cancelled: child_cancelled.clone(),
+                cancellation_seen: cancellation_seen.clone(),
+            });
+        let model = scripted_model(vec![vec![ToolCall {
+            id: "call_hanging".into(),
+            name: "hanging_lookup".into(),
+            arguments: json!({ "city": "Kyiv" }),
+        }]]);
+        let agent = Agent::builder()
+            .instructions("Run the hanging lookup.")
+            .model(model)
+            .advanced_capability(capability)
+            .build()
+            .expect("valid agent");
+        let cancellation = CancellationToken::new();
+        let cancel_from_test = cancellation.clone();
+
+        let run = tokio::spawn(async move {
+            agent
+                .session()
+                .run_with("start", RunOptions::new().cancel_token(cancellation))
+                .await
+        });
+        timeout(Duration::from_secs(2), started.notified())
+            .await
+            .expect("tool started");
+        cancel_from_test.cancel();
+
+        let turn = timeout(Duration::from_secs(2), run)
+            .await
+            .expect("run stopped")
+            .expect("task joined")
+            .expect("run result");
+        assert_eq!(turn.stop_reason, TurnStopReason::Cancelled);
+        timeout(Duration::from_secs(2), child_cancelled.notified())
+            .await
+            .expect("child observed call cancellation");
+        assert!(cancellation_seen.load(Ordering::SeqCst));
+    }
+}

--- a/crates/everruns/src/events.rs
+++ b/crates/everruns/src/events.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use everruns_core::error::Result as CoreResult;
 use everruns_core::events::{
     self, Event, EventData, EventRequest, OutputMessageDeltaData, ToolCompletedData,
-    ToolStartedData, TurnFailedData,
+    ToolProgressData, ToolStartedData, TurnFailedData,
 };
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::EventId;
@@ -101,6 +101,15 @@ pub enum SessionEventKind {
         /// Whether the tool call succeeded.
         success: bool,
     },
+    /// A best-effort progress update emitted by an in-flight tool.
+    ToolProgress {
+        /// Opaque id of the tool call.
+        tool_call_id: String,
+        /// Name of the tool emitting progress.
+        tool_name: String,
+        /// Human-readable interim status.
+        message: String,
+    },
     /// Any other runtime event, carried through unprojected.
     ///
     /// `event_type` is the stable dot-notation type string (e.g.
@@ -126,6 +135,7 @@ impl SessionEvent {
             SessionEventKind::TextDelta { .. } => events::OUTPUT_MESSAGE_DELTA,
             SessionEventKind::ToolStarted { .. } => events::TOOL_STARTED,
             SessionEventKind::ToolCompleted { .. } => events::TOOL_COMPLETED,
+            SessionEventKind::ToolProgress { .. } => events::TOOL_PROGRESS,
             SessionEventKind::Other { event_type, .. } => event_type,
         }
     }
@@ -176,6 +186,19 @@ impl SessionEvent {
                     tool_call_id: tool_call_id.clone(),
                     tool_name: tool_name.clone(),
                     success: *success,
+                },
+                _ => Self::other_kind(event),
+            },
+            events::TOOL_PROGRESS => match &event.data {
+                EventData::ToolProgress(ToolProgressData {
+                    tool_call_id,
+                    tool_name,
+                    message,
+                    ..
+                }) => SessionEventKind::ToolProgress {
+                    tool_call_id: tool_call_id.clone(),
+                    tool_name: tool_name.clone(),
+                    message: message.clone(),
                 },
                 _ => Self::other_kind(event),
             },

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -37,6 +37,8 @@ extern crate self as everruns;
 
 // --- Value-first agent description and execution -------------------------
 mod agent;
+#[cfg(feature = "capabilities")]
+pub mod capability;
 mod compaction;
 mod context;
 mod events;
@@ -162,6 +164,8 @@ pub use everruns_runtime as runtime;
 pub mod prelude {
     #[cfg(feature = "local")]
     pub use crate::LocalConfig;
+    #[cfg(feature = "capabilities")]
+    pub use crate::capability;
     #[cfg(feature = "macros")]
     pub use crate::tool;
     pub use crate::{

--- a/crates/everruns/src/persistence.rs
+++ b/crates/everruns/src/persistence.rs
@@ -1,7 +1,7 @@
 //! File-backed session persistence for standalone library processes (EVE-836).
 //!
 //! The facade's default backends keep a session's conversation in memory, so a
-//! process that exits loses the history. [`jsonl::JsonlSessionStore`] persists
+//! process that exits loses the history. [`JsonlSessionStore`] persists
 //! that history as an append-only JSONL file and reloads it, letting a fresh
 //! process resume a multi-turn session with only `everruns` and the `jsonl`
 //! feature — no database, no platform store.

--- a/crates/everruns/src/providers.rs
+++ b/crates/everruns/src/providers.rs
@@ -3,7 +3,7 @@
 //! Each provider lives behind its own cargo feature so the default facade build
 //! stays fully offline — no provider crate, no Reqwest edge. Enable the `openai`
 //! feature to configure OpenAI-backed models through
-//! [`openai::OpenAI`](crate::providers::openai::OpenAI).
+//! [`openai::OpenAI`].
 
 #[cfg(feature = "openai")]
 pub mod openai;

--- a/crates/everruns/src/providers/openai.rs
+++ b/crates/everruns/src/providers/openai.rs
@@ -1,7 +1,7 @@
 //! OpenAI-backed model configuration (requires the `openai` feature).
 //!
 //! [`OpenAI`] is the value-first entry point for talking to OpenAI's Responses
-//! API. Convert it into a [`Model`](crate::Model) — directly or via
+//! API. Convert it into a [`Model`] — directly or via
 //! [`AgentBuilder::model`](crate::AgentBuilder::model) — and the agent's runtime
 //! registers the OpenAI driver automatically.
 //!
@@ -49,7 +49,7 @@ impl fmt::Display for ModelError {
 
 impl std::error::Error for ModelError {}
 
-/// Configuration for an OpenAI-backed [`Model`](crate::Model).
+/// Configuration for an OpenAI-backed [`Model`].
 ///
 /// Build one with [`OpenAI::new`] (explicit, deterministic — reads no
 /// environment) or [`OpenAI::from_env`] (reads `OPENAI_API_KEY` and, when set,

--- a/crates/everruns/src/tool.rs
+++ b/crates/everruns/src/tool.rs
@@ -258,7 +258,7 @@ impl Capability for FunctionCapability {
 /// An agent tool: either a reference to an existing capability id, or a
 /// closure-backed [`FunctionTool`].
 ///
-/// This is the application-facing adapter that [`AgentBuilder::tool`] accepts
+/// This is the application-facing adapter that [`AgentBuilder::tool`](crate::AgentBuilder::tool) accepts
 /// via [`IntoTool`]. A `&str`/`String` names a capability-referenced tool; a
 /// [`FunctionTool`] carries its own handler.
 #[derive(Clone, Debug)]

--- a/crates/everruns/tests/advanced_capabilities.rs
+++ b/crates/everruns/tests/advanced_capabilities.rs
@@ -1,0 +1,113 @@
+//! Consumer-facing API test for the advanced capability SPI.
+//!
+//! Imports only `everruns`: no core/runtime registry, store, host, or tenancy
+//! type is needed to define and install a multi-tool capability.
+
+#![cfg(feature = "capabilities")]
+
+use everruns::{Agent, BuildError, Model, capability};
+
+#[derive(capability::Deserialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct SumInput {
+    values: Vec<i64>,
+}
+
+#[derive(capability::Serialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct SumOutput {
+    total: i64,
+}
+
+struct Sum;
+
+#[capability::async_trait]
+impl capability::Handler for Sum {
+    type Input = SumInput;
+    type Output = SumOutput;
+    type Error = capability::Error;
+
+    fn name(&self) -> &str {
+        "sum_values"
+    }
+
+    fn description(&self) -> &str {
+        "Sum a list of integer values."
+    }
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        _context: capability::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(SumOutput {
+            total: input.values.into_iter().sum(),
+        })
+    }
+}
+
+#[test]
+fn installs_capability_and_exposes_typed_protocol() {
+    let arithmetic = capability::Definition::new(
+        "custom_arithmetic",
+        "Custom arithmetic",
+        "Application-owned arithmetic tools.",
+    )
+    .tool(Sum);
+
+    let schema = arithmetic.tools()[0].spec();
+    assert_eq!(
+        schema.input_schema()["properties"]["values"]["type"],
+        "array"
+    );
+    assert_eq!(
+        schema.output_schema()["properties"]["total"]["type"],
+        "integer"
+    );
+
+    let agent = Agent::builder()
+        .instructions("Use arithmetic tools when asked.")
+        .model(Model::simulated("done"))
+        .advanced_capability(arithmetic)
+        .build();
+    assert!(agent.is_ok(), "public advanced SPI should build: {agent:?}");
+}
+
+#[test]
+fn rejects_invalid_descriptors_and_colliding_tools() {
+    let empty = capability::Definition::new("empty", "Empty", "No tools.");
+    let error = Agent::builder()
+        .instructions("Do math.")
+        .model(Model::simulated("done"))
+        .advanced_capability(empty)
+        .build()
+        .expect_err("an advanced capability must define a tool");
+    assert!(matches!(error, BuildError::InvalidCapability { .. }));
+
+    let invalid = capability::Definition::new("bad id", "Bad", "Invalid id.").tool(Sum);
+    let error = Agent::builder()
+        .instructions("Do math.")
+        .model(Model::simulated("done"))
+        .advanced_capability(invalid)
+        .build()
+        .expect_err("invalid capability id must fail");
+    assert!(matches!(error, BuildError::InvalidCapability { .. }));
+
+    let first = capability::Definition::new("first", "First", "First tool.").tool(Sum);
+    let second = capability::Definition::new("second", "Second", "Second tool.").tool(Sum);
+    let error = Agent::builder()
+        .instructions("Do math.")
+        .model(Model::simulated("done"))
+        .advanced_capability(first)
+        .advanced_capability(second)
+        .build()
+        .expect_err("tool names must be unique across capabilities");
+    assert_eq!(
+        error,
+        BuildError::DuplicateTool {
+            name: "sum_values".into(),
+        }
+    );
+}

--- a/crates/everruns/tests/trybuild.rs
+++ b/crates/everruns/tests/trybuild.rs
@@ -10,10 +10,14 @@
 fn ui() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/pass_signatures.rs");
+    #[cfg(feature = "capabilities")]
+    t.pass("tests/ui/pass_advanced_capability.rs");
     t.compile_fail("tests/ui/fail_not_async.rs");
     t.compile_fail("tests/ui/fail_receiver.rs");
     t.compile_fail("tests/ui/fail_generic.rs");
     t.compile_fail("tests/ui/fail_missing_description.rs");
     t.compile_fail("tests/ui/fail_tuple_param.rs");
     t.compile_fail("tests/ui/fail_unknown_option.rs");
+    #[cfg(feature = "capabilities")]
+    t.compile_fail("tests/ui/fail_capability_output_contract.rs");
 }

--- a/crates/everruns/tests/ui/fail_capability_output_contract.rs
+++ b/crates/everruns/tests/ui/fail_capability_output_contract.rs
@@ -1,0 +1,29 @@
+use everruns::capability;
+
+#[derive(capability::Deserialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct Input;
+
+struct NotSerializableOrSchema;
+struct Broken;
+
+#[capability::async_trait]
+impl capability::Handler for Broken {
+    type Input = Input;
+    type Output = NotSerializableOrSchema;
+    type Error = capability::Error;
+
+    fn name(&self) -> &str { "broken" }
+    fn description(&self) -> &str { "Does not satisfy the output contract." }
+
+    async fn execute(
+        &self,
+        _input: Self::Input,
+        _context: capability::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(NotSerializableOrSchema)
+    }
+}
+
+fn main() {}

--- a/crates/everruns/tests/ui/fail_capability_output_contract.stderr
+++ b/crates/everruns/tests/ui/fail_capability_output_contract.stderr
@@ -1,0 +1,55 @@
+error[E0277]: the trait bound `NotSerializableOrSchema: everruns::capability::JsonSchema` is not satisfied
+  --> tests/ui/fail_capability_output_contract.rs:14:19
+   |
+14 |     type Output = NotSerializableOrSchema;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `everruns::capability::JsonSchema` is not implemented for `NotSerializableOrSchema`
+  --> tests/ui/fail_capability_output_contract.rs:8:1
+   |
+ 8 | struct NotSerializableOrSchema;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `everruns::capability::JsonSchema`:
+             &'a T
+             &'a mut T
+             ()
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+           and $N others
+note: required by a bound in `everruns::capability::Handler::Output`
+  --> src/capability.rs
+   |
+   |     type Output: Serialize + JsonSchema + Send + 'static;
+   |                              ^^^^^^^^^^ required by this bound in `Handler::Output`
+
+error[E0277]: the trait bound `NotSerializableOrSchema: serde::Serialize` is not satisfied
+  --> tests/ui/fail_capability_output_contract.rs:14:19
+   |
+14 |     type Output = NotSerializableOrSchema;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `everruns::capability::Serialize` is not implemented for `NotSerializableOrSchema`
+  --> tests/ui/fail_capability_output_contract.rs:8:1
+   |
+ 8 | struct NotSerializableOrSchema;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `NotSerializableOrSchema` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `everruns::capability::Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+note: required by a bound in `everruns::capability::Handler::Output`
+  --> src/capability.rs
+   |
+   |     type Output: Serialize + JsonSchema + Send + 'static;
+   |                  ^^^^^^^^^ required by this bound in `Handler::Output`

--- a/crates/everruns/tests/ui/pass_advanced_capability.rs
+++ b/crates/everruns/tests/ui/pass_advanced_capability.rs
@@ -1,0 +1,45 @@
+use everruns::{Agent, Model, capability};
+
+#[derive(capability::Deserialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct Input {
+    value: u64,
+}
+
+#[derive(capability::Serialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct Output {
+    doubled: u64,
+}
+
+struct Double;
+
+#[capability::async_trait]
+impl capability::Handler for Double {
+    type Input = Input;
+    type Output = Output;
+    type Error = capability::Error;
+
+    fn name(&self) -> &str { "double" }
+    fn description(&self) -> &str { "Double an integer." }
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        _context: capability::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(Output { doubled: input.value * 2 })
+    }
+}
+
+fn main() {
+    let capability = capability::Definition::new("math", "Math", "Typed math.").tool(Double);
+    let _agent = Agent::builder()
+        .instructions("Do math.")
+        .model(Model::simulated("done"))
+        .advanced_capability(capability)
+        .build()
+        .unwrap();
+}

--- a/docs/framework/advanced-capabilities.md
+++ b/docs/framework/advanced-capabilities.md
@@ -1,0 +1,179 @@
+---
+title: Author tools and advanced capabilities
+description: Choose #[everruns::tool] for ordinary functions or everruns::capability for reusable typed capability packages.
+sidebar:
+  order: 1
+---
+
+Everruns has two public Framework extension levels. Use the smallest one that
+fits the behavior you own.
+
+| Contract | `#[everruns::tool]` | `everruns::capability` |
+|---|---|---|
+| Best for | One application function | A reusable capability package |
+| Typed input and result | Yes | Yes |
+| Generated input schema | Yes | Yes |
+| Inspectable output schema | No | Yes |
+| Multiple tools | Register functions separately | One stable capability id |
+| Capability instructions and metadata | No | Yes |
+| Session/workspace identity and locale | No | Curated `Context` accessors |
+| Progress events | No | `Context::progress` |
+| Child-work cancellation | Turn future only | `Context::cancellation` |
+| Backend/store/tenancy access | No | No |
+
+## Ordinary tools
+
+Annotate a typed async function. Its doc comment becomes the description and
+its arguments become JSON Schema.
+
+```rust
+/// Convert Celsius to Fahrenheit.
+#[everruns::tool]
+async fn fahrenheit(celsius: f64) -> f64 {
+    celsius * 1.8 + 32.0
+}
+
+let agent = everruns::Agent::builder()
+    .instructions("Use the conversion tool.")
+    .model(everruns::Model::simulated("done"))
+    .tool(fahrenheit())
+    .build()?;
+# Ok::<(), everruns::BuildError>(())
+```
+
+Prefer this until you need a capability-level contract.
+
+## Advanced capabilities
+
+An advanced capability is an immutable `capability::Definition`. It owns a
+stable id, catalog text, optional instructions and JSON metadata, and one or
+more typed handlers. `AgentBuilder::advanced_capability` installs it on the
+private in-process runtime and activates it for the agent.
+
+```rust
+use everruns::{Agent, Model, capability};
+
+#[derive(capability::Deserialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct LookupInput {
+    id: String,
+}
+
+#[derive(capability::Serialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct Record {
+    id: String,
+    score: f64,
+    labels: Vec<String>,
+}
+
+struct Lookup;
+
+#[capability::async_trait]
+impl capability::Handler for Lookup {
+    type Input = LookupInput;
+    type Output = Record;
+    type Error = capability::Error;
+
+    fn name(&self) -> &str { "lookup_record" }
+    fn description(&self) -> &str { "Look up one record by exact id." }
+
+    fn hints(&self) -> capability::Hints {
+        capability::Hints::default()
+            .readonly(true)
+            .idempotent(true)
+    }
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        context: capability::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        context.progress("Looking up the record").await;
+        if input.id != "rec_42" {
+            return Err(capability::Error::user(
+                "record_not_found",
+                "No record has that id",
+            ).details(capability::serde_json::json!({ "id": input.id })));
+        }
+        Ok(Record {
+            id: input.id,
+            score: 0.98,
+            labels: vec!["verified".into()],
+        })
+    }
+}
+
+let records = capability::Definition::new(
+    "records",
+    "Records",
+    "Application-owned record lookup.",
+)
+.instructions("Use exact record ids and do not infer missing records.")
+.metadata(capability::serde_json::json!({ "owner": "risk" }))
+.tool(Lookup);
+
+let agent = Agent::builder()
+    .instructions("Answer with verified record data.")
+    .model(Model::simulated("done"))
+    .advanced_capability(records)
+    .build()?;
+# Ok::<(), everruns::BuildError>(())
+```
+
+Both input and output types must satisfy the compile-time protocol bounds. The
+generated schemas are available through `Definition::tools()[..].spec()` for
+tests, documentation, or a host catalog. Results are serialized directly to
+JSON, so structs, arrays, numbers, booleans, and null do not pass through a
+string conversion.
+
+## Errors
+
+Return `capability::Error::user(code, message)` for an expected domain failure.
+Add bounded JSON details when they help the model recover. The code, message,
+and details travel through the model-visible tool-error channel.
+
+Return `capability::Error::internal(code, message)` for diagnostic details that
+are unsafe to show to the model, such as network internals or implementation
+bugs. The engine logs the diagnostic and gives the model a generic error;
+internal details do not cross the model boundary. Never include credential
+values or other secrets in any error because host logs may retain internal
+diagnostics.
+
+Custom application error enums can implement `Into<capability::Error>` and be
+used as `Handler::Error`.
+
+## Context, progress, and cancellation
+
+`capability::Context` exposes only stable lifecycle data:
+
+- opaque session and workspace ids;
+- the resolved locale, when present;
+- best-effort correlated `tool.progress` events;
+- a call-scoped cancellation signal.
+
+Observe progress through `Session::events()` and
+`SessionEventKind::ToolProgress`. Everruns does not currently expose a custom
+capability result-streaming protocol; return one typed result when execution
+finishes.
+
+Normal awaited work needs no cancellation branch. Cancelling a turn drops the
+handler future. Clone `context.cancellation()` only into child tasks, processes,
+or watchers that might otherwise survive after `execute` is dropped. The signal
+fires on cancellation and on every other call completion path.
+
+## Security boundary
+
+The advanced SPI intentionally does not export provider credentials, stores,
+tenant or organization objects, registries, payment authority, filesystem
+backends, or other host services. Pass application-owned clients or state into
+your handler struct when constructing the definition. A handler is trusted
+application code and retains whatever process authority those values provide;
+`Hints` describe behavior but do not enforce authorization, egress, or approval
+policy. Apply authorization, egress policy, timeouts, and input bounds at those
+application boundaries, and never place secrets in capability or tool metadata.
+
+For a complete provider-backed program, run the
+[`advanced_capability` example](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/advanced_capability.rs).

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -48,6 +48,7 @@ before importing `everruns-runtime` directly.
 ## Extend and operate
 
 - [Custom providers](/framework/custom-providers/) — attach a custom `ChatDriver` without changing a closed enum.
+- [Advanced capabilities](/framework/advanced-capabilities/) — package typed tools with stable metadata and lifecycle context.
 - [Custom backends](/framework/custom-backends/) — cross into low-level host composition deliberately.
 - [Testing and simulation](/framework/testing-and-simulation/) — deterministic tests without credentials.
 - [Runnable examples](/framework/examples/) — complete programs maintained with the crate.


### PR DESCRIPTION
## What changed

Framework users can now publish reusable, code-defined capabilities through the curated everruns::capability module and AgentBuilder::advanced_capability without depending on core/runtime contracts. The SPI provides typed input and JSON result protocols, inspectable schemas and metadata, structured user/internal errors, opaque session/workspace context, progress events, and call-scoped cancellation. Ordinary one-function tools remain unchanged through #[everruns::tool].

A provider-backed example, compile-pass/fail contracts, runtime success/error/cancellation coverage, complete rustdoc, and a focused Framework guide ship with the API. The capabilities feature is default-enabled but independently gateable and preserves the bare no-default-features build.

## Why

Reusable Framework extensions previously had no deliberate public authoring boundary. Authors either stayed within single function tools or reached into host implementation crates, coupling packages to registries, stores, tenancy, and runtime internals.

## Before / After

Before: a multi-tool capability package needed low-level everruns-core/everruns-runtime traits and registration, and custom tool success values were commonly forced through String-oriented adapters.

After: a consumer imports only everruns::{Agent, capability}, implements capability::Handler with typed Input/Output/Error, groups handlers in a stable Definition, and installs it with advanced_capability. Non-string JSON values remain structured, internal diagnostics are model-redacted, and progress/cancellation flow through the existing engine lifecycle.

Evidence:
- cargo test -p everruns --all-features: 56 unit, 24 integration, trybuild API contracts, and 9 doctests passed
- all-features, bare, and capabilities-only cargo check passed
- Clippy with warnings denied and strict rustdoc with warnings denied passed
- docs check/build rendered 484 pages and validated all internal links
- just pre-push passed all 12 repository gates

## Risk

- Medium
- Runtime capability registration and public event projection are extended. Descriptor validation rejects duplicate ids/tool names and invalid schemas before runtime assembly; end-to-end tests cover success, recoverable errors, progress, call completion, and turn cancellation.

## Security

- Threat categories reviewed: TM-API-005, TM-TOOL-001, TM-TOOL-005, TM-AGENT-002, TM-AGENT-012, TM-AGENT-014
- Findings and resolutions: internal error details remain model-generic; only explicitly registered and validated definitions execute; results retain the tool_result boundary and existing 64 KiB hard limit; context identity is engine-supplied and opaque. The SPI exports no credentials, stores, tenancy, registries, payment authority, filesystem backend, or host implementation type. Handlers are trusted in-process application code, and docs state that hints do not grant authorization or egress authority. No new threat class was introduced.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)