### PR TITLE
feat(framework): add workspace access policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,10 +471,11 @@ jobs:
           # picked up automatically rather than silently skipped. `--features lua`
           # so the lua code-mode integration test compiles and runs in the same pass.
           cargo test -p everruns-runtime --features lua -- --test-threads=1
-          # everruns facade (EVE-830): whole crate — the facade_smoke integration
-          # test and the lib doctest both build one session and run one llmsim turn
-          # importing only `everruns`. Pure, no network/credentials.
-          cargo test -p everruns
+          # everruns facade (EVE-830): whole crate across every optional facade
+          # feature, plus a bare-facade compile so public policy configuration
+          # cannot accidentally acquire a feature-only dependency.
+          cargo test -p everruns --all-features
+          cargo check -p everruns --no-default-features
           # Dynamically inventories every crates/everruns/examples/*.rs target,
           # rejects internal-crate imports, and compiles the complete set offline.
           bash scripts/lib/check-everruns-examples.sh

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -172,6 +172,7 @@ export default defineConfig({
                   label: "Core APIs",
                   items: [
                     { label: "Agents", slug: "framework/agents" },
+                    { label: "Workspace Security", slug: "framework/workspace-security" },
                     { label: "Models and Providers", slug: "framework/models-and-providers" },
                     { label: "Tools and Macros", slug: "framework/tools-and-macros" },
                     { label: "Sessions", slug: "framework/sessions" },

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -122,6 +122,7 @@ pub mod task_observer;
 pub mod vector_store;
 pub mod wake_queue;
 pub mod workspace;
+pub mod workspace_policy;
 pub mod workspace_roots;
 
 // Multi-platform channel abstractions (thread context, delivery, routing)
@@ -255,6 +256,7 @@ pub use user_facing_error::{
     is_usage_limit_message, metadata_keys as user_facing_error_metadata_keys,
     parse_usage_limit_reset_at, trim_error_chain_prefixes,
 };
+pub use workspace_policy::{WorkspacePolicy, WorkspacePolicyBuilder, WorkspacePolicyError};
 pub use workspace_roots::{
     ADDITIONAL_ROOTS_MOUNT, PRIMARY_WORKSPACE_ROOT_NAME, RelPath, ResolvedPath, WorkspaceRoot,
     WorkspaceRootSet,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -543,6 +543,10 @@ pub trait SessionFileSystem: Send + Sync {
     /// This is how a shell seeds its working directory: [`MountFs`] returns a
     /// path in its stable agent-facing namespace, so the shell and file tools
     /// share the same identity. The default is the flat VFS session form.
+    /// Security decorators may authorize the returned path, so providers that
+    /// accept additional aliases must use the same contained mapping here and
+    /// in their I/O methods. An alias must never resolve to one workspace path
+    /// here and a different storage object during the subsequent operation.
     ///
     /// [`MountFs`]: crate::mount_fs::MountFs
     fn resolve_path(&self, input: &str) -> String {

--- a/crates/core/src/workspace_policy.rs
+++ b/crates/core/src/workspace_policy.rs
@@ -1,0 +1,679 @@
+//! Backend-independent policy for session workspace access.
+//!
+//! A policy speaks only in the model-facing `/workspace` namespace. Concrete
+//! providers remain responsible for mapping that namespace to storage and, for
+//! host filesystems, for preventing traversal and symlink escapes during I/O.
+
+use std::fmt;
+
+const SENSITIVE_COMPONENTS: &[&str] = &[
+    ".aws",
+    ".azure",
+    ".docker",
+    ".git",
+    ".git-credentials",
+    ".gnupg",
+    ".kube",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    ".ssh",
+    "credentials",
+    "credentials.json",
+    "gcloud",
+];
+
+const DEFAULT_WRITE_DENY_COMPONENTS: &[&str] = &[
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".venv",
+    "venv",
+    ".tox",
+    ".gradle",
+];
+
+/// A validated, composable workspace access policy.
+///
+/// [`Default`] is intentionally read-only: ordinary non-hidden files are
+/// readable throughout `/workspace`, while writes, hidden paths (except the
+/// framework-managed `.agents` tree), and common credential locations are
+/// denied. Use [`WorkspacePolicy::builder`] for
+/// narrower scopes or [`WorkspacePolicy::read_write`] for an explicit opt-in
+/// to ordinary writes.
+///
+/// Denies always win over allows. Composed policies are restrictive: an
+/// operation must be allowed by every layer, so adding a policy can never
+/// broaden access.
+///
+/// Protected path names are defense in depth, not content-based secret
+/// detection. Keep credentials outside the workspace and add application
+/// denies for any project-specific secret locations.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspacePolicy {
+    layers: Vec<PolicyLayer>,
+}
+
+/// Builder for a custom [`WorkspacePolicy`].
+///
+/// A custom builder starts with no readable or writable paths. Hidden and
+/// sensitive paths remain protected unless explicitly opted in.
+#[derive(Clone, Debug, Default)]
+pub struct WorkspacePolicyBuilder {
+    read: Vec<String>,
+    write: Vec<String>,
+    deny_read: Vec<String>,
+    deny_write: Vec<String>,
+    deny_write_components: Vec<String>,
+    hidden: Vec<String>,
+    sensitive: Vec<String>,
+    recursive_delete: bool,
+}
+
+/// Invalid policy configuration or a denied workspace operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspacePolicyError {
+    message: String,
+}
+
+impl WorkspacePolicyError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for WorkspacePolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for WorkspacePolicyError {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PolicyLayer {
+    read: Vec<PolicyPath>,
+    write: Vec<PolicyPath>,
+    deny_read: Vec<PolicyPath>,
+    deny_write: Vec<PolicyPath>,
+    deny_write_components: Vec<String>,
+    hidden: Vec<PolicyPath>,
+    sensitive: Vec<PolicyPath>,
+    recursive_delete: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PolicyPath(Vec<String>);
+
+impl WorkspacePolicy {
+    /// Return the secure default policy.
+    ///
+    /// Ordinary files are readable, writes are denied, and hidden or common
+    /// sensitive paths are inaccessible. The framework-managed `.agents` tree
+    /// remains readable so configured skills and instructions continue to work.
+    pub fn read_only() -> Self {
+        Self {
+            layers: vec![PolicyLayer {
+                read: vec![PolicyPath::root()],
+                write: Vec::new(),
+                deny_read: Vec::new(),
+                deny_write: Vec::new(),
+                deny_write_components: Vec::new(),
+                hidden: vec![PolicyPath(vec![".agents".to_string()])],
+                sensitive: Vec::new(),
+                recursive_delete: false,
+            }],
+        }
+    }
+
+    /// Allow reads and writes throughout the ordinary workspace.
+    ///
+    /// This is an explicit opt-in. Hidden and common sensitive paths remain
+    /// denied, common dependency/build directory names remain non-writable at
+    /// every depth, and recursive directory deletion remains disabled. Build a
+    /// custom policy to choose different component restrictions.
+    pub fn read_write() -> Self {
+        Self {
+            layers: vec![PolicyLayer {
+                read: vec![PolicyPath::root()],
+                write: vec![PolicyPath::root()],
+                deny_read: Vec::new(),
+                deny_write: vec![PolicyPath(vec![".agents".to_string()])],
+                deny_write_components: DEFAULT_WRITE_DENY_COMPONENTS
+                    .iter()
+                    .map(|component| (*component).to_string())
+                    .collect(),
+                hidden: vec![PolicyPath(vec![".agents".to_string()])],
+                sensitive: Vec::new(),
+                recursive_delete: false,
+            }],
+        }
+    }
+
+    /// Start a custom, deny-by-default policy.
+    pub fn builder() -> WorkspacePolicyBuilder {
+        WorkspacePolicyBuilder::default()
+    }
+
+    /// Compose an additional restriction with this policy.
+    ///
+    /// Both policies must allow an operation. This makes composition safe for
+    /// libraries that add constraints to an application-supplied policy.
+    pub fn compose(mut self, additional: Self) -> Self {
+        self.layers.extend(additional.layers);
+        self
+    }
+
+    /// Whether `path` may be read.
+    ///
+    /// Invalid paths, including traversal attempts, are denied.
+    pub fn permits_read(&self, path: &str) -> bool {
+        PolicyPath::parse(path)
+            .is_ok_and(|path| self.layers.iter().all(|layer| layer.permits_read(&path)))
+    }
+
+    /// Whether `path` may be written, created, or deleted.
+    ///
+    /// Invalid paths, including traversal attempts, are denied.
+    pub fn permits_write(&self, path: &str) -> bool {
+        PolicyPath::parse(path)
+            .is_ok_and(|path| self.layers.iter().all(|layer| layer.permits_write(&path)))
+    }
+
+    /// Whether a directory may be traversed to reach a readable descendant.
+    ///
+    /// This is useful to filesystem providers implementing filtered directory
+    /// listings for a narrowly scoped policy.
+    pub fn permits_read_traversal(&self, path: &str) -> bool {
+        PolicyPath::parse(path).is_ok_and(|path| {
+            self.layers
+                .iter()
+                .all(|layer| layer.permits_read_traversal(&path))
+        })
+    }
+
+    /// Validate workspace path syntax without making an access decision.
+    ///
+    /// Filesystem providers can use this before resolving provider-specific
+    /// aliases, then authorize the resolved canonical path with
+    /// [`check_read`](Self::check_read) or [`check_write`](Self::check_write).
+    pub fn validate_path(path: &str) -> Result<(), WorkspacePolicyError> {
+        PolicyPath::parse(path).map(|_| ())
+    }
+
+    /// Validate a read and return a diagnostic suitable for a tool error.
+    pub fn check_read(&self, path: &str) -> Result<(), WorkspacePolicyError> {
+        let normalized = PolicyPath::parse(path)?;
+        if self
+            .layers
+            .iter()
+            .all(|layer| layer.permits_read(&normalized))
+        {
+            Ok(())
+        } else {
+            Err(WorkspacePolicyError::new(format!(
+                "workspace policy denied read of `{}`",
+                normalized.display()
+            )))
+        }
+    }
+
+    /// Validate a write, create, or delete and return a tool-safe diagnostic.
+    pub fn check_write(&self, path: &str) -> Result<(), WorkspacePolicyError> {
+        let normalized = PolicyPath::parse(path)?;
+        if self
+            .layers
+            .iter()
+            .all(|layer| layer.permits_write(&normalized))
+        {
+            Ok(())
+        } else {
+            Err(WorkspacePolicyError::new(format!(
+                "workspace policy denied write to `{}`",
+                normalized.display()
+            )))
+        }
+    }
+
+    /// Whether recursive directory deletion is explicitly allowed by every
+    /// composed policy layer.
+    pub fn permits_recursive_delete(&self) -> bool {
+        self.layers.iter().all(|layer| layer.recursive_delete)
+    }
+}
+
+impl Default for WorkspacePolicy {
+    fn default() -> Self {
+        Self::read_only()
+    }
+}
+
+impl WorkspacePolicyBuilder {
+    /// Add a readable path scope.
+    ///
+    /// Paths may be relative to `/workspace`, workspace-absolute
+    /// (`/workspace/src`), or session-absolute (`/src`).
+    pub fn allow_read(mut self, path: impl Into<String>) -> Self {
+        self.read.push(path.into());
+        self
+    }
+
+    /// Add a writable path scope.
+    pub fn allow_write(mut self, path: impl Into<String>) -> Self {
+        self.write.push(path.into());
+        self
+    }
+
+    /// Deny reads at and below a path, even when an allow scope matches.
+    pub fn deny_read(mut self, path: impl Into<String>) -> Self {
+        self.deny_read.push(path.into());
+        self
+    }
+
+    /// Deny writes at and below a path, even when an allow scope matches.
+    pub fn deny_write(mut self, path: impl Into<String>) -> Self {
+        self.deny_write.push(path.into());
+        self
+    }
+
+    /// Deny writes when any path segment has exactly this name.
+    ///
+    /// Unlike [`deny_write`](Self::deny_write), this applies at every depth.
+    /// It is useful for dependency or build directories such as
+    /// `node_modules` and `target`.
+    pub fn deny_write_component(mut self, component: impl Into<String>) -> Self {
+        self.deny_write_components.push(component.into());
+        self
+    }
+
+    /// Permit hidden path components at and below a specific scope.
+    ///
+    /// This does not override the sensitive-path protection. For example,
+    /// allowing `.github` is safe without also exposing `.git` or `.env`.
+    pub fn allow_hidden(mut self, path: impl Into<String>) -> Self {
+        self.hidden.push(path.into());
+        self
+    }
+
+    /// Permit a common sensitive path at and below a specific scope.
+    ///
+    /// This is the strongest filesystem-policy opt-in and also permits hidden
+    /// components within that scope. Prefer the narrowest possible path.
+    pub fn allow_sensitive(mut self, path: impl Into<String>) -> Self {
+        self.sensitive.push(path.into());
+        self
+    }
+
+    /// Explicitly permit recursive directory deletion.
+    ///
+    /// The default is `false`, because deleting an allowed parent could also
+    /// remove denied or sensitive descendants that a lexical path check cannot
+    /// see.
+    pub fn allow_recursive_delete(mut self, allow: bool) -> Self {
+        self.recursive_delete = allow;
+        self
+    }
+
+    /// Validate every configured scope and build the policy.
+    pub fn build(self) -> Result<WorkspacePolicy, WorkspacePolicyError> {
+        Ok(WorkspacePolicy {
+            layers: vec![PolicyLayer {
+                read: parse_paths("read allow", self.read)?,
+                write: parse_paths("write allow", self.write)?,
+                deny_read: parse_paths("read deny", self.deny_read)?,
+                deny_write: parse_paths("write deny", self.deny_write)?,
+                deny_write_components: parse_components(
+                    "write deny component",
+                    self.deny_write_components,
+                )?,
+                hidden: parse_paths("hidden allow", self.hidden)?,
+                sensitive: parse_paths("sensitive allow", self.sensitive)?,
+                recursive_delete: self.recursive_delete,
+            }],
+        })
+    }
+}
+
+impl PolicyLayer {
+    fn permits_read(&self, path: &PolicyPath) -> bool {
+        self.read.iter().any(|scope| scope.contains(path))
+            && !self.deny_read.iter().any(|scope| scope.contains(path))
+            && self.permits_protected_components(path)
+    }
+
+    fn permits_read_traversal(&self, path: &PolicyPath) -> bool {
+        (self
+            .read
+            .iter()
+            .any(|scope| scope.contains(path) || path.contains(scope)))
+            && !self.deny_read.iter().any(|scope| scope.contains(path))
+            && self.permits_protected_traversal(path)
+    }
+
+    fn permits_write(&self, path: &PolicyPath) -> bool {
+        self.write.iter().any(|scope| scope.contains(path))
+            && !self.deny_write.iter().any(|scope| scope.contains(path))
+            && !path.has_any_component(&self.deny_write_components)
+            && self.permits_protected_components(path)
+    }
+
+    fn permits_protected_components(&self, path: &PolicyPath) -> bool {
+        if self.sensitive.iter().any(|scope| scope.contains(path)) {
+            return true;
+        }
+        if path.has_sensitive_component() {
+            return false;
+        }
+        !path.has_hidden_component() || self.hidden.iter().any(|scope| scope.contains(path))
+    }
+
+    fn permits_protected_traversal(&self, path: &PolicyPath) -> bool {
+        if path.has_sensitive_component() {
+            return self
+                .sensitive
+                .iter()
+                .any(|scope| scope.contains(path) || path.contains(scope));
+        }
+        !path.has_hidden_component()
+            || self
+                .hidden
+                .iter()
+                .any(|scope| scope.contains(path) || path.contains(scope))
+    }
+}
+
+impl PolicyPath {
+    fn root() -> Self {
+        Self(Vec::new())
+    }
+
+    fn parse(input: &str) -> Result<Self, WorkspacePolicyError> {
+        let trimmed = input.trim();
+        if trimmed.contains('\0') {
+            return Err(WorkspacePolicyError::new(format!(
+                "workspace path contains a NUL byte: {input:?}"
+            )));
+        }
+        if trimmed.contains('\\') {
+            return Err(WorkspacePolicyError::new(format!(
+                "workspace paths must use forward slashes: {input:?}"
+            )));
+        }
+
+        let canonical = crate::session_path::to_session_path(trimmed);
+        let without_alias = canonical.trim_start_matches('/');
+
+        let mut components = Vec::new();
+        for component in without_alias.split('/') {
+            match component {
+                "" | "." => {}
+                ".." => {
+                    return Err(WorkspacePolicyError::new(format!(
+                        "workspace path traversal is not allowed: {input:?}"
+                    )));
+                }
+                // Match conservatively across case-sensitive and
+                // case-insensitive providers. This can over-restrict two
+                // distinct Unix paths, but cannot turn a deny into an allow
+                // when the same storage object has multiple case spellings.
+                value => components.push(value.to_ascii_lowercase()),
+            }
+        }
+        Ok(Self(components))
+    }
+
+    fn contains(&self, candidate: &Self) -> bool {
+        candidate.0.starts_with(&self.0)
+    }
+
+    fn has_hidden_component(&self) -> bool {
+        self.0.iter().any(|component| component.starts_with('.'))
+    }
+
+    fn has_any_component(&self, denied: &[String]) -> bool {
+        self.0.iter().any(|component| denied.contains(component))
+    }
+
+    fn has_sensitive_component(&self) -> bool {
+        self.0.iter().any(|component| {
+            component == ".env"
+                || component.starts_with(".env.")
+                || SENSITIVE_COMPONENTS.contains(&component.as_str())
+        })
+    }
+
+    fn display(&self) -> String {
+        if self.0.is_empty() {
+            "/workspace".to_string()
+        } else {
+            format!("/workspace/{}", self.0.join("/"))
+        }
+    }
+}
+
+fn parse_paths(kind: &str, paths: Vec<String>) -> Result<Vec<PolicyPath>, WorkspacePolicyError> {
+    paths
+        .into_iter()
+        .map(|path| {
+            if path.trim().is_empty() {
+                return Err(WorkspacePolicyError::new(format!(
+                    "invalid {kind} scope {path:?}: path must not be empty"
+                )));
+            }
+            PolicyPath::parse(&path).map_err(|error| {
+                WorkspacePolicyError::new(format!("invalid {kind} scope {path:?}: {error}"))
+            })
+        })
+        .collect()
+}
+
+fn parse_components(
+    kind: &str,
+    components: Vec<String>,
+) -> Result<Vec<String>, WorkspacePolicyError> {
+    components
+        .into_iter()
+        .map(|component| {
+            let trimmed = component.trim();
+            if trimmed.is_empty()
+                || matches!(trimmed, "." | "..")
+                || trimmed.contains(['/', '\\', '\0'])
+            {
+                return Err(WorkspacePolicyError::new(format!(
+                    "invalid {kind} {component:?}: expected one path component"
+                )));
+            }
+            Ok(trimmed.to_ascii_lowercase())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_read_only_and_hides_sensitive_paths() {
+        let policy = WorkspacePolicy::default();
+        assert!(policy.permits_read("/workspace/src/lib.rs"));
+        assert!(!policy.permits_write("/workspace/src/lib.rs"));
+        assert!(!policy.permits_read("/workspace/.env"));
+        assert!(!policy.permits_read("/workspace/.git/config"));
+        assert!(policy.permits_read("/workspace/.agents/skills/example/SKILL.md"));
+        assert!(!policy.permits_recursive_delete());
+    }
+
+    #[test]
+    fn read_write_keeps_framework_managed_content_read_only() {
+        let policy = WorkspacePolicy::read_write();
+
+        assert!(policy.permits_read("/.agents/skills/example/SKILL.md"));
+        assert!(!policy.permits_write("/.agents/skills/example/SKILL.md"));
+        assert!(policy.permits_write("/generated/report.md"));
+        assert!(!policy.permits_write("/crates/example/target/output"));
+        assert!(!policy.permits_write("/web/node_modules/package/index.js"));
+    }
+
+    #[test]
+    fn custom_component_write_deny_applies_at_every_depth() {
+        let policy = WorkspacePolicy::builder()
+            .allow_write("/")
+            .deny_write_component("vendor")
+            .build()
+            .unwrap();
+
+        assert!(policy.permits_write("/src/generated.rs"));
+        assert!(!policy.permits_write("/src/vendor/generated.rs"));
+        assert!(!policy.permits_write("/VENDOR/generated.rs"));
+    }
+
+    #[test]
+    fn deny_wins_over_allow() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/")
+            .allow_write("/workspace/output")
+            .deny_read("private")
+            .deny_write("output/locked")
+            .build()
+            .unwrap();
+
+        assert!(policy.permits_read("notes.txt"));
+        assert!(!policy.permits_read("private/notes.txt"));
+        assert!(policy.permits_write("output/result.txt"));
+        assert!(!policy.permits_write("output/locked/result.txt"));
+    }
+
+    #[test]
+    fn scoped_policy_allows_parent_traversal_but_not_parent_reads() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read("src/generated")
+            .build()
+            .unwrap();
+
+        assert!(policy.permits_read_traversal("/workspace"));
+        assert!(policy.permits_read_traversal("/workspace/src"));
+        assert!(!policy.permits_read("/workspace/src"));
+        assert!(policy.permits_read("/workspace/src/generated/file.rs"));
+        assert!(!policy.permits_read("/workspace/tests/test.rs"));
+    }
+
+    #[test]
+    fn hidden_and_sensitive_paths_require_separate_explicit_opt_ins() {
+        let hidden = WorkspacePolicy::builder()
+            .allow_read("/")
+            .allow_hidden(".github")
+            .allow_hidden(".git")
+            .build()
+            .unwrap();
+        assert!(hidden.permits_read(".github/workflows/ci.yml"));
+        assert!(!hidden.permits_read(".git/config"));
+
+        let sensitive = WorkspacePolicy::builder()
+            .allow_read("/")
+            .allow_sensitive(".env.example")
+            .build()
+            .unwrap();
+        assert!(sensitive.permits_read(".env.example"));
+        assert!(!sensitive.permits_read(".env"));
+    }
+
+    #[test]
+    fn narrow_protected_scope_allows_only_ancestor_traversal() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read(".ssh/id_ed25519")
+            .allow_sensitive(".ssh/id_ed25519")
+            .build()
+            .unwrap();
+
+        assert!(policy.permits_read_traversal("/.ssh"));
+        assert!(!policy.permits_read("/.ssh"));
+        assert!(policy.permits_read("/.ssh/id_ed25519"));
+        assert!(!policy.permits_read("/.ssh/config"));
+    }
+
+    #[test]
+    fn composition_can_only_restrict() {
+        let application = WorkspacePolicy::read_write();
+        let library = WorkspacePolicy::builder()
+            .allow_read("src")
+            .allow_write("src/generated")
+            .build()
+            .unwrap();
+        let policy = application.compose(library);
+
+        assert!(policy.permits_read("src/lib.rs"));
+        assert!(!policy.permits_read("Cargo.toml"));
+        assert!(policy.permits_write("src/generated/mod.rs"));
+        assert!(!policy.permits_write("src/lib.rs"));
+    }
+
+    #[test]
+    fn traversal_nul_and_platform_separators_fail_closed() {
+        let policy = WorkspacePolicy::read_write();
+        assert!(!policy.permits_read("src/../.env"));
+        assert!(!policy.permits_write("../outside"));
+        assert!(!policy.permits_read("src\\..\\secret"));
+        assert!(!policy.permits_read("bad\0path"));
+    }
+
+    #[test]
+    fn workspace_and_session_absolute_paths_share_one_namespace() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/workspace/src")
+            .allow_write("/output")
+            .build()
+            .unwrap();
+        assert!(policy.permits_read("src/lib.rs"));
+        assert!(policy.permits_read("/src/lib.rs"));
+        assert!(policy.permits_read("/workspace/src/lib.rs"));
+        assert!(policy.permits_write("/workspace/output/report.md"));
+    }
+
+    #[test]
+    fn repeated_slashes_cannot_bypass_a_deny_scope() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/")
+            .deny_read("private")
+            .build()
+            .unwrap();
+        assert!(!policy.permits_read("//workspace//private//secret.txt"));
+    }
+
+    #[test]
+    fn alternate_ascii_case_cannot_bypass_a_deny_or_sensitive_path() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/")
+            .deny_read("Private")
+            .build()
+            .unwrap();
+
+        assert!(!policy.permits_read("/private/secret.txt"));
+        assert!(!policy.permits_read("/.ENV"));
+        assert!(!policy.permits_read("/.Git/config"));
+    }
+
+    #[test]
+    fn invalid_custom_scope_is_reported_at_build_time() {
+        let error = WorkspacePolicy::builder()
+            .allow_read("../outside")
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains("traversal"));
+
+        let error = WorkspacePolicy::builder()
+            .deny_write_component("nested/vendor")
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains("one path component"));
+
+        let error = WorkspacePolicy::builder()
+            .allow_write("  ")
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains("must not be empty"));
+    }
+}

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -95,6 +95,9 @@ trybuild = { workspace = true }
 tempfile = { workspace = true }
 
 [[example]]
+name = "workspace_policy"
+
+[[example]]
 name = "production_agent"
 required-features = ["openai"]
 

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -167,6 +167,7 @@ model for new Framework applications.
 
 The [example catalog](./examples/README.md) includes:
 
+- `workspace_policy` — secure workspace scopes with an offline simulator
 - `hello` — smallest live-provider program
 - `production_agent` — production-style composition
 - `github_monitor --simulate` — credential-free typed-tool flow
@@ -191,6 +192,7 @@ Examples are compiled in CI and import only `everruns`.
 
 - [Everruns Framework](https://docs.everruns.com/framework/)
 - [Framework quickstart](https://docs.everruns.com/framework/quickstart/)
+- [Workspace security](https://docs.everruns.com/framework/workspace-security/)
 - [Models and providers](https://docs.everruns.com/framework/models-and-providers/)
 - [Tools and macros](https://docs.everruns.com/framework/tools-and-macros/)
 - [Sessions](https://docs.everruns.com/framework/sessions/)

--- a/crates/everruns/examples/README.md
+++ b/crates/everruns/examples/README.md
@@ -1,11 +1,12 @@
 # `everruns` examples
 
 These examples use the application-facing [`everruns`](../README.md) crate.
-Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`; `session_work` runs
-entirely offline.
+Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`; `session_work` and
+`workspace_policy` run entirely offline.
 
 | Example | What it demonstrates | Run |
 |---|---|---|
+| [`workspace_policy.rs`](workspace_policy.rs) | Safe read/write scopes, default restrictions, and trusted starter files | `cargo run -p everruns --example workspace_policy` |
 | [`hello.rs`](hello.rs) | Minimal agent, typed tool, turn result, and event observation | `cargo run -p everruns --features openai --example hello` |
 | [`production_agent.rs`](production_agent.rs) | Tool safety boundary and production-shaped multi-turn use | `cargo run -p everruns --features openai --example production_agent` |
 | [`github_monitor.rs`](github_monitor.rs) | Host-owned background work that wakes an agent when it finishes | `cargo run -p everruns --features openai --example github_monitor -- --simulate` |

--- a/crates/everruns/examples/workspace_policy.rs
+++ b/crates/everruns/examples/workspace_policy.rs
@@ -1,0 +1,36 @@
+//! Configure portable workspace access without importing runtime backends.
+
+use everruns::{Agent, Model, WorkspacePolicy};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace = tempfile::tempdir()?;
+    let policy = WorkspacePolicy::builder()
+        .allow_read("input")
+        .allow_write("generated")
+        .deny_write("generated/locked")
+        .build()?;
+
+    assert!(policy.permits_read("input/brief.md"));
+    assert!(policy.permits_write("generated/report.md"));
+    assert!(!policy.permits_write("generated/locked/report.md"));
+    assert!(!policy.permits_read(".env"));
+
+    let agent = Agent::builder()
+        .instructions("Use only files permitted by the workspace policy.")
+        .model(Model::simulated("Workspace policy configured."))
+        .workspace(workspace.path())
+        .workspace_policy(policy)
+        .readonly_file("input/brief.md", "Summarize the workspace policy.")
+        .build()?;
+
+    let turn = agent.session().run("Confirm the policy is active.").await?;
+    assert_eq!(turn.response, "Workspace policy configured.");
+    assert_eq!(
+        std::fs::read_to_string(workspace.path().join("input/brief.md"))?,
+        "Summarize the workspace policy."
+    );
+
+    println!("{}", turn.response);
+    Ok(())
+}

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -251,6 +251,7 @@ pub struct Agent {
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
     workspace_root: Option<PathBuf>,
+    workspace_policy: everruns_core::WorkspacePolicy,
     mcp_servers: everruns_core::ScopedMcpServers,
     plugin_warnings: Vec<String>,
     #[cfg(feature = "local")]
@@ -374,7 +375,8 @@ impl Agent {
             .harness(harness)
             .agent(agent)
             .session(session)
-            .model_spec(self.model.spec.clone());
+            .model_spec(self.model.spec.clone())
+            .workspace_policy(self.workspace_policy.clone());
 
         let mut backends = HostBackends::in_memory();
         if let Some(event_sink) = event_sink {
@@ -476,6 +478,7 @@ pub struct AgentBuilder {
     initial_files: Vec<InitialFile>,
     parallel_tool_calls: Option<bool>,
     workspace_root: Option<PathBuf>,
+    workspace_policy: everruns_core::WorkspacePolicy,
     mcp_servers: Vec<crate::McpServer>,
     plugin_warnings: Vec<String>,
     compaction: Option<crate::CompactionConfig>,
@@ -702,6 +705,18 @@ impl AgentBuilder {
         self
     }
 
+    /// Set the read and write policy for this agent's workspace.
+    ///
+    /// The default is [`WorkspacePolicy::read_only`](crate::WorkspacePolicy::read_only):
+    /// ordinary files are readable, writes and hidden or sensitive paths are
+    /// denied, and framework-managed `.agents` content remains readable.
+    /// Select [`WorkspacePolicy::read_write`](crate::WorkspacePolicy::read_write)
+    /// or build narrower scopes for an explicit write opt-in.
+    pub fn workspace_policy(mut self, policy: crate::WorkspacePolicy) -> Self {
+        self.workspace_policy = policy;
+        self
+    }
+
     /// Add a scoped MCP server to this agent.
     pub fn mcp_server(mut self, server: crate::McpServer) -> Self {
         self.mcp_servers.push(server);
@@ -898,6 +913,7 @@ impl AgentBuilder {
             initial_files: self.initial_files,
             parallel_tool_calls: self.parallel_tool_calls,
             workspace_root: self.workspace_root,
+            workspace_policy: self.workspace_policy,
             mcp_servers,
             plugin_warnings: self.plugin_warnings,
             #[cfg(feature = "local")]
@@ -1096,6 +1112,52 @@ mod tests {
             .build()
             .expect("valid agent");
         assert_eq!(agent.name, "assistant");
+    }
+
+    #[test]
+    fn workspace_policy_defaults_to_read_only() {
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("Sure."))
+            .build()
+            .expect("valid agent");
+
+        assert!(agent.workspace_policy.permits_read("notes.txt"));
+        assert!(!agent.workspace_policy.permits_write("notes.txt"));
+        assert!(!agent.workspace_policy.permits_read(".env"));
+    }
+
+    #[tokio::test]
+    async fn custom_workspace_policy_reaches_the_high_level_runtime() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let policy = crate::WorkspacePolicy::builder()
+            .allow_read("public")
+            .build()
+            .expect("valid policy");
+        let agent = Agent::builder()
+            .instructions("Read the workspace.")
+            .model(Model::simulated("Sure."))
+            .workspace(workspace.path())
+            .workspace_policy(policy)
+            .file("public/note.txt", "visible")
+            .file("private/note.txt", "hidden")
+            .build()
+            .expect("valid agent");
+
+        let session_id = SessionId::new();
+        let runtime = agent
+            .build_runtime_with_backends(session_id, None, None)
+            .await
+            .expect("runtime builds");
+        let visible = runtime
+            .read_file(session_id, "public/note.txt")
+            .await
+            .expect("allowed read")
+            .expect("seeded file");
+        assert_eq!(visible.content.as_deref(), Some("visible"));
+
+        let denied = runtime.read_file(session_id, "private/note.txt").await;
+        assert!(denied.is_err());
     }
 
     #[cfg(feature = "openai")]

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -132,7 +132,7 @@ pub use everruns_core::{
     InputMessage, LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmResponseStream,
     LlmStreamEvent, MessageRole, ModelSpec, PlatformDefinition, Provider, ProviderAuth,
     ProviderAuthRequest, ProviderEndpoint, ProviderKey, ProviderRegistry, SessionId,
-    StaticHeaderAuth,
+    StaticHeaderAuth, WorkspacePolicy, WorkspacePolicyBuilder, WorkspacePolicyError,
 };
 
 // --- Deterministic in-process LLM simulator -----------------------------
@@ -177,6 +177,7 @@ pub mod prelude {
         InitialFile, IntoHookResult, IntoTool, IntoToolResult, McpServer, Model, PluginError,
         RunError, RunOptions, Session, SessionContext, SessionEvent, SessionEventKind, SessionId,
         Tool, ToolEndContext, ToolInfo, ToolResponse, ToolStartContext, Turn, TurnStartContext,
+        WorkspacePolicy, WorkspacePolicyBuilder, WorkspacePolicyError,
     };
     #[cfg(feature = "openai")]
     pub use crate::{ModelError, OpenAI};

--- a/crates/host/src/file_store_decorators.rs
+++ b/crates/host/src/file_store_decorators.rs
@@ -1,8 +1,10 @@
 // Composable host `SessionFileSystem` decorators for policy enforcement.
 //
 // EVE-478: promoted from `examples/coding-cli` so any non-server embedder can
-// compose them on top of `RealDiskFileStore`. Two concerns are layered here:
+// compose them on top of `RealDiskFileStore`. Three concerns are layered here:
 //
+//   * `PolicyFileStore` — apply portable workspace read/write policy to any
+//     provider selected by the runtime.
 //   * `WriteBlocklistFileStore` — reject writes/deletes inside vendored or
 //     build directories (`.git/`, `node_modules/`, `target/`, …) at any depth.
 //     Reads pass through.
@@ -10,24 +12,25 @@
 //     embedder-supplied async `FileApprovalGate`. Reads pass through. The
 //     embedder owns the UI / oneshot wiring; this crate only cares about the
 //     yes/no answer.
-//
-// Compose as `ApprovalGatingFileStore::new(WriteBlocklistFileStore::new(real_disk), gate)`.
-// Reads short-circuit through both layers; only the destructive paths take
-// the policy decisions.
 
 use async_trait::async_trait;
+use everruns_core::WorkspacePolicy;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session_file::{
     FileInfo, FileStat, GrepMatch, GrepOptions, GrepSearchResult, InitialFile, SessionFile,
+    build_grep_search_result,
 };
 use everruns_core::traits::SessionFileSystem;
 use everruns_core::typed_id::SessionId;
+use std::collections::{HashSet, VecDeque};
 use std::path::Component;
 use std::sync::Arc;
 
+const MAX_POLICY_WALK_ENTRIES: usize = 100_000;
+
 /// Default vendored / build directory names that `WriteBlocklistFileStore`
 /// rejects writes into. Embedders can override via `with_blocklist`.
-pub const DEFAULT_WRITE_BLOCKLIST: &[&str] = &[
+const LEGACY_WRITE_BLOCKLIST: &[&str] = &[
     ".git",
     "node_modules",
     "target",
@@ -39,6 +42,289 @@ pub const DEFAULT_WRITE_BLOCKLIST: &[&str] = &[
     ".tox",
     ".gradle",
 ];
+
+/// Legacy default for [`WriteBlocklistFileStore`].
+///
+/// New applications should configure [`WorkspacePolicy`] instead. This alias
+/// remains only for 0.17 source compatibility; policy defaults are owned by the
+/// policy value and may evolve without a permanent public list.
+#[deprecated(since = "0.17.25", note = "use WorkspacePolicy instead")]
+pub const DEFAULT_WRITE_BLOCKLIST: &[&str] = LEGACY_WRITE_BLOCKLIST;
+
+/// Apply a backend-independent [`WorkspacePolicy`] to a session filesystem.
+///
+/// Every model-driven read, listing, search, write, create, and delete flows
+/// through the same policy regardless of the concrete provider. Starter-file
+/// seeding bypasses the policy because it is trusted application configuration;
+/// later model access to a seeded path is still checked normally. Custom
+/// providers must honor the canonical-path contract of
+/// [`SessionFileSystem::resolve_path`].
+pub struct PolicyFileStore {
+    inner: Arc<dyn SessionFileSystem>,
+    policy: WorkspacePolicy,
+}
+
+impl PolicyFileStore {
+    /// Wrap `inner` with `policy`.
+    pub fn new(inner: Arc<dyn SessionFileSystem>, policy: WorkspacePolicy) -> Self {
+        Self { inner, policy }
+    }
+
+    fn checked_path(&self, path: &str) -> Result<String> {
+        WorkspacePolicy::validate_path(path)
+            .map(|()| self.inner.resolve_path(path))
+            .map_err(|error| AgentLoopError::tool(error.to_string()))
+    }
+
+    fn check_read(&self, path: &str) -> Result<()> {
+        // THREAT[TM-FS-015]: every read spelling is normalized and checked at
+        // the shared filesystem seam before a provider sees it.
+        self.checked_path(path).and_then(|path| {
+            self.policy
+                .check_read(&path)
+                .map_err(|error| AgentLoopError::tool(error.to_string()))
+        })
+    }
+
+    fn check_write(&self, path: &str) -> Result<()> {
+        // THREAT[TM-FS-015]: deny precedence and protected-path defaults apply
+        // uniformly to every provider and every mutating capability.
+        self.checked_path(path).and_then(|path| {
+            self.policy
+                .check_write(&path)
+                .map_err(|error| AgentLoopError::tool(error.to_string()))
+        })
+    }
+
+    async fn check_recursive_delete(&self, session_id: SessionId, path: &str) -> Result<()> {
+        if !self.policy.permits_recursive_delete() {
+            return Err(AgentLoopError::tool(format!(
+                "workspace policy denied recursive delete of `{path}`; recursive deletion requires an explicit opt-in"
+            )));
+        }
+
+        let Some(target) = self.inner.stat_file(session_id, path).await? else {
+            return Ok(());
+        };
+        if !target.is_directory {
+            return Ok(());
+        }
+
+        // THREAT[TM-FS-015]: an opt-in to recursive deletion does not override
+        // denied descendants. Inspect through the inner provider so protected
+        // entries hidden from model-facing listings still block the delete.
+        // A same-user filesystem mutation can still race this preflight; host
+        // embedders that need a stronger boundary must add OS isolation.
+        let mut pending = VecDeque::from([target.path]);
+        let mut visited = HashSet::new();
+        let mut entries_seen = 0usize;
+        while let Some(directory) = pending.pop_front() {
+            if !visited.insert(directory.clone()) {
+                continue;
+            }
+            for entry in self.inner.list_directory(session_id, &directory).await? {
+                entries_seen += 1;
+                if entries_seen > MAX_POLICY_WALK_ENTRIES {
+                    return Err(AgentLoopError::tool(format!(
+                        "workspace policy stopped recursive delete after {MAX_POLICY_WALK_ENTRIES} entries"
+                    )));
+                }
+                self.check_write(&entry.path)?;
+                if entry.is_directory {
+                    pending.push_back(entry.path);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SessionFileSystem for PolicyFileStore {
+    fn display_root(&self) -> String {
+        self.inner.display_root()
+    }
+
+    fn display_path(&self, path: &str) -> String {
+        self.inner.display_path(path)
+    }
+
+    fn resolve_path(&self, input: &str) -> String {
+        self.inner.resolve_path(input)
+    }
+
+    fn is_mount_resolver(&self) -> bool {
+        self.inner.is_mount_resolver()
+    }
+
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        self.check_read(path)?;
+        self.inner.read_file(session_id, path).await
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        self.check_write(path)?;
+        self.inner
+            .write_file(session_id, path, content, encoding)
+            .await
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        self.check_write(path)?;
+        self.inner
+            .write_file_if_content_matches(
+                session_id,
+                path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
+            .await
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
+        self.check_write(path)?;
+        if recursive {
+            self.check_recursive_delete(session_id, path).await?;
+        }
+        self.inner.delete_file(session_id, path, recursive).await
+    }
+
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
+        let canonical = self.checked_path(path)?;
+        if !self.policy.permits_read_traversal(&canonical) {
+            self.policy
+                .check_read(&canonical)
+                .map_err(|error| AgentLoopError::tool(error.to_string()))?;
+        }
+        let mut entries = self.inner.list_directory(session_id, path).await?;
+        entries.retain(|entry| {
+            self.checked_path(&entry.path).is_ok_and(|canonical| {
+                self.policy.permits_read(&canonical)
+                    || self.policy.permits_read_traversal(&canonical)
+            })
+        });
+        Ok(entries)
+    }
+
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
+        let canonical = self.checked_path(path)?;
+        if !self.policy.permits_read_traversal(&canonical) {
+            self.policy
+                .check_read(&canonical)
+                .map_err(|error| AgentLoopError::tool(error.to_string()))?;
+        }
+        self.inner.stat_file(session_id, path).await
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        let result = self
+            .grep_files_with_options(
+                session_id,
+                pattern,
+                &GrepOptions {
+                    path_pattern: path_pattern.map(ToString::to_string),
+                    ..GrepOptions::default()
+                },
+            )
+            .await?;
+        Ok(result.matches)
+    }
+
+    async fn grep_files_with_options(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        options: &GrepOptions,
+    ) -> Result<GrepSearchResult> {
+        let regex = crate::grep_limits::build_regex(pattern)?;
+        crate::grep_limits::validate_path_pattern(options.path_pattern.as_deref())?;
+        let path_pattern = options
+            .path_pattern
+            .as_deref()
+            .map(everruns_core::session_path::GrepPathPattern::new)
+            .transpose()?;
+
+        // Walk through the policy-filtered listing surface and read only files
+        // the policy permits. Calling the provider's grep directly and
+        // filtering its output would still make it open denied files.
+        let mut pending = VecDeque::from(["/".to_string()]);
+        let mut visited = HashSet::new();
+        let mut text_files = Vec::new();
+        let mut total_scanned = 0usize;
+        let mut entries_seen = 0usize;
+        while let Some(directory) = pending.pop_front() {
+            if !visited.insert(directory.clone()) {
+                continue;
+            }
+            for entry in self.list_directory(session_id, &directory).await? {
+                entries_seen += 1;
+                if entries_seen > MAX_POLICY_WALK_ENTRIES {
+                    return Err(AgentLoopError::tool(format!(
+                        "workspace policy stopped grep after {MAX_POLICY_WALK_ENTRIES} entries"
+                    )));
+                }
+                if entry.is_directory {
+                    pending.push_back(entry.path);
+                    continue;
+                }
+                if path_pattern
+                    .as_ref()
+                    .is_some_and(|matcher| !matcher.is_match(&entry.path))
+                {
+                    continue;
+                }
+                let Some(file) = self.read_file(session_id, &entry.path).await? else {
+                    continue;
+                };
+                if file.encoding != "text" {
+                    continue;
+                }
+                let Some(content) = file.content else {
+                    continue;
+                };
+                if crate::grep_limits::account_scan(&mut total_scanned, content.len())? {
+                    text_files.push((entry.path, content));
+                }
+            }
+        }
+        Ok(build_grep_search_result(text_files, &regex, options))
+    }
+
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
+        self.check_write(path)?;
+        self.inner.create_directory(session_id, path).await
+    }
+
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        self.inner.seed_initial_file(session_id, file).await
+    }
+}
 
 /// Reject writes into vendored / build directories at any depth.
 ///
@@ -56,11 +342,11 @@ pub struct WriteBlocklistFileStore {
 }
 
 impl WriteBlocklistFileStore {
-    /// Wrap `inner` with the [`DEFAULT_WRITE_BLOCKLIST`].
+    /// Wrap `inner` with the compatibility blocklist.
     pub fn new(inner: Arc<dyn SessionFileSystem>) -> Self {
         Self {
             inner,
-            blocklist: DEFAULT_WRITE_BLOCKLIST
+            blocklist: LEGACY_WRITE_BLOCKLIST
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
@@ -474,6 +760,214 @@ mod tests {
             .await
             .expect_err("custom blocklist entry must be enforced");
         assert!(format!("{err}").contains("forbidden"));
+    }
+
+    #[tokio::test]
+    async fn workspace_policy_filters_reads_listings_and_grep_summaries() {
+        let inner_store: Arc<dyn SessionFileSystem> = inner();
+        for (path, content) in [
+            ("/src/lib.rs", "visible sentinel"),
+            ("/.env", "hidden sentinel"),
+            ("/private/secret.txt", "private sentinel"),
+        ] {
+            inner_store
+                .write_file(sid(), path, content, "text")
+                .await
+                .unwrap();
+        }
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/")
+            .deny_read("private")
+            .build()
+            .unwrap();
+        let store = PolicyFileStore::new(inner_store, policy);
+
+        assert!(store.read_file(sid(), "/src/lib.rs").await.is_ok());
+        assert!(store.read_file(sid(), "/.env").await.is_err());
+        assert!(store.read_file(sid(), "/private/secret.txt").await.is_err());
+
+        let listed = store.list_directory(sid(), "/").await.unwrap();
+        assert_eq!(
+            listed
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/src"]
+        );
+
+        let result = store
+            .grep_files_with_options(sid(), "sentinel", &GrepOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(result.returned_matches, 1);
+        assert_eq!(result.total_matches, 1);
+        assert_eq!(result.matches[0].path, "/src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn workspace_policy_enforces_write_scope_deny_precedence_and_recursive_opt_in() {
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/")
+            .allow_write("output")
+            .deny_write("output/locked")
+            .allow_recursive_delete(false)
+            .build()
+            .unwrap();
+        let store = PolicyFileStore::new(inner(), policy);
+
+        store
+            .write_file(sid(), "/output/report.txt", "ok", "text")
+            .await
+            .unwrap();
+        assert!(
+            store
+                .write_file(sid(), "/output/locked/report.txt", "no", "text")
+                .await
+                .is_err()
+        );
+        assert!(
+            store
+                .write_file(sid(), "/src/lib.rs", "no", "text")
+                .await
+                .is_err()
+        );
+        assert!(store.delete_file(sid(), "/output", true).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn recursive_delete_opt_in_does_not_override_a_denied_descendant() {
+        let inner_store: Arc<dyn SessionFileSystem> = inner();
+        inner_store
+            .write_file(sid(), "/output/report.txt", "ok", "text")
+            .await
+            .unwrap();
+        inner_store
+            .write_file(sid(), "/output/locked/secret.txt", "no", "text")
+            .await
+            .unwrap();
+        let policy = WorkspacePolicy::builder()
+            .allow_write("output")
+            .deny_write("output/locked")
+            .allow_recursive_delete(true)
+            .build()
+            .unwrap();
+        let store = PolicyFileStore::new(inner_store.clone(), policy);
+
+        let error = store.delete_file(sid(), "/output", true).await.unwrap_err();
+        assert!(error.to_string().contains("/workspace/output/locked"));
+        assert!(
+            inner_store
+                .read_file(sid(), "/output/report.txt")
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn trusted_seed_bypasses_policy_but_later_access_does_not() {
+        let store = PolicyFileStore::new(inner(), WorkspacePolicy::default());
+        store
+            .seed_initial_file(
+                sid(),
+                &InitialFile {
+                    path: "/.env".to_string(),
+                    content: "TOKEN=secret".to_string(),
+                    encoding: "text".to_string(),
+                    is_readonly: true,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.read_file(sid(), "/.env").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn workspace_policy_rejects_traversal_before_backend_access() {
+        let store = PolicyFileStore::new(inner(), WorkspacePolicy::read_write());
+        let error = store
+            .write_file(sid(), "/workspace/src/../../outside", "no", "text")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("traversal"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn host_symlink_swap_between_operations_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(workspace.path().join("current")).unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "outside").unwrap();
+        let inner: Arc<dyn SessionFileSystem> =
+            Arc::new(crate::real_disk::RealDiskFileStore::new(workspace.path()).unwrap());
+        let store = PolicyFileStore::new(inner, WorkspacePolicy::read_write());
+
+        store
+            .write_file(sid(), "/current/safe.txt", "inside", "text")
+            .await
+            .unwrap();
+        std::fs::remove_dir_all(workspace.path().join("current")).unwrap();
+        symlink(outside.path(), workspace.path().join("current")).unwrap();
+
+        let error = store
+            .read_file(sid(), "/current/secret.txt")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("symlink"));
+    }
+
+    #[tokio::test]
+    async fn host_absolute_path_outside_root_cannot_expose_host_file() {
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(outside.path(), "outside").unwrap();
+        let inner: Arc<dyn SessionFileSystem> =
+            Arc::new(crate::real_disk::RealDiskFileStore::new(workspace.path()).unwrap());
+        let store = PolicyFileStore::new(inner, WorkspacePolicy::read_write());
+
+        match store
+            .read_file(sid(), outside.path().to_str().unwrap())
+            .await
+        {
+            Ok(None) | Err(_) => {}
+            Ok(Some(file)) => assert_ne!(
+                file.content.as_deref(),
+                Some("outside"),
+                "an absolute path outside the root must not expose that host file"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn host_absolute_alias_cannot_bypass_canonical_deny_scope() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::create_dir(workspace.path().join("private")).unwrap();
+        let secret = workspace.path().join("private/secret.txt");
+        std::fs::write(&secret, "secret").unwrap();
+        let inner: Arc<dyn SessionFileSystem> =
+            Arc::new(crate::real_disk::RealDiskFileStore::new(workspace.path()).unwrap());
+        let policy = WorkspacePolicy::builder()
+            .allow_read("/")
+            .deny_read("private")
+            .build()
+            .unwrap();
+        let store = PolicyFileStore::new(inner, policy);
+
+        // `RealDiskFileStore::display_root` exposes the canonical host root, so
+        // use the same spelling a model could echo back from tool output.
+        let canonical_secret = secret.canonicalize().unwrap();
+        let error = store
+            .read_file(sid(), canonical_secret.to_str().unwrap())
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("/workspace/private/secret.txt"),
+            "unexpected policy diagnostic: {message}"
+        );
     }
 
     struct RecordingGate {

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -47,8 +47,10 @@ pub use events::{
 pub use everruns_core::AssembledTurnContext;
 pub use everruns_core::task_observer::{TaskTransition, TaskTransitionObserver};
 pub use everruns_core::turn::TurnStopReason;
+#[allow(deprecated)]
 pub use file_store_decorators::{
-    ApprovalGatingFileStore, DEFAULT_WRITE_BLOCKLIST, FileApprovalGate, WriteBlocklistFileStore,
+    ApprovalGatingFileStore, DEFAULT_WRITE_BLOCKLIST, FileApprovalGate, PolicyFileStore,
+    WriteBlocklistFileStore,
 };
 
 pub use host::{

--- a/crates/host/src/real_disk.rs
+++ b/crates/host/src/real_disk.rs
@@ -150,6 +150,10 @@ impl RealDiskFileStore {
     /// are allowed so callers can create new files/directories after all
     /// existing ancestors have been checked.
     async fn reject_symlink_path(&self, absolute: &Path) -> Result<()> {
+        // THREAT[TM-FS-016]: recheck every existing component immediately
+        // before I/O. This catches swaps between operations; the local provider
+        // is not an OS sandbox against a same-user process racing the final
+        // path-based syscall.
         let root = self.root();
         let relative = absolute.strip_prefix(&root).map_err(|_| {
             AgentLoopError::tool(format!(
@@ -214,6 +218,13 @@ impl SessionFileSystem for RealDiskFileStore {
             Ok(rel) => self.paths.to_display(&rel),
             Err(_) => path.to_string(),
         }
+    }
+
+    fn resolve_path(&self, input: &str) -> String {
+        self.paths
+            .parse_input(input)
+            .map(|path| path.to_session_path())
+            .unwrap_or_else(|_| input.to_string())
     }
 
     fn is_mount_resolver(&self) -> bool {

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -194,6 +194,7 @@ pub struct InProcessRuntimeBuilder {
     model_spec: Option<everruns_core::ModelSpec>,
     legacy_provider_config: Option<everruns_core::ProviderConfig>,
     backends: Option<HostBackends>,
+    workspace_policy: Option<everruns_core::WorkspacePolicy>,
     session_file_system_factory_context: SessionFileSystemFactoryContext,
     harnesses: Vec<Harness>,
     agents: Vec<Agent>,
@@ -239,6 +240,7 @@ impl InProcessRuntimeBuilder {
             model_spec: None,
             legacy_provider_config: None,
             backends: None,
+            workspace_policy: None,
             session_file_system_factory_context: SessionFileSystemFactoryContext::new(),
             harnesses: Vec::new(),
             agents: Vec::new(),
@@ -311,6 +313,16 @@ impl InProcessRuntimeBuilder {
     /// Supply a custom backend bundle instead of the built-in in-memory stores.
     pub fn backends(mut self, backends: HostBackends) -> Self {
         self.backends = Some(backends);
+        self
+    }
+
+    /// Apply a backend-independent policy to the resolved session filesystem.
+    ///
+    /// The policy wraps whichever factory the platform selected, so in-memory,
+    /// host-disk, database, and custom providers receive identical access
+    /// checks without changing their implementations.
+    pub fn workspace_policy(mut self, policy: everruns_core::WorkspacePolicy) -> Self {
+        self.workspace_policy = Some(policy);
         self
     }
 
@@ -488,11 +500,14 @@ impl InProcessRuntimeBuilder {
             Some(backends) => backends,
             None => HostBackends::in_memory(),
         };
-        let file_store = resolve_session_file_system(
+        let mut file_store = resolve_session_file_system(
             &self.platform_definition,
             self.session_file_system_factory_context.clone(),
         )
         .await?;
+        if let Some(policy) = self.workspace_policy.take() {
+            file_store = Arc::new(crate::PolicyFileStore::new(file_store, policy));
+        }
 
         if let Some(config) = self.llm_sim_config.take() {
             let driver = LlmSimDriver::new(config);

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -10,7 +10,7 @@ use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
     Agent, CapabilityRegistry, DriverId, Harness, InitialFile, Message, MessageRole,
     PlatformDefinition, ResolvedModel, Session, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext, ToolCall,
+    SessionFileSystemFactoryContext, ToolCall, WorkspacePolicy,
 };
 use everruns_runtime::{
     AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
@@ -658,6 +658,51 @@ async fn runtime_uses_platform_session_file_system_factory() {
         .unwrap();
     assert_eq!(file.content.as_deref(), Some("from platform factory"));
     assert!(tempdir.path().join("seed.txt").exists());
+}
+
+#[tokio::test]
+async fn workspace_policy_wraps_custom_platform_file_system_factory() {
+    let harness_id = "harness_00000000000000000000000000000054".parse().unwrap();
+    let session_id = "session_00000000000000000000000000000054".parse().unwrap();
+    let tempdir = tempfile::tempdir().unwrap();
+    let platform = PlatformDefinition::builder()
+        .capability_registry(CapabilityRegistry::new())
+        .driver_registry(DriverRegistry::new())
+        .session_file_system_factory(Arc::new(ContextRealDiskFactory))
+        .build();
+    let policy = WorkspacePolicy::builder()
+        .allow_read("public")
+        .build()
+        .unwrap();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .session_file_system_factory_context(
+            SessionFileSystemFactoryContext::new().with(Arc::new(tempdir.path().to_path_buf())),
+        )
+        .workspace_policy(policy)
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .harness(harness(harness_id))
+        .session(session(session_id, harness_id, None))
+        .seed_text_file(session_id, "/public/readme.md", "visible")
+        .seed_text_file(session_id, "/private/secret.txt", "hidden")
+        .build()
+        .await
+        .unwrap();
+
+    assert!(
+        runtime
+            .read_file(session_id, "/public/readme.md")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        runtime
+            .read_file(session_id, "/private/secret.txt")
+            .await
+            .is_err()
+    );
 }
 
 #[tokio::test]

--- a/docs/framework/agents.md
+++ b/docs/framework/agents.md
@@ -32,7 +32,9 @@ a session starts.
 
 Choose workspace roots from trusted application configuration. Model output and
 untrusted request fields must not select executable paths or host directories.
-The underlying filesystem boundary rejects traversal and symlink escape.
+The underlying filesystem boundary rejects traversal and symlink escape. Use a
+[`WorkspacePolicy`](/framework/workspace-security/) to configure portable read,
+write, hidden-path, and recursive-delete restrictions.
 
 ## MCP and plugins
 

--- a/docs/framework/examples.md
+++ b/docs/framework/examples.md
@@ -8,6 +8,7 @@ contains the maintained public examples. Each imports the `everruns` facade.
 
 | Example | Demonstrates | Command |
 | --- | --- | --- |
+| [`workspace_policy.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/workspace_policy.rs) | Safe workspace scopes and trusted starter files, fully offline | `cargo run -p everruns --example workspace_policy` |
 | [`hello.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/hello.rs) | Small live-provider agent | `cargo run -p everruns --features openai --example hello` |
 | [`production_agent.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/production_agent.rs) | Tools, files, and production-style setup | `cargo run -p everruns --features openai --example production_agent` |
 | [`github_monitor.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/github_monitor.rs) | Typed tools and an offline simulation mode | `cargo run -p everruns --features openai --example github_monitor -- --simulate` |
@@ -16,8 +17,9 @@ contains the maintained public examples. Each imports the `everruns` facade.
 | [`observe_and_cancel.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/observe_and_cancel.rs) | Live events and cancellation | `cargo run -p everruns --features openai --example observe_and_cancel` |
 | [`lifecycle_hooks.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/lifecycle_hooks.rs) | Awaited agent, turn, tool, and completion handlers | `cargo run -p everruns --features openai --example lifecycle_hooks` |
 
-Live modes use `gpt-5.6-terra` and require `OPENAI_API_KEY`. `session_work` is
-fully offline; the GitHub monitor also offers a simulated GitHub flow:
+Live modes use `gpt-5.6-terra` and require `OPENAI_API_KEY`. `session_work` and
+`workspace_policy` are fully offline; the GitHub monitor also offers a simulated
+GitHub flow:
 
 ```bash
 cargo run -p everruns --features openai --example github_monitor -- --simulate

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -39,6 +39,7 @@ before importing `everruns-runtime` directly.
 
 - [Quickstart](/framework/quickstart/) — install the crate and run an offline agent.
 - [Agents](/framework/agents/) — instructions, files, workspaces, MCP, plugins, and context inspection.
+- [Workspace security](/framework/workspace-security/) — configure portable read and write scopes with secure defaults.
 - [Models and providers](/framework/models-and-providers/) — simulation, OpenAI, and the open provider boundary.
 - [Tools and macros](/framework/tools-and-macros/) — typed function tools through `everruns::tool`.
 - [Sessions](/framework/sessions/) — independent, multi-turn conversations.

--- a/docs/framework/workspace-security.md
+++ b/docs/framework/workspace-security.md
@@ -1,0 +1,134 @@
+---
+title: Workspace Security
+description: Configure safe read and write scopes for in-process Everruns agents.
+---
+
+`WorkspacePolicy` is the portable security boundary for files visible to an
+in-process agent. Applications configure it through `everruns`; they do not
+need `RealDiskFileStore`, `RuntimeBackends`, or a runtime-owned blocklist.
+
+```rust
+use everruns::{Agent, Model, WorkspacePolicy};
+
+fn build(root: &std::path::Path) -> Result<Agent, Box<dyn std::error::Error>> {
+    let policy = WorkspacePolicy::builder()
+        .allow_read("/")
+        .allow_write("generated")
+        .deny_write("generated/locked")
+        .allow_hidden(".github")
+        .build()?;
+
+    Ok(Agent::builder()
+        .instructions("Work only inside the configured workspace.")
+        .model(Model::simulated("ready"))
+        .workspace(root)
+        .workspace_policy(policy)
+        .build()?)
+}
+```
+
+## Defaults
+
+`WorkspacePolicy::default()` and `WorkspacePolicy::read_only()` use the same
+secure baseline:
+
+| Operation | Default |
+|---|---|
+| Read ordinary workspace files | Allowed |
+| Write, create, or delete | Denied |
+| Read or write hidden paths | Denied |
+| Read or write common credential paths | Denied |
+| Read framework-managed `.agents` content | Allowed |
+| Recursively delete a directory | Denied |
+
+`WorkspacePolicy::read_write()` is an explicit opt-in to ordinary writes. It
+does not expose additional hidden or sensitive paths and does not enable
+recursive deletion. It also keeps common dependency and build directories such
+as `node_modules` and `target` non-writable at every depth. For narrower access,
+start with
+`WorkspacePolicy::builder()`, which has no readable or writable scopes until
+you add them.
+
+A custom builder does not inherit the default `.agents` exception. If the
+agent needs workspace-provided instructions or skills, add both a readable
+scope and a narrow `allow_hidden(".agents")` opt-in.
+
+Protected path names are defense in depth, not content-based secret scanning.
+Keep credentials outside the mounted workspace, add explicit deny scopes for
+application-specific secret locations, and never place credentials in `.agents`
+content.
+
+## Matching and precedence
+
+Scopes are literal path prefixes, not globs, and compare ASCII letters without
+case sensitivity so a deny cannot be bypassed on a case-insensitive provider.
+`generated` therefore includes `generated/report.md` but not
+`other/generated/report.md`.
+
+- A deny scope always wins over an allow scope.
+- `deny_write_component` rejects an exact directory or file name at every
+  depth; `deny_write` rejects one rooted path subtree.
+- Hidden paths need `allow_hidden` for the narrow path that should be visible.
+- Common credential paths need the stronger `allow_sensitive` opt-in, which
+  also permits hidden components inside that specific scope.
+- `compose` is restrictive: every composed policy must allow the operation.
+  A library can add constraints without accidentally broadening the
+  application's policy.
+
+Trusted starter files are installed before model access is enforced. This lets
+an application seed a read-only file even under a non-writable policy. Later
+reads, writes, and deletes of that file still go through the policy, so seeding
+a hidden file does not automatically expose it.
+
+## Paths and containment
+
+Policy paths live in one portable workspace namespace. These spellings identify
+the same file:
+
+```text
+src/lib.rs
+/src/lib.rs
+/workspace/src/lib.rs
+```
+
+Traversal (`..`), NUL bytes, and backslash-separated paths fail closed. Host
+absolute paths are provider-specific and are not portable policy scopes; use
+`/workspace/...` in application configuration and model instructions.
+
+The policy layer controls visibility and mutation. The selected filesystem
+provider remains responsible for mapping workspace paths to storage. The local
+host provider canonicalizes its root, keeps resolved paths contained, and
+rejects symlinks in existing path components before every operation. An
+absolute path outside the configured root cannot expose that host file.
+
+The policy governs capabilities that use Everruns' session filesystem. A
+custom tool that calls `std::fs`, launches a shell, or uses another storage API
+does not pass through this boundary. Apply equivalent restrictions to those
+tools or run them in a sandbox.
+
+## Symlinks and races
+
+The built-in local provider rejects a symlink introduced after the workspace
+was configured because it rechecks components on every operation. This blocks
+normal traversal and symlink-swap attempts between operations.
+
+It is not an OS sandbox. A malicious process running as the same operating
+system user can race a final path check and filesystem syscall. If local
+processes are mutually untrusted, use an isolated sandbox/filesystem provider
+or operating-system isolation. Do not use `WorkspacePolicy` as a substitute for
+that process boundary.
+
+## Provider extension
+
+The in-process host applies the policy after resolving the platform's
+filesystem factory. In-memory, local-disk, database, and custom providers all
+receive the same policy checks. Provider authors still own containment,
+symlink-safe I/O, quotas, durability, and atomic update guarantees for their
+storage system.
+
+Directory listings and grep are enforced at the same seam as direct reads.
+Denied files are not opened by policy grep, and denied names, match counts, and
+byte totals are not returned. Recursive deletes inspect descendants through the
+provider before deletion, so opting into recursion does not override a deny or
+protected descendant. Providers with mutable external state must still treat
+that preflight-to-delete window as a race boundary.

--- a/knowledge/runtime-resources/file-store.md
+++ b/knowledge/runtime-resources/file-store.md
@@ -520,17 +520,34 @@ See the runnable examples for the full wiring against a real
 
 ## Policy Decorators
 
-Embedders that need to apply policy to LLM-driven writes can compose
-`SessionFileSystem` decorators on top of a base store. Two are shipped in
-`everruns-runtime`:
+`WorkspacePolicy` is the application-facing policy value. The in-process host
+wraps the filesystem selected by the platform factory, so the same
+policy applies to in-memory, host-disk, database, and third-party providers.
+The policy owns portable `/workspace` access decisions; concrete providers
+still own storage mapping, containment, symlink handling, and atomic I/O.
 
-- `WriteBlocklistFileStore` — rejects `write_file`, `delete_file`,
-  `create_directory`, `seed_initial_file`, and
-  `write_file_if_content_matches` whose path contains any blocked directory
-  component (`.git`, `node_modules`, `target`, …) at any depth. Reads,
-  listings, stats, and greps pass through. The blocklist defaults to
-  `DEFAULT_WRITE_BLOCKLIST` and is fully overridable via
-  `WriteBlocklistFileStore::with_blocklist(inner, custom)`.
+The safe default permits reads of ordinary workspace files and denies writes,
+hidden paths, sensitive paths, and recursive deletes. Applications opt into
+writes and protected paths with explicit scopes. The broad read-write
+convenience retains component-level denies for common dependency and build
+directories; custom policies can configure their own component restrictions.
+Denies win, and composition is an intersection so adding a layer cannot broaden
+access. See the source for the API contract rather than duplicating its methods
+here.
+
+`PolicyFileStore` performs the uniform enforcement. Trusted application seed
+files bypass mutation policy while being installed; every later model-driven
+read or mutation is checked. Directory listings and grep output are filtered so
+denied path names, content, counts, and byte totals are not returned.
+
+The older `WriteBlocklistFileStore` remains as a low-level compatibility
+decorator. Its `DEFAULT_WRITE_BLOCKLIST` export is deprecated and retained only
+for 0.17 source compatibility; new policy behavior does not depend on that
+global list. New applications use `WorkspacePolicy` instead of importing a
+concrete store or a blocklist constant.
+
+The independent approval decorator remains available:
+
 - `ApprovalGatingFileStore` — gates `write_file`, `delete_file`, and the
   inner write inside `write_file_if_content_matches` through an embedder
   supplied `FileApprovalGate`. The trait has two async methods,
@@ -541,32 +558,11 @@ Embedders that need to apply policy to LLM-driven writes can compose
   files are embedder-supplied, not LLM-driven). Writes always read the
   inner store's existing content first so the embedder can render a diff.
 
-The intended composition (eliding boilerplate):
-
-```rust,ignore
-let disk: Arc<dyn SessionFileSystem> =
-    Arc::new(RealDiskFileStore::new(&workspace_root)?);
-let blocklisted: Arc<dyn SessionFileSystem> =
-    Arc::new(WriteBlocklistFileStore::new(disk));
-let gated: Arc<dyn SessionFileSystem> =
-    Arc::new(ApprovalGatingFileStore::new(blocklisted, gate));
-```
-
-Reads short-circuit through both layers; only the destructive paths take
-the policy decisions. Each layer holds `Arc<dyn SessionFileSystem>` rather
-than a generic inner so decorator stacks compose without coherence
-gymnastics.
-
-Smell to acknowledge: this puts policy in the storage layer rather than the
-tool layer. The trade-off is uniformity — every built-in capability that
+Enforcement sits at the filesystem seam so every built-in capability that
 calls `ToolContext.file_store` / `SystemPromptContext.file_store` (today:
 `file_system`, `agent_instructions`, `skills`, `web_fetch`,
-`tool_output_persistence`) picks the policy up for free. The alternative
-(tool-layer policy) would require every capability to wire its own gate and
-its own blocklist, which the [examples/coding-cli][cli] prototype
-demonstrated is the wrong default.
-
-[cli]: ../../examples/coding-cli
+`tool_output_persistence`) observes one policy rather than reimplementing path
+rules at each tool boundary.
 
 ## Non-goals
 
@@ -597,17 +593,19 @@ APIs or the `SessionFileSystem` trait.
   (`to_session_path`, `to_display_path`)
 - `crates/core/src/workspace_roots.rs` — `WorkspaceRootSet` and host-root
   resolver for multi-root host sessions
-- `crates/runtime/src/real_disk.rs` — `RealDiskFileStore` + its private
+- `crates/core/src/workspace_policy.rs` — portable `WorkspacePolicy`
+- `crates/host/src/real_disk.rs` — `RealDiskFileStore` + its private
   `HostPathMap` (virtual ⇄ host mapping; the only host-rooted backend)
 - `crates/core/src/traits.rs` — `SessionFileSystem` trait
   (`display_path`/`display_root`/`resolve_path`)
 - `crates/core/src/session_file.rs` — `SessionFile`, `FileInfo`,
   `FileStat`, `GrepMatch`, `InitialFile`
-- `crates/runtime/src/backends.rs` — `RuntimeBackends`
-- `crates/runtime/src/file_store_decorators.rs` — `WriteBlocklistFileStore`,
-  `ApprovalGatingFileStore`, `FileApprovalGate`, `DEFAULT_WRITE_BLOCKLIST`
-- `crates/runtime/src/in_memory.rs` — `InMemorySessionFileStore`
-- `crates/runtime/src/real_disk.rs` — `RealDiskFileStore`
+- `crates/host/src/backends.rs` — `HostBackends`
+- `crates/host/src/file_store_decorators.rs` — `PolicyFileStore`,
+  `WriteBlocklistFileStore`, its deprecated compatibility constant,
+  `ApprovalGatingFileStore`, `FileApprovalGate`
+- `crates/host/src/in_memory.rs` — `InMemorySessionFileStore`
+- `crates/host/src/real_disk.rs` — `RealDiskFileStore`
 - `crates/runtime/examples/real_disk_agent_instructions.rs` — wiring
   example for `AgentInstructionsCapability`
 - `crates/runtime/examples/real_disk_file_system_tools.rs` — wiring

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -406,6 +406,8 @@ Code references:
 | TM-FS-012 | Offloaded object content unencrypted at rest (S3) | Low | Bytes stored in the object store rely on bucket-side encryption (SSE / SSE-KMS); application-level envelope encryption of blobs is out of scope (mirrors TM-FS-006 for inline PostgreSQL storage). | **ACCEPTED** |
 | TM-FS-013 | Multi-root host workspace escape | High | `WorkspaceRootSet` canonicalizes every registered host root, rejects duplicates and overlapping directories, rejects host-absolute paths outside the registered root set, and routes additional roots only through `/workspace/roots/<name>/...`. Each mounted root is backed by its own `RealDiskFileStore`, preserving per-root symlink rejection and containment checks; `MountFs` rejects `..` traversal under additional-root prefixes before normalization so an attempted escape cannot silently reroute to the primary root. | MITIGATED |
 | TM-FS-014 | Canonical event JSONL exposes conversation content to other local users | Medium | `JsonlEventLog` creates new files with owner-only `0600` permissions on Unix. The embedder selects and protects the containing data directory; existing files retain their operator-managed permissions. | MITIGATED |
+| TM-FS-015 | Framework workspace-policy bypass through alternate paths or hidden content | High | `WorkspacePolicy` validates one portable `/workspace` namespace, fails closed on traversal, NUL bytes, and platform separators, compares ASCII case conservatively across case-sensitive and case-insensitive providers, applies deny-over-allow precedence, protects hidden and common sensitive paths by default, and supports exact component write denies at every depth without depending on a public global blocklist. Listings and grep summaries are filtered as well as direct reads. Recursive-delete opt-in preflights every provider-visible descendant so it cannot override a deny. The host applies policy after resolving any platform filesystem factory, so custom providers do not bypass it. Concrete host providers retain responsibility for host-path containment and symlink handling. | MITIGATED |
+| TM-FS-016 | Host filesystem symlink-swap race between validation and I/O | High | `RealDiskFileStore` rejects symlinks in every existing path component immediately before each operation, including symlinks introduced after store construction; regression coverage swaps a checked directory for an outside symlink between operations. The local host provider is not an OS sandbox, and a same-user process can still race the final check and path-based syscall. Applications with mutually untrusted local processes must use a sandboxed filesystem provider or OS isolation rather than treating `WorkspacePolicy` as a process boundary. | **ACCEPTED** |
 
 ### Mitigation Details
 
@@ -421,6 +423,19 @@ Per-session and per-file byte quotas are enforced at the application layer in bo
 - `SESSION_FILE_SINGLE_MAX_BYTES` — per-file ceiling (default 100 MB)
 
 Writes that would exceed either limit fail with a clear error before any DB insert.
+
+**TM-FS-015/016 — Framework Host Workspaces:**
+
+Policy is intentionally split from storage. `WorkspacePolicy` decides which
+model-facing paths are visible or mutable, while the selected provider decides
+how those paths map to storage. This keeps policy portable and provider-extensible
+without claiming that a path policy is a host-process sandbox. The real-disk
+provider rechecks symlink components per operation and fails closed for swaps
+that happen before the check; eliminating a malicious same-user TOCTOU race
+requires descriptor-relative/no-follow I/O or a sandbox provider.
+Filesystem policy applies at `SessionFileSystem`; a custom tool that performs
+direct host I/O or launches a shell is a separate capability boundary and must
+be restricted or sandboxed by its embedder.
 
 ## 6. Session SQL Database (TM-SQL)
 


### PR DESCRIPTION
## What changed
Adds a backend-independent `WorkspacePolicy` to the application-facing `everruns` API with a secure read-only default, explicit read/write and protected-path opt-ins, restrictive composition, and `AgentBuilder::workspace_policy`.

The in-process host enforces the policy after resolving any filesystem factory, so in-memory, local-disk, database, and custom providers share direct-read, listing, grep, write, create, and delete checks. Trusted starter-file seeding remains application-controlled; later access is policy-checked. The legacy runtime blocklist constant remains deprecated for 0.17 source compatibility and does not define the new policy.

Adds the public Workspace Security guide, minimal Framework navigation and catalog links, an offline runnable example, and facade all-feature plus no-default CI coverage.

## Why
Framework applications need a safe, ergonomic workspace boundary without importing `RealDiskFileStore`, assembling `RuntimeBackends`, or treating a public global blocklist as policy configuration.

## Before / After
Before: `AgentBuilder::workspace` selected a root, but ordinary applications had no provider-neutral way to scope reads and writes or protect hidden/sensitive paths.

After: applications configure the boundary directly:

```rust
let policy = WorkspacePolicy::builder()
    .allow_read("input")
    .allow_write("generated")
    .deny_write("generated/locked")
    .build()?;

let agent = Agent::builder()
    .workspace(root)
    .workspace_policy(policy)
    // ...
    .build()?;
```

Evidence:
- `cargo run -p everruns --example workspace_policy` prints `Workspace policy configured.` offline.
- 13 focused policy cases and 8 policy-decorator/provider cases cover defaults, allow/deny precedence, composition, protected paths, traversal, absolute aliases, symlink swaps, recursive deletion, filtered grep/listing, trusted seeding, and custom factories.
- `cargo test -p everruns --all-features`, `cargo check -p everruns --no-default-features`, docs check/build/link validation, and `just pre-push` pass.

## Risk
- Medium
- Filesystem authorization semantics change for high-level `Agent` sessions: writes are denied by default and hidden/sensitive reads fail closed. Low-level runtime builders retain compatibility unless they opt into a policy.
- Generic policy-aware grep walks filtered provider listings rather than opening denied files; entry count and existing content-byte limits bound the work.
- Same-user host processes can still race the final symlink check and path syscall; this residual risk is documented and requires OS isolation or a sandbox provider.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL, TM-DOS
- Findings and resolutions: path traversal, alternate absolute aliases, case-insensitive deny bypass, hidden/sensitive leakage, recursive-delete descendants, and symlink swaps are covered by normalization, deny precedence, filtered metadata/search surfaces, preflight checks, and regression tests. Provider walks are bounded. TM-FS-015 is mitigated; the final-syscall race is explicitly accepted as TM-FS-016. Direct `std::fs` or shell tools remain a separate capability boundary and are called out in public docs.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)