### PR TITLE
feat(framework): expose canonical session events

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -179,6 +179,7 @@ export default defineConfig({
                     { label: "Session Work and Wakes", slug: "framework/background-work" },
                     { label: "Session History", slug: "framework/session-history" },
                     { label: "Events and Cancellation", slug: "framework/events-and-cancellation" },
+                    { label: "Canonical Events", slug: "framework/canonical-events" },
                     { label: "Lifecycle Hooks", slug: "framework/lifecycle-hooks" },
                     { label: "Persistence", slug: "framework/persistence" },
                   ],

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -112,7 +112,7 @@ let stopped = session.run_with("Do not start.", options).await?;
 
 assert!(first.success);
 assert!(!stopped.success);
-while let Some(event) = events.try_recv() {
+while let Some(event) = events.try_recv()? {
     println!("{}", event.event_type());
 }
 # Ok::<(), everruns::RunError>(())
@@ -157,7 +157,7 @@ catalog alongside its real workspace and task/schedule state.
 - Value-first `Agent`, open `ModelSpec`/`Provider`, and deterministic simulation
 - Typed and dynamic function tools
 - Independent multi-turn `Session`s, typed resume, bounded history, and next-turn context inspection
-- Live typed events, lossless unknown-event projection, and cancellation
+- Live typed events, lossless canonical envelopes, and cancellation
 - Session-owned immediate and scheduled work with leased, at-least-once delivery
 - Awaited, typed lifecycle hooks with explicit failure isolation
 - Editable/read-only files, one trusted workspace, scoped MCP, and plugins
@@ -172,6 +172,7 @@ The [example catalog](./examples/README.md) includes:
 - `production_agent` — production-style composition
 - `github_monitor --simulate` — credential-free typed-tool flow
 - `session_work` — offline background work and completion wakes
+- `canonical_events` — offline lossless event recording and typed rendering
 - `subagents` — public-facade delegation
 - `observe_and_cancel` — events and cancellation
 - `session_history` — offline durable resume and bounded history pages
@@ -202,6 +203,7 @@ Examples are compiled in CI and import only `everruns`.
 - [Session work and wakes](https://docs.everruns.com/framework/background-work/)
 - [Events and cancellation](https://docs.everruns.com/framework/events-and-cancellation/)
 - [Lifecycle hooks](https://docs.everruns.com/framework/lifecycle-hooks/)
+- [Canonical events](https://docs.everruns.com/framework/canonical-events/)
 - [API reference](https://docs.rs/everruns)
 
 ## Extend agents

--- a/crates/everruns/examples/README.md
+++ b/crates/everruns/examples/README.md
@@ -1,8 +1,8 @@
 # `everruns` examples
 
 These examples use the application-facing [`everruns`](../README.md) crate.
-Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`; `session_work` and
-`workspace_policy` and `session_history` run entirely offline.
+Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`; `canonical_events`,
+`session_work`, `workspace_policy`, and `session_history` run entirely offline.
 
 | Example | What it demonstrates | Run |
 |---|---|---|
@@ -12,6 +12,7 @@ Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`; `session_work` and
 | [`github_monitor.rs`](github_monitor.rs) | Host-owned background work that wakes an agent when it finishes | `cargo run -p everruns --features openai --example github_monitor -- --simulate` |
 | [`session_work.rs`](session_work.rs) | Session-owned work, leased delivery, and completion wakes | `cargo run -p everruns --example session_work` |
 | [`session_history.rs`](session_history.rs) | Durable local resume and bounded, event-derived history pages | `cargo run -p everruns --features local --example session_history` |
+| [`canonical_events.rs`](canonical_events.rs) | Lossless recording and typed rendering of live canonical events | `cargo run -p everruns --example canonical_events` |
 | [`subagents.rs`](subagents.rs) | Concurrent child agents managed by an application-owned task registry | `cargo run -p everruns --features openai --example subagents` |
 | [`observe_and_cancel.rs`](observe_and_cancel.rs) | Live event streaming and cooperative cancellation | `cargo run -p everruns --features openai --example observe_and_cancel` |
 | [`advanced_capability.rs`](advanced_capability.rs) | Curated capability SPI with typed protocol, metadata, progress, and structured errors | `cargo run -p everruns --features openai --example advanced_capability` |

--- a/crates/everruns/examples/advanced_capability.rs
+++ b/crates/everruns/examples/advanced_capability.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut session = agent.session();
     let mut events = session.events();
     let observer = tokio::spawn(async move {
-        while let Some(event) = events.recv().await {
+        while let Some(event) = events.recv().await? {
             if let SessionEventKind::ToolProgress { message, .. } = &event.kind {
                 eprintln!("progress: {message}");
             }
@@ -101,10 +101,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 break;
             }
         }
+        Ok::<_, everruns::EventStreamError>(())
     });
 
     let turn = session.run("What is product EVR-42?").await?;
     println!("{}", turn.response);
-    observer.await?;
+    observer.await??;
     Ok(())
 }

--- a/crates/everruns/examples/canonical_events.rs
+++ b/crates/everruns/examples/canonical_events.rs
@@ -1,0 +1,65 @@
+//! Record and render a complete turn through the canonical Framework event API.
+//!
+//! Run offline with:
+//!
+//! ```text
+//! cargo run -p everruns --example canonical_events
+//! ```
+
+use everruns::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let agent = Agent::builder()
+        .instructions("Answer concisely.")
+        .model(Model::simulated("Hello from Everruns."))
+        .build()?;
+    let mut session = agent.session();
+    let mut events = session.events();
+
+    let observer = tokio::spawn(async move {
+        let mut rendered = String::new();
+        let mut recorded = Vec::new();
+
+        loop {
+            let event = match events.recv().await {
+                Ok(Some(event)) => event,
+                Ok(None) => break,
+                Err(error) => return Err(error),
+            };
+            recorded.push(event.as_json().clone());
+
+            match event.kind {
+                SessionEventKind::OutputStarted { .. } => print!("assistant: "),
+                SessionEventKind::TextDelta { delta } => {
+                    rendered.push_str(&delta);
+                    print!("{delta}");
+                }
+                SessionEventKind::ToolStarted { tool_name, .. } => {
+                    eprintln!("starting tool {tool_name}");
+                }
+                SessionEventKind::ToolCompleted {
+                    tool_name, success, ..
+                } => eprintln!("tool {tool_name} completed: {success}"),
+                SessionEventKind::TurnCompleted => println!("\n[turn completed]"),
+                SessionEventKind::TurnFailed { error } => eprintln!("turn failed: {error}"),
+                _ => {}
+            }
+        }
+
+        Ok((rendered, recorded))
+    });
+
+    let turn = session.run("Say hello.").await?;
+    drop(session); // closes the stream after every buffered event is drained
+    let (rendered, recorded) = observer.await??;
+
+    assert_eq!(rendered, turn.response);
+    assert!(
+        recorded
+            .iter()
+            .any(|event| event["type"] == "output.message.completed")
+    );
+    println!("recorded {} canonical envelopes", recorded.len());
+    Ok(())
+}

--- a/crates/everruns/examples/hello.rs
+++ b/crates/everruns/examples/hello.rs
@@ -7,7 +7,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use everruns::{Agent, OpenAI, SessionEventKind};
+use everruns::{Agent, EventStreamError, OpenAI, SessionEventKind};
 
 /// Return the current Unix time in seconds.
 #[everruns::tool]
@@ -32,13 +32,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut events = session.events();
     let observer = tokio::spawn(async move {
         let mut event_types = Vec::new();
-        while let Some(event) = events.recv().await {
+        while let Some(event) = events.recv().await? {
             event_types.push(event.event_type().to_string());
             if matches!(event.kind, SessionEventKind::TurnCompleted) {
                 break;
             }
         }
-        event_types
+        Ok::<_, EventStreamError>(event_types)
     });
 
     let turn = session.run("what time is it?").await?;
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     println!("\nevents:");
-    for (index, event_type) in observer.await?.into_iter().enumerate() {
+    for (index, event_type) in observer.await??.into_iter().enumerate() {
         println!("  {:>2}. {event_type}", index + 1);
     }
 

--- a/crates/everruns/examples/observe_and_cancel.rs
+++ b/crates/everruns/examples/observe_and_cancel.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Read the event stream on a background task while the turn runs.
     let observer = tokio::spawn(async move {
         let mut rendered = String::new();
-        while let Some(event) = events.recv().await {
+        while let Some(event) = events.recv().await? {
             match event.kind {
                 SessionEventKind::TurnStarted => println!("[turn started]"),
                 SessionEventKind::TextDelta { delta } => {
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 _ => {}
             }
         }
-        rendered
+        Ok::<_, EventStreamError>(rendered)
     });
 
     let turn = session.run("hi").await?;
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Drop the session so the stream closes and the observer finishes.
     drop(session);
-    let rendered = observer.await?;
+    let rendered = observer.await??;
     assert_eq!(rendered, turn.response);
 
     // --- Cancel a turn ---------------------------------------------------

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -125,6 +125,15 @@ impl Model {
         )
     }
 
+    /// Test-only: a simulated provider failure used to prove the facade event
+    /// bridge retains failure lifecycle and diagnostic payloads end to end.
+    pub(crate) fn simulated_error(message: impl Into<String>) -> Self {
+        Self::with_provider(
+            ModelSpec::on("llmsim", "llmsim-model"),
+            Provider::new("llmsim", LlmSimDriver::new(LlmSimConfig::error(message))),
+        )
+    }
+
     /// Test-only: a simulated model that emits the given per-turn tool-call
     /// sequence before replying with `response`. Lets a facade test drive the
     /// end-to-end tool-execution loop for a function tool.

--- a/crates/everruns/src/capability.rs
+++ b/crates/everruns/src/capability.rs
@@ -953,7 +953,7 @@ mod tests {
         assert_eq!(turn.tool_calls, 1);
 
         let mut saw_progress = false;
-        while let Ok(Some(event)) = timeout(Duration::from_millis(50), events.recv()).await {
+        while let Ok(Ok(Some(event))) = timeout(Duration::from_millis(50), events.recv()).await {
             if matches!(
                 event.kind,
                 SessionEventKind::ToolProgress {

--- a/crates/everruns/src/events.rs
+++ b/crates/everruns/src/events.rs
@@ -1,46 +1,62 @@
-//! Observable and cancellable turns (EVE-833).
+//! Observable and cancellable turns.
 //!
 //! This module promotes two capabilities onto the [`Session`](crate::Session)
-//! surface without leaking the runtime's event bus or the core event/store
-//! types:
+//! surface without leaking host/runtime internals or core event/store types:
 //!
 //! - **Observation.** [`Session::events`](crate::Session::events) returns an
 //!   [`EventStream`] — a live feed of [`SessionEvent`]s projected from the
-//!   runtime's in-process event bus. The stream is backed by a broadcast
-//!   channel, so a slow or dropped consumer can never stall the turn that
-//!   produces the events; it only lags and skips.
+//!   host's canonical event emitter. Every event retains the canonical event
+//!   protocol as JSON and also exposes a typed convenience projection. The
+//!   stream is bounded, so a slow or dropped consumer can never stall the turn
+//!   that produces the events; lag is reported explicitly to the consumer.
 //! - **Cancellation.** [`Session::run_with`](crate::Session::run_with) accepts a
 //!   [`RunOptions`] carrying an optional [`CancellationToken`]. Cancelling the
 //!   token stops the in-flight turn by dropping its future — the same
 //!   cooperative, drop-based cancellation the runtime already uses to tear down
 //!   tool work — and the turn resolves to a stable [`Turn`](crate::Turn) with
-//!   [`TurnStopReason::Cancelled`](everruns_core::turn::TurnStopReason::Cancelled).
+//!   [`TurnStopReason::Cancelled`](crate::TurnStopReason::Cancelled).
 //!
 //! Only facade types appear on the public surface: no `EventBus`,
 //! `EventEmitter`, `EventRequest`, or core event/store types.
+//!
+//! The live subscriber is not persistence. Everruns' host `EventLog` commits
+//! durable canonical events; its `EventHistory` is a read-only projection built
+//! by replay. The host `EventSink` and this facade's [`EventStream`] observe
+//! post-commit durable events plus live-only ephemeral events. Sink absence,
+//! lag, or failure cannot create, roll back, or replace conversation history.
+
+use std::sync::Mutex;
 
 use everruns_core::events::{
-    self, Event, EventData, OutputMessageDeltaData, ToolCompletedData, ToolProgressData,
-    ToolStartedData, TurnFailedData,
+    self, Event, EventContext, EventData, EventRequest, InputMessageData,
+    OutputMessageCompletedData, OutputMessageDeltaData, OutputMessageReplacedData,
+    OutputMessageStartedData, ReasonCompletedData, ToolCompletedData, ToolOutputDeltaData,
+    ToolProgressData, ToolStartedData, TurnCancelledData, TurnFailedData,
 };
+use everruns_core::typed_id::{SessionId, TurnId};
 use everruns_host::{EventSink, EventSinkError};
 use serde_json::Value;
 use tokio::sync::broadcast;
 
 /// Capacity of the per-session broadcast channel that backs [`EventStream`].
 ///
-/// A turn emits well under this many events, so a consumer that keeps up never
-/// lags. A consumer that falls behind by more than this drops the oldest events
-/// (reported as a skip) rather than applying back-pressure to the turn — the
-/// runner must never block on an observer.
-const EVENT_CHANNEL_CAPACITY: usize = 4096;
+/// A turn normally emits well under this many events. If a consumer falls
+/// behind, the channel evicts its oldest unread events and reports the exact
+/// gap through [`EventStreamError::Lagged`] rather than applying backpressure to
+/// the turn — the runner must never block on an observer.
+pub const EVENT_STREAM_CAPACITY: usize = 4096;
 
 /// A single observed event from a running [`Session`](crate::Session).
 ///
-/// A small, stable projection of one runtime event. The correlation ids
-/// (`event_id`, `session_id`, and the optional `turn_id`) are preserved on every
-/// event so a consumer can line events up with a [`Turn`](crate::Turn); the
-/// [`kind`](SessionEvent::kind) carries the event-specific payload.
+/// This is an explicitly lossless typed/raw bridge to Everruns' canonical event
+/// protocol. [`kind`](SessionEvent::kind) is the ergonomic typed projection used
+/// by renderers, while [`as_json`](SessionEvent::as_json) returns the complete
+/// canonical event envelope without translation or omitted fields. The JSON
+/// form includes the event timestamp, optional persisted sequence, correlation
+/// context, full event-specific data, metadata, and tags.
+///
+/// The correlation ids (`event_id`, `session_id`, and the optional `turn_id`)
+/// are also promoted as strings for common logging and matching tasks.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct SessionEvent {
@@ -52,17 +68,29 @@ pub struct SessionEvent {
     pub turn_id: Option<String>,
     /// The event-specific projection.
     pub kind: SessionEventKind,
+    raw: Value,
 }
 
 /// The event-specific payload of a [`SessionEvent`].
 ///
-/// Non-exhaustive on purpose: new hosted event types are surfaced through the
-/// [`Other`](SessionEventKind::Other) fallback, which carries the stable event
-/// type string and the raw JSON payload, so promoting a new event to a typed
-/// variant later never breaks a consumer that already matches with a wildcard.
+/// Non-exhaustive on purpose: event kinds useful to an application renderer are
+/// promoted here, while every other event is surfaced through
+/// [`Other`](SessionEventKind::Other). The full event remains available through
+/// [`SessionEvent::as_json`] for every variant, including newly added event
+/// types that this version of the crate does not recognize.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum SessionEventKind {
+    /// A user input message was committed to the canonical event history.
+    InputMessage {
+        /// Stable id of the user message.
+        message_id: String,
+    },
+    /// Assistant output began streaming.
+    OutputStarted {
+        /// Stable id shared by the output's deltas and completion.
+        message_id: String,
+    },
     /// A turn began executing.
     TurnStarted,
     /// A turn finished successfully.
@@ -78,6 +106,18 @@ pub enum SessionEventKind {
     TextDelta {
         /// The new text appended by this delta.
         delta: String,
+    },
+    /// Streaming output was replaced, for example by an output guardrail.
+    OutputReplaced {
+        /// Stable id of the assistant message being replaced.
+        message_id: String,
+        /// Replacement text that is safe to render.
+        replacement: String,
+    },
+    /// An assistant output message completed.
+    OutputCompleted {
+        /// Stable id shared by the output's start and deltas.
+        message_id: String,
     },
     /// A tool call started executing.
     ToolStarted {
@@ -95,19 +135,44 @@ pub enum SessionEventKind {
         /// Whether the tool call succeeded.
         success: bool,
     },
-    /// A best-effort progress update emitted by an in-flight tool.
+    /// A running tool reported human-readable progress.
     ToolProgress {
         /// Opaque id of the tool call.
         tool_call_id: String,
-        /// Name of the tool emitting progress.
+        /// Name of the tool being invoked.
         tool_name: String,
-        /// Human-readable interim status.
+        /// Progress message suitable for a timeline or terminal.
         message: String,
     },
-    /// Any other runtime event, carried through unprojected.
+    /// A running tool produced an incremental output chunk.
+    ToolOutputDelta {
+        /// Opaque id of the tool call.
+        tool_call_id: String,
+        /// Name of the tool being invoked.
+        tool_name: String,
+        /// Output stream identifier, such as `"stdout"` or `"stderr"`.
+        stream: String,
+        /// New output appended to that stream.
+        delta: String,
+    },
+    /// A model reasoning step began.
+    ReasonStarted,
+    /// A model reasoning step completed.
+    ReasonCompleted {
+        /// Whether the model call succeeded.
+        success: bool,
+        /// Provider/model failure detail, when the step failed.
+        error: Option<String>,
+    },
+    /// A complete model-generation record was emitted.
+    ///
+    /// The model input, output, tool requests, usage, and timing remain in the
+    /// canonical payload returned by [`SessionEvent::data`].
+    ModelGeneration,
+    /// Any other canonical event, carried through unprojected.
     ///
     /// `event_type` is the stable dot-notation type string (e.g.
-    /// `"reason.started"`); `payload` is the raw event data as JSON. This is the
+    /// `"act.started"`); `payload` is the raw event data as JSON. This is the
     /// forward-compatibility fallback — match it with a wildcard arm.
     Other {
         /// Stable dot-notation event type string.
@@ -119,19 +184,64 @@ pub enum SessionEventKind {
 
 impl SessionEvent {
     /// The stable dot-notation type string for this event (e.g.
-    /// `"turn.started"`), matching the runtime event protocol.
+    /// `"turn.started"`), matching the canonical event protocol.
     pub fn event_type(&self) -> &str {
-        match &self.kind {
-            SessionEventKind::TurnStarted => events::TURN_STARTED,
-            SessionEventKind::TurnCompleted => events::TURN_COMPLETED,
-            SessionEventKind::TurnFailed { .. } => events::TURN_FAILED,
-            SessionEventKind::TurnCancelled => events::TURN_CANCELLED,
-            SessionEventKind::TextDelta { .. } => events::OUTPUT_MESSAGE_DELTA,
-            SessionEventKind::ToolStarted { .. } => events::TOOL_STARTED,
-            SessionEventKind::ToolCompleted { .. } => events::TOOL_COMPLETED,
-            SessionEventKind::ToolProgress { .. } => events::TOOL_PROGRESS,
-            SessionEventKind::Other { event_type, .. } => event_type,
-        }
+        self.raw
+            .get("type")
+            .and_then(Value::as_str)
+            .expect("canonical events always carry a string type")
+    }
+
+    /// Persisted replay sequence within this session.
+    ///
+    /// Durable events return `Some(sequence)` with a monotonically increasing
+    /// per-session position. Ephemeral live-only events such as output deltas
+    /// return `None`. [`EventStream`] preserves live channel arrival order; this
+    /// canonical field must not be treated as a delivery counter.
+    pub fn sequence(&self) -> Option<i32> {
+        self.raw
+            .get("sequence")
+            .and_then(Value::as_i64)
+            .and_then(|value| i32::try_from(value).ok())
+    }
+
+    /// RFC 3339 timestamp from the canonical event envelope.
+    pub fn timestamp(&self) -> &str {
+        self.raw
+            .get("ts")
+            .and_then(Value::as_str)
+            .expect("canonical events always carry a string timestamp")
+    }
+
+    /// The complete canonical event envelope as JSON.
+    ///
+    /// This is the same serialized representation used by Everruns' public
+    /// event protocol. It is the lossless side of the typed/raw bridge: no
+    /// event fields are omitted even when [`kind`](Self::kind) is a compact
+    /// renderer-oriented projection or [`SessionEventKind::Other`].
+    pub fn as_json(&self) -> &Value {
+        &self.raw
+    }
+
+    /// Consume the event and return its complete canonical JSON envelope.
+    pub fn into_json(self) -> Value {
+        self.raw
+    }
+
+    /// The canonical event-specific `data` payload.
+    ///
+    /// Use this when a renderer needs a field not promoted onto
+    /// [`SessionEventKind`], such as tool narration, a completed message's
+    /// structured content, model token usage, or failure classification.
+    pub fn data(&self) -> &Value {
+        self.raw
+            .get("data")
+            .expect("canonical events always carry data")
+    }
+
+    /// Human-readable tool narration, when the event carries it.
+    pub fn narration(&self) -> Option<&str> {
+        self.data().get("narration").and_then(Value::as_str)
     }
 
     /// Project a core [`Event`] into a facade [`SessionEvent`].
@@ -140,27 +250,63 @@ impl SessionEvent {
     /// type is carried through the [`Other`](SessionEventKind::Other) fallback,
     /// so no event is ever dropped.
     fn from_core_event(event: &Event) -> Self {
+        let raw = serde_json::to_value(event).expect("canonical events are JSON serializable");
         let turn_id = event.context.turn_id.map(|id| id.to_string());
         let kind = match event.event_type.as_str() {
+            events::INPUT_MESSAGE => match &event.data {
+                EventData::InputMessage(InputMessageData { message }) => {
+                    SessionEventKind::InputMessage {
+                        message_id: message.id.to_string(),
+                    }
+                }
+                _ => Self::other_kind(event),
+            },
+            events::OUTPUT_MESSAGE_STARTED => match &event.data {
+                EventData::OutputMessageStarted(OutputMessageStartedData {
+                    message_id, ..
+                }) => SessionEventKind::OutputStarted {
+                    message_id: message_id.to_string(),
+                },
+                _ => Self::other_kind(event),
+            },
             events::TURN_STARTED => SessionEventKind::TurnStarted,
             events::TURN_COMPLETED => SessionEventKind::TurnCompleted,
             events::TURN_CANCELLED => SessionEventKind::TurnCancelled,
-            events::TURN_FAILED => {
-                let error = match &event.data {
-                    EventData::TurnFailed(TurnFailedData { error, .. }) => error.clone(),
-                    _ => String::new(),
-                };
-                SessionEventKind::TurnFailed { error }
-            }
-            events::OUTPUT_MESSAGE_DELTA => {
-                let delta = match &event.data {
-                    EventData::OutputMessageDelta(OutputMessageDeltaData { delta, .. }) => {
-                        delta.clone()
+            events::TURN_FAILED => match &event.data {
+                EventData::TurnFailed(TurnFailedData { error, .. }) => {
+                    SessionEventKind::TurnFailed {
+                        error: error.clone(),
                     }
-                    _ => String::new(),
-                };
-                SessionEventKind::TextDelta { delta }
-            }
+                }
+                _ => Self::other_kind(event),
+            },
+            events::OUTPUT_MESSAGE_DELTA => match &event.data {
+                EventData::OutputMessageDelta(OutputMessageDeltaData { delta, .. }) => {
+                    SessionEventKind::TextDelta {
+                        delta: delta.clone(),
+                    }
+                }
+                _ => Self::other_kind(event),
+            },
+            events::OUTPUT_MESSAGE_REPLACED => match &event.data {
+                EventData::OutputMessageReplaced(OutputMessageReplacedData {
+                    message_id,
+                    replacement,
+                    ..
+                }) => SessionEventKind::OutputReplaced {
+                    message_id: message_id.to_string(),
+                    replacement: replacement.clone(),
+                },
+                _ => Self::other_kind(event),
+            },
+            events::OUTPUT_MESSAGE_COMPLETED => match &event.data {
+                EventData::OutputMessageCompleted(OutputMessageCompletedData {
+                    message, ..
+                }) => SessionEventKind::OutputCompleted {
+                    message_id: message.id.to_string(),
+                },
+                _ => Self::other_kind(event),
+            },
             events::TOOL_STARTED => match &event.data {
                 EventData::ToolStarted(ToolStartedData { tool_call, .. }) => {
                     SessionEventKind::ToolStarted {
@@ -196,6 +342,31 @@ impl SessionEvent {
                 },
                 _ => Self::other_kind(event),
             },
+            events::TOOL_OUTPUT_DELTA => match &event.data {
+                EventData::ToolOutputDelta(ToolOutputDeltaData {
+                    tool_call_id,
+                    tool_name,
+                    stream,
+                    delta,
+                }) => SessionEventKind::ToolOutputDelta {
+                    tool_call_id: tool_call_id.clone(),
+                    tool_name: tool_name.clone(),
+                    stream: stream.clone(),
+                    delta: delta.clone(),
+                },
+                _ => Self::other_kind(event),
+            },
+            events::REASON_STARTED => SessionEventKind::ReasonStarted,
+            events::REASON_COMPLETED => match &event.data {
+                EventData::ReasonCompleted(ReasonCompletedData { success, error, .. }) => {
+                    SessionEventKind::ReasonCompleted {
+                        success: *success,
+                        error: error.clone(),
+                    }
+                }
+                _ => Self::other_kind(event),
+            },
+            events::LLM_GENERATION => SessionEventKind::ModelGeneration,
             _ => Self::other_kind(event),
         };
         Self {
@@ -203,13 +374,15 @@ impl SessionEvent {
             session_id: event.session_id.to_string(),
             turn_id,
             kind,
+            raw,
         }
     }
 
     fn other_kind(event: &Event) -> SessionEventKind {
         SessionEventKind::Other {
             event_type: event.event_type.clone(),
-            payload: serde_json::to_value(&event.data).unwrap_or(Value::Null),
+            payload: serde_json::to_value(&event.data)
+                .expect("canonical event data is JSON serializable"),
         }
     }
 }
@@ -217,12 +390,39 @@ impl SessionEvent {
 /// A live feed of [`SessionEvent`]s for one [`Session`](crate::Session).
 ///
 /// Obtain one from [`Session::events`](crate::Session::events) before running a
-/// turn. Consume it with [`recv`](Self::recv) in a loop. Backed by a broadcast
-/// channel: dropping the stream never affects a running turn, and a consumer
-/// that falls behind skips old events rather than blocking the runner.
+/// turn. Consume it with [`recv`](Self::recv) in a loop. Backed by a bounded
+/// broadcast channel: dropping the stream never affects a running turn, and a
+/// consumer that falls behind receives [`EventStreamError::Lagged`] rather than
+/// blocking the runner or silently losing events.
 pub struct EventStream {
     rx: broadcast::Receiver<SessionEvent>,
 }
+
+/// Why an [`EventStream`] could not deliver the next event losslessly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EventStreamError {
+    /// The consumer fell behind the bounded stream buffer.
+    ///
+    /// The next call can continue from the oldest retained event, but the
+    /// consumer must treat its live projection as incomplete. Durable terminal
+    /// events remain authoritative, and services that require replay should use
+    /// a durable event transport rather than this in-process live stream.
+    Lagged {
+        /// Number of events evicted before this consumer could read them.
+        missed: u64,
+    },
+}
+
+impl std::fmt::Display for EventStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Lagged { missed } => write!(f, "event stream lagged by {missed} events"),
+        }
+    }
+}
+
+impl std::error::Error for EventStreamError {}
 
 impl EventStream {
     fn new(rx: broadcast::Receiver<SessionEvent>) -> Self {
@@ -231,32 +431,32 @@ impl EventStream {
 
     /// Await the next event.
     ///
-    /// Returns `None` once the session is dropped and no further events can
-    /// arrive. If the consumer fell behind and the channel dropped events, those
-    /// events are skipped silently and the next available event is returned.
-    pub async fn recv(&mut self) -> Option<SessionEvent> {
-        loop {
-            match self.rx.recv().await {
-                Ok(event) => return Some(event),
-                // The consumer lagged; skip the dropped events and keep reading.
-                Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(broadcast::error::RecvError::Closed) => return None,
+    /// Returns `Ok(None)` once the session is dropped and no further events can
+    /// arrive. Returns [`EventStreamError::Lagged`] if the consumer fell behind
+    /// and events were evicted from the bounded buffer; no loss is hidden.
+    pub async fn recv(&mut self) -> Result<Option<SessionEvent>, EventStreamError> {
+        match self.rx.recv().await {
+            Ok(event) => Ok(Some(event)),
+            Err(broadcast::error::RecvError::Lagged(missed)) => {
+                Err(EventStreamError::Lagged { missed })
             }
+            Err(broadcast::error::RecvError::Closed) => Ok(None),
         }
     }
 
     /// Return the next already-available event without waiting.
     ///
-    /// Returns `None` when no event is currently buffered (or the session has
-    /// ended). Skips past a lagged gap the same way [`recv`](Self::recv) does.
-    pub fn try_recv(&mut self) -> Option<SessionEvent> {
-        loop {
-            match self.rx.try_recv() {
-                Ok(event) => return Some(event),
-                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
-                Err(broadcast::error::TryRecvError::Empty)
-                | Err(broadcast::error::TryRecvError::Closed) => return None,
+    /// Returns `Ok(None)` when no event is currently buffered (or the session
+    /// has ended). Returns [`EventStreamError::Lagged`] rather than hiding a
+    /// gap.
+    pub fn try_recv(&mut self) -> Result<Option<SessionEvent>, EventStreamError> {
+        match self.rx.try_recv() {
+            Ok(event) => Ok(Some(event)),
+            Err(broadcast::error::TryRecvError::Lagged(missed)) => {
+                Err(EventStreamError::Lagged { missed })
             }
+            Err(broadcast::error::TryRecvError::Empty)
+            | Err(broadcast::error::TryRecvError::Closed) => Ok(None),
         }
     }
 }
@@ -326,27 +526,495 @@ impl CancellationToken {
 /// observer can never stall or fail a turn.
 pub(crate) struct FacadeEventBus {
     sender: broadcast::Sender<SessionEvent>,
+    active_turn: Mutex<Option<EventContext>>,
 }
 
 impl FacadeEventBus {
     pub(crate) fn new() -> Self {
-        let (sender, _rx) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
-        Self { sender }
+        Self::with_capacity(EVENT_STREAM_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        let (sender, _rx) = broadcast::channel(capacity);
+        Self {
+            sender,
+            active_turn: Mutex::new(None),
+        }
     }
 
     /// Subscribe a new [`EventStream`] to this bus.
     pub(crate) fn subscribe(&self) -> EventStream {
         EventStream::new(self.sender.subscribe())
     }
+
+    /// Build a correlated terminal request after the facade drops a cancelled
+    /// turn future. The host emitter commits it before live delivery.
+    pub(crate) fn cancellation_request(&self, session_id: SessionId) -> (TurnId, EventRequest) {
+        let context = self
+            .active_turn
+            .lock()
+            .expect("active-turn lock poisoned")
+            .take()
+            .unwrap_or_else(|| EventContext {
+                turn_id: Some(TurnId::new()),
+                ..EventContext::default()
+            });
+        let turn_id = context.turn_id.unwrap_or_default();
+        let request = EventRequest::new(
+            session_id,
+            EventContext {
+                turn_id: Some(turn_id),
+                ..context
+            },
+            TurnCancelledData {
+                turn_id,
+                reason: Some("cancelled by application".to_string()),
+                usage: None,
+            },
+        );
+        (turn_id, request)
+    }
+
+    fn observe(&self, event: &Event) -> Result<(), EventSinkError> {
+        match event.event_type.as_str() {
+            events::TURN_STARTED => {
+                *self.active_turn.lock().expect("active-turn lock poisoned") =
+                    Some(event.context.clone());
+            }
+            events::TURN_COMPLETED
+            | events::TURN_FAILED
+            | events::TURN_CANCELLED
+            | events::TURN_SEALED => {
+                self.active_turn
+                    .lock()
+                    .expect("active-turn lock poisoned")
+                    .take();
+            }
+            _ => {}
+        }
+        // A broadcast sender with no current receiver is still open: callers
+        // can subscribe before the next turn. Observation is best-effort and
+        // absence is equivalent to the host's no-op sink, not a delivery
+        // failure worth counting on every canonical append.
+        let _ = self.sender.send(SessionEvent::from_core_event(event));
+        Ok(())
+    }
 }
 
 impl EventSink for FacadeEventBus {
     fn try_send(&self, event: Event) -> Result<(), EventSinkError> {
-        // Ignore the send result: an error means there are simply no live
-        // subscribers, which must not affect the turn.
-        self.sender
-            .send(SessionEvent::from_core_event(&event))
-            .map(|_| ())
-            .map_err(|_| EventSinkError::Closed)
+        self.observe(&event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use everruns_core::events::{
+        ActStartedData, OutputMessageDeltaData, OutputMessageReplacedData, ToolStartedData,
+        TurnCancelledData, TurnStartedData,
+    };
+    use everruns_core::traits::EventEmitter;
+    use everruns_core::{MessageId, SessionId, ToolCall, TurnId};
+    use everruns_host::{HostEventEmitter, InMemoryEventLog};
+    use serde_json::json;
+
+    use super::{EventStreamError, FacadeEventBus, SessionEventKind};
+    use crate::{Agent, Model};
+
+    fn host(bus: Arc<FacadeEventBus>) -> HostEventEmitter {
+        HostEventEmitter::new(Arc::new(InMemoryEventLog::new()), bus)
+    }
+
+    fn turn_started(session_id: SessionId, turn_id: TurnId) -> everruns_core::EventRequest {
+        let input_message_id = MessageId::new();
+        everruns_core::EventRequest::new(
+            session_id,
+            everruns_core::EventContext::turn(turn_id, input_message_id),
+            TurnStartedData {
+                turn_id,
+                input_message_id,
+                input_content: Some("hello".to_string()),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn public_event_json_is_the_exact_canonical_envelope() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+
+        let request = turn_started(session_id, turn_id)
+            .with_metadata(json!({"provider": "simulated"}))
+            .with_tags(vec!["terminal".to_string()]);
+        let canonical = emitter.emit(request).await.expect("event emits");
+        let observed = stream
+            .recv()
+            .await
+            .expect("stream remains lossless")
+            .expect("event is delivered");
+
+        assert!(matches!(observed.kind, SessionEventKind::TurnStarted));
+        assert_eq!(
+            observed.as_json(),
+            &serde_json::to_value(canonical).expect("canonical event serializes")
+        );
+        assert_eq!(observed.event_type(), "turn.started");
+        assert_eq!(
+            observed.turn_id.as_deref(),
+            Some(turn_id.to_string().as_str())
+        );
+        assert_eq!(observed.as_json()["sequence"], 1);
+        assert_eq!(observed.sequence(), Some(1));
+        assert!(!observed.timestamp().is_empty());
+        assert_eq!(observed.data()["input_content"], "hello");
+        assert_eq!(observed.as_json()["metadata"]["provider"], "simulated");
+        assert_eq!(observed.as_json()["tags"], json!(["terminal"]));
+    }
+
+    #[tokio::test]
+    async fn bounded_stream_reports_lag_instead_of_hiding_loss() {
+        let session_id = SessionId::new();
+        let bus = Arc::new(FacadeEventBus::with_capacity(2));
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+
+        for _ in 0..3 {
+            emitter
+                .emit(turn_started(session_id, TurnId::new()))
+                .await
+                .expect("event emits without observer backpressure");
+        }
+
+        assert!(matches!(
+            stream.recv().await,
+            Err(EventStreamError::Lagged { missed: 1 })
+        ));
+        assert!(stream.recv().await.expect("gap reported").is_some());
+    }
+
+    #[tokio::test]
+    async fn no_subscriber_is_a_noop_not_a_closed_sink_failure() {
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus);
+
+        emitter
+            .emit(turn_started(SessionId::new(), TurnId::new()))
+            .await
+            .expect("observation absence cannot reverse the append");
+
+        assert_eq!(emitter.delivery_stats().closed, 0);
+    }
+
+    #[tokio::test]
+    async fn live_arrival_interleaves_durable_and_sequence_less_ephemeral_events() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let message_id = MessageId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+
+        emitter
+            .emit(turn_started(session_id, turn_id))
+            .await
+            .unwrap();
+        emitter
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::EventContext::turn(turn_id, message_id),
+                OutputMessageDeltaData {
+                    turn_id,
+                    message_id,
+                    delta: "hi".to_string(),
+                    accumulated: "hi".to_string(),
+                    phase: None,
+                },
+            ))
+            .await
+            .unwrap();
+        emitter
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::EventContext::turn(turn_id, message_id),
+                TurnCancelledData {
+                    turn_id,
+                    reason: Some("test".to_string()),
+                    usage: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        let started = stream.recv().await.unwrap().unwrap();
+        let delta = stream.recv().await.unwrap().unwrap();
+        let cancelled = stream.recv().await.unwrap().unwrap();
+
+        assert_eq!(started.event_type(), "turn.started");
+        assert_eq!(delta.event_type(), "output.message.delta");
+        assert_eq!(cancelled.event_type(), "turn.cancelled");
+        assert_eq!(started.sequence(), Some(1));
+        assert_eq!(delta.sequence(), None);
+        assert!(delta.as_json().get("sequence").is_none());
+        assert_eq!(cancelled.sequence(), Some(2));
+    }
+
+    #[tokio::test]
+    async fn cancellation_uses_the_active_turn_and_canonical_sequence() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+        emitter
+            .emit(turn_started(session_id, turn_id))
+            .await
+            .expect("turn starts");
+
+        let (cancelled_turn_id, request) = bus.cancellation_request(session_id);
+        emitter.emit(request).await.expect("cancellation commits");
+        assert_eq!(cancelled_turn_id, turn_id);
+
+        let started = stream.recv().await.expect("no lag").expect("start event");
+        let cancelled = stream.recv().await.expect("no lag").expect("cancel event");
+        assert!(matches!(started.kind, SessionEventKind::TurnStarted));
+        assert!(matches!(cancelled.kind, SessionEventKind::TurnCancelled));
+        assert_eq!(
+            cancelled.turn_id.as_deref(),
+            Some(turn_id.to_string().as_str())
+        );
+        assert_eq!(cancelled.as_json()["sequence"], 2);
+        assert_eq!(
+            cancelled.data(),
+            &serde_json::to_value(TurnCancelledData {
+                turn_id,
+                reason: Some("cancelled by application".to_string()),
+                usage: None,
+            })
+            .expect("cancel data serializes")
+        );
+    }
+
+    #[tokio::test]
+    async fn output_replacement_retains_rebuildable_message_identity_and_text() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let message_id = MessageId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+        emitter
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::EventContext {
+                    turn_id: Some(turn_id),
+                    ..everruns_core::EventContext::default()
+                },
+                OutputMessageReplacedData {
+                    turn_id,
+                    message_id,
+                    guardrail_capability_id: "guardrails".to_string(),
+                    guardrail_id: "output-policy".to_string(),
+                    reason_code: "blocked".to_string(),
+                    replacement: "Response withheld.".to_string(),
+                },
+            ))
+            .await
+            .expect("replacement emits");
+
+        let replacement = stream
+            .recv()
+            .await
+            .expect("no lag")
+            .expect("replacement delivered");
+        assert!(matches!(
+            &replacement.kind,
+            SessionEventKind::OutputReplaced {
+                message_id: observed_id,
+                replacement,
+            } if observed_id == &message_id.to_string() && replacement == "Response withheld."
+        ));
+        assert_eq!(replacement.data()["message_id"], message_id.to_string());
+        assert_eq!(replacement.data()["replacement"], "Response withheld.");
+    }
+
+    #[tokio::test]
+    async fn tool_narration_is_preserved_for_renderers() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+
+        emitter
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::EventContext {
+                    turn_id: Some(turn_id),
+                    ..everruns_core::EventContext::default()
+                },
+                ToolStartedData {
+                    tool_call: ToolCall {
+                        id: "call_1".to_string(),
+                        name: "lookup".to_string(),
+                        arguments: json!({"key": "answer"}),
+                    },
+                    tool_call_fingerprint: None,
+                    display_name: Some("Knowledge lookup".to_string()),
+                    narration: Some("Looking up the answer".to_string()),
+                },
+            ))
+            .await
+            .expect("tool start emits");
+
+        let observed = stream.recv().await.unwrap().unwrap();
+        assert_eq!(observed.narration(), Some("Looking up the answer"));
+        assert_eq!(observed.data()["display_name"], "Knowledge lookup");
+    }
+
+    #[tokio::test]
+    async fn unpromoted_event_kind_retains_its_complete_canonical_payload() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+        let mut stream = bus.subscribe();
+        let canonical = emitter
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::EventContext {
+                    turn_id: Some(turn_id),
+                    ..everruns_core::EventContext::default()
+                },
+                ActStartedData {
+                    tool_calls: Vec::new(),
+                    headline: Some("running tools".to_string()),
+                },
+            ))
+            .await
+            .expect("event emits");
+
+        let observed = stream.recv().await.unwrap().unwrap();
+        assert!(matches!(
+            &observed.kind,
+            SessionEventKind::Other { event_type, payload }
+                if event_type == "act.started" && payload["headline"] == "running tools"
+        ));
+        assert_eq!(
+            observed.as_json(),
+            &serde_json::to_value(canonical).expect("canonical event serializes")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_failure_retains_reason_and_turn_terminal_payloads() {
+        let agent = Agent::builder()
+            .instructions("Answer concisely.")
+            .model(Model::simulated_error("provider unavailable"))
+            .build()
+            .expect("valid agent");
+        let mut session = agent.session();
+        let mut stream = session.events();
+        let result = session
+            .run("hello")
+            .await
+            .expect("provider failure resolves to a failed turn");
+        assert!(!result.success);
+        drop(session);
+
+        let mut observed = Vec::new();
+        while let Some(event) = stream.recv().await.expect("failure stream does not lag") {
+            observed.push(event);
+        }
+
+        let reason_failure = observed
+            .iter()
+            .find(|event| {
+                matches!(
+                    event.kind,
+                    SessionEventKind::ReasonCompleted { success: false, .. }
+                )
+            })
+            .expect("reason.completed preserves the provider failure");
+        assert!(
+            reason_failure.data()["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("provider unavailable"))
+        );
+
+        let turn_failure = observed
+            .iter()
+            .find(|event| matches!(event.kind, SessionEventKind::TurnFailed { .. }))
+            .expect("turn.failed is the terminal event");
+        assert_eq!(turn_failure.event_type(), "turn.failed");
+        assert_eq!(
+            turn_failure.turn_id.as_deref(),
+            Some(result.turn_id.as_str())
+        );
+        assert!(turn_failure.data()["error"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn tool_lifecycle_retains_arguments_result_and_order() {
+        let tool = crate::FunctionTool::new(
+            "lookup",
+            "Look up a value.",
+            json!({
+                "type": "object",
+                "properties": { "key": { "type": "string" } },
+                "required": ["key"]
+            }),
+            |arguments: serde_json::Value| async move {
+                Ok::<_, String>(json!({ "value": arguments["key"] }))
+            },
+        );
+        let agent = Agent::builder()
+            .instructions("Use the lookup tool.")
+            .model(Model::simulated_scripted(
+                "done",
+                vec![
+                    vec![ToolCall {
+                        id: "call_lookup_1".to_string(),
+                        name: "lookup".to_string(),
+                        arguments: json!({ "key": "answer" }),
+                    }],
+                    vec![],
+                ],
+            ))
+            .tool(tool)
+            .build()
+            .expect("valid agent");
+        let mut session = agent.session();
+        let mut stream = session.events();
+        let result = session.run("look it up").await.expect("tool turn runs");
+        assert!(result.success);
+        drop(session);
+
+        let mut observed = Vec::new();
+        while let Some(event) = stream.recv().await.expect("tool stream does not lag") {
+            observed.push(event);
+        }
+        let started = observed
+            .iter()
+            .find(|event| matches!(event.kind, SessionEventKind::ToolStarted { .. }))
+            .expect("tool.started");
+        let completed = observed
+            .iter()
+            .find(|event| matches!(event.kind, SessionEventKind::ToolCompleted { .. }))
+            .expect("tool.completed");
+
+        assert!(
+            started.sequence().expect("tool start is durable")
+                < completed.sequence().expect("tool completion is durable")
+        );
+        assert_eq!(started.data()["tool_call"]["id"], "call_lookup_1");
+        assert_eq!(started.data()["tool_call"]["arguments"]["key"], "answer");
+        assert_eq!(completed.data()["tool_call_id"], "call_lookup_1");
+        assert_eq!(completed.data()["status"], "success");
+        assert!(completed.data()["result"].is_array());
     }
 }

--- a/crates/everruns/src/hooks.rs
+++ b/crates/everruns/src/hooks.rs
@@ -588,7 +588,7 @@ mod tests {
             .run_completion(CompletionContext {
                 agent_name: "agent".into(),
                 session_id: crate::SessionId::new(),
-                turn: crate::Turn::cancelled(),
+                turn: crate::Turn::cancelled(everruns_core::typed_id::TurnId::new()),
             })
             .await;
 

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -54,7 +54,10 @@ pub mod work;
 pub use agent::{Agent, AgentBuilder, BuildError, Model};
 pub use compaction::{CompactionConfig, CompactionStrategy};
 pub use context::{ContextMessage, SessionContext, ToolInfo};
-pub use events::{CancellationToken, EventStream, RunOptions, SessionEvent, SessionEventKind};
+pub use events::{
+    CancellationToken, EVENT_STREAM_CAPACITY, EventStream, EventStreamError, RunOptions,
+    SessionEvent, SessionEventKind,
+};
 pub use history::{
     HistoryCursor, HistoryCursorParseError, HistoryError, HistoryPage, HistoryPages, HistoryQuery,
     ResumeError, SessionMessage,
@@ -180,13 +183,13 @@ pub mod prelude {
     };
     pub use crate::{
         Agent, AgentBuilder, AgentStartContext, BuildError, CancellationToken, CompactionConfig,
-        CompactionStrategy, CompletionContext, EventStream, FunctionTool, HistoryCursor,
-        HistoryCursorParseError, HistoryError, HistoryPage, HistoryPages, HistoryQuery,
-        HookFailure, HookPoint, InitialFile, IntoHookResult, IntoTool, IntoToolResult, McpServer,
-        Model, PluginError, ResumeError, RunError, RunOptions, Session, SessionContext,
-        SessionEvent, SessionEventKind, SessionId, SessionMessage, Tool, ToolEndContext, ToolInfo,
-        ToolResponse, ToolStartContext, Turn, TurnStartContext, WorkspacePolicy,
-        WorkspacePolicyBuilder, WorkspacePolicyError,
+        CompactionStrategy, CompletionContext, EventStream, EventStreamError, FunctionTool,
+        HistoryCursor, HistoryCursorParseError, HistoryError, HistoryPage, HistoryPages,
+        HistoryQuery, HookFailure, HookPoint, InitialFile, IntoHookResult, IntoTool,
+        IntoToolResult, McpServer, Model, PluginError, ResumeError, RunError, RunOptions, Session,
+        SessionContext, SessionEvent, SessionEventKind, SessionId, SessionMessage, Tool,
+        ToolEndContext, ToolInfo, ToolResponse, ToolStartContext, Turn, TurnStartContext,
+        WorkspacePolicy, WorkspacePolicyBuilder, WorkspacePolicyError,
     };
     #[cfg(feature = "openai")]
     pub use crate::{ModelError, OpenAI};

--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -9,6 +9,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use everruns_core::traits::EventEmitter;
 use everruns_core::turn::TurnStopReason;
 use everruns_core::typed_id::TurnId;
 use everruns_core::{AgentLoopError, InputMessage, SessionId};
@@ -123,7 +124,15 @@ impl Session {
     /// created (subscribe before calling [`run`](Session::run)). Multiple streams
     /// can observe the same session independently, and each session's events are
     /// isolated — one session never sees another's. Dropping a stream, or letting
-    /// a consumer fall behind, never affects a running turn.
+    /// a consumer fall behind, never affects a running turn. The stream is
+    /// bounded and reports an explicit [`EventStreamError::Lagged`](crate::EventStreamError::Lagged)
+    /// gap; it never hides loss or applies observer backpressure to execution.
+    /// Each [`SessionEvent`](crate::SessionEvent) also retains the complete
+    /// canonical event envelope through
+    /// [`SessionEvent::as_json`](crate::SessionEvent::as_json).
+    /// Use [`history`](Session::history) to rebuild a bounded persisted
+    /// transcript after live lag or a process restart; ephemeral streaming
+    /// deltas are intentionally not part of that projection.
     ///
     /// Events are non-blocking observation. For application work that must be
     /// awaited at a lifecycle boundary, register an
@@ -185,7 +194,7 @@ impl Session {
             )
             .await
             {
-                HookRun::Cancelled => return Ok(Turn::cancelled()),
+                HookRun::Cancelled => return self.emit_cancelled().await,
                 HookRun::Completed(Err(failure)) => return Err(RunError::Hook(failure)),
                 HookRun::Completed(Ok(())) => self.agent_started = true,
             }
@@ -202,7 +211,7 @@ impl Session {
         )
         .await
         {
-            HookRun::Cancelled => return Ok(Turn::cancelled()),
+            HookRun::Cancelled => return self.emit_cancelled().await,
             HookRun::Completed(Err(failure)) => return Err(RunError::Hook(failure)),
             HookRun::Completed(Ok(())) => {}
         }
@@ -216,18 +225,22 @@ impl Session {
                 Turn::from(result)
             }
             Some(token) => {
-                // Race the turn against cancellation. `biased` checks the token
-                // first, so a pre-cancelled token stops the turn before it runs.
-                // On cancellation the turn future is dropped, which is the
-                // runtime's own cooperative teardown path — no second stop
-                // mechanism is introduced.
+                if token.is_cancelled() {
+                    return self.emit_cancelled().await;
+                }
+
+                // Race the turn against cancellation. A completed result wins
+                // when both branches become ready together, preventing a
+                // synthetic cancellation after a committed terminal event. On
+                // cancellation the turn future is dropped, which is the
+                // runtime's own cooperative teardown path.
                 tokio::select! {
                     biased;
+                    result = runtime.run_turn(self.session_id, input) => Turn::from(result?),
                     () = token.cancelled() => {
                         self.hook_state.take_failures();
-                        return Ok(Turn::cancelled());
+                        return self.emit_cancelled().await;
                     },
-                    result = runtime.run_turn(self.session_id, input) => Turn::from(result?),
                 }
             }
         };
@@ -279,6 +292,14 @@ impl Session {
             );
         }
         Ok(())
+    }
+
+    async fn emit_cancelled(&mut self) -> Result<Turn, RunError> {
+        self.ensure_runtime().await?;
+        let runtime = self.runtime.as_ref().expect("runtime built above");
+        let (turn_id, request) = self.event_bus.cancellation_request(self.session_id);
+        runtime.host_event_emitter().emit(request).await?;
+        Ok(Turn::cancelled(turn_id))
     }
 }
 
@@ -339,12 +360,12 @@ impl Turn {
     /// Synthesized by [`Session::run_with`] when a turn is cancelled in flight:
     /// its future is dropped before the runtime can report an outcome, so the
     /// facade maps that to a non-success turn carrying
-    /// [`TurnStopReason::Cancelled`]. The `turn_id` is a fresh correlation id —
-    /// the dropped turn's own id is not recoverable.
-    pub(crate) fn cancelled() -> Self {
+    /// [`TurnStopReason::Cancelled`]. `turn_id` is shared with the durable
+    /// cancellation event emitted after the run future is dropped.
+    pub(crate) fn cancelled(turn_id: TurnId) -> Self {
         Self {
             response: String::new(),
-            turn_id: TurnId::new().to_string(),
+            turn_id: turn_id.to_string(),
             stop_reason: TurnStopReason::Cancelled,
             iterations: 0,
             tool_calls: 0,
@@ -408,9 +429,13 @@ impl From<AgentLoopError> for RunError {
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use everruns_core::events::EventData;
     use everruns_core::turn::TurnStopReason;
     use everruns_core::{ContentPart, InputMessage, MessageRole, TurnId};
-    use everruns_host::TurnResult;
+    use everruns_host::{
+        EventHistory, EventHistoryReadLimit, EventHistoryReadRequest, EventReadLimit,
+        EventReadRequest, TurnResult,
+    };
 
     use super::Turn;
     use crate::{Agent, Model};
@@ -434,6 +459,57 @@ mod tests {
             calls[1].len() > calls[0].len(),
             "the second turn's request must include the first turn's messages"
         );
+    }
+
+    #[tokio::test]
+    async fn normal_session_history_is_rebuilt_from_canonical_events() {
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .model(Model::simulated("ok"))
+            .build()
+            .expect("valid agent");
+        let mut session = agent.session();
+        let session_id = session.session_id();
+
+        session.run("hello").await.expect("turn runs");
+
+        let runtime = session.runtime.as_ref().expect("run built the runtime");
+        let event_log = runtime.event_log();
+        let events = event_log
+            .read_page(EventReadRequest::new(session_id, EventReadLimit::default()))
+            .await
+            .expect("canonical events replay");
+        assert!(
+            events.events.iter().all(|event| event.sequence.is_some()),
+            "durable replay excludes sequence-less live deltas"
+        );
+
+        let canonical_messages: Vec<_> = events
+            .events
+            .iter()
+            .filter_map(|event| match &event.data {
+                EventData::InputMessage(data) => Some(data.message.clone()),
+                EventData::OutputMessageCompleted(data) => Some(data.message.clone()),
+                _ => None,
+            })
+            .collect();
+        let history = EventHistory::new(event_log);
+        let page = history
+            .read_page(EventHistoryReadRequest::new(
+                session_id,
+                EventHistoryReadLimit::new(8).expect("valid message limit"),
+            ))
+            .await
+            .expect("event-derived history page");
+
+        assert_eq!(
+            serde_json::to_value(&page.messages).expect("history serializes"),
+            serde_json::to_value(&canonical_messages).expect("events serialize")
+        );
+        assert_eq!(page.messages.len(), 2);
+        assert_eq!(page.messages[0].text(), Some("hello"));
+        assert_eq!(page.messages[1].text(), Some("ok"));
+        assert!(page.next_cursor.is_none());
     }
 
     #[tokio::test]
@@ -523,7 +599,7 @@ mod tests {
 
     async fn drain(mut stream: crate::EventStream) -> Vec<SessionEvent> {
         let mut events = Vec::new();
-        while let Some(event) = stream.recv().await {
+        while let Some(event) = stream.recv().await.expect("event stream stays lossless") {
             events.push(event);
         }
         events

--- a/crates/everruns/tests/session_events.rs
+++ b/crates/everruns/tests/session_events.rs
@@ -11,7 +11,7 @@ use everruns::prelude::*;
 /// Collect every event from a stream until it closes (the session is dropped).
 async fn drain(mut stream: EventStream) -> Vec<SessionEvent> {
     let mut events = Vec::new();
-    while let Some(event) = stream.recv().await {
+    while let Some(event) = stream.recv().await.expect("event stream stays lossless") {
         events.push(event);
     }
     events
@@ -44,10 +44,20 @@ async fn stream_emits_ordered_start_delta_completion() {
         .expect("at least one text delta");
     let completed = position(|e| matches!(e.kind, SessionEventKind::TurnCompleted))
         .expect("a turn.completed event");
+    let output_started = position(|e| matches!(e.kind, SessionEventKind::OutputStarted { .. }))
+        .expect("an output.message.started event");
+    let output_completed = position(|e| matches!(e.kind, SessionEventKind::OutputCompleted { .. }))
+        .expect("an output.message.completed event");
+    let model_generation = position(|e| matches!(e.kind, SessionEventKind::ModelGeneration))
+        .expect("an llm.generation event");
 
     assert!(
-        started < delta && delta < completed,
-        "expected ordered start < delta < completion, got indices {started}/{delta}/{completed}"
+        started < output_started
+            && output_started < delta
+            && delta < output_completed
+            && model_generation < output_completed
+            && output_completed < completed,
+        "expected ordered turn start < output start < delta < output completion < turn completion"
     );
 
     // The concatenated deltas reconstruct the assistant's response.
@@ -59,6 +69,70 @@ async fn stream_emits_ordered_start_delta_completion() {
         })
         .collect();
     assert_eq!(streamed, "Hello, world!");
+
+    // The raw side of the bridge is the complete canonical event protocol, not
+    // a second facade vocabulary. Durable replay sequence is optional because
+    // live-only deltas are ephemeral; channel arrival order is the live ordering
+    // contract. Every envelope retains timestamp, context, data, metadata, and
+    // tags semantics.
+    let sequences: Vec<i64> = events
+        .iter()
+        .filter_map(|event| {
+            let raw = event.as_json();
+            assert!(raw["id"].as_str().is_some());
+            assert_eq!(raw["type"], event.event_type());
+            assert!(raw["ts"].as_str().is_some());
+            assert!(raw["session_id"].as_str().is_some());
+            assert!(raw["context"].is_object());
+            assert!(raw.get("data").is_some());
+            let raw_sequence = raw.get("sequence").and_then(serde_json::Value::as_i64);
+            assert_eq!(raw_sequence.map(|value| value as i32), event.sequence());
+            raw_sequence
+        })
+        .collect();
+    assert!(
+        sequences.windows(2).all(|pair| pair[0] < pair[1]),
+        "durable events retain strictly increasing replay positions"
+    );
+    assert!(
+        events
+            .iter()
+            .filter(|event| matches!(event.kind, SessionEventKind::TextDelta { .. }))
+            .all(|event| event.sequence().is_none()),
+        "ephemeral deltas are ordered by live arrival, not replay sequence"
+    );
+
+    let output_message_ids: Vec<&str> = events
+        .iter()
+        .filter_map(|event| match &event.kind {
+            SessionEventKind::OutputStarted { message_id }
+            | SessionEventKind::OutputCompleted { message_id } => Some(message_id.as_str()),
+            SessionEventKind::TextDelta { .. } => event.data()["message_id"].as_str(),
+            _ => None,
+        })
+        .collect();
+    assert!(!output_message_ids.is_empty());
+    assert!(
+        output_message_ids.windows(2).all(|pair| pair[0] == pair[1]),
+        "one assistant message id spans start, deltas, and completion"
+    );
+
+    // Conversation history is rebuildable from canonical message events. The
+    // facade adds no second writable message representation.
+    let input = events
+        .iter()
+        .find(|event| event.event_type() == "input.message")
+        .expect("canonical input message");
+    let output = events
+        .iter()
+        .find(|event| event.event_type() == "output.message.completed")
+        .expect("canonical assistant message");
+    assert!(matches!(input.kind, SessionEventKind::InputMessage { .. }));
+    assert_eq!(input.data()["message"]["role"], "user");
+    assert!(input.data()["message"]["content"].is_array());
+    assert_eq!(output.data()["message"]["role"], "agent");
+    assert!(output.data()["message"]["content"].is_array());
+    assert!(input.sequence().unwrap() < output.sequence().unwrap());
 
     // Correlation ids are preserved: turn-scoped events share one turn id, and
     // every event carries the same session id.
@@ -93,6 +167,7 @@ async fn pre_cancelled_token_yields_cancelled_stop_reason() {
         .expect("valid agent");
 
     let mut session = agent.session();
+    let stream = session.events();
     let token = CancellationToken::new();
     token.cancel();
     assert!(token.is_cancelled());
@@ -104,6 +179,16 @@ async fn pre_cancelled_token_yields_cancelled_stop_reason() {
         .expect("run_with resolves");
     assert!(!turn.success, "a cancelled turn is not a success");
     assert_eq!(turn.stop_reason, TurnStopReason::Cancelled);
+
+    drop(session);
+    let events = drain(stream).await;
+    let cancelled = events
+        .iter()
+        .find(|event| matches!(event.kind, SessionEventKind::TurnCancelled))
+        .expect("cancellation emits its canonical terminal event");
+    assert_eq!(cancelled.turn_id.as_deref(), Some(turn.turn_id.as_str()));
+    assert_eq!(cancelled.data()["reason"], "cancelled by application");
+    assert!(cancelled.sequence().is_some(), "cancellation is durable");
 }
 
 #[tokio::test]

--- a/docs/framework/canonical-events.md
+++ b/docs/framework/canonical-events.md
@@ -1,0 +1,154 @@
+---
+title: Canonical Framework events
+description: Observe a complete agent turn through a lossless typed/raw bridge while keeping durability, live delivery, and derived history distinct.
+sidebar:
+  order: 2
+---
+
+`Session::events()` installs an in-process subscriber without exposing runtime
+event buses or core event types. Subscribe before `Session::run()` so the stream
+sees the turn from its first event.
+
+```rust
+use everruns::prelude::*;
+
+let agent = Agent::builder()
+    .instructions("Answer concisely.")
+    .model(Model::simulated("Hello!"))
+    .build()?;
+let mut session = agent.session();
+let mut events = session.events();
+
+let observer = tokio::spawn(async move {
+    let mut canonical_events = Vec::new();
+    while let Some(event) = events.recv().await? {
+        // Lossless recording: the complete public event envelope.
+        canonical_events.push(event.as_json().clone());
+
+        // Typed rendering for common terminal/service UI concerns.
+        match event.kind {
+            SessionEventKind::TextDelta { delta } => print!("{delta}"),
+            SessionEventKind::ToolStarted { tool_name, .. } => {
+                eprintln!("starting {tool_name}");
+            }
+            SessionEventKind::ToolCompleted {
+                tool_name,
+                success,
+                ..
+            } => eprintln!("{tool_name}: {success}"),
+            SessionEventKind::TurnFailed { error } => eprintln!("failed: {error}"),
+            SessionEventKind::TurnCancelled => eprintln!("cancelled"),
+            _ => {}
+        }
+    }
+    Ok::<_, EventStreamError>(canonical_events)
+});
+
+let turn = session.run("hello").await?;
+drop(session); // closes the subscriber once buffered events are drained
+let recorded = observer.await??;
+assert!(!recorded.is_empty());
+```
+
+## One protocol, two views
+
+`SessionEventKind` is a convenience projection for application renderers. It
+promotes assistant output lifecycle and deltas, model reasoning/generation,
+tool lifecycle/progress/output, and turn terminal states. It is non-exhaustive,
+so match it with a fallback arm.
+
+`SessionEvent::as_json()` is the lossless side of the bridge. It returns the
+same canonical envelope used by the public Everruns event protocol, including
+the event id and type, timestamp, optional persisted sequence, correlation
+context, full typed payload, metadata, and tags. `SessionEvent::data()` accesses
+its complete payload directly. Use it for details intentionally not duplicated
+into the convenience projection, such as:
+
+- tool arguments, results, status, narration, and duration;
+- complete structured assistant messages, phases, model metadata, and usage;
+- stable failure codes and localization fields;
+- newly added event types unknown to this version of the Framework.
+
+This bridge does not define a second wire schema. The canonical event contract,
+compatibility rules, and lifecycle semantics remain documented in
+[Events](/explanation/events/).
+
+## Durability, observation, and derived history
+
+These roles are deliberately separate:
+
+- `EventLog` is the host's sole durable conversation write authority. It stores
+  complete canonical event envelopes and provides bounded cursor replay.
+- `EventSink` is the host's post-commit, nonblocking live-delivery seam.
+  `Session::events()` exposes that observation path as an ergonomic
+  `EventStream` subscriber. Neither sink nor subscriber is durable or
+  authoritative.
+- `EventHistory` is one read-only message projection rebuilt from `EventLog`
+  replay. It is an index/view, never a second writable message store.
+
+Framework applications read that bounded projection through
+[`Session::history()`](/framework/session-history/). It pages messages from a
+stable event-log snapshot; it does not maintain or write an independent
+transcript.
+
+Rebuild a transcript in persisted sequence order from `input.message`,
+`output.message.completed`, and relevant `tool.completed` events. An
+`output.message.replaced` event alone creates no history message; the subsequent
+completed message contains the safe replacement. If a crash leaves a
+replacement without completion, replay correctly omits that incomplete output.
+The Framework stream exposes the complete payloads and introduces no independent
+writable message history.
+
+Canonical recordings can contain user messages, agent instructions, model
+inputs, tool arguments, and tool results. Treat them as application data with
+the same access controls and retention policy as the session itself; do not log
+them indiscriminately. Model and tool text is untrusted: terminal renderers
+should strip or escape control sequences, and web renderers should escape it as
+content rather than interpreting it as markup or commands. Provider credentials
+are not part of the event protocol.
+
+## Ordering and bounded delivery
+
+A subscriber receives events in channel arrival order and each session has its
+own stream. The canonical `sequence` field is a replay position, not a live
+delivery counter: durable events carry `Some(sequence)` and live-only ephemeral
+events such as streaming deltas carry no sequence. Persisted sequences increase
+monotonically per session and may have gaps. Ephemeral events do not consume
+replay positions.
+
+The live stream has a bounded buffer and never applies backpressure to the agent
+turn. A dropped or slow subscriber cannot stall model or tool execution. If a
+subscriber falls behind, `recv()` and `try_recv()` return
+`EventStreamError::Lagged { missed }`; loss is never hidden. The next receive can
+continue from the oldest retained event, but the renderer must treat its live
+projection as incomplete.
+
+Streaming deltas are provisional and sink-only. Completed assistant/tool events
+are authoritative, and an output-replacement event means accumulated text for
+that message must be discarded. Durable events reach the live sink only after
+their log append commits; ephemeral events go directly to the sink and never
+enter history. After live lag, a Framework application can rebuild its
+persisted transcript with bounded
+[`Session::history()` pages](/framework/session-history/). That projection
+excludes ephemeral deltas by design. Applications that need raw durable
+envelopes rather than derived messages can provide and read an `EventLog`
+through the advanced `everruns-host` SPI; neither recovery path relies on the
+in-process subscriber.
+
+## Cancellation and failure
+
+Pass a `CancellationToken` through `RunOptions` to stop a turn. Cancellation
+produces both a `Turn` with `TurnStopReason::Cancelled` and a correlated
+`turn.cancelled` event carrying the same `turn_id`.
+
+Runtime failures remain available through `Session::run()`'s outcome/error
+semantics and the event stream. Subscribe before running and continue draining
+the stream after the run resolves to retain the terminal failure event and its
+full structured payload.
+
+The complete runnable example is
+[`canonical_events.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/canonical_events.rs):
+
+```bash
+cargo run -p everruns --example canonical_events
+```

--- a/docs/framework/events-and-cancellation.md
+++ b/docs/framework/events-and-cancellation.md
@@ -18,7 +18,7 @@ let mut session = agent.session();
 let mut events = session.events();
 
 let turn = session.run("Start.").await?;
-while let Some(event) = events.try_recv() {
+while let Some(event) = events.try_recv()? {
     println!("{}", event.event_type());
 }
 assert!(turn.success);
@@ -26,13 +26,18 @@ assert!(turn.success);
 # }
 ```
 
-Known events have typed `SessionEventKind` values. Unknown runtime event types
+Known events have typed `SessionEventKind` values. Unknown canonical event types
 are preserved as `Other` with their payload, so the projection does not silently
 drop information. The feed is live and non-blocking: a slow or dropped consumer
 does not stop the turn, and it is not a durable replay API.
 
 Use [lifecycle hooks](/framework/lifecycle-hooks/) instead when application work
 must be awaited at an execution boundary or its failure must affect the run.
+
+See [Canonical Framework events](/framework/canonical-events/) for lossless
+envelopes, explicit lag handling, ordering, and the durability boundary.
+Use [Session History and Resume](/framework/session-history/) to rebuild a
+bounded persisted transcript after live lag or a process restart.
 
 ## Cancel a turn
 

--- a/docs/framework/examples.md
+++ b/docs/framework/examples.md
@@ -14,13 +14,14 @@ contains the maintained public examples. Each imports the `everruns` facade.
 | [`github_monitor.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/github_monitor.rs) | Typed tools and an offline simulation mode | `cargo run -p everruns --features openai --example github_monitor -- --simulate` |
 | [`session_work.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/session_work.rs) | Offline session work, leased delivery, and completion wakes | `cargo run -p everruns --example session_work` |
 | [`session_history.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/session_history.rs) | Offline durable resume and bounded history pages | `cargo run -p everruns --features local --example session_history` |
+| [`canonical_events.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/canonical_events.rs) | Offline lossless recording and typed rendering of live events | `cargo run -p everruns --example canonical_events` |
 | [`subagents.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/subagents.rs) | Public facade composition for delegated work | `cargo run -p everruns --features openai --example subagents` |
 | [`observe_and_cancel.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/observe_and_cancel.rs) | Live events and cancellation | `cargo run -p everruns --features openai --example observe_and_cancel` |
 | [`lifecycle_hooks.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/lifecycle_hooks.rs) | Awaited agent, turn, tool, and completion handlers | `cargo run -p everruns --features openai --example lifecycle_hooks` |
 
-Live modes use `gpt-5.6-terra` and require `OPENAI_API_KEY`. `session_work` and
-`workspace_policy` and `session_history` are fully offline; the GitHub monitor
-also offers a simulated GitHub flow:
+Live modes use `gpt-5.6-terra` and require `OPENAI_API_KEY`. `canonical_events`,
+`session_work`, `workspace_policy`, and `session_history` are fully offline;
+the GitHub monitor also offers a simulated GitHub flow:
 
 ```bash
 cargo run -p everruns --features openai --example github_monitor -- --simulate

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -47,6 +47,7 @@ before importing `everruns-runtime` directly.
 - [Session History and Resume](/framework/session-history/) — bounded transcript pages and typed continuation.
 - [Events and cancellation](/framework/events-and-cancellation/) — observe a live turn and stop work cooperatively.
 - [Lifecycle hooks](/framework/lifecycle-hooks/) — run awaited application behavior at execution boundaries.
+- [Canonical events](/framework/canonical-events/) — render or record the lossless event protocol.
 - [Persistence](/framework/persistence/) — Agent-lifetime memory and crash-durable local state.
 
 ## Extend and operate

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -75,7 +75,7 @@ async fn run_prompt(session: &mut Session, prompt: &str) -> Result<()> {
     let turn = session.run(prompt).await.context("run turn")?;
 
     // Events emitted during the turn are buffered on the stream; drain them.
-    while let Some(event) = events.try_recv() {
+    while let Some(event) = events.try_recv().context("read turn events")? {
         match event.kind {
             SessionEventKind::ToolStarted { tool_name, .. } => eprintln!("  → {tool_name}"),
             SessionEventKind::ToolCompleted {


### PR DESCRIPTION
## What changed
Framework sessions now expose a bounded, typed live subscriber backed by the host's canonical `EventSink`. Every `SessionEvent` retains the complete canonical envelope through `as_json()` while promoting output lifecycle/streaming, model generation/reasoning, tool lifecycle/progress/output, narration, cancellation, completion, and failure details for renderers.

Live delivery preserves channel arrival order, reports receiver lag explicitly, keeps durable `Some(sequence)` replay positions distinct from sequence-less ephemeral deltas, and never backpressures execution. Durable events are observed only after their `EventLog` commit; ephemeral events remain sink-only.

Conversation history remains event-authoritative. The existing bounded `Session::history()` projection is read-only and rebuilds messages from canonical events; this change adds no writable message store or competing history/cursor vocabulary.

## Why
The prior facade projected only selected payload fields, silently skipped lagged events, and could not record a lossless full turn without importing lower-level crates. Framework applications need one ergonomic surface for terminal/service rendering without creating a third event protocol or a second conversation write authority.

## Before / After
Before, `EventStream::recv()` silently advanced across broadcast gaps and `SessionEvent` did not retain the full envelope (sequence, timestamp, context, metadata, tags, and complete payload were unavailable).

After, the offline smoke example prints:

```text
assistant: Hello from Everruns.
[turn completed]
recorded 12 canonical envelopes
```

Focused evidence also proves exact JSON equality with the host `Event`, ordered durable/ephemeral interleaving, tool arguments/results/narration, provider failure payloads, correlated durable cancellation, and event-derived history equality.

No UI surface changed; screenshots are not applicable.

## Risk
- Medium
- `EventStream::recv()` and `try_recv()` now return `Result<_, EventStreamError>` so applications must handle explicit lag instead of receiving silently incomplete output. Maintained examples and consumers are migrated.
- The sink is fixed-capacity (4096) and nonblocking; slow receivers can lag, but execution and committed history are unaffected.
- Cancellation emits a canonical durable terminal event after cooperative teardown and reuses the active turn correlation id.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-LLM, TM-TENANT, TM-DOS.
- Findings and resolutions: canonical envelopes may contain sensitive application message/tool data, so rustdoc/docs require session-equivalent access/retention controls and warn against indiscriminate logging. Model/tool text is documented as untrusted and must be escaped for terminal/web rendering. Provider credentials are not part of the event protocol. Per-session sinks preserve isolation, and the fixed shared channel capacity plus explicit lag bounds observer memory/work. No new server ingress, auth boundary, dependency, filesystem, network, SQL, or executable-content path is introduced; no threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

