### PR TITLE
feat(framework)!: separate provider and model configuration

### DIFF
--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -6,7 +6,7 @@
 [![Documentation](https://docs.rs/everruns/badge.svg)](https://docs.rs/everruns)
 [![License](https://img.shields.io/crates/l/everruns.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns` provides value-first agents, open model/provider configuration,
+`everruns` provides value-first agents, plain model ids, open provider configuration,
 typed tools, isolated multi-turn sessions, live events, cancellation, files,
 typed lifecycle hooks, MCP, plugins, and context inspection without requiring
 a server, worker, or database.
@@ -60,14 +60,15 @@ use everruns::{Agent, OpenAI};
 
 let agent = Agent::builder()
     .instructions("You are concise.")
-    .model(OpenAI::from_env("gpt-5.6-terra")?)
+    .provider(OpenAI::from_env()?)
+    .model("gpt-5.6-terra")
     .build()?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Custom services use the same open boundary: pair a credential-free `ModelSpec`
-with a `Provider` backed by your `ChatDriver`. No closed model enum or
-provider-specific application branch is required.
+Custom services use the same open boundary: attach a `Provider` backed by your
+`ChatDriver`, then select its model with a plain string id. No `ModelSpec`,
+closed model enum, or provider-specific application branch is required.
 
 ## Typed Tools
 
@@ -154,7 +155,7 @@ catalog alongside its real workspace and task/schedule state.
 
 ## What It Provides
 
-- Value-first `Agent`, open `ModelSpec`/`Provider`, and deterministic simulation
+- Value-first `Agent`, plain model ids, open `Provider`, and deterministic simulation
 - Typed and dynamic function tools
 - Independent multi-turn `Session`s, typed resume, bounded history, and next-turn context inspection
 - Live typed events, lossless unknown-event projection, and cancellation

--- a/crates/everruns/examples/advanced_capability.rs
+++ b/crates/everruns/examples/advanced_capability.rs
@@ -86,7 +86,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
         .name("catalog-assistant")
         .instructions("Answer questions using the product catalog capability.")
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .advanced_capability(catalog)
         .build()?;
 

--- a/crates/everruns/examples/github_monitor.rs
+++ b/crates/everruns/examples/github_monitor.rs
@@ -163,7 +163,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .instructions(
             "Start one detached GitHub checks watch, end the turn, and review its completion wake.",
         )
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .tool(monitor)
         .build()?;
 

--- a/crates/everruns/examples/hello.rs
+++ b/crates/everruns/examples/hello.rs
@@ -24,7 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
         .name("hello")
         .instructions("Use current_time to answer time questions. Be terse.")
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .tool(current_time())
         .build()?;
 

--- a/crates/everruns/examples/lifecycle_hooks.rs
+++ b/crates/everruns/examples/lifecycle_hooks.rs
@@ -22,7 +22,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
         .name("lifecycle-demo")
         .instructions("Always call service_status before answering a status question.")
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .tool(service_status())
         .on_agent_start(|context| async move {
             println!(

--- a/crates/everruns/examples/observe_and_cancel.rs
+++ b/crates/everruns/examples/observe_and_cancel.rs
@@ -16,7 +16,8 @@ use everruns::prelude::*;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
         .instructions("You are concise.")
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .build()?;
 
     // --- Observe a turn's events -----------------------------------------

--- a/crates/everruns/examples/production_agent.rs
+++ b/crates/everruns/examples/production_agent.rs
@@ -25,7 +25,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
         .name("support-agent")
         .instructions("Answer from tool results; do not invent order status.")
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .tool(lookup_order())
         .build()?;
 

--- a/crates/everruns/examples/subagents.rs
+++ b/crates/everruns/examples/subagents.rs
@@ -76,7 +76,8 @@ fn spawn_tool(tasks: Arc<ChildTasks>) -> FunctionTool {
                         let child = Agent::builder()
                             .name(format!("worker-{}", index + 1))
                             .instructions("Complete the assigned independent task.")
-                            .model(OpenAI::from_env(MODEL_ID).map_err(|error| error.to_string())?)
+                            .provider(OpenAI::from_env().map_err(|error| error.to_string())?)
+                            .model(MODEL_ID)
                             .build()
                             .map_err(|error| error.to_string())?;
                         let result = child
@@ -201,7 +202,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let parent = Agent::builder()
         .name("coordinator")
         .instructions("Delegate five independent reviews, then wait for and summarize all results.")
-        .model(OpenAI::from_env(MODEL_ID)?)
+        .provider(OpenAI::from_env()?)
+        .model(MODEL_ID)
         .tool(spawn_tool(child_tasks.clone()))
         .tool(wait_tool(child_tasks.clone()))
         .build()?;

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -27,14 +27,14 @@ use tokio::sync::OnceCell;
 
 use crate::tool::{FunctionTool, IntoTool, Tool, validate_tool_name, validate_tool_schema};
 
-/// How an [`Agent`] talks to a model.
+/// A model selected for an [`Agent`].
 ///
-/// A `Model` carries a credential-free specification and may bundle a ready-made
-/// provider assembly. [`Model::simulated`] uses the same provider path as every
-/// network-backed model.
+/// Live models are named with a plain provider-visible id and configured with a
+/// separate [`AgentBuilder::provider`] call. [`Model::simulated`] bundles its
+/// private offline provider so deterministic agents need no extra setup.
 #[derive(Clone)]
 pub struct Model {
-    spec: ModelSpec,
+    id: String,
     bundled_provider: Option<Provider>,
 }
 
@@ -44,8 +44,8 @@ impl Model {
     /// Backed by the `llmsim` driver, so an agent using it runs entirely
     /// offline — no credentials, no network.
     pub fn simulated(response: impl Into<String>) -> Self {
-        Self::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
+        Self::bundled(
+            "llmsim-model",
             Provider::new("llmsim", LlmSimDriver::new(LlmSimConfig::fixed(response))),
         )
     }
@@ -56,39 +56,33 @@ impl Model {
     /// responses, tool-call sequences, and the other controls exposed by
     /// [`LlmSimConfig`].
     pub fn simulated_with_config(config: LlmSimConfig) -> Self {
-        Self::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
+        Self::bundled(
+            "llmsim-model",
             Provider::new("llmsim", LlmSimDriver::new(config)),
         )
     }
 
-    /// Build a `Model` that targets OpenAI's Responses API.
-    ///
-    /// The convenience produces the same public model/provider pair callers can
-    /// assemble directly with [`ModelSpec`] and [`Provider`].
-    #[cfg(feature = "openai")]
-    pub(crate) fn openai(config: crate::providers::openai::OpenAI) -> Self {
-        let (model, api_key, base_url) = config.into_parts();
-        let mut provider = everruns_openai::provider("openai", api_key);
-        if let Some(base_url) = base_url {
-            provider = provider.base_url(base_url);
-        }
-        Self::with_provider(ModelSpec::on("openai", model), provider)
-    }
-
-    /// Pair a model specification with a ready-to-use provider assembly.
-    pub fn with_provider(spec: ModelSpec, provider: Provider) -> Self {
+    fn bundled(id: impl Into<String>, provider: Provider) -> Self {
         Self {
-            spec,
+            id: id.into(),
             bundled_provider: Some(provider),
         }
     }
 }
 
-impl From<ModelSpec> for Model {
-    fn from(spec: ModelSpec) -> Self {
+impl From<&str> for Model {
+    fn from(id: &str) -> Self {
         Self {
-            spec,
+            id: id.to_string(),
+            bundled_provider: None,
+        }
+    }
+}
+
+impl From<String> for Model {
+    fn from(id: String) -> Self {
+        Self {
+            id,
             bundled_provider: None,
         }
     }
@@ -105,8 +99,8 @@ impl Model {
     ) -> Self {
         let mut sim = LlmSimConfig::fixed(response);
         sim.message_capture = Some(capture);
-        Self::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
+        Self::bundled(
+            "llmsim-model",
             Provider::new("llmsim", LlmSimDriver::new(sim)),
         )
     }
@@ -119,8 +113,8 @@ impl Model {
         delay: std::time::Duration,
     ) -> Self {
         let sim = LlmSimConfig::fixed(response).with_response_delay(delay);
-        Self::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
+        Self::bundled(
+            "llmsim-model",
             Provider::new("llmsim", LlmSimDriver::new(sim)),
         )
     }
@@ -133,8 +127,8 @@ impl Model {
         tool_call_sequence: Vec<Vec<everruns_core::ToolCall>>,
     ) -> Self {
         let sim = LlmSimConfig::fixed(response).with_tool_call_sequence(tool_call_sequence);
-        Self::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
+        Self::bundled(
+            "llmsim-model",
             Provider::new("llmsim", LlmSimDriver::new(sim)),
         )
     }
@@ -143,7 +137,7 @@ impl Model {
 impl fmt::Debug for Model {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Model")
-            .field("spec", &self.spec)
+            .field("id", &self.id)
             .field("bundled_provider", &self.bundled_provider)
             .finish()
     }
@@ -190,13 +184,10 @@ pub enum BuildError {
         /// The colliding capability id.
         id: String,
     },
-    /// Two providers used the same normalized identity.
-    DuplicateProvider { id: String },
-    /// The selected model names a provider that was not registered.
-    UnknownProvider {
-        requested: String,
-        registered: Vec<String>,
-    },
+    /// A live model was selected without a provider.
+    MissingProvider,
+    /// More than one provider was attached to the agent.
+    MultipleProviders { registered: Vec<String> },
     /// MCP server configuration was invalid or duplicated.
     InvalidMcpServer { reason: String },
     /// Context compaction configuration was invalid.
@@ -225,13 +216,10 @@ impl fmt::Display for BuildError {
             BuildError::DuplicateCapability { id } => {
                 write!(f, "duplicate advanced capability id {id:?}")
             }
-            BuildError::DuplicateProvider { id } => write!(f, "duplicate provider {id:?}"),
-            BuildError::UnknownProvider {
-                requested,
-                registered,
-            } => write!(
+            BuildError::MissingProvider => write!(f, "agent requires a provider for a live model"),
+            BuildError::MultipleProviders { registered } => write!(
                 f,
-                "provider {requested:?} is not registered; registered providers: [{}]",
+                "agent accepts one provider; registered providers: [{}]",
                 registered.join(", ")
             ),
             BuildError::InvalidMcpServer { reason } => {
@@ -256,8 +244,8 @@ impl std::error::Error for BuildError {}
 pub struct Agent {
     name: String,
     instructions: String,
-    model: Model,
-    providers: Vec<Provider>,
+    model: ModelSpec,
+    provider: Provider,
     capabilities: Vec<AgentCapabilityConfig>,
     function_tools: Vec<FunctionTool>,
     #[cfg(feature = "capabilities")]
@@ -323,7 +311,7 @@ impl fmt::Debug for Agent {
             .field("name", &self.name)
             .field("instructions", &self.instructions)
             .field("model", &self.model)
-            .field("providers", &self.providers)
+            .field("provider", &self.provider)
             .field("capabilities", &self.capabilities)
             .field("function_tools", &self.function_tools)
             .field("initial_files", &self.initial_files)
@@ -592,7 +580,7 @@ impl Agent {
             .harness(harness)
             .agent(agent)
             .session(session)
-            .model_spec(self.model.spec.clone())
+            .model_spec(self.model.clone())
             .workspace_policy(self.workspace_policy.clone());
 
         let mut backends = self
@@ -654,18 +642,17 @@ impl Agent {
         if let Some(capability) = hook_capability {
             builder = builder.capability(capability);
         }
-        for provider in &self.providers {
-            builder = builder.provider(provider.clone());
-        }
+        builder = builder.provider(self.provider.clone());
         builder.build().await
     }
 }
 
 /// Fluent builder behind [`Agent::builder`].
 ///
-/// Instructions and a model are required; everything else is optional. Blank
-/// instructions or a missing model fail [`build`](Self::build) with a typed
-/// [`BuildError`].
+/// Instructions and a model are required. A live string model also requires
+/// exactly one provider; deterministic [`Model::simulated`] values supply their
+/// own offline provider. Invalid configurations fail [`build`](Self::build)
+/// with a typed [`BuildError`].
 ///
 /// Lifecycle methods such as [`on_turn_start`](Self::on_turn_start) accept
 /// async `Fn` handlers. The Framework awaits each per-point chain in builder
@@ -706,17 +693,21 @@ impl AgentBuilder {
 
     /// Select the model the agent talks to. Required.
     ///
-    /// Accepts a [`Model`] directly or anything convertible into one — for
-    /// example an [`OpenAI`](crate::providers::openai::OpenAI) configuration
-    /// under the `openai` feature.
+    /// Live models use their provider-visible string id. Configure how to reach
+    /// that model separately with [`provider`](Self::provider). A
+    /// [`Model::simulated`] value needs no provider.
     pub fn model(mut self, model: impl Into<Model>) -> Self {
         self.model = Some(model.into());
         self
     }
 
-    /// Register a service provider selected by the model specification.
-    pub fn provider(mut self, provider: Provider) -> Self {
-        self.providers.push(provider);
+    /// Configure the service provider used by the selected live model.
+    ///
+    /// Accepts a raw [`Provider`] or a provider convenience such as
+    /// [`OpenAI`](crate::providers::openai::OpenAI) with the `openai` feature.
+    /// An agent currently accepts exactly one provider.
+    pub fn provider(mut self, provider: impl Into<Provider>) -> Self {
+        self.providers.push(provider.into());
         self
     }
 
@@ -985,6 +976,8 @@ impl AgentBuilder {
     /// - [`BuildError::BlankInstructions`] if instructions are missing or only
     ///   whitespace.
     /// - [`BuildError::MissingModel`] if no model was set.
+    /// - [`BuildError::MissingProvider`] if a live model has no provider.
+    /// - [`BuildError::MultipleProviders`] if more than one provider was set.
     /// - [`BuildError::InvalidToolName`] if a function tool's name is not a
     ///   valid model-facing identifier.
     /// - [`BuildError::InvalidToolSchema`] if a function tool's JSON schema is
@@ -1004,28 +997,22 @@ impl AgentBuilder {
         }
         let model = self.model.ok_or(BuildError::MissingModel)?;
         let mut providers = self.providers;
-        if let Some(provider) = model.bundled_provider.clone() {
+        if let Some(provider) = model.bundled_provider {
             providers.push(provider);
         }
-        let mut provider_ids = HashSet::new();
-        for provider in &providers {
-            if !provider_ids.insert(provider.id().clone()) {
-                return Err(BuildError::DuplicateProvider {
-                    id: provider.id().to_string(),
-                });
-            }
+        if providers.is_empty() {
+            return Err(BuildError::MissingProvider);
         }
-        if !provider_ids.contains(&model.spec.provider) {
-            let mut registered = provider_ids
+        if providers.len() > 1 {
+            let mut registered = providers
                 .iter()
-                .map(ToString::to_string)
+                .map(|provider| provider.id().to_string())
                 .collect::<Vec<_>>();
             registered.sort();
-            return Err(BuildError::UnknownProvider {
-                requested: model.spec.provider.to_string(),
-                registered,
-            });
+            return Err(BuildError::MultipleProviders { registered });
         }
+        let provider = providers.pop().expect("provider count checked above");
+        let model = ModelSpec::on(provider.id().clone(), model.id);
         let name = self.name.unwrap_or_else(|| "agent".to_string());
 
         // Validate tools and split them into capability refs (attached to the
@@ -1121,7 +1108,7 @@ impl AgentBuilder {
             name,
             instructions,
             model,
-            providers,
+            provider,
             capabilities,
             function_tools,
             #[cfg(feature = "capabilities")]
@@ -1333,6 +1320,52 @@ mod tests {
     }
 
     #[test]
+    fn build_resolves_plain_model_id_against_provider() {
+        let agent = Agent::builder()
+            .instructions("You are concise.")
+            .provider(Provider::new(
+                "acme",
+                LlmSimDriver::new(LlmSimConfig::fixed("Sure.")),
+            ))
+            .model("assistant-v1")
+            .build()
+            .expect("valid agent");
+
+        assert_eq!(agent.model, ModelSpec::on("acme", "assistant-v1"));
+        assert_eq!(agent.provider.id().as_str(), "acme");
+    }
+
+    #[test]
+    fn build_rejects_live_model_without_provider() {
+        let err = Agent::builder()
+            .instructions("You are concise.")
+            .model("assistant-v1")
+            .build()
+            .unwrap_err();
+
+        assert_eq!(err, BuildError::MissingProvider);
+    }
+
+    #[test]
+    fn build_rejects_multiple_providers() {
+        let provider = |id| Provider::new(id, LlmSimDriver::new(LlmSimConfig::fixed("Sure.")));
+        let err = Agent::builder()
+            .instructions("You are concise.")
+            .provider(provider("zeta"))
+            .provider(provider("alpha"))
+            .model("assistant-v1")
+            .build()
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            BuildError::MultipleProviders {
+                registered: vec!["alpha".to_string(), "zeta".to_string()],
+            }
+        );
+    }
+
+    #[test]
     fn workspace_policy_defaults_to_read_only() {
         let agent = Agent::builder()
             .instructions("You are concise.")
@@ -1380,17 +1413,12 @@ mod tests {
 
     #[cfg(feature = "openai")]
     #[test]
-    fn openai_model_reports_provider_without_leaking_key() {
+    fn openai_provider_converts_without_leaking_key() {
         use crate::providers::openai::OpenAI;
 
-        let model = Model::openai(OpenAI::new("gpt-5-mini", "sk-super-secret"));
-        assert_eq!(model.spec, ModelSpec::on("openai", "gpt-5-mini"));
-        assert_eq!(
-            model.bundled_provider.as_ref().unwrap().id().as_str(),
-            "openai"
-        );
-        // The value-first `Debug` reports shape only, never the key.
-        let rendered = format!("{model:?}");
+        let provider: Provider = OpenAI::new("sk-super-secret").into();
+        assert_eq!(provider.id().as_str(), "openai");
+        let rendered = format!("{provider:?}");
         assert!(!rendered.contains("sk-super-secret"), "got {rendered}");
     }
 
@@ -1404,7 +1432,8 @@ mod tests {
         // contacted when a turn actually runs, which this test never does.
         let agent = Agent::builder()
             .instructions("You are concise.")
-            .model(OpenAI::new("gpt-5-mini", "sk-test"))
+            .provider(OpenAI::new("sk-test"))
+            .model("gpt-5-mini")
             .build()
             .expect("valid agent");
 

--- a/crates/everruns/src/capability.rs
+++ b/crates/everruns/src/capability.rs
@@ -767,9 +767,9 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
-    use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
+    use everruns_core::llmsim_driver::LlmSimConfig;
     use everruns_core::tools::Tool as _;
-    use everruns_core::{ModelSpec, Provider, SessionId, ToolCall, ToolContext};
+    use everruns_core::{SessionId, ToolCall, ToolContext};
     use serde_json::{Value, json};
     use tokio::sync::Notify;
     use tokio::time::timeout;
@@ -829,10 +829,7 @@ mod tests {
 
     fn scripted_model(calls: Vec<Vec<ToolCall>>) -> Model {
         let sim = LlmSimConfig::fixed("done").with_tool_call_sequence(calls);
-        Model::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
-            Provider::new("llmsim", LlmSimDriver::new(sim)),
-        )
+        Model::simulated_with_config(sim)
     }
 
     #[test]

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -1,8 +1,8 @@
 //! The application-facing crate for the [Everruns Framework](https://docs.everruns.com/framework/).
 //!
-//! Build agents, attach open model/provider configuration and typed tools, run
-//! isolated multi-turn sessions, read bounded history, resume typed session
-//! identities, observe events, cancel work, and inspect the next model context
+//! Build agents, attach provider configuration, select model ids, add typed
+//! tools, run isolated multi-turn sessions, read bounded history, resume typed
+//! session identities, observe events, cancel work, and inspect the next model context
 //! without constructing an execution host. Default features stay offline; the
 //! deterministic simulator needs no credentials or network.
 //!
@@ -120,7 +120,7 @@ pub mod __macro_support {
 // their feature is enabled. `openai` adds `providers::openai::OpenAI`.
 pub mod providers;
 #[cfg(feature = "openai")]
-pub use providers::openai::{ModelError, OpenAI};
+pub use providers::openai::{OpenAI, OpenAIError};
 
 // --- Runtime construction and execution ---------------------------------
 // Note: the value-first `AgentBuilder` above intentionally replaces the runtime
@@ -189,7 +189,7 @@ pub mod prelude {
         WorkspacePolicyBuilder, WorkspacePolicyError,
     };
     #[cfg(feature = "openai")]
-    pub use crate::{ModelError, OpenAI};
+    pub use crate::{OpenAI, OpenAIError};
     pub use everruns_core::turn::TurnStopReason;
     pub use everruns_core::{ContentPart, InputMessage, MessageRole};
 }

--- a/crates/everruns/src/providers/openai.rs
+++ b/crates/everruns/src/providers/openai.rs
@@ -1,9 +1,8 @@
-//! OpenAI-backed model configuration (requires the `openai` feature).
+//! OpenAI provider configuration (requires the `openai` feature).
 //!
-//! [`OpenAI`] is the value-first entry point for talking to OpenAI's Responses
-//! API. Convert it into a [`Model`] — directly or via
-//! [`AgentBuilder::model`](crate::AgentBuilder::model) — and the agent's runtime
-//! registers the OpenAI driver automatically.
+//! [`OpenAI`] is the value-first provider configuration for talking to OpenAI's
+//! Responses API. Pass it to [`AgentBuilder::provider`](crate::AgentBuilder::provider)
+//! and select the provider-visible model id separately.
 //!
 //! The existing `everruns-openai` drivers are re-exported here
 //! ([`OpenAIChatDriver`], [`OpenAICompletionsChatDriver`], [`register_driver`])
@@ -11,7 +10,7 @@
 
 use std::fmt;
 
-use crate::Model;
+use crate::Provider;
 
 /// API key environment variable, matching the repo-wide convention documented on
 /// `everruns_core::credential_provider::EnvCredentialProvider`.
@@ -23,13 +22,13 @@ const OPENAI_BASE_URL_ENV: &str = "OPENAI_BASE_URL";
 /// Re-exported `everruns-openai` drivers for direct, low-level use.
 pub use everruns_openai::{OpenAIChatDriver, OpenAICompletionsChatDriver, register_driver};
 
-/// Why an [`OpenAI`] configuration could not be produced.
+/// Why an [`OpenAI`] provider configuration could not be produced.
 ///
 /// Typed and cheap to match on. Credential values never appear in the error —
 /// only the name of the missing environment variable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum ModelError {
+pub enum OpenAIError {
     /// A required environment variable was unset or empty.
     MissingEnvVar {
         /// The variable name that was expected (e.g. `OPENAI_API_KEY`).
@@ -37,35 +36,34 @@ pub enum ModelError {
     },
 }
 
-impl fmt::Display for ModelError {
+impl fmt::Display for OpenAIError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ModelError::MissingEnvVar { var } => {
+            OpenAIError::MissingEnvVar { var } => {
                 write!(f, "required environment variable {var} is not set")
             }
         }
     }
 }
 
-impl std::error::Error for ModelError {}
+impl std::error::Error for OpenAIError {}
 
-/// Configuration for an OpenAI-backed [`Model`].
+/// OpenAI provider configuration.
 ///
-/// Build one with [`OpenAI::new`] (explicit, deterministic — reads no
-/// environment) or [`OpenAI::from_env`] (reads `OPENAI_API_KEY` and, when set,
-/// `OPENAI_BASE_URL`). Both target OpenAI's Responses API via the recommended
-/// [`OpenAIChatDriver`].
+/// Build one with [`OpenAI::new`] (explicit, deterministic — reads no environment)
+/// or [`OpenAI::from_env`] (reads `OPENAI_API_KEY` and, when set,
+/// `OPENAI_BASE_URL`). Select the model separately on the agent builder. Both
+/// paths target OpenAI's Responses API via the recommended [`OpenAIChatDriver`].
 ///
 /// The API key is redacted from [`Debug`] output.
 #[derive(Clone)]
 pub struct OpenAI {
-    model: String,
     api_key: String,
     base_url: Option<String>,
 }
 
 impl OpenAI {
-    /// Configure OpenAI with an explicit model id and API key.
+    /// Configure OpenAI with an explicit API key.
     ///
     /// Deterministic: reads no environment. Use [`from_env`](Self::from_env)
     /// to pick the key up from `OPENAI_API_KEY` instead.
@@ -73,12 +71,11 @@ impl OpenAI {
     /// ```
     /// use everruns::providers::openai::OpenAI;
     ///
-    /// let model = OpenAI::new("gpt-5-mini", "sk-your-key");
-    /// # let _ = model;
+    /// let provider = OpenAI::new("sk-your-key");
+    /// # let _ = provider;
     /// ```
-    pub fn new(model: impl Into<String>, api_key: impl Into<String>) -> Self {
+    pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            model: model.into(),
             api_key: api_key.into(),
             base_url: None,
         }
@@ -89,7 +86,7 @@ impl OpenAI {
     ///
     /// Reads `OPENAI_API_KEY` (required) and `OPENAI_BASE_URL` (optional),
     /// matching the repo-wide credential-variable convention. An unset or empty
-    /// `OPENAI_API_KEY` returns [`ModelError::MissingEnvVar`] rather than
+    /// `OPENAI_API_KEY` returns [`OpenAIError::MissingEnvVar`] rather than
     /// panicking.
     ///
     /// This is the sanctioned standalone/dev entry point for env-based
@@ -102,20 +99,21 @@ impl OpenAI {
     /// // Requires `OPENAI_API_KEY` in the environment.
     /// let agent = Agent::builder()
     ///     .instructions("You are concise.")
-    ///     .model(OpenAI::from_env("gpt-5-mini")?)
+    ///     .provider(OpenAI::from_env()?)
+    ///     .model("gpt-5-mini")
     ///     .build()?;
     /// # let _ = agent;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_env(model: impl Into<String>) -> Result<Self, ModelError> {
-        Self::from_lookup(model, |name| std::env::var(name).ok())
+    pub fn from_env() -> Result<Self, OpenAIError> {
+        Self::from_lookup(|name| std::env::var(name).ok())
     }
 
     /// Resolve from an injectable variable lookup — the testable core of
     /// [`from_env`](Self::from_env), so tests never mutate the process
     /// environment.
-    fn from_lookup<F>(model: impl Into<String>, lookup: F) -> Result<Self, ModelError>
+    fn from_lookup<F>(lookup: F) -> Result<Self, OpenAIError>
     where
         F: Fn(&str) -> Option<String>,
     {
@@ -123,15 +121,11 @@ impl OpenAI {
         let api_key =
             lookup(OPENAI_API_KEY_ENV)
                 .and_then(non_empty)
-                .ok_or(ModelError::MissingEnvVar {
+                .ok_or(OpenAIError::MissingEnvVar {
                     var: OPENAI_API_KEY_ENV,
                 })?;
         let base_url = lookup(OPENAI_BASE_URL_ENV).and_then(non_empty);
-        Ok(Self {
-            model: model.into(),
-            api_key,
-            base_url,
-        })
+        Ok(Self { api_key, base_url })
     }
 
     /// Override the API base URL (OpenAI-compatible proxy, self-hosted endpoint,
@@ -141,27 +135,30 @@ impl OpenAI {
         self
     }
 
-    /// Consume the config into its `(model, api_key, base_url)` parts for the
-    /// facade's `Model` constructor. Crate-internal so the public surface never
-    /// leaks the raw key.
-    pub(crate) fn into_parts(self) -> (String, String, Option<String>) {
-        (self.model, self.api_key, self.base_url)
+    /// Consume the config into its provider assembly parts. Crate-internal so
+    /// the public surface never leaks the raw key.
+    fn into_parts(self) -> (String, Option<String>) {
+        (self.api_key, self.base_url)
     }
 }
 
 impl fmt::Debug for OpenAI {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpenAI")
-            .field("model", &self.model)
             .field("base_url", &self.base_url)
             .field("api_key", &"[REDACTED]")
             .finish()
     }
 }
 
-impl From<OpenAI> for Model {
+impl From<OpenAI> for Provider {
     fn from(config: OpenAI) -> Self {
-        Model::openai(config)
+        let (api_key, base_url) = config.into_parts();
+        let mut provider = everruns_openai::provider("openai", api_key);
+        if let Some(base_url) = base_url {
+            provider = provider.base_url(base_url);
+        }
+        provider
     }
 }
 
@@ -171,33 +168,31 @@ mod tests {
 
     #[test]
     fn new_is_environment_free_and_sets_no_base_url() {
-        let config = OpenAI::new("gpt-5-mini", "sk-explicit");
-        let (model, api_key, base_url) = config.into_parts();
-        assert_eq!(model, "gpt-5-mini");
+        let config = OpenAI::new("sk-explicit");
+        let (api_key, base_url) = config.into_parts();
         assert_eq!(api_key, "sk-explicit");
         assert_eq!(base_url, None);
     }
 
     #[test]
     fn from_lookup_reads_key_and_optional_base_url() {
-        let config = OpenAI::from_lookup("gpt-5-mini", |name| match name {
+        let config = OpenAI::from_lookup(|name| match name {
             "OPENAI_API_KEY" => Some("sk-env".to_string()),
             "OPENAI_BASE_URL" => Some("https://proxy.example/v1".to_string()),
             _ => None,
         })
         .expect("key present");
-        let (model, api_key, base_url) = config.into_parts();
-        assert_eq!(model, "gpt-5-mini");
+        let (api_key, base_url) = config.into_parts();
         assert_eq!(api_key, "sk-env");
         assert_eq!(base_url, Some("https://proxy.example/v1".to_string()));
     }
 
     #[test]
     fn from_lookup_missing_key_is_typed_error() {
-        let err = OpenAI::from_lookup("gpt-5-mini", |_| None).unwrap_err();
+        let err = OpenAI::from_lookup(|_| None).unwrap_err();
         assert_eq!(
             err,
-            ModelError::MissingEnvVar {
+            OpenAIError::MissingEnvVar {
                 var: "OPENAI_API_KEY"
             }
         );
@@ -205,13 +200,11 @@ mod tests {
 
     #[test]
     fn from_lookup_empty_key_is_missing() {
-        let err = OpenAI::from_lookup("gpt-5-mini", |name| {
-            (name == "OPENAI_API_KEY").then(String::new)
-        })
-        .unwrap_err();
+        let err =
+            OpenAI::from_lookup(|name| (name == "OPENAI_API_KEY").then(String::new)).unwrap_err();
         assert_eq!(
             err,
-            ModelError::MissingEnvVar {
+            OpenAIError::MissingEnvVar {
                 var: "OPENAI_API_KEY"
             }
         );
@@ -219,7 +212,7 @@ mod tests {
 
     #[test]
     fn base_url_builder_overrides() {
-        let (_, _, base_url) = OpenAI::new("gpt-5-mini", "sk-explicit")
+        let (_, base_url) = OpenAI::new("sk-explicit")
             .base_url("https://custom.example/v1")
             .into_parts();
         assert_eq!(base_url, Some("https://custom.example/v1".to_string()));
@@ -229,16 +222,15 @@ mod tests {
     fn debug_redacts_api_key() {
         let rendered = format!(
             "{:?}",
-            OpenAI::new("gpt-5-mini", "sk-super-secret").base_url("https://x/v1")
+            OpenAI::new("sk-super-secret").base_url("https://x/v1")
         );
         assert!(!rendered.contains("sk-super-secret"), "got {rendered}");
         assert!(rendered.contains("[REDACTED]"), "got {rendered}");
-        assert!(rendered.contains("gpt-5-mini"), "got {rendered}");
     }
 
     #[test]
-    fn model_error_display_names_the_variable_only() {
-        let rendered = ModelError::MissingEnvVar {
+    fn openai_error_display_names_the_variable_only() {
+        let rendered = OpenAIError::MissingEnvVar {
             var: "OPENAI_API_KEY",
         }
         .to_string();

--- a/crates/everruns/tests/custom_provider.rs
+++ b/crates/everruns/tests/custom_provider.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use everruns::{
     Agent, AgentLoopError, ChatDriver, LlmCallConfig, LlmMessage, LlmResponseStream,
-    LlmStreamEvent, ModelSpec, Provider, ProviderEndpoint,
+    LlmStreamEvent, Provider, ProviderEndpoint,
 };
 
 #[derive(Clone)]
@@ -26,12 +26,12 @@ impl ChatDriver for DownstreamProtocol {
 async fn downstream_provider_needs_only_the_everruns_api() {
     let agent = Agent::builder()
         .instructions("Reply through the configured provider.")
-        .model(ModelSpec::on("my-gateway", "custom-model"))
         .provider(
             Provider::new("my-gateway", DownstreamProtocol)
                 .base_url("https://gateway.example/v1")
                 .header("x-tenant", "tenant-a"),
         )
+        .model("custom-model")
         .build()
         .unwrap();
 

--- a/crates/openai/README.md
+++ b/crates/openai/README.md
@@ -29,7 +29,8 @@ use everruns::{Agent, OpenAI};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
         .instructions("Answer clearly and concisely.")
-        .model(OpenAI::from_env("gpt-5.6-terra")?)
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
         .build()?;
     let result = agent
         .session()

--- a/docs/framework/custom-providers.md
+++ b/docs/framework/custom-providers.md
@@ -5,23 +5,19 @@ description: Implement and attach a custom model provider through the open Frame
 
 Use a custom provider when an application talks to a model service that the
 Framework does not configure for you. The extension boundary is the public
-`ChatDriver` trait plus a credential-free `ModelSpec` and a `Provider` value.
+`ChatDriver` trait plus a `Provider` value. The agent selects that provider's
+model with a plain credential-free string id.
 
 At a high level:
 
 ```rust
-use everruns::{Agent, BuildError, ChatDriver, Model, ModelSpec, Provider};
+use everruns::{Agent, BuildError, ChatDriver, Provider};
 
 fn agent_for(driver: impl ChatDriver) -> Result<Agent, BuildError> {
-    let provider = Provider::new("company-gateway", driver);
-    let model = Model::with_provider(
-        ModelSpec::on("company-gateway", "assistant-v2"),
-        provider,
-    );
-
     Agent::builder()
         .instructions("Use the company model gateway.")
-        .model(model)
+        .provider(Provider::new("company-gateway", driver))
+        .model("assistant-v2")
         .build()
 }
 ```
@@ -32,7 +28,7 @@ an `LlmResponseStream`. Exact trait methods and event shapes live in the
 [`everruns::ChatDriver` API reference](https://docs.rs/everruns/latest/everruns/trait.ChatDriver.html).
 
 Keep credential lookup and refresh in trusted host/provider configuration.
-`ModelSpec` must remain safe to log, compare, store, and pass across application
+Model ids must remain safe to log, compare, store, and pass across application
 boundaries. Provider errors should preserve useful classifications without
 including secrets.
 

--- a/docs/framework/models-and-providers.md
+++ b/docs/framework/models-and-providers.md
@@ -5,12 +5,13 @@ description: Select credential-free model identities and attach provider impleme
 
 The Framework separates **what model to use** from **how to reach it**:
 
-- `ModelSpec` is a credential-free provider and model identity.
+- `.model("id")` selects the provider-visible model with a credential-free string.
 - `Provider` supplies the driver, endpoint, and authentication needed by the host.
-- `Model` pairs those values for an `Agent`.
+- An agent currently accepts one provider, configured separately with `.provider(...)`.
 
 This boundary is open: a new provider does not require a new closed enum variant
-or provider-specific branch in application code.
+or provider-specific branch in application code. The Framework constructs its
+execution-facing model specification internally when the agent builds.
 
 ## Offline simulation
 
@@ -34,31 +35,28 @@ use everruns::{Agent, OpenAI};
 
 let agent = Agent::builder()
     .instructions("Be concise.")
-    .model(OpenAI::from_env("gpt-5.6-terra")?)
+    .provider(OpenAI::from_env()?)
+    .model("gpt-5.6-terra")
     .build()?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Use `OpenAI::new(model, key)` when the host already owns an explicitly resolved
-credential. Never put credentials in a `ModelSpec`, log them as model identity,
-or select provider behavior with vendor-specific detection.
+Use `OpenAI::new(key)` when the host already owns an explicitly resolved
+credential. Never put credentials in a model id, log them as model identity, or
+select provider behavior with vendor-specific detection.
 
 ## Explicit assembly
 
 Applications with their own driver can use the shared boundary directly:
 
 ```rust
-use everruns::{Agent, BuildError, ChatDriver, Model, ModelSpec, Provider};
+use everruns::{Agent, BuildError, ChatDriver, Provider};
 
 fn agent_for(driver: impl ChatDriver) -> Result<Agent, BuildError> {
-    let provider = Provider::new("acme", driver);
-    let model = Model::with_provider(
-        ModelSpec::on("acme", "assistant-v1"),
-        provider,
-    );
     Agent::builder()
         .instructions("Use the configured provider.")
-        .model(model)
+        .provider(Provider::new("acme", driver))
+        .model("assistant-v1")
         .build()
 }
 ```

--- a/docs/framework/quickstart.md
+++ b/docs/framework/quickstart.md
@@ -53,14 +53,14 @@ use everruns::{Agent, OpenAI};
 
 let agent = Agent::builder()
     .instructions("You are a concise assistant.")
-    .model(OpenAI::from_env("gpt-5.6-terra")?)
+    .provider(OpenAI::from_env()?)
+    .model("gpt-5.6-terra")
     .build()?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-The model identity stays credential-free. `OpenAI::from_env` attaches the
-provider configuration at the application boundary and redacts the key from
-debug output.
+The model id stays credential-free. `OpenAI::from_env` configures the separate
+provider at the application boundary and redacts the key from debug output.
 
 Continue with [Agents](/framework/agents/), [Tools and macros](/framework/tools-and-macros/),
 and [Sessions](/framework/sessions/).

--- a/docs/framework/runtime-compatibility.md
+++ b/docs/framework/runtime-compatibility.md
@@ -17,7 +17,7 @@ users should depend on `everruns` and use the Framework.
 | Existing runtime concern | Framework path |
 | --- | --- |
 | Build a harness/agent/session graph for one application | `Agent::builder()` and `Agent::session()` |
-| Construct provider-specific model records | credential-free `ModelSpec` plus an attached `Provider` or provider convenience |
+| Construct provider-specific model records | attach one `Provider`, then select its model with a plain string id |
 | Register an application function tool | `#[everruns::tool]` or `FunctionTool` |
 | Seed application files | `AgentBuilder::file` and `readonly_file` |
 | Use one real workspace | `AgentBuilder::workspace` or feature-gated `LocalConfig` |

--- a/evals/generic/src/subject.rs
+++ b/evals/generic/src/subject.rs
@@ -2,7 +2,7 @@
 //! server, no HTTP, no database. Each sample gets a fresh [`Agent`] and
 //! [`Session`] built from the matrix case:
 //!
-//! - target → Framework `Model` + provider (`anthropic`, `openai`, `openrouter`)
+//! - target → Framework model id + provider (`anthropic`, `openai`, `openrouter`)
 //! - `harness` axis → a [`HarnessProfile`](crate::profiles::HarnessProfile)
 //!   (system prompt + capability set)
 //! - `config` axis → a [`ConfigProfile`](crate::profiles::ConfigProfile)
@@ -23,8 +23,8 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
 
 use everruns::{
-    Agent, AgentCapabilityConfig, ContentPart, Controls, ImageContentPart, InputMessage, Model,
-    ModelSpec, ReasoningConfig, Session, SessionEvent, SessionEventKind,
+    Agent, AgentCapabilityConfig, ContentPart, Controls, ImageContentPart, InputMessage, Provider,
+    ReasoningConfig, Session, SessionEvent, SessionEventKind,
 };
 
 use mira::subject::summarize_events;
@@ -293,7 +293,8 @@ fn build_session(
     let mut builder = Agent::builder()
         .name(format!("generic-eval-{}", sample.id))
         .instructions(harness.system_prompt)
-        .model(model(target)?)
+        .provider(provider(target)?)
+        .model(target.model.clone())
         .max_iterations(config.max_iterations);
 
     for capability in harness.capabilities {
@@ -337,9 +338,9 @@ fn workspace_path(root: &Path, model_path: &str) -> Result<PathBuf, String> {
     Ok(root.join(path))
 }
 
-/// Map the matrix target onto a Framework model/provider pair. Keys are read
-/// here (study side); Mira targets stay key-free labels.
-fn model(target: &Target) -> Result<Model, String> {
+/// Map the matrix target onto a Framework provider. Keys are read here (study
+/// side); Mira targets stay key-free labels.
+fn provider(target: &Target) -> Result<Provider, String> {
     let provider = match target.provider.as_str() {
         "anthropic" => {
             let key_name = "ANTHROPIC_API_KEY";
@@ -362,10 +363,7 @@ fn model(target: &Target) -> Result<Model, String> {
             ));
         }
     };
-    Ok(Model::with_provider(
-        ModelSpec::on(target.provider.clone(), target.model.clone()),
-        provider,
-    ))
+    Ok(provider)
 }
 
 /// True when a provider error says the selected route cannot accept the
@@ -465,7 +463,7 @@ mod tests {
 
     #[test]
     fn unsupported_provider_is_rejected() {
-        let err = model(&Target::new("x", "acme", "m")).unwrap_err();
+        let err = provider(&Target::new("x", "acme", "m")).unwrap_err();
         assert!(err.contains("unsupported provider"));
     }
 

--- a/examples/coding-cli/src/lib.rs
+++ b/examples/coding-cli/src/lib.rs
@@ -14,7 +14,7 @@
 use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
-use everruns::{Agent, BuildError, Model};
+use everruns::{Agent, AgentBuilder};
 
 /// System prompt describing the agent and the tools it can call.
 pub const SYSTEM_PROMPT: &str = "\
@@ -124,18 +124,13 @@ async fn list_dir(path: Option<String>) -> Result<serde_json::Value, String> {
     Ok(serde_json::json!({ "path": rel, "entries": entries }))
 }
 
-/// Build the coding [`Agent`] wired with the file tools and the given model.
-///
-/// `model` is anything convertible into a [`Model`] — a [`Model::simulated`] for
-/// offline runs, or an `everruns::OpenAI` config with the `openai` feature.
-pub fn build_agent(model: impl Into<Model>) -> Result<Agent, BuildError> {
+/// Start a coding [`Agent`] builder wired with the file tools.
+pub fn agent_builder() -> AgentBuilder {
     Agent::builder()
         .instructions(SYSTEM_PROMPT)
-        .model(model)
         .tool(read_file())
         .tool(write_file())
         .tool(list_dir())
-        .build()
 }
 
 #[cfg(test)]

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use everruns::Model;
 use everruns::{OpenAI, Session, SessionEventKind};
-use everruns_coding_cli::{build_agent, set_workspace};
+use everruns_coding_cli::{agent_builder, set_workspace};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 #[derive(Parser, Debug)]
@@ -50,13 +50,15 @@ async fn main() -> Result<()> {
     set_workspace(root);
 
     let agent = if cli.offline {
-        build_agent(Model::simulated(
-            "Offline simulator: set up a real model with --model to use the tools.",
-        ))
+        agent_builder()
+            .model(Model::simulated(
+                "Offline simulator: set up a real model with --model to use the tools.",
+            ))
+            .build()
     } else {
-        let model = OpenAI::from_env(&cli.model)
+        let provider = OpenAI::from_env()
             .context("configure OpenAI (set OPENAI_API_KEY, or pass --offline)")?;
-        build_agent(model)
+        agent_builder().provider(provider).model(cli.model).build()
     }
     .context("build the coding agent")?;
 

--- a/examples/coding-cli/tests/facade_only.rs
+++ b/examples/coding-cli/tests/facade_only.rs
@@ -7,11 +7,14 @@
 use std::path::Path;
 
 use everruns::Model;
-use everruns_coding_cli::build_agent;
+use everruns_coding_cli::agent_builder;
 
 #[tokio::test]
 async fn offline_smoke_runs_a_turn() {
-    let agent = build_agent(Model::simulated("Done.")).expect("agent builds via the facade");
+    let agent = agent_builder()
+        .model(Model::simulated("Done."))
+        .build()
+        .expect("agent builds via the facade");
     let mut session = agent.session();
     let turn = session
         .run("list the files")
@@ -29,7 +32,10 @@ async fn offline_smoke_runs_a_turn() {
 async fn session_history_persists_across_two_prompts() {
     // One session, two prompts — the second reuses the first's runtime and
     // accumulated history. Both must run cleanly through the public API.
-    let agent = build_agent(Model::simulated("ack")).expect("agent builds");
+    let agent = agent_builder()
+        .model(Model::simulated("ack"))
+        .build()
+        .expect("agent builds");
     let mut session = agent.session();
 
     let first = session.run("first prompt").await.expect("first turn");

--- a/knowledge/foundations/models.md
+++ b/knowledge/foundations/models.md
@@ -279,7 +279,8 @@ Persisted model rows resolve to a `ModelSpec`; the exact provider record resolve
 independently into a non-serializable runtime `Provider`. For the `0.17.x`
 patch, the public `everruns-runtime::ResolvedModel` input remains available as a
 transitional adapter and is converted immediately into these canonical parts.
-The high-level `everruns` facade accepts only `ModelSpec` plus runtime providers.
+The high-level `everruns` facade accepts a plain provider-visible model id plus
+one runtime provider and constructs the `ModelSpec` internally.
 
 ### LLM Model Profile
 

--- a/knowledge/foundations/providers.md
+++ b/knowledge/foundations/providers.md
@@ -83,7 +83,8 @@ published `everruns-runtime` and hosted provider-management integration. They
 are a compatibility/catalog adapter: descriptor factories compose the same
 runtime `Provider`, and execution checks direct runtime providers first. They
 must not acquire an independent resolution or execution algorithm. The
-high-level `everruns` facade accepts only `ModelSpec` and runtime `Provider`.
+high-level `everruns` facade accepts a plain model id and one runtime `Provider`,
+then constructs the canonical `ModelSpec` internally.
 
 The `mai` integration is a first-party example layered on a generic protocol:
 Microsoft MAI uses the OpenAI-compatible Chat Completions driver while its

--- a/knowledge/framework/application-api.md
+++ b/knowledge/framework/application-api.md
@@ -30,7 +30,8 @@ provider registry, model resolution, turn semantics, or execution algorithm.
 
 The Framework owns value-first configuration for:
 
-- agent instructions, models, providers, tools, and capability references;
+- agent instructions, plain model ids, one provider per agent, tools, and
+  capability references;
 - editable and read-only initial files plus an optional real-disk workspace;
 - scoped HTTP or local-process MCP servers;
 - local plugin directory loading and non-fatal compile warnings;
@@ -117,7 +118,7 @@ remove. Host implementations may continue using the compatibility crate in
 | Audited use case | Classification | Why / Framework mapping |
 |---|---|---|
 | Runtime README, skill, and documentation quickstarts | Promote | Ordinary agent/model/session execution is the Framework's primary path. |
-| Built-in simulation and real or custom model providers | Promote | Applications select a credential-free model and attach provider configuration or a custom protocol driver without constructing a platform registry. |
+| Built-in simulation and real or custom model providers | Promote | Applications select a plain credential-free model id and attach one provider configuration or custom protocol driver without constructing a `ModelSpec` or platform registry. |
 | Application-defined function tools and initial files | Promote | These are agent behavior and workspace inputs, not host entities. |
 | In-process and OpenAI runtime examples | Promote | They map to normal agent construction and one or more Framework sessions. |
 | Context-inspection example and evaluation assertions | Promote | Applications receive a curated next-turn context rather than stored records or backend assembly types. |

--- a/knowledge/framework/library-experience.md
+++ b/knowledge/framework/library-experience.md
@@ -23,6 +23,8 @@ Application-facing behavior should have these qualities:
   worker language;
 - configuration errors surface before execution when the application can fix
   them;
+- the common live-provider path reads as separate provider configuration and a
+  plain model id, without exposing execution-facing model specifications;
 - multi-turn state is isolated by session and inspectable without backend
   access;
 - live observation and cancellation never require ownership of the host event
@@ -30,7 +32,7 @@ Application-facing behavior should have these qualities:
 - awaited lifecycle extensions are explicit and distinct from non-blocking
   observation events;
 - credentials, tenant records, and host lifecycle entities do not leak through
-  model or agent values;
+  model identity or diagnostic values;
 - optional integrations remain feature-gated and do not enlarge the default
   offline build;
 - advanced host composition stays possible without making it the newcomer path.

--- a/knowledge/framework/provider-extension.md
+++ b/knowledge/framework/provider-extension.md
@@ -14,8 +14,10 @@ tags:
 
 Model selection is application configuration; provider execution is an open
 extension. The Framework therefore keeps model identity credential-free and
-pairs it with a provider assembly that supplies protocol behavior, endpoint
-configuration, and authentication at the trusted host boundary.
+pairs a plain provider-visible model id with a provider assembly that supplies
+protocol behavior, endpoint configuration, and authentication at the trusted
+host boundary. An ordinary Framework agent accepts one provider; the facade
+constructs the execution-facing `ModelSpec` internally when the agent builds.
 
 This separation lets applications name, compare, store, and route models
 without carrying secrets. It also lets a new provider integrate without adding
@@ -27,11 +29,17 @@ branches.
 - Model identity must be safe to log and move through application values.
 - Provider configuration owns credentials and must redact them from diagnostic
   output.
+- Application code selects a live model with `.provider(provider).model(id)`;
+  it does not construct a `ModelSpec` or bundle provider configuration into a
+  model value.
+- An agent accepts exactly one provider until the Framework has a concrete
+  application-level multi-provider routing contract. Missing or multiple
+  providers fail during agent construction.
+- Deterministic simulation may bundle its private offline provider because it
+  has no endpoint or credential configuration.
 - Built-in provider conveniences and custom providers converge on the same
   resolution and execution path.
 - Provider-specific protocol differences remain behind the driver boundary.
-- Unknown, duplicate, or mismatched provider identities fail explicitly before
-  they can select an unintended implementation.
 
 The exact driver trait, provider constructors, and stream events live in the
 public API reference. Framework usage lives in the public [Models and


### PR DESCRIPTION
## What changed
Live Framework agents now configure a provider separately from a plain model id:

```rust
Agent::builder()
    .provider(OpenAI::from_env()?)
    .model("gpt-5.6-terra")
    .build()?;
```

The facade accepts exactly one provider for a live model, constructs `ModelSpec` internally, and preserves provider-free `Model::simulated(...)` setup. Specs, docs, examples, the coding CLI, and generic evals use the new API.

## Why
The previous `.model(OpenAI::from_env("gpt-5.6-terra")?)` call mixed model identity, provider selection, and credential loading. Separating them keeps the model id credential-free and matches the Framework provider boundary.

## Before / After
Before:

```rust
.model(OpenAI::from_env("gpt-5.6-terra")?)
```

After:

```rust
.provider(OpenAI::from_env()?)
.model("gpt-5.6-terra")
```

End-to-end proof: `downstream_provider_needs_only_the_everruns_api` builds a custom provider plus plain model id and completes a session turn.

## Risk
- Medium
- This intentionally breaks the new Framework API: `OpenAI::from_env` and `OpenAI::new` no longer accept a model id, `ModelError` becomes `OpenAIError`, and live agents accept one provider. All first-party callers are migrated.

## Security
- Threat categories reviewed: TM-LLM-002, TM-LLM-003, TM-LLM-004
- Findings and resolutions: No findings. Model values remain credential-free, provider debug output remains redacted, and credential lookup errors disclose only the environment variable name. No new threat or mitigation change requires a threat-model update.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
