### PR TITLE
fix(framework): bundle simulated error provider

### DIFF
--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -122,8 +122,8 @@ impl Model {
     /// Test-only: a simulated provider failure used to prove the facade event
     /// bridge retains failure lifecycle and diagnostic payloads end to end.
     pub(crate) fn simulated_error(message: impl Into<String>) -> Self {
-        Self::with_provider(
-            ModelSpec::on("llmsim", "llmsim-model"),
+        Self::bundled(
+            "llmsim-model",
             Provider::new("llmsim", LlmSimDriver::new(LlmSimConfig::error(message))),
         )
     }


### PR DESCRIPTION
## What changed
The test-only `Model::simulated_error` constructor now uses the internal bundled-provider constructor, matching the other simulated model constructors.

## Why
PR #3093 removed `Model::with_provider`, while a newer `main` commit had added a test-only caller of that helper. Their combination caused post-merge `main` Clippy to fail in [CI run 31330783784](https://github.com/everruns/everruns/actions/runs/31330783784).

## Before / After
Before, `simulated_error` called the removed `Model::with_provider` helper. After, it calls `Model::bundled("llmsim-model", provider)`, preserving the same simulator behavior through the current internal API.

## Risk
- Low
- The change affects only a test-only constructor and aligns it with existing simulated model construction.

## Security
- Threat categories reviewed: TM-LLM-002, TM-LLM-003, TM-LLM-004
- Findings and resolutions: No findings. The fix changes only an internal test simulator constructor and does not alter credential, provider, or production model handling.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
