### PR TITLE
feat(framework)!: unify capability configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ deterministic simulator; opt-in providers, typed tools, multi-turn sessions, eve
 cancellation, files, MCP, and context inspection all stay on the same public facade. Start with
 the [Framework quickstart](https://docs.everruns.com/framework/quickstart/).
 
-Reusable capability packages can use the curated
+Typed built-ins, dynamic third-party references, and reusable packages all use
+`AgentBuilder::capability`; packages can implement the open `IntoCapability`
+contract or use the curated
 [`everruns::capability`](https://docs.everruns.com/framework/advanced-capabilities/) authoring API.
 
 Advanced execution hosts combine `everruns` with `everruns-host` and focused sibling crates.

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -126,3 +126,7 @@ required-features = ["openai"]
 [[example]]
 name = "advanced_capability"
 required-features = ["capabilities", "openai"]
+
+[[example]]
+name = "capability_configuration"
+required-features = ["capabilities"]

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -93,6 +93,47 @@ The default-enabled macro generates the argument schema and adapter. The
 `everruns-macros` package is an implementation crate re-exported as
 `everruns::tool`; applications do not need to depend on it directly.
 
+## Unified Capability Configuration
+
+Every capability uses one scalable builder entrypoint. Typed built-ins,
+code-defined packages, open third-party values, plain default-config IDs, and
+dynamic JSON references all implement `IntoCapability`:
+
+```rust
+use everruns::{
+    Agent, CapabilityRef, CompactionConfig, Model, ToolSearch, capability,
+};
+use serde_json::json;
+
+let weather_definition = capability::Definition::new(
+    "weather",
+    "Weather",
+    "Application-defined weather tools.",
+).tool(weather_handler);
+
+let agent = Agent::builder()
+    .instructions("Use configured capabilities when relevant.")
+    .model(Model::simulated("Done."))
+    .capability(CompactionConfig::new().budget_percent(0.85))
+    .capability(ToolSearch::automatic())
+    .capability(weather_definition)
+    .capability(
+        CapabilityRef::new("vendor.custom")
+            .config(json!({ "mode": "database-driven" })),
+    )
+    .build()?;
+# Ok::<(), everruns::BuildError>(())
+```
+
+`CapabilityRef` is the explicit database/plugin escape hatch: the Framework
+validates its stable open ID and JSON object at build time, and known built-ins
+validate their own schemas. Duplicate IDs and code-implementation collisions
+are errors, never silent overwrites. Third-party crates can implement the
+non-sealed `IntoCapability` trait without importing `everruns-core`.
+
+Keep ordinary functions on `#[everruns::tool]` and `.tool(...)`; a function
+tool is not a capability reference.
+
 ## Sessions, Events, and Cancellation
 
 An agent opens independent live sessions. `send` accepts a message immediately,
@@ -222,7 +263,7 @@ Examples are compiled in CI and import only `everruns`.
 Use `#[everruns::tool]` for an ordinary typed async function. Reusable packages
 that need multiple typed tools, capability metadata, execution context,
 progress, or call-scoped cancellation use the curated `everruns::capability`
-SPI and `AgentBuilder::advanced_capability`.
+SPI and the same `AgentBuilder::capability` entrypoint.
 
 See the [Framework capability-authoring guide](../../docs/framework/advanced-capabilities.md)
 and the [runnable advanced example](examples/advanced_capability.rs).

--- a/crates/everruns/examples/README.md
+++ b/crates/everruns/examples/README.md
@@ -1,12 +1,13 @@
 # `everruns` examples
 
 These examples use the application-facing [`everruns`](../README.md) crate.
-Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`; `canonical_events`,
-`live_session`,
-`session_work`, `workspace_policy`, and `session_history` run entirely offline.
+Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`;
+`capability_configuration`, `canonical_events`, `live_session`, `session_work`,
+`workspace_policy`, and `session_history` run entirely offline.
 
 | Example | What it demonstrates | Run |
 |---|---|---|
+| [`capability_configuration.rs`](capability_configuration.rs) | One open entrypoint for typed Compaction and ToolSearch, a code-defined Definition, and a dynamic vendor reference | `cargo run -p everruns --example capability_configuration` |
 | [`workspace_policy.rs`](workspace_policy.rs) | Safe read/write scopes, default restrictions, and trusted starter files | `cargo run -p everruns --example workspace_policy` |
 | [`live_session.rs`](live_session.rs) | Non-blocking send, automatic steering, and optional waiting | `cargo run -p everruns --example live_session` |
 | [`hello.rs`](hello.rs) | Minimal agent, typed tool, turn result, and event observation | `cargo run -p everruns --features openai --example hello` |

--- a/crates/everruns/examples/advanced_capability.rs
+++ b/crates/everruns/examples/advanced_capability.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .instructions("Answer questions using the product catalog capability.")
         .provider(OpenAI::from_env()?)
         .model("gpt-5.6-terra")
-        .advanced_capability(catalog)
+        .capability(catalog)
         .build()?;
 
     let session = agent.session();

--- a/crates/everruns/examples/capability_configuration.rs
+++ b/crates/everruns/examples/capability_configuration.rs
@@ -1,0 +1,76 @@
+//! Configure every capability kind through one open Framework entrypoint.
+//!
+//! Run offline with:
+//! `cargo run -p everruns --example capability_configuration`
+
+use everruns::{Agent, CapabilityRef, CompactionConfig, Model, ToolSearch, capability};
+
+#[derive(capability::Deserialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct WeatherInput {
+    city: String,
+}
+
+#[derive(capability::Serialize, capability::JsonSchema)]
+#[serde(crate = "everruns::capability::serde")]
+#[schemars(crate = "everruns::capability::schemars")]
+struct WeatherOutput {
+    summary: String,
+}
+
+struct Weather;
+
+#[capability::async_trait]
+impl capability::Handler for Weather {
+    type Input = WeatherInput;
+    type Output = WeatherOutput;
+    type Error = capability::Error;
+
+    fn name(&self) -> &str {
+        "weather_forecast"
+    }
+
+    fn description(&self) -> &str {
+        "Return the sample forecast for one city."
+    }
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        _context: capability::Context,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(WeatherOutput {
+            summary: format!("Clear skies in {}", input.city),
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let weather_definition = capability::Definition::new(
+        "weather",
+        "Weather",
+        "Application-defined sample weather tools.",
+    )
+    .tool(Weather);
+
+    let agent = Agent::builder()
+        .instructions("Use configured capabilities when relevant.")
+        .model(Model::simulated("Configured."))
+        .capability(CompactionConfig::new().budget_percent(0.85))
+        .capability(ToolSearch::automatic())
+        .capability(weather_definition)
+        .capability(
+            CapabilityRef::new("vendor.custom")
+                .config(capability::serde_json::json!({ "mode": "database-driven" })),
+        )
+        .build()?;
+
+    let turn = agent
+        .session()
+        .run("Confirm the agent is configured.")
+        .await?;
+    println!("{}", turn.response);
+    Ok(())
+}

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -181,14 +181,14 @@ pub enum BuildError {
         /// The colliding tool name.
         name: String,
     },
-    /// An advanced capability's public descriptor is invalid.
+    /// A capability identifier, configuration, or public descriptor is invalid.
     InvalidCapability {
         /// The rejected capability id.
         id: String,
         /// Why the descriptor was rejected.
         reason: String,
     },
-    /// Two advanced capability registrations used the same stable id.
+    /// Two capability inputs resolve to the same stable implementation id.
     DuplicateCapability {
         /// The colliding capability id.
         id: String,
@@ -199,8 +199,6 @@ pub enum BuildError {
     MultipleProviders { registered: Vec<String> },
     /// MCP server configuration was invalid or duplicated.
     InvalidMcpServer { reason: String },
-    /// Context compaction configuration was invalid.
-    InvalidCompaction { reason: String },
 }
 
 impl fmt::Display for BuildError {
@@ -220,10 +218,10 @@ impl fmt::Display for BuildError {
                 write!(f, "duplicate tool name {name:?}")
             }
             BuildError::InvalidCapability { id, reason } => {
-                write!(f, "invalid advanced capability {id:?}: {reason}")
+                write!(f, "invalid capability {id:?}: {reason}")
             }
             BuildError::DuplicateCapability { id } => {
-                write!(f, "duplicate advanced capability id {id:?}")
+                write!(f, "duplicate capability id {id:?}")
             }
             BuildError::MissingProvider => write!(f, "agent requires a provider for a live model"),
             BuildError::MultipleProviders { registered } => write!(
@@ -233,9 +231,6 @@ impl fmt::Display for BuildError {
             ),
             BuildError::InvalidMcpServer { reason } => {
                 write!(f, "invalid MCP server configuration: {reason}")
-            }
-            BuildError::InvalidCompaction { reason } => {
-                write!(f, "invalid compaction configuration: {reason}")
             }
         }
     }
@@ -256,9 +251,7 @@ pub struct Agent {
     model: ModelSpec,
     provider: Provider,
     capabilities: Vec<AgentCapabilityConfig>,
-    function_tools: Vec<FunctionTool>,
-    #[cfg(feature = "capabilities")]
-    advanced_capabilities: Vec<crate::capability::Definition>,
+    capability_implementations: Vec<CapabilityImplementation>,
     initial_files: Vec<InitialFile>,
     max_iterations: Option<usize>,
     parallel_tool_calls: Option<bool>,
@@ -270,6 +263,39 @@ pub struct Agent {
     local: Option<crate::LocalConfig>,
     lifecycle_hooks: crate::hooks::LifecycleHooks,
     state: Arc<AgentState>,
+}
+
+#[derive(Clone)]
+enum CapabilityImplementation {
+    Function(FunctionTool),
+    #[cfg(feature = "capabilities")]
+    Definition(crate::capability::Definition),
+}
+
+impl CapabilityImplementation {
+    fn register(&self, builder: InProcessRuntimeBuilder) -> InProcessRuntimeBuilder {
+        match self {
+            Self::Function(tool) => builder.capability(tool.clone().into_capability()),
+            #[cfg(feature = "capabilities")]
+            Self::Definition(definition) => builder.capability(definition.runtime_adapter()),
+        }
+    }
+}
+
+impl fmt::Debug for CapabilityImplementation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Function(tool) => formatter
+                .debug_tuple("Function")
+                .field(&tool.name())
+                .finish(),
+            #[cfg(feature = "capabilities")]
+            Self::Definition(definition) => formatter
+                .debug_tuple("Definition")
+                .field(&definition.id())
+                .finish(),
+        }
+    }
 }
 
 struct AgentState {
@@ -316,13 +342,21 @@ impl fmt::Debug for AgentState {
 
 impl fmt::Debug for Agent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let capability_ids = self
+            .capabilities
+            .iter()
+            .map(AgentCapabilityConfig::capability_id)
+            .collect::<Vec<_>>();
         f.debug_struct("Agent")
             .field("name", &self.name)
             .field("instructions", &self.instructions)
             .field("model", &self.model)
             .field("provider", &self.provider)
-            .field("capabilities", &self.capabilities)
-            .field("function_tools", &self.function_tools)
+            .field("capabilities", &capability_ids)
+            .field(
+                "capability_implementations",
+                &self.capability_implementations,
+            )
             .field("initial_files", &self.initial_files)
             .field("max_iterations", &self.max_iterations)
             .field("parallel_tool_calls", &self.parallel_tool_calls)
@@ -375,7 +409,7 @@ impl Agent {
     ///     .instructions("You are concise.")
     ///     .model(Model::simulated("Sure."))
     ///     .name("assistant")
-    ///     .tool("test_math")
+    ///     .capability("test_math")
     ///     .parallel_tool_calls(true)
     ///     .build()?;
     /// # Ok::<(), everruns::BuildError>(())
@@ -638,15 +672,12 @@ impl Agent {
                 .build();
             builder = builder.platform_definition(platform);
         }
-        // Register each function tool as a closure-backed, single-tool
-        // capability so the runtime can execute the model's calls; the matching
-        // capability ref was attached to the harness/agent/session above.
-        for tool in &self.function_tools {
-            builder = builder.capability(tool.clone().into_capability());
-        }
-        #[cfg(feature = "capabilities")]
-        for capability in &self.advanced_capabilities {
-            builder = builder.capability(capability.runtime_adapter());
+        // References and code-defined implementations were normalized and
+        // collision-checked together at Agent build time. Register each
+        // implementation once on this session's private runtime; the matching
+        // activation ref is already attached at every configuration layer.
+        for implementation in &self.capability_implementations {
+            builder = implementation.register(builder);
         }
         if let Some(capability) = hook_capability {
             builder = builder.capability(capability);
@@ -676,10 +707,8 @@ pub struct AgentBuilder {
     instructions: Option<String>,
     model: Option<Model>,
     providers: Vec<Provider>,
-    capabilities: Vec<AgentCapabilityConfig>,
+    capabilities: Vec<crate::CapabilitySpec>,
     tools: Vec<Tool>,
-    #[cfg(feature = "capabilities")]
-    advanced_capabilities: Vec<crate::capability::Definition>,
     initial_files: Vec<InitialFile>,
     max_iterations: Option<usize>,
     parallel_tool_calls: Option<bool>,
@@ -687,7 +716,6 @@ pub struct AgentBuilder {
     workspace_policy: everruns_core::WorkspacePolicy,
     mcp_servers: Vec<crate::McpServer>,
     plugin_warnings: Vec<String>,
-    compaction: Option<crate::CompactionConfig>,
     #[cfg(feature = "local")]
     local: Option<crate::LocalConfig>,
     lifecycle_hooks: crate::hooks::LifecycleHooks,
@@ -728,10 +756,10 @@ impl AgentBuilder {
 
     /// Add a tool the agent can call.
     ///
-    /// Accepts anything that is [`IntoTool`](crate::IntoTool): a
+    /// Accepts anything that is [`IntoTool`](crate::IntoTool), including a
     /// [`FunctionTool`](crate::FunctionTool) backed by an async function or
-    /// closure, or a `&str`/`String` capability id for a capability-referenced
-    /// tool. Tool names and JSON schemas are validated, and duplicate names
+    /// closure. Capability references use [`capability`](Self::capability)
+    /// instead. Tool names and JSON schemas are validated, and duplicate names
     /// rejected, at [`build`](Self::build).
     ///
     /// # Example
@@ -743,7 +771,7 @@ impl AgentBuilder {
     /// let agent = Agent::builder()
     ///     .instructions("You are concise.")
     ///     .model(Model::simulated("done"))
-    ///     .tool("test_math")
+    ///     .capability("test_math")
     ///     .tool(FunctionTool::new(
     ///         "roll",
     ///         "Roll a die.",
@@ -844,28 +872,28 @@ impl AgentBuilder {
         self
     }
 
-    /// Add a capability the agent can use.
-    pub fn capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
-        self.capabilities.push(capability.into());
+    /// Add one capability through the Framework's open conversion contract.
+    ///
+    /// Accepts typed built-ins such as [`CompactionConfig`](crate::CompactionConfig)
+    /// and [`ToolSearch`](crate::ToolSearch), a code-defined
+    /// `capability::Definition` (with the `capabilities` feature), a dynamic
+    /// [`CapabilityRef`](crate::CapabilityRef), or any third-party value that
+    /// implements [`IntoCapability`](crate::IntoCapability). Plain strings are
+    /// concise references with default configuration.
+    ///
+    /// Conversion happens immediately and is infallible. Identifier and JSON
+    /// validation, built-in schema validation, duplicate detection, and
+    /// implementation/reference collision checks happen together in
+    /// [`build`](Self::build). A stable ID may be activated only once; duplicate
+    /// inputs are errors rather than last-write-wins overrides.
+    pub fn capability(mut self, capability: impl crate::IntoCapability) -> Self {
+        self.capabilities.push(capability.into_capability());
         self
     }
 
     /// Limit the number of model/tool iterations allowed in one turn.
     pub fn max_iterations(mut self, max_iterations: usize) -> Self {
         self.max_iterations = Some(max_iterations);
-        self
-    }
-
-    /// Register a code-defined capability through the curated advanced SPI.
-    ///
-    /// This both installs the implementation on the private in-process runtime
-    /// and activates its stable id on the agent. Use [`#[everruns::tool]`](crate::tool)
-    /// for ordinary single-function tools; use this method when a reusable
-    /// capability needs typed protocol descriptors, context, progress, or
-    /// call-scoped cancellation.
-    #[cfg(feature = "capabilities")]
-    pub fn advanced_capability(mut self, capability: crate::capability::Definition) -> Self {
-        self.advanced_capabilities.push(capability);
         self
     }
 
@@ -913,10 +941,10 @@ impl AgentBuilder {
         if !self
             .capabilities
             .iter()
-            .any(|capability| capability.capability_id() == "session_file_system")
+            .any(|capability| capability.capability_ref().id() == "session_file_system")
         {
             self.capabilities
-                .push(AgentCapabilityConfig::new("session_file_system"));
+                .push(crate::CapabilityRef::new("session_file_system").into());
         }
         self
     }
@@ -953,12 +981,6 @@ impl AgentBuilder {
         Ok(self)
     }
 
-    /// Configure automatic context compaction for long-running sessions.
-    pub fn compaction(mut self, config: crate::CompactionConfig) -> Self {
-        self.compaction = Some(config);
-        self
-    }
-
     /// Enable restart-survivable local state and a real workspace.
     ///
     /// Task, schedule, and session identity state is stored in SQLite.
@@ -970,10 +992,10 @@ impl AgentBuilder {
         if !self
             .capabilities
             .iter()
-            .any(|capability| capability.capability_id() == "session_file_system")
+            .any(|capability| capability.capability_ref().id() == "session_file_system")
         {
             self.capabilities
-                .push(AgentCapabilityConfig::new("session_file_system"));
+                .push(crate::CapabilityRef::new("session_file_system").into());
         }
         self
     }
@@ -994,11 +1016,11 @@ impl AgentBuilder {
     /// - [`BuildError::DuplicateTool`] if two `.tool(..)` calls share a name.
     /// - [`BuildError::InvalidMcpServer`] if an MCP server is unnamed,
     ///   incomplete, or duplicates another server name.
-    /// - [`BuildError::InvalidCompaction`] if the proactive context budget is
-    ///   outside the supported range.
-    /// - [`BuildError::InvalidCapability`] if an advanced capability descriptor
-    ///   is invalid.
-    /// - [`BuildError::DuplicateCapability`] if advanced capabilities share an id.
+    /// - [`BuildError::InvalidCapability`] if a capability ID, JSON config, or
+    ///   code-defined descriptor is invalid.
+    /// - [`BuildError::DuplicateCapability`] if two inputs resolve to the same
+    ///   capability implementation, including aliases and reference/implementation
+    ///   collisions.
     pub fn build(self) -> Result<Agent, BuildError> {
         let instructions = self.instructions.unwrap_or_default();
         if instructions.trim().is_empty() {
@@ -1024,10 +1046,9 @@ impl AgentBuilder {
         let model = ModelSpec::on(provider.id().clone(), model.id);
         let name = self.name.unwrap_or_else(|| "agent".to_string());
 
-        // Validate tools and split them into capability refs (attached to the
-        // agent) and function tools (also registered on the runtime). Names
-        // must be unique across all `.tool(..)` calls.
-        let mut capabilities = self.capabilities;
+        // Function tools retain their own public entrypoint. Privately they are
+        // registered as single-tool capabilities, so their names participate in
+        // the same implementation-ID collision checks as every other input.
         let mut function_tools = Vec::new();
         let mut seen_tool_names: HashSet<String> = HashSet::new();
         for tool in self.tools {
@@ -1035,60 +1056,83 @@ impl AgentBuilder {
             if !seen_tool_names.insert(tool_name.clone()) {
                 return Err(BuildError::DuplicateTool { name: tool_name });
             }
-            match tool {
-                Tool::Capability(config) => capabilities.push(config),
-                Tool::Function(function_tool) => {
-                    validate_tool_name(function_tool.name()).map_err(|reason| {
-                        BuildError::InvalidToolName {
-                            name: tool_name.clone(),
-                            reason,
-                        }
-                    })?;
-                    validate_tool_schema(function_tool.schema()).map_err(|reason| {
-                        BuildError::InvalidToolSchema {
-                            name: tool_name.clone(),
-                            reason,
-                        }
-                    })?;
-                    capabilities.push(AgentCapabilityConfig::new(function_tool.name()));
-                    function_tools.push(function_tool);
+            let function_tool = tool.into_function();
+            validate_tool_name(function_tool.name()).map_err(|reason| {
+                BuildError::InvalidToolName {
+                    name: tool_name.clone(),
+                    reason,
                 }
-            }
+            })?;
+            validate_tool_schema(function_tool.schema()).map_err(|reason| {
+                BuildError::InvalidToolSchema {
+                    name: tool_name,
+                    reason,
+                }
+            })?;
+            function_tools.push(function_tool);
         }
 
         let mcp_servers = crate::mcp::into_scoped(self.mcp_servers)
             .map_err(|reason| BuildError::InvalidMcpServer { reason })?;
-        if let Some(compaction) = self.compaction {
-            if !(compaction.budget_percent.is_finite()
-                && 0.1 <= compaction.budget_percent
-                && compaction.budget_percent <= 1.0)
-            {
-                return Err(BuildError::InvalidCompaction {
-                    reason: "budget_percent must be at least 0.1 and at most 1".to_string(),
-                });
-            }
-            capabilities.push(compaction.capability_config());
-        }
 
-        #[cfg(feature = "capabilities")]
-        let advanced_capabilities = {
-            let mut seen_capability_ids: HashSet<String> = capabilities
-                .iter()
-                .map(|config| config.capability_id().to_string())
-                .collect();
-            for capability in &self.advanced_capabilities {
-                capability
+        // Use the same built-in set that this Agent will place on each private
+        // runtime. This makes build-time schema checks and implementation
+        // collision detection match execution instead of relying on a closed
+        // facade-owned list.
+        let capability_registry = {
+            #[cfg(feature = "local")]
+            if self.local.is_some() {
+                everruns_core::CapabilityRegistry::with_builtins()
+            } else {
+                everruns_core::CapabilityRegistry::runtime_builtins()
+            }
+            #[cfg(not(feature = "local"))]
+            {
+                everruns_core::CapabilityRegistry::runtime_builtins()
+            }
+        };
+
+        let mut capabilities = Vec::new();
+        let mut capability_implementations = Vec::new();
+        let mut seen_capability_ids = HashSet::new();
+
+        for input in self.capabilities {
+            let parts = input.into_parts();
+            let input_id = parts.reference.id().to_string();
+            crate::capability_config::validate_capability_id(&input_id).map_err(|reason| {
+                BuildError::InvalidCapability {
+                    id: input_id.clone(),
+                    reason,
+                }
+            })?;
+            crate::capability_config::validate_capability_config(parts.reference.config_value())
+                .map_err(|reason| BuildError::InvalidCapability {
+                    id: input_id.clone(),
+                    reason,
+                })?;
+
+            let canonical_id = capability_registry
+                .canonical_id(&input_id)
+                .unwrap_or(&input_id)
+                .to_string();
+            if seen_capability_ids.contains(&canonical_id) {
+                return Err(BuildError::DuplicateCapability { id: canonical_id });
+            }
+
+            #[cfg(feature = "capabilities")]
+            if let Some(definition) = parts.definition {
+                definition
                     .validate()
                     .map_err(|reason| BuildError::InvalidCapability {
-                        id: capability.id().to_string(),
+                        id: input_id.clone(),
                         reason,
                     })?;
-                if !seen_capability_ids.insert(capability.id().to_string()) {
+                if capability_registry.get(definition.id()).is_some() {
                     return Err(BuildError::DuplicateCapability {
-                        id: capability.id().to_string(),
+                        id: definition.id().to_string(),
                     });
                 }
-                for tool in capability.tools() {
+                for tool in definition.tools() {
                     let spec = tool.spec();
                     validate_tool_name(spec.name()).map_err(|reason| {
                         BuildError::InvalidToolName {
@@ -1108,10 +1152,35 @@ impl AgentBuilder {
                         });
                     }
                 }
-                capabilities.push(AgentCapabilityConfig::new(capability.id()));
+                capability_implementations.push(CapabilityImplementation::Definition(definition));
             }
-            self.advanced_capabilities
-        };
+
+            validate_registered_capability_config(
+                &capability_registry,
+                &canonical_id,
+                parts.reference.config_value(),
+            )?;
+            seen_capability_ids.insert(canonical_id.clone());
+            capabilities.push(AgentCapabilityConfig::with_config(
+                canonical_id,
+                parts.reference.config_value().clone(),
+            ));
+        }
+
+        for function_tool in function_tools {
+            let id = function_tool.name().to_string();
+            crate::capability_config::validate_capability_id(&id).map_err(|reason| {
+                BuildError::InvalidCapability {
+                    id: id.clone(),
+                    reason,
+                }
+            })?;
+            if capability_registry.get(&id).is_some() || !seen_capability_ids.insert(id.clone()) {
+                return Err(BuildError::DuplicateCapability { id });
+            }
+            capabilities.push(AgentCapabilityConfig::new(id.as_str()));
+            capability_implementations.push(CapabilityImplementation::Function(function_tool));
+        }
 
         Ok(Agent {
             name,
@@ -1119,9 +1188,7 @@ impl AgentBuilder {
             model,
             provider,
             capabilities,
-            function_tools,
-            #[cfg(feature = "capabilities")]
-            advanced_capabilities,
+            capability_implementations,
             initial_files: self.initial_files,
             max_iterations: self.max_iterations,
             parallel_tool_calls: self.parallel_tool_calls,
@@ -1135,6 +1202,76 @@ impl AgentBuilder {
             state: Arc::new(AgentState::new()),
         })
     }
+}
+
+fn validate_registered_capability_config(
+    registry: &everruns_core::CapabilityRegistry,
+    id: &str,
+    config: &serde_json::Value,
+) -> Result<(), BuildError> {
+    if let Some(capability) = registry.get(id) {
+        capability
+            .validate_config(config)
+            .map_err(|reason| BuildError::InvalidCapability {
+                id: id.to_string(),
+                reason,
+            })?;
+    }
+
+    if id == everruns_core::AUTO_TOOL_SEARCH_CAPABILITY_ID {
+        validate_tool_search_config(config).map_err(|reason| BuildError::InvalidCapability {
+            id: id.to_string(),
+            reason,
+        })?;
+    }
+
+    if everruns_core::is_declarative_capability(id) || everruns_core::is_plugin_capability(id) {
+        let definition = serde_json::from_value::<everruns_core::DeclarativeCapabilityDefinition>(
+            config.clone(),
+        )
+        .map_err(|error| BuildError::InvalidCapability {
+            id: id.to_string(),
+            reason: format!("invalid declarative capability config: {error}"),
+        })?;
+        everruns_core::validate_declarative_capability_definition(&definition).map_err(
+            |reason| BuildError::InvalidCapability {
+                id: id.to_string(),
+                reason,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_tool_search_config(config: &serde_json::Value) -> Result<(), String> {
+    let object = config
+        .as_object()
+        .expect("capability config object validated before built-in schema");
+    for key in object.keys() {
+        if key != "threshold" && key != "never_defer" {
+            return Err(format!("unknown tool-search config field {key:?}"));
+        }
+    }
+    if let Some(threshold) = object.get("threshold") {
+        let value = threshold
+            .as_u64()
+            .ok_or_else(|| "threshold must be a non-negative integer".to_string())?;
+        usize::try_from(value)
+            .map_err(|_| "threshold is too large for this platform".to_string())?;
+    }
+    if let Some(never_defer) = object.get("never_defer") {
+        let names = never_defer
+            .as_array()
+            .ok_or_else(|| "never_defer must be an array of tool names".to_string())?;
+        for name in names {
+            let name = name
+                .as_str()
+                .ok_or_else(|| "never_defer must contain only tool names".to_string())?;
+            validate_tool_name(name)
+                .map_err(|reason| format!("invalid never_defer tool {name:?}: {reason}"))?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/everruns/src/capability.rs
+++ b/crates/everruns/src/capability.rs
@@ -62,7 +62,7 @@
 //! let agent = Agent::builder()
 //!     .instructions("You are a concise assistant.")
 //!     .model(Model::simulated("done"))
-//!     .advanced_capability(weather)
+//!     .capability(weather)
 //!     .build()?;
 //! # let _ = agent;
 //! # Ok::<(), everruns::BuildError>(())
@@ -178,7 +178,7 @@ impl Definition {
     }
 
     pub(crate) fn validate(&self) -> Result<(), String> {
-        validate_identifier(&self.id, "capability")?;
+        crate::capability_config::validate_capability_id(&self.id)?;
         if self.name.trim().is_empty() {
             return Err("capability name must not be blank".to_string());
         }
@@ -211,29 +211,6 @@ impl Definition {
     pub(crate) fn runtime_adapter(&self) -> RuntimeDefinition {
         RuntimeDefinition(self.clone())
     }
-}
-
-fn validate_identifier(value: &str, noun: &str) -> Result<(), String> {
-    if value.is_empty() {
-        return Err(format!("{noun} id must not be empty"));
-    }
-    if value.len() > 64 {
-        return Err(format!("{noun} id must be at most 64 characters"));
-    }
-    let mut chars = value.chars();
-    let first = chars.next().expect("non-empty checked above");
-    if !(first.is_ascii_alphabetic() || first == '_') {
-        return Err(format!("{noun} id must start with a letter or underscore"));
-    }
-    if value
-        .chars()
-        .any(|ch| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
-    {
-        return Err(format!(
-            "{noun} id may only contain letters, digits, '_' or '-'"
-        ));
-    }
-    Ok(())
 }
 
 impl fmt::Debug for Definition {
@@ -939,7 +916,7 @@ mod tests {
         let agent = Agent::builder()
             .instructions("Use the weather capability.")
             .model(model)
-            .advanced_capability(lookup_capability())
+            .capability(lookup_capability())
             .build()
             .expect("valid agent");
         let session = agent.session();
@@ -980,7 +957,7 @@ mod tests {
         let agent = Agent::builder()
             .instructions("Try the lookup and handle errors.")
             .model(model)
-            .advanced_capability(capability)
+            .capability(capability)
             .build()
             .expect("valid agent");
 
@@ -1047,7 +1024,7 @@ mod tests {
         let agent = Agent::builder()
             .instructions("Run the completing lookup.")
             .model(model)
-            .advanced_capability(capability)
+            .capability(capability)
             .build()
             .expect("valid agent");
 
@@ -1115,7 +1092,7 @@ mod tests {
         let agent = Agent::builder()
             .instructions("Run the hanging lookup.")
             .model(model)
-            .advanced_capability(capability)
+            .capability(capability)
             .build()
             .expect("valid agent");
         let cancellation = CancellationToken::new();

--- a/crates/everruns/src/capability_config.rs
+++ b/crates/everruns/src/capability_config.rs
@@ -1,0 +1,257 @@
+//! Open, value-first capability configuration for Framework agents.
+
+use std::fmt;
+
+use serde_json::{Map, Value};
+
+/// Convert an application value into one Framework capability registration.
+///
+/// This trait is intentionally public and non-sealed. Third-party crates can
+/// implement it without depending on `everruns-core` or host internals: return
+/// a [`CapabilitySpec`] built from a stable [`CapabilityRef`]. The Framework
+/// validates identifiers, JSON configuration, duplicates, and implementation
+/// collisions when [`AgentBuilder::build`](crate::AgentBuilder::build) runs.
+/// Conversion itself is infallible and performs no registration.
+///
+/// # Example
+///
+/// ```
+/// use everruns::{CapabilityRef, CapabilitySpec, IntoCapability};
+/// use serde_json::json;
+///
+/// struct VendorSearch {
+///     index: String,
+/// }
+///
+/// impl IntoCapability for VendorSearch {
+///     fn into_capability(self) -> CapabilitySpec {
+///         CapabilityRef::new("vendor.search")
+///             .config(json!({ "index": self.index }))
+///             .into()
+///     }
+/// }
+/// ```
+pub trait IntoCapability {
+    /// Consume the value and return its normalized Framework specification.
+    fn into_capability(self) -> CapabilitySpec;
+}
+
+/// A dynamic reference to a capability implementation plus per-agent JSON.
+///
+/// Use this escape hatch when capability identity or configuration comes from
+/// a database, plugin, or another runtime catalog. IDs are open strings rather
+/// than variants in a Framework-owned enum. They must use a stable identifier
+/// made from ASCII letters, digits, `_`, `-`, `.`, or `:`, start with a letter
+/// or `_`, and fit within 128 bytes. The `__everruns_` namespace is reserved.
+///
+/// Configuration defaults to `{}` and must be a JSON object. At agent build
+/// time, known built-ins also run their implementation-owned validator;
+/// declarative/plugin payloads run the shared declarative validator. For an
+/// otherwise unknown third-party ID, the Framework can validate only the ID
+/// and object boundary—the referenced implementation owns the inner schema.
+///
+/// Configuration is redacted from `Debug`, but it is not a secret store: hosts
+/// may persist or otherwise inspect it. Put credentials in a provider-owned
+/// secret mechanism and pass only a non-secret handle here.
+#[derive(Clone, PartialEq)]
+pub struct CapabilityRef {
+    id: String,
+    config: Value,
+}
+
+impl fmt::Debug for CapabilityRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CapabilityRef")
+            .field("id", &self.id)
+            .field("config", &"<redacted>")
+            .finish()
+    }
+}
+
+impl CapabilityRef {
+    /// Reference a stable capability ID with default (`{}`) configuration.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            config: Value::Object(Map::new()),
+        }
+    }
+
+    /// Attach implementation-defined per-agent JSON configuration.
+    ///
+    /// Validation is deferred to [`AgentBuilder::build`](crate::AgentBuilder::build)
+    /// so capability values remain easy to compose and pass through application
+    /// configuration layers.
+    pub fn config(mut self, config: impl Into<Value>) -> Self {
+        self.config = config.into();
+        self
+    }
+
+    /// The stable capability identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The implementation-defined JSON configuration.
+    pub fn config_value(&self) -> &Value {
+        &self.config
+    }
+}
+
+/// The normalized Framework value produced by [`IntoCapability`].
+///
+/// A spec always activates exactly one [`CapabilityRef`]. With the default
+/// `capabilities` feature it may also carry the matching code-defined
+/// `capability::Definition` that the private in-process host must register when
+/// the `capabilities` feature is enabled. Applications normally construct specs
+/// by converting a [`CapabilityRef`], a typed built-in value, or a `Definition`.
+///
+/// Duplicate IDs are never merged and later registrations never overwrite
+/// earlier ones. [`AgentBuilder::build`](crate::AgentBuilder::build) rejects
+/// duplicates after resolving built-in aliases, including a reference paired
+/// with a code-defined implementation and an implementation that would shadow
+/// a built-in.
+#[derive(Clone, Debug)]
+pub struct CapabilitySpec {
+    reference: CapabilityRef,
+    #[cfg(feature = "capabilities")]
+    definition: Option<crate::capability::Definition>,
+}
+
+impl CapabilitySpec {
+    /// Normalize a dynamic capability reference.
+    pub fn reference(reference: CapabilityRef) -> Self {
+        Self {
+            reference,
+            #[cfg(feature = "capabilities")]
+            definition: None,
+        }
+    }
+
+    /// Normalize a code-defined capability and activate its stable ID.
+    #[cfg(feature = "capabilities")]
+    pub fn definition(definition: crate::capability::Definition) -> Self {
+        Self {
+            reference: CapabilityRef::new(definition.id()),
+            definition: Some(definition),
+        }
+    }
+
+    /// The reference that will be activated for the agent.
+    pub fn capability_ref(&self) -> &CapabilityRef {
+        &self.reference
+    }
+
+    pub(crate) fn into_parts(self) -> CapabilitySpecParts {
+        CapabilitySpecParts {
+            reference: self.reference,
+            #[cfg(feature = "capabilities")]
+            definition: self.definition,
+        }
+    }
+}
+
+pub(crate) struct CapabilitySpecParts {
+    pub reference: CapabilityRef,
+    #[cfg(feature = "capabilities")]
+    pub definition: Option<crate::capability::Definition>,
+}
+
+impl From<CapabilityRef> for CapabilitySpec {
+    fn from(reference: CapabilityRef) -> Self {
+        Self::reference(reference)
+    }
+}
+
+impl IntoCapability for CapabilitySpec {
+    fn into_capability(self) -> CapabilitySpec {
+        self
+    }
+}
+
+impl IntoCapability for CapabilityRef {
+    fn into_capability(self) -> CapabilitySpec {
+        self.into()
+    }
+}
+
+impl IntoCapability for &str {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new(self).into()
+    }
+}
+
+impl IntoCapability for String {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new(self).into()
+    }
+}
+
+impl IntoCapability for &String {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new(self.as_str()).into()
+    }
+}
+
+// Retain the 0.17 raw-config input without making it part of the documented
+// Framework surface. CapabilityRef is the stable application API.
+impl IntoCapability for everruns_core::AgentCapabilityConfig {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new(self.capability_id())
+            .config(self.config)
+            .into()
+    }
+}
+
+#[cfg(feature = "capabilities")]
+impl From<crate::capability::Definition> for CapabilitySpec {
+    fn from(definition: crate::capability::Definition) -> Self {
+        Self::definition(definition)
+    }
+}
+
+#[cfg(feature = "capabilities")]
+impl IntoCapability for crate::capability::Definition {
+    fn into_capability(self) -> CapabilitySpec {
+        self.into()
+    }
+}
+
+pub(crate) fn validate_capability_id(id: &str) -> Result<(), String> {
+    if id.is_empty() {
+        return Err("capability id must not be empty".to_string());
+    }
+    if id.len() > 128 {
+        return Err(format!(
+            "capability id must be at most 128 bytes (got {})",
+            id.len()
+        ));
+    }
+    if id.starts_with("__everruns_") {
+        return Err("capability id uses the reserved '__everruns_' namespace".to_string());
+    }
+    let mut chars = id.chars();
+    let first = chars.next().expect("non-empty checked above");
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err("capability id must start with a letter or underscore".to_string());
+    }
+    if id
+        .chars()
+        .any(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':')))
+    {
+        return Err(
+            "capability id may only contain ASCII letters, digits, '_', '-', '.' or ':'"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_capability_config(config: &Value) -> Result<(), String> {
+    if config.is_object() {
+        Ok(())
+    } else {
+        Err("capability config must be a JSON object".to_string())
+    }
+}

--- a/crates/everruns/src/compaction.rs
+++ b/crates/everruns/src/compaction.rs
@@ -65,17 +65,6 @@ impl CompactionConfig {
         self.budget_percent = budget_percent;
         self
     }
-
-    pub(crate) fn capability_config(self) -> everruns_core::AgentCapabilityConfig {
-        everruns_core::AgentCapabilityConfig::with_config(
-            "compaction",
-            serde_json::json!({
-                "strategy": self.strategy.as_str(),
-                "proactive": self.proactive,
-                "budget_percent": self.budget_percent,
-            }),
-        )
-    }
 }
 
 impl Default for CompactionConfig {
@@ -85,5 +74,17 @@ impl Default for CompactionConfig {
             proactive: true,
             budget_percent: 0.85,
         }
+    }
+}
+
+impl crate::IntoCapability for CompactionConfig {
+    fn into_capability(self) -> crate::CapabilitySpec {
+        crate::CapabilityRef::new("compaction")
+            .config(serde_json::json!({
+                "strategy": self.strategy.as_str(),
+                "proactive": self.proactive,
+                "budget_percent": self.budget_percent,
+            }))
+            .into()
     }
 }

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -40,6 +40,7 @@ extern crate self as everruns;
 mod agent;
 #[cfg(feature = "capabilities")]
 pub mod capability;
+mod capability_config;
 mod compaction;
 mod context;
 mod events;
@@ -49,9 +50,11 @@ mod mcp;
 mod plugin;
 mod session;
 mod tool;
+mod tool_search;
 /// Session-owned background work, scheduling, cancellation, and wakes.
 pub mod work;
 pub use agent::{Agent, AgentBuilder, BuildError, Model};
+pub use capability_config::{CapabilityRef, CapabilitySpec, IntoCapability};
 pub use compaction::{CompactionConfig, CompactionStrategy};
 pub use context::{ContextMessage, SessionContext, ToolInfo};
 pub use events::{
@@ -70,6 +73,7 @@ pub use mcp::McpServer;
 pub use plugin::PluginError;
 pub use session::{CancelError, RunError, SendDisposition, SentMessage, Session, Turn, TurnHandle};
 pub use tool::{FunctionTool, IntoTool, IntoToolResult, Tool, ToolResponse};
+pub use tool_search::ToolSearch;
 
 #[cfg(feature = "local")]
 mod local;
@@ -135,12 +139,14 @@ pub use everruns_host::{
 };
 
 // --- Portable message, model, and platform types ------------------------
+#[doc(hidden)]
+pub use everruns_core::AgentCapabilityConfig;
 pub use everruns_core::turn::TurnStopReason;
 pub use everruns_core::{
-    AgentCapabilityConfig, AgentLoopError, BearerAuth, CapabilityRegistry, ChatDriver, ContentPart,
-    Controls, ImageContentPart, InitialFile, InputMessage, LlmCallConfig, LlmCompletionMetadata,
-    LlmMessage, LlmResponseStream, LlmStreamEvent, MessageRole, ModelSpec, PlatformDefinition,
-    Provider, ProviderAuth, ProviderAuthRequest, ProviderEndpoint, ProviderKey, ProviderRegistry,
+    AgentLoopError, BearerAuth, CapabilityRegistry, ChatDriver, ContentPart, Controls,
+    ImageContentPart, InitialFile, InputMessage, LlmCallConfig, LlmCompletionMetadata, LlmMessage,
+    LlmResponseStream, LlmStreamEvent, MessageRole, ModelSpec, PlatformDefinition, Provider,
+    ProviderAuth, ProviderAuthRequest, ProviderEndpoint, ProviderKey, ProviderRegistry,
     ReasoningConfig, SessionId, StaticHeaderAuth, ToolCall, WorkspacePolicy,
     WorkspacePolicyBuilder, WorkspacePolicyError,
 };
@@ -183,14 +189,14 @@ pub mod prelude {
     };
     pub use crate::{
         Agent, AgentBuilder, AgentStartContext, BuildError, CancelError, CancellationToken,
-        CompactionConfig, CompactionStrategy, CompletionContext, EventStream, EventStreamError,
-        FunctionTool, HistoryCursor, HistoryCursorParseError, HistoryError, HistoryPage,
-        HistoryPages, HistoryQuery, HookFailure, HookPoint, InitialFile, IntoHookResult, IntoTool,
-        IntoToolResult, LlmSimConfig, McpServer, Model, PluginError, ResumeError, RunError,
-        RunOptions, SendDisposition, SentMessage, Session, SessionContext, SessionEvent,
-        SessionEventKind, SessionId, SessionMessage, Tool, ToolEndContext, ToolInfo, ToolResponse,
-        ToolStartContext, Turn, TurnHandle, TurnStartContext, WorkspacePolicy,
-        WorkspacePolicyBuilder, WorkspacePolicyError,
+        CapabilityRef, CapabilitySpec, CompactionConfig, CompactionStrategy, CompletionContext,
+        EventStream, EventStreamError, FunctionTool, HistoryCursor, HistoryCursorParseError,
+        HistoryError, HistoryPage, HistoryPages, HistoryQuery, HookFailure, HookPoint, InitialFile,
+        IntoCapability, IntoHookResult, IntoTool, IntoToolResult, LlmSimConfig, McpServer, Model,
+        PluginError, ResumeError, RunError, RunOptions, SendDisposition, SentMessage, Session,
+        SessionContext, SessionEvent, SessionEventKind, SessionId, SessionMessage, Tool,
+        ToolEndContext, ToolInfo, ToolResponse, ToolSearch, ToolStartContext, Turn, TurnHandle,
+        TurnStartContext, WorkspacePolicy, WorkspacePolicyBuilder, WorkspacePolicyError,
     };
     #[cfg(feature = "openai")]
     pub use crate::{OpenAI, OpenAIError};

--- a/crates/everruns/src/plugin.rs
+++ b/crates/everruns/src/plugin.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use everruns_core::plugin_capability_id;
 use everruns_core::plugins::{PluginFileSet, compile_plugin};
-use everruns_core::{AgentCapabilityConfig, plugin_capability_id};
 
 /// Failure while reading or compiling a local plugin directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,7 +29,7 @@ impl fmt::Display for PluginError {
 impl std::error::Error for PluginError {}
 
 pub(crate) struct LoadedPlugin {
-    pub capability: AgentCapabilityConfig,
+    pub capability: crate::CapabilitySpec,
     pub warnings: Vec<String>,
 }
 
@@ -51,7 +51,9 @@ pub(crate) fn load(path: &Path) -> Result<LoadedPlugin, PluginError> {
         message: error.to_string(),
     })?;
     Ok(LoadedPlugin {
-        capability: AgentCapabilityConfig::with_config(capability_id, config),
+        capability: crate::CapabilityRef::new(capability_id)
+            .config(config)
+            .into(),
         warnings: compiled.warnings,
     })
 }

--- a/crates/everruns/src/tool.rs
+++ b/crates/everruns/src/tool.rs
@@ -6,11 +6,11 @@
 //! arguments as a [`serde_json::Value`] and returns any [`IntoToolResult`]
 //! (a `serde_json::Value`, a `String`, or an explicit [`ToolResponse`]).
 //!
-//! [`AgentBuilder::tool`](crate::AgentBuilder::tool) accepts anything that is
-//! [`IntoTool`]: a [`FunctionTool`], or a `&str`/`String` capability id for the
-//! existing capability-referenced tools. The builder validates tool names and
-//! JSON schemas and rejects duplicate names before an [`Agent`](crate::Agent)
-//! is produced.
+//! [`AgentBuilder::tool`](crate::AgentBuilder::tool) accepts function tools via
+//! [`IntoTool`]. Capability references use the separate, scalable
+//! [`AgentBuilder::capability`](crate::AgentBuilder::capability) entrypoint. The
+//! builder validates tool names and JSON schemas and rejects duplicates before
+//! an [`Agent`](crate::Agent) is produced.
 //!
 //! Under the hood a `FunctionTool` is adapted to the core tool-execution
 //! contract ([`everruns_core::tools::Tool`]) and registered as a single-tool,
@@ -54,7 +54,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use everruns_core::AgentCapabilityConfig;
 use everruns_core::capabilities::Capability;
 use everruns_core::tools::{Tool as CoreTool, ToolExecutionResult};
 use serde_json::Value;
@@ -230,9 +229,9 @@ impl CoreTool for FunctionTool {
 
 /// A closure-backed [`Capability`] exposing exactly one [`FunctionTool`].
 ///
-/// Its capability id equals the tool name, so a single
-/// [`AgentCapabilityConfig`] reference wires the tool onto the agent. This is
-/// the bridge from a library-user function to the core capability/tool contract.
+/// Its capability id equals the tool name. The Framework creates the matching
+/// private activation when `.tool(...)` is built; applications never configure
+/// this implementation as a public capability reference.
 pub(crate) struct FunctionCapability {
     tool: FunctionTool,
 }
@@ -255,16 +254,13 @@ impl Capability for FunctionCapability {
     }
 }
 
-/// An agent tool: either a reference to an existing capability id, or a
-/// closure-backed [`FunctionTool`].
+/// A closure-backed function tool accepted by [`AgentBuilder::tool`](crate::AgentBuilder::tool).
 ///
-/// This is the application-facing adapter that [`AgentBuilder::tool`](crate::AgentBuilder::tool) accepts
-/// via [`IntoTool`]. A `&str`/`String` names a capability-referenced tool; a
-/// [`FunctionTool`] carries its own handler.
+/// Capability references are deliberately not represented here; configure
+/// those through [`AgentBuilder::capability`](crate::AgentBuilder::capability).
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Tool {
-    /// A tool provided by an existing capability, referenced by id.
-    Capability(AgentCapabilityConfig),
     /// A custom tool backed by an async function or closure.
     Function(FunctionTool),
 }
@@ -273,17 +269,22 @@ impl Tool {
     /// The model-facing name of this tool.
     pub(crate) fn name(&self) -> &str {
         match self {
-            Tool::Capability(config) => config.capability_id(),
             Tool::Function(tool) => &tool.name,
+        }
+    }
+
+    pub(crate) fn into_function(self) -> FunctionTool {
+        match self {
+            Self::Function(tool) => tool,
         }
     }
 }
 
 /// Conversion into a [`Tool`] for [`AgentBuilder::tool`](crate::AgentBuilder::tool).
 ///
-/// Implemented for [`FunctionTool`], for `&str`/`String` (a capability id), and
-/// for [`AgentCapabilityConfig`], so the same `.tool(..)` call accepts both a
-/// custom function tool and an existing capability-referenced tool.
+/// Implemented for [`FunctionTool`] and the [`Tool`] wrapper emitted by public
+/// tool adapters. Capability IDs implement
+/// [`IntoCapability`](crate::IntoCapability), not `IntoTool`.
 pub trait IntoTool {
     /// Convert `self` into a [`Tool`].
     fn into_tool(self) -> Tool;
@@ -298,30 +299,6 @@ impl IntoTool for Tool {
 impl IntoTool for FunctionTool {
     fn into_tool(self) -> Tool {
         Tool::Function(self)
-    }
-}
-
-impl IntoTool for AgentCapabilityConfig {
-    fn into_tool(self) -> Tool {
-        Tool::Capability(self)
-    }
-}
-
-impl IntoTool for &str {
-    fn into_tool(self) -> Tool {
-        Tool::Capability(AgentCapabilityConfig::new(self))
-    }
-}
-
-impl IntoTool for String {
-    fn into_tool(self) -> Tool {
-        Tool::Capability(AgentCapabilityConfig::new(self))
-    }
-}
-
-impl IntoTool for &String {
-    fn into_tool(self) -> Tool {
-        Tool::Capability(AgentCapabilityConfig::new(self.as_str()))
     }
 }
 
@@ -485,22 +462,12 @@ mod tests {
     }
 
     #[test]
-    fn into_tool_maps_str_to_capability_ref() {
-        match "test_math".into_tool() {
-            Tool::Capability(config) => assert_eq!(config.capability_id(), "test_math"),
-            other => panic!("expected capability ref, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn into_tool_maps_function_tool() {
         let tool = FunctionTool::new("noop", "no-op", obj_schema(), |_: Value| async move {
             Ok::<_, String>(json!({}))
         });
-        match tool.into_tool() {
-            Tool::Function(f) => assert_eq!(f.name(), "noop"),
-            other => panic!("expected function tool, got {other:?}"),
-        }
+        let Tool::Function(function) = tool.into_tool();
+        assert_eq!(function.name(), "noop");
     }
 
     #[test]

--- a/crates/everruns/src/tool_search.rs
+++ b/crates/everruns/src/tool_search.rs
@@ -1,0 +1,60 @@
+//! Typed configuration for model-adaptive deferred tool loading.
+
+/// Model-adaptive tool-search capability configuration.
+///
+/// [`ToolSearch::automatic`] activates the existing `auto_tool_search`
+/// implementation: models with native hosted search use it, and every other
+/// model uses the provider-agnostic client-side search capability. The default
+/// activation threshold is owned by that implementation.
+///
+/// The optional `threshold` and `never_defer` values map directly to the
+/// existing built-in configuration. `never_defer` affects the generic fallback;
+/// hosted providers continue to honor the deferrability policy on each tool.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ToolSearch {
+    threshold: Option<usize>,
+    never_defer: Vec<String>,
+}
+
+impl ToolSearch {
+    /// Select hosted tool search when the model supports it and the generic
+    /// client-side implementation otherwise.
+    pub fn automatic() -> Self {
+        Self::default()
+    }
+
+    /// Override the minimum total tool count at which schemas are deferred.
+    pub fn threshold(mut self, threshold: usize) -> Self {
+        self.threshold = Some(threshold);
+        self
+    }
+
+    /// Keep these tools' full schemas visible under the generic fallback.
+    ///
+    /// Names are validated with the same model-facing rules as ordinary
+    /// function tools when [`AgentBuilder::build`](crate::AgentBuilder::build)
+    /// runs.
+    pub fn never_defer<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.never_defer.extend(names.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl crate::IntoCapability for ToolSearch {
+    fn into_capability(self) -> crate::CapabilitySpec {
+        let mut config = serde_json::Map::new();
+        if let Some(threshold) = self.threshold {
+            config.insert("threshold".to_string(), threshold.into());
+        }
+        if !self.never_defer.is_empty() {
+            config.insert("never_defer".to_string(), self.never_defer.into());
+        }
+        crate::CapabilityRef::new("auto_tool_search")
+            .config(serde_json::Value::Object(config))
+            .into()
+    }
+}

--- a/crates/everruns/tests/advanced_capabilities.rs
+++ b/crates/everruns/tests/advanced_capabilities.rs
@@ -70,7 +70,7 @@ fn installs_capability_and_exposes_typed_protocol() {
     let agent = Agent::builder()
         .instructions("Use arithmetic tools when asked.")
         .model(Model::simulated("done"))
-        .advanced_capability(arithmetic)
+        .capability(arithmetic)
         .build();
     assert!(agent.is_ok(), "public advanced SPI should build: {agent:?}");
 }
@@ -81,7 +81,7 @@ fn rejects_invalid_descriptors_and_colliding_tools() {
     let error = Agent::builder()
         .instructions("Do math.")
         .model(Model::simulated("done"))
-        .advanced_capability(empty)
+        .capability(empty)
         .build()
         .expect_err("an advanced capability must define a tool");
     assert!(matches!(error, BuildError::InvalidCapability { .. }));
@@ -90,7 +90,7 @@ fn rejects_invalid_descriptors_and_colliding_tools() {
     let error = Agent::builder()
         .instructions("Do math.")
         .model(Model::simulated("done"))
-        .advanced_capability(invalid)
+        .capability(invalid)
         .build()
         .expect_err("invalid capability id must fail");
     assert!(matches!(error, BuildError::InvalidCapability { .. }));
@@ -100,8 +100,8 @@ fn rejects_invalid_descriptors_and_colliding_tools() {
     let error = Agent::builder()
         .instructions("Do math.")
         .model(Model::simulated("done"))
-        .advanced_capability(first)
-        .advanced_capability(second)
+        .capability(first)
+        .capability(second)
         .build()
         .expect_err("tool names must be unique across capabilities");
     assert_eq!(

--- a/crates/everruns/tests/agent_builder.rs
+++ b/crates/everruns/tests/agent_builder.rs
@@ -35,10 +35,10 @@ fn invalid_compaction_budget_is_a_typed_error() {
         let err = Agent::builder()
             .instructions("You are concise.")
             .model(Model::simulated("ok"))
-            .compaction(CompactionConfig::new().budget_percent(invalid))
+            .capability(CompactionConfig::new().budget_percent(invalid))
             .build()
             .unwrap_err();
-        assert!(matches!(err, BuildError::InvalidCompaction { .. }));
+        assert!(matches!(err, BuildError::InvalidCapability { ref id, .. } if id == "compaction"));
     }
 }
 

--- a/crates/everruns/tests/application_parity.rs
+++ b/crates/everruns/tests/application_parity.rs
@@ -14,7 +14,7 @@ async fn compaction_is_configured_without_checkpoint_store_types() {
     let agent = Agent::builder()
         .instructions("Keep long conversations useful.")
         .model(Model::simulated("ok"))
-        .compaction(
+        .capability(
             CompactionConfig::new()
                 .strategy(CompactionStrategy::ObservationMasking)
                 .budget_percent(0.75),

--- a/crates/everruns/tests/capability_configuration.rs
+++ b/crates/everruns/tests/capability_configuration.rs
@@ -1,0 +1,338 @@
+//! Downstream-style coverage for the unified Framework capability entrypoint.
+
+use everruns::{
+    Agent, BuildError, CapabilityRef, CapabilitySpec, CompactionConfig, FunctionTool,
+    IntoCapability, Model, ToolSearch,
+};
+use serde_json::{Value, json};
+
+fn builder() -> everruns::AgentBuilder {
+    Agent::builder()
+        .instructions("Use the configured capabilities.")
+        .model(Model::simulated("done"))
+}
+
+#[tokio::test]
+async fn typed_compaction_runs_offline() {
+    let agent = builder()
+        .capability(CompactionConfig::new().budget_percent(0.85))
+        .build()
+        .expect("typed compaction config builds");
+
+    let turn = agent
+        .session()
+        .run("Keep this context useful.")
+        .await
+        .expect("offline turn runs");
+    assert!(turn.success);
+}
+
+#[tokio::test]
+async fn typed_tool_search_activates_the_model_adaptive_builtin() {
+    let agent = builder()
+        .capability(
+            ToolSearch::automatic()
+                .threshold(1)
+                .never_defer(["get_current_time"]),
+        )
+        .capability("current_time")
+        .build()
+        .expect("typed tool search builds");
+
+    let session = agent.session();
+    let context = session.inspect().await.expect("context assembles");
+    assert!(context.tools.iter().any(|tool| tool.name == "tool_search"));
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "get_current_time")
+    );
+}
+
+#[tokio::test]
+async fn dynamic_reference_activates_a_known_capability() {
+    let agent = builder()
+        .capability(CapabilityRef::new("current_time").config(json!({})))
+        .build()
+        .expect("dynamic reference builds");
+
+    let session = agent.session();
+    let context = session.inspect().await.expect("context assembles");
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "get_current_time")
+    );
+}
+
+struct ExternalCurrentTime;
+
+impl IntoCapability for ExternalCurrentTime {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new("current_time").into()
+    }
+}
+
+#[tokio::test]
+async fn external_conversion_contract_needs_only_the_facade() {
+    let agent = builder()
+        .capability(ExternalCurrentTime)
+        .build()
+        .expect("external capability value builds");
+
+    let session = agent.session();
+    let context = session.inspect().await.expect("context assembles");
+    assert!(
+        context
+            .tools
+            .iter()
+            .any(|tool| tool.name == "get_current_time")
+    );
+}
+
+#[tokio::test]
+async fn unknown_dynamic_reference_remains_an_open_noop_until_implemented() {
+    let agent = builder()
+        .capability(
+            CapabilityRef::new("vendor.custom").config(json!({ "mode": "database-driven" })),
+        )
+        .build()
+        .expect("open third-party reference builds");
+
+    let turn = agent
+        .session()
+        .run("Continue without a local implementation.")
+        .await
+        .expect("unknown references do not break offline execution");
+    assert!(turn.success);
+}
+
+#[test]
+fn invalid_ids_and_json_boundaries_are_rejected() {
+    for id in [
+        "",
+        "2fast",
+        "has space",
+        "vendor/custom",
+        "__everruns_private",
+    ] {
+        let error = builder()
+            .capability(CapabilityRef::new(id))
+            .build()
+            .expect_err("invalid capability id must fail");
+        assert!(matches!(error, BuildError::InvalidCapability { .. }));
+    }
+
+    let error = builder()
+        .capability(CapabilityRef::new("vendor.custom").config(json!(["not", "an", "object"])))
+        .build()
+        .expect_err("non-object config must fail");
+    assert!(matches!(error, BuildError::InvalidCapability { .. }));
+}
+
+#[test]
+fn dynamic_config_is_redacted_from_framework_debug_output() {
+    let reference = CapabilityRef::new("vendor.custom").config(json!({
+        "credential": "must-not-appear"
+    }));
+    assert!(!format!("{reference:?}").contains("must-not-appear"));
+
+    let agent = builder()
+        .capability(reference)
+        .build()
+        .expect("dynamic reference builds");
+    assert!(!format!("{agent:?}").contains("must-not-appear"));
+}
+
+#[test]
+fn known_builtin_configs_use_the_implementation_validator() {
+    let error = builder()
+        .capability(CapabilityRef::new("compaction").config(json!({ "budget_percent": 2.0 })))
+        .build()
+        .expect_err("invalid built-in config must fail at Agent build");
+    assert!(matches!(
+        error,
+        BuildError::InvalidCapability { ref id, .. } if id == "compaction"
+    ));
+
+    let error = builder()
+        .capability(CapabilityRef::new("auto_tool_search").config(json!({
+            "never_defer": ["bad name"]
+        })))
+        .build()
+        .expect_err("invalid typed tool-search field must fail");
+    assert!(matches!(
+        error,
+        BuildError::InvalidCapability { ref id, .. } if id == "auto_tool_search"
+    ));
+}
+
+#[test]
+fn duplicate_ids_across_typed_dynamic_and_string_inputs_are_rejected() {
+    let error = builder()
+        .capability(CompactionConfig::new())
+        .capability(CapabilityRef::new("compaction"))
+        .build()
+        .expect_err("typed and dynamic refs must collide");
+    assert_eq!(
+        error,
+        BuildError::DuplicateCapability {
+            id: "compaction".into(),
+        }
+    );
+
+    let error = builder()
+        .capability(ToolSearch::automatic())
+        .capability("auto_tool_search")
+        .build()
+        .expect_err("typed and string refs must collide");
+    assert_eq!(
+        error,
+        BuildError::DuplicateCapability {
+            id: "auto_tool_search".into(),
+        }
+    );
+
+    let error = builder()
+        .capability(CapabilityRef::new("virtual_bash"))
+        .capability("bashkit_shell")
+        .build()
+        .expect_err("a built-in alias and canonical ID must collide");
+    assert_eq!(
+        error,
+        BuildError::DuplicateCapability {
+            id: "bashkit_shell".into(),
+        }
+    );
+}
+
+#[test]
+fn function_tool_and_capability_reference_do_not_overwrite_each_other() {
+    let tool = FunctionTool::new(
+        "vendor_lookup",
+        "Look up a vendor record.",
+        json!({ "type": "object", "properties": {} }),
+        |_: Value| async move { Ok::<_, String>(json!({ "found": true })) },
+    );
+    let error = builder()
+        .capability("vendor_lookup")
+        .tool(tool)
+        .build()
+        .expect_err("function implementation and reference must collide");
+    assert_eq!(
+        error,
+        BuildError::DuplicateCapability {
+            id: "vendor_lookup".into(),
+        }
+    );
+
+    let reserved = FunctionTool::new(
+        "__everruns_framework_lifecycle_hooks",
+        "Attempt to shadow a private implementation.",
+        json!({ "type": "object", "properties": {} }),
+        |_: Value| async move { Ok::<_, String>(json!({})) },
+    );
+    let error = builder()
+        .tool(reserved)
+        .build()
+        .expect_err("function implementation must not use a reserved capability id");
+    assert!(matches!(
+        error,
+        BuildError::InvalidCapability { ref id, .. }
+            if id == "__everruns_framework_lifecycle_hooks"
+    ));
+}
+
+#[cfg(feature = "capabilities")]
+mod definitions {
+    use everruns::{Agent, BuildError, CapabilityRef, Model, capability};
+
+    #[derive(capability::Deserialize, capability::JsonSchema)]
+    #[serde(crate = "everruns::capability::serde")]
+    #[schemars(crate = "everruns::capability::schemars")]
+    struct EchoInput {
+        value: String,
+    }
+
+    #[derive(capability::Serialize, capability::JsonSchema)]
+    #[serde(crate = "everruns::capability::serde")]
+    #[schemars(crate = "everruns::capability::schemars")]
+    struct EchoOutput {
+        value: String,
+    }
+
+    struct Echo;
+
+    #[capability::async_trait]
+    impl capability::Handler for Echo {
+        type Input = EchoInput;
+        type Output = EchoOutput;
+        type Error = capability::Error;
+
+        fn name(&self) -> &str {
+            "vendor_echo"
+        }
+
+        fn description(&self) -> &str {
+            "Echo one vendor value."
+        }
+
+        async fn execute(
+            &self,
+            input: Self::Input,
+            _context: capability::Context,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(EchoOutput { value: input.value })
+        }
+    }
+
+    fn builder() -> everruns::AgentBuilder {
+        Agent::builder()
+            .instructions("Use vendor tools.")
+            .model(Model::simulated("done"))
+    }
+
+    fn definition(id: &str) -> capability::Definition {
+        capability::Definition::new(id, "Vendor", "Vendor-defined tools.").tool(Echo)
+    }
+
+    #[tokio::test]
+    async fn code_definition_registers_and_activates_through_capability() {
+        let agent = builder()
+            .capability(definition("vendor.echo"))
+            .build()
+            .expect("code definition builds");
+
+        let session = agent.session();
+        let context = session.inspect().await.expect("context assembles");
+        assert!(context.tools.iter().any(|tool| tool.name == "vendor_echo"));
+    }
+
+    #[test]
+    fn definition_reference_and_builtin_implementation_collisions_are_rejected() {
+        let error = builder()
+            .capability(CapabilityRef::new("vendor.echo"))
+            .capability(definition("vendor.echo"))
+            .build()
+            .expect_err("reference and implementation must collide");
+        assert_eq!(
+            error,
+            BuildError::DuplicateCapability {
+                id: "vendor.echo".into(),
+            }
+        );
+
+        let error = builder()
+            .capability(definition("current_time"))
+            .build()
+            .expect_err("code definition must not shadow a built-in");
+        assert_eq!(
+            error,
+            BuildError::DuplicateCapability {
+                id: "current_time".into(),
+            }
+        );
+    }
+}

--- a/crates/everruns/tests/function_tools.rs
+++ b/crates/everruns/tests/function_tools.rs
@@ -17,7 +17,7 @@ fn schema() -> Value {
 }
 
 #[test]
-fn registers_function_and_capability_tools_via_public_api() {
+fn registers_function_and_capability_via_separate_public_entrypoints() {
     let weather = FunctionTool::new(
         "get_weather",
         "Look up the weather for a city.",
@@ -31,12 +31,11 @@ fn registers_function_and_capability_tools_via_public_api() {
         },
     );
 
-    // A function tool and a capability-referenced tool coexist on the same
-    // builder, with no core/registry types in sight.
+    // Function tools and capability references remain distinct public inputs.
     let agent = Agent::builder()
         .instructions("You are a helpful weather assistant.")
         .model(Model::simulated("Clear skies."))
-        .tool("test_math")
+        .capability("current_time")
         .tool(weather)
         .build();
 

--- a/crates/everruns/tests/trybuild.rs
+++ b/crates/everruns/tests/trybuild.rs
@@ -12,6 +12,8 @@ fn ui() {
     t.pass("tests/ui/pass_signatures.rs");
     #[cfg(feature = "capabilities")]
     t.pass("tests/ui/pass_advanced_capability.rs");
+    #[cfg(feature = "capabilities")]
+    t.pass("tests/ui/pass_into_capability.rs");
     t.compile_fail("tests/ui/fail_not_async.rs");
     t.compile_fail("tests/ui/fail_receiver.rs");
     t.compile_fail("tests/ui/fail_generic.rs");

--- a/crates/everruns/tests/ui/pass_advanced_capability.rs
+++ b/crates/everruns/tests/ui/pass_advanced_capability.rs
@@ -39,7 +39,7 @@ fn main() {
     let _agent = Agent::builder()
         .instructions("Do math.")
         .model(Model::simulated("done"))
-        .advanced_capability(capability)
+        .capability(capability)
         .build()
         .unwrap();
 }

--- a/crates/everruns/tests/ui/pass_into_capability.rs
+++ b/crates/everruns/tests/ui/pass_into_capability.rs
@@ -1,0 +1,24 @@
+use everruns::{Agent, CapabilityRef, CapabilitySpec, IntoCapability, Model};
+
+struct VendorCapability {
+    region: String,
+}
+
+impl IntoCapability for VendorCapability {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new("vendor.search")
+            .config(everruns::capability::serde_json::json!({ "region": self.region }))
+            .into()
+    }
+}
+
+fn main() {
+    let _agent = Agent::builder()
+        .instructions("Use vendor search when available.")
+        .model(Model::simulated("done"))
+        .capability(VendorCapability {
+            region: "us-central".into(),
+        })
+        .build()
+        .unwrap();
+}

--- a/docs/framework/advanced-capabilities.md
+++ b/docs/framework/advanced-capabilities.md
@@ -1,12 +1,85 @@
 ---
-title: Author tools and advanced capabilities
-description: Choose #[everruns::tool] for ordinary functions or everruns::capability for reusable typed capability packages.
+title: Configure and author capabilities
+description: Use one open AgentBuilder capability entrypoint for typed built-ins, dynamic references, and code-defined packages.
 sidebar:
   order: 1
 ---
 
-Everruns has two public Framework extension levels. Use the smallest one that
-fits the behavior you own.
+Every agent capability enters through `AgentBuilder::capability`. The method
+accepts the public, non-sealed `IntoCapability` contract, so Framework built-ins
+and third-party packages compose without adding a method or enum variant to
+`AgentBuilder`.
+
+## Configure capabilities
+
+Use typed values when the Framework exposes a stable configuration, a
+`capability::Definition` for application code, and `CapabilityRef` when the ID
+and JSON arrive dynamically:
+
+```rust
+use everruns::{
+    Agent, CapabilityRef, CompactionConfig, Model, ToolSearch,
+};
+use serde_json::json;
+
+let weather_definition = build_weather_capability();
+let agent = Agent::builder()
+    .instructions("Use configured capabilities when relevant.")
+    .model(Model::simulated("done"))
+    .capability(CompactionConfig::new().budget_percent(0.85))
+    .capability(ToolSearch::automatic())
+    .capability(weather_definition)
+    .capability(
+        CapabilityRef::new("vendor.custom")
+            .config(json!({ "mode": "database-driven" })),
+    )
+    .build()?;
+```
+
+`ToolSearch::automatic` uses hosted deferred loading on supported models and
+the existing provider-neutral client-side implementation everywhere else. Its
+optional threshold and never-defer allowlist map to the built-in's real
+configuration; there are no provider fields on the Framework value.
+
+`CapabilityRef` is the explicit escape hatch for database, plugin, or catalog
+configuration. Its ID stays open. An unknown ID is retained as a reference but
+contributes nothing until the selected host or plugin provides that
+implementation. This is not a function tool: ordinary functions remain on
+`AgentBuilder::tool` and `#[everruns::tool]`.
+
+JSON capability config is not a credential store. Framework debug output
+redacts it, but a host may persist or inspect it; pass a provider-owned secret
+handle rather than API keys or tokens.
+
+Conversion is infallible. `AgentBuilder::build` validates ID syntax and the JSON
+object boundary, runs known built-in and declarative/plugin validators, and
+rejects duplicate IDs after built-in alias resolution. A code implementation
+cannot shadow a built-in or be paired with a second reference of the same ID;
+registrations never use last-write-wins behavior.
+
+Third-party typed values implement `IntoCapability` using only `everruns`:
+
+```rust
+use everruns::{CapabilityRef, CapabilitySpec, IntoCapability};
+
+struct VendorSearch {
+    index: String,
+}
+
+impl IntoCapability for VendorSearch {
+    fn into_capability(self) -> CapabilitySpec {
+        CapabilityRef::new("vendor.search")
+            .config(serde_json::json!({ "index": self.index }))
+            .into()
+    }
+}
+```
+
+No `everruns-core`, registry, store, or host dependency is needed.
+
+## Choose an authoring level
+
+Use the smallest extension contract that fits the behavior you own.
 
 | Contract | `#[everruns::tool]` | `everruns::capability` |
 |---|---|---|
@@ -47,8 +120,8 @@ Prefer this until you need a capability-level contract.
 
 An advanced capability is an immutable `capability::Definition`. It owns a
 stable id, catalog text, optional instructions and JSON metadata, and one or
-more typed handlers. `AgentBuilder::advanced_capability` installs it on the
-private in-process runtime and activates it for the agent.
+more typed handlers. `AgentBuilder::capability` installs its implementation on
+the private in-process runtime and activates that stable id once.
 
 ```rust
 use everruns::{Agent, Model, capability};
@@ -118,7 +191,7 @@ let records = capability::Definition::new(
 let agent = Agent::builder()
     .instructions("Answer with verified record data.")
     .model(Model::simulated("done"))
-    .advanced_capability(records)
+    .capability(records)
     .build()?;
 # Ok::<(), everruns::BuildError>(())
 ```

--- a/docs/framework/agents.md
+++ b/docs/framework/agents.md
@@ -21,8 +21,11 @@ let agent = Agent::builder()
 ```
 
 Builder validation catches blank instructions, a missing model, duplicate
-providers or tools, invalid tool schemas, and invalid MCP configuration before
-a session starts.
+providers, tools, or capabilities, invalid tool schemas, invalid capability
+IDs/configuration, implementation collisions, and invalid MCP configuration
+before a session starts. Configure typed built-ins, code-defined packages, and
+dynamic references through the single `capability(...)` entrypoint; see
+[Configure and author capabilities](/framework/advanced-capabilities/).
 
 ## Files and workspaces
 

--- a/docs/framework/examples.md
+++ b/docs/framework/examples.md
@@ -8,6 +8,7 @@ contains the maintained public examples. Each imports the `everruns` facade.
 
 | Example | Demonstrates | Command |
 | --- | --- | --- |
+| [`capability_configuration.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/capability_configuration.rs) | Typed Compaction and ToolSearch, a code-defined Definition, and a dynamic third-party reference through one entrypoint | `cargo run -p everruns --example capability_configuration` |
 | [`workspace_policy.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/workspace_policy.rs) | Safe workspace scopes and trusted starter files, fully offline | `cargo run -p everruns --example workspace_policy` |
 | [`live_session.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/live_session.rs) | Non-blocking send, automatic steering, and optional waiting, fully offline | `cargo run -p everruns --example live_session` |
 | [`hello.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/hello.rs) | Small live-provider agent | `cargo run -p everruns --features openai --example hello` |
@@ -18,12 +19,13 @@ contains the maintained public examples. Each imports the `everruns` facade.
 | [`canonical_events.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/canonical_events.rs) | Offline lossless recording and typed rendering of live events | `cargo run -p everruns --example canonical_events` |
 | [`subagents.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/subagents.rs) | Public facade composition for delegated work | `cargo run -p everruns --features openai --example subagents` |
 | [`observe_and_cancel.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/observe_and_cancel.rs) | Live events and cancellation | `cargo run -p everruns --features openai --example observe_and_cancel` |
+| [`advanced_capability.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/advanced_capability.rs) | Code-defined capability through the unified `capability(...)` entrypoint | `cargo run -p everruns --features openai --example advanced_capability` |
 | [`lifecycle_hooks.rs`](https://github.com/everruns/everruns/blob/main/crates/everruns/examples/lifecycle_hooks.rs) | Awaited agent, turn, tool, and completion handlers | `cargo run -p everruns --features openai --example lifecycle_hooks` |
 
 Live-provider modes use `gpt-5.6-terra` and require `OPENAI_API_KEY`.
-`canonical_events`, `live_session`, `session_work`, `workspace_policy`, and
-`session_history` are fully offline; the GitHub monitor also offers a simulated
-GitHub flow:
+`capability_configuration`, `canonical_events`, `live_session`, `session_work`,
+`workspace_policy`, and `session_history` are fully offline;
+the GitHub monitor also offers a simulated GitHub flow:
 
 ```bash
 cargo run -p everruns --features openai --example github_monitor -- --simulate

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -54,7 +54,7 @@ users should follow the [runtime migration guide](/framework/runtime-compatibili
 ## Extend and operate
 
 - [Custom providers](/framework/custom-providers/) — attach a custom `ChatDriver` without changing a closed enum.
-- [Advanced capabilities](/framework/advanced-capabilities/) — package typed tools with stable metadata and lifecycle context.
+- [Capabilities](/framework/advanced-capabilities/) — configure typed built-ins and open references, or package typed tools with stable metadata and lifecycle context.
 - [Custom backends](/framework/custom-backends/) — cross into low-level host composition deliberately.
 - [Testing and simulation](/framework/testing-and-simulation/) — deterministic tests without credentials.
 - [Runnable examples](/framework/examples/) — complete programs maintained with the crate.

--- a/examples/coding-cli/tests/application_parity.rs
+++ b/examples/coding-cli/tests/application_parity.rs
@@ -13,7 +13,7 @@ async fn compaction_policy_runs_without_host_checkpoint_types() {
     let agent = Agent::builder()
         .instructions("Keep long conversations useful.")
         .model(Model::simulated("ok"))
-        .compaction(
+        .capability(
             CompactionConfig::new()
                 .strategy(CompactionStrategy::ObservationMasking)
                 .budget_percent(0.75),

--- a/knowledge/framework/application-api.md
+++ b/knowledge/framework/application-api.md
@@ -30,8 +30,9 @@ provider registry, model resolution, turn semantics, or execution algorithm.
 
 The Framework owns value-first configuration for:
 
-- agent instructions, plain model ids, one provider per agent, tools, and
-  capability references;
+- agent instructions, plain model ids, one provider per agent, function tools,
+  and one open capability-configuration entrypoint for typed built-ins,
+  code-defined implementations, and dynamic references;
 - editable and read-only initial files plus an optional real-disk workspace;
 - scoped HTTP or local-process MCP servers;
 - local plugin directory loading and non-fatal compile warnings;
@@ -40,11 +41,13 @@ The Framework owns value-first configuration for:
   credential-free model identity;
 - canonical, lossless session events and lifecycle hooks through curated
   application values rather than engine or worker phase records;
-- high-level context-compaction behavior without checkpoint-store plumbing;
+- high-level context-compaction and model-adaptive tool-search behavior without
+  checkpoint-store or provider-specific plumbing;
 - high-level task, background-message, wake, and workspace-policy behavior
   without route-claiming or filesystem-backend plumbing;
-- an advanced capability-author SPI with typed schemas, narrow call context,
-  progress, cancellation, and structured errors;
+- an open, non-sealed capability conversion contract plus a curated
+  capability-author SPI with typed schemas, narrow call context, progress,
+  cancellation, and structured errors;
 - an opt-in local profile that combines real workspace files with local
   task/schedule state;
 - event-derived session history and resume, without promoting writable message
@@ -132,6 +135,7 @@ remove. Host implementations may continue using the compatibility crate in
 | Event-derived local history and resume | Promote | Conversation identity and restart continuation are application behavior; canonical events are the durable truth and history is a rebuildable projection. |
 | Legacy writable message-store trait | Isolate for `0.17.x` compatibility | The deprecated runtime-only shim is non-authoritative and execution never calls it; maintained history uses event replay. |
 | Context compaction policy | Promote | Applications choose high-level strategy and proactive budget; durable checkpoint storage remains host-owned. |
+| Capability configuration and dynamic references | Promote | Every capability enters through one open conversion contract. Typed values expose stable built-in schemas; database/plugin catalogs use an ID plus JSON without a closed enum or host dependency. |
 | Local task/schedule state used by an agent | Promote | The local profile supplies the state behind activated Framework capabilities. |
 | Canonical events, post-turn sinks, and typed lifecycle hooks | Promote | Applications observe lossless values and register behavior; engine buses, worker phases, and durable event-store topology remain host-owned. |
 | High-level tasks, background messages, wake, and workspace policy | Promote | Applications configure behavior and resume work without taking ownership of route claims, delivery daemons, or filesystem implementations. |
@@ -176,6 +180,12 @@ and multi-host lifecycle management remain host concerns.
   synchronized canonical envelope. Any projection index is rebuildable.
 - Promoting an application concern must not expose credentials, tenant records,
   backend stores, or host lifecycle entities.
+- Capability values converge through one builder entrypoint. New built-ins do
+  not add builder methods, and third-party values must not require a core or
+  host dependency. Dynamic references validate their open ID and JSON object
+  boundary at agent build time; known implementations additionally own schema
+  validation. Duplicate references and implementation collisions are errors,
+  never registry overwrites.
 - Local-process MCP stays opt-in and must not enter hosted builds by default.
 - Real workspaces keep the runtime filesystem's traversal and symlink-escape
   protections.
@@ -199,6 +209,8 @@ dependency while allowing focused host and sibling crates.
 ## Source index
 
 - `crates/everruns/src/agent.rs`
+- `crates/everruns/src/capability_config.rs`
+- `crates/everruns/src/tool_search.rs`
 - `crates/everruns/src/hooks.rs`
 - `crates/everruns/src/compaction.rs`
 - `crates/everruns/src/session.rs`
@@ -208,6 +220,7 @@ dependency while allowing focused host and sibling crates.
 - `crates/everruns/src/local.rs`
 - `crates/everruns/src/work.rs`
 - `crates/everruns/tests/application_parity.rs`
+- `crates/everruns/tests/capability_configuration.rs`
 - `crates/everruns/tests/session_work.rs`
 - `crates/everruns/tests/lifecycle_hooks.rs`
 - `examples/coding-cli/tests/application_parity.rs`


### PR DESCRIPTION
## What changed
- Added one open `AgentBuilder::capability(...)` entrypoint backed by the public, non-sealed `IntoCapability` contract and curated `CapabilitySpec` value.
- Added typed `ToolSearch`, routed `CompactionConfig` and code-defined `capability::Definition` through the same path, and added `CapabilityRef` for stable IDs plus dynamic JSON.
- Unified validation, alias normalization, collision detection, activation, and private host registration. Function tools remain on `#[everruns::tool]` and `.tool(...)`.
- Kept the raw core config conversion and doc-hidden root re-export only for 0.17 source compatibility; ordinary Framework docs and the prelude use `CapabilityRef`.
- Added runtime, negative, downstream compile, facade-only, docs, and executable offline example coverage.

## Why
Capability configuration had accumulated separate builder paths for references, compaction, code-defined implementations, and string tools. That does not scale to new built-ins or third-party capabilities and allowed the public tool API to conflate a function implementation with a capability reference.

## Before / After
Before:
```rust
Agent::builder()
    .compaction(CompactionConfig::new())
    .advanced_capability(weather_definition)
    .tool("current_time");
```

After:
```rust
Agent::builder()
    .capability(CompactionConfig::new().budget_percent(0.85))
    .capability(ToolSearch::automatic())
    .capability(weather_definition)
    .capability(CapabilityRef::new("vendor.custom").config(json_config))
    .tool(function_tool);
```

Evidence: `cargo run -p everruns --example capability_configuration` completes offline and prints `Configured.`. The dedicated capability suite covers all accepted inputs, invalid IDs/config, alias duplicates, implementation/reference collisions, reserved implementation IDs, and config redaction.

## Risk
- Medium
- This intentionally removes the capability-specific builder methods and string/core capability conversions from `.tool(...)`. Downstream callers must migrate those inputs to `.capability(...)`.
- Registry behavior is stricter: duplicate aliases, built-in shadowing, and implementation/reference collisions now fail at agent build instead of allowing a later overwrite.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-DOS, TM-PLUGIN, TM-OBS
- Findings and resolutions: capability IDs and JSON object boundaries are validated at build time; known built-in and declarative/plugin schemas use their existing validators; aliases and implementation IDs cannot overwrite registrations; the private lifecycle-hook namespace is reserved across references, Definitions, and function implementations; dynamic config is redacted from Framework debug output and documented as non-secret configuration that hosts may persist. No new network, credential, authorization, store, sandbox, or resource-requirement surface was introduced, so no threat-model entry changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)