### PR TITLE
chore(release): prepare v0.17.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.26] - 2026-08-10
+
+### Highlights
+
+- **Live, steerable sessions** - Sessions are now live and steerable, with canonical session events, session history and resume, and a session work and wake API ([#3095](https://github.com/everruns/everruns/pull/3095), [#3090](https://github.com/everruns/everruns/pull/3090), [#3089](https://github.com/everruns/everruns/pull/3089), [#3083](https://github.com/everruns/everruns/pull/3083)).
+- **Sessions as the operational list** - The Sessions surface was rebuilt as the operational list, recording session source and offering a filterable list with facet counts ([#3078](https://github.com/everruns/everruns/pull/3078), [#3073](https://github.com/everruns/everruns/pull/3073)).
+- **Advanced capability authoring** - New advanced capability authoring API with typed lifecycle hooks, a workspace access policy, unified capability configuration, and separated provider and model configuration ([#3084](https://github.com/everruns/everruns/pull/3084), [#3086](https://github.com/everruns/everruns/pull/3086), [#3085](https://github.com/everruns/everruns/pull/3085), [#3096](https://github.com/everruns/everruns/pull/3096), [#3093](https://github.com/everruns/everruns/pull/3093)).
+- **Daytona workspace recovery** - Sandboxes recover Daytona workspaces after instance loss ([#3092](https://github.com/everruns/everruns/pull/3092)).
+
+### What's Changed
+
+- feat(framework)!: unify capability configuration ([#3096](https://github.com/everruns/everruns/pull/3096)) by [@chaliy](https://github.com/chaliy)
+- docs(runtime): add 0.17 migration path ([#3091](https://github.com/everruns/everruns/pull/3091)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): make sessions live and steerable ([#3095](https://github.com/everruns/everruns/pull/3095)) by [@chaliy](https://github.com/chaliy)
+- feat(sandbox): recover Daytona workspaces after instance loss ([#3092](https://github.com/everruns/everruns/pull/3092)) by [@chaliy](https://github.com/chaliy)
+- fix(framework): bundle simulated error provider ([#3094](https://github.com/everruns/everruns/pull/3094)) by [@chaliy](https://github.com/chaliy)
+- feat(framework)!: separate provider and model configuration ([#3093](https://github.com/everruns/everruns/pull/3093)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): expose canonical session events ([#3090](https://github.com/everruns/everruns/pull/3090)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): add session history and resume ([#3089](https://github.com/everruns/everruns/pull/3089)) by [@chaliy](https://github.com/chaliy)
+- refactor(runtime): migrate first-party consumers off compatibility crate ([#3088](https://github.com/everruns/everruns/pull/3088)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): add workspace access policy ([#3085](https://github.com/everruns/everruns/pull/3085)) by [@chaliy](https://github.com/chaliy)
+- refactor(runtime): make runtime a host compatibility adapter ([#3087](https://github.com/everruns/everruns/pull/3087)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): add typed lifecycle hooks ([#3086](https://github.com/everruns/everruns/pull/3086)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): add advanced capability authoring API ([#3084](https://github.com/everruns/everruns/pull/3084)) by [@chaliy](https://github.com/chaliy)
+- feat(everruns): add session work and wake API ([#3083](https://github.com/everruns/everruns/pull/3083)) by [@chaliy](https://github.com/chaliy)
+- refactor(host): extract shared orchestration ([#3082](https://github.com/everruns/everruns/pull/3082)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): expose typed session identity by [@chaliy](https://github.com/chaliy)
+- docs(framework): establish primary library documentation by [@chaliy](https://github.com/chaliy)
+- feat(everruns): close application runtime API gaps ([#3079](https://github.com/everruns/everruns/pull/3079)) by [@chaliy](https://github.com/chaliy)
+- fix(features): hide disabled surfaces ([#3075](https://github.com/everruns/everruns/pull/3075)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): rebuild Sessions as the operational list ([#3078](https://github.com/everruns/everruns/pull/3078)) by [@chaliy](https://github.com/chaliy)
+- fix(security): resolve open Dependabot advisories in ui and docs ([#3076](https://github.com/everruns/everruns/pull/3076)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): port public everruns examples ([#3074](https://github.com/everruns/everruns/pull/3074)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): regenerate stale API types and gate the UI job on the spec ([#3077](https://github.com/everruns/everruns/pull/3077)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): redact reflected bound credentials ([#3062](https://github.com/everruns/everruns/pull/3062)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): record session source, filterable list with facet counts ([#3073](https://github.com/everruns/everruns/pull/3073)) by [@chaliy](https://github.com/chaliy)
+- chore(macros): move crate to concise path ([#3070](https://github.com/everruns/everruns/pull/3070)) by [@chaliy](https://github.com/chaliy)
+- fix(security): gate machine-payment custody surfaces ([#3069](https://github.com/everruns/everruns/pull/3069)) by [@chaliy](https://github.com/chaliy)
+- refactor(provider): separate providers from drivers ([#3072](https://github.com/everruns/everruns/pull/3072)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.17.25] - 2026-08-09
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2415,11 +2415,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.25"
+version = "0.17.26"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3074,11 +3074,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.25"
+version = "0.17.26"
 
 [[package]]
 name = "everruns-platform"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4874,9 +4874,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce93912abc8220a3fdb768b2c4a826a7a9a4b1599cfb4d760d422eaa1faf88c7"
+checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
 dependencies = [
  "ahash",
  "bytecount",
@@ -4903,18 +4903,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8165657ebed4d32c50f3c250c1986d8428b16fbfeac355222e8fec50aa26eb1d"
+checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069c5fdda3e9c2242bba49d811d5bbdb488abd8d234ed44a6312fd2891113e1"
+checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
 dependencies = [
  "ahash",
  "bytecount",
@@ -5486,9 +5486,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -6491,9 +6491,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -7131,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39f4c36ce0f50e96fb740d895f1cad34cfa76c4ab5c36934d6590bcd7029087"
+checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -9788,9 +9788,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.25"
+version = "0.17.26"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -168,19 +168,19 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-core = { path = "crates/core", version = "0.17.25" }
-everruns-engine = { path = "crates/engine", version = "0.17.25" }
-everruns-host = { path = "crates/host", version = "0.17.25" }
-everruns-platform = { path = "crates/platform", version = "0.17.25" }
-everruns-provider = { path = "crates/provider", version = "0.17.25" }
+everruns-core = { path = "crates/core", version = "0.17.26" }
+everruns-engine = { path = "crates/engine", version = "0.17.26" }
+everruns-host = { path = "crates/host", version = "0.17.26" }
+everruns-platform = { path = "crates/platform", version = "0.17.26" }
+everruns-provider = { path = "crates/provider", version = "0.17.26" }
 everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.25" }
-everruns-ard = { path = "crates/ard", version = "0.17.25" }
+everruns-mcp = { path = "crates/mcp", version = "0.17.26" }
+everruns-ard = { path = "crates/ard", version = "0.17.26" }
 everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-runtime = { path = "crates/runtime", version = "0.17.25" }
-everruns-local = { path = "crates/local", version = "0.17.25" }
-everruns = { path = "crates/everruns", version = "0.17.25" }
-everruns-macros = { path = "crates/macros", version = "0.17.25" }
+everruns-runtime = { path = "crates/runtime", version = "0.17.26" }
+everruns-local = { path = "crates/local", version = "0.17.26" }
+everruns = { path = "crates/everruns", version = "0.17.26" }
+everruns-macros = { path = "crates/macros", version = "0.17.26" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.25",
+  "version": "0.17.26",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.25" }
+everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.25" }
+everruns-provider = { path = "../provider", version = "0.17.26" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -136,10 +136,10 @@ inventory.workspace = true
 llmsim = { version = "0.5.1", default-features = false, optional = true }
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.17.25", optional = true }
+everruns-openui = { path = "../openui", version = "0.17.26", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.17.25", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.17.26", optional = true }
 
 # A2A outbound agent delegation (optional; behind the `a2a` feature). Pulls the
 # tonic/prost gRPC stack and a second reqwest major, so it is the largest single

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.25" }
+everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
 # Integration tests + the inline driver test use core's runtime harness

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -21,7 +21,7 @@ async-trait.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-everruns-provider = { path = "../provider", version = "0.17.25" }
+everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # default-features = false sheds core's heavy optional subtrees
 # (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
 # need, keeping the standalone crate's dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.25" }
+everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
 # a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
 # is what keeps the standalone `everruns-openrouter` dependency tree small.
-everruns-provider = { path = "../provider", version = "0.17.25" }
+everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
 # Integration tests use core's in-memory runtime + llmsim harness.

--- a/tests/fixtures/runtime-migration/Cargo.lock
+++ b/tests/fixtures/runtime-migration/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-runtime"
-version = "0.17.25"
+version = "0.17.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce93912abc8220a3fdb768b2c4a826a7a9a4b1599cfb4d760d422eaa1faf88c7"
+checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2219,18 +2219,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8165657ebed4d32c50f3c250c1986d8428b16fbfeac355222e8fec50aa26eb1d"
+checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069c5fdda3e9c2242bba49d811d5bbdb488abd8d234ed44a6312fd2891113e1"
+checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2886,9 +2886,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3306,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.8"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39f4c36ce0f50e96fb740d895f1cad34cfa76c4ab5c36934d6590bcd7029087"
+checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
 dependencies = [
  "ahash",
  "fluent-uri",


### PR DESCRIPTION
## What changed

Cuts the **v0.17.26** patch release. Bumps the workspace version (`Cargo.toml`), UI (`apps/ui/package.json`), and all publish path-dependency pins to `0.17.26`, adds the CHANGELOG entry, and refreshes lockfiles (including the `tests/fixtures/runtime-migration/Cargo.lock` fixture). No functional code changes — this is a release-cut PR that triggers auto-tagging on merge.

Release highlights (28 commits since v0.17.25):
- **Live, steerable sessions** — canonical session events, history and resume, session work/wake API
- **Sessions as the operational list** — session source recording, filterable list with facet counts
- **Advanced capability authoring** — capability authoring API, typed lifecycle hooks, workspace access policy, unified capability configuration, separated provider/model config
- **Daytona workspace recovery** after instance loss

See `CHANGELOG.md` for the full list.

## Why

Ship accumulated changes on `main` as a tagged release. Patch bump per release cadence.

## Before / After

Version-only change. `workspace.package.version` and `apps/ui/package.json` move `0.17.25 → 0.17.26`; `python3 scripts/sync-publish-pin-versions.py --check` reports all path-dep pins at 0.17.26. Migration ordering verified sequential (001..118). The runtime-migration fixture lockfile was regenerated so `--locked` builds pass.

## Risk
- Low
- Release-cut mechanical change; auto-tagging and downstream publish workflows fire on merge.

## Security
- Threat categories reviewed: No security-relevant code changes (version bumps, changelog, lockfiles). Included fixes from the range (`fix(security)` #3076, #3069, `fix(mcp)` #3062) already landed on main.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release cut)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR (all 40 check-runs green)
- [x] All review comments addressed (code change or written reasoning)