### PR TITLE
fix(release): correct everruns-local publish dependency map

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -163,7 +163,8 @@ jobs:
               ],
               "crates/local/Cargo.toml": [
                   "everruns-core",
-                  "everruns-runtime",
+                  "everruns-host",
+                  "everruns-platform",
               ],
               "crates/openai/Cargo.toml": [
                   "everruns-provider",

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -47,7 +47,7 @@ INNER_PINS: dict[str, list[str]] = {
         "everruns-local",
         "everruns-macros",
     ],
-    "crates/local/Cargo.toml": ["everruns-core", "everruns-runtime"],
+    "crates/local/Cargo.toml": ["everruns-core", "everruns-host", "everruns-platform"],
     "crates/openai/Cargo.toml": ["everruns-provider"],
     "crates/anthropic/Cargo.toml": ["everruns-provider"],
     "crates/openrouter/Cargo.toml": ["everruns-provider"],


### PR DESCRIPTION
## What changed

Fixes the crates.io publish step for releases. The runtime→host refactor (#3087, #3088) moved `crates/local` (`everruns-local`) off `everruns-runtime` onto `everruns-host` + `everruns-platform`, but the publish-crates version-verification map still listed `everruns-runtime` for that manifest. The verifier hard-indexes each mapped dependency, so it failed with `KeyError: 'everruns-runtime'` before any crate was published.

Updates the `crates/local/Cargo.toml` entry to its real workspace-versioned deps (`everruns-core`, `everruns-host`, `everruns-platform`) in both the workflow map (`.github/workflows/publish-crates.yml`) and the pin-sync map (`scripts/sync-publish-pin-versions.py`), keeping them in lockstep.

## Why

`v0.17.26`'s `Publish Crates` run failed at "Verify workspace version matches tag" ([run](https://github.com/everruns/everruns/actions/runs/31353849864)). Any release after the runtime→host refactor would hit the same failure. After this merges, `Publish Crates` can be re-dispatched for `v0.17.26`.

## Before / After

Before: publish-crates verify step raises `KeyError: 'everruns-runtime'` on `crates/local/Cargo.toml`.
After: validated the full `dependency_versions` map against the actual crate manifests — zero stale entries; `python3 scripts/sync-publish-pin-versions.py --check` passes.

## Risk
- Low
- Config-only change to the release publish pipeline; no runtime code touched.

## Security
- Threat categories reviewed: No security-relevant code changes (CI config + release tooling map).
- Findings and resolutions: None.

## Follow-ups
Re-run `Publish Crates` for `v0.17.26` once merged.

## Checklist
- [x] Tests added or updated (n/a — validated the map against manifests)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)