### PR TITLE
test: use obvious credential fixtures

### DIFF
--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -759,7 +759,7 @@ mod tests {
     async fn test_secret_store_without_context() {
         let tool = SecretStoreTool;
         let result = tool
-            .execute(json!({"operation": "set", "name": "api_key", "value": "secret123"}))
+            .execute(json!({"operation": "set", "name": "api_key", "value": "YExample0"}))
             .await;
 
         if let ToolExecutionResult::ToolError(msg) = result {

--- a/crates/server/src/api/app_endpoint_auth.rs
+++ b/crates/server/src/api/app_endpoint_auth.rs
@@ -612,24 +612,29 @@ mod tests {
     use crate::storage::password::hash_password;
     use axum::http::HeaderValue;
 
+    const EXAMPLE_USERNAME: &str = "example";
+    const EXAMPLE_PASSWORD: &str = "YExample0";
+
+    fn example_basic_auth_header() -> HeaderValue {
+        let credentials = BASE64_STANDARD.encode(format!("{EXAMPLE_USERNAME}:{EXAMPLE_PASSWORD}"));
+        HeaderValue::from_bytes(format!("basic {credentials}").as_bytes()).unwrap()
+    }
+
     #[test]
     fn extracts_basic_credentials() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_static("basic YWxpY2U6c2VjcmV0"),
-        );
+        headers.insert(AUTHORIZATION, example_basic_auth_header());
         assert_eq!(
             extract_basic_credentials(&headers),
-            Some(("alice".to_string(), "secret".to_string()))
+            Some((EXAMPLE_USERNAME.to_string(), EXAMPLE_PASSWORD.to_string()))
         );
     }
 
     #[test]
     fn shared_secret_uses_bearer() {
         let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, HeaderValue::from_static("bearer secret"));
-        assert!(verify_shared_secret(&headers, "secret").is_ok());
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("bearer YExample0"));
+        assert!(verify_shared_secret(&headers, EXAMPLE_PASSWORD).is_ok());
         assert_eq!(
             verify_shared_secret(&headers, "other").unwrap_err(),
             AppEndpointAuthError::Unauthorized
@@ -639,16 +644,13 @@ mod tests {
     #[test]
     fn basic_auth_verifies_argon2_password_hash() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_static("basic YWxpY2U6c2VjcmV0"),
-        );
+        headers.insert(AUTHORIZATION, example_basic_auth_header());
         let auth = AppEndpointAuthConfig {
             mode: AppEndpointAuthMode::HttpBasic,
             provider: Some(AppEndpointAuthProviderConfig::HttpBasic {
-                username: "alice".to_string(),
+                username: EXAMPLE_USERNAME.to_string(),
                 password: None,
-                password_hash: Some(hash_password("secret").unwrap()),
+                password_hash: Some(hash_password(EXAMPLE_PASSWORD).unwrap()),
             }),
             requirements: AppEndpointAuthRequirements::default(),
         };

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -954,11 +954,11 @@ mod tests {
     fn handshake_advertises_auth_when_token_configured() {
         let app = test_app("Secret", None);
         let mut config = default_config();
-        config.token = Some("hunter2".to_string());
+        config.token = Some("YExample0".to_string());
         let rendered = render_handshake(&app, &config);
         assert!(rendered.contains("Authorization: Bearer"));
         assert!(rendered.contains("X-Everruns-FCP-Token"));
-        assert!(!rendered.contains("hunter2"), "must never leak the token");
+        assert!(!rendered.contains("YExample0"), "must never leak the token");
     }
 
     #[test]
@@ -1131,16 +1131,16 @@ mod tests {
     fn check_token_required_rejects_missing() {
         let headers = HeaderMap::new();
         let mut config = default_config();
-        config.token = Some("hunter2".to_string());
+        config.token = Some("YExample0".to_string());
         assert!(check_token(&headers, &config).is_err());
     }
 
     #[test]
     fn check_token_required_accepts_matching_bearer() {
         let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, "Bearer hunter2".parse().unwrap());
+        headers.insert(AUTHORIZATION, "Bearer YExample0".parse().unwrap());
         let mut config = default_config();
-        config.token = Some("hunter2".to_string());
+        config.token = Some("YExample0".to_string());
         assert!(check_token(&headers, &config).is_ok());
     }
 
@@ -1149,7 +1149,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, "Bearer wrong".parse().unwrap());
         let mut config = default_config();
-        config.token = Some("hunter2".to_string());
+        config.token = Some("YExample0".to_string());
         assert!(check_token(&headers, &config).is_err());
     }
 

--- a/crates/server/src/api/payments.rs
+++ b/crates/server/src/api/payments.rs
@@ -390,7 +390,7 @@ mod tests {
     fn test_app(machine_payments_enabled: bool) -> Router {
         let db = Arc::new(StorageBackend::in_memory());
         let encryption =
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap();
         routes(
             AppState::new(

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -860,15 +860,15 @@ mod tests {
         // Test that AdminConfig stores credentials correctly
         let admin = AdminConfig {
             email: "admin@example.com".to_string(),
-            password: "secret123".to_string(),
+            password: "YExample0".to_string(),
         };
 
         assert_eq!(admin.email, "admin@example.com");
-        assert_eq!(admin.password, "secret123");
+        assert_eq!(admin.password, "YExample0");
 
         // Simulate credential check (same logic as login handler)
         let test_email = "admin@example.com";
-        let test_password = "secret123";
+        let test_password = "YExample0";
         assert!(
             test_email == admin.email && test_password == admin.password,
             "Matching credentials should pass"

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -4440,7 +4440,7 @@ mod tests {
     fn test_encryption() -> Arc<crate::storage::EncryptionService> {
         Arc::new(
             crate::storage::EncryptionService::new(
-                "kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=",
+                "kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
                 &[],
             )
             .unwrap(),

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -1594,7 +1594,7 @@ mod error_tests {
 
     #[test]
     fn http_adapter_redacts_internal_detail() {
-        let err = CommandError::internal(anyhow::anyhow!("db handle exhausted: secret=hunter2"));
+        let err = CommandError::internal(anyhow::anyhow!("db handle exhausted: secret=YExample0"));
         let (_status, body) = <(StatusCode, Json<ErrorResponse>)>::from(err);
         // detail is the safe generic string, never the anyhow message.
         assert_eq!(body.0.detail.as_deref(), Some("Internal server error"));

--- a/crates/server/src/domains/evals/dataset.rs
+++ b/crates/server/src/domains/evals/dataset.rs
@@ -483,9 +483,9 @@ mod tests {
                 "content": [{
                     "type": "tool_call",
                     "arguments": {
-                        "api_key": "hunter2",
+                        "api_key": "YExampleApi0",
                         "access-key": "shorttok",
-                        "nested": { "password": "p@ssw0rd" }
+                        "nested": { "password": "YExamplePassword0" }
                     }
                 }],
                 "metadata": {
@@ -493,7 +493,7 @@ mod tests {
                     "openai_api_key": "raw-openai-value",
                     "client_secret": "raw-client-secret",
                     "refresh_token": "raw-refresh-token",
-                    "authorization": "Basic dXNlcjpwYXNz",
+                    "authorization": "Basic YExample0",
                     "input_tokens": 1234,
                     "safe": "keep me"
                 }
@@ -504,16 +504,16 @@ mod tests {
         sanitize_value(&mut value, false);
 
         let serialized = serde_json::to_string(&value).unwrap();
-        assert!(!serialized.contains("hunter2"));
+        assert!(!serialized.contains("YExampleApi0"));
         assert!(!serialized.contains("shorttok"));
-        assert!(!serialized.contains("p@ssw0rd"));
+        assert!(!serialized.contains("YExamplePassword0"));
         assert!(!serialized.contains("metasecret"));
         assert!(!serialized.contains("bearer-token-value"));
         // Compound credential key names must also be redacted.
         assert!(!serialized.contains("raw-openai-value"));
         assert!(!serialized.contains("raw-client-secret"));
         assert!(!serialized.contains("raw-refresh-token"));
-        assert!(!serialized.contains("dXNlcjpwYXNz"));
+        assert!(!serialized.contains("Basic YExample0"));
         assert!(serialized.contains("keep me"));
         // Token *count* metadata must survive (not a credential).
         assert_eq!(

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -842,7 +842,7 @@ mod tests {
 
     fn test_encryption() -> Arc<EncryptionService> {
         Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         )
     }

--- a/crates/server/src/domains/payments/commands.rs
+++ b/crates/server/src/domains/payments/commands.rs
@@ -637,7 +637,7 @@ mod tests {
 
     fn test_ctx() -> Ctx {
         let encryption =
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap();
         Ctx::minimal_for_test(
             Caller::internal(DEFAULT_ORG_ID),

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -3,6 +3,7 @@ use tonic::service::Interceptor;
 
 // Env-var-mutating tests must not run in parallel.
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+const EXAMPLE_TOKEN: &str = "YExample0";
 
 async fn test_worker_service() -> WorkerServiceImpl {
     test_worker_service_with_runner(None).await
@@ -15,7 +16,7 @@ async fn test_worker_service_with_runner(
     let grade = everruns_core::DeploymentGrade::Dev;
     let platform_definition = crate::oss_platform_definition_for_grade(grade);
     let encryption = Some(Arc::new(
-        EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+        EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
             .expect("valid test encryption key"),
     ));
 
@@ -115,7 +116,7 @@ async fn test_worker_service_with_completing_runner() -> WorkerServiceImpl {
     let grade = everruns_core::DeploymentGrade::Dev;
     let platform_definition = crate::oss_platform_definition_for_grade(grade);
     let encryption = Some(Arc::new(
-        EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+        EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
             .expect("valid test encryption key"),
     ));
 
@@ -199,17 +200,17 @@ fn test_interceptor_allows_when_no_token_configured() {
 
 #[test]
 fn test_interceptor_allows_valid_bearer_token() {
-    let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
+    let mut interceptor = GrpcAuthInterceptor::new(Some(EXAMPLE_TOKEN.to_string()));
     let mut request = Request::new(());
     request
         .metadata_mut()
-        .insert("authorization", "Bearer secret123".parse().unwrap());
+        .insert("authorization", "Bearer YExample0".parse().unwrap());
     assert!(interceptor.call(request).is_ok());
 }
 
 #[test]
 fn test_interceptor_rejects_missing_token() {
-    let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
+    let mut interceptor = GrpcAuthInterceptor::new(Some(EXAMPLE_TOKEN.to_string()));
     let request = Request::new(());
     let err = interceptor.call(request).unwrap_err();
     assert_eq!(err.code(), tonic::Code::Unauthenticated);
@@ -218,7 +219,7 @@ fn test_interceptor_rejects_missing_token() {
 
 #[test]
 fn test_interceptor_rejects_wrong_token() {
-    let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
+    let mut interceptor = GrpcAuthInterceptor::new(Some(EXAMPLE_TOKEN.to_string()));
     let mut request = Request::new(());
     request
         .metadata_mut()
@@ -232,11 +233,11 @@ fn test_interceptor_rejects_wrong_token() {
 fn test_interceptor_rejects_same_length_wrong_token() {
     // Same length as the expected token so the constant-time compare reaches
     // its byte-comparison branch rather than short-circuiting on length.
-    let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
+    let mut interceptor = GrpcAuthInterceptor::new(Some(EXAMPLE_TOKEN.to_string()));
     let mut request = Request::new(());
     request
         .metadata_mut()
-        .insert("authorization", "Bearer secret124".parse().unwrap());
+        .insert("authorization", "Bearer YExample1".parse().unwrap());
     let err = interceptor.call(request).unwrap_err();
     assert_eq!(err.code(), tonic::Code::Unauthenticated);
     assert!(err.message().contains("Invalid"));
@@ -244,11 +245,11 @@ fn test_interceptor_rejects_same_length_wrong_token() {
 
 #[test]
 fn test_interceptor_rejects_non_bearer_scheme() {
-    let mut interceptor = GrpcAuthInterceptor::new(Some("secret123".to_string()));
+    let mut interceptor = GrpcAuthInterceptor::new(Some(EXAMPLE_TOKEN.to_string()));
     let mut request = Request::new(());
     request
         .metadata_mut()
-        .insert("authorization", "Basic secret123".parse().unwrap());
+        .insert("authorization", "Basic YExample0".parse().unwrap());
     let err = interceptor.call(request).unwrap_err();
     assert_eq!(err.code(), tonic::Code::Unauthenticated);
 }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2831,7 +2831,7 @@ mod tests {
     // --- DEFAULT_*_API_KEY materialization (single-tenant/dev) ---
 
     fn test_encryption() -> EncryptionService {
-        EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[]).unwrap()
+        EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[]).unwrap()
     }
 
     fn auth_config(mode: AuthMode, disable_signup: bool) -> AuthConfig {

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -337,7 +337,7 @@ mod tests {
 
         let db = Arc::new(StorageBackend::in_memory());
         let encryption = Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         );
         let registry = Arc::new(DriverRegistry::new());
@@ -512,7 +512,7 @@ mod tests {
 
         let db = Arc::new(StorageBackend::in_memory());
         let encryption = Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         );
         let registry = Arc::new(DriverRegistry::new());
@@ -585,7 +585,7 @@ mod tests {
         use everruns_core::DEFAULT_ORG_ID;
         let db = Arc::new(StorageBackend::in_memory());
         let encryption = Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         );
         let registry = Arc::new(DriverRegistry::new());
@@ -614,7 +614,7 @@ mod tests {
         use everruns_core::DEFAULT_ORG_ID;
         let db = Arc::new(StorageBackend::in_memory());
         let enc_v1 = Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         );
         let encrypted = enc_v1.encrypt_string("sk-secret").unwrap();

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -905,7 +905,7 @@ mod tests {
 
     fn test_encryption() -> Arc<EncryptionService> {
         Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         )
     }

--- a/crates/server/src/storage/compaction_checkpoint_store.rs
+++ b/crates/server/src/storage/compaction_checkpoint_store.rs
@@ -140,7 +140,7 @@ mod tests {
 
     fn encryption() -> Arc<EncryptionService> {
         Arc::new(
-            EncryptionService::new("test:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("test:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .unwrap(),
         )
     }

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -581,7 +581,7 @@ mod tests {
     use everruns_core::{DEFAULT_ORG_ID, PrincipalId};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    const TEST_KEY: &str = "kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=";
+    const TEST_KEY: &str = "kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
     struct FakeRefreshExchange {
         calls: AtomicUsize,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -222,7 +222,7 @@ impl TestServer {
 
         // Initialize encryption service (use test key)
         let encryption = Some(Arc::new(
-            EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            EncryptionService::new("kek-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", &[])
                 .expect("Invalid test encryption key"),
         ));
 

--- a/integrations/browserless/SPEC.md
+++ b/integrations/browserless/SPEC.md
@@ -174,7 +174,7 @@ Multi-step browser interactions.
 The `browserless_interact` tool supports `${{secrets.<name>}}` placeholders in step `value` fields. This allows agents to fill login forms and other sensitive inputs without ever seeing the plaintext credentials.
 
 **Flow:**
-1. User stores credentials via `secret_store set login_password hunter2`
+1. User stores credentials via `secret_store set login_password YExample0`
 2. Agent references them: `{ "action": "type", "selector": "#password", "value": "${{secrets.login_password}}" }`
 3. Tool resolves `login_password` from `session_secrets` at execution time, substitutes into the step, executes
 4. Plaintext never appears in tool arguments, agent messages, or tool results

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -594,8 +594,11 @@ mod tests {
     #[test]
     fn test_substitute_secrets_basic() {
         let mut resolved = std::collections::HashMap::new();
-        resolved.insert("pw".to_string(), "hunter2".to_string());
-        assert_eq!(substitute_secrets("${{secrets.pw}}", &resolved), "hunter2");
+        resolved.insert("pw".to_string(), "YExample0".to_string());
+        assert_eq!(
+            substitute_secrets("${{secrets.pw}}", &resolved),
+            "YExample0"
+        );
     }
 
     #[test]
@@ -647,10 +650,10 @@ mod tests {
             }),
         ];
         let mut resolved = std::collections::HashMap::new();
-        resolved.insert("pw".to_string(), "hunter2".to_string());
+        resolved.insert("pw".to_string(), "YExample0".to_string());
 
         let result = substitute_step_secrets(&steps, &resolved);
-        assert_eq!(result[0]["value"], "hunter2");
+        assert_eq!(result[0]["value"], "YExample0");
         assert_eq!(result[0]["selector"], "#password"); // untouched
         assert_eq!(result[1]["selector"], "#submit"); // untouched
     }


### PR DESCRIPTION
## What changed
Replaced realistic-looking test credentials with unmistakable examples while preserving every tested format and assertion. Basic-auth tests now encode explicit `example:YExample0` credentials at runtime, ordinary secret fixtures use `YExample*`, and test encryption uses a valid all-zero key.

## Why
Opaque Base64 credentials and random-looking test encryption keys are easy to mistake for real secrets and can create noisy reviews or scanner findings.

## Before / After
No observable production behavior changes.

Before: test sources contained opaque Basic credentials, common password-like values, and a random-looking 256-bit encryption key repeated across server tests.

After: the audited test scopes contain explicit example values; the previous opaque and password-like fixture patterns return no matches. The full server unit suite passes with the replacement key and credentials.

## Risk
- Low
- Test fixtures could fail to satisfy a parser or credential-format precondition; the complete server unit suite and focused package tests passed.

## Security
- Threat categories reviewed: TM-AUTH and secret handling. No security-relevant production code changes; all changes are confined to test modules, test harnesses, and a test example spec.
- Findings and resolutions: realistic-looking test key material and opaque Basic credentials were replaced with format-valid obvious examples. Format-sensitive PAT/JWT/PKCE/EVM/redaction fixtures and the stable local-development encryption key were intentionally preserved.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
